### PR TITLE
spike: prototype telemetry query architecture

### DIFF
--- a/server/clickhouse/spikes/telemetry_v2.sql
+++ b/server/clickhouse/spikes/telemetry_v2.sql
@@ -1,0 +1,174 @@
+-- SPIKE ONLY. This file is not part of the authoritative ClickHouse schema and
+-- is not consumed by migration tooling. It demonstrates the intended physical
+-- shape for native telemetry signals, one canonical fact, and one rollup.
+
+-- A replacement must keep organization_id, project_id, event_time, and
+-- record_id stable because ReplacingMergeTree deduplicates on the complete
+-- ORDER BY tuple. Corrections change ingest_version and payload fields only.
+CREATE TABLE IF NOT EXISTS telemetry_log_records (
+    organization_id UUID,
+    project_id UUID,
+    event_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    observed_at DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    record_id UUID,
+    ingest_version UInt64,
+    schema_version UInt16,
+    source LowCardinality(String),
+    ingress LowCardinality(String),
+    normalizer LowCardinality(String),
+    trace_id String DEFAULT '' CODEC(ZSTD),
+    span_id String DEFAULT '' CODEC(ZSTD),
+    severity_number UInt8 DEFAULT 0,
+    severity_text LowCardinality(String) DEFAULT '',
+    event_name LowCardinality(String) DEFAULT '',
+    body String DEFAULT '' CODEC(ZSTD),
+    attributes JSON CODEC(ZSTD),
+    source_payload String DEFAULT '' CODEC(ZSTD(3))
+) ENGINE = ReplacingMergeTree(ingest_version)
+PARTITION BY toYYYYMMDD(event_time)
+ORDER BY (organization_id, project_id, event_time, record_id)
+TTL event_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_log_records_trace_id
+ON telemetry_log_records (trace_id)
+TYPE bloom_filter(0.01) GRANULARITY 1;
+
+-- start_time is immutable identity metadata for a span replacement.
+CREATE TABLE IF NOT EXISTS telemetry_spans (
+    organization_id UUID,
+    project_id UUID,
+    start_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    end_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    observed_at DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    trace_id FixedString(32),
+    span_id FixedString(16),
+    parent_span_id String DEFAULT '' CODEC(ZSTD),
+    ingest_version UInt64,
+    schema_version UInt16,
+    source LowCardinality(String),
+    ingress LowCardinality(String),
+    normalizer LowCardinality(String),
+    name LowCardinality(String),
+    kind Enum8(
+        'unspecified' = 0,
+        'internal' = 1,
+        'server' = 2,
+        'client' = 3,
+        'producer' = 4,
+        'consumer' = 5
+    ),
+    status Enum8(
+        'unset' = 0,
+        'ok' = 1,
+        'error' = 2
+    ),
+    status_message String DEFAULT '' CODEC(ZSTD),
+    attributes JSON CODEC(ZSTD),
+    source_payload String DEFAULT '' CODEC(ZSTD(3))
+) ENGINE = ReplacingMergeTree(ingest_version)
+PARTITION BY toYYYYMMDD(start_time)
+ORDER BY (organization_id, project_id, start_time, trace_id, span_id)
+TTL start_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+CREATE INDEX IF NOT EXISTS idx_telemetry_spans_trace_id
+ON telemetry_spans (trace_id)
+TYPE bloom_filter(0.01) GRANULARITY 1;
+
+-- point_time is immutable identity metadata for a metric-point replacement.
+CREATE TABLE IF NOT EXISTS telemetry_metric_points (
+    organization_id UUID,
+    project_id UUID,
+    point_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    start_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    observed_at DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    record_id UUID,
+    ingest_version UInt64,
+    schema_version UInt16,
+    source LowCardinality(String),
+    ingress LowCardinality(String),
+    normalizer LowCardinality(String),
+    metric_name LowCardinality(String),
+    unit LowCardinality(String) DEFAULT '',
+    value_kind Enum8(
+        'gauge' = 1,
+        'sum' = 2,
+        'histogram' = 3
+    ),
+    aggregation_temporality Enum8(
+        'unspecified' = 0,
+        'delta' = 1,
+        'cumulative' = 2
+    ),
+    is_monotonic Bool DEFAULT false,
+    number_value Float64 DEFAULT 0,
+    histogram_count UInt64 DEFAULT 0,
+    histogram_sum Float64 DEFAULT 0,
+    histogram_bounds Array(Float64) DEFAULT [],
+    histogram_bucket_counts Array(UInt64) DEFAULT [],
+    attributes JSON CODEC(ZSTD),
+    source_payload String DEFAULT '' CODEC(ZSTD(3))
+) ENGINE = ReplacingMergeTree(ingest_version)
+PARTITION BY toYYYYMMDD(point_time)
+ORDER BY (organization_id, project_id, point_time, metric_name, record_id)
+TTL point_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+-- event_time is immutable identity metadata for a fact replacement. If the
+-- product requires correcting event_time itself, this sorting key must change
+-- or the writer must explicitly retract the previous identity.
+CREATE TABLE IF NOT EXISTS telemetry_usage_facts (
+    organization_id UUID,
+    project_id UUID,
+    event_time DateTime64(9, 'UTC') CODEC(Delta, ZSTD),
+    fact_id UUID,
+    fact_version UInt64,
+    schema_version UInt16,
+    source_record_ids Array(UUID),
+    source LowCardinality(String),
+    provider LowCardinality(String) DEFAULT '',
+    model LowCardinality(String) DEFAULT '',
+    billing_mode LowCardinality(String) DEFAULT '',
+    user_id String DEFAULT '' CODEC(ZSTD),
+    account_id String DEFAULT '' CODEC(ZSTD),
+    trace_id String DEFAULT '' CODEC(ZSTD),
+    session_id String DEFAULT '' CODEC(ZSTD),
+    input_tokens UInt64 DEFAULT 0,
+    output_tokens UInt64 DEFAULT 0,
+    cache_read_input_tokens UInt64 DEFAULT 0,
+    cache_creation_input_tokens UInt64 DEFAULT 0,
+    total_tokens UInt64 MATERIALIZED
+        input_tokens + output_tokens + cache_read_input_tokens + cache_creation_input_tokens,
+    total_cost Decimal(20, 12) DEFAULT 0
+) ENGINE = ReplacingMergeTree(fact_version)
+PARTITION BY toYYYYMMDD(event_time)
+ORDER BY (organization_id, project_id, event_time, fact_id)
+TTL event_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+-- Refreshable rather than incremental: the source uses replacement semantics,
+-- so an insert-triggered additive MV could permanently double-count a retried
+-- or corrected fact. The default refresh mode replaces the complete target.
+CREATE MATERIALIZED VIEW IF NOT EXISTS telemetry_usage_daily
+REFRESH EVERY 5 MINUTE
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(day)
+ORDER BY (organization_id, project_id, day, provider, model, source)
+AS SELECT
+    organization_id,
+    project_id,
+    toStartOfDay(event_time) AS day,
+    provider,
+    model,
+    source,
+    toUInt64(count()) AS requests,
+    sum(input_tokens) AS input_tokens,
+    sum(output_tokens) AS output_tokens,
+    sum(cache_read_input_tokens) AS cache_read_input_tokens,
+    sum(cache_creation_input_tokens) AS cache_creation_input_tokens,
+    sum(total_tokens) AS total_tokens,
+    sum(total_cost) AS total_cost
+FROM telemetry_usage_facts FINAL
+WHERE event_time >= now64(9, 'UTC') - INTERVAL 90 DAY
+GROUP BY organization_id, project_id, day, provider, model, source;

--- a/server/internal/telemetry/analytics/CURRENT_QUERY_MIGRATION.md
+++ b/server/internal/telemetry/analytics/CURRENT_QUERY_MIGRATION.md
@@ -1,0 +1,320 @@
+# Current telemetry query migration catalog
+
+This document maps every exported `*repo.Queries` operation under `server/internal/telemetry/repo` to the proposed telemetry architecture. Private SQL builders are covered by the exported operation that owns them. `WithConn` is excluded because it changes the connection used by a repository and does not issue a query.
+
+The important conclusion is that one aggregate DSL should not absorb every database operation. The current repository contains four different kinds of work:
+
+| Kind | Production boundary | Examples |
+| --- | --- | --- |
+| Aggregate analytics | Closed semantic `Query` and physical planner | totals, time series, breakdowns, unique counts |
+| Detail and search | Bounded, typed search specifications | log rows, trace rows, sessions, chats |
+| Operational lookup | Dedicated repository method | deduplication, attribution lookup, staging work |
+| Command | Dedicated writer | inserts, promotions, score writes, inventory updates |
+
+Only the first category belongs in the aggregate query mechanism demonstrated by this spike. Detail searches can share the same mandatory `Scope`, `TimeRange`, dimension registry, and plan-selection infrastructure, but need cursor and row-projection semantics rather than `GROUP BY` measures. Operational lookups and commands should remain explicit methods.
+
+## Target vocabulary used below
+
+The examples in this document are target-state pseudocode. Only the `usage` subset exists in the compilable spike.
+
+```go
+query := telemetry.NewQuery(telemetry.DatasetToolCalls, scope, interval).
+    AtGrain(telemetry.GrainDay).
+    GroupBy(telemetry.DimensionTarget, telemetry.DimensionTool).
+    Select(
+        telemetry.MeasureEvents,
+        telemetry.MeasureSuccesses,
+        telemetry.MeasureFailures,
+        telemetry.MeasureFailureRate,
+    ).
+    Where(
+        telemetry.OneOf(telemetry.DimensionTargetType, targetTypes...),
+        telemetry.OneOf(telemetry.DimensionUser, users...),
+    ).
+    OrderBy(telemetry.Descending(telemetry.MeasureEvents)).
+    WithLimit(25)
+```
+
+The likely datasets are:
+
+| Dataset | Row grain before aggregation | Likely physical sources |
+| --- | --- | --- |
+| `model_usage` | one canonical model-usage observation | usage facts, hourly/daily usage rollups |
+| `tool_calls` | one canonical tool-call outcome | tool-call facts, tool-call rollups |
+| `hook_events` | one hook event or normalized hook trace | hook facts, hook rollups |
+| `skill_uses` | one skill invocation/version observation | skill facts, skill-version rollups |
+| `chat_sessions` | one normalized chat/session | session facts and summaries |
+| `employee_activity` | one attributed employee activity | attributed facts and employee rollups |
+| `shadow_mcp_usage` | one attributed unproxied MCP call | tool-call facts filtered by target class |
+| `chat_analysis` | one chat-analysis verdict | score store and verdict summaries |
+| `skill_efficacy` | one scored skill session | efficacy scores and insight rollups |
+| `data_flow_edges` | one normalized source-to-destination edge | precomputed edge facts |
+
+The likely reusable dimensions include project, provider, model, source, hook source, account type, user, email, department, division, role, target type, target, tool, status, client, session, chat, skill, skill version, and verdict. Measures include events, requests, successes, failures, failure rate, unique users, unique tools, unique targets, latency, input/output/cache token categories, total tokens, cost, active sessions, and score statistics.
+
+## Model usage, general metrics, and overview
+
+```go
+// GetTimeSeriesMetrics or the token portion of GetMetricsSummary.
+telemetry.NewQuery(telemetry.DatasetModelUsage, scope, interval).
+    AtGrain(bucketGrain).
+    Select(
+        telemetry.MeasureRequests,
+        telemetry.MeasureInputTokens,
+        telemetry.MeasureOutputTokens,
+        telemetry.MeasureCacheReadInputTokens,
+        telemetry.MeasureCacheCreationInputTokens,
+        telemetry.MeasureTotalCost,
+    )
+
+// GetToolMetricsBreakdown.
+telemetry.NewQuery(telemetry.DatasetToolCalls, scope, interval).
+    GroupBy(telemetry.DimensionTool).
+    Select(telemetry.MeasureEvents, telemetry.MeasureFailures, telemetry.MeasureLatency).
+    OrderBy(telemetry.Descending(telemetry.MeasureEvents))
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `GetMetricsSummary` | Composite repository call over `model_usage` and `tool_calls`; each subquery is semantic and may select a different rollup. |
+| `GetTimeSeriesMetrics` | `model_usage` and/or `tool_calls` with the requested time grain. Split mixed-domain measures rather than rebuilding one raw-log query. |
+| `GetToolMetricsBreakdown` | `tool_calls`, grouped by tool and optionally target, selecting events, failures, and latency. |
+| `GetOverviewSummary` | Application-level composition of semantic summary queries; no SQL of its own. |
+| `GetTopUsers` | `employee_activity` or `tool_calls`, grouped by user, ordered by activity. |
+| `GetTopServers` | `tool_calls`, grouped by target/server, ordered by events. |
+| `GetLLMClientBreakdown` | `model_usage` or `tool_calls`, grouped by client/hook source; `SessionMode` becomes an explicit dataset choice instead of changing SQL branches. |
+| `GetActiveCounts` | Semantic unique-user and unique-target measures over the selected dataset. |
+
+## Canonical model usage and tokens under management
+
+Tokens under management should reuse canonical usage facts but have a separately governed measure definition and population policy. The billing definition must not be an arbitrary expression supplied by a caller.
+
+```go
+telemetry.NewQuery(telemetry.DatasetModelUsage, scope, billingWindow).
+    AtGrain(telemetry.GrainDay).
+    GroupBy(telemetry.DimensionModel).
+    Select(telemetry.MeasureTokensUnderManagement).
+    Where(telemetry.Exclude(telemetry.DimensionHookSource, gramHostedSources...))
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `GetTokensUnderManagementByDay` | `model_usage`, day grain, governed `tokens_under_management` measure. |
+| `GetTumWindowTotal` | Same dataset, filters, and governed measure without a time grain. |
+| `GetTumBreakdownTotalsByDay` | Same day query selecting governed input, output, cache-creation, and total measures. |
+| `GetTumBreakdownDimByDay` | Same measure grouped by one cataloged dimension. Canonical email and multi-valued role behavior belong in dimension definitions, not caller SQL. |
+| `GetClaudeTurnUsageByChatIDs` | `model_usage` filtered by chat IDs and grouped by chat/turn; use a dedicated batch-result adapter if the caller requires a map keyed by chat. |
+| `GetClaudeToolUsageByChatIDs` | `tool_calls` filtered by chat IDs and grouped by chat/turn/tool. |
+
+## Tool calls, target attribution, and MCP activity
+
+The current tool-usage family already shares a large normalized CTE. In the target design that normalization becomes the `tool_calls` fact writer, and all projections use the same semantic dataset.
+
+```go
+base := telemetry.NewQuery(telemetry.DatasetToolCalls, scope, interval).
+    Where(
+        telemetry.OneOf(telemetry.DimensionTargetType, targetTypes...),
+        telemetry.OneOf(telemetry.DimensionTarget, targets...),
+        telemetry.OneOf(telemetry.DimensionUser, users...),
+        telemetry.OneOf(telemetry.DimensionStatus, statuses...),
+    )
+
+totals := base.Select(
+    telemetry.MeasureEvents,
+    telemetry.MeasureSuccesses,
+    telemetry.MeasureFailures,
+    telemetry.MeasureFailureRate,
+    telemetry.MeasureUniqueTools,
+    telemetry.MeasureUniqueUsers,
+    telemetry.MeasureUniqueTargets,
+)
+
+targets := base.GroupBy(telemetry.DimensionTarget).
+    Select(telemetry.MeasureEvents, telemetry.MeasureUniqueTools, telemetry.MeasureFailureRate)
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `GetToolUsageSummary` | Composite application call that executes the semantic totals, target, user, time-series, and cross-breakdown queries below. |
+| `GetToolUsageTotals` | `tool_calls` totals query. |
+| `GetToolUsageTargets` | `tool_calls` grouped by target type/kind/ID/label. |
+| `GetToolUsageUsers` | `tool_calls` grouped by normalized user identity. |
+| `GetToolUsageTargetTimeSeries` | `tool_calls`, time grain plus target dimensions. |
+| `GetToolUsageUserTimeSeries` | `tool_calls`, time grain plus user dimensions. |
+| `GetToolUsageUsersByTarget` | `tool_calls` grouped by target and user. |
+| `GetToolUsageTargetToolBreakdown` | `tool_calls` grouped by target and tool. |
+| `GetMcpServerActivity` | `tool_calls` grouped by MCP target, selecting total, recent, and last-seen measures. |
+| `GetToolUsageFilterOptions` | Dimension-value discovery over `tool_calls`; use cataloged dimensions and the same base scope/window. |
+| `ListToolUsageTraces` | Typed `TraceSearchSpec` over tool-call/trace facts with cursor pagination; not an aggregate query. |
+| `GetUnproxiedMcpServerUsageTimeSeries` | `tool_calls` filtered to unproxied/shadow targets, grouped by time and server. |
+| `GetUnproxiedMcpServerToolUsage` | Same filter, grouped by server and tool with semantic pagination/order. |
+| `GetUnproxiedMcpServerUserUsage` | Same filter, grouped by server and user. |
+| `GetUnproxiedMcpServerClientUsage` | Same filter, grouped by server and client. |
+| `ListShadowMCPInventoryUsage` | `shadow_mcp_usage` or filtered `tool_calls`, grouped by discovered server. |
+| `ListShadowMCPInventoryUsers` | Same dataset grouped by discovered server and user. |
+
+## Hooks and skills
+
+Hooks and skills share several filters but have different product grains. They should be two datasets backed by facts written from native log/span records, rather than repeated `trace_summaries` interpretation.
+
+```go
+telemetry.NewQuery(telemetry.DatasetHookEvents, scope, interval).
+    AtGrain(bucketGrain).
+    GroupBy(telemetry.DimensionHookSource, telemetry.DimensionStatus).
+    Select(telemetry.MeasureEvents, telemetry.MeasureUniqueUsers)
+
+telemetry.NewQuery(telemetry.DatasetSkillUses, scope, interval).
+    GroupBy(telemetry.DimensionSkill, telemetry.DimensionSkillVersion).
+    Select(telemetry.MeasureEvents, telemetry.MeasureActiveSessions)
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `GetHooksSummary` | `hook_events` grouped by server/source, selecting events, users, sessions, and outcomes. |
+| `GetHooksSessionCount` | `hook_events` or `chat_sessions`, selecting unique sessions with hook filters. |
+| `GetHooksUserSummary` | `hook_events` grouped by user. |
+| `GetHooksBreakdown` | `hook_events` grouped by the requested cataloged hook dimension. |
+| `GetHooksTimeSeries` | `hook_events` with a time grain. |
+| `ListHooksTraces` | Typed `TraceSearchSpec` filtered to hook traces. |
+| `ListRecentHookEventsForOnboarding` | Typed `HookEventSearchSpec`; this is recent-row retrieval, not aggregation. |
+| `CountRecentHookEventsForOnboarding` | `hook_events` selecting the event-count measure with the same scope/window as the search. |
+| `GetSkillsSummary` | `skill_uses` grouped by skill, selecting invocations, sessions, and users. |
+| `GetSkillBreakdown` | `skill_uses` grouped by the requested cataloged dimension. |
+| `GetSkillTimeSeries` | `skill_uses` with a time grain. |
+| `QuerySkillVersionMetricsTable` | `skill_uses` grouped by skill version and requested cataloged dimensions. |
+| `QuerySkillVersionMetricsTimeseries` | Same dataset with a time grain. |
+
+## Chats and sessions
+
+Row-oriented chat/session pages need a bounded search specification. Aggregates over those entities use semantic datasets.
+
+```go
+search := telemetry.NewSessionSearch(scope, interval).
+    Where(telemetry.OneOf(telemetry.DimensionUser, users...)).
+    OrderBy(telemetry.DescendingTime()).
+    After(cursor).
+    WithLimit(50)
+
+summary := telemetry.NewQuery(telemetry.DatasetChatSessions, scope, interval).
+    GroupBy(telemetry.DimensionUser).
+    Select(telemetry.MeasureSessions, telemetry.MeasureTotalTokens)
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `ListChats` | Typed `ChatSearchSpec` over chat/session summaries. |
+| `GetChatMetricsByIDs` | Dedicated authorized batch lookup over chat/session facts, or semantic query filtered by bounded chat IDs. |
+| `ListSessions` | Typed `SessionSearchSpec` with cataloged filters and cursor ordering. |
+| `GetChatSessionFactsByChatIDs` | Dedicated authorized batch lookup; it serves enrichment rather than interactive analytics. |
+| `GetChatMetricsSummaryByIDs` | Dedicated batch aggregate over bounded chat IDs, implemented through the `chat_sessions` dataset where practical. |
+
+## Users, employee analytics, dimensions, and data flow
+
+```go
+telemetry.NewQuery(telemetry.DatasetEmployeeActivity, scope, interval).
+    GroupBy(telemetry.DimensionDepartment, telemetry.DimensionUser).
+    Select(telemetry.MeasureEvents, telemetry.MeasureTotalTokens, telemetry.MeasureUniqueTools)
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `SearchUsers` | Typed employee/user search over an employee-activity rollup. |
+| `SearchEmployeeAgentUsage` | Same employee search specification with agent-usage measures. |
+| `GetUserMetricsSummary` | `employee_activity` filtered by user, selecting usage and tool-call measures. |
+| `GetEmployeeDataFlowGraph` | `data_flow_edges` grouped by source/destination/type; do not reconstruct graph edges from raw logs at read time. |
+| `ListFilterOptions` | Catalog-driven dimension-value discovery against the selected dataset and window. |
+| `ListAttributeKeys` | Catalog metadata plus an explicit dynamic-attribute registry; not a raw query escape hatch. |
+| `ListEmaillessIdentities` | Dedicated data-quality lookup. It is operational and should not enter the analytics DSL. |
+
+## Existing generic attribute analytics
+
+The current generic attribute APIs are the closest predecessor to the semantic catalog. Migration should preserve their public dimension IDs while moving SQL expressions and compatible sources into dataset definitions.
+
+| Current operation | Target conversion |
+| --- | --- |
+| `QueryAttributeMetricsTable` | Compatibility adapter from the existing request into a cataloged dataset query with dimensions and measures. Reject paths not registered for that dataset. |
+| `QueryAttributeMetricsTimeseries` | Same adapter with a time grain. |
+
+The adapter should be temporary. New product code should construct semantic query values directly.
+
+## Skill efficacy and chat analysis
+
+| Current operation | Target conversion |
+| --- | --- |
+| `QuerySkillInsights` | `skill_efficacy`, grouped by skill/version/time and selecting score, success, and sample-count measures. |
+| `ListSkillEfficacyScoreSessions` | Typed scored-session search; row retrieval rather than an aggregate query. |
+| `GetChatAnalysisVerdictsByChatIDs` | Dedicated authorized batch lookup by bounded chat IDs. |
+| `ListChatAnalysisVerdicts` | Typed verdict search with cataloged verdict/user/time filters. |
+
+## Trace and log detail
+
+Detail endpoints intentionally retain a search-oriented repository. They should still share authenticated scope construction, bounded time ranges, registered filters, plan selection, and parameterization.
+
+```go
+telemetry.NewLogSearch(scope, interval).
+    Where(telemetry.Equals(telemetry.DimensionTraceID, traceID)).
+    SearchText(searchText).
+    After(cursor).
+    WithLimit(100)
+
+telemetry.NewTraceSearch(scope, interval).
+    Where(telemetry.OneOf(telemetry.DimensionStatus, statuses...)).
+    After(cursor).
+    WithLimit(50)
+```
+
+| Current operation | Target conversion |
+| --- | --- |
+| `ListTelemetryLogs` | Typed `LogSearchSpec`; raw/native log detail is a legitimate raw-table read. |
+| `ListToolTraces` | Typed `TraceSearchSpec` backed by trace summaries/facts. |
+
+## Shadow MCP inventory state
+
+Inventory URL records are mutable product state, not time-series analytics. They should remain behind a dedicated repository even if ClickHouse continues to store them.
+
+| Current operation | Target conversion |
+| --- | --- |
+| `GetShadowMCPInventoryURL` | Dedicated inventory lookup. |
+| `ListExistingShadowMCPInventoryURLs` | Dedicated bounded existence lookup. |
+| `ListShadowMCPInventoryURLsByCanonicalURLs` | Dedicated inventory lookup. |
+| `ListShadowMCPInventoryURLsBySlugHash` | Dedicated inventory lookup. |
+| `ListShadowMCPInventoryURLs` | Typed inventory search/read model. |
+
+## Ingestion, staging, attribution, and diagnostics
+
+These operations are deliberately outside the query DSL. Their narrow method names are useful governance because they describe the exact mutation or operational lookup being performed.
+
+| Current operation | Target conversion |
+| --- | --- |
+| `InsertTelemetryLog`, `InsertTelemetryLogs`, `InsertTelemetryLogsSync` | Native-signal writer commands with batching and acknowledged async-insert policy. |
+| `InsertTelemetryLogsStaging` | Staging writer command. |
+| `InsertPromotedTelemetryLogs` | Promotion command that writes validated native rows. |
+| `DeleteStagedTelemetryLogs` | Explicit staging cleanup command. |
+| `ListStagedTelemetryLogs` | Operational promotion work lookup. |
+| `ListStagedTelemetryProjects` | Operational promotion work lookup. |
+| `ListExistingTelemetryLogIDs` | Operational ingestion deduplication lookup. |
+| `ListIngestedEventHashes` | Operational event deduplication lookup. |
+| `LookupMCPProvenanceByToolCallID` | Operational attribution lookup used by the fact writer. |
+| `ReplaceIdentityMap` | Identity-map writer command. |
+| `ListLiteLLMTrafficDiagnostics` | Explicit diagnostic query, isolated from customer-facing analytics. |
+| `InsertSkillSessionVersions` | Skill-session/version fact writer command. |
+| `InsertSkillEfficacyScores` | Score writer command. |
+| `ListExistingSkillEfficacyScoreIDs` | Operational score-deduplication lookup. |
+| `InsertChatAnalysisScores` | Chat-analysis writer command. |
+| `ListExistingChatAnalysisScoreIDs` | Operational score-deduplication lookup. |
+| `UpsertShadowMCPInventoryURLs` | Inventory state command. |
+| `UpdateShadowMCPInventoryURLNameOverride` | Inventory state command. |
+
+## Migration order
+
+The safest migration sequence follows dependencies rather than file order:
+
+1. Introduce native logs, spans, and metric points while preserving current writes.
+2. Materialize canonical `model_usage`, `tool_calls`, `hook_events`, `skill_uses`, and `chat_sessions` facts in parallel with current views.
+3. Add semantic datasets and parity tests for one query family at a time.
+4. Move summaries and breakdowns first because they benefit most from governed rollups.
+5. Add typed trace/log/session search specifications without forcing them into aggregate semantics.
+6. Leave ingestion, staging, stateful inventory, diagnostics, and bounded lookups as explicit repository methods.
+7. Remove old query implementations only after shadow comparisons establish row and measure parity.
+
+This separation is also the future-sprawl rule: a new dashboard aggregation must register a dataset, dimensions, measures, and compatible plans. A new detail page must use a typed search specification. Operational commands and lookups remain narrow methods and do not gain a generic SQL escape hatch.

--- a/server/internal/telemetry/analytics/README.md
+++ b/server/internal/telemetry/analytics/README.md
@@ -1,0 +1,98 @@
+# Telemetry analytics architecture spike
+
+This package is a narrow, compilable spike for the two Draft telemetry RFCs. It demonstrates the intended boundaries without changing the authoritative ClickHouse schema, generating migrations, wiring Pub/Sub, or moving an existing endpoint.
+
+The complete example has two parts:
+
+- [`server/clickhouse/spikes/telemetry_v2.sql`](../../../clickhouse/spikes/telemetry_v2.sql) contains executable DDL for the three native signal tables, canonical usage facts, and a refreshable daily usage rollup.
+- This package contains a closed semantic catalog, immutable `Query`, mandatory tenant and time constructors, physical-plan selection, and parameterized ClickHouse compilation.
+
+Two additional walkthroughs show how the design is consumed and migrated:
+
+- [`example/main.go`](example/main.go) is a compilable production-style caller covering every supported grain, dimension, measure, filter operator, order direction, physical plan, default, and rejection path.
+- [`CURRENT_QUERY_MIGRATION.md`](CURRENT_QUERY_MIGRATION.md) inventories every exported telemetry repository operation and maps it to a semantic query, typed detail search, operational lookup, or command.
+
+## Shape
+
+```text
+authenticated caller
+       │
+       ▼
+NewScope + NewTimeRange
+       │
+       ▼
+NewUsageQuery
+  dimensions: provider, model, source
+  measures: requests, token categories, cost
+       │
+       ▼
+Planner.Compile
+       │
+       ├── fresh, complete, day-aligned ──► telemetry_usage_daily
+       │
+       └── within fact retention ─────────► telemetry_usage_facts FINAL
+```
+
+Callers name product semantics rather than tables or SQL expressions:
+
+```go
+scope, err := analytics.NewScope(organizationID, projectIDs...)
+if err != nil {
+    return err
+}
+interval, err := analytics.NewTimeRange(from, to)
+if err != nil {
+    return err
+}
+
+query := analytics.NewUsageQuery(scope, interval).
+    AtGrain(analytics.GrainDay).
+    GroupBy(analytics.DimensionProvider, analytics.DimensionModel).
+    Select(
+        analytics.MeasureRequests,
+        analytics.MeasureTotalTokens,
+        analytics.MeasureTotalCost,
+    ).
+    Where(analytics.OneOf(analytics.DimensionSource, sources...)).
+    OrderBy(analytics.Descending(analytics.MeasureTotalCost)).
+    WithLimit(10)
+
+compiled, err := planner.Compile(query)
+```
+
+`Query` has no table, expression, join, function, or setting field. The compiler accepts only cataloged dimensions, measures, filters, grains, sorts, and limits. Filter values are Squirrel parameters. A valid query always contains a non-empty authenticated project set and a half-open UTC interval.
+
+## What the DDL demonstrates
+
+The native tables have product-specific grains and stable identities. Frequently filtered fields use native ClickHouse types; variable attributes use `JSON`; source payloads remain compressed escape hatches. The `ORDER BY` prefix follows every supported query's organization, project, and time filters. Daily partitions are bounded by the 90-day TTL and must still be validated against production part counts before becoming authoritative schema.
+
+`telemetry_usage_facts` is one row per logical usage observation, not one row per raw signal. `ReplacingMergeTree(fact_version)` models late attribution and replay without `ALTER UPDATE`. Analytical reads use `FINAL` because background replacement is eventual. Replacement identity is the complete `ORDER BY` tuple, so event timestamps are immutable identity metadata in this example; correcting a timestamp would require a different key design or an explicit retraction protocol.
+
+`telemetry_usage_daily` is a refreshable materialized view over deduplicated facts. It replaces its complete 90-day target every five minutes in this spike. That is safe for corrected facts, but it is not the RFC's final 730-day partition-refresh controller. A production implementation must benchmark full refreshes and either stage and replace complete dirty partitions or prove that full-target refresh is cheap enough.
+
+The spike uses `Decimal(20, 12)` for `total_cost` to make the fixed-precision boundary concrete. This is an explicit assumption, not a billing decision. Billing must confirm source precision before migration DDL is approved.
+
+## Requirement coverage
+
+| RFC requirement | Spike artifact | Status |
+| --- | --- | --- |
+| Separate native log, span, and metric grains | `telemetry_v2.sql` | Demonstrated, not migrated |
+| Stable identities and replacement versions | Native tables and `telemetry_usage_facts` | Demonstrated |
+| Typed fields plus dynamic attributes | Native table DDL | Demonstrated |
+| Canonical usage fact | Fact DDL and usage semantic catalog | Demonstrated for one domain |
+| Simple deduplicated rollup | Refreshable daily MV | Demonstrated for 90 days |
+| Mandatory tenant and time scope | `NewScope`, `NewTimeRange`, `NewUsageQuery` | Implemented and tested |
+| Closed dimensions and measures | `catalog.go` | Provider, model, source and seven measures |
+| Rollup/fact physical planning | `Planner.Compile` | Implemented and tested |
+| Parameterized SQL | `compiler.go` | Implemented and tested |
+| Pub/Sub, writers, and replay | None | Intentionally skipped |
+| Existing endpoint migration and shadow comparison | None | Intentionally skipped |
+| Tool-call facts and other datasets | None | Intentionally skipped |
+| Raw-query registry and `glint` enforcement | None | Intentionally skipped |
+| Production schema and migrations | None | Intentionally skipped while RFCs remain Draft |
+
+## ClickHouse provenance
+
+The schema follows `schema-pk-plan-before-creation`, `schema-pk-prioritize-filters`, `schema-pk-filter-on-orderby`, `schema-types-native-types`, `schema-types-lowcardinality`, `schema-types-avoid-nullable`, `schema-json-when-to-use`, `schema-partition-lifecycle`, and `insert-mutation-avoid-update`.
+
+The refreshable rollup follows `query-mv-refreshable` and `decision-real-time-preaggregation`. Avoiding an incremental additive view over replacement facts is derived from ClickHouse's inserted-block MV semantics and the RFC's at-least-once delivery model. Production writers would still need batching or acknowledged async inserts per `insert-batch-size` and `insert-async-small-batches`.

--- a/server/internal/telemetry/analytics/catalog.go
+++ b/server/internal/telemetry/analytics/catalog.go
@@ -1,0 +1,343 @@
+package analytics
+
+import (
+	"fmt"
+	"slices"
+	"time"
+)
+
+// PlanID identifies a compiler-owned physical plan without exposing it in the
+// semantic Query type.
+type PlanID string
+
+const (
+	// PlanUsageDaily reads the refreshable daily usage rollup.
+	PlanUsageDaily PlanID = "usage_daily"
+
+	// PlanUsageFacts reads deduplicated canonical usage facts.
+	PlanUsageFacts PlanID = "usage_facts"
+)
+
+// DimensionMetadata describes one public grouping and filtering axis.
+type DimensionMetadata struct {
+	// ID is the stable semantic dimension identifier.
+	ID DimensionID
+
+	// ValueType describes the values accepted by filters and returned in rows.
+	ValueType string
+
+	// Operators lists the filter operations accepted for this dimension.
+	Operators []Operator
+}
+
+// MeasureMetadata describes one public aggregation.
+type MeasureMetadata struct {
+	// ID is the stable semantic measure identifier.
+	ID MeasureID
+
+	// Unit describes the measure's result unit.
+	Unit string
+
+	// Exact reports whether the measure must preserve exact parity.
+	Exact bool
+
+	// Sortable reports whether callers may order by the measure.
+	Sortable bool
+}
+
+type dimensionDefinition struct {
+	id          DimensionID
+	alias       string
+	valueType   string
+	operators   map[Operator]struct{}
+	expressions map[PlanID]string
+}
+
+type measureDefinition struct {
+	id          MeasureID
+	alias       string
+	unit        string
+	exact       bool
+	sortable    bool
+	expressions map[PlanID]string
+}
+
+type planKind uint8
+
+const (
+	planKindRollup planKind = iota + 1
+	planKindFact
+)
+
+type planDefinition struct {
+	id              PlanID
+	kind            planKind
+	table           string
+	timeColumn      string
+	dayExpression   string
+	usesFinal       bool
+	supportedGrains map[Grain]struct{}
+}
+
+type datasetDefinition struct {
+	id              DatasetID
+	dimensions      map[DimensionID]dimensionDefinition
+	measures        map[MeasureID]measureDefinition
+	plans           []planDefinition
+	maxRange        time.Duration
+	factRetention   time.Duration
+	defaultLimit    int
+	maxLimit        int
+	maxDimensions   int
+	maxFilterValues int
+}
+
+var usageDataset = datasetDefinition{
+	id: DatasetUsage,
+	dimensions: map[DimensionID]dimensionDefinition{
+		DimensionProvider: {
+			id:        DimensionProvider,
+			alias:     "provider",
+			valueType: "string",
+			operators: map[Operator]struct{}{
+				OperatorEquals: {},
+				OperatorIn:     {},
+			},
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "provider",
+				PlanUsageFacts: "provider",
+			},
+		},
+		DimensionModel: {
+			id:        DimensionModel,
+			alias:     "model",
+			valueType: "string",
+			operators: map[Operator]struct{}{
+				OperatorEquals: {},
+				OperatorIn:     {},
+			},
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "model",
+				PlanUsageFacts: "model",
+			},
+		},
+		DimensionSource: {
+			id:        DimensionSource,
+			alias:     "source",
+			valueType: "string",
+			operators: map[Operator]struct{}{
+				OperatorEquals: {},
+				OperatorIn:     {},
+			},
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "source",
+				PlanUsageFacts: "source",
+			},
+		},
+	},
+	measures: map[MeasureID]measureDefinition{
+		MeasureRequests: {
+			id:       MeasureRequests,
+			alias:    "requests",
+			unit:     "requests",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(requests)",
+				PlanUsageFacts: "count()",
+			},
+		},
+		MeasureInputTokens: {
+			id:       MeasureInputTokens,
+			alias:    "input_tokens",
+			unit:     "tokens",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(input_tokens)",
+				PlanUsageFacts: "sum(input_tokens)",
+			},
+		},
+		MeasureOutputTokens: {
+			id:       MeasureOutputTokens,
+			alias:    "output_tokens",
+			unit:     "tokens",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(output_tokens)",
+				PlanUsageFacts: "sum(output_tokens)",
+			},
+		},
+		MeasureCacheReadInputTokens: {
+			id:       MeasureCacheReadInputTokens,
+			alias:    "cache_read_input_tokens",
+			unit:     "tokens",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(cache_read_input_tokens)",
+				PlanUsageFacts: "sum(cache_read_input_tokens)",
+			},
+		},
+		MeasureCacheCreationInputTokens: {
+			id:       MeasureCacheCreationInputTokens,
+			alias:    "cache_creation_input_tokens",
+			unit:     "tokens",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(cache_creation_input_tokens)",
+				PlanUsageFacts: "sum(cache_creation_input_tokens)",
+			},
+		},
+		MeasureTotalTokens: {
+			id:       MeasureTotalTokens,
+			alias:    "total_tokens",
+			unit:     "tokens",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(total_tokens)",
+				PlanUsageFacts: "sum(total_tokens)",
+			},
+		},
+		MeasureTotalCost: {
+			id:       MeasureTotalCost,
+			alias:    "total_cost",
+			unit:     "currency",
+			exact:    true,
+			sortable: true,
+			expressions: map[PlanID]string{
+				PlanUsageDaily: "sum(total_cost)",
+				PlanUsageFacts: "sum(total_cost)",
+			},
+		},
+	},
+	plans: []planDefinition{
+		{
+			id:            PlanUsageDaily,
+			kind:          planKindRollup,
+			table:         "telemetry_usage_daily",
+			timeColumn:    "day",
+			dayExpression: "day",
+			usesFinal:     false,
+			supportedGrains: map[Grain]struct{}{
+				GrainDay: {},
+			},
+		},
+		{
+			id:            PlanUsageFacts,
+			kind:          planKindFact,
+			table:         "telemetry_usage_facts",
+			timeColumn:    "event_time",
+			dayExpression: "toStartOfDay(event_time)",
+			usesFinal:     true,
+			supportedGrains: map[Grain]struct{}{
+				GrainNone: {},
+				GrainDay:  {},
+			},
+		},
+	},
+	maxRange:        730 * 24 * time.Hour,
+	factRetention:   90 * 24 * time.Hour,
+	defaultLimit:    100,
+	maxLimit:        1000,
+	maxDimensions:   3,
+	maxFilterValues: 100,
+}
+
+// UsageDimensions returns a stable, sorted snapshot of the usage dimensions.
+func UsageDimensions() []DimensionMetadata {
+	result := make([]DimensionMetadata, 0, len(usageDataset.dimensions))
+	for _, definition := range usageDataset.dimensions {
+		operators := make([]Operator, 0, len(definition.operators))
+		for operator := range definition.operators {
+			operators = append(operators, operator)
+		}
+		slices.Sort(operators)
+		result = append(result, DimensionMetadata{
+			ID:        definition.id,
+			ValueType: definition.valueType,
+			Operators: operators,
+		})
+	}
+	slices.SortFunc(result, func(a, b DimensionMetadata) int {
+		return stringCompare(string(a.ID), string(b.ID))
+	})
+	return result
+}
+
+// UsageMeasures returns a stable, sorted snapshot of the usage measures.
+func UsageMeasures() []MeasureMetadata {
+	result := make([]MeasureMetadata, 0, len(usageDataset.measures))
+	for _, definition := range usageDataset.measures {
+		result = append(result, MeasureMetadata{
+			ID:       definition.id,
+			Unit:     definition.unit,
+			Exact:    definition.exact,
+			Sortable: definition.sortable,
+		})
+	}
+	slices.SortFunc(result, func(a, b MeasureMetadata) int {
+		return stringCompare(string(a.ID), string(b.ID))
+	})
+	return result
+}
+
+func stringCompare(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func validateCatalog(dataset datasetDefinition) error {
+	planIDs := make(map[PlanID]struct{}, len(dataset.plans))
+	for _, plan := range dataset.plans {
+		if plan.id == "" || plan.table == "" || plan.timeColumn == "" {
+			return fmt.Errorf("plan has incomplete physical metadata")
+		}
+		if _, exists := planIDs[plan.id]; exists {
+			return fmt.Errorf("plan %q is duplicated", plan.id)
+		}
+		planIDs[plan.id] = struct{}{}
+	}
+
+	aliases := make(map[string]string, len(dataset.dimensions)+len(dataset.measures))
+	for id, dimension := range dataset.dimensions {
+		if dimension.id != id || dimension.alias == "" || len(dimension.expressions) == 0 {
+			return fmt.Errorf("dimension %q has incomplete metadata", id)
+		}
+		if previous, exists := aliases[dimension.alias]; exists {
+			return fmt.Errorf("dimension %q reuses alias %q from %s", id, dimension.alias, previous)
+		}
+		aliases[dimension.alias] = "dimension " + string(id)
+		for planID := range dimension.expressions {
+			if _, exists := planIDs[planID]; !exists {
+				return fmt.Errorf("dimension %q references unknown plan %q", id, planID)
+			}
+		}
+	}
+
+	for id, measure := range dataset.measures {
+		if measure.id != id || measure.alias == "" || len(measure.expressions) == 0 {
+			return fmt.Errorf("measure %q has incomplete metadata", id)
+		}
+		if previous, exists := aliases[measure.alias]; exists {
+			return fmt.Errorf("measure %q reuses alias %q from %s", id, measure.alias, previous)
+		}
+		aliases[measure.alias] = "measure " + string(id)
+		for planID := range measure.expressions {
+			if _, exists := planIDs[planID]; !exists {
+				return fmt.Errorf("measure %q references unknown plan %q", id, planID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/internal/telemetry/analytics/compiler.go
+++ b/server/internal/telemetry/analytics/compiler.go
@@ -1,0 +1,298 @@
+package analytics
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/google/uuid"
+)
+
+const timeBucketAlias = "time_bucket"
+
+// RollupAvailability records the complete interval served by a rollup.
+type RollupAvailability struct {
+	coverageStart time.Time
+	freshThrough  time.Time
+}
+
+// NewRollupAvailability creates rollup coverage metadata. A zero value means
+// the rollup is unavailable and forces a fact-plan fallback.
+func NewRollupAvailability(coverageStart, freshThrough time.Time) (RollupAvailability, error) {
+	if coverageStart.IsZero() || freshThrough.IsZero() {
+		return RollupAvailability{}, fmt.Errorf("%w: rollup coverage bounds are required", ErrInvalidQuery)
+	}
+	coverageStart = coverageStart.UTC()
+	freshThrough = freshThrough.UTC()
+	if !coverageStart.Before(freshThrough) {
+		return RollupAvailability{}, fmt.Errorf("%w: rollup coverage start must precede freshness", ErrInvalidQuery)
+	}
+
+	return RollupAvailability{
+		coverageStart: coverageStart,
+		freshThrough:  freshThrough,
+	}, nil
+}
+
+// Planner validates semantic queries and selects an eligible physical source.
+type Planner struct {
+	now             time.Time
+	usageDailyState RollupAvailability
+}
+
+// NewPlanner creates a deterministic planner for the supplied evaluation time.
+func NewPlanner(now time.Time, usageDailyState RollupAvailability) Planner {
+	return Planner{
+		now:             now.UTC(),
+		usageDailyState: usageDailyState,
+	}
+}
+
+// CompiledQuery is the repository-facing output of semantic compilation.
+type CompiledQuery struct {
+	// PlanID is a stable diagnostic identifier rather than a physical table name.
+	PlanID PlanID
+
+	// SQL is compiler-owned ClickHouse SQL with parameter placeholders.
+	SQL string
+
+	// Args are the bound values for SQL in placeholder order.
+	Args []any
+}
+
+// Compile validates a semantic query, selects a source, and emits ClickHouse SQL.
+func (p Planner) Compile(query Query) (CompiledQuery, error) {
+	if err := validateCatalog(usageDataset); err != nil {
+		return CompiledQuery{}, fmt.Errorf("validate usage catalog: %w", err)
+	}
+	if err := validateQuery(query, usageDataset); err != nil {
+		return CompiledQuery{}, err
+	}
+
+	plan, err := p.selectPlan(query, usageDataset)
+	if err != nil {
+		return CompiledQuery{}, err
+	}
+
+	compiled, err := compileQuery(query, usageDataset, plan)
+	if err != nil {
+		return CompiledQuery{}, fmt.Errorf("compile %s query with %s: %w", query.dataset, plan.id, err)
+	}
+	return compiled, nil
+}
+
+func validateQuery(query Query, dataset datasetDefinition) error {
+	if query.dataset != dataset.id {
+		return fmt.Errorf("%w: dataset %q is not cataloged", ErrInvalidQuery, query.dataset)
+	}
+	if query.scope.organizationID == uuid.Nil || len(query.scope.projectIDs) == 0 {
+		return fmt.Errorf("%w: tenant scope is required", ErrInvalidQuery)
+	}
+	if query.timeRange.from.IsZero() || query.timeRange.to.IsZero() || !query.timeRange.from.Before(query.timeRange.to) {
+		return fmt.Errorf("%w: a valid half-open time range is required", ErrInvalidQuery)
+	}
+	if query.timeRange.to.Sub(query.timeRange.from) > dataset.maxRange {
+		return fmt.Errorf("%w: range exceeds %s", ErrInvalidQuery, dataset.maxRange)
+	}
+	if len(query.measures) == 0 {
+		return fmt.Errorf("%w: at least one measure is required", ErrInvalidQuery)
+	}
+	if len(query.dimensions) > dataset.maxDimensions {
+		return fmt.Errorf("%w: at most %d dimensions are allowed", ErrInvalidQuery, dataset.maxDimensions)
+	}
+	if query.grain != GrainNone && query.grain != GrainDay {
+		return fmt.Errorf("%w: grain %q is not cataloged", ErrInvalidQuery, query.grain)
+	}
+	if query.limit < 0 || query.limit > dataset.maxLimit {
+		return fmt.Errorf("%w: limit must be between 0 and %d", ErrInvalidQuery, dataset.maxLimit)
+	}
+
+	seenDimensions := make(map[DimensionID]struct{}, len(query.dimensions))
+	for _, dimensionID := range query.dimensions {
+		if _, exists := dataset.dimensions[dimensionID]; !exists {
+			return fmt.Errorf("%w: dimension %q is not cataloged", ErrInvalidQuery, dimensionID)
+		}
+		if _, exists := seenDimensions[dimensionID]; exists {
+			return fmt.Errorf("%w: dimension %q is duplicated", ErrInvalidQuery, dimensionID)
+		}
+		seenDimensions[dimensionID] = struct{}{}
+	}
+
+	seenMeasures := make(map[MeasureID]struct{}, len(query.measures))
+	for _, measureID := range query.measures {
+		if _, exists := dataset.measures[measureID]; !exists {
+			return fmt.Errorf("%w: measure %q is not cataloged", ErrInvalidQuery, measureID)
+		}
+		if _, exists := seenMeasures[measureID]; exists {
+			return fmt.Errorf("%w: measure %q is duplicated", ErrInvalidQuery, measureID)
+		}
+		seenMeasures[measureID] = struct{}{}
+	}
+
+	for _, filter := range query.filters {
+		dimension, exists := dataset.dimensions[filter.dimension]
+		if !exists {
+			return fmt.Errorf("%w: filter dimension %q is not cataloged", ErrInvalidQuery, filter.dimension)
+		}
+		if _, exists := dimension.operators[filter.operator]; !exists {
+			return fmt.Errorf("%w: operator %q is not supported by %q", ErrInvalidQuery, filter.operator, filter.dimension)
+		}
+		if len(filter.values) == 0 || len(filter.values) > dataset.maxFilterValues {
+			return fmt.Errorf("%w: filter %q requires 1 to %d values", ErrInvalidQuery, filter.dimension, dataset.maxFilterValues)
+		}
+		if filter.operator == OperatorEquals && len(filter.values) != 1 {
+			return fmt.Errorf("%w: equals filter %q requires one value", ErrInvalidQuery, filter.dimension)
+		}
+	}
+
+	for _, order := range query.orders {
+		measure, exists := dataset.measures[order.measure]
+		if !exists || !measure.sortable {
+			return fmt.Errorf("%w: measure %q is not sortable", ErrInvalidQuery, order.measure)
+		}
+		if _, selected := seenMeasures[order.measure]; !selected {
+			return fmt.Errorf("%w: ordered measure %q must be selected", ErrInvalidQuery, order.measure)
+		}
+		if order.direction != DirectionAscending && order.direction != DirectionDescending {
+			return fmt.Errorf("%w: order direction %q is invalid", ErrInvalidQuery, order.direction)
+		}
+	}
+
+	return nil
+}
+
+func (p Planner) selectPlan(query Query, dataset datasetDefinition) (planDefinition, error) {
+	for _, plan := range dataset.plans {
+		if !planSupportsQuery(plan, query, dataset) {
+			continue
+		}
+
+		switch plan.kind {
+		case planKindRollup:
+			if !isDayAligned(query.timeRange.from) || !isDayAligned(query.timeRange.to) {
+				continue
+			}
+			if p.usageDailyState.coverageStart.IsZero() || p.usageDailyState.freshThrough.IsZero() {
+				continue
+			}
+			if query.timeRange.from.Before(p.usageDailyState.coverageStart) || query.timeRange.to.After(p.usageDailyState.freshThrough) {
+				continue
+			}
+			return plan, nil
+		case planKindFact:
+			if p.now.IsZero() {
+				continue
+			}
+			if query.timeRange.from.Before(p.now.Add(-dataset.factRetention)) {
+				continue
+			}
+			return plan, nil
+		}
+	}
+
+	return planDefinition{}, fmt.Errorf("%w: dataset=%s range=[%s,%s) grain=%s", ErrNoCompatiblePlan, query.dataset, query.timeRange.from.Format(time.RFC3339), query.timeRange.to.Format(time.RFC3339), query.grain)
+}
+
+func planSupportsQuery(plan planDefinition, query Query, dataset datasetDefinition) bool {
+	if _, supported := plan.supportedGrains[query.grain]; !supported {
+		return false
+	}
+	for _, dimensionID := range query.dimensions {
+		if _, supported := dataset.dimensions[dimensionID].expressions[plan.id]; !supported {
+			return false
+		}
+	}
+	for _, measureID := range query.measures {
+		if _, supported := dataset.measures[measureID].expressions[plan.id]; !supported {
+			return false
+		}
+	}
+	for _, filter := range query.filters {
+		if _, supported := dataset.dimensions[filter.dimension].expressions[plan.id]; !supported {
+			return false
+		}
+	}
+	return true
+}
+
+func compileQuery(query Query, dataset datasetDefinition, plan planDefinition) (CompiledQuery, error) {
+	selects := make([]string, 0, 1+len(query.dimensions)+len(query.measures))
+	groups := make([]string, 0, 1+len(query.dimensions))
+	if query.grain == GrainDay {
+		selects = append(selects, plan.dayExpression+" AS "+timeBucketAlias)
+		groups = append(groups, timeBucketAlias)
+	}
+	for _, dimensionID := range query.dimensions {
+		dimension := dataset.dimensions[dimensionID]
+		selects = append(selects, dimension.expressions[plan.id]+" AS "+dimension.alias)
+		groups = append(groups, dimension.alias)
+	}
+	for _, measureID := range query.measures {
+		measure := dataset.measures[measureID]
+		selects = append(selects, measure.expressions[plan.id]+" AS "+measure.alias)
+	}
+
+	table := plan.table
+	if plan.usesFinal {
+		table += " FINAL"
+	}
+	builder := squirrel.StatementBuilder.
+		PlaceholderFormat(squirrel.Question).
+		Select(selects...).
+		From(table).
+		Where(squirrel.Eq{"organization_id": query.scope.organizationID}).
+		Where(squirrel.Eq{"project_id": query.scope.projectIDs}).
+		Where(squirrel.GtOrEq{plan.timeColumn: query.timeRange.from}).
+		Where(squirrel.Lt{plan.timeColumn: query.timeRange.to})
+
+	for _, filter := range query.filters {
+		expression := dataset.dimensions[filter.dimension].expressions[plan.id]
+		switch filter.operator {
+		case OperatorEquals:
+			builder = builder.Where(squirrel.Eq{expression: filter.values[0]})
+		case OperatorIn:
+			builder = builder.Where(squirrel.Eq{expression: filter.values})
+		}
+	}
+	if len(groups) > 0 {
+		builder = builder.GroupBy(groups...)
+	}
+
+	if len(query.orders) > 0 {
+		for _, order := range query.orders {
+			alias := dataset.measures[order.measure].alias
+			builder = builder.OrderBy(alias + " " + strings.ToUpper(string(order.direction)))
+		}
+	} else {
+		if query.grain == GrainDay {
+			builder = builder.OrderBy(timeBucketAlias + " ASC")
+		}
+		for _, dimensionID := range query.dimensions {
+			builder = builder.OrderBy(dataset.dimensions[dimensionID].alias + " ASC")
+		}
+	}
+
+	limit := query.limit
+	if limit == 0 {
+		limit = dataset.defaultLimit
+	}
+	builder = builder.Limit(uint64(limit))
+
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return CompiledQuery{}, err
+	}
+	return CompiledQuery{
+		PlanID: plan.id,
+		SQL:    sql,
+		Args:   slices.Clone(args),
+	}, nil
+}
+
+func isDayAligned(value time.Time) bool {
+	value = value.UTC()
+	startOfDay := time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
+	return value.Equal(startOfDay)
+}

--- a/server/internal/telemetry/analytics/example/main.go
+++ b/server/internal/telemetry/analytics/example/main.go
@@ -1,0 +1,214 @@
+// Command example compiles representative production telemetry queries.
+//
+// It deliberately stops before database execution. In production the telemetry
+// repository would execute CompiledQuery.SQL with CompiledQuery.Args and scan a
+// result type owned by the selected dataset.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/telemetry/analytics"
+)
+
+type queryExample struct {
+	name    string
+	planner analytics.Planner
+	query   analytics.Query
+	wantErr error
+}
+
+func main() {
+	if err := run(os.Stdout); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(output io.Writer) error {
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+
+	// A service obtains these IDs from the authenticated organization and its
+	// authorized project set. Request payloads must not create Scope directly.
+	organizationID := uuid.MustParse("10000000-0000-0000-0000-000000000001")
+	projectIDs := []uuid.UUID{
+		uuid.MustParse("20000000-0000-0000-0000-000000000001"),
+		uuid.MustParse("20000000-0000-0000-0000-000000000002"),
+	}
+	scope, err := analytics.NewScope(organizationID, projectIDs...)
+	if err != nil {
+		return fmt.Errorf("create authenticated telemetry scope: %w", err)
+	}
+
+	// Rollup coverage comes from rollup-control metadata. It is not supplied by
+	// the API caller because callers cannot decide that incomplete data is safe.
+	rollupAvailability, err := analytics.NewRollupAvailability(
+		time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		return fmt.Errorf("create usage rollup availability: %w", err)
+	}
+	rollupPlanner := analytics.NewPlanner(now, rollupAvailability)
+	factOnlyPlanner := analytics.NewPlanner(now, analytics.RollupAvailability{})
+
+	dailyRange, err := analytics.NewTimeRange(
+		time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 3, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		return fmt.Errorf("create daily example range: %w", err)
+	}
+	preciseRange, err := analytics.NewTimeRange(
+		time.Date(2026, time.August, 23, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		return fmt.Errorf("create precise example range: %w", err)
+	}
+	oldRange, err := analytics.NewTimeRange(
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		return fmt.Errorf("create out-of-retention example range: %w", err)
+	}
+
+	examples := []queryExample{
+		{
+			name:    "whole-window totals use exact facts",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, preciseRange).Select(
+				analytics.MeasureRequests,
+				analytics.MeasureInputTokens,
+				analytics.MeasureOutputTokens,
+				analytics.MeasureCacheReadInputTokens,
+				analytics.MeasureCacheCreationInputTokens,
+				analytics.MeasureTotalTokens,
+				analytics.MeasureTotalCost,
+			),
+			wantErr: nil,
+		},
+		{
+			name:    "daily totals use the complete rollup",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, dailyRange).
+				AtGrain(analytics.GrainDay).
+				Select(analytics.MeasureRequests, analytics.MeasureTotalTokens, analytics.MeasureTotalCost),
+			wantErr: nil,
+		},
+		{
+			name:    "daily cube combines every dimension and filter operator",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, dailyRange).
+				AtGrain(analytics.GrainDay).
+				GroupBy(analytics.DimensionProvider, analytics.DimensionModel, analytics.DimensionSource).
+				Select(analytics.MeasureRequests, analytics.MeasureTotalTokens, analytics.MeasureTotalCost).
+				Where(
+					analytics.Equals(analytics.DimensionModel, "example-model"),
+					analytics.OneOf(analytics.DimensionSource, "provider_otel", "provider_api"),
+				).
+				OrderBy(analytics.Descending(analytics.MeasureTotalCost)).
+				WithLimit(50),
+			wantErr: nil,
+		},
+		{
+			name:    "sub-day provider leaderboard falls back to facts",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, preciseRange).
+				AtGrain(analytics.GrainDay).
+				GroupBy(analytics.DimensionProvider).
+				Select(analytics.MeasureRequests, analytics.MeasureTotalTokens, analytics.MeasureTotalCost).
+				OrderBy(analytics.Ascending(analytics.MeasureTotalTokens)).
+				WithLimit(25),
+			wantErr: nil,
+		},
+		{
+			name:    "daily model series falls back when rollup state is unavailable",
+			planner: factOnlyPlanner,
+			query: analytics.NewUsageQuery(scope, dailyRange).
+				AtGrain(analytics.GrainDay).
+				GroupBy(analytics.DimensionModel).
+				Select(
+					analytics.MeasureInputTokens,
+					analytics.MeasureOutputTokens,
+					analytics.MeasureCacheReadInputTokens,
+					analytics.MeasureCacheCreationInputTokens,
+				),
+			wantErr: nil,
+		},
+		{
+			name:    "default ordering and row limit are compiler policy",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, dailyRange).
+				AtGrain(analytics.GrainDay).
+				GroupBy(analytics.DimensionSource).
+				Select(analytics.MeasureRequests),
+			wantErr: nil,
+		},
+		{
+			name:    "a query without measures is rejected",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, dailyRange).
+				AtGrain(analytics.GrainDay).
+				GroupBy(analytics.DimensionProvider),
+			wantErr: analytics.ErrInvalidQuery,
+		},
+		{
+			name:    "an uncataloged dimension is rejected",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, preciseRange).
+				GroupBy(analytics.DimensionID("arbitrary_sql")).
+				Select(analytics.MeasureRequests),
+			wantErr: analytics.ErrInvalidQuery,
+		},
+		{
+			name:    "an excessive result limit is rejected",
+			planner: rollupPlanner,
+			query: analytics.NewUsageQuery(scope, preciseRange).
+				Select(analytics.MeasureRequests).
+				WithLimit(1001),
+			wantErr: analytics.ErrInvalidQuery,
+		},
+		{
+			name:    "a valid range outside every physical source is rejected",
+			planner: factOnlyPlanner,
+			query: analytics.NewUsageQuery(scope, oldRange).
+				AtGrain(analytics.GrainDay).
+				Select(analytics.MeasureRequests),
+			wantErr: analytics.ErrNoCompatiblePlan,
+		},
+	}
+
+	var report strings.Builder
+	for _, example := range examples {
+		compiled, compileErr := example.planner.Compile(example.query)
+		_, _ = report.WriteString("\n## " + example.name + "\n")
+		if example.wantErr != nil {
+			if !errors.Is(compileErr, example.wantErr) {
+				return fmt.Errorf("compile %q: expected %v, got %v", example.name, example.wantErr, compileErr)
+			}
+			_, _ = report.WriteString("rejected: " + compileErr.Error() + "\n")
+			continue
+		}
+		if compileErr != nil {
+			return fmt.Errorf("compile %q: %w", example.name, compileErr)
+		}
+
+		_, _ = report.WriteString("plan: " + string(compiled.PlanID) + "\n")
+		_, _ = report.WriteString("sql:  " + compiled.SQL + "\n")
+		_, _ = report.WriteString(fmt.Sprintf("args: %#v\n", compiled.Args))
+	}
+
+	if _, err := io.WriteString(output, report.String()); err != nil {
+		return fmt.Errorf("write compiled query examples: %w", err)
+	}
+	return nil
+}

--- a/server/internal/telemetry/analytics/query.go
+++ b/server/internal/telemetry/analytics/query.go
@@ -1,0 +1,266 @@
+// Package analytics defines the bounded semantic query language used by the
+// telemetry architecture spike.
+package analytics
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrInvalidScope marks a missing or malformed tenant scope.
+	ErrInvalidScope = errors.New("invalid telemetry query scope")
+
+	// ErrInvalidTimeRange marks an empty or reversed query interval.
+	ErrInvalidTimeRange = errors.New("invalid telemetry query time range")
+
+	// ErrInvalidQuery marks a query that is not present in the semantic catalog.
+	ErrInvalidQuery = errors.New("invalid telemetry query")
+
+	// ErrNoCompatiblePlan marks a valid semantic query with no available source.
+	ErrNoCompatiblePlan = errors.New("no compatible telemetry query plan")
+)
+
+// DatasetID identifies a product dataset without exposing a physical table.
+type DatasetID string
+
+// DatasetUsage is the canonical model-usage dataset.
+const DatasetUsage DatasetID = "usage"
+
+// DimensionID identifies a cataloged grouping and filtering dimension.
+type DimensionID string
+
+const (
+	// DimensionProvider groups usage by the normalized model provider.
+	DimensionProvider DimensionID = "provider"
+
+	// DimensionModel groups usage by the normalized model identifier.
+	DimensionModel DimensionID = "model"
+
+	// DimensionSource groups usage by the normalized observation source.
+	DimensionSource DimensionID = "source"
+)
+
+// MeasureID identifies a cataloged aggregation.
+type MeasureID string
+
+const (
+	// MeasureRequests counts canonical usage observations.
+	MeasureRequests MeasureID = "requests"
+
+	// MeasureInputTokens sums non-cache input tokens.
+	MeasureInputTokens MeasureID = "input_tokens"
+
+	// MeasureOutputTokens sums output tokens.
+	MeasureOutputTokens MeasureID = "output_tokens"
+
+	// MeasureCacheReadInputTokens sums cache-read input tokens.
+	MeasureCacheReadInputTokens MeasureID = "cache_read_input_tokens"
+
+	// MeasureCacheCreationInputTokens sums cache-creation input tokens.
+	MeasureCacheCreationInputTokens MeasureID = "cache_creation_input_tokens"
+
+	// MeasureTotalTokens sums every token category.
+	MeasureTotalTokens MeasureID = "total_tokens"
+
+	// MeasureTotalCost sums fixed-precision model cost.
+	MeasureTotalCost MeasureID = "total_cost"
+)
+
+// Grain identifies a supported time bucket.
+type Grain string
+
+const (
+	// GrainNone aggregates the complete requested interval.
+	GrainNone Grain = ""
+
+	// GrainDay groups results into UTC calendar days.
+	GrainDay Grain = "day"
+)
+
+// Operator identifies a cataloged filter operation.
+type Operator string
+
+const (
+	// OperatorEquals compares a dimension with one value.
+	OperatorEquals Operator = "equals"
+
+	// OperatorIn compares a dimension with a bounded set of values.
+	OperatorIn Operator = "in"
+)
+
+// Direction identifies an allowed result ordering direction.
+type Direction string
+
+const (
+	// DirectionAscending sorts the requested measure from low to high.
+	DirectionAscending Direction = "asc"
+
+	// DirectionDescending sorts the requested measure from high to low.
+	DirectionDescending Direction = "desc"
+)
+
+// Scope is an authenticated organization and its authorized project set.
+// Its fields are private so a valid scope can only be created by NewScope.
+type Scope struct {
+	organizationID uuid.UUID
+	projectIDs     []uuid.UUID
+}
+
+// NewScope creates an immutable tenant scope and removes duplicate projects.
+func NewScope(organizationID uuid.UUID, projectIDs ...uuid.UUID) (Scope, error) {
+	if organizationID == uuid.Nil {
+		return Scope{}, fmt.Errorf("%w: organization id is required", ErrInvalidScope)
+	}
+	if len(projectIDs) == 0 {
+		return Scope{}, fmt.Errorf("%w: at least one project id is required", ErrInvalidScope)
+	}
+
+	seen := make(map[uuid.UUID]struct{}, len(projectIDs))
+	projects := make([]uuid.UUID, 0, len(projectIDs))
+	for _, projectID := range projectIDs {
+		if projectID == uuid.Nil {
+			return Scope{}, fmt.Errorf("%w: project id is required", ErrInvalidScope)
+		}
+		if _, ok := seen[projectID]; ok {
+			continue
+		}
+		seen[projectID] = struct{}{}
+		projects = append(projects, projectID)
+	}
+
+	return Scope{
+		organizationID: organizationID,
+		projectIDs:     projects,
+	}, nil
+}
+
+// TimeRange is a half-open UTC interval [from, to).
+// Its fields are private so a valid range can only be created by NewTimeRange.
+type TimeRange struct {
+	from time.Time
+	to   time.Time
+}
+
+// NewTimeRange creates a half-open UTC interval.
+func NewTimeRange(from, to time.Time) (TimeRange, error) {
+	if from.IsZero() || to.IsZero() {
+		return TimeRange{}, fmt.Errorf("%w: both bounds are required", ErrInvalidTimeRange)
+	}
+	from = from.UTC()
+	to = to.UTC()
+	if !from.Before(to) {
+		return TimeRange{}, fmt.Errorf("%w: from must be before to", ErrInvalidTimeRange)
+	}
+
+	return TimeRange{from: from, to: to}, nil
+}
+
+// Filter is a cataloged dimension predicate with parameterized values.
+type Filter struct {
+	dimension DimensionID
+	operator  Operator
+	values    []string
+}
+
+// Equals creates an equality predicate for a cataloged dimension.
+func Equals(dimension DimensionID, value string) Filter {
+	return Filter{
+		dimension: dimension,
+		operator:  OperatorEquals,
+		values:    []string{value},
+	}
+}
+
+// OneOf creates a set-membership predicate for a cataloged dimension.
+func OneOf(dimension DimensionID, values ...string) Filter {
+	return Filter{
+		dimension: dimension,
+		operator:  OperatorIn,
+		values:    append([]string(nil), values...),
+	}
+}
+
+// Order requests sorting by a selected measure.
+type Order struct {
+	measure   MeasureID
+	direction Direction
+}
+
+// Ascending sorts a selected measure from low to high.
+func Ascending(measure MeasureID) Order {
+	return Order{measure: measure, direction: DirectionAscending}
+}
+
+// Descending sorts a selected measure from high to low.
+func Descending(measure MeasureID) Order {
+	return Order{measure: measure, direction: DirectionDescending}
+}
+
+// Query is an immutable semantic request. Physical tables and SQL expressions
+// are deliberately absent from this type.
+type Query struct {
+	dataset    DatasetID
+	scope      Scope
+	timeRange  TimeRange
+	dimensions []DimensionID
+	measures   []MeasureID
+	filters    []Filter
+	grain      Grain
+	orders     []Order
+	limit      int
+}
+
+// NewUsageQuery creates a usage query with mandatory tenant and time bounds.
+func NewUsageQuery(scope Scope, timeRange TimeRange) Query {
+	return Query{
+		dataset:    DatasetUsage,
+		scope:      scope,
+		timeRange:  timeRange,
+		dimensions: nil,
+		measures:   nil,
+		filters:    nil,
+		grain:      GrainNone,
+		orders:     nil,
+		limit:      0,
+	}
+}
+
+// GroupBy returns a query grouped by the supplied cataloged dimensions.
+func (q Query) GroupBy(dimensions ...DimensionID) Query {
+	q.dimensions = append(append([]DimensionID(nil), q.dimensions...), dimensions...)
+	return q
+}
+
+// Select returns a query containing the supplied cataloged measures.
+func (q Query) Select(measures ...MeasureID) Query {
+	q.measures = append(append([]MeasureID(nil), q.measures...), measures...)
+	return q
+}
+
+// Where returns a query constrained by the supplied cataloged filters.
+func (q Query) Where(filters ...Filter) Query {
+	q.filters = append(append([]Filter(nil), q.filters...), filters...)
+	return q
+}
+
+// AtGrain returns a query grouped by the supplied time grain.
+func (q Query) AtGrain(grain Grain) Query {
+	q.grain = grain
+	return q
+}
+
+// OrderBy returns a query ordered by selected measures.
+func (q Query) OrderBy(orders ...Order) Query {
+	q.orders = append(append([]Order(nil), q.orders...), orders...)
+	return q
+}
+
+// WithLimit returns a query with a bounded result-row limit.
+func (q Query) WithLimit(limit int) Query {
+	q.limit = limit
+	return q
+}

--- a/server/internal/telemetry/analytics/query_test.go
+++ b/server/internal/telemetry/analytics/query_test.go
@@ -1,0 +1,224 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testOrganizationID = uuid.MustParse("10000000-0000-0000-0000-000000000001")
+	testProjectIDOne   = uuid.MustParse("20000000-0000-0000-0000-000000000001")
+	testProjectIDTwo   = uuid.MustParse("20000000-0000-0000-0000-000000000002")
+)
+
+func TestNewScopeRequiresOrganization(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewScope(uuid.Nil, testProjectIDOne)
+	require.ErrorIs(t, err, ErrInvalidScope)
+}
+
+func TestNewScopeRequiresProjects(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewScope(testOrganizationID)
+	require.ErrorIs(t, err, ErrInvalidScope)
+}
+
+func TestNewScopeDeduplicatesProjects(t *testing.T) {
+	t.Parallel()
+
+	scope, err := NewScope(testOrganizationID, testProjectIDOne, testProjectIDOne, testProjectIDTwo)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{testProjectIDOne, testProjectIDTwo}, scope.projectIDs)
+}
+
+func TestNewTimeRangeRequiresIncreasingBounds(t *testing.T) {
+	t.Parallel()
+
+	bound := time.Date(2026, time.August, 24, 10, 0, 0, 0, time.UTC)
+	_, err := NewTimeRange(bound, bound)
+	require.ErrorIs(t, err, ErrInvalidTimeRange)
+}
+
+func TestUsageCatalogMetadataIsStable(t *testing.T) {
+	t.Parallel()
+
+	dimensions := UsageDimensions()
+	require.Equal(t, []DimensionID{DimensionModel, DimensionProvider, DimensionSource}, []DimensionID{
+		dimensions[0].ID,
+		dimensions[1].ID,
+		dimensions[2].ID,
+	})
+	require.Equal(t, []Operator{OperatorEquals, OperatorIn}, dimensions[0].Operators)
+
+	measures := UsageMeasures()
+	require.Len(t, measures, 7)
+	require.Equal(t, MeasureCacheCreationInputTokens, measures[0].ID)
+	require.True(t, measures[0].Exact)
+	require.True(t, measures[0].Sortable)
+}
+
+func TestCatalogIsInternallyConsistent(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateCatalog(usageDataset))
+}
+
+func TestPlannerSelectsFreshDailyRollup(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	availability, err := NewRollupAvailability(
+		time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 3, 0, 0, 0, 0, time.UTC),
+	)
+
+	query := NewUsageQuery(scope, timeRange).
+		AtGrain(GrainDay).
+		GroupBy(DimensionProvider, DimensionModel).
+		Select(MeasureRequests, MeasureTotalTokens, MeasureTotalCost).
+		Where(OneOf(DimensionSource, "provider_otel", "provider_api")).
+		OrderBy(Descending(MeasureTotalCost)).
+		WithLimit(10)
+
+	compiled, err := NewPlanner(now, availability).Compile(query)
+	require.NoError(t, err)
+	require.Equal(t, PlanUsageDaily, compiled.PlanID)
+	require.Contains(t, compiled.SQL, "FROM telemetry_usage_daily")
+	require.Contains(t, compiled.SQL, "organization_id = ?")
+	require.Contains(t, compiled.SQL, "project_id IN (?,?)")
+	require.Contains(t, compiled.SQL, "day >= ? AND day < ?")
+	require.Contains(t, compiled.SQL, "GROUP BY time_bucket, provider, model")
+	require.Contains(t, compiled.SQL, "ORDER BY total_cost DESC")
+	require.Contains(t, compiled.SQL, "LIMIT 10")
+	require.Contains(t, compiled.Args, "provider_otel")
+	require.Contains(t, compiled.Args, "provider_api")
+}
+
+func TestPlannerFallsBackToFactsForUnalignedRange(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	availability, err := NewRollupAvailability(
+		time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(t, err)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 23, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC),
+	)
+
+	query := NewUsageQuery(scope, timeRange).
+		AtGrain(GrainDay).
+		GroupBy(DimensionProvider).
+		Select(MeasureRequests)
+
+	compiled, err := NewPlanner(now, availability).Compile(query)
+	require.NoError(t, err)
+	require.Equal(t, PlanUsageFacts, compiled.PlanID)
+	require.Contains(t, compiled.SQL, "FROM telemetry_usage_facts FINAL")
+	require.Contains(t, compiled.SQL, "event_time >= ? AND event_time < ?")
+}
+
+func TestPlannerRejectsRangeOutsideAvailableSources(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC),
+	)
+	query := NewUsageQuery(scope, timeRange).
+		AtGrain(GrainDay).
+		Select(MeasureRequests)
+
+	_, err := NewPlanner(now, RollupAvailability{}).Compile(query)
+	require.ErrorIs(t, err, ErrNoCompatiblePlan)
+}
+
+func TestCompilerParameterizesFilterValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	dangerousValue := "model') OR 1 = 1 --"
+	query := NewUsageQuery(scope, timeRange).
+		Select(MeasureRequests).
+		Where(Equals(DimensionModel, dangerousValue))
+
+	compiled, err := NewPlanner(now, RollupAvailability{}).Compile(query)
+	require.NoError(t, err)
+	require.NotContains(t, compiled.SQL, dangerousValue)
+	require.Contains(t, compiled.Args, dangerousValue)
+}
+
+func TestCompilerRejectsUnknownDimension(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	query := NewUsageQuery(scope, timeRange).
+		GroupBy(DimensionID("arbitrary_sql")).
+		Select(MeasureRequests)
+
+	_, err := NewPlanner(now, RollupAvailability{}).Compile(query)
+	require.ErrorIs(t, err, ErrInvalidQuery)
+}
+
+func TestCompilerRequiresOrderedMeasureToBeSelected(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	query := NewUsageQuery(scope, timeRange).
+		Select(MeasureRequests).
+		OrderBy(Descending(MeasureTotalCost))
+
+	_, err := NewPlanner(now, RollupAvailability{}).Compile(query)
+	require.ErrorIs(t, err, ErrInvalidQuery)
+}
+
+func TestCompilerRejectsExcessiveLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	scope, timeRange := testScopeAndRange(t,
+		time.Date(2026, time.August, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.August, 24, 0, 0, 0, 0, time.UTC),
+	)
+	query := NewUsageQuery(scope, timeRange).
+		Select(MeasureRequests).
+		WithLimit(1001)
+
+	_, err := NewPlanner(now, RollupAvailability{}).Compile(query)
+	require.ErrorIs(t, err, ErrInvalidQuery)
+}
+
+func testScopeAndRange(t *testing.T, from, to time.Time) (Scope, TimeRange) {
+	t.Helper()
+
+	scope, err := NewScope(testOrganizationID, testProjectIDOne, testProjectIDTwo)
+	require.NoError(t, err)
+	timeRange, err := NewTimeRange(from, to)
+	require.NoError(t, err)
+	return scope, timeRange
+}


### PR DESCRIPTION
POC for improved telemetry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prototypes a semantic telemetry query architecture without changing production behavior. Adds a closed `usage` dataset catalog, an immutable `Query` API with planner/compiler, and demonstrative ClickHouse DDL for native signals, canonical usage facts, and a refreshable daily rollup.

- Review notes
  - Adds `server/clickhouse/spikes/telemetry_v2.sql` with non-authoritative tables: `telemetry_log_records`, `telemetry_spans`, `telemetry_metric_points`, `telemetry_usage_facts` (ReplacingMergeTree with `FINAL` reads), and `telemetry_usage_daily` (refresh every 5 minutes, 90-day TTL).
  - Introduces `server/internal/telemetry/analytics`:
    - Catalog for `usage` with dimensions `provider`, `model`, `source`; measures `requests`, token categories, `total_cost`; grains `none` and `day`.
    - `NewScope` and `NewTimeRange` enforce tenant and half-open UTC intervals. `NewUsageQuery` builds immutable queries; no SQL or table names leak.
    - Planner selects `usage_daily` when the range is day-aligned and within rollup coverage; falls back to `usage_facts` within 90-day retention; otherwise returns `ErrNoCompatiblePlan`.
    - Compiler emits parameterized ClickHouse SQL via Squirrel, validates cataloged dimensions/measures/operators, enforces sortability, default ordering, and row limits.
  - Adds `example/main.go` showing representative queries and `query_test.go` covering validation, plan selection, and parameterization.
  - `server/internal/telemetry/analytics/CURRENT_QUERY_MIGRATION.md` maps existing repo queries to target datasets/search specs and proposes a migration order.

- Rollout/migration
  - No runtime paths are wired; no migrations run; no behavior change. Required actions: none.

<sup>Written for commit 123b0a629fce5f317220d2c98f85ab524872604f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

