### PR TITLE
fix: enforce sliding dashboard session expiry

### DIFF
--- a/.changeset/session-idle-timeout.md
+++ b/.changeset/session-idle-timeout.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Dashboard sessions now expire after 72 hours of inactivity and extend while actively used, replacing the static 30-day session cookie.

--- a/server/design/security/gram_session.go
+++ b/server/design/security/gram_session.go
@@ -20,10 +20,11 @@ var WriteSessionCookie = func() {
 	Cookie(fmt.Sprintf("session_cookie:%s", constants.SessionCookie), String, func() {
 	})
 	// TODO: We want to restrict cookie domain here
-	CookieMaxAge(2592000) // 30 days in seconds
+	CookieMaxAge(constants.SessionCookieMaxAgeSeconds)
 	CookieSecure()
 	CookieHTTPOnly()
 	CookiePath("/")
+	CookieSameSite(CookieSameSiteLax)
 }
 
 var DeleteSessionCookie = func() {

--- a/server/gen/http/auth/server/encode_decode.go
+++ b/server/gen/http/auth/server/encode_decode.go
@@ -30,10 +30,11 @@ func EncodeCallbackResponse(encoder func(context.Context, http.ResponseWriter) g
 		http.SetCookie(w, &http.Cookie{
 			Name:     "gram_session",
 			Value:    sessionCookie,
-			MaxAge:   2592000,
+			MaxAge:   259200,
 			Path:     "/",
 			Secure:   true,
 			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		})
 		w.WriteHeader(http.StatusTemporaryRedirect)
 		return nil
@@ -435,10 +436,11 @@ func EncodeSwitchScopesResponse(encoder func(context.Context, http.ResponseWrite
 		http.SetCookie(w, &http.Cookie{
 			Name:     "gram_session",
 			Value:    sessionCookie,
-			MaxAge:   2592000,
+			MaxAge:   259200,
 			Path:     "/",
 			Secure:   true,
 			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		})
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -647,10 +649,11 @@ func EncodeEnterDemoResponse(encoder func(context.Context, http.ResponseWriter) 
 		http.SetCookie(w, &http.Cookie{
 			Name:     "gram_session",
 			Value:    sessionCookie,
-			MaxAge:   2592000,
+			MaxAge:   259200,
 			Path:     "/",
 			Secure:   true,
 			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		})
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -1259,10 +1262,11 @@ func EncodeInfoResponse(encoder func(context.Context, http.ResponseWriter) goaht
 		http.SetCookie(w, &http.Cookie{
 			Name:     "gram_session",
 			Value:    sessionCookie,
-			MaxAge:   2592000,
+			MaxAge:   259200,
 			Path:     "/",
 			Secure:   true,
 			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
 		})
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)

--- a/server/internal/auth/authenticate_test.go
+++ b/server/internal/auth/authenticate_test.go
@@ -12,6 +12,30 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
+func TestAuthenticateRefreshesValidatedSession(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+	require.NoError(t, instance.createTestOrganization(ctx, userInfo.Organizations[0], userInfo.UserID))
+
+	session := sessions.Session{
+		SessionID:            "refresh-validated-session",
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: userInfo.Organizations[0].ID,
+	}
+	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
+
+	var refreshedSessionID string
+	ctx = contextvalues.WithSessionCookieRefresh(ctx, func(sessionID string) {
+		refreshedSessionID = sessionID
+	})
+	_, err := instance.sessionManager.Authenticate(ctx, session.SessionID)
+	require.NoError(t, err)
+	require.Equal(t, session.SessionID, refreshedSessionID)
+}
+
 // A validated, unexpired support session lets a platform admin access a non-member org.
 func TestAuthenticate_SupportAdminCanAccessNonMemberOrg(t *testing.T) {
 	t.Parallel()

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -851,8 +851,9 @@ func (s *Service) SwitchScopes(ctx context.Context, payload *gen.SwitchScopesPay
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error loading existing session").LogError(ctx, s.logger)
 	}
-	existingSession.ActiveOrganizationID = authCtx.ActiveOrganizationID
-	if err := s.sessions.UpdateSession(ctx, existingSession); err != nil {
+	updatedSession := existingSession
+	updatedSession.ActiveOrganizationID = authCtx.ActiveOrganizationID
+	if err := s.sessions.UpdateSession(ctx, existingSession, updatedSession); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating auth session").LogError(ctx, s.logger)
 	}
 
@@ -886,13 +887,14 @@ func (s *Service) EnterDemo(ctx context.Context, payload *gen.EnterDemoPayload) 
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error loading existing session").LogError(ctx, s.logger)
 	}
-	existingSession.ActiveOrganizationID = constants.DemoOrganizationID
+	updatedSession := existingSession
+	updatedSession.ActiveOrganizationID = constants.DemoOrganizationID
 	// Entering the shared demo ends support access. Otherwise the support
 	// target would no longer match the active organization and the next
 	// authenticated request would reject the session.
-	existingSession.SupportOrganizationID = ""
-	existingSession.SupportExpiresAt = time.Time{}
-	if err := s.sessions.UpdateSession(ctx, existingSession); err != nil {
+	updatedSession.SupportOrganizationID = ""
+	updatedSession.SupportExpiresAt = time.Time{}
+	if err := s.sessions.UpdateSession(ctx, existingSession, updatedSession); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating auth session").LogError(ctx, s.logger)
 	}
 
@@ -1188,8 +1190,9 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error loading existing session").LogError(ctx, s.logger)
 	}
-	existingSession.ActiveOrganizationID = org.ID
-	if err := s.sessions.UpdateSession(ctx, existingSession); err != nil {
+	updatedSession := existingSession
+	updatedSession.ActiveOrganizationID = org.ID
+	if err := s.sessions.UpdateSession(ctx, existingSession, updatedSession); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error storing session").LogError(ctx, s.logger)
 	}
 

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -147,6 +148,9 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 			authCtx.Email = &email
 			authCtx.IsAdmin = userInfo.Admin
 		}
+		if err := s.refreshSession(ctx, session); err != nil {
+			return ctx, err
+		}
 		ctx = contextvalues.SetAuthContext(ctx, authCtx)
 		return ctx, nil
 	}
@@ -187,6 +191,10 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 	authCtx.OrganizationSlug = orgMetadata.Slug
 	authCtx.Email = &email
 
+	if err := s.refreshSession(ctx, session); err != nil {
+		return ctx, err
+	}
+
 	if validatedSupportAdmin {
 		ctx = contextvalues.WithValidatedSupportSession(ctx, authCtx)
 	} else {
@@ -194,6 +202,18 @@ func (s *Manager) Authenticate(ctx context.Context, key string) (context.Context
 	}
 
 	return ctx, nil
+}
+
+func (s *Manager) refreshSession(ctx context.Context, session Session) error {
+	refreshed, err := s.sessionCache.CompareAndSwap(ctx, session, session)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error refreshing session expiry").LogError(ctx, s.logger)
+	}
+	if !refreshed {
+		return oops.C(oops.CodeUnauthorized)
+	}
+	contextvalues.RefreshSessionCookie(ctx, session.SessionID)
+	return nil
 }
 
 func (s *Manager) AuthenticateWithCookie(ctx context.Context) (context.Context, error) {
@@ -233,9 +253,15 @@ func (s *Manager) StoreSession(ctx context.Context, session Session) error {
 }
 
 func (s *Manager) UpdateSession(ctx context.Context, session Session) error {
-	err := s.sessionCache.Update(ctx, session)
-	if err != nil {
+	if err := s.sessionCache.Update(ctx, session); err != nil {
 		return fmt.Errorf("update session: %w", err)
+	}
+	refreshed, err := s.sessionCache.CompareAndSwap(ctx, session, session)
+	if err != nil {
+		return fmt.Errorf("refresh updated session ttl: %w", err)
+	}
+	if !refreshed {
+		return errors.New("refresh updated session ttl: session no longer exists")
 	}
 
 	return nil

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -252,16 +252,13 @@ func (s *Manager) StoreSession(ctx context.Context, session Session) error {
 	return nil
 }
 
-func (s *Manager) UpdateSession(ctx context.Context, session Session) error {
-	if err := s.sessionCache.Update(ctx, session); err != nil {
+func (s *Manager) UpdateSession(ctx context.Context, expected, replacement Session) error {
+	updated, err := s.sessionCache.CompareAndSwap(ctx, expected, replacement)
+	if err != nil {
 		return fmt.Errorf("update session: %w", err)
 	}
-	refreshed, err := s.sessionCache.CompareAndSwap(ctx, session, session)
-	if err != nil {
-		return fmt.Errorf("refresh updated session ttl: %w", err)
-	}
-	if !refreshed {
-		return errors.New("refresh updated session ttl: session no longer exists")
+	if !updated {
+		return errors.New("update session: session changed or no longer exists")
 	}
 
 	return nil

--- a/server/internal/auth/sessions/sessions_test.go
+++ b/server/internal/auth/sessions/sessions_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
 func TestValidSupportSessionRejectsExpiredSession(t *testing.T) {
@@ -18,6 +20,21 @@ func TestValidSupportSessionRejectsExpiredSession(t *testing.T) {
 		SupportExpiresAt:      now.Add(-time.Second),
 	}
 	require.False(t, validSupportSession(session, true, now))
+}
+
+func TestSessionTTLUsesIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, constants.SessionIdleTimeout, (Session{}).TTL())
+	require.Equal(t, "sessions:v2:session-id", SessionCacheKey("session-id"))
+}
+
+func TestSupportSessionTTLUsesAbsoluteExpiry(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(time.Hour)
+	ttl := (Session{SupportExpiresAt: expiresAt}).TTL()
+	require.InDelta(t, time.Hour, ttl, float64(time.Second))
 }
 
 func TestNewSessionID(t *testing.T) {

--- a/server/internal/auth/sessions/types.go
+++ b/server/internal/auth/sessions/types.go
@@ -4,12 +4,10 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
-const (
-	sessionCacheExpiry  = 15 * 24 * time.Hour
-	userInfoCacheExpiry = 15 * time.Minute
-)
+const userInfoCacheExpiry = 15 * time.Minute
 
 var _ cache.CacheableObject[Session] = (*Session)(nil)
 
@@ -24,7 +22,9 @@ type Session struct {
 }
 
 func SessionCacheKey(sessionID string) string {
-	return "sessions:" + sessionID
+	// Version the namespace so sessions created under the previous, longer
+	// expiry policy cannot bypass the 72-hour idle timeout after rollout.
+	return "sessions:v2:" + sessionID
 }
 
 func (s Session) CacheKey() string {
@@ -35,7 +35,7 @@ func (s Session) TTL() time.Duration {
 	if !s.SupportExpiresAt.IsZero() {
 		return time.Until(s.SupportExpiresAt)
 	}
-	return sessionCacheExpiry
+	return constants.SessionIdleTimeout
 }
 
 var _ cache.CacheableObject[CachedUserInfo] = (*CachedUserInfo)(nil)

--- a/server/internal/constants/auth.go
+++ b/server/internal/constants/auth.go
@@ -1,5 +1,7 @@
 package constants
 
+import "time"
+
 const (
 	KeySecurityScheme = "apikey"
 	APIKeyHeader      = "Gram-Key"
@@ -7,9 +9,11 @@ const (
 	FunctionTokenSecurityScheme = "function_token"
 	FunctionTokenHeader         = "Authorization"
 
-	SessionSecurityScheme = "session"
-	SessionHeader         = "Gram-Session"
-	SessionCookie         = "gram_session"
+	SessionSecurityScheme      = "session"
+	SessionHeader              = "Gram-Session"
+	SessionCookie              = "gram_session"
+	SessionIdleTimeout         = 72 * time.Hour
+	SessionCookieMaxAgeSeconds = int(SessionIdleTimeout / time.Second)
 
 	ChatSessionsTokenSecurityScheme = "chat_sessions_token"
 	ChatSessionsTokenHeader         = "Gram-Chat-Session" //nolint:gosec // this is a valid header name

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -77,17 +77,18 @@ type RPCContext struct {
 }
 
 const (
-	SessionTokenContextKey      contextKey = "sessionTokenKey"
-	SessionValueContextKey      contextKey = "sessionValueKey"
-	RequestContextKey           contextKey = "requestContextKey"
-	RBACScopeOverrideContextKey contextKey = "rbacScopeOverrideKey"
-	AssistantPrincipalKey       contextKey = "assistantPrincipalKey"
-	AdminSessionTokenContextKey contextKey = "adminSessionTokenKey"
-	AdminAuthContextKey         contextKey = "adminAuthKey"
-	RPCContextKey               contextKey = "rpcContextKey"
-	pubsubSubscriberContextKey  contextKey = "pubsubSubscriberKey"
-	oauthClientIDContextKey     contextKey = "oauthClientIDKey"
-	actingSurfaceContextKey     contextKey = "actingSurfaceKey"
+	SessionTokenContextKey         contextKey = "sessionTokenKey"
+	sessionCookieRefreshContextKey contextKey = "sessionCookieRefreshKey"
+	SessionValueContextKey         contextKey = "sessionValueKey"
+	RequestContextKey              contextKey = "requestContextKey"
+	RBACScopeOverrideContextKey    contextKey = "rbacScopeOverrideKey"
+	AssistantPrincipalKey          contextKey = "assistantPrincipalKey"
+	AdminSessionTokenContextKey    contextKey = "adminSessionTokenKey"
+	AdminAuthContextKey            contextKey = "adminAuthKey"
+	RPCContextKey                  contextKey = "rpcContextKey"
+	pubsubSubscriberContextKey     contextKey = "pubsubSubscriberKey"
+	oauthClientIDContextKey        contextKey = "oauthClientIDKey"
+	actingSurfaceContextKey        contextKey = "actingSurfaceKey"
 )
 
 func SetSessionTokenInContext(ctx context.Context, value string) context.Context {
@@ -97,6 +98,16 @@ func SetSessionTokenInContext(ctx context.Context, value string) context.Context
 func GetSessionTokenFromContext(ctx context.Context) (string, bool) {
 	value, ok := ctx.Value(SessionTokenContextKey).(string)
 	return value, ok
+}
+
+func WithSessionCookieRefresh(ctx context.Context, refresh func(sessionID string)) context.Context {
+	return context.WithValue(ctx, sessionCookieRefreshContextKey, refresh)
+}
+
+func RefreshSessionCookie(ctx context.Context, sessionID string) {
+	if refresh, ok := ctx.Value(sessionCookieRefreshContextKey).(func(string)); ok {
+		refresh(sessionID)
+	}
 }
 
 func SetAuthContext(ctx context.Context, value *AuthContext) context.Context {

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -105,7 +105,7 @@ func WithSessionCookieRefresh(ctx context.Context, refresh func(sessionID string
 }
 
 func RefreshSessionCookie(ctx context.Context, sessionID string) {
-	if refresh, ok := ctx.Value(sessionCookieRefreshContextKey).(func(string)); ok {
+	if refresh, ok := ctx.Value(sessionCookieRefreshContextKey).(func(string)); ok && refresh != nil {
 		refresh(sessionID)
 	}
 }

--- a/server/internal/contextvalues/context_test.go
+++ b/server/internal/contextvalues/context_test.go
@@ -21,3 +21,10 @@ func TestIsSupportSessionRequiresValidatedContext(t *testing.T) {
 	require.False(t, IsSupportSession(WithValidatedSupportSession(t.Context(), &nonAdmin)))
 
 }
+
+func TestRefreshSessionCookieIgnoresNilCallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithSessionCookieRefresh(t.Context(), nil)
+	require.NotPanics(t, func() { RefreshSessionCookie(ctx, "session-id") })
+}

--- a/server/internal/middleware/session.go
+++ b/server/internal/middleware/session.go
@@ -13,13 +13,30 @@ func SessionMiddleware(next http.Handler) http.Handler {
 		cookie, err := r.Cookie(constants.SessionCookie)
 		if err == nil {
 			ctx := contextvalues.SetSessionTokenInContext(r.Context(), cookie.Value)
+			if shouldRefreshSessionCookie(r.URL.Path) {
+				ctx = contextvalues.WithSessionCookieRefresh(ctx, func(sessionID string) {
+					if sessionID != cookie.Value {
+						return
+					}
+					//nolint:exhaustruct // only desired fields — avoid unexpected zero-value behavior
+					http.SetCookie(w, &http.Cookie{
+						Name:     constants.SessionCookie,
+						Value:    sessionID,
+						MaxAge:   constants.SessionCookieMaxAgeSeconds,
+						Path:     "/",
+						Secure:   true,
+						HttpOnly: true,
+						SameSite: http.SameSiteLaxMode,
+					})
+				})
+			}
 			r = r.WithContext(ctx)
 		}
 		// Can delete this strangeness on 11/15/25 (after all these bad cookies expire)
 		if strings.HasSuffix(r.URL.Path, "rpc/auth.info") {
 			//nolint:exhaustruct // we only desire these fields and dont want to accidentally change behavior with some unexpected zero valu
 			http.SetCookie(w, &http.Cookie{
-				Name:     "gram_session",
+				Name:     constants.SessionCookie,
 				Value:    "",
 				MaxAge:   -1,
 				Path:     "/rpc",
@@ -29,4 +46,16 @@ func SessionMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func shouldRefreshSessionCookie(path string) bool {
+	switch {
+	case strings.HasSuffix(path, "rpc/auth.logout"),
+		strings.HasSuffix(path, "rpc/auth.info"),
+		strings.HasSuffix(path, "rpc/auth.switchScopes"),
+		strings.HasSuffix(path, "rpc/auth.enterDemo"):
+		return false
+	default:
+		return true
+	}
 }

--- a/server/internal/middleware/session_test.go
+++ b/server/internal/middleware/session_test.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+func TestSessionMiddlewareRefreshesAuthenticatedCookie(t *testing.T) {
+	t.Parallel()
+
+	var observedSessionID string
+	var foundSession bool
+	handler := SessionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observedSessionID, foundSession = contextvalues.GetSessionTokenFromContext(r.Context())
+		contextvalues.RefreshSessionCookie(r.Context(), observedSessionID)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/rpc/projects.list", nil)
+	req.AddCookie(&http.Cookie{Name: constants.SessionCookie, Value: "session-id"})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.True(t, foundSession)
+	require.Equal(t, "session-id", observedSessionID)
+	var refreshed *http.Cookie
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == constants.SessionCookie && cookie.Path == "/" {
+			refreshed = cookie
+		}
+	}
+	require.NotNil(t, refreshed)
+	require.Equal(t, "session-id", refreshed.Value)
+	require.Equal(t, constants.SessionCookieMaxAgeSeconds, refreshed.MaxAge)
+	require.True(t, refreshed.Secure)
+	require.True(t, refreshed.HttpOnly)
+	require.Equal(t, http.SameSiteLaxMode, refreshed.SameSite)
+}
+
+func TestSessionMiddlewareDoesNotRefreshDifferentSession(t *testing.T) {
+	t.Parallel()
+
+	handler := SessionMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		contextvalues.RefreshSessionCookie(r.Context(), "header-session")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/rpc/projects.list", nil)
+	req.AddCookie(&http.Cookie{Name: constants.SessionCookie, Value: "cookie-session"})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	for _, cookie := range recorder.Result().Cookies() {
+		require.NotEqual(t, "header-session", cookie.Value)
+	}
+}
+
+func TestSessionMiddlewareDoesNotRefreshLogoutCookie(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, shouldRefreshSessionCookie("/rpc/auth.logout"))
+	require.False(t, shouldRefreshSessionCookie("/rpc/auth.info"))
+	require.False(t, shouldRefreshSessionCookie("/rpc/auth.switchScopes"))
+	require.False(t, shouldRefreshSessionCookie("/rpc/auth.enterDemo"))
+
+	handler := SessionMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		contextvalues.RefreshSessionCookie(r.Context(), "session-id")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil)
+	req.AddCookie(&http.Cookie{Name: constants.SessionCookie, Value: "session-id"})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Empty(t, recorder.Result().Cookies())
+}

--- a/server/internal/middleware/session_test.go
+++ b/server/internal/middleware/session_test.go
@@ -55,9 +55,7 @@ func TestSessionMiddlewareDoesNotRefreshDifferentSession(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 
-	for _, cookie := range recorder.Result().Cookies() {
-		require.NotEqual(t, "header-session", cookie.Value)
-	}
+	require.Empty(t, recorder.Result().Cookies())
 }
 
 func TestSessionMiddlewareDoesNotRefreshLogoutCookie(t *testing.T) {

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/email"
@@ -1554,9 +1555,9 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 
 	//nolint:exhaustruct // only desired fields — avoid unexpected zero-value behavior
 	http.SetCookie(w, &http.Cookie{
-		Name:     "gram_session",
+		Name:     constants.SessionCookie,
 		Value:    sessionID,
-		MaxAge:   2592000,
+		MaxAge:   constants.SessionCookieMaxAgeSeconds,
 		Path:     "/",
 		Secure:   true,
 		HttpOnly: true,

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -15,6 +15,7 @@ import (
 	goahttp "goa.design/goa/v3/http"
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/organizations"
@@ -33,6 +34,14 @@ func TestInviteCallback_AdminInviteNotifiesTrialAdminAdded(t *testing.T) {
 
 	recorder := serveInviteCallback(t, ti, rawToken)
 	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	var sessionCookie *http.Cookie
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == constants.SessionCookie {
+			sessionCookie = cookie
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	require.Equal(t, constants.SessionCookieMaxAgeSeconds, sessionCookie.MaxAge)
 	require.Equal(t, []adminAddedNotification{{
 		organizationID: authCtx.ActiveOrganizationID,
 		userID:         "user_01INVITEE",


### PR DESCRIPTION
## Summary
- replace long-lived dashboard sessions with a 72-hour sliding idle timeout
- renew Redis expiry and the browser cookie only after successful session validation
- invalidate legacy session-cache entries on rollout and issue cookies with explicit `SameSite=Lax`
- avoid renewing logout responses or duplicating cookies on endpoints that already issue them

Closes DNO-761

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a 72-hour sliding idle timeout for dashboard sessions and sets the `gram_session` cookie to SameSite=Lax. Previously sessions used a 30-day cookie and a 15-day cache TTL; now the TTL and cookie extend only after successful validation to address DNO-761.

- Breaks existing sessions by versioning the cache key to sessions:v2; users must log in after rollout.
- Uses Compare-And-Swap to renew session expiry during authentication and to update sessions; `UpdateSession` now accepts (expected, replacement) and returns unauthorized/failed update on CAS mismatch.
- Refreshes the cookie only when the validated session matches the request cookie and only on non-exempt endpoints; skips `/rpc/auth.logout`, `/rpc/auth.info`, `/rpc/auth.switchScopes`, and `/rpc/auth.enterDemo`.
- Issues cookies with SameSite=Lax and a 72-hour Max-Age across auth handlers and invite callback; support sessions retain absolute expiry, others use the 72-hour idle timeout.

<sup>Written for commit c5900b57bb150638756981c14d713b1eb4bec3aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

