### PR TITLE
feat: admin organizations stat update to enterprise and payg only

### DIFF
--- a/.changeset/admin-stat-strip-customers.md
+++ b/.changeset/admin-stat-strip-customers.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The first cell of the admin organizations stat strip now counts customers — organizations on a payg or enterprise account type — instead of every organization on the platform, and pressing it filters the list to those two types. The `organizations.stats` admin endpoint gains `customers` and `customers_created_last_7_days`; `total` and `created_last_7_days` are unchanged.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -60716,6 +60716,14 @@ components:
           type: integer
           description: Organizations created in the last 7 days, whatever their current status.
           format: int64
+        customers:
+          type: integer
+          description: Organizations on a paid account type (payg or enterprise), disabled ones included.
+          format: int64
+        customers_created_last_7_days:
+          type: integer
+          description: Customers created in the last 7 days, whatever their current status.
+          format: int64
         disabled:
           type: integer
           description: Organizations with disabled_at set.
@@ -60736,6 +60744,8 @@ components:
       required:
         - total
         - created_last_7_days
+        - customers
+        - customers_created_last_7_days
         - trials_ending_soon
         - disabled
         - disabled_last_7_days

--- a/client/admin/index.html
+++ b/client/admin/index.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate icon" href="/favicon.ico" />
 
-    <title>Speakeasy AICP Admin</title>
+    <title>Speakeasy AI Control Plane Admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/admin/src/components/app-sidebar.tsx
+++ b/client/admin/src/components/app-sidebar.tsx
@@ -55,7 +55,9 @@ export function AppSidebar({
             >
               <Link to="/">
                 <SpeakeasyMark className="!size-5 group-data-[collapsible=icon]:!size-4" />
-                <span className="text-base font-semibold">AI Control Plane Admin</span>
+                <span className="text-base font-semibold">
+                  AI Control Plane Admin
+                </span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/client/admin/src/components/app-sidebar.tsx
+++ b/client/admin/src/components/app-sidebar.tsx
@@ -55,7 +55,7 @@ export function AppSidebar({
             >
               <Link to="/">
                 <SpeakeasyMark className="!size-5 group-data-[collapsible=icon]:!size-4" />
-                <span className="text-base font-semibold">AICP Admin</span>
+                <span className="text-base font-semibold">AI Control Plane Admin</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -89,6 +89,8 @@ describe("writeOrganizationToCache", () => {
   const FRESH = {
     total: 2,
     created_last_7_days: 1,
+    customers: 1,
+    customers_created_last_7_days: 0,
     trials_ending_soon: 1,
     disabled: 1,
     disabled_last_7_days: 1,
@@ -154,6 +156,8 @@ describe("writeOrganizationToCache", () => {
     qc.setQueryData(organizationsStatsQuery.queryKey, {
       total: 1,
       created_last_7_days: 0,
+      customers: 0,
+      customers_created_last_7_days: 0,
       trials_ending_soon: 0,
       disabled: 0,
       disabled_last_7_days: 0,

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -268,6 +268,9 @@ export function listOrganizations(
 export type AdminOrganizationStats = {
   total: number;
   created_last_7_days: number;
+  /** Organizations on a paid account type, payg or enterprise. */
+  customers: number;
+  customers_created_last_7_days: number;
   trials_ending_soon: number;
   disabled: number;
   disabled_last_7_days: number;

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -540,6 +540,8 @@ describe("Overview", () => {
             resolve({
               total: 1,
               created_last_7_days: 0,
+              customers: 0,
+              customers_created_last_7_days: 0,
               trials_ending_soon: 0,
               disabled: 0,
               disabled_last_7_days: 0,
@@ -554,6 +556,8 @@ describe("Overview", () => {
     qc.setQueryData(organizationsStatsQuery.queryKey, {
       total: 2,
       created_last_7_days: 0,
+      customers: 0,
+      customers_created_last_7_days: 0,
       trials_ending_soon: 0,
       disabled: 0,
       disabled_last_7_days: 0,

--- a/client/admin/src/pages/organizations/CreateOrganization.test.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.test.tsx
@@ -143,6 +143,8 @@ beforeEach(() => {
   mocks.getOrganizationStats.mockResolvedValue({
     total: 0,
     created_last_7_days: 0,
+    customers: 0,
+    customers_created_last_7_days: 0,
     trials_ending_soon: 0,
     disabled: 0,
     disabled_last_7_days: 0,

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -51,6 +51,8 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 const STATS: AdminOrganizationStats = {
   total: 48213,
   created_last_7_days: 1372,
+  customers: 7318,
+  customers_created_last_7_days: 2417,
   trials_ending_soon: 926,
   disabled: 5904,
   disabled_last_7_days: 1064,
@@ -74,7 +76,7 @@ const ORGS: AdminOrganization[] = [
 // Spoken, never painted: each cell ends with a sentence naming what pressing
 // it does.
 const ACTION: Record<string, string> = {
-  Organizations: "Show every organization",
+  Customers: "Show the PAYG and enterprise organizations",
   "Trials ending in 7 days": "Show the trials ending in 7 days",
   Disabled: "Show the disabled organizations",
 };
@@ -117,7 +119,7 @@ function lastListParams(): ListOrganizationsParams {
 async function renderList(initialPath = "/organizations"): Promise<AnyRouter> {
   const { router } = await renderRouteTree(routeTree, { initialPath });
   await waitFor(() => {
-    expect(within(strip()).getByText(figure(STATS.total))).toBeTruthy();
+    expect(within(strip()).getByText(figure(STATS.customers))).toBeTruthy();
   });
   return router;
 }
@@ -146,8 +148,8 @@ describe("organizations stat strip figures", () => {
   it("reads each cell out of the field the contract names for it", async () => {
     await renderList();
 
-    expect(cell("Organizations").textContent).toBe(
-      `Organizations${figure(STATS.total)}${figure(STATS.created_last_7_days)} new this week${ACTION["Organizations"]}`,
+    expect(cell("Customers").textContent).toBe(
+      `Customers${figure(STATS.customers)}${figure(STATS.customers_created_last_7_days)} new this week${ACTION["Customers"]}`,
     );
     expect(cell("Trials ending in 7 days").textContent).toBe(
       `Trials ending in 7 days${figure(STATS.trials_ending_soon)}${ACTION["Trials ending in 7 days"]}`,
@@ -163,7 +165,7 @@ describe("organizations stat strip figures", () => {
     const trials = cell("Trials ending in 7 days");
     expect(within(trials).queryByText(/this week/)).toBeNull();
     expect(trials.querySelectorAll("span").length).toBe(3);
-    expect(cell("Organizations").querySelectorAll("span").length).toBe(4);
+    expect(cell("Customers").querySelectorAll("span").length).toBe(4);
   });
 
   it("renders a figure of zero as a figure, not as a missing one", async () => {
@@ -187,7 +189,20 @@ describe("organizations stat strip figures", () => {
     expect(cell("Disabled").textContent).toBe(
       `Disabled${figure(STATS.disabled)}— this week${ACTION["Disabled"]}`,
     );
-    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    expect(cell("Customers").textContent).toContain(figure(STATS.customers));
+  });
+
+  it("counts customers, not the platform, in the first cell", async () => {
+    await renderList();
+
+    // The two figures are distinct in STATS, so a cell reading `total` by
+    // mistake shows a number no assertion here accepts.
+    expect(within(strip()).queryByText(figure(STATS.total))).toBeNull();
+    expect(
+      within(strip()).queryByText(figure(STATS.created_last_7_days), {
+        exact: false,
+      }),
+    ).toBeNull();
   });
 
   it("says nothing where the figures have not arrived", async () => {
@@ -200,14 +215,14 @@ describe("organizations stat strip figures", () => {
 
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    expect(cell("Organizations").textContent).toBe(
-      `Organizations—${ACTION["Organizations"]}`,
+    expect(cell("Customers").textContent).toBe(
+      `Customers—${ACTION["Customers"]}`,
     );
     expect(cell("Disabled").textContent).toBe(`Disabled—${ACTION["Disabled"]}`);
 
     settle(STATS);
     await waitFor(() => {
-      expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+      expect(cell("Customers").textContent).toContain(figure(STATS.customers));
     });
   });
 
@@ -223,8 +238,8 @@ describe("organizations stat strip figures", () => {
     );
     // The cells too: a failure falling back to a figure would put three zeroes
     // above a table full of rows.
-    expect(cell("Organizations").textContent).toBe(
-      `Organizations—${ACTION["Organizations"]}`,
+    expect(cell("Customers").textContent).toBe(
+      `Customers—${ACTION["Customers"]}`,
     );
     expect(cell("Trials ending in 7 days").textContent).toBe(
       `Trials ending in 7 days—${ACTION["Trials ending in 7 days"]}`,
@@ -265,23 +280,42 @@ describe("organizations stat strip figures", () => {
 });
 
 describe("organizations stat strip navigation", () => {
-  it("opens every organization from the first cell, disabled ones included", async () => {
+  it("opens the paying organizations from the first cell, disabled ones included", async () => {
     const router = await renderList(
       urlFor({ type: ["pro"], trial: ["running"], disabled: ["disabled"] }),
     );
 
-    fireEvent.click(cell("Organizations"));
+    fireEvent.click(cell("Customers"));
 
-    // Spelled out, because an absent status filter is not "no filter": the
+    // Both paid types, in the order the Type picker offers them. The status is
+    // spelled out, because an absent status filter is not "no filter": the
     // server reads it as active only.
     await waitFor(() => {
-      expect(currentSearch(router)).toBe('?disabled=["active","disabled"]');
+      expect(currentSearch(router)).toBe(
+        '?type=["payg","enterprise"]&disabled=["active","disabled"]',
+      );
     });
     await waitFor(() => {
-      expect(lastListParams().disabled_states).toEqual(["active", "disabled"]);
+      expect(lastListParams().account_types).toEqual(["payg", "enterprise"]);
     });
-    expect(lastListParams().account_types).toBeUndefined();
+    expect(lastListParams().disabled_states).toEqual(["active", "disabled"]);
     expect(lastListParams().trial_states).toBeUndefined();
+  });
+
+  it("names both paid types on the type control rather than counting them", async () => {
+    await renderList();
+
+    fireEvent.click(cell("Customers"));
+
+    // Type has no "all" label, so two chosen values are counted. What matters
+    // is that the control does not read "All types" over a filtered list.
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("button", { name: /^Type filter:/ })
+          .getAttribute("aria-label"),
+      ).toBe("Type filter: 2 selected");
+    });
   });
 
   it("filters to the trials the middle cell counted, at either status", async () => {
@@ -441,7 +475,7 @@ describe("organizations stat strip navigation", () => {
   it("names the whole platform on the status control rather than counting it", async () => {
     await renderList();
 
-    fireEvent.click(cell("Organizations"));
+    fireEvent.click(cell("Customers"));
 
     // "2 selected" reads as a narrowing, and "Active only" would be false.
     await waitFor(() => {
@@ -513,6 +547,8 @@ describe("organizations stat strip and the table's filters", () => {
     mocks.getOrganizationStats.mockResolvedValue({
       total: 1,
       created_last_7_days: 1,
+      customers: 1,
+      customers_created_last_7_days: 1,
       trials_ending_soon: 1,
       disabled: 1,
       disabled_last_7_days: 1,
@@ -526,7 +562,7 @@ describe("organizations stat strip and the table's filters", () => {
       expect(lastListParams().disabled_states).toEqual(["disabled"]);
     });
 
-    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    expect(cell("Customers").textContent).toContain(figure(STATS.customers));
     expect(cell("Disabled").textContent).toContain(figure(STATS.disabled));
   });
 
@@ -539,7 +575,7 @@ describe("organizations stat strip and the table's filters", () => {
     });
 
     expect(currentSearch(router)).toBe('?disabled=["disabled"]');
-    expect(cell("Organizations").textContent).toContain(figure(STATS.total));
+    expect(cell("Customers").textContent).toContain(figure(STATS.customers));
     expect(cell("Trials ending in 7 days").textContent).toContain(
       figure(STATS.trials_ending_soon),
     );
@@ -571,17 +607,13 @@ describe("organizations stat strip placement", () => {
       within(strip())
         .getAllByRole("button")
         .map((control) => control.querySelector("span")?.textContent),
-    ).toEqual(["Organizations", "Trials ending in 7 days", "Disabled"]);
+    ).toEqual(["Customers", "Trials ending in 7 days", "Disabled"]);
   });
 
   it("offers each figure as a control the keyboard reaches", async () => {
     await renderList();
 
-    for (const label of [
-      "Organizations",
-      "Trials ending in 7 days",
-      "Disabled",
-    ]) {
+    for (const label of ["Customers", "Trials ending in 7 days", "Disabled"]) {
       const control = cell(label);
       // A div with an onClick answers no key; a bare button in a form submits.
       expect(control.tagName).toBe("BUTTON");
@@ -596,7 +628,7 @@ describe("organizations stat strip accessible names", () => {
 
     // The computed name: an aria-label added later would drop the figure.
     for (const name of [
-      `Organizations ${figure(STATS.total)} ${figure(STATS.created_last_7_days)} new this week ${ACTION["Organizations"]}`,
+      `Customers ${figure(STATS.customers)} ${figure(STATS.customers_created_last_7_days)} new this week ${ACTION["Customers"]}`,
       `Trials ending in 7 days ${figure(STATS.trials_ending_soon)} ${ACTION["Trials ending in 7 days"]}`,
       `Disabled ${figure(STATS.disabled)} ${figure(STATS.disabled_last_7_days)} this week ${ACTION["Disabled"]}`,
     ]) {
@@ -614,11 +646,7 @@ describe("organizations stat strip accessible names", () => {
   it("leaves the name to come from the contents", async () => {
     await renderList();
 
-    for (const label of [
-      "Organizations",
-      "Trials ending in 7 days",
-      "Disabled",
-    ]) {
+    for (const label of ["Customers", "Trials ending in 7 days", "Disabled"]) {
       expect(cell(label).getAttribute("aria-label")).toBeNull();
       expect(cell(label).getAttribute("aria-labelledby")).toBeNull();
     }
@@ -634,11 +662,11 @@ describe("organizations stat strip accessible names", () => {
 
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
-    expect(cell("Organizations").getAttribute("aria-busy")).toBe("true");
+    expect(cell("Customers").getAttribute("aria-busy")).toBe("true");
 
     settle(STATS);
     await waitFor(() => {
-      expect(cell("Organizations").getAttribute("aria-busy")).toBe("false");
+      expect(cell("Customers").getAttribute("aria-busy")).toBe("false");
     });
   });
 });

--- a/client/admin/src/pages/organizations/StatStrip.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { JSX } from "react";
 
+import type { AccountType } from "@/lib/accountTypes";
 import { organizationsStatsQuery } from "@/lib/adminQueries";
 import {
   errorMessage,
@@ -20,6 +21,11 @@ import { useApplyFilters } from "./applyFilters";
 // a misspelling would filter on nothing rather than on the wrong thing.
 const ENDING_SOON: TrialState = "ending_soon";
 const DISABLED: DisabledState = "disabled";
+
+// The paid account types, which is what `stats.customers` counts. In the order
+// the Type picker offers them, so the URL the cell writes is the one the picker
+// would have written for the same choice.
+const CUSTOMER_ACCOUNT_TYPES: AccountType[] = ["payg", "enterprise"];
 
 // The correction two of these cells carry: an absent status filter means active
 // only, and every figure here counts the disabled organizations too.
@@ -42,11 +48,20 @@ type StatCell = {
 
 const STAT_CELLS: StatCell[] = [
   {
-    label: "Organizations",
-    value: (stats) => stats.total,
-    subLine: (stats) => `${figure(stats.created_last_7_days)} new this week`,
-    filters: { ...NO_FILTERS, disabled: EVERY_STATUS },
-    action: "Show every organization",
+    // Paying organizations, not every organization: the platform total is
+    // mostly free sign-ups, and the operators reading this strip are here for
+    // the accounts that are billed. `stats.total` is still on the payload for
+    // anything that wants the whole platform.
+    label: "Customers",
+    value: (stats) => stats.customers,
+    subLine: (stats) =>
+      `${figure(stats.customers_created_last_7_days)} new this week`,
+    filters: {
+      ...NO_FILTERS,
+      type: [...CUSTOMER_ACCOUNT_TYPES],
+      disabled: EVERY_STATUS,
+    },
+    action: "Show the PAYG and enterprise organizations",
   },
   {
     // No sub-line: the design's "N with no owner" is cut, Gram has no owners.

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -158,6 +158,8 @@ const ORGS: AdminOrganization[] = [
 const STATS: AdminOrganizationStats = {
   total: 12,
   created_last_7_days: 3,
+  customers: 4,
+  customers_created_last_7_days: 1,
   trials_ending_soon: 2,
   disabled: 1,
   disabled_last_7_days: 1,

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -140,10 +140,12 @@ var AdminListOrganizationsResult = Type("AdminListOrganizationsResult", func() {
 
 var AdminOrganizationStats = Type("AdminOrganizationStats", func() {
 	Description("Platform-wide organization counts surfaced above the admin organizations list.")
-	Required("total", "created_last_7_days", "trials_ending_soon", "disabled", "disabled_last_7_days")
+	Required("total", "created_last_7_days", "customers", "customers_created_last_7_days", "trials_ending_soon", "disabled", "disabled_last_7_days")
 
 	Attribute("total", Int64, "Every organization on the platform, disabled ones included.")
 	Attribute("created_last_7_days", Int64, "Organizations created in the last 7 days, whatever their current status.")
+	Attribute("customers", Int64, "Organizations on a paid account type (payg or enterprise), disabled ones included.")
+	Attribute("customers_created_last_7_days", Int64, "Customers created in the last 7 days, whatever their current status.")
 	Attribute("trials_ending_soon", Int64, "Organizations whose trial_state is ending_soon.")
 	Attribute("disabled", Int64, "Organizations with disabled_at set.")
 	Attribute("disabled_last_7_days", Int64, "Organizations disabled in the last 7 days.")

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -223,6 +223,11 @@ type AdminOrganizationStats struct {
 	Total int64
 	// Organizations created in the last 7 days, whatever their current status.
 	CreatedLast7Days int64
+	// Organizations on a paid account type (payg or enterprise), disabled ones
+	// included.
+	Customers int64
+	// Customers created in the last 7 days, whatever their current status.
+	CustomersCreatedLast7Days int64
 	// Organizations whose trial_state is ending_soon.
 	TrialsEndingSoon int64
 	// Organizations with disabled_at set.

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -403,6 +403,11 @@ type GetOrganizationStatsResponseBody struct {
 	Total *int64 `form:"total,omitempty" json:"total,omitempty" xml:"total,omitempty"`
 	// Organizations created in the last 7 days, whatever their current status.
 	CreatedLast7Days *int64 `form:"created_last_7_days,omitempty" json:"created_last_7_days,omitempty" xml:"created_last_7_days,omitempty"`
+	// Organizations on a paid account type (payg or enterprise), disabled ones
+	// included.
+	Customers *int64 `form:"customers,omitempty" json:"customers,omitempty" xml:"customers,omitempty"`
+	// Customers created in the last 7 days, whatever their current status.
+	CustomersCreatedLast7Days *int64 `form:"customers_created_last_7_days,omitempty" json:"customers_created_last_7_days,omitempty" xml:"customers_created_last_7_days,omitempty"`
 	// Organizations whose trial_state is ending_soon.
 	TrialsEndingSoon *int64 `form:"trials_ending_soon,omitempty" json:"trials_ending_soon,omitempty" xml:"trials_ending_soon,omitempty"`
 	// Organizations with disabled_at set.
@@ -7429,11 +7434,13 @@ func NewRearmTrialGatewayError(body *RearmTrialGatewayErrorResponseBody) *goa.Se
 // "getOrganizationStats" endpoint result from a HTTP "OK" response.
 func NewGetOrganizationStatsAdminOrganizationStatsOK(body *GetOrganizationStatsResponseBody) *admin.AdminOrganizationStats {
 	v := &admin.AdminOrganizationStats{
-		Total:             *body.Total,
-		CreatedLast7Days:  *body.CreatedLast7Days,
-		TrialsEndingSoon:  *body.TrialsEndingSoon,
-		Disabled:          *body.Disabled,
-		DisabledLast7Days: *body.DisabledLast7Days,
+		Total:                     *body.Total,
+		CreatedLast7Days:          *body.CreatedLast7Days,
+		Customers:                 *body.Customers,
+		CustomersCreatedLast7Days: *body.CustomersCreatedLast7Days,
+		TrialsEndingSoon:          *body.TrialsEndingSoon,
+		Disabled:                  *body.Disabled,
+		DisabledLast7Days:         *body.DisabledLast7Days,
 	}
 
 	return v
@@ -9242,6 +9249,12 @@ func ValidateGetOrganizationStatsResponseBody(body *GetOrganizationStatsResponse
 	}
 	if body.CreatedLast7Days == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_last_7_days", "body"))
+	}
+	if body.Customers == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("customers", "body"))
+	}
+	if body.CustomersCreatedLast7Days == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("customers_created_last_7_days", "body"))
 	}
 	if body.TrialsEndingSoon == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("trials_ending_soon", "body"))

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -405,6 +405,11 @@ type GetOrganizationStatsResponseBody struct {
 	Total int64 `form:"total" json:"total" xml:"total"`
 	// Organizations created in the last 7 days, whatever their current status.
 	CreatedLast7Days int64 `form:"created_last_7_days" json:"created_last_7_days" xml:"created_last_7_days"`
+	// Organizations on a paid account type (payg or enterprise), disabled ones
+	// included.
+	Customers int64 `form:"customers" json:"customers" xml:"customers"`
+	// Customers created in the last 7 days, whatever their current status.
+	CustomersCreatedLast7Days int64 `form:"customers_created_last_7_days" json:"customers_created_last_7_days" xml:"customers_created_last_7_days"`
 	// Organizations whose trial_state is ending_soon.
 	TrialsEndingSoon int64 `form:"trials_ending_soon" json:"trials_ending_soon" xml:"trials_ending_soon"`
 	// Organizations with disabled_at set.
@@ -5085,11 +5090,13 @@ func NewRearmTrialResponseBody(res *admin.AdminOrganization) *RearmTrialResponse
 // result of the "getOrganizationStats" endpoint of the "admin" service.
 func NewGetOrganizationStatsResponseBody(res *admin.AdminOrganizationStats) *GetOrganizationStatsResponseBody {
 	body := &GetOrganizationStatsResponseBody{
-		Total:             res.Total,
-		CreatedLast7Days:  res.CreatedLast7Days,
-		TrialsEndingSoon:  res.TrialsEndingSoon,
-		Disabled:          res.Disabled,
-		DisabledLast7Days: res.DisabledLast7Days,
+		Total:                     res.Total,
+		CreatedLast7Days:          res.CreatedLast7Days,
+		Customers:                 res.Customers,
+		CustomersCreatedLast7Days: res.CustomersCreatedLast7Days,
+		TrialsEndingSoon:          res.TrialsEndingSoon,
+		Disabled:                  res.Disabled,
+		DisabledLast7Days:         res.DisabledLast7Days,
 	}
 	return body
 }

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -62012,6 +62012,14 @@ components:
                     type: integer
                     description: Organizations created in the last 7 days, whatever their current status.
                     format: int64
+                customers:
+                    type: integer
+                    description: Organizations on a paid account type (payg or enterprise), disabled ones included.
+                    format: int64
+                customers_created_last_7_days:
+                    type: integer
+                    description: Customers created in the last 7 days, whatever their current status.
+                    format: int64
                 disabled:
                     type: integer
                     description: Organizations with disabled_at set.
@@ -62032,6 +62040,8 @@ components:
             required:
                 - total
                 - created_last_7_days
+                - customers
+                - customers_created_last_7_days
                 - trials_ending_soon
                 - disabled
                 - disabled_last_7_days

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -655,11 +655,13 @@ func (s *Service) GetOrganizationStats(ctx context.Context, payload *gen.GetOrga
 	}
 
 	return &gen.AdminOrganizationStats{
-		Total:             row.Total,
-		CreatedLast7Days:  row.CreatedLast7Days,
-		TrialsEndingSoon:  row.TrialsEndingSoon,
-		Disabled:          row.Disabled,
-		DisabledLast7Days: row.DisabledLast7Days,
+		Total:                     row.Total,
+		CreatedLast7Days:          row.CreatedLast7Days,
+		Customers:                 row.Customers,
+		CustomersCreatedLast7Days: row.CustomersCreatedLast7Days,
+		TrialsEndingSoon:          row.TrialsEndingSoon,
+		Disabled:                  row.Disabled,
+		DisabledLast7Days:         row.DisabledLast7Days,
 	}, nil
 }
 

--- a/server/internal/admin/organizationstats_test.go
+++ b/server/internal/admin/organizationstats_test.go
@@ -73,12 +73,14 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 		// Active, never trialled. Two old, three inside the created window.
 		// Account types are spread over the corpus: a customer count that
 		// only looked at one of payg or enterprise, or that dropped disabled
-		// customers, reads short of the eight below.
+		// customers, reads short of the six below. The one customer inside the
+		// created window is a disabled one, so customers_created_last_7_days
+		// cannot pass by counting active customers only.
 		{id: "org_stats_old_a", created: -60 * 24 * time.Hour, accountType: "enterprise"},
 		{id: "org_stats_old_b", created: -90 * 24 * time.Hour, accountType: "payg"},
-		{id: "org_stats_new_a", created: -2 * 24 * time.Hour, accountType: "payg"},
+		{id: "org_stats_new_a", created: -2 * 24 * time.Hour, accountType: "pro"},
 		{id: "org_stats_new_b", created: -5 * 24 * time.Hour, accountType: "pro"},
-		{id: "org_stats_new_c", created: -6 * 24 * time.Hour, accountType: "payg"},
+		{id: "org_stats_new_c", created: -6 * 24 * time.Hour},
 
 		// Disabled. The second is also inside the created window, so a
 		// created count that excludes disabled organizations reads one short.
@@ -111,8 +113,8 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 	require.Equal(t, &gen.AdminOrganizationStats{
 		Total:                     16,
 		CreatedLast7Days:          5,
-		Customers:                 8,
-		CustomersCreatedLast7Days: 3,
+		Customers:                 6,
+		CustomersCreatedLast7Days: 1,
 		TrialsEndingSoon:          4,
 		Disabled:                  3,
 		DisabledLast7Days:         2,

--- a/server/internal/admin/organizationstats_test.go
+++ b/server/internal/admin/organizationstats_test.go
@@ -57,8 +57,8 @@ func seedStatsCorpus(t *testing.T, ctx context.Context, conn *pgxpool.Pool, corp
 	}
 }
 
-// TestGetOrganizationStats_Counts pins all five figures against one corpus in a
-// single assertion. No two of the five are equal, so a handler that deals two
+// TestGetOrganizationStats_Counts pins all seven figures against one corpus in a
+// single assertion. No two of the seven are equal, so a handler that deals two
 // fields out in the wrong order cannot pass by matching a neighbour's value.
 func TestGetOrganizationStats_Counts(t *testing.T) {
 	t.Parallel()
@@ -73,12 +73,12 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 		// Active, never trialled. Two old, three inside the created window.
 		// Account types are spread over the corpus: a customer count that
 		// only looked at one of payg or enterprise, or that dropped disabled
-		// customers, reads short of the seven below.
+		// customers, reads short of the eight below.
 		{id: "org_stats_old_a", created: -60 * 24 * time.Hour, accountType: "enterprise"},
 		{id: "org_stats_old_b", created: -90 * 24 * time.Hour, accountType: "payg"},
 		{id: "org_stats_new_a", created: -2 * 24 * time.Hour, accountType: "payg"},
 		{id: "org_stats_new_b", created: -5 * 24 * time.Hour, accountType: "pro"},
-		{id: "org_stats_new_c", created: -6 * 24 * time.Hour},
+		{id: "org_stats_new_c", created: -6 * 24 * time.Hour, accountType: "payg"},
 
 		// Disabled. The second is also inside the created window, so a
 		// created count that excludes disabled organizations reads one short.
@@ -111,8 +111,8 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 	require.Equal(t, &gen.AdminOrganizationStats{
 		Total:                     16,
 		CreatedLast7Days:          5,
-		Customers:                 7,
-		CustomersCreatedLast7Days: 2,
+		Customers:                 8,
+		CustomersCreatedLast7Days: 3,
 		TrialsEndingSoon:          4,
 		Disabled:                  3,
 		DisabledLast7Days:         2,

--- a/server/internal/admin/organizationstats_test.go
+++ b/server/internal/admin/organizationstats_test.go
@@ -21,7 +21,9 @@ type statsFixture struct {
 	// disabled is the age of disabled_at at seed time; zero leaves the
 	// organization active.
 	disabled time.Duration
-	trial    *trialFixture
+	// accountType is the organization's gram_account_type; empty seeds free.
+	accountType string
+	trial       *trialFixture
 }
 
 func seedStatsCorpus(t *testing.T, ctx context.Context, conn *pgxpool.Pool, corpus []statsFixture) {
@@ -41,6 +43,7 @@ func seedStatsCorpus(t *testing.T, ctx context.Context, conn *pgxpool.Pool, corp
 			id:          f.id,
 			name:        "Org " + f.id,
 			slug:        f.id,
+			accountType: f.accountType,
 			whitelisted: true,
 			disabledAt:  disabledAt,
 			createdAt:   &createdAt,
@@ -68,22 +71,25 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 
 	corpus := []statsFixture{
 		// Active, never trialled. Two old, three inside the created window.
-		{id: "org_stats_old_a", created: -60 * 24 * time.Hour},
-		{id: "org_stats_old_b", created: -90 * 24 * time.Hour},
-		{id: "org_stats_new_a", created: -2 * 24 * time.Hour},
-		{id: "org_stats_new_b", created: -5 * 24 * time.Hour},
+		// Account types are spread over the corpus: a customer count that
+		// only looked at one of payg or enterprise, or that dropped disabled
+		// customers, reads short of the seven below.
+		{id: "org_stats_old_a", created: -60 * 24 * time.Hour, accountType: "enterprise"},
+		{id: "org_stats_old_b", created: -90 * 24 * time.Hour, accountType: "payg"},
+		{id: "org_stats_new_a", created: -2 * 24 * time.Hour, accountType: "payg"},
+		{id: "org_stats_new_b", created: -5 * 24 * time.Hour, accountType: "pro"},
 		{id: "org_stats_new_c", created: -6 * 24 * time.Hour},
 
 		// Disabled. The second is also inside the created window, so a
 		// created count that excludes disabled organizations reads one short.
-		{id: "org_stats_disabled_recent_a", created: -60 * 24 * time.Hour, disabled: -24 * time.Hour},
-		{id: "org_stats_disabled_recent_b", created: -3 * 24 * time.Hour, disabled: -2 * 24 * time.Hour},
+		{id: "org_stats_disabled_recent_a", created: -60 * 24 * time.Hour, disabled: -24 * time.Hour, accountType: "enterprise"},
+		{id: "org_stats_disabled_recent_b", created: -3 * 24 * time.Hour, disabled: -2 * 24 * time.Hour, accountType: "payg"},
 		// Disabled long ago but created long ago too, so counting
 		// disabled_last_7_days off created_at cannot accidentally agree.
-		{id: "org_stats_disabled_old", created: -200 * 24 * time.Hour, disabled: -30 * 24 * time.Hour},
+		{id: "org_stats_disabled_old", created: -200 * 24 * time.Hour, disabled: -30 * 24 * time.Hour, accountType: "pro"},
 
 		// Trials that are ending soon.
-		{id: "org_stats_trial_soon_a", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
+		{id: "org_stats_trial_soon_a", created: -40 * 24 * time.Hour, accountType: "enterprise", trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
 		{id: "org_stats_trial_soon_b", created: -4 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(6 * 24 * time.Hour)}},
 		{id: "org_stats_trial_soon_c", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(5 * 24 * time.Hour)}},
 		{id: "org_stats_trial_soon_d", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(24 * time.Hour)}},
@@ -93,7 +99,7 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 		{id: "org_stats_trial_converted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), convertedAt: &convertedAt}},
 		{id: "org_stats_trial_demoted", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(3 * 24 * time.Hour), demotedAt: &demotedAt}},
 		{id: "org_stats_trial_expired", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(-24 * time.Hour)}},
-		{id: "org_stats_trial_running", created: -40 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}},
+		{id: "org_stats_trial_running", created: -40 * 24 * time.Hour, accountType: "payg", trial: &trialFixture{endsAt: now.Add(30 * 24 * time.Hour)}},
 	}
 
 	seedStatsCorpus(t, ctx, conn, corpus)
@@ -103,11 +109,13 @@ func TestGetOrganizationStats_Counts(t *testing.T) {
 	require.NotNil(t, res)
 
 	require.Equal(t, &gen.AdminOrganizationStats{
-		Total:             16,
-		CreatedLast7Days:  5,
-		TrialsEndingSoon:  4,
-		Disabled:          3,
-		DisabledLast7Days: 2,
+		Total:                     16,
+		CreatedLast7Days:          5,
+		Customers:                 7,
+		CustomersCreatedLast7Days: 2,
+		TrialsEndingSoon:          4,
+		Disabled:                  3,
+		DisabledLast7Days:         2,
 	}, res)
 }
 
@@ -159,7 +167,7 @@ func TestGetOrganizationStats_IgnoresFilters(t *testing.T) {
 
 	now := time.Now().UTC()
 	seedStatsCorpus(t, ctx, conn, []statsFixture{
-		{id: "org_filterproof_active", created: -2 * 24 * time.Hour},
+		{id: "org_filterproof_active", created: -2 * 24 * time.Hour, accountType: "payg"},
 		{id: "org_filterproof_disabled", created: -60 * 24 * time.Hour, disabled: -24 * time.Hour},
 		{id: "org_filterproof_soon", created: -60 * 24 * time.Hour, trial: &trialFixture{endsAt: now.Add(2 * 24 * time.Hour)}},
 	})
@@ -168,6 +176,7 @@ func TestGetOrganizationStats_IgnoresFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.ListOrganizations(ctx, &gen.ListOrganizationsPayload{
+		AccountTypes:   []string{"free"},
 		TrialStates:    []string{"expired"},
 		DisabledStates: []string{"disabled"},
 	})
@@ -178,11 +187,13 @@ func TestGetOrganizationStats_IgnoresFilters(t *testing.T) {
 
 	require.Equal(t, before, after)
 	require.Equal(t, &gen.AdminOrganizationStats{
-		Total:             3,
-		CreatedLast7Days:  1,
-		TrialsEndingSoon:  1,
-		Disabled:          1,
-		DisabledLast7Days: 1,
+		Total:                     3,
+		CreatedLast7Days:          1,
+		Customers:                 1,
+		CustomersCreatedLast7Days: 1,
+		TrialsEndingSoon:          1,
+		Disabled:                  1,
+		DisabledLast7Days:         1,
 	}, after)
 }
 
@@ -226,12 +237,28 @@ func TestGetOrganizationStats_Boundaries(t *testing.T) {
 			createdAt:   &createdAt,
 		})
 	}
+	seedBoundaryCustomer := func(id string, createdAt time.Time) {
+		seedOrg(t, ctx, tx, orgFixture{
+			id:          id,
+			name:        "Org " + id,
+			slug:        id,
+			accountType: "enterprise",
+			whitelisted: true,
+			createdAt:   &createdAt,
+		})
+	}
 	at := func(ts time.Time) *time.Time { return &ts }
 
 	// created_at > now() - INTERVAL '7 days': exactly seven days old is out.
 	seedBoundaryOrg("org_bound_created_inside", windowEdge.Add(time.Hour), nil)
 	seedBoundaryOrg("org_bound_created_exact", windowEdge, nil)
 	seedBoundaryOrg("org_bound_created_outside", windowEdge.Add(-time.Hour), nil)
+
+	// The same edge again for customers_created_last_7_days, which has its own
+	// predicate and so its own chance to include the boundary.
+	seedBoundaryCustomer("org_bound_customer_inside", windowEdge.Add(time.Hour))
+	seedBoundaryCustomer("org_bound_customer_exact", windowEdge)
+	seedBoundaryCustomer("org_bound_customer_outside", windowEdge.Add(-time.Hour))
 
 	// disabled_at > now() - INTERVAL '7 days': the same edge, the other column.
 	seedBoundaryOrg("org_bound_disabled_inside", old, at(windowEdge.Add(time.Hour)))
@@ -255,11 +282,13 @@ func TestGetOrganizationStats_Boundaries(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, repo.AdminGetOrganizationStatsRow{
-		Total:             10,
-		CreatedLast7Days:  1,
-		TrialsEndingSoon:  2,
-		Disabled:          3,
-		DisabledLast7Days: 1,
+		Total:                     13,
+		CreatedLast7Days:          2,
+		Customers:                 3,
+		CustomersCreatedLast7Days: 1,
+		TrialsEndingSoon:          2,
+		Disabled:                  3,
+		DisabledLast7Days:         1,
 	}, row)
 }
 

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -231,10 +231,15 @@ WHERE coalesce(cardinality(sqlc.arg('trial_states')::text[]), 0) = 0 OR trial_st
 --
 -- The join stays count-safe because organization_id is the trials primary key.
 -- Both 7-day windows exclude their boundary: exactly seven days old is outside.
+--
+-- A customer is an organization on a paid account type, payg or enterprise. The
+-- pair is the same one the organizations service uses to tell a paying account
+-- from the rest, and the customer figures count disabled customers too.
 WITH orgs AS (
     SELECT
         om.created_at,
         om.disabled_at,
+        om.gram_account_type IN ('payg', 'enterprise') AS is_customer,
         -- Must stay identical to AdminListOrganizations: a figure counted from a
         -- shortened predicate would disagree with the rows clicking it lands on.
         CASE
@@ -251,6 +256,8 @@ WITH orgs AS (
 SELECT
     count(*)::bigint AS total,
     count(*) FILTER (WHERE created_at > now() - INTERVAL '7 days')::bigint AS created_last_7_days,
+    count(*) FILTER (WHERE is_customer)::bigint AS customers,
+    count(*) FILTER (WHERE is_customer AND created_at > now() - INTERVAL '7 days')::bigint AS customers_created_last_7_days,
     count(*) FILTER (WHERE trial_state = 'ending_soon')::bigint AS trials_ending_soon,
     count(*) FILTER (WHERE disabled_at IS NOT NULL)::bigint AS disabled,
     count(*) FILTER (WHERE disabled_at > now() - INTERVAL '7 days')::bigint AS disabled_last_7_days

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -253,6 +253,7 @@ WITH orgs AS (
     SELECT
         om.created_at,
         om.disabled_at,
+        om.gram_account_type IN ('payg', 'enterprise') AS is_customer,
         -- Must stay identical to AdminListOrganizations: a figure counted from a
         -- shortened predicate would disagree with the rows clicking it lands on.
         CASE
@@ -269,6 +270,8 @@ WITH orgs AS (
 SELECT
     count(*)::bigint AS total,
     count(*) FILTER (WHERE created_at > now() - INTERVAL '7 days')::bigint AS created_last_7_days,
+    count(*) FILTER (WHERE is_customer)::bigint AS customers,
+    count(*) FILTER (WHERE is_customer AND created_at > now() - INTERVAL '7 days')::bigint AS customers_created_last_7_days,
     count(*) FILTER (WHERE trial_state = 'ending_soon')::bigint AS trials_ending_soon,
     count(*) FILTER (WHERE disabled_at IS NOT NULL)::bigint AS disabled,
     count(*) FILTER (WHERE disabled_at > now() - INTERVAL '7 days')::bigint AS disabled_last_7_days
@@ -276,11 +279,13 @@ FROM orgs
 `
 
 type AdminGetOrganizationStatsRow struct {
-	Total             int64
-	CreatedLast7Days  int64
-	TrialsEndingSoon  int64
-	Disabled          int64
-	DisabledLast7Days int64
+	Total                     int64
+	CreatedLast7Days          int64
+	Customers                 int64
+	CustomersCreatedLast7Days int64
+	TrialsEndingSoon          int64
+	Disabled                  int64
+	DisabledLast7Days         int64
 }
 
 // Blind to the list's filters by design: these figures must not move when an
@@ -290,12 +295,18 @@ type AdminGetOrganizationStatsRow struct {
 //
 // The join stays count-safe because organization_id is the trials primary key.
 // Both 7-day windows exclude their boundary: exactly seven days old is outside.
+//
+// A customer is an organization on a paid account type, payg or enterprise. The
+// pair is the same one the organizations service uses to tell a paying account
+// from the rest, and the customer figures count disabled customers too.
 func (q *Queries) AdminGetOrganizationStats(ctx context.Context) (AdminGetOrganizationStatsRow, error) {
 	row := q.db.QueryRow(ctx, adminGetOrganizationStats)
 	var i AdminGetOrganizationStatsRow
 	err := row.Scan(
 		&i.Total,
 		&i.CreatedLast7Days,
+		&i.Customers,
+		&i.CustomersCreatedLast7Days,
 		&i.TrialsEndingSoon,
 		&i.Disabled,
 		&i.DisabledLast7Days,


### PR DESCRIPTION
## Summary

The first cell of the admin `/organizations` stat strip counted every organization on the platform, which is mostly free sign-ups. It now counts **customers** — organizations on a `payg` or `enterprise` account type — and pressing it filters the list to those two types.

- **Server** — `organizations.stats` gains `customers` and `customers_created_last_7_days`. Both count disabled organizations too, like the existing figures. `total` and `created_last_7_days` are unchanged, so nothing else reading the payload breaks. The paid-type predicate is the same `('payg', 'enterprise')` pair the organizations service already uses.
- **Admin client** — the cell is relabelled "Customers", its sub-line is "N new this week" among customers, and its click applies `type=["payg","enterprise"]` plus both statuses (an absent status filter reads as active-only server-side, which would undercount versus the figure).
- **Rename** — the sidebar header and browser-tab title read "AI Control Plane Admin" instead of "AICP Admin".

## Testing

- Go: `TestGetOrganizationStats_*` extended — the corpus now carries account types so both new figures are pinned (disabled customers included, and a customer on the 7-day boundary). `go vet` and `gcl` (golangci-lint + glint) are clean. The Go suite itself needs testcontainers and Docker was wedged on my machine, so it is relying on CI here.
- Client: vitest 287/287 across the five admin suites that build a stats payload; `tsc`, oxlint, oxfmt clean. New tests assert the cell does not render `total`, and that the Type control reads "2 selected" after clicking.
- Regenerated Goa, `openapi3.yaml`, `.speakeasy/out.openapi.yaml`, and the admin sqlc package on top of current `main` with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfmQDqEPbfXoPkCZKzxx56