### PR TITLE
mig: add visibility to meta MCP servers

### DIFF
--- a/.changeset/meta-mcp-visibility-column.md
+++ b/.changeset/meta-mcp-visibility-column.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+---
+
+Adds a `visibility` column to `meta_mcp_servers`, mirroring `mcp_servers.visibility`, so a Gateway Endpoint can express whether it is disabled or requires an authenticated caller. Today a gateway has no such column, so the runtime infers that from whether an issuer happens to be attached — an overload that cannot represent a disabled gateway at all.
+
+Schema only: nothing reads the column yet, so behavior is unchanged. It defaults to `private`, the closed state.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4501,6 +4501,9 @@ CREATE TABLE IF NOT EXISTS meta_mcp_servers (
   user_session_issuer_id uuid,
 
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),
+  -- Values are validated in application code. Defaults to the closed state so
+  -- existing rows require an authenticated caller.
+  visibility TEXT NOT NULL DEFAULT 'private',
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1301,6 +1301,7 @@ type MetaMcpServer struct {
 	ProjectID           uuid.UUID
 	UserSessionIssuerID uuid.NullUUID
 	Name                string
+	Visibility          string
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/internal/metamcp/repo/models.go
+++ b/server/internal/metamcp/repo/models.go
@@ -15,6 +15,7 @@ type MetaMcpServer struct {
 	ProjectID           uuid.UUID
 	UserSessionIssuerID uuid.NullUUID
 	Name                string
+	Visibility          string
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -70,7 +70,7 @@ VALUES (
     $3,
     $4
 )
-RETURNING id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMetaMCPServerParams struct {
@@ -94,6 +94,7 @@ func (q *Queries) CreateMetaMCPServer(ctx context.Context, arg CreateMetaMCPServ
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -256,7 +257,7 @@ WHERE id = $1
   AND organization_id = $2
   AND project_id = $3
   AND deleted IS FALSE
-RETURNING id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMetaMCPServerParams struct {
@@ -274,6 +275,7 @@ func (q *Queries) DeleteMetaMCPServer(ctx context.Context, arg DeleteMetaMCPServ
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -313,7 +315,7 @@ func (q *Queries) GetMetaMCPMember(ctx context.Context, arg GetMetaMCPMemberPara
 }
 
 const getMetaMCPServer = `-- name: GetMetaMCPServer :one
-SELECT id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 FROM meta_mcp_servers
 WHERE id = $1
   AND organization_id = $2
@@ -336,6 +338,7 @@ func (q *Queries) GetMetaMCPServer(ctx context.Context, arg GetMetaMCPServerPara
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -345,7 +348,7 @@ func (q *Queries) GetMetaMCPServer(ctx context.Context, arg GetMetaMCPServerPara
 }
 
 const getMetaMCPServerByIDAndProjectID = `-- name: GetMetaMCPServerByIDAndProjectID :one
-SELECT id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 FROM meta_mcp_servers
 WHERE id = $1
   AND project_id = $2
@@ -369,6 +372,7 @@ func (q *Queries) GetMetaMCPServerByIDAndProjectID(ctx context.Context, arg GetM
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -437,7 +441,7 @@ func (q *Queries) ListMetaMCPMembers(ctx context.Context, arg ListMetaMCPMembers
 }
 
 const listMetaMCPServers = `-- name: ListMetaMCPServers :many
-SELECT id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 FROM meta_mcp_servers
 WHERE organization_id = $1
   AND project_id = $2
@@ -465,6 +469,7 @@ func (q *Queries) ListMetaMCPServers(ctx context.Context, arg ListMetaMCPServers
 			&i.ProjectID,
 			&i.UserSessionIssuerID,
 			&i.Name,
+			&i.Visibility,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -574,7 +579,7 @@ func (q *Queries) LockMetaMCPMember(ctx context.Context, arg LockMetaMCPMemberPa
 }
 
 const lockMetaMCPServer = `-- name: LockMetaMCPServer :one
-SELECT id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 FROM meta_mcp_servers
 WHERE id = $1
   AND organization_id = $2
@@ -598,6 +603,7 @@ func (q *Queries) LockMetaMCPServer(ctx context.Context, arg LockMetaMCPServerPa
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -672,7 +678,7 @@ WHERE id = $3
   AND organization_id = $4
   AND project_id = $5
   AND deleted IS FALSE
-RETURNING id, organization_id, project_id, user_session_issuer_id, name, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, user_session_issuer_id, name, visibility, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMetaMCPServerParams struct {
@@ -699,6 +705,7 @@ func (q *Queries) UpdateMetaMCPServer(ctx context.Context, arg UpdateMetaMCPServ
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Name,
+		&i.Visibility,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260824205231_add-meta-mcp-visibility.sql
+++ b/server/migrations/20260824205231_add-meta-mcp-visibility.sql
@@ -1,0 +1,2 @@
+-- Modify "meta_mcp_servers" table
+ALTER TABLE "meta_mcp_servers" ADD COLUMN "visibility" text NOT NULL DEFAULT 'private';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Z5VjnGQ7XMDbKMInWWdSnXijOBccmsXaWMKtiYfLq4U=
+h1:/Spjx2Q9GRxZDhQwSWGkJbOC6EaggiOlNyIph32//ic=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -361,3 +361,4 @@ h1:Z5VjnGQ7XMDbKMInWWdSnXijOBccmsXaWMKtiYfLq4U=
 20260820193631_user-session-client-asymmetric-auth.sql h1:gnmZD+REuCyrzSBVkS1Aw7mdaq+M794XwNu09qJUKLM=
 20260820223741_add-meta-mcp-servers.sql h1:IeASYht+IS0A2fUpejqgmnveRLsI/toU3TXQkk0eR0U=
 20260824101637_session-quarantines.sql h1:u9OuwdWdmTtmMQAKi87E16bPyf37dcYtyD8eVl8i+Ps=
+20260824205231_add-meta-mcp-visibility.sql h1:sNzUickcYBYZhyuODqZl5gQkHRg20UNRtul3fKxd+oE=


### PR DESCRIPTION
Adds `visibility` to `meta_mcp_servers`, mirroring `mcp_servers.visibility`. Schema only — nothing reads the column yet, so behavior is unchanged.

## Why

Every other MCP backend carries visibility, and the runtime reads it directly to decide whether a caller must authenticate: `NewResolvedMcpEndpointFromMcpServer` derives `IsPublic` from the column, and `authnchallenge_authorize.go:161` forces the IDP off the result. Gateways have no such column, so `NewResolvedMcpEndpointFromMetaMcpServer` infers the same flag from `UserSessionIssuerID` — its own comment says so.

That overload conflates two things the rest of the system keeps separate. For `mcp_servers` the issuer means _"an authorization server exists for this resource"_ — remote and tunneled servers carry one for their lifetime independent of visibility (see `mcp_servers_issuer_required_check`) — while visibility means _"must a caller authenticate."_ Because a gateway has only the issuer to go on, it cannot express a disabled state at all.

## Shape

`TEXT NOT NULL`, no `CHECK`. Allowed values are validated in application code, so the set can change without a migration and the schema does not encode an enum.

`DEFAULT 'private'` is the closed state. A migration cannot backfill (migrations are DDL-only here), so every existing row takes the default and requires an authenticated caller. That direction fails closed, and the table is effectively empty regardless — the feature is unreleased and flag-gated.

## Not included

The coherence constraint (`private` implies an issuer) is **deliberately deferred** to the service PR. Gateway creation does not attach an issuer today, so adding that constraint now would make every `metaMcp.create` fail the moment the column defaults to `private`. It lands alongside the create-path change that guarantees the invariant.

## Critical lines

- `server/database/schema.sql` — the column (this is the SDL; the migration is generated from it).
- `server/migrations/20260824205231_add-meta-mcp-visibility.sql` — one `ALTER TABLE`, generated by `mise db:diff`.
- `server/internal/metamcp/repo/queries.sql.go` — regenerated; the `SELECT *` queries now carry the column.

AGE-3299
