### PR TITLE
feat: add S-token calculator page to the admin dashboard

### DIFF
--- a/.changeset/admin-stoken-calculator.md
+++ b/.changeset/admin-stoken-calculator.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The admin dashboard gains an S-token calculator page, reachable from the sidebar. It converts provider-reported monthly token totals into a conservative s-token estimate range per provider and combined, with editable tokenizer assumptions and shareable URL state. Links copied from the standalone estimator restore the same worksheet.

--- a/client/admin/src/components/app-sidebar.tsx
+++ b/client/admin/src/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, JSX } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { BuildingIcon, FolderIcon } from "lucide-react";
+import { BuildingIcon, CalculatorIcon, FolderIcon } from "lucide-react";
 import { Link, useLocation, useMatchRoute } from "@tanstack/react-router";
 
 import { NavUser } from "@/components/nav-user";
@@ -24,6 +24,11 @@ import { organizationQuery } from "@/lib/adminQueries";
 const navItems = [
   { to: "/organizations", label: "Organizations", icon: BuildingIcon },
   { to: "/projects", label: "Projects", icon: FolderIcon },
+  {
+    to: "/stoken-calculator",
+    label: "S-token calculator",
+    icon: CalculatorIcon,
+  },
 ] as const;
 
 export function AppSidebar({

--- a/client/admin/src/lib/stoken/calculator.test.ts
+++ b/client/admin/src/lib/stoken/calculator.test.ts
@@ -30,6 +30,15 @@ describe("estimateSTokens", () => {
     });
   });
 
+  test("rejects a ratio small enough to overflow the division", () => {
+    // 1e-320 is a valid positive number, but P ÷ 2 ÷ min is Infinity.
+    expectError(
+      Number.MAX_SAFE_INTEGER,
+      { min: 1e-320, max: 1e-320 },
+      TOKENIZER_RANGE_ERROR,
+    );
+  });
+
   test("accepts zero provider usage", () => {
     expect(estimateSTokens(0, { min: 1, max: 1 })).toEqual({
       ok: true,

--- a/client/admin/src/lib/stoken/calculator.test.ts
+++ b/client/admin/src/lib/stoken/calculator.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import {
+  estimateSTokens,
+  sumEstimates,
+  type Estimate,
+  type TokenizerRange,
+} from "./calculator";
+
+const TOKEN_COUNT_ERROR =
+  "Enter a whole monthly token count from 0 to 9,007,199,254,740,991.";
+const TOKENIZER_RANGE_ERROR =
+  "Enter tokenizer ratios greater than 0, with minimum no greater than maximum.";
+
+function expectError(
+  providerTokens: number,
+  tokenizerRange: TokenizerRange,
+  error: string,
+): void {
+  expect(estimateSTokens(providerTokens, tokenizerRange)).toEqual({
+    ok: false,
+    error,
+  });
+}
+
+describe("estimateSTokens", () => {
+  test("calculates the conservative Anthropic scenario envelope", () => {
+    expect(estimateSTokens(120_000_000, { min: 1.2, max: 1.6 })).toEqual({
+      ok: true,
+      value: { low: 25_000_000, high: 50_000_000 },
+    });
+  });
+
+  test("accepts zero provider usage", () => {
+    expect(estimateSTokens(0, { min: 1, max: 1 })).toEqual({
+      ok: true,
+      value: { low: 0, high: 0 },
+    });
+  });
+
+  test.each([
+    -1,
+    0.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])("rejects invalid provider token count %p", (providerTokens) => {
+    expectError(providerTokens, { min: 1, max: 1 }, TOKEN_COUNT_ERROR);
+  });
+
+  test.each([
+    { min: 0, max: 1 },
+    { min: -1, max: 1 },
+    { min: 1, max: 0 },
+    { min: 1, max: -1 },
+    { min: Number.NaN, max: 1 },
+    { min: 1, max: Number.POSITIVE_INFINITY },
+    { min: 1.6, max: 1.2 },
+  ])("rejects invalid tokenizer range %o", (tokenizerRange) => {
+    expectError(1, tokenizerRange, TOKENIZER_RANGE_ERROR);
+  });
+});
+
+describe("sumEstimates", () => {
+  test("sums low and high endpoints independently", () => {
+    const anthropic = estimateSTokens(120_000_000, {
+      min: 1.2,
+      max: 1.6,
+    });
+    const openAI = estimateSTokens(100_000_000, { min: 1, max: 1 });
+
+    if (!anthropic.ok || !openAI.ok) {
+      throw new Error("Expected valid estimates");
+    }
+
+    const total = sumEstimates([anthropic.value, openAI.value]);
+    expect(total.low).toBeCloseTo(58_333_333.333, 3);
+    expect(total.high).toBe(100_000_000);
+  });
+
+  test("returns a zero envelope for no estimates", () => {
+    expect(sumEstimates([] as Estimate[])).toEqual({ low: 0, high: 0 });
+  });
+});

--- a/client/admin/src/lib/stoken/calculator.ts
+++ b/client/admin/src/lib/stoken/calculator.ts
@@ -1,0 +1,61 @@
+export type TokenizerRange = { min: number; max: number };
+
+export type Estimate = { low: number; high: number };
+
+export type EstimateResult =
+  | { ok: true; value: Estimate }
+  | { ok: false; error: string };
+
+export const HIDDEN_MULTIPLIERS = {
+  lowEstimate: 3,
+  highEstimate: 2,
+} as const;
+
+const TOKEN_COUNT_ERROR =
+  "Enter a whole monthly token count from 0 to 9,007,199,254,740,991.";
+const TOKENIZER_RANGE_ERROR =
+  "Enter tokenizer ratios greater than 0, with minimum no greater than maximum.";
+
+export function estimateSTokens(
+  providerTokens: number,
+  providerTokensPerSToken: TokenizerRange,
+): EstimateResult {
+  if (
+    !Number.isFinite(providerTokens) ||
+    !Number.isSafeInteger(providerTokens) ||
+    providerTokens < 0
+  ) {
+    return { ok: false, error: TOKEN_COUNT_ERROR };
+  }
+
+  const { min, max } = providerTokensPerSToken;
+  if (
+    !Number.isFinite(min) ||
+    !Number.isFinite(max) ||
+    min <= 0 ||
+    max <= 0 ||
+    min > max
+  ) {
+    return { ok: false, error: TOKENIZER_RANGE_ERROR };
+  }
+
+  return {
+    ok: true,
+    value: {
+      low: providerTokens / HIDDEN_MULTIPLIERS.lowEstimate / max,
+      high: providerTokens / HIDDEN_MULTIPLIERS.highEstimate / min,
+    },
+  };
+}
+
+export function sumEstimates(estimates: Estimate[]): Estimate {
+  let low = 0;
+  let high = 0;
+
+  for (const estimate of estimates) {
+    low += estimate.low;
+    high += estimate.high;
+  }
+
+  return { low, high };
+}

--- a/client/admin/src/lib/stoken/calculator.ts
+++ b/client/admin/src/lib/stoken/calculator.ts
@@ -39,13 +39,14 @@ export function estimateSTokens(
     return { ok: false, error: TOKENIZER_RANGE_ERROR };
   }
 
-  return {
-    ok: true,
-    value: {
-      low: providerTokens / HIDDEN_MULTIPLIERS.lowEstimate / max,
-      high: providerTokens / HIDDEN_MULTIPLIERS.highEstimate / min,
-    },
-  };
+  const low = providerTokens / HIDDEN_MULTIPLIERS.lowEstimate / max;
+  const high = providerTokens / HIDDEN_MULTIPLIERS.highEstimate / min;
+  // A ratio small enough to overflow the division is a ratio, not a range.
+  if (!Number.isFinite(low) || !Number.isFinite(high)) {
+    return { ok: false, error: TOKENIZER_RANGE_ERROR };
+  }
+
+  return { ok: true, value: { low, high } };
 }
 
 export function sumEstimates(estimates: Estimate[]): Estimate {

--- a/client/admin/src/lib/stoken/token-count.test.ts
+++ b/client/admin/src/lib/stoken/token-count.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { formatTokenCount, parseTokenCount } from "./token-count";
+
+describe("parseTokenCount", () => {
+  test.each([
+    ["0", 0],
+    ["120000000", 120_000_000],
+    ["120,000,000", 120_000_000],
+    ["120M", 120_000_000],
+    ["120 m", 120_000_000],
+    ["1.5B", 1_500_000_000],
+    [".5K", 500],
+    ["1.234K", 1_234],
+    ["+2T", 2_000_000_000_000],
+    ["9007.199254740991T", Number.MAX_SAFE_INTEGER],
+  ])("parses %s as %p tokens", (input, expected) => {
+    expect(parseTokenCount(input)).toEqual({ ok: true, value: expected });
+  });
+
+  test.each([
+    "",
+    " ",
+    "-1",
+    "1.2345K",
+    "1MM",
+    "1,00M",
+    "NaN",
+    "Infinity",
+    "9007.199254740992T",
+  ])("rejects invalid token count %p", (input) => {
+    const result = parseTokenCount(input);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("You can use K, M, B, or T.");
+    }
+  });
+});
+
+describe("formatTokenCount", () => {
+  test.each([
+    [0, "0"],
+    [999.4, "999"],
+    [1_000, "1K"],
+    [1_250, "1.3K"],
+    [999_950, "1M"],
+    [25_000_000, "25M"],
+    [58_333_333.333, "58.3M"],
+    [1_200_000_000, "1.2B"],
+    [2_000_000_000_000, "2T"],
+  ])("formats %p as %s", (value, expected) => {
+    expect(formatTokenCount(value)).toBe(expected);
+  });
+});

--- a/client/admin/src/lib/stoken/token-count.ts
+++ b/client/admin/src/lib/stoken/token-count.ts
@@ -1,0 +1,98 @@
+export type TokenCountParseResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+const TOKEN_COUNT_INPUT_ERROR =
+  "Enter a whole monthly token count from 0 to 9,007,199,254,740,991. You can use K, M, B, or T.";
+
+const SUFFIX_EXPONENTS: Record<string, number> = {
+  "": 0,
+  K: 3,
+  M: 6,
+  B: 9,
+  T: 12,
+};
+
+const TOKEN_COUNT_PATTERN =
+  /^([+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?|\.\d+))\s*([KMBT])?$/i;
+
+const DENOMINATIONS = [
+  { value: 1_000_000_000_000, suffix: "T" },
+  { value: 1_000_000_000, suffix: "B" },
+  { value: 1_000_000, suffix: "M" },
+  { value: 1_000, suffix: "K" },
+] as const;
+
+const compactNumberFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+});
+const integerFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+export function parseTokenCount(input: string): TokenCountParseResult {
+  const trimmed = input.trim();
+  if (trimmed.length === 0 || trimmed.length > 64) {
+    return { ok: false, error: TOKEN_COUNT_INPUT_ERROR };
+  }
+
+  const match = TOKEN_COUNT_PATTERN.exec(trimmed);
+  // The first group is not optional in the pattern, so a match always fills
+  // it; the guard is for the index type rather than for a real case.
+  if (!match || match[1] === undefined) {
+    return { ok: false, error: TOKEN_COUNT_INPUT_ERROR };
+  }
+
+  const numericPart = match[1].replaceAll(",", "");
+  if (numericPart.startsWith("-")) {
+    return { ok: false, error: TOKEN_COUNT_INPUT_ERROR };
+  }
+
+  const unsignedNumericPart = numericPart.startsWith("+")
+    ? numericPart.slice(1)
+    : numericPart;
+  const [wholePart = "", fractionPart = ""] = unsignedNumericPart.split(".");
+  const digits = `${wholePart || "0"}${fractionPart}`;
+  const suffix = (match[2] ?? "").toUpperCase();
+  const decimalShift = (SUFFIX_EXPONENTS[suffix] ?? 0) - fractionPart.length;
+  let tokenCount = BigInt(digits);
+
+  if (decimalShift >= 0) {
+    tokenCount *= 10n ** BigInt(decimalShift);
+  } else {
+    const divisor = 10n ** BigInt(-decimalShift);
+    if (tokenCount % divisor !== 0n) {
+      return { ok: false, error: TOKEN_COUNT_INPUT_ERROR };
+    }
+    tokenCount /= divisor;
+  }
+
+  if (tokenCount > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return { ok: false, error: TOKEN_COUNT_INPUT_ERROR };
+  }
+
+  return { ok: true, value: Number(tokenCount) };
+}
+
+export function formatTokenCount(tokenCount: number): string {
+  const roundedTokenCount = Math.round(tokenCount);
+
+  for (const [index, denomination] of DENOMINATIONS.entries()) {
+    if (roundedTokenCount < denomination.value) continue;
+
+    let scaled = roundedTokenCount / denomination.value;
+    let suffix: string = denomination.suffix;
+    const roundedScaled = Math.round(scaled * 10) / 10;
+
+    // 999.96M rounds to 1,000.0M, which reads better as 1B.
+    const largerDenomination = index > 0 ? DENOMINATIONS[index - 1] : undefined;
+    if (roundedScaled >= 1_000 && largerDenomination) {
+      scaled = roundedTokenCount / largerDenomination.value;
+      suffix = largerDenomination.suffix;
+    }
+
+    return `${compactNumberFormatter.format(scaled)}${suffix}`;
+  }
+
+  return integerFormatter.format(roundedTokenCount);
+}

--- a/client/admin/src/lib/stoken/url-state.test.ts
+++ b/client/admin/src/lib/stoken/url-state.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  DEFAULT_PROVIDER_ROWS,
+  decodeProviderRows,
+  encodeProviderRows,
+  rowsFromSearch,
+  searchFromRows,
+  stokenSearchSchema,
+  type ProviderRow,
+} from "./url-state";
+
+const SHARED_ROWS: ProviderRow[] = [
+  {
+    id: "row-1",
+    provider: "other",
+    customName: "Mistral 日本語",
+    providerTokens: "11M",
+    tokenizerMin: "1.10",
+    tokenizerMax: "1.10",
+  },
+  {
+    id: "row-2",
+    provider: "anthropic",
+    customName: "",
+    providerTokens: "120M",
+    tokenizerMin: "1.20",
+    tokenizerMax: "1.60",
+  },
+];
+
+function encodeRawJson(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+describe("provider row URL state", () => {
+  test("round-trips all row fields through UTF-8 Base64URL", () => {
+    const encoded = encodeProviderRows(SHARED_ROWS);
+
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(encoded).not.toContain("=");
+    expect(decodeProviderRows(encoded)).toEqual(SHARED_ROWS);
+  });
+
+  test.each(["", "a", "%5B%5D", "not+base64", "💥"])(
+    "rejects malformed encoded value %p",
+    (value) => {
+      expect(decodeProviderRows(value)).toBeNull();
+    },
+  );
+
+  test("rejects decoded JSON outside the provider-row contract", () => {
+    expect(
+      decodeProviderRows(encodeRawJson({ provider: "openai" })),
+    ).toBeNull();
+    expect(
+      decodeProviderRows(
+        encodeRawJson([
+          { ...SHARED_ROWS[0], id: "row-1" },
+          { ...SHARED_ROWS[1], id: "row-1" },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  test("preserves an explicitly empty worksheet", () => {
+    expect(decodeProviderRows(encodeProviderRows([]))).toEqual([]);
+  });
+});
+
+describe("stoken search schema", () => {
+  test("keeps a rows value that decodes and drops one that does not", () => {
+    const encoded = encodeProviderRows(SHARED_ROWS);
+
+    expect(stokenSearchSchema({ rows: encoded })).toEqual({ rows: encoded });
+    expect(stokenSearchSchema({ rows: "not+base64" })).toEqual({});
+    expect(stokenSearchSchema({ rows: 123 })).toEqual({});
+    expect(stokenSearchSchema({})).toEqual({});
+  });
+
+  test("reads the default worksheet from an absent param", () => {
+    expect(rowsFromSearch({})).toEqual(DEFAULT_PROVIDER_ROWS);
+    expect(rowsFromSearch({ rows: encodeProviderRows(SHARED_ROWS) })).toEqual(
+      SHARED_ROWS,
+    );
+  });
+
+  test("writes the default worksheet as no param at all", () => {
+    expect(searchFromRows(DEFAULT_PROVIDER_ROWS)).toEqual({});
+    expect(searchFromRows([...DEFAULT_PROVIDER_ROWS])).toEqual({});
+  });
+
+  test("writes any other worksheet, an empty one included", () => {
+    expect(searchFromRows(SHARED_ROWS)).toEqual({
+      rows: encodeProviderRows(SHARED_ROWS),
+    });
+    expect(searchFromRows([])).toEqual({ rows: encodeProviderRows([]) });
+  });
+
+  test("accepts a link written by the standalone estimator", () => {
+    // Captured from speakeasy-api/stoken-estimator: one Anthropic row at 120M.
+    const standalone =
+      "W3siaWQiOiJyb3ctMSIsInByb3ZpZGVyIjoiYW50aHJvcGljIiwiY3VzdG9tTmFtZSI6IiIsInByb3ZpZGVyVG9rZW5zIjoiMTIwTSIsInRva2VuaXplck1pbiI6IjEuMjAiLCJ0b2tlbml6ZXJNYXgiOiIxLjYwIn1d";
+
+    expect(rowsFromSearch(stokenSearchSchema({ rows: standalone }))).toEqual([
+      {
+        id: "row-1",
+        provider: "anthropic",
+        customName: "",
+        providerTokens: "120M",
+        tokenizerMin: "1.20",
+        tokenizerMax: "1.60",
+      },
+    ]);
+  });
+});

--- a/client/admin/src/lib/stoken/url-state.test.ts
+++ b/client/admin/src/lib/stoken/url-state.test.ts
@@ -69,6 +69,15 @@ describe("provider row URL state", () => {
     ).toBeNull();
   });
 
+  test.each(["toString", "constructor", "__proto__", "OpenAI"])(
+    "rejects a provider that is not one of the four keys: %p",
+    (provider) => {
+      expect(
+        decodeProviderRows(encodeRawJson([{ ...SHARED_ROWS[1], provider }])),
+      ).toBeNull();
+    },
+  );
+
   test("preserves an explicitly empty worksheet", () => {
     expect(decodeProviderRows(encodeProviderRows([]))).toEqual([]);
   });

--- a/client/admin/src/lib/stoken/url-state.ts
+++ b/client/admin/src/lib/stoken/url-state.ts
@@ -55,7 +55,9 @@ function validateProviderRows(value: unknown): ProviderRow[] | null {
       !ROW_ID_PATTERN.test(row["id"]) ||
       ids.has(row["id"]) ||
       typeof row["provider"] !== "string" ||
-      !(row["provider"] in PROVIDER_KEYS) ||
+      // Own keys only: `in` walks the prototype, so a crafted link naming
+      // "toString" or "constructor" would otherwise pass as a provider.
+      !Object.hasOwn(PROVIDER_KEYS, row["provider"]) ||
       typeof row["customName"] !== "string" ||
       typeof row["providerTokens"] !== "string" ||
       typeof row["tokenizerMin"] !== "string" ||

--- a/client/admin/src/lib/stoken/url-state.ts
+++ b/client/admin/src/lib/stoken/url-state.ts
@@ -1,0 +1,167 @@
+// The worksheet's URL state: provider rows encoded as unpadded UTF-8 Base64URL
+// in the `rows` search param. Ported from speakeasy-api/stoken-estimator with
+// the same wire format, so a link copied from the standalone estimator pastes
+// onto the admin route and restores the same worksheet.
+//
+// The nuqs parser the standalone app used is replaced by a search schema the
+// route's `validateSearch` runs, which is how every other admin list keeps its
+// state in the URL.
+
+export type ProviderKey = "openai" | "anthropic" | "gemini" | "other";
+
+export type ProviderRow = {
+  id: string;
+  provider: ProviderKey;
+  customName: string;
+  providerTokens: string;
+  tokenizerMin: string;
+  tokenizerMax: string;
+};
+
+export const DEFAULT_PROVIDER_ROWS: ProviderRow[] = [
+  {
+    id: "row-1",
+    provider: "openai",
+    customName: "",
+    providerTokens: "",
+    tokenizerMin: "1.00",
+    tokenizerMax: "1.00",
+  },
+];
+
+const PROVIDER_KEYS: Record<ProviderKey, true> = {
+  openai: true,
+  anthropic: true,
+  gemini: true,
+  other: true,
+};
+const ROW_ID_PATTERN = /^row-\d+$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+function validateProviderRows(value: unknown): ProviderRow[] | null {
+  if (!Array.isArray(value)) return null;
+
+  const rows: ProviderRow[] = [];
+  const ids = new Set<string>();
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== "object") return null;
+
+    const row = candidate as Record<string, unknown>;
+    if (
+      typeof row["id"] !== "string" ||
+      row["id"].length > 32 ||
+      !ROW_ID_PATTERN.test(row["id"]) ||
+      ids.has(row["id"]) ||
+      typeof row["provider"] !== "string" ||
+      !(row["provider"] in PROVIDER_KEYS) ||
+      typeof row["customName"] !== "string" ||
+      typeof row["providerTokens"] !== "string" ||
+      typeof row["tokenizerMin"] !== "string" ||
+      typeof row["tokenizerMax"] !== "string"
+    ) {
+      return null;
+    }
+
+    ids.add(row["id"]);
+    rows.push({
+      id: row["id"],
+      provider: row["provider"] as ProviderKey,
+      customName: row["customName"],
+      providerTokens: row["providerTokens"],
+      tokenizerMin: row["tokenizerMin"],
+      tokenizerMax: row["tokenizerMax"],
+    });
+  }
+
+  return rows;
+}
+
+function providerRowsEqual(left: ProviderRow[], right: ProviderRow[]): boolean {
+  if (left.length !== right.length) return false;
+
+  return left.every((row, index) => {
+    const other = right[index];
+    return (
+      other !== undefined &&
+      row.id === other.id &&
+      row.provider === other.provider &&
+      row.customName === other.customName &&
+      row.providerTokens === other.providerTokens &&
+      row.tokenizerMin === other.tokenizerMin &&
+      row.tokenizerMax === other.tokenizerMax
+    );
+  });
+}
+
+export function encodeProviderRows(rows: ProviderRow[]): string {
+  const bytes = textEncoder.encode(JSON.stringify(rows));
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+export function decodeProviderRows(value: string): ProviderRow[] | null {
+  if (!BASE64URL_PATTERN.test(value) || value.length % 4 === 1) return null;
+
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const paddedBase64 = base64.padEnd(
+      base64.length + ((4 - (base64.length % 4)) % 4),
+      "=",
+    );
+    const binary = atob(paddedBase64);
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0),
+    );
+    return validateProviderRows(JSON.parse(textDecoder.decode(bytes)));
+  } catch {
+    return null;
+  }
+}
+
+/** The one search param the calculator keeps. Absent means the default row. */
+export type StokenSearch = {
+  rows?: string;
+};
+
+/**
+ * Reads the `rows` param the way the standalone estimator's parser did: a
+ * value that does not decode to valid rows is treated as absent, so a mangled
+ * link opens the default worksheet rather than a broken one. The param is kept
+ * encoded here and decoded by the page, so the URL never carries a value a
+ * reload would refuse.
+ */
+export function stokenSearchSchema(
+  search: Record<string, unknown>,
+): StokenSearch {
+  const value = search["rows"];
+  if (typeof value !== "string" || decodeProviderRows(value) === null) {
+    return {};
+  }
+  return { rows: value };
+}
+
+/** The rows a validated search holds; the default row when it holds none. */
+export function rowsFromSearch(search: StokenSearch): ProviderRow[] {
+  const rows =
+    search.rows === undefined ? null : decodeProviderRows(search.rows);
+  return rows ?? DEFAULT_PROVIDER_ROWS;
+}
+
+/**
+ * What the URL should say for a set of rows. The default worksheet is written
+ * as no param at all, so a link only carries what the operator changed. An
+ * explicitly empty worksheet is not the default, and is kept.
+ */
+export function searchFromRows(rows: ProviderRow[]): StokenSearch {
+  if (providerRowsEqual(rows, DEFAULT_PROVIDER_ROWS)) return {};
+  return { rows: encodeProviderRows(rows) };
+}

--- a/client/admin/src/pages/stoken/StokenCalculator.test.tsx
+++ b/client/admin/src/pages/stoken/StokenCalculator.test.tsx
@@ -1,0 +1,234 @@
+import type { AnyRouter } from "@tanstack/react-router";
+import {
+  cleanup,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  decodeProviderRows,
+  encodeProviderRows,
+  type ProviderRow,
+} from "@/lib/stoken/url-state";
+import { routeTree } from "@/routeTree.gen";
+import { renderRouteTree } from "@/test/harness";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+// The layout's user menu is the only request this page's frame makes.
+vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
+  return { ...actual, getSession: mocks.getSession };
+});
+
+// The row every fresh worksheet opens on, spelled out so a change to the
+// default is a change to this file too.
+const OPENAI_ROW: ProviderRow = {
+  id: "row-1",
+  provider: "openai",
+  customName: "",
+  providerTokens: "",
+  tokenizerMin: "1.00",
+  tokenizerMax: "1.00",
+};
+
+// The worked example the method notes quote: 120M at R = 1.20–1.60 is
+// 25M–50M s-tokens, which makes the figures on screen checkable by hand.
+const ANTHROPIC_ROW: ProviderRow = {
+  id: "row-1",
+  provider: "anthropic",
+  customName: "",
+  providerTokens: "120M",
+  tokenizerMin: "1.20",
+  tokenizerMax: "1.60",
+};
+
+function currentRows(router: AnyRouter): ProviderRow[] | null {
+  const rows = new URLSearchParams(router.state.location.searchStr).get("rows");
+  return rows === null ? null : decodeProviderRows(rows);
+}
+
+function tokensInput(rowId = "row-1"): HTMLInputElement {
+  return document.getElementById(`${rowId}-tokens`) as HTMLInputElement;
+}
+
+function resultPanel(): HTMLElement {
+  return screen.getByRole("complementary", { name: "Monthly s-token range" });
+}
+
+async function renderCalculator(search = ""): Promise<AnyRouter> {
+  const { router } = await renderRouteTree(routeTree, {
+    initialPath: `/stoken-calculator${search}`,
+  });
+  await screen.findByRole("heading", { name: "Monthly usage" });
+  return router;
+}
+
+beforeEach(() => {
+  mocks.getSession.mockReset();
+  mocks.getSession.mockResolvedValue({
+    email: "ops@example.test",
+    name: "Ops",
+  });
+});
+
+afterEach(cleanup);
+
+describe("stoken calculator route", () => {
+  it("is reachable from the sidebar", async () => {
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/projects",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "S-token calculator" }));
+
+    await screen.findByRole("heading", { name: "Monthly usage" });
+    expect(router.state.location.pathname).toBe("/stoken-calculator");
+  });
+
+  it("names itself in the breadcrumb", async () => {
+    await renderCalculator();
+
+    expect(
+      screen.getByRole("navigation", { name: "breadcrumb" }).textContent,
+    ).toBe("S-token calculator");
+  });
+
+  it("opens on the default worksheet with nothing in the URL", async () => {
+    const router = await renderCalculator();
+
+    expect(currentRows(router)).toBeNull();
+    expect(tokensInput().value).toBe("");
+    expect(resultPanel().textContent).toContain(
+      "Add provider usage to estimate s-tokens.",
+    );
+  });
+
+  it("restores a worksheet from a link the standalone estimator wrote", async () => {
+    await renderCalculator(`?rows=${encodeProviderRows([ANTHROPIC_ROW])}`);
+
+    expect(tokensInput().value).toBe("120M");
+    expect(screen.getByRole("combobox").textContent).toBe("Anthropic");
+    // Low = 120M ÷ 3 ÷ 1.60 = 25M; high = 120M ÷ 2 ÷ 1.20 = 50M.
+    expect(within(resultPanel()).getByText("25M–50M")).toBeTruthy();
+  });
+
+  it("falls back to the default worksheet for a link that does not decode", async () => {
+    const router = await renderCalculator("?rows=not+base64");
+
+    expect(currentRows(router)).toBeNull();
+    expect(tokensInput().value).toBe("");
+  });
+});
+
+describe("stoken calculator worksheet", () => {
+  it("writes a typed total to the URL and shows its range", async () => {
+    const router = await renderCalculator();
+
+    fireEvent.change(tokensInput(), { target: { value: "120M" } });
+
+    await waitFor(() => {
+      expect(currentRows(router)).toEqual([
+        { ...OPENAI_ROW, providerTokens: "120M" },
+      ]);
+    });
+    // OpenAI's preset is 1.00–1.00: low = 120M ÷ 3 = 40M, high = 120M ÷ 2 = 60M.
+    expect(within(resultPanel()).getByText("40M–60M")).toBeTruthy();
+    expect(tokensInput().value).toBe("120M");
+  });
+
+  it("replaces history rather than pushing an entry per keystroke", async () => {
+    const router = await renderCalculator();
+    const before = router.history.length;
+
+    fireEvent.change(tokensInput(), { target: { value: "1" } });
+    fireEvent.change(tokensInput(), { target: { value: "12" } });
+    await waitFor(() => {
+      expect(tokensInput().value).toBe("12");
+    });
+
+    expect(router.history.length).toBe(before);
+  });
+
+  it("adds a provider row and moves focus to its picker", async () => {
+    const router = await renderCalculator();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add provider" }));
+
+    await waitFor(() => {
+      expect(currentRows(router)?.map((row) => row.id)).toEqual([
+        "row-1",
+        "row-2",
+      ]);
+    });
+    expect(document.activeElement?.id).toBe("row-2-provider");
+  });
+
+  it("removes a row and writes an explicitly empty worksheet", async () => {
+    const router = await renderCalculator();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove OpenAI provider row 1" }),
+    );
+
+    await waitFor(() => {
+      expect(currentRows(router)).toEqual([]);
+    });
+    expect(
+      screen.getByText("No provider rows. Add provider usage to continue."),
+    ).toBeTruthy();
+    expect(document.activeElement?.id).toBe("add-provider");
+  });
+
+  it("applies the preset when the provider changes", async () => {
+    const router = await renderCalculator();
+
+    const select = screen.getByRole("combobox");
+    fireEvent.keyDown(select, { key: "ArrowDown" });
+    fireEvent.click(await screen.findByRole("option", { name: "Anthropic" }));
+
+    await waitFor(() => {
+      expect(currentRows(router)?.[0]).toMatchObject({
+        provider: "anthropic",
+        tokenizerMin: "1.20",
+        tokenizerMax: "1.60",
+      });
+    });
+    expect(screen.getByText("Tokenizer assumption · 1.20–1.60")).toBeTruthy();
+  });
+
+  it("flags a total it cannot parse and counts it as needing attention", async () => {
+    await renderCalculator();
+
+    fireEvent.change(tokensInput(), { target: { value: "twelve" } });
+
+    await waitFor(() => {
+      expect(tokensInput().getAttribute("aria-invalid")).toBe("true");
+    });
+    expect(
+      screen
+        .getByText(/Enter a whole monthly token count/)
+        .hasAttribute("hidden"),
+    ).toBe(false);
+    expect(resultPanel().textContent).toContain("1 row needs attention");
+  });
+
+  it("sums the rows into the combined envelope", async () => {
+    await renderCalculator(
+      `?rows=${encodeProviderRows([
+        ANTHROPIC_ROW,
+        { ...OPENAI_ROW, id: "row-2", providerTokens: "120M" },
+      ])}`,
+    );
+
+    // 25M–50M from the Anthropic row plus 40M–60M from the OpenAI one.
+    expect(within(resultPanel()).getByText("65M–110M")).toBeTruthy();
+    expect(resultPanel().textContent).toContain("Low 65M");
+    expect(resultPanel().textContent).toContain("High 110M");
+  });
+});

--- a/client/admin/src/pages/stoken/StokenCalculator.tsx
+++ b/client/admin/src/pages/stoken/StokenCalculator.tsx
@@ -1,0 +1,711 @@
+import { useEffect, useRef, type CSSProperties, type JSX } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  estimateSTokens,
+  sumEstimates,
+  type Estimate,
+} from "@/lib/stoken/calculator";
+import { formatTokenCount, parseTokenCount } from "@/lib/stoken/token-count";
+import {
+  rowsFromSearch,
+  searchFromRows,
+  type ProviderKey,
+  type ProviderRow,
+} from "@/lib/stoken/url-state";
+
+// Ported from speakeasy-api/stoken-estimator. The methodology, the presets,
+// and the copy are that worksheet's; the markup is rebuilt on the admin's
+// primitives so it reads as one app next to the organizations list.
+
+const ROUTE_ID = "/stoken-calculator";
+
+type ProviderPreset = {
+  label: string;
+  tokenizerMin: string;
+  tokenizerMax: string;
+};
+
+// Presets are editable business assumptions, not vendor facts: picking a
+// provider writes them into the row, and the operator can change them there.
+const PROVIDER_PRESETS: Record<ProviderKey, ProviderPreset> = {
+  openai: { label: "OpenAI", tokenizerMin: "1.00", tokenizerMax: "1.00" },
+  anthropic: {
+    label: "Anthropic",
+    tokenizerMin: "1.20",
+    tokenizerMax: "1.60",
+  },
+  gemini: {
+    label: "Google Gemini",
+    tokenizerMin: "1.00",
+    tokenizerMax: "1.00",
+  },
+  other: { label: "Other", tokenizerMin: "1.00", tokenizerMax: "1.00" },
+};
+
+// The picker's order. `other` last, because it is the one that asks for more.
+const PROVIDER_KEYS: ProviderKey[] = ["openai", "anthropic", "gemini", "other"];
+
+const integerFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+// Which of the two errors `estimateSTokens` reports, told apart by prefix: the
+// calculator has one message per field and the row shows each under its own.
+const TOKEN_COUNT_ERROR_PREFIX = "Enter a whole monthly token count";
+
+type RowCalculation = {
+  estimate: Estimate | null;
+  tokenError: string | null;
+  tokenizerError: string | null;
+};
+
+const EMPTY_CALCULATION: RowCalculation = {
+  estimate: null,
+  tokenError: null,
+  tokenizerError: null,
+};
+
+function createProviderRow(rows: ProviderRow[]): ProviderRow {
+  const ids = new Set(rows.map((row) => row.id));
+  let nextId = 1;
+  while (ids.has(`row-${nextId}`)) nextId += 1;
+
+  const preset = PROVIDER_PRESETS.openai;
+  return {
+    id: `row-${nextId}`,
+    provider: "openai",
+    customName: "",
+    providerTokens: "",
+    tokenizerMin: preset.tokenizerMin,
+    tokenizerMax: preset.tokenizerMax,
+  };
+}
+
+function providerName(row: ProviderRow): string {
+  if (row.provider === "other" && row.customName.trim()) {
+    return row.customName.trim();
+  }
+  return PROVIDER_PRESETS[row.provider].label;
+}
+
+function formatRange(estimate: Estimate): string {
+  return `${formatTokenCount(estimate.low)}–${formatTokenCount(estimate.high)}`;
+}
+
+function formatExactRange(estimate: Estimate): string {
+  return `${integerFormatter.format(estimate.low)}–${integerFormatter.format(estimate.high)}`;
+}
+
+function calculateProviderRow(row: ProviderRow): RowCalculation {
+  if (row.providerTokens.trim() === "") return EMPTY_CALCULATION;
+
+  const parsed = parseTokenCount(row.providerTokens);
+  if (!parsed.ok) {
+    return { ...EMPTY_CALCULATION, tokenError: parsed.error };
+  }
+
+  const result = estimateSTokens(parsed.value, {
+    min: Number(row.tokenizerMin),
+    max: Number(row.tokenizerMax),
+  });
+  if (!result.ok) {
+    return result.error.startsWith(TOKEN_COUNT_ERROR_PREFIX)
+      ? { ...EMPTY_CALCULATION, tokenError: result.error }
+      : { ...EMPTY_CALCULATION, tokenizerError: result.error };
+  }
+
+  return { ...EMPTY_CALCULATION, estimate: result.value };
+}
+
+// The small caps heading each panel opens with, the same in all three.
+function SectionIndex({ children }: { children: string }): JSX.Element {
+  return (
+    <p className="text-primary text-xs font-semibold tracking-wider uppercase">
+      {children}
+    </p>
+  );
+}
+
+type ProviderRowEditorProps = {
+  row: ProviderRow;
+  index: number;
+  calculation: RowCalculation;
+  onChange: (id: string, patch: Partial<ProviderRow>) => void;
+  onRemove: (id: string) => void;
+};
+
+function ProviderRowEditor({
+  row,
+  index,
+  calculation,
+  onChange,
+  onRemove,
+}: ProviderRowEditorProps): JSX.Element {
+  const tokenInputId = `${row.id}-tokens`;
+  const tokenHelperId = `${row.id}-tokens-helper`;
+  const tokenErrorId = `${row.id}-tokens-error`;
+  const customNameId = `${row.id}-custom-name`;
+  const tokenizerMinId = `${row.id}-tokenizer-min`;
+  const tokenizerMaxId = `${row.id}-tokenizer-max`;
+  const tokenizerErrorId = `${row.id}-tokenizer-error`;
+  const providerSelectId = `${row.id}-provider`;
+  const name = providerName(row);
+  const exactRange = calculation.estimate
+    ? formatExactRange(calculation.estimate)
+    : null;
+  const min = Number(row.tokenizerMin);
+  const max = Number(row.tokenizerMax);
+  const minInvalid =
+    Boolean(calculation.tokenizerError) &&
+    (!Number.isFinite(min) || min <= 0 || (Number.isFinite(max) && min > max));
+  const maxInvalid =
+    Boolean(calculation.tokenizerError) &&
+    (!Number.isFinite(max) || max <= 0 || (Number.isFinite(min) && min > max));
+
+  return (
+    <fieldset className="space-y-3 border-t px-4 py-4">
+      <legend className="sr-only">
+        Provider {index + 1}: {name}
+      </legend>
+
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,1fr)_auto] md:items-start">
+        <div className="space-y-1.5">
+          <label htmlFor={providerSelectId} className="text-sm font-medium">
+            Provider
+          </label>
+          <Select
+            value={row.provider}
+            onValueChange={(value) => {
+              const provider = value as ProviderKey;
+              const preset = PROVIDER_PRESETS[provider];
+              onChange(row.id, {
+                provider,
+                tokenizerMin: preset.tokenizerMin,
+                tokenizerMax: preset.tokenizerMax,
+              });
+            }}
+          >
+            <SelectTrigger id={providerSelectId} className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PROVIDER_KEYS.map((key) => (
+                <SelectItem key={key} value={key}>
+                  {PROVIDER_PRESETS[key].label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {row.provider === "other" ? (
+            <div className="space-y-1.5 pt-1">
+              <label htmlFor={customNameId} className="text-sm font-medium">
+                Provider name
+              </label>
+              <Input
+                id={customNameId}
+                type="text"
+                autoComplete="off"
+                value={row.customName}
+                onChange={(event) =>
+                  onChange(row.id, { customName: event.target.value })
+                }
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor={tokenInputId} className="text-sm font-medium">
+            All-in monthly provider tokens
+          </label>
+          <Input
+            id={tokenInputId}
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            autoCapitalize="characters"
+            spellCheck={false}
+            placeholder="120M"
+            aria-describedby={`${tokenHelperId} ${tokenErrorId}`}
+            aria-invalid={Boolean(calculation.tokenError)}
+            value={row.providerTokens}
+            onChange={(event) =>
+              onChange(row.id, { providerTokens: event.target.value })
+            }
+          />
+          <p id={tokenHelperId} className="sr-only">
+            Enter an exact count or use K, M, B, or T (for example, 120M or
+            1.5B). Use raw input + output token counts, not spend or
+            cache-discount-weighted billing units. Do not add reasoning or
+            cached-token breakdowns to a total that already includes them.
+          </p>
+          <p
+            id={tokenErrorId}
+            className="text-destructive text-xs"
+            hidden={!calculation.tokenError}
+          >
+            {calculation.tokenError}
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="block text-sm font-medium">
+            Estimated s-token range
+          </span>
+          <output
+            className="block py-2 text-base font-semibold tabular-nums"
+            title={exactRange ? `${exactRange} s-tokens` : undefined}
+            aria-label={
+              exactRange ? `${exactRange} estimated s-tokens` : undefined
+            }
+          >
+            {calculation.estimate ? formatRange(calculation.estimate) : "—"}
+          </output>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-destructive md:mt-6"
+          aria-label={`Remove ${name} provider row ${index + 1}`}
+          onClick={() => onRemove(row.id)}
+        >
+          <Trash2Icon />
+        </Button>
+      </div>
+
+      <details className="group rounded-md border">
+        <summary className="text-primary cursor-pointer list-none px-3 py-2 text-xs font-semibold select-none">
+          Tokenizer assumption · {row.tokenizerMin || "—"}–
+          {row.tokenizerMax || "—"}
+        </summary>
+        <div className="space-y-3 border-t px-3 py-3">
+          <p className="text-muted-foreground text-xs">
+            Editable business assumption, not a vendor fact. Higher ratios
+            produce fewer s-tokens. The minimum ratio sets the high end; the
+            maximum ratio sets the low end.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <label htmlFor={tokenizerMinId} className="text-sm font-medium">
+                Minimum provider tokens per 1 s-token
+              </label>
+              <Input
+                id={tokenizerMinId}
+                type="number"
+                min="0.01"
+                step="0.01"
+                inputMode="decimal"
+                aria-describedby={tokenizerErrorId}
+                aria-invalid={minInvalid}
+                value={row.tokenizerMin}
+                onChange={(event) =>
+                  onChange(row.id, { tokenizerMin: event.target.value })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor={tokenizerMaxId} className="text-sm font-medium">
+                Maximum provider tokens per 1 s-token
+              </label>
+              <Input
+                id={tokenizerMaxId}
+                type="number"
+                min="0.01"
+                step="0.01"
+                inputMode="decimal"
+                aria-describedby={tokenizerErrorId}
+                aria-invalid={maxInvalid}
+                value={row.tokenizerMax}
+                onChange={(event) =>
+                  onChange(row.id, { tokenizerMax: event.target.value })
+                }
+              />
+            </div>
+          </div>
+          <p
+            id={tokenizerErrorId}
+            className="text-destructive text-xs"
+            hidden={!calculation.tokenizerError}
+          >
+            {calculation.tokenizerError}
+          </p>
+        </div>
+      </details>
+    </fieldset>
+  );
+}
+
+type ResultPanelProps = {
+  total: Estimate;
+  validRowCount: number;
+  attentionCount: number;
+};
+
+function ResultPanel({
+  total,
+  validRowCount,
+  attentionCount,
+}: ResultPanelProps): JSX.Element {
+  const attentionText = `${attentionCount} ${attentionCount === 1 ? "row needs" : "rows need"} attention`;
+  const hasValidRows = validRowCount > 0;
+  const exactRange = formatExactRange(total);
+  const low = formatTokenCount(total.low);
+  const high = formatTokenCount(total.high);
+  const exactLow = integerFormatter.format(total.low);
+  const exactHigh = integerFormatter.format(total.high);
+  const lowPosition = total.high === 0 ? 0 : (total.low / total.high) * 100;
+  const accessibleRange = `Low ${exactLow} s-tokens; high ${exactHigh} s-tokens`;
+  const railStyle = { "--low-position": `${lowPosition}%` } as CSSProperties;
+  const liveText = hasValidRows
+    ? `${accessibleRange}. ${validRowCount} valid provider ${validRowCount === 1 ? "row" : "rows"}.${attentionCount ? ` ${attentionText}.` : ""}`
+    : attentionCount
+      ? `No usable provider rows. ${attentionText}.`
+      : "Add provider usage to estimate s-tokens.";
+
+  return (
+    <aside
+      className="h-fit rounded-lg border px-4 py-4"
+      aria-labelledby="result-heading"
+    >
+      <div className="border-b pb-3">
+        <SectionIndex>Combined envelope</SectionIndex>
+        <h2 id="result-heading" className="text-lg font-semibold">
+          Monthly s-token range
+        </h2>
+      </div>
+
+      {hasValidRows ? (
+        <div className="space-y-4 pt-4">
+          <output
+            className="block text-3xl font-semibold tabular-nums"
+            title={`${exactRange} s-tokens`}
+            aria-label={`${exactRange} s-tokens`}
+          >
+            {formatRange(total)}
+          </output>
+
+          {/* The rail: the low end sits at low/high along the track and the
+              high end at the right edge, so the width of the fill is how
+              wide the envelope is. */}
+          <div
+            role="img"
+            aria-label={accessibleRange}
+            title={accessibleRange}
+            style={railStyle}
+            className="space-y-2"
+          >
+            <div
+              className="bg-muted relative h-2 rounded-full"
+              aria-hidden="true"
+            >
+              <span className="bg-primary/60 absolute inset-y-0 right-0 left-(--low-position) rounded-full" />
+              <span className="bg-primary absolute top-1/2 left-(--low-position) size-3 -translate-x-1/2 -translate-y-1/2 rounded-full" />
+              <span className="bg-primary absolute top-1/2 right-0 size-3 translate-x-1/2 -translate-y-1/2 rounded-full" />
+            </div>
+            <div
+              className="text-muted-foreground flex justify-between text-xs"
+              aria-hidden="true"
+            >
+              <span>Low {low}</span>
+              <span>High {high}</span>
+            </div>
+          </div>
+
+          <dl className="space-y-2 text-sm">
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-muted-foreground">
+                Low · 3× hidden · max tokenizer
+              </dt>
+              <dd
+                className="font-medium tabular-nums"
+                title={`${exactLow} s-tokens`}
+                aria-label={`${exactLow} s-tokens`}
+              >
+                {low}
+              </dd>
+            </div>
+            <div className="flex items-baseline justify-between gap-3">
+              <dt className="text-muted-foreground">
+                High · 2× hidden · min tokenizer
+              </dt>
+              <dd
+                className="font-medium tabular-nums"
+                title={`${exactHigh} s-tokens`}
+                aria-label={`${exactHigh} s-tokens`}
+              >
+                {high}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <p className="text-muted-foreground pt-4 text-sm">
+          Add provider usage to estimate s-tokens.
+        </p>
+      )}
+
+      <p
+        className="text-destructive pt-3 text-xs"
+        hidden={attentionCount === 0}
+      >
+        {attentionCount === 0 ? "" : attentionText}
+      </p>
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveText}
+      </p>
+    </aside>
+  );
+}
+
+function MethodSection(): JSX.Element {
+  return (
+    <section
+      className="space-y-4 rounded-lg border px-4 py-4"
+      aria-labelledby="method-heading"
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] lg:items-start">
+        <div className="space-y-1">
+          <SectionIndex>Method notes</SectionIndex>
+          <h2 id="method-heading" className="text-lg font-semibold">
+            How this estimate works
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Start with <strong>P</strong>, the prospect’s all-in monthly
+            provider total. Both adjustments divide; provider-counted components
+            already included in P are never added again.
+          </p>
+        </div>
+
+        <div
+          className="grid gap-3 sm:grid-cols-2"
+          aria-label="S-token endpoint equations"
+        >
+          <div className="space-y-2 rounded-md border px-3 py-3">
+            <SectionIndex>Low endpoint</SectionIndex>
+            <code className="block font-mono text-sm">
+              S<sub>low</sub> = P ÷ 3 ÷ R<sub>max</sub>
+            </code>
+          </div>
+          <div className="space-y-2 rounded-md border px-3 py-3">
+            <SectionIndex>High endpoint</SectionIndex>
+            <code className="block font-mono text-sm">
+              S<sub>high</sub> = P ÷ 2 ÷ R<sub>min</sub>
+            </code>
+          </div>
+        </div>
+      </div>
+
+      <div className="text-muted-foreground grid gap-3 border-t pt-4 text-sm md:grid-cols-2">
+        <p>
+          <strong className="text-foreground">Hidden-content divisor H.</strong>{" "}
+          Dividing by 2–3 removes hidden reasoning, system, compaction, and
+          other provider-counted content that is not scanned.
+        </p>
+        <p>
+          <strong className="text-foreground">Tokenizer divisor R.</strong>{" "}
+          Dividing by a ratio above 1 removes the provider tokenizer’s extra
+          tokens for the same visible workload measured with{" "}
+          <code className="font-mono">o200k_base</code>.
+        </p>
+      </div>
+
+      <p className="flex flex-wrap items-baseline gap-3 border-t pt-4 text-sm">
+        <SectionIndex>Anthropic example</SectionIndex>
+        <code className="font-mono">
+          120M provider tokens at R = 1.20–1.60 → 25M–50M s-tokens.
+        </code>
+      </p>
+
+      <p className="border-t pt-4 text-sm font-medium">
+        Quote estimate, not measured usage. This band combines the outer
+        hidden-content and tokenizer scenarios; it is not a statistical
+        confidence interval and has no implied midpoint. Actual conversion
+        varies by model, tokenizer version, language, and workload.
+      </p>
+
+      <details className="border-t pt-4">
+        <summary className="cursor-pointer text-sm font-semibold select-none">
+          How to calibrate the assumptions
+        </summary>
+        <div className="text-muted-foreground space-y-3 pt-3 text-sm">
+          <p>
+            Match the exact payload occurrences sent to the scanner over the
+            same representative time window and model/workload mix. Use ratios
+            of sums, not averages of per-message or per-session ratios. The
+            worksheet reports a combined scenario envelope, not a statistical
+            confidence interval.
+          </p>
+          <code className="block font-mono text-xs">
+            H<sub>calibrated</sub> = Σ all-in provider tokens ÷ Σ provider-token
+            count of scanner payloads
+          </code>
+          <code className="block font-mono text-xs">
+            R<sub>calibrated</sub> = Σ provider-token count of those scanner
+            payloads ÷ Σ o200k_base count of those same payloads
+          </code>
+          <p>
+            Keep H and R separate only when H was measured in provider-token
+            units. If telemetry provides provider total P and directly measured
+            s-tokens S, use the combined factor C = P ÷ S and S = P ÷ C. That
+            direct P / S factor replaces—rather than compounds with—the
+            tokenizer ratio; dividing by R again would double-correct tokenizer
+            differences.
+          </p>
+        </div>
+      </details>
+    </section>
+  );
+}
+
+/** A worksheet turning provider-reported monthly usage into an s-token range. */
+export function StokenCalculator(): JSX.Element {
+  const search = useSearch({ from: ROUTE_ID });
+  const navigate = useNavigate({ from: ROUTE_ID });
+  const rows = rowsFromSearch(search);
+  const pendingFocusId = useRef<string | null>(null);
+
+  // Adding or removing a row moves focus to the row that took its place, and
+  // the element does not exist until the URL change has rendered.
+  useEffect(() => {
+    if (!pendingFocusId.current) return;
+    document.getElementById(pendingFocusId.current)?.focus();
+    pendingFocusId.current = null;
+  }, [rows]);
+
+  const calculations = rows.map(calculateProviderRow);
+  const estimates: Estimate[] = [];
+  let attentionCount = 0;
+  for (const [index, calculation] of calculations.entries()) {
+    if (calculation.estimate) {
+      estimates.push(calculation.estimate);
+    } else if (rows[index]?.providerTokens.trim() !== "") {
+      attentionCount += 1;
+    }
+  }
+  const total = sumEstimates(estimates);
+
+  // Replaced, not pushed: every keystroke writes the URL, and Back should
+  // leave the calculator rather than undo one character.
+  function setRows(next: ProviderRow[]): void {
+    void navigate({ search: searchFromRows(next), replace: true });
+  }
+
+  function updateRow(id: string, patch: Partial<ProviderRow>): void {
+    setRows(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+  }
+
+  function addProvider(): void {
+    const row = createProviderRow(rows);
+    pendingFocusId.current = `${row.id}-provider`;
+    setRows([...rows, row]);
+  }
+
+  function removeProvider(id: string): void {
+    const index = rows.findIndex((row) => row.id === id);
+    if (index === -1) return;
+
+    const remaining = rows.filter((row) => row.id !== id);
+    const nextRow = remaining[Math.min(index, remaining.length - 1)];
+    pendingFocusId.current = nextRow
+      ? `${nextRow.id}-provider`
+      : "add-provider";
+    setRows(remaining);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <section
+          className="rounded-lg border"
+          aria-labelledby="worksheet-heading"
+        >
+          <div className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+            <div>
+              <SectionIndex>Provider inputs</SectionIndex>
+              <h2 id="worksheet-heading" className="text-lg font-semibold">
+                Monthly usage
+              </h2>
+            </div>
+            <div className="text-muted-foreground space-y-1 text-xs">
+              <p className="font-medium">
+                Presets are editable business assumptions, not vendor facts.
+              </p>
+              <p>
+                Enter an exact count or use K, M, B, or T (for example, 120M or
+                1.5B). Use raw input + output token counts, not spend or
+                cache-discount-weighted billing units. Do not add reasoning or
+                cached-token breakdowns to a total that already includes them.
+              </p>
+            </div>
+          </div>
+
+          {rows.map((row, index) => (
+            <ProviderRowEditor
+              key={row.id}
+              row={row}
+              index={index}
+              calculation={calculations[index] ?? EMPTY_CALCULATION}
+              onChange={updateRow}
+              onRemove={removeProvider}
+            />
+          ))}
+          <p
+            className="text-muted-foreground border-t px-4 py-4 text-sm"
+            hidden={rows.length !== 0}
+          >
+            No provider rows. Add provider usage to continue.
+          </p>
+
+          <footer className="flex flex-wrap items-center justify-between gap-3 border-t px-4 py-4">
+            <div className="space-y-0.5">
+              <span className="text-muted-foreground block text-xs">
+                Combined monthly s-token range
+              </span>
+              <output
+                className="block text-base font-semibold tabular-nums"
+                title={
+                  estimates.length
+                    ? `${formatExactRange(total)} s-tokens`
+                    : undefined
+                }
+                aria-label={
+                  estimates.length
+                    ? `${formatExactRange(total)} s-tokens`
+                    : undefined
+                }
+              >
+                {estimates.length ? formatRange(total) : "—"}
+              </output>
+            </div>
+            <Button id="add-provider" type="button" onClick={addProvider}>
+              <PlusIcon />
+              Add provider
+            </Button>
+          </footer>
+        </section>
+
+        <ResultPanel
+          total={total}
+          validRowCount={estimates.length}
+          attentionCount={attentionCount}
+        />
+      </div>
+
+      <MethodSection />
+    </div>
+  );
+}

--- a/client/admin/src/routeTree.gen.ts
+++ b/client/admin/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as ProjectsRouteImport } from './routes/projects'
+import { Route as StokenCalculatorRouteImport } from './routes/stoken-calculator'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
 import { Route as OrganizationsIdOrSlugRouteImport } from './routes/organizations.$idOrSlug'
 import { Route as ProjectsIndexRouteImport } from './routes/projects.index'
@@ -36,6 +37,11 @@ const OrganizationsRoute = OrganizationsRouteImport.update({
 const ProjectsRoute = ProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StokenCalculatorRoute = StokenCalculatorRouteImport.update({
+  id: '/stoken-calculator',
+  path: '/stoken-calculator',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OrganizationsIndexRoute = OrganizationsIndexRouteImport.update({
@@ -99,6 +105,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/projects': typeof ProjectsRouteWithChildren
+  '/stoken-calculator': typeof StokenCalculatorRoute
   '/organizations/$idOrSlug': typeof OrganizationsIdOrSlugRouteWithChildren
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
   '/organizations/': typeof OrganizationsIndexRoute
@@ -112,6 +119,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/stoken-calculator': typeof StokenCalculatorRoute
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
   '/organizations': typeof OrganizationsIndexRoute
   '/projects': typeof ProjectsIndexRoute
@@ -127,6 +135,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/projects': typeof ProjectsRouteWithChildren
+  '/stoken-calculator': typeof StokenCalculatorRoute
   '/organizations/$idOrSlug': typeof OrganizationsIdOrSlugRouteWithChildren
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
   '/organizations/': typeof OrganizationsIndexRoute
@@ -144,6 +153,7 @@ export interface FileRouteTypes {
     | '/'
     | '/organizations'
     | '/projects'
+    | '/stoken-calculator'
     | '/organizations/$idOrSlug'
     | '/projects/$idOrSlug'
     | '/organizations/'
@@ -157,6 +167,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/stoken-calculator'
     | '/projects/$idOrSlug'
     | '/organizations'
     | '/projects'
@@ -171,6 +182,7 @@ export interface FileRouteTypes {
     | '/'
     | '/organizations'
     | '/projects'
+    | '/stoken-calculator'
     | '/organizations/$idOrSlug'
     | '/projects/$idOrSlug'
     | '/organizations/'
@@ -187,6 +199,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
   ProjectsRoute: typeof ProjectsRouteWithChildren
+  StokenCalculatorRoute: typeof StokenCalculatorRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -210,6 +223,13 @@ declare module '@tanstack/react-router' {
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof ProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/stoken-calculator': {
+      id: '/stoken-calculator'
+      path: '/stoken-calculator'
+      fullPath: '/stoken-calculator'
+      preLoaderRoute: typeof StokenCalculatorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/organizations/': {
@@ -342,6 +362,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
   ProjectsRoute: ProjectsRouteWithChildren,
+  StokenCalculatorRoute: StokenCalculatorRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/client/admin/src/routes/stoken-calculator.tsx
+++ b/client/admin/src/routes/stoken-calculator.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { stokenSearchSchema } from "@/lib/stoken/url-state";
+import { StokenCalculator } from "@/pages/stoken/StokenCalculator";
+
+// The worksheet keeps its rows in the URL, the same way the organizations list
+// keeps its filters: the address is the worksheet, so an operator can paste
+// the estimate they are looking at to a colleague and get the same rows back.
+export const Route = createFileRoute("/stoken-calculator")({
+  component: StokenCalculator,
+  validateSearch: stokenSearchSchema,
+  staticData: { crumb: "S-token calculator" },
+});


### PR DESCRIPTION
## Summary

Adds an **S-token calculator** page to the admin dashboard, reachable from the sidebar at `/stoken-calculator`. It is a port of the standalone [stoken-estimator](https://github.com/speakeasy-api/stoken-estimator) worksheet: provider-reported monthly token totals in, a conservative s-token estimate range per provider and combined out, with editable tokenizer assumptions and shareable URL state.

- **Logic carried over verbatim** — `calculator.ts` (the `P ÷ H ÷ R` envelope), `token-count.ts` (`K/M/B/T` parsing and compact formatting), and the Base64URL row encoder/validator from `url-state.ts` now live in `client/admin/src/lib/stoken/`, with their test suites ported from `bun:test` to vitest. The only edits are guards the admin's `noUncheckedIndexedAccess` requires.
- **URL state through the router, not nuqs** — the `?rows=<base64url>` param keeps the standalone app's wire format, read through TanStack Router `validateSearch` like the organizations list. A link copied from the GitHub Pages estimator pastes onto this route and restores the same worksheet (pinned by a test). Edits replace history rather than push, so Back leaves the page instead of undoing a keystroke.
- **UI rebuilt on the admin's primitives** — `Input`, `Select`, `Button`, and Tailwind utilities replace the standalone stylesheet. Same structure: combined-envelope panel with the low/high rail, provider rows with the collapsible tokenizer assumptions, add/remove with focus management, and the method notes verbatim.
- Sidebar entry ("S-token calculator", calculator icon) and breadcrumb.

## Testing

- vitest: 57 ported logic tests plus 12 route/page tests (sidebar navigation, breadcrumb, default worksheet, standalone-link restore, malformed-link fallback, URL write on edit, replace-not-push history, add/remove with focus, preset on provider change, invalid-total attention count, multi-row sum). Whole admin suite: 767/767.
- `tsc`, oxlint, oxfmt clean; `vite build` regenerated `routeTree.gen.ts`.
- Rendered the built app against a faked session endpoint and checked the page by eye: the method notes' worked example (120M Anthropic at R = 1.20–1.60) shows 25M–50M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfmQDqEPbfXoPkCZKzxx56

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an S-token calculator page to the admin at /stoken-calculator to estimate a conservative s-token range from provider-reported monthly tokens. Previously unavailable; now available via a sidebar link, with shareable links compatible with the standalone estimator.

- Keeps worksheet state in `?rows=<base64url>` using `@tanstack/react-router` `validateSearch`; malformed links fall back to the default worksheet; edits replace history instead of pushing entries.
- Ports logic into `client/admin/src/lib/stoken/` (calculator, token-count parsing, Base64URL row state) with stricter TypeScript guards; additionally rejects prototype-key providers in decoded links and any non-finite s-token endpoints.
- Rebuilds the UI on admin primitives (`Input`, `Select`, `Button`) with provider rows, editable tokenizer assumptions, and a combined envelope rail; adds a sidebar entry and route.
- Adds `vitest` suites covering logic and the route/page (navigation, default/restore, malformed fallback, URL writes, focus on add/remove, presets, validation, and combined sum).

<sup>Written for commit 97e9505641568496f32ab255657d8ff324142c7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

