### PR TITLE
fix: say Speakeasy's, not Gram's, in Event Feed description

### DIFF
--- a/.changeset/event-feed-speakeasy-copy.md
+++ b/.changeset/event-feed-speakeasy-copy.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Event Feed description now says Speakeasy's /otel/v1 endpoints, matching product branding.

--- a/client/dashboard/src/pages/data/EventFeed.tsx
+++ b/client/dashboard/src/pages/data/EventFeed.tsx
@@ -270,7 +270,7 @@ function EventFeedWorkbench(): JSX.Element {
       eyebrow="Data"
       title="Event Feed"
       stage="preview"
-      description="Every OpenTelemetry log record and span ingested through Gram's /otel/v1 endpoints across this organization."
+      description="Every OpenTelemetry log record and span ingested through Speakeasy's /otel/v1 endpoints across this organization."
       filters={
         <Page.Toolbar>
           <Page.Toolbar.Search

--- a/client/dashboard/src/pages/data/EventFeed.tsx
+++ b/client/dashboard/src/pages/data/EventFeed.tsx
@@ -415,7 +415,7 @@ function EventFeedRows({
           description={
             hasActiveFilters
               ? "Try adjusting your filters or time range."
-              : "Events appear here as OpenTelemetry logs and spans are ingested through Gram."
+              : "Events appear here as OpenTelemetry logs and spans are ingested through Speakeasy."
           }
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DNO-961.

The new Event Feed page description said:

> Every OpenTelemetry log record and span ingested through Gram's /otel/v1 endpoints across this organization.

User-facing copy should use Speakeasy branding. This updates:

1. The page subtitle to **Speakeasy's /otel/v1 endpoints**
2. The empty-state line, which still said events are ingested **through Gram**

Verified on the local Event Feed page (`/speakeasy/data`): no remaining "Gram" copy on the page.

![Event Feed page with Speakeasy branding](https://cursor.com/artifacts/c/art-2131de30-d416-4be8-bec2-f14ac41f5499)
![Event Feed description using Speakeasy](https://cursor.com/artifacts/c/art-664fd2c9-203f-43c9-a1d3-7f9534658052)
![Event Feed empty state using Speakeasy](https://cursor.com/artifacts/c/art-c48c6c14-66a8-4c75-9385-4d388032650d)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-961](https://linear.app/speakeasy/issue/DNO-961/fix-in-the-new-event-feed-it-says-every-opentelemetry-log-record-and)

<div><a href="https://cursor.com/agents/bc-0705d167-834a-454a-a22d-9e73633c5d53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0705d167-834a-454a-a22d-9e73633c5d53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

