### PR TITLE
fix(playground): stop claiming tool access when none resolve

### DIFF
--- a/client/dashboard/src/elements/components/MessageContent.tsx
+++ b/client/dashboard/src/elements/components/MessageContent.tsx
@@ -33,6 +33,7 @@ const STUB_CONTEXT: ElementsContextType = {
   plugins: recommended,
   mcpTools: undefined,
   mcpToolsLoading: false,
+  mcpToolsError: null,
 };
 
 export interface MessageContentProps {

--- a/client/dashboard/src/elements/components/Replay.tsx
+++ b/client/dashboard/src/elements/components/Replay.tsx
@@ -109,6 +109,7 @@ export const Replay = ({
       plugins,
       mcpTools: undefined,
       mcpToolsLoading: false,
+      mcpToolsError: null,
     }),
     [config, plugins],
   );

--- a/client/dashboard/src/elements/components/assistant-ui/follow-on-suggestions.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/follow-on-suggestions.tsx
@@ -5,9 +5,11 @@ import { FC } from "react";
 
 import { Button } from "@/elements/components/ui/button";
 import { useDensity } from "@/elements/hooks/useDensity";
+import { useElements } from "@/elements/hooks/useElements";
 import { useFollowOnSuggestions } from "@/elements/hooks/useFollowOnSuggestions";
 import { useRadius } from "@/elements/hooks/useRadius";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
+import { mcpToolsSendBlocked } from "@/elements/lib/mcpToolsAvailability";
 import { cn } from "@/lib/utils";
 
 const suggestionVariants = {
@@ -60,11 +62,20 @@ const containerVariants = {
  * These are dynamically generated based on the conversation context.
  */
 export const FollowOnSuggestions: FC = () => {
+  const { config, mcpTools, mcpToolsLoading, mcpToolsError } = useElements();
   const { suggestions, isLoading } = useFollowOnSuggestions();
   const r = useRadius();
   const d = useDensity();
 
-  const showSuggestions = !isLoading && suggestions.length > 0;
+  const showSuggestions =
+    !isLoading &&
+    suggestions.length > 0 &&
+    !mcpToolsSendBlocked(
+      config.composer?.requireMcpTools,
+      mcpToolsLoading,
+      mcpTools,
+      mcpToolsError,
+    );
 
   return (
     <div

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -94,6 +94,7 @@ import { getApiUrl } from "@/elements/lib/api";
 import { dictationAdapter } from "@/elements/lib/dictation";
 import {
   mcpToolsAvailability,
+  mcpToolsSendBlocked,
   mcpToolsSendTooltip,
 } from "@/elements/lib/mcpToolsAvailability";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
@@ -397,11 +398,22 @@ const ThreadWelcome: FC = () => {
 };
 
 const ThreadSuggestions: FC = () => {
-  const { config } = useElements();
+  const { config, mcpTools, mcpToolsLoading, mcpToolsError } = useElements();
   const r = useRadius();
   const d = useDensity();
   const suggestions = config.welcome?.suggestions ?? [];
   const isStandalone = config.variant === "standalone";
+
+  if (
+    mcpToolsSendBlocked(
+      config.composer?.requireMcpTools,
+      mcpToolsLoading,
+      mcpTools,
+      mcpToolsError,
+    )
+  ) {
+    return null;
+  }
 
   if (suggestions.length === 0) return null;
 
@@ -731,8 +743,12 @@ export const Composer: FC<ComposerProps> = ({
     mcpTools,
     mcpToolsError,
   );
-  const sendBlocked =
-    composerConfig.requireMcpTools === true && toolsAvailability !== "ready";
+  const sendBlocked = mcpToolsSendBlocked(
+    composerConfig.requireMcpTools,
+    mcpToolsLoading,
+    mcpTools,
+    mcpToolsError,
+  );
   const sendTooltip = sendBlocked
     ? mcpToolsSendTooltip(toolsAvailability)
     : "Send message";

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -92,6 +92,10 @@ import { useThemeProps } from "@/elements/hooks/useThemeProps";
 import { useToolMentions } from "@/elements/hooks/useToolMentions";
 import { getApiUrl } from "@/elements/lib/api";
 import { dictationAdapter } from "@/elements/lib/dictation";
+import {
+  mcpToolsAvailability,
+  mcpToolsSendTooltip,
+} from "@/elements/lib/mcpToolsAvailability";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
 import { groupAssistantMessageParts } from "@/elements/lib/messagePartGrouping";
 import {
@@ -620,7 +624,7 @@ export const Composer: FC<ComposerProps> = ({
   showThreadAffordances = true,
   autoFocus = true,
 }) => {
-  const { config, mcpTools } = useElements();
+  const { config, mcpTools, mcpToolsLoading, mcpToolsError } = useElements();
   const { isResolved, setUnresolved } = useChatResolution();
   const r = useRadius();
   const d = useDensity();
@@ -722,7 +726,19 @@ export const Composer: FC<ComposerProps> = ({
   const composerTextRef = useRef(composerText);
   composerTextRef.current = composerText;
 
+  const toolsAvailability = mcpToolsAvailability(
+    mcpToolsLoading,
+    mcpTools,
+    mcpToolsError,
+  );
+  const sendBlocked =
+    composerConfig.requireMcpTools === true && toolsAvailability !== "ready";
+  const sendTooltip = sendBlocked
+    ? mcpToolsSendTooltip(toolsAvailability)
+    : "Send message";
+
   const runSlashCommand = (command: ComposerSlashCommand) => {
+    if (sendBlocked) return;
     const composer = aui.composer();
     composer.setText(command.prompt);
     composer.send();
@@ -811,7 +827,11 @@ export const Composer: FC<ComposerProps> = ({
           ref={composerRootRef}
           // Capture: the menu owns Up/Down/Enter while it is open, before the
           // textarea inserts a newline or the composer sends the raw query.
-          onSubmit={() => {
+          onSubmit={(event) => {
+            if (sendBlocked) {
+              event.preventDefault();
+              return;
+            }
             promptHistory.record(composerTextRef.current);
           }}
           onKeyDownCapture={(event) => {
@@ -919,7 +939,11 @@ export const Composer: FC<ComposerProps> = ({
               isDictating && "invisible",
             )}
           />
-          <ComposerAction showRunState={showThreadAffordances} />
+          <ComposerAction
+            showRunState={showThreadAffordances}
+            sendBlocked={sendBlocked}
+            sendTooltip={sendTooltip}
+          />
         </ComposerPrimitive.Root>
       )}
     </div>
@@ -1779,8 +1803,14 @@ const ComposerDictate: FC = () => {
   );
 };
 
-const ComposerAction: FC<{ showRunState?: boolean }> = ({
+const ComposerAction: FC<{
+  showRunState?: boolean;
+  sendBlocked?: boolean;
+  sendTooltip?: string;
+}> = ({
   showRunState = true,
+  sendBlocked = false,
+  sendTooltip = "Send message",
 }) => {
   const { config } = useElements();
   const r = useRadius();
@@ -1820,13 +1850,14 @@ const ComposerAction: FC<{ showRunState?: boolean }> = ({
         {!showRunState && (
           <ComposerPrimitive.Send asChild>
             <TooltipIconButton
-              tooltip="Send message"
+              tooltip={sendTooltip}
               side="bottom"
               type="submit"
               variant="default"
               size="icon"
+              disabled={sendBlocked}
               className={cn("aui-composer-send size-[34px] p-1", r("full"))}
-              aria-label="Send message"
+              aria-label={sendTooltip}
             >
               <ArrowUpIcon className="aui-composer-send-icon size-5" />
             </TooltipIconButton>
@@ -1837,13 +1868,14 @@ const ComposerAction: FC<{ showRunState?: boolean }> = ({
           <ThreadPrimitive.If running={false}>
             <ComposerPrimitive.Send asChild>
               <TooltipIconButton
-                tooltip="Send message"
+                tooltip={sendTooltip}
                 side="bottom"
                 type="submit"
                 variant="default"
                 size="icon"
+                disabled={sendBlocked}
                 className={cn("aui-composer-send size-[34px] p-1", r("full"))}
-                aria-label="Send message"
+                aria-label={sendTooltip}
               >
                 <ArrowUpIcon className="aui-composer-send-icon size-5" />
               </TooltipIconButton>

--- a/client/dashboard/src/elements/components/assistant-ui/tooltip-icon-button.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/tooltip-icon-button.tsx
@@ -28,25 +28,29 @@ export const TooltipIconButton = forwardRef<
       side = "bottom",
       align = "center",
       className,
+      disabled,
       ...rest
     },
     ref,
   ) => {
+    const button = (
+      <Button
+        variant="ghost"
+        size="icon"
+        disabled={disabled}
+        {...rest}
+        className={cn("aui-button-icon size-6 p-1", className)}
+        ref={ref}
+      >
+        <Slottable>{children}</Slottable>
+        <span className="aui-sr-only sr-only">{tooltip}</span>
+      </Button>
+    );
+
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="inline-flex">
-            <Button
-              variant="ghost"
-              size="icon"
-              {...rest}
-              className={cn("aui-button-icon size-6 p-1", className)}
-              ref={ref}
-            >
-              <Slottable>{children}</Slottable>
-              <span className="aui-sr-only sr-only">{tooltip}</span>
-            </Button>
-          </span>
+          {disabled ? <span className="inline-flex">{button}</span> : button}
         </TooltipTrigger>
         <TooltipContent side={side} align={align}>
           {tooltip}

--- a/client/dashboard/src/elements/components/assistant-ui/tooltip-icon-button.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/tooltip-icon-button.tsx
@@ -35,16 +35,18 @@ export const TooltipIconButton = forwardRef<
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            {...rest}
-            className={cn("aui-button-icon size-6 p-1", className)}
-            ref={ref}
-          >
-            <Slottable>{children}</Slottable>
-            <span className="aui-sr-only sr-only">{tooltip}</span>
-          </Button>
+          <span className="inline-flex">
+            <Button
+              variant="ghost"
+              size="icon"
+              {...rest}
+              className={cn("aui-button-icon size-6 p-1", className)}
+              ref={ref}
+            >
+              <Slottable>{children}</Slottable>
+              <span className="aui-sr-only sr-only">{tooltip}</span>
+            </Button>
+          </span>
         </TooltipTrigger>
         <TooltipContent side={side} align={align}>
           {tooltip}

--- a/client/dashboard/src/elements/contexts/ElementsProvider.tsx
+++ b/client/dashboard/src/elements/contexts/ElementsProvider.tsx
@@ -245,6 +245,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
     data: mcpTools,
     mcpHeaders,
     isLoading: mcpQueryLoading,
+    error: mcpToolsQueryError,
   } = useMCPTools({
     auth,
     mcp: config.mcp,
@@ -258,6 +259,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
   // tool-list consumer would briefly see an empty, settled state before tools
   // arrive.
   const mcpToolsLoading = auth.isLoading || mcpQueryLoading;
+  const mcpToolsError = mcpToolsQueryError ?? null;
 
   // Store approval helpers in ref so they can be used in async contexts
   const approvalHelpersRef = useRef<ApprovalHelpers>({
@@ -619,8 +621,18 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
       plugins,
       mcpTools,
       mcpToolsLoading,
+      mcpToolsError,
     }),
-    [config, model, isExpanded, isOpen, plugins, mcpTools, mcpToolsLoading],
+    [
+      config,
+      model,
+      isExpanded,
+      isOpen,
+      plugins,
+      mcpTools,
+      mcpToolsLoading,
+      mcpToolsError,
+    ],
   );
 
   const frontendTools = config.tools?.frontendTools ?? {};

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -19,8 +19,11 @@ describe("mcpToolsAvailability", () => {
     );
   });
 
+  it("stays loading when the query has not run yet", () => {
+    expect(mcpToolsAvailability(false, undefined, null)).toBe("loading");
+  });
+
   it("is unavailable when settled with zero tools", () => {
-    expect(mcpToolsAvailability(false, undefined, null)).toBe("unavailable");
     expect(mcpToolsAvailability(false, {}, null)).toBe("unavailable");
   });
 

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  mcpToolsAvailability,
+  mcpToolsSendTooltip,
+  mcpToolsWelcomeSubtitle,
+  NO_MCP_TOOLS_MESSAGE,
+} from "./mcpToolsAvailability";
+
+describe("mcpToolsAvailability", () => {
+  it("stays loading even when tools and error are empty", () => {
+    expect(mcpToolsAvailability(true, undefined, null)).toBe("loading");
+    expect(mcpToolsAvailability(true, {}, new Error("401"))).toBe("loading");
+  });
+
+  it("is unavailable when settled with an error", () => {
+    expect(mcpToolsAvailability(false, undefined, new Error("401"))).toBe(
+      "unavailable",
+    );
+  });
+
+  it("is unavailable when settled with zero tools", () => {
+    expect(mcpToolsAvailability(false, undefined, null)).toBe("unavailable");
+    expect(mcpToolsAvailability(false, {}, null)).toBe("unavailable");
+  });
+
+  it("is ready only when settled with at least one tool", () => {
+    expect(mcpToolsAvailability(false, { list_issues: {} }, null)).toBe(
+      "ready",
+    );
+  });
+
+  it("does not claim access while loading or when empty", () => {
+    expect(mcpToolsWelcomeSubtitle("loading", READY_SUBTITLE)).toBe(
+      "Loading tools from this server…",
+    );
+    expect(mcpToolsWelcomeSubtitle("unavailable", READY_SUBTITLE)).toBe(
+      NO_MCP_TOOLS_MESSAGE,
+    );
+    expect(mcpToolsWelcomeSubtitle("ready", READY_SUBTITLE)).toBe(
+      READY_SUBTITLE,
+    );
+  });
+
+  it("explains a blocked send", () => {
+    expect(mcpToolsSendTooltip("loading")).toBe("Loading tools…");
+    expect(mcpToolsSendTooltip("unavailable")).toBe(NO_MCP_TOOLS_MESSAGE);
+    expect(mcpToolsSendTooltip("ready")).toBe("Send message");
+  });
+});
+
+const READY_SUBTITLE =
+  "This chat has access to the selected MCP server. Use it to test your tools.";

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   mcpToolsAvailability,
+  mcpToolsSendBlocked,
   mcpToolsSendTooltip,
   mcpToolsWelcomeSubtitle,
   NO_MCP_TOOLS_MESSAGE,
@@ -45,6 +46,15 @@ describe("mcpToolsAvailability", () => {
     expect(mcpToolsSendTooltip("loading")).toBe("Loading tools…");
     expect(mcpToolsSendTooltip("unavailable")).toBe(NO_MCP_TOOLS_MESSAGE);
     expect(mcpToolsSendTooltip("ready")).toBe("Send message");
+  });
+
+  it("blocks send only when the host requires tools and they are not ready", () => {
+    expect(mcpToolsSendBlocked(undefined, false, {}, null)).toBe(false);
+    expect(mcpToolsSendBlocked(true, true, undefined, null)).toBe(true);
+    expect(mcpToolsSendBlocked(true, false, {}, new Error("401"))).toBe(true);
+    expect(mcpToolsSendBlocked(true, false, { list_issues: {} }, null)).toBe(
+      false,
+    );
   });
 });
 

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -20,6 +20,19 @@ export function mcpToolsAvailability(
   return "ready";
 }
 
+/** True when a host opted into `requireMcpTools` and tools are not ready. */
+export function mcpToolsSendBlocked(
+  requireMcpTools: boolean | undefined,
+  loading: boolean,
+  tools: Record<string, unknown> | undefined,
+  error: unknown,
+): boolean {
+  return (
+    requireMcpTools === true &&
+    mcpToolsAvailability(loading, tools, error) !== "ready"
+  );
+}
+
 export function mcpToolsSendTooltip(
   availability: McpToolsAvailability,
 ): string {

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -1,0 +1,48 @@
+export type McpToolsAvailability = "loading" | "ready" | "unavailable";
+
+/** Shown when tools/list settled empty or failed — Playground must not claim access. */
+export const NO_MCP_TOOLS_MESSAGE =
+  "No tools loaded from this server — connect authentication to test it.";
+
+/**
+ * Distinguishes in-flight tools/list from a settled empty/error result so
+ * callers can avoid flashing the empty state during normal load.
+ */
+export function mcpToolsAvailability(
+  loading: boolean,
+  tools: Record<string, unknown> | undefined,
+  error: unknown,
+): McpToolsAvailability {
+  if (loading) return "loading";
+  if (error || !tools || Object.keys(tools).length === 0) {
+    return "unavailable";
+  }
+  return "ready";
+}
+
+export function mcpToolsSendTooltip(
+  availability: McpToolsAvailability,
+): string {
+  switch (availability) {
+    case "loading":
+      return "Loading tools…";
+    case "unavailable":
+      return NO_MCP_TOOLS_MESSAGE;
+    case "ready":
+      return "Send message";
+  }
+}
+
+export function mcpToolsWelcomeSubtitle(
+  availability: McpToolsAvailability,
+  readySubtitle: string | undefined,
+): string {
+  switch (availability) {
+    case "loading":
+      return "Loading tools from this server…";
+    case "unavailable":
+      return NO_MCP_TOOLS_MESSAGE;
+    case "ready":
+      return readySubtitle ?? "";
+  }
+}

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -13,7 +13,10 @@ export function mcpToolsAvailability(
   tools: Record<string, unknown> | undefined,
   error: unknown,
 ): McpToolsAvailability {
-  if (loading) return "loading";
+  // Disabled/idle queries (auth settling, no server yet) report not-loading
+  // with undefined data. Treat that as in-flight so we don't flash the
+  // settled-empty warning before tools/list has run.
+  if (loading || (!error && tools === undefined)) return "loading";
   if (error || !tools || Object.keys(tools).length === 0) {
     return "unavailable";
   }

--- a/client/dashboard/src/elements/types/index.ts
+++ b/client/dashboard/src/elements/types/index.ts
@@ -1064,6 +1064,13 @@ export interface ComposerConfig {
    * the draft and sends it, so these are shortcuts rather than editable text.
    */
   slashCommands?: ComposerSlashCommand[];
+
+  /**
+   * When true, disable send until the MCP tool list has settled with at least
+   * one tool. Used by the Playground so a tools/list 401 or empty result
+   * cannot produce a confident "no tools" model reply.
+   */
+  requireMcpTools?: boolean;
 }
 
 export interface ComposerSlashCommand {
@@ -1292,4 +1299,6 @@ export type ElementsContextType = {
   mcpTools: Record<string, unknown> | undefined;
   /** True while the MCP tool list is actively being fetched. */
   mcpToolsLoading: boolean;
+  /** Set when tools/list failed (e.g. 401 on an issuer-gated server). */
+  mcpToolsError: Error | null;
 };

--- a/client/dashboard/src/pages/playground/PlaygroundChat.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundChat.tsx
@@ -24,7 +24,10 @@ import {
   PlaygroundMcpAppsProvider,
   PlaygroundMcpToolFallback,
 } from "./PlaygroundMcpApps";
-import { GramThreadWelcome } from "./PlaygroundElementsOverrides";
+import {
+  GramThreadWelcome,
+  PlaygroundNoToolsBanner,
+} from "./PlaygroundElementsOverrides";
 
 interface PlaygroundChatProps {
   /** Resolved MCP server URL (Gram origin `/mcp/<slug>`). */
@@ -190,6 +193,7 @@ export function PlaygroundChat({
         composer: {
           placeholder: "Send a message...",
           toolMentions: true,
+          requireMcpTools: true,
         },
         theme: {
           colorScheme: resolvedTheme === "dark" ? "dark" : "light",
@@ -227,6 +231,7 @@ export function PlaygroundChat({
             <div className="flex items-center gap-2">{additionalActions}</div>
           </div>
           {banner}
+          <PlaygroundNoToolsBanner />
           <div className="min-h-0 flex-1 overflow-hidden">
             <Chat />
           </div>

--- a/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.test.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.test.tsx
@@ -1,0 +1,109 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { NO_MCP_TOOLS_MESSAGE } from "@/elements/lib/mcpToolsAvailability";
+
+const mocks = vi.hoisted(() => ({
+  ctx: {
+    config: {
+      welcome: {
+        title: "Test Your MCP Server",
+        subtitle:
+          "This chat has access to the selected MCP server. Use it to test your tools.",
+        suggestions: [
+          {
+            title: "Explore tools",
+            label: "See what's available",
+            prompt: "What tools does this server have?",
+          },
+        ],
+      },
+    },
+    mcpTools: undefined as Record<string, unknown> | undefined,
+    mcpToolsLoading: false,
+    mcpToolsError: null as Error | null,
+  },
+}));
+
+vi.mock("@/elements", () => ({
+  useGramElements: () => mocks.ctx,
+}));
+
+vi.mock("@assistant-ui/react", () => ({
+  ThreadPrimitive: {
+    Suggestion: ({ children }: { children: React.ReactNode }) => children,
+  },
+}));
+
+import {
+  GramThreadWelcome,
+  PlaygroundNoToolsBanner,
+} from "./PlaygroundElementsOverrides";
+
+const ACCESS_CLAIM =
+  "This chat has access to the selected MCP server. Use it to test your tools.";
+
+describe("GramThreadWelcome", () => {
+  it("does not claim access while tools are loading", () => {
+    mocks.ctx.mcpToolsLoading = true;
+    mocks.ctx.mcpTools = undefined;
+    mocks.ctx.mcpToolsError = null;
+
+    const html = renderToStaticMarkup(<GramThreadWelcome />);
+
+    expect(html).toContain("Loading tools from this server");
+    expect(html).not.toContain(ACCESS_CLAIM);
+    expect(html).not.toContain("Explore tools");
+  });
+
+  it("replaces the access claim when tools settle empty", () => {
+    mocks.ctx.mcpToolsLoading = false;
+    mocks.ctx.mcpTools = {};
+    mocks.ctx.mcpToolsError = new Error("401 Unauthorized");
+
+    const html = renderToStaticMarkup(<GramThreadWelcome />);
+
+    expect(html).toContain(NO_MCP_TOOLS_MESSAGE);
+    expect(html).not.toContain(ACCESS_CLAIM);
+    expect(html).not.toContain("Explore tools");
+  });
+
+  it("keeps the access claim and suggestions when tools resolve", () => {
+    mocks.ctx.mcpToolsLoading = false;
+    mocks.ctx.mcpTools = { list_issues: {} };
+    mocks.ctx.mcpToolsError = null;
+
+    const html = renderToStaticMarkup(<GramThreadWelcome />);
+
+    expect(html).toContain(ACCESS_CLAIM);
+    expect(html).toContain("Explore tools");
+    expect(html).not.toContain(NO_MCP_TOOLS_MESSAGE);
+  });
+});
+
+describe("PlaygroundNoToolsBanner", () => {
+  it("stays hidden while tools are loading", () => {
+    mocks.ctx.mcpToolsLoading = true;
+    mocks.ctx.mcpTools = undefined;
+    mocks.ctx.mcpToolsError = null;
+
+    expect(renderToStaticMarkup(<PlaygroundNoToolsBanner />)).toBe("");
+  });
+
+  it("renders the honest warning when settled empty", () => {
+    mocks.ctx.mcpToolsLoading = false;
+    mocks.ctx.mcpTools = {};
+    mocks.ctx.mcpToolsError = null;
+
+    const html = renderToStaticMarkup(<PlaygroundNoToolsBanner />);
+
+    expect(html).toContain(NO_MCP_TOOLS_MESSAGE);
+  });
+
+  it("stays hidden when tools resolve", () => {
+    mocks.ctx.mcpToolsLoading = false;
+    mocks.ctx.mcpTools = { list_issues: {} };
+    mocks.ctx.mcpToolsError = null;
+
+    expect(renderToStaticMarkup(<PlaygroundNoToolsBanner />)).toBe("");
+  });
+});

--- a/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.test.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.test.tsx
@@ -97,6 +97,18 @@ describe("PlaygroundNoToolsBanner", () => {
     const html = renderToStaticMarkup(<PlaygroundNoToolsBanner />);
 
     expect(html).toContain(NO_MCP_TOOLS_MESSAGE);
+    expect(html).toContain('role="alert"');
+  });
+
+  it("renders the honest warning when tools/list errors", () => {
+    mocks.ctx.mcpToolsLoading = false;
+    mocks.ctx.mcpTools = { leftover: {} };
+    mocks.ctx.mcpToolsError = new Error("401 Unauthorized");
+
+    const html = renderToStaticMarkup(<PlaygroundNoToolsBanner />);
+
+    expect(html).toContain(NO_MCP_TOOLS_MESSAGE);
+    expect(html).toContain('role="alert"');
   });
 
   it("stays hidden when tools resolve", () => {

--- a/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
@@ -1,6 +1,12 @@
 import { Text } from "@/components/ui/Text";
 import { ThreadPrimitive } from "@assistant-ui/react";
 import { useGramElements } from "@/elements";
+import {
+  mcpToolsAvailability,
+  mcpToolsWelcomeSubtitle,
+  NO_MCP_TOOLS_MESSAGE,
+} from "@/elements/lib/mcpToolsAvailability";
+import { AlertCircle } from "lucide-react";
 import type { FC } from "react";
 
 /**
@@ -8,8 +14,17 @@ import type { FC } from "react";
  * Displays centered empty state with title, subtitle, and optional suggestions.
  */
 export const GramThreadWelcome: FC = () => {
-  const { config } = useGramElements();
+  const { config, mcpTools, mcpToolsLoading, mcpToolsError } =
+    useGramElements();
   const { title, subtitle, suggestions } = config.welcome ?? {};
+  const availability = mcpToolsAvailability(
+    mcpToolsLoading,
+    mcpTools,
+    mcpToolsError,
+  );
+  const resolvedSubtitle = mcpToolsWelcomeSubtitle(availability, subtitle);
+  const visibleSuggestions =
+    availability === "ready" ? (suggestions ?? []) : [];
 
   return (
     <div className="flex size-full flex-col items-center justify-center gap-3 p-8 text-center">
@@ -18,12 +33,12 @@ export const GramThreadWelcome: FC = () => {
           {title}
         </Text>
         <Text variant="small" muted>
-          {subtitle}
+          {resolvedSubtitle}
         </Text>
       </div>
-      {suggestions && suggestions.length > 0 && (
+      {visibleSuggestions.length > 0 && (
         <div className="mt-4 flex flex-wrap justify-center gap-2">
-          {suggestions.map((suggestion, index) => (
+          {visibleSuggestions.map((suggestion, index) => (
             <ThreadPrimitive.Suggestion
               key={index}
               prompt={suggestion.prompt}
@@ -43,3 +58,21 @@ export const GramThreadWelcome: FC = () => {
     </div>
   );
 };
+
+/** Persistent warning when tools/list settled empty or failed. Hidden while loading. */
+export function PlaygroundNoToolsBanner(): JSX.Element | null {
+  const { mcpTools, mcpToolsLoading, mcpToolsError } = useGramElements();
+  if (
+    mcpToolsAvailability(mcpToolsLoading, mcpTools, mcpToolsError) !==
+    "unavailable"
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="bg-warning/15 border-warning/30 text-warning-foreground flex items-center gap-2 border-b px-4 py-2.5 text-sm font-medium">
+      <AlertCircle className="size-4 shrink-0" />
+      <span>{NO_MCP_TOOLS_MESSAGE}</span>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundElementsOverrides.tsx
@@ -70,7 +70,10 @@ export function PlaygroundNoToolsBanner(): JSX.Element | null {
   }
 
   return (
-    <div className="bg-warning/15 border-warning/30 text-warning-foreground flex items-center gap-2 border-b px-4 py-2.5 text-sm font-medium">
+    <div
+      role="alert"
+      className="bg-warning/15 border-warning/30 text-warning-foreground flex items-center gap-2 border-b px-4 py-2.5 text-sm font-medium"
+    >
       <AlertCircle className="size-4 shrink-0" />
       <span>{NO_MCP_TOOLS_MESSAGE}</span>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playground no longer claims “this chat has access to the selected MCP server” when `tools/list` settles empty or errors (typical for a fresh OAuth-gated remote server). Send is disabled until at least one tool resolves, and loading is distinguished from settled-empty so the honest state does not flash during normal load.

Fixes GRW-12.

## What changed

- Elements now surfaces `mcpToolsError` from `useMCPTools`.
- Shared `mcpToolsAvailability()` helper: `loading | ready | unavailable`.
- Playground sets `composer.requireMcpTools: true`.
- Welcome copy: loading → “Loading tools from this server…”; empty/error → “No tools loaded from this server — connect authentication to test it.”; ready → original access claim.
- Persistent banner on settled empty/error; send button, form submit, slash commands, and suggestion chips stay off until tools resolve.
- Assistants / dock are unchanged (explicitly de-scoped).

## Test plan

- [x] Unit tests for `mcpToolsAvailability` (loading vs empty vs error vs ready).
- [x] Component tests for welcome + banner across the three states.
- [x] `aube run -F dashboard type-check`
- [x] Browser: ready server still claims access and send stays enabled.
- [x] Browser: intercept `/mcp/<slug>` tools/list 401 → banner, no access claim, send disabled.

![Playground ready: access claim and enabled send](https://cursor.com/artifacts/c/art-379d3f66-30e5-4800-bf20-8998ff28053b)
![Playground empty tools: honest banner and disabled send](https://cursor.com/artifacts/c/art-8643815d-7983-41e5-9c3a-39d19a78adff)
<a href="https://cursor.com/agents/bc-bbd0bc58-06da-4cd2-a7b6-f793e33e1f0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayground-empty-tools-honesty.mp4"><img src="https://cursor.com/artifacts/c/art-0af10df8-e73b-49a8-a864-44756b45cfb6" alt="playground-empty-tools-honesty.mp4" /></a>

## Notes

Frontend-only. Catalog-add creating a toolset is not viable (remote-backed servers cannot have a toolset). Assistant dock / list “no toolset” conflation is out of scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-12](https://linear.app/speakeasy/issue/GRW-12/fix-playground-falsely-claims-tool-access-when-zero-tools-resolve)

<div><a href="https://cursor.com/agents/bc-bbd0bc58-06da-4cd2-a7b6-f793e33e1f0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbd0bc58-06da-4cd2-a7b6-f793e33e1f0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the Playground from claiming MCP tool access when none resolve and block sending until tools are ready. Previously it claimed access and allowed sending; now we show loading while fetching, show a banner for settled empty/error, hide suggestions, disable send with an accessible tooltip, and treat idle (not-yet-run) queries as loading to avoid empty flashes. Satisfies GRW-12.

- Elements exposes `mcpToolsError` and adds availability helpers (`loading | ready | unavailable`) plus tooltip/welcome copy helpers.
- Composer honors `composer.requireMcpTools`; blocks submit (button, Enter, slash commands), keeps a reachable send tooltip while disabled, and only wraps the button when disabled to preserve aria-describedby.
- Suggestions are gated: welcome and follow-on suggestions do not render until tools are ready.
- Playground sets `requireMcpTools: true`, replaces the welcome subtitle via availability, and renders a persistent role="alert" “No tools loaded…” banner on settled empty/error.
- Tests: unit tests for availability/tooltip logic; SSR tests for `GramThreadWelcome` and `PlaygroundNoToolsBanner` cover loading, empty/error, and ready states. Frontend-only.

<sup>Written for commit 04c6c518032c5aaee2c7090237635d9f2080b148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

