### PR TITLE
fix: route zero-org onboarding through sign-up

### DIFF
--- a/client/dashboard/src/components/app-layout.test.tsx
+++ b/client/dashboard/src/components/app-layout.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -26,7 +27,7 @@ vi.mock("@/contexts/Sdk.tsx", () => ({
   }),
 }));
 
-import { ImpersonationBanner } from "./app-layout";
+import { ImpersonationBanner, LoginCheck } from "./app-layout";
 import { useShowsImpersonationBanner } from "./impersonation-banner-state";
 
 let originalLocation: Location | undefined;
@@ -156,3 +157,35 @@ describe("trusted support banner", () => {
     ).toBeTruthy();
   });
 });
+
+describe("LoginCheck", () => {
+  it("sends authenticated zero-org sessions to sign-up with their destination", () => {
+    mocks.useSession.mockReturnValue({
+      ...baseSession,
+      session: "<SESSION>",
+      activeOrganizationId: "",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/projects?tab=overview"]}>
+        <Routes>
+          <Route element={<LoginCheck />}>
+            <Route path="/projects" element={<div>projects</div>} />
+          </Route>
+          <Route path="/sign-up" element={<CurrentLocation />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/sign-up?redirect=%2Fprojects%3Ftab%3Doverview",
+    );
+  });
+});
+
+function CurrentLocation(): JSX.Element {
+  const location = useLocation();
+  return (
+    <div data-testid="location">{location.pathname + location.search}</div>
+  );
+}

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -32,7 +32,7 @@ export const LoginCheck = (): JSX.Element => {
 
   if (!session.activeOrganizationId) {
     const redirectTo = encodeURIComponent(location.pathname + location.search);
-    return <Navigate to={`/register?redirect=${redirectTo}`} />;
+    return <Navigate to={`/sign-up?redirect=${redirectTo}`} />;
   }
 
   return <Outlet />;

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   openSafeExternalUrl,
   safeExternalHttpUrl,
+  safeSameOriginPath,
   safeSameOriginUrl,
 } from "./safe-external-url";
 
@@ -99,6 +100,15 @@ describe("safeSameOriginUrl", () => {
   it("accepts same-origin absolute URLs", () => {
     const absolute = new URL("/plugins?installed=true", window.location.origin);
     expect(safeSameOriginUrl(absolute.href)).toBe(absolute.href);
+  });
+
+  it("converts same-origin URLs to router locations", () => {
+    expect(
+      safeSameOriginPath(
+        new URL("/projects/default?tab=tools#details", window.location.origin)
+          .href,
+      ),
+    ).toBe("/projects/default?tab=tools#details");
   });
 
   it.each([

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -57,3 +57,14 @@ export function safeSameOriginUrl(
     return null;
   }
 }
+
+/** Return a validated same-origin redirect in React Router's location format. */
+export function safeSameOriginPath(
+  raw: string | null | undefined,
+): string | null {
+  const href = safeSameOriginUrl(raw);
+  if (!href) return null;
+
+  const url = new URL(href);
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/client/dashboard/src/pages/cli/CliCallback.test.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CliCallback from "./CliCallback";
+
+const mocks = vi.hoisted(() => ({
+  createKey: vi.fn(),
+  authorizeCode: vi.fn(),
+  locationSetter: vi.fn(),
+  useSessionData: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({ useSessionData: mocks.useSessionData }));
+vi.mock("@gram/client/react-query/createAPIKey", () => ({
+  useCreateAPIKeyMutation: () => ({ mutateAsync: mocks.createKey }),
+}));
+vi.mock("@gram/client/react-query/cliAuthAuthorize", () => ({
+  useCliAuthAuthorizeMutation: () => ({ mutateAsync: mocks.authorizeCode }),
+}));
+
+let originalLocation: Location | undefined;
+
+beforeEach(() => {
+  mocks.locationSetter.mockReset();
+  mocks.createKey.mockReset().mockResolvedValue({ key: "test-key" });
+  mocks.authorizeCode.mockReset();
+  originalLocation = window.location;
+  // @ts-expect-error test-only location replacement for redirect assertion
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      get href() {
+        return "https://app.example/cli/callback?state=abc";
+      },
+      set href(value: string) {
+        mocks.locationSetter(value);
+      },
+      replace: vi.fn(),
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalLocation) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  }
+  vi.clearAllMocks();
+});
+
+describe("CliCallback", () => {
+  it("sends an authenticated zero-org session to sign-up with the callback destination", async () => {
+    mocks.useSessionData.mockReturnValue({
+      status: "success",
+      session: {
+        session: "<SESSION>",
+        activeOrganizationId: "",
+        organization: { projects: [] },
+        user: { email: "" },
+      },
+    });
+
+    render(
+      <CliCallback
+        localCallbackUrl="http://localhost:3000/callback"
+        callbackMethod="get"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.locationSetter).toHaveBeenCalledWith(
+        "/sign-up?redirect=https%3A%2F%2Fapp.example%2Fcli%2Fcallback%3Fstate%3Dabc",
+      );
+    });
+  });
+});

--- a/client/dashboard/src/pages/cli/CliCallback.test.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.test.tsx
@@ -76,5 +76,8 @@ describe("CliCallback", () => {
         "/sign-up?redirect=https%3A%2F%2Fapp.example%2Fcli%2Fcallback%3Fstate%3Dabc",
       );
     });
+
+    expect(mocks.createKey).not.toHaveBeenCalled();
+    expect(mocks.authorizeCode).not.toHaveBeenCalled();
   });
 });

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -64,7 +64,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
     }
 
     if (!session?.activeOrganizationId) {
-      window.location.href = `/register?redirect=${redirectUrl}`;
+      window.location.href = `/sign-up?redirect=${redirectUrl}`;
       return;
     }
   }, [session, status]);

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -71,6 +71,7 @@ export default function CliCallback(props: CliCallbackProps): JSX.Element {
 
   useEffect(() => {
     if (!session) return;
+    if (!session.activeOrganizationId) return;
     if (hasCreatedKey.current) return;
 
     if (!validCallback) {

--- a/client/dashboard/src/pages/login/Register.test.tsx
+++ b/client/dashboard/src/pages/login/Register.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Register from "./Register";
+
+const mocks = vi.hoisted(() => ({
+  useSearchParams: vi.fn(),
+  useSession: vi.fn(),
+  useRoutes: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({ useSession: mocks.useSession }));
+vi.mock("@/routes", () => ({ useRoutes: mocks.useRoutes }));
+vi.mock("react-router", () => ({
+  Navigate: ({ to }: { to: string }) => (
+    <div data-testid="navigate" data-to={to} />
+  ),
+  useSearchParams: mocks.useSearchParams,
+}));
+vi.mock("./components/auth-shell", () => ({
+  AuthShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("./components/register-panel", () => ({
+  RegisterPanel: () => <div data-testid="register-panel" />,
+}));
+
+function renderAt(path: string) {
+  const [, search = ""] = path.split("?");
+  mocks.useSearchParams.mockReturnValue([new URLSearchParams(search), vi.fn()]);
+  render(<Register />);
+}
+
+let originalLocation: Location | undefined;
+
+beforeEach(() => {
+  mocks.useRoutes.mockReturnValue({ mcp: { goTo: vi.fn() } });
+  originalLocation = window.location;
+  // @ts-expect-error test-only location replacement for same-origin URL parsing
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin: "https://app.example" },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalLocation) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  }
+  vi.clearAllMocks();
+});
+
+describe("Register", () => {
+  it("redirects logged-out /register traffic to /sign-up", () => {
+    mocks.useSession.mockReturnValue({ session: "", activeOrganizationId: "" });
+
+    renderAt("/register?redirect=%2Fcli%2Fcallback");
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
+      "/sign-up?redirect=https%3A%2F%2Fapp.example%2Fcli%2Fcallback",
+    );
+  });
+
+  it("preserves assistants disposition", () => {
+    mocks.useSession.mockReturnValue({ session: "", activeOrganizationId: "" });
+
+    renderAt("/register?disposition=assistants");
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
+      "/login?disposition=assistants",
+    );
+  });
+
+  it("drops an external legacy redirect", () => {
+    mocks.useSession.mockReturnValue({ session: "", activeOrganizationId: "" });
+
+    renderAt("/register?redirect=https%3A%2F%2Fevil.example");
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
+      "/sign-up",
+    );
+  });
+});

--- a/client/dashboard/src/pages/login/Register.test.tsx
+++ b/client/dashboard/src/pages/login/Register.test.tsx
@@ -86,4 +86,19 @@ describe("Register", () => {
     expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe("/");
     expect(screen.queryByTestId("register-panel")).toBeNull();
   });
+
+  it("preserves the path, search, and hash for an authenticated redirect", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "<ORG_ID>",
+    });
+
+    renderAt(
+      "/register?redirect=https%3A%2F%2Fapp.example%2Fprojects%2Fdefault%3Ftab%3Dtools%23details",
+    );
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
+      "/projects/default?tab=tools#details",
+    );
+  });
 });

--- a/client/dashboard/src/pages/login/Register.test.tsx
+++ b/client/dashboard/src/pages/login/Register.test.tsx
@@ -7,11 +7,9 @@ import Register from "./Register";
 const mocks = vi.hoisted(() => ({
   useSearchParams: vi.fn(),
   useSession: vi.fn(),
-  useRoutes: vi.fn(),
 }));
 
 vi.mock("@/contexts/Auth", () => ({ useSession: mocks.useSession }));
-vi.mock("@/routes", () => ({ useRoutes: mocks.useRoutes }));
 vi.mock("react-router", () => ({
   Navigate: ({ to }: { to: string }) => (
     <div data-testid="navigate" data-to={to} />
@@ -34,7 +32,6 @@ function renderAt(path: string) {
 let originalLocation: Location | undefined;
 
 beforeEach(() => {
-  mocks.useRoutes.mockReturnValue({ mcp: { goTo: vi.fn() } });
   originalLocation = window.location;
   // @ts-expect-error test-only location replacement for same-origin URL parsing
   delete window.location;
@@ -84,5 +81,17 @@ describe("Register", () => {
     expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
       "/sign-up",
     );
+  });
+
+  it("redirects an authenticated session with an organization to the root", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "<ORG_ID>",
+    });
+
+    renderAt("/register");
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe("/");
+    expect(screen.queryByTestId("register-panel")).toBeNull();
   });
 });

--- a/client/dashboard/src/pages/login/Register.test.tsx
+++ b/client/dashboard/src/pages/login/Register.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import Register from "./Register";
@@ -16,13 +15,6 @@ vi.mock("react-router", () => ({
   ),
   useSearchParams: mocks.useSearchParams,
 }));
-vi.mock("./components/auth-shell", () => ({
-  AuthShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-}));
-vi.mock("./components/register-panel", () => ({
-  RegisterPanel: () => <div data-testid="register-panel" />,
-}));
-
 function renderAt(path: string) {
   const [, search = ""] = path.split("?");
   mocks.useSearchParams.mockReturnValue([new URLSearchParams(search), vi.fn()]);

--- a/client/dashboard/src/pages/login/Register.tsx
+++ b/client/dashboard/src/pages/login/Register.tsx
@@ -1,5 +1,5 @@
 import { useSession } from "@/contexts/Auth";
-import { safeSameOriginUrl } from "@/lib/safe-external-url";
+import { safeSameOriginPath, safeSameOriginUrl } from "@/lib/safe-external-url";
 import { Navigate, useSearchParams } from "react-router";
 
 export default function Register(): JSX.Element {
@@ -16,7 +16,8 @@ export default function Register(): JSX.Element {
     );
   }
 
-  const redirect = safeSameOriginUrl(searchParams.get("redirect"));
+  const rawRedirect = searchParams.get("redirect");
+  const redirect = safeSameOriginUrl(rawRedirect);
   const signUpTarget = redirect
     ? "/sign-up?redirect=" + encodeURIComponent(redirect)
     : "/sign-up";
@@ -25,5 +26,5 @@ export default function Register(): JSX.Element {
     return <Navigate to={signUpTarget} replace />;
   }
 
-  return <Navigate to={redirect ?? "/"} replace />;
+  return <Navigate to={safeSameOriginPath(rawRedirect) ?? "/"} replace />;
 }

--- a/client/dashboard/src/pages/login/Register.tsx
+++ b/client/dashboard/src/pages/login/Register.tsx
@@ -1,8 +1,6 @@
 import { useSession } from "@/contexts/Auth";
 import { safeSameOriginUrl } from "@/lib/safe-external-url";
 import { useRoutes } from "@/routes";
-import { AuthShell } from "./components/auth-shell";
-import { RegisterPanel } from "./components/register-panel";
 import { Navigate, useSearchParams } from "react-router";
 
 export default function Register(): JSX.Element {
@@ -20,18 +18,20 @@ export default function Register(): JSX.Element {
     );
   }
 
-  if (session.activeOrganizationId !== "") {
-    const redirect = safeSameOriginUrl(searchParams.get("redirect"));
-    if (redirect) {
-      window.location.href = redirect;
-    } else {
-      routes.mcp.goTo();
-    }
+  const redirect = safeSameOriginUrl(searchParams.get("redirect"));
+  const signUpTarget = redirect
+    ? "/sign-up?redirect=" + encodeURIComponent(redirect)
+    : "/sign-up";
+
+  if (session.session === "" || session.activeOrganizationId === "") {
+    return <Navigate to={signUpTarget} replace />;
   }
 
-  return (
-    <AuthShell page="Register">
-      <RegisterPanel />
-    </AuthShell>
-  );
+  if (redirect) {
+    window.location.href = redirect;
+  } else {
+    routes.mcp.goTo();
+  }
+
+  return <></>;
 }

--- a/client/dashboard/src/pages/login/Register.tsx
+++ b/client/dashboard/src/pages/login/Register.tsx
@@ -1,10 +1,8 @@
 import { useSession } from "@/contexts/Auth";
 import { safeSameOriginUrl } from "@/lib/safe-external-url";
-import { useRoutes } from "@/routes";
 import { Navigate, useSearchParams } from "react-router";
 
 export default function Register(): JSX.Element {
-  const routes = useRoutes();
   const session = useSession();
   const [searchParams] = useSearchParams();
 
@@ -27,11 +25,5 @@ export default function Register(): JSX.Element {
     return <Navigate to={signUpTarget} replace />;
   }
 
-  if (redirect) {
-    window.location.href = redirect;
-  } else {
-    routes.mcp.goTo();
-  }
-
-  return <></>;
+  return <Navigate to={redirect ?? "/"} replace />;
 }

--- a/client/dashboard/src/pages/login/SignUp.test.tsx
+++ b/client/dashboard/src/pages/login/SignUp.test.tsx
@@ -5,15 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SignUp from "./SignUp";
 
 const mocks = vi.hoisted(() => ({
-  locationSetter: vi.fn(),
   useSearchParams: vi.fn(),
   useSession: vi.fn(),
-  useRoutes: vi.fn(),
 }));
 
 vi.mock("@/contexts/Auth", () => ({ useSession: mocks.useSession }));
-vi.mock("@/routes", () => ({ useRoutes: mocks.useRoutes }));
 vi.mock("react-router", () => ({
+  Navigate: ({ to }: { to: string }) => (
+    <div data-testid="navigate" data-to={to} />
+  ),
   useSearchParams: mocks.useSearchParams,
 }));
 vi.mock("./components/auth-shell", () => ({
@@ -31,9 +31,7 @@ vi.mock("./components/register-panel", () => ({
 let originalLocation: Location | undefined;
 
 beforeEach(() => {
-  mocks.locationSetter.mockReset();
   mocks.useSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()]);
-  mocks.useRoutes.mockReturnValue({ mcp: { goTo: vi.fn() } });
   originalLocation = window.location;
   // @ts-expect-error test-only location replacement for redirect assertion
   delete window.location;
@@ -41,9 +39,6 @@ beforeEach(() => {
     configurable: true,
     value: {
       origin: "https://app.example",
-      set href(value: string) {
-        mocks.locationSetter(value);
-      },
     },
   });
 });
@@ -85,7 +80,7 @@ describe("SignUp", () => {
     ).toBe("https://app.example/cli/callback");
   });
 
-  it("returns an authenticated session with an organization to the requested destination", () => {
+  it("redirects an authenticated session with an organization to the requested destination", () => {
     mocks.useSession.mockReturnValue({
       session: "<SESSION>",
       activeOrganizationId: "<ORG_ID>",
@@ -96,8 +91,20 @@ describe("SignUp", () => {
 
     render(<SignUp />);
 
-    expect(mocks.locationSetter).toHaveBeenCalledWith(
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
       "https://app.example/projects/default",
     );
+  });
+
+  it("redirects an authenticated session with an organization to the root", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "<ORG_ID>",
+    });
+
+    render(<SignUp />);
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe("/");
+    expect(screen.queryByTestId("register-panel")).toBeNull();
   });
 });

--- a/client/dashboard/src/pages/login/SignUp.test.tsx
+++ b/client/dashboard/src/pages/login/SignUp.test.tsx
@@ -107,7 +107,25 @@ describe("SignUp", () => {
     render(<SignUp />);
 
     expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
-      "https://app.example/projects/default",
+      "/projects/default",
+    );
+  });
+
+  it("preserves search and hash in the requested destination", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "<ORG_ID>",
+    });
+    mocks.useSearchParams.mockReturnValue([
+      new URLSearchParams(
+        "redirect=https%3A%2F%2Fapp.example%2Fprojects%2Fdefault%3Ftab%3Dtools%23details",
+      ),
+    ]);
+
+    render(<SignUp />);
+
+    expect(screen.getByTestId("navigate").getAttribute("data-to")).toBe(
+      "/projects/default?tab=tools#details",
     );
   });
 

--- a/client/dashboard/src/pages/login/SignUp.test.tsx
+++ b/client/dashboard/src/pages/login/SignUp.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import SignUp from "./SignUp";
+
+const mocks = vi.hoisted(() => ({
+  locationSetter: vi.fn(),
+  useSearchParams: vi.fn(),
+  useSession: vi.fn(),
+  useRoutes: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({ useSession: mocks.useSession }));
+vi.mock("@/routes", () => ({ useRoutes: mocks.useRoutes }));
+vi.mock("react-router", () => ({
+  useSearchParams: mocks.useSearchParams,
+}));
+vi.mock("./components/auth-shell", () => ({
+  AuthShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("./components/signup-panel", () => ({
+  SignUpPanel: () => <div data-testid="signup-panel" />,
+}));
+vi.mock("./components/register-panel", () => ({
+  RegisterPanel: ({ redirectTo }: { redirectTo?: string | null }) => (
+    <div data-testid="register-panel" data-redirect-to={redirectTo} />
+  ),
+}));
+
+let originalLocation: Location | undefined;
+
+beforeEach(() => {
+  mocks.locationSetter.mockReset();
+  mocks.useSearchParams.mockReturnValue([new URLSearchParams(), vi.fn()]);
+  mocks.useRoutes.mockReturnValue({ mcp: { goTo: vi.fn() } });
+  originalLocation = window.location;
+  // @ts-expect-error test-only location replacement for redirect assertion
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      origin: "https://app.example",
+      set href(value: string) {
+        mocks.locationSetter(value);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalLocation) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  }
+  vi.clearAllMocks();
+});
+
+describe("SignUp", () => {
+  it("renders the existing signup form when logged out", () => {
+    mocks.useSession.mockReturnValue({ session: "", activeOrganizationId: "" });
+
+    render(<SignUp />);
+
+    expect(screen.getByTestId("signup-panel")).toBeTruthy();
+    expect(screen.queryByTestId("register-panel")).toBeNull();
+  });
+
+  it("renders organization registration for an authenticated zero-org session", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "",
+    });
+    mocks.useSearchParams.mockReturnValue([
+      new URLSearchParams("redirect=%2Fcli%2Fcallback"),
+    ]);
+
+    render(<SignUp />);
+
+    expect(
+      screen.getByTestId("register-panel").getAttribute("data-redirect-to"),
+    ).toBe("https://app.example/cli/callback");
+  });
+
+  it("returns an authenticated session with an organization to the requested destination", () => {
+    mocks.useSession.mockReturnValue({
+      session: "<SESSION>",
+      activeOrganizationId: "<ORG_ID>",
+    });
+    mocks.useSearchParams.mockReturnValue([
+      new URLSearchParams("redirect=%2Fprojects%2Fdefault"),
+    ]);
+
+    render(<SignUp />);
+
+    expect(mocks.locationSetter).toHaveBeenCalledWith(
+      "https://app.example/projects/default",
+    );
+  });
+});

--- a/client/dashboard/src/pages/login/SignUp.test.tsx
+++ b/client/dashboard/src/pages/login/SignUp.test.tsx
@@ -20,7 +20,9 @@ vi.mock("./components/auth-shell", () => ({
   AuthShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 vi.mock("./components/signup-panel", () => ({
-  SignUpPanel: () => <div data-testid="signup-panel" />,
+  SignUpPanel: ({ redirectTo }: { redirectTo?: string | null }) => (
+    <div data-testid="signup-panel" data-redirect-to={redirectTo} />
+  ),
 }));
 vi.mock("./components/register-panel", () => ({
   RegisterPanel: ({ redirectTo }: { redirectTo?: string | null }) => (
@@ -62,6 +64,19 @@ describe("SignUp", () => {
 
     expect(screen.getByTestId("signup-panel")).toBeTruthy();
     expect(screen.queryByTestId("register-panel")).toBeNull();
+  });
+
+  it("passes the requested destination to the logged-out signup form", () => {
+    mocks.useSession.mockReturnValue({ session: "", activeOrganizationId: "" });
+    mocks.useSearchParams.mockReturnValue([
+      new URLSearchParams("redirect=%2Fcli%2Fcallback"),
+    ]);
+
+    render(<SignUp />);
+
+    expect(
+      screen.getByTestId("signup-panel").getAttribute("data-redirect-to"),
+    ).toBe("https://app.example/cli/callback");
   });
 
   it("renders organization registration for an authenticated zero-org session", () => {

--- a/client/dashboard/src/pages/login/SignUp.tsx
+++ b/client/dashboard/src/pages/login/SignUp.tsx
@@ -1,10 +1,35 @@
+import { useSession } from "@/contexts/Auth";
+import { safeSameOriginUrl } from "@/lib/safe-external-url";
+import { useRoutes } from "@/routes";
 import { AuthShell } from "./components/auth-shell";
+import { RegisterPanel } from "./components/register-panel";
 import { SignUpPanel } from "./components/signup-panel";
+import { useSearchParams } from "react-router";
 
 export default function SignUp(): JSX.Element {
+  const session = useSession();
+  const routes = useRoutes();
+  const [searchParams] = useSearchParams();
+  const redirectTo = safeSameOriginUrl(searchParams.get("redirect"));
+
+  if (session.session !== "" && session.activeOrganizationId !== "") {
+    if (redirectTo) {
+      window.location.href = redirectTo;
+    } else {
+      routes.mcp.goTo();
+    }
+  }
+
+  const panel =
+    session.session === "" ? (
+      <SignUpPanel />
+    ) : (
+      <RegisterPanel redirectTo={redirectTo} />
+    );
+
   return (
     <AuthShell page="Sign up" contentClassName="max-w-[400px] gap-5">
-      <SignUpPanel />
+      {panel}
     </AuthShell>
   );
 }

--- a/client/dashboard/src/pages/login/SignUp.tsx
+++ b/client/dashboard/src/pages/login/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useSession } from "@/contexts/Auth";
-import { safeSameOriginUrl } from "@/lib/safe-external-url";
+import { safeSameOriginPath, safeSameOriginUrl } from "@/lib/safe-external-url";
 import { AuthShell } from "./components/auth-shell";
 import { RegisterPanel } from "./components/register-panel";
 import { SignUpPanel } from "./components/signup-panel";
@@ -8,10 +8,11 @@ import { Navigate, useSearchParams } from "react-router";
 export default function SignUp(): JSX.Element {
   const session = useSession();
   const [searchParams] = useSearchParams();
-  const redirectTo = safeSameOriginUrl(searchParams.get("redirect"));
+  const redirect = searchParams.get("redirect");
+  const redirectTo = safeSameOriginUrl(redirect);
 
   if (session.session !== "" && session.activeOrganizationId !== "") {
-    return <Navigate to={redirectTo ?? "/"} replace />;
+    return <Navigate to={safeSameOriginPath(redirect) ?? "/"} replace />;
   }
 
   const panel =

--- a/client/dashboard/src/pages/login/SignUp.tsx
+++ b/client/dashboard/src/pages/login/SignUp.tsx
@@ -1,23 +1,17 @@
 import { useSession } from "@/contexts/Auth";
 import { safeSameOriginUrl } from "@/lib/safe-external-url";
-import { useRoutes } from "@/routes";
 import { AuthShell } from "./components/auth-shell";
 import { RegisterPanel } from "./components/register-panel";
 import { SignUpPanel } from "./components/signup-panel";
-import { useSearchParams } from "react-router";
+import { Navigate, useSearchParams } from "react-router";
 
 export default function SignUp(): JSX.Element {
   const session = useSession();
-  const routes = useRoutes();
   const [searchParams] = useSearchParams();
   const redirectTo = safeSameOriginUrl(searchParams.get("redirect"));
 
   if (session.session !== "" && session.activeOrganizationId !== "") {
-    if (redirectTo) {
-      window.location.href = redirectTo;
-    } else {
-      routes.mcp.goTo();
-    }
+    return <Navigate to={redirectTo ?? "/"} replace />;
   }
 
   const panel =

--- a/client/dashboard/src/pages/login/SignUp.tsx
+++ b/client/dashboard/src/pages/login/SignUp.tsx
@@ -16,7 +16,7 @@ export default function SignUp(): JSX.Element {
 
   const panel =
     session.session === "" ? (
-      <SignUpPanel />
+      <SignUpPanel redirectTo={redirectTo} />
     ) : (
       <RegisterPanel redirectTo={redirectTo} />
     );

--- a/client/dashboard/src/pages/login/components/register-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/register-panel.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RegisterPanel } from "./register-panel";
+
+const mocks = vi.hoisted(() => ({
+  buildRegisterMutation: vi.fn(),
+  useGramContext: vi.fn(),
+  useMutation: vi.fn(),
+  useTelemetry: vi.fn(),
+}));
+
+vi.mock("@/contexts/Telemetry", () => ({ useTelemetry: mocks.useTelemetry }));
+vi.mock("@gram/client/funcs/authInfo", () => ({ authInfo: vi.fn() }));
+vi.mock("@gram/client/react-query/_context.js", () => ({
+  useGramContext: mocks.useGramContext,
+}));
+vi.mock("@gram/client/react-query/register.js", () => ({
+  buildRegisterMutation: mocks.buildRegisterMutation,
+}));
+vi.mock("@tanstack/react-query", () => ({ useMutation: mocks.useMutation }));
+
+beforeEach(() => {
+  mocks.useTelemetry.mockReturnValue({ capture: vi.fn() });
+  mocks.useGramContext.mockReturnValue({});
+  mocks.useMutation.mockImplementation(({ onSuccess }) => ({
+    error: null,
+    isPending: false,
+    mutate: () => onSuccess(),
+  }));
+  vi.stubGlobal("location", {
+    origin: "https://app.example",
+    replace: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("RegisterPanel", () => {
+  it("returns to the preserved destination after organization creation", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <RegisterPanel redirectTo="/cli/callback" />
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText("Company name"), "Acme Inc");
+    await user.click(
+      screen.getByRole("button", { name: /create organization/i }),
+    );
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      "https://app.example/cli/callback",
+    );
+  });
+
+  it("returns to the dashboard root when no destination was preserved", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <RegisterPanel />
+      </MemoryRouter>,
+    );
+
+    await user.type(screen.getByLabelText("Company name"), "Acme Inc");
+    await user.click(
+      screen.getByRole("button", { name: /create organization/i }),
+    );
+
+    expect(window.location.replace).toHaveBeenCalledWith("/");
+  });
+});

--- a/client/dashboard/src/pages/login/components/register-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/register-panel.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RegisterPanel } from "./register-panel";
 
+const locationReplace = vi.fn();
+
 const mocks = vi.hoisted(() => ({
   buildRegisterMutation: vi.fn(),
   useGramContext: vi.fn(),
@@ -32,7 +34,7 @@ beforeEach(() => {
   }));
   vi.stubGlobal("location", {
     origin: "https://app.example",
-    replace: vi.fn(),
+    replace: locationReplace,
   });
 });
 
@@ -56,7 +58,7 @@ describe("RegisterPanel", () => {
       screen.getByRole("button", { name: /create organization/i }),
     );
 
-    expect(window.location.replace).toHaveBeenCalledWith(
+    expect(locationReplace).toHaveBeenCalledWith(
       "https://app.example/cli/callback",
     );
   });
@@ -74,6 +76,6 @@ describe("RegisterPanel", () => {
       screen.getByRole("button", { name: /create organization/i }),
     );
 
-    expect(window.location.replace).toHaveBeenCalledWith("/");
+    expect(locationReplace).toHaveBeenCalledWith("/");
   });
 });

--- a/client/dashboard/src/pages/login/components/register-panel.tsx
+++ b/client/dashboard/src/pages/login/components/register-panel.tsx
@@ -1,4 +1,5 @@
 import { useTelemetry } from "@/contexts/Telemetry";
+import { safeSameOriginUrl } from "@/lib/safe-external-url";
 import { cn } from "@/lib/utils";
 import { authInfo } from "@gram/client/funcs/authInfo";
 import { useGramContext } from "@gram/client/react-query/_context.js";
@@ -16,7 +17,11 @@ import {
   validateOrgName,
 } from "./org-name";
 
-export function RegisterPanel(): JSX.Element {
+export function RegisterPanel({
+  redirectTo,
+}: {
+  redirectTo?: string | null;
+}): JSX.Element {
   const telemetry = useTelemetry();
   const [companyName, setCompanyName] = useState("");
   const [validationError, setValidationError] = useState("");
@@ -47,7 +52,8 @@ export function RegisterPanel(): JSX.Element {
         company_name: companyName,
         is_gram: true,
       });
-      window.location.replace("/");
+      const destination = safeSameOriginUrl(redirectTo) ?? "/";
+      window.location.replace(destination);
     },
     onError: (error) => {
       setValidationError(error.message);

--- a/client/dashboard/src/pages/login/components/signup-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.test.tsx
@@ -16,10 +16,10 @@ afterEach(() => {
   telemetryCapture.mockReset();
 });
 
-function renderPanel(initialEntry = "/sign-up") {
+function renderPanel(initialEntry = "/sign-up", redirectTo?: string | null) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <SignUpPanel />
+      <SignUpPanel redirectTo={redirectTo} />
     </MemoryRouter>,
   );
 }
@@ -158,6 +158,26 @@ describe("SignUpPanel", () => {
     expect(target).toContain("/rpc/auth.login");
     expect(target).toContain("org_name=Acme+Inc");
     expect(target).toContain("email=someone%40example.com");
+
+    assign.mockRestore();
+  });
+
+  it("preserves the requested destination in the login handoff", async () => {
+    const assign = vi
+      .spyOn(window.location, "assign")
+      .mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    renderPanel("/sign-up", "https://app.example/cli/callback");
+
+    await user.type(screen.getByLabelText("Work email"), "someone@example.com");
+    await user.type(screen.getByLabelText("Company name"), "Acme Inc");
+    await user.click(screen.getByRole("button", { name: /start trial/i }));
+
+    const target = assign.mock.calls[0]?.[0] as string;
+    expect(new URL(target).searchParams.get("redirect")).toBe(
+      "https://app.example/cli/callback",
+    );
 
     assign.mockRestore();
   });

--- a/client/dashboard/src/pages/login/components/signup-panel.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.tsx
@@ -30,7 +30,11 @@ function firstError(errors: unknown[]): string | undefined {
   return typeof error === "string" ? error : undefined;
 }
 
-export function SignUpPanel(): JSX.Element {
+export function SignUpPanel({
+  redirectTo,
+}: {
+  redirectTo?: string | null;
+}): JSX.Element {
   const telemetry = useTelemetry();
   const form = useForm({
     defaultValues: { email: "", companyName: "" },
@@ -51,7 +55,7 @@ export function SignUpPanel(): JSX.Element {
       // arrives pre-filled, and is never stored at all.
       window.location.assign(
         buildLoginRedirectURL(
-          null,
+          redirectTo ?? null,
           normalizeOrgName(value.companyName),
           value.email.trim(),
         ),


### PR DESCRIPTION
Linear: [AGE-3146](https://linear.app/speakeasy/issue/AGE-3146/route-zero-org-onboarding-through-session-aware-sign-up)

## Summary

- Users who are already signed in but do not have an organization are now sent to `/sign-up` from protected app routes and the CLI flow.
- `/sign-up` shows the existing organization form for those users, while continuing to show the normal WorkOS signup form to logged-out visitors.
- Redirect destinations survive signup and organization creation, so users return to the app or CLI flow that started onboarding.
- `/register` now redirects to `/sign-up` for compatibility. The assistants flow and `auth.register` behavior are unchanged.

## Motivation

The recent login change sends users without an existing account to `/sign-up`, but users who are already authenticated and only need to create an organization were still routed through `/register`. This makes `/sign-up` the single onboarding entry point without sending authenticated users through WorkOS again or changing server-side organization provisioning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes authenticated zero-organization sessions through `/sign-up` and normalizes same-origin redirects for router navigation, making `/sign-up` the single onboarding entry point (AGE-3146). Previously these users hit `/register`; now `/sign-up` renders the organization form and preserves the originating destination.

- Login checks and the CLI callback now send zero-org sessions to `/sign-up?redirect=<same-origin>`. The CLI defers API key creation/authorization until an organization exists.
- `/register` acts as a compatibility redirect: logged-out traffic goes to `/sign-up` with a validated redirect, assistants disposition still targets `/login`, and active sessions navigate to the requested same-origin route or `/`.
- Adds `safeSameOriginPath` to convert same-origin URLs to router paths, preserving path/search/hash while dropping external redirects.

<sup>Written for commit 3d68a894effc5942c25b9c1537f6f75808296892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

