### PR TITLE
mig(platform-mcp): add operation receipt result payload

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -7084,6 +7084,9 @@ CREATE TABLE IF NOT EXISTS platform_mcp_operation_receipts (
   input_hash TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'pending',
   result_code TEXT,
+  -- Safe, operation-specific result projection used to replay completed
+  -- idempotent writes without re-reading mutable domain state.
+  result_payload JSONB,
   expires_at timestamptz NOT NULL,
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1769,6 +1769,7 @@ type PlatformMcpOperationReceipt struct {
 	InputHash            string
 	Status               string
 	ResultCode           pgtype.Text
+	ResultPayload        []byte
 	ExpiresAt            pgtype.Timestamptz
 	CreatedAt            pgtype.Timestamptz
 	UpdatedAt            pgtype.Timestamptz

--- a/server/internal/platformmcp/repo/models.go
+++ b/server/internal/platformmcp/repo/models.go
@@ -134,6 +134,7 @@ type PlatformMcpOperationReceipt struct {
 	InputHash            string
 	Status               string
 	ResultCode           pgtype.Text
+	ResultPayload        []byte
 	ExpiresAt            pgtype.Timestamptz
 	CreatedAt            pgtype.Timestamptz
 	UpdatedAt            pgtype.Timestamptz

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -19,7 +19,7 @@ SET registration_id = $1,
 WHERE id = $2
   AND organization_id = $3
   AND status = 'pending'
-RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, expires_at, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
 
 type AttachPlatformMCPOperationReceiptRegistrationParams struct {
@@ -45,6 +45,7 @@ func (q *Queries) AttachPlatformMCPOperationReceiptRegistration(ctx context.Cont
 		&i.InputHash,
 		&i.Status,
 		&i.ResultCode,
+		&i.ResultPayload,
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -171,7 +172,7 @@ SET registration_id = $1,
     updated_at = clock_timestamp()
 WHERE id = $4
   AND organization_id = $5
-RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, expires_at, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
 
 type CompletePlatformMCPOperationReceiptParams struct {
@@ -205,6 +206,7 @@ func (q *Queries) CompletePlatformMCPOperationReceipt(ctx context.Context, arg C
 		&i.InputHash,
 		&i.Status,
 		&i.ResultCode,
+		&i.ResultPayload,
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -936,7 +938,7 @@ INSERT INTO platform_mcp_operation_receipts (
     $12,
     $13
 )
-RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, expires_at, created_at, updated_at
+RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
 
 type CreatePlatformMCPOperationReceiptParams struct {
@@ -986,6 +988,7 @@ func (q *Queries) CreatePlatformMCPOperationReceipt(ctx context.Context, arg Cre
 		&i.InputHash,
 		&i.Status,
 		&i.ResultCode,
+		&i.ResultPayload,
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -2595,7 +2598,7 @@ func (q *Queries) GetPlatformMCPOnboardingSelectedProject(ctx context.Context, a
 }
 
 const getPlatformMCPOperationReceipt = `-- name: GetPlatformMCPOperationReceipt :one
-SELECT receipt.id, receipt.organization_id, receipt.project_id, receipt.registration_id, receipt.connection_id, receipt.connection_generation, receipt.user_id, receipt.acting_surface, receipt.operation, receipt.idempotency_key, receipt.input_hash, receipt.status, receipt.result_code, receipt.expires_at, receipt.created_at, receipt.updated_at
+SELECT receipt.id, receipt.organization_id, receipt.project_id, receipt.registration_id, receipt.connection_id, receipt.connection_generation, receipt.user_id, receipt.acting_surface, receipt.operation, receipt.idempotency_key, receipt.input_hash, receipt.status, receipt.result_code, receipt.result_payload, receipt.expires_at, receipt.created_at, receipt.updated_at
 FROM platform_mcp_operation_receipts AS receipt
 LEFT JOIN platform_mcp_connections AS connection
   ON connection.id = receipt.connection_id
@@ -2649,6 +2652,7 @@ func (q *Queries) GetPlatformMCPOperationReceipt(ctx context.Context, arg GetPla
 		&i.InputHash,
 		&i.Status,
 		&i.ResultCode,
+		&i.ResultPayload,
 		&i.ExpiresAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260825013503_platform-mcp-operation-receipt-result-payload.sql
+++ b/server/migrations/20260825013503_platform-mcp-operation-receipt-result-payload.sql
@@ -1,0 +1,2 @@
+-- Modify "platform_mcp_operation_receipts" table
+ALTER TABLE "platform_mcp_operation_receipts" ADD COLUMN "result_payload" jsonb NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/Spjx2Q9GRxZDhQwSWGkJbOC6EaggiOlNyIph32//ic=
+h1:Fn2dYKwc3o6YxYqF80AOf23wCbhaE8bpehc/M2Pt4nY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -362,3 +362,4 @@ h1:/Spjx2Q9GRxZDhQwSWGkJbOC6EaggiOlNyIph32//ic=
 20260820223741_add-meta-mcp-servers.sql h1:IeASYht+IS0A2fUpejqgmnveRLsI/toU3TXQkk0eR0U=
 20260824101637_session-quarantines.sql h1:u9OuwdWdmTtmMQAKi87E16bPyf37dcYtyD8eVl8i+Ps=
 20260824205231_add-meta-mcp-visibility.sql h1:sNzUickcYBYZhyuODqZl5gQkHRg20UNRtul3fKxd+oE=
+20260825013503_platform-mcp-operation-receipt-result-payload.sql h1:WjXtdhOf4ZTjor8hkwXynhj2TI2Gv5iO4z/EzFaK0lQ=


### PR DESCRIPTION
AGE-3168

## Summary

- add a nullable JSON result projection to Platform MCP operation receipts
- regenerate the Atlas migration checksum and SQLc receipt models/scans
- keep the change additive and isolated from the D3 application behavior that will consume it

## Motivation

D3 risk policy and exclusion mutations need exact idempotent retries to return the original safe result without re-reading mutable domain state. Landing the nullable storage first preserves deployment ordering: existing servers ignore it, and later application PRs can begin writing it only after the schema is available.

## Rollout / deployment notes

Deploy this migration before the D3 mutation-infrastructure PR. Rollback leaves the nullable column in place; no backfill or data mutation is required.

Local file-scoped migration checks, SQLc generation, formatting, diff checks, and Platform MCP compile validation passed. Full Atlas dry-run/apply and database-backed package tests were blocked by stale local Atlas history and a local PostgreSQL test instance entering recovery; CI should run these checks in a clean environment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nullable JSONB result_payload to Platform MCP operation receipts to store a safe, operation-specific result projection. This enables exact idempotent retries for D3 risk policy and exclusion mutations (AGE-3168) by returning the original result without re-reading mutable state.

- Review notes
  - Additive schema: old behavior returned only result_code; new behavior also persists and returns optional result_payload via repo queries; no runtime change until writers set it.
  - Updated `sqlc` models and repo scans to include result_payload in SELECT/RETURNING paths; stored as JSONB and allowed to be null.

- Rollout
  - Apply this migration before deploying the D3 mutation infrastructure that writes result_payload.
  - No backfill required; rollback leaves the nullable column in place.

<sup>Written for commit 94857be18e3ae0e1cbd57b06bac20699f98a9101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

