### PR TITLE
feat(dashboard): organization admin UI for JSON Web Key Sets

### DIFF
--- a/.changeset/org-admin-jwks-ui.md
+++ b/.changeset/org-admin-jwks-ui.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": minor
+---
+
+Organization admins can now manage JSON Web Key Sets from the Encryption Keys page: a new Signing Keys (JWKS) section lists an organization's key sets, a guided sheet creates one from a GCP KMS key, and each set's detail page shows its history, its published keys with activate / retire / revoke actions and a publish flow that re-points the backing key, and a settings tab for renaming and deleting the set. The `auditlogs.list` endpoint gains an optional repeated `subject_ids` filter so a resource's feed can include the child resources whose events name the child as the subject.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -8888,11 +8888,11 @@ paths:
             description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
             type: string
         - allowEmptyValue: true
-          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
           in: query
           name: subject_ids
           schema:
-            description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+            description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
             items:
               type: string
             maxItems: 200
@@ -70027,7 +70027,7 @@ components:
           type: array
           items:
             type: string
-          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
           maxItems: 200
         subject_type:
           type: string

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -8888,6 +8888,16 @@ paths:
             description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
             type: string
         - allowEmptyValue: true
+          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+          in: query
+          name: subject_ids
+          schema:
+            description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+            items:
+              type: string
+            maxItems: 200
+            type: array
+        - allowEmptyValue: true
           description: Acting surface to filter audit logs to changes made through one surface, e.g. 'platform_mcp' to review agent-driven activity alone.
           in: query
           name: acting_surface
@@ -70013,6 +70023,12 @@ components:
         subject_id:
           type: string
           description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
+        subject_ids:
+          type: array
+          items:
+            type: string
+          description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+          maxItems: 200
         subject_type:
           type: string
           description: Subject type to filter audit logs to a specific kind of subject. When omitted, assistant activity events are excluded; pass 'assistant' to list them.

--- a/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
+++ b/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
@@ -53,6 +53,7 @@ export function ResourceAuditFeed({
     hasNextPage,
     isFetching,
     isFetchingNextPage,
+    isFetchNextPageError,
     isPending,
     refetch,
   } = useAuditLogsInfinite({ subjectIds }, undefined, {
@@ -117,14 +118,20 @@ export function ResourceAuditFeed({
       </div>
       {error && (
         <div className="flex items-center justify-between gap-4 border-t px-4 py-3">
+          {/* A failed "load more" and a failed refresh of the rows already on
+              screen are different failures with different retries. */}
           <Text small muted>
-            The next page of activity could not be loaded.
+            {isFetchNextPageError
+              ? "The next page of activity could not be loaded."
+              : "The activity could not be refreshed."}
           </Text>
           <Button
             size="sm"
             variant="secondary"
-            onClick={() => void fetchNextPage()}
-            disabled={isFetchingNextPage}
+            onClick={() =>
+              void (isFetchNextPageError ? fetchNextPage() : refetch())
+            }
+            disabled={isFetching}
           >
             <Button.Text>Retry</Button.Text>
           </Button>

--- a/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
+++ b/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
@@ -53,7 +53,7 @@ export function ResourceAuditFeed({
     hasNextPage,
     isFetching,
     isFetchingNextPage,
-    isLoading,
+    isPending,
     refetch,
   } = useAuditLogsInfinite({ subjectIds }, undefined, {
     enabled,
@@ -69,7 +69,7 @@ export function ResourceAuditFeed({
     [logs],
   );
 
-  if (!enabled || isLoading) {
+  if (!enabled || isPending) {
     return (
       <div className="text-muted-foreground flex items-center gap-2 py-6">
         <Icon name="loader-circle" className="size-4 animate-spin" />

--- a/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
+++ b/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
@@ -1,0 +1,170 @@
+import {
+  ActionIconTile,
+  AuditFeedFooter,
+  DateGroupHeader,
+} from "@/components/auditlogs/feed";
+import { subjectHref } from "@/components/auditlogs/subject-href";
+import { Button } from "@/components/ui/Button";
+import { Icon } from "@/components/ui/Icon";
+import { Link as TextLink } from "@/components/ui/Link";
+import { Text } from "@/components/ui/Text";
+import { useSlugs } from "@/contexts/Sdk";
+import {
+  formatTimeOnly,
+  groupLogsByDate,
+  type TimestampMode,
+} from "@/lib/audit-log-feed";
+import {
+  formatSubjectLabel,
+  getActorLabel,
+  renderVerb,
+} from "@/lib/audit-log-format";
+import type { AuditLog } from "@gram/client/models/components/auditlog.js";
+import { useAuditLogsInfinite } from "@gram/client/react-query/auditLogs.js";
+import React, { useMemo } from "react";
+import { Link } from "react-router";
+
+const TIMESTAMP_MODE: TimestampMode = "local";
+
+// ResourceAuditFeed is the audit trail of one resource, embedded in its detail
+// page: every entry whose subject is one of `subjectIds`. A resource's own
+// events name it as the subject; events on its children name the child, which
+// is why the caller passes the children's ids too rather than a single id.
+//
+// The list is exact and paginated server-side, so "load more" and the end of
+// the feed mean what they say. Pass `enabled: false` until the child ids are
+// known, otherwise the first page would be fetched twice.
+export function ResourceAuditFeed({
+  subjectIds,
+  enabled = true,
+  noun = "event",
+  emptyMessage = "No activity recorded yet.",
+}: {
+  subjectIds: string[];
+  enabled?: boolean;
+  noun?: string;
+  emptyMessage?: string;
+}): JSX.Element {
+  const { orgSlug } = useSlugs();
+  const {
+    data,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isLoading,
+    refetch,
+  } = useAuditLogsInfinite({ subjectIds }, undefined, {
+    enabled,
+    throwOnError: false,
+  });
+
+  const logs = useMemo(
+    () => data?.pages.flatMap((page) => page.result.logs) ?? [],
+    [data],
+  );
+  const dateGroups = useMemo(
+    () => groupLogsByDate(logs, TIMESTAMP_MODE),
+    [logs],
+  );
+
+  if (!enabled || isLoading) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-2 py-6">
+        <Icon name="loader-circle" className="size-4 animate-spin" />
+        <Text small muted>
+          Loading activity…
+        </Text>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-start gap-2 py-6">
+        <Text muted>Failed to load activity.</Text>
+        <Button size="sm" variant="secondary" onClick={() => void refetch()}>
+          <Button.Text>Retry</Button.Text>
+        </Button>
+      </div>
+    );
+  }
+
+  if (logs.length === 0) {
+    return (
+      <Text muted className="py-6">
+        {emptyMessage}
+      </Text>
+    );
+  }
+
+  return (
+    <div className="bg-card overflow-hidden border">
+      <div className="divide-border divide-y">
+        {dateGroups.map((group) => (
+          <React.Fragment key={group.key}>
+            <DateGroupHeader date={group.date} mode={TIMESTAMP_MODE} />
+            {group.logs.map((log) => (
+              <ResourceAuditRow key={log.id} log={log} orgSlug={orgSlug} />
+            ))}
+          </React.Fragment>
+        ))}
+      </div>
+      <AuditFeedFooter
+        count={logs.length}
+        noun={noun}
+        hasNextPage={hasNextPage ?? false}
+        isFetching={isFetching}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={() => {
+          void fetchNextPage();
+        }}
+        endLabel="End of activity"
+      />
+    </div>
+  );
+}
+
+function ResourceAuditRow({
+  log,
+  orgSlug,
+}: {
+  log: AuditLog;
+  orgSlug: string | undefined;
+}): JSX.Element {
+  const raw = log.subjectDisplayName || log.subjectSlug || log.subjectId;
+  const label = formatSubjectLabel(raw, log.subjectType);
+  const href = orgSlug ? subjectHref(log, orgSlug) : null;
+
+  return (
+    <div className="bg-card flex items-center gap-3 px-4 py-2.5">
+      <ActionIconTile action={log.action} />
+      <div className="min-w-0 flex-1 text-sm leading-5">
+        <strong className="text-foreground font-semibold">
+          {getActorLabel(log)}
+        </strong>{" "}
+        <span className="text-muted-foreground">{renderVerb(log)}</span>{" "}
+        {href ? (
+          <TextLink
+            asChild
+            size="xs"
+            underline={false}
+            className="font-mono text-xs"
+          >
+            <Link to={href} title={raw}>
+              {label}
+            </Link>
+          </TextLink>
+        ) : (
+          <span className="text-muted-foreground font-mono text-xs" title={raw}>
+            {label}
+          </span>
+        )}
+      </div>
+      <span className="text-muted-foreground shrink-0 font-mono text-xs tabular-nums">
+        {formatTimeOnly(log.createdAt, TIMESTAMP_MODE)}
+      </span>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
+++ b/client/dashboard/src/components/auditlogs/resource-audit-feed.tsx
@@ -80,7 +80,11 @@ export function ResourceAuditFeed({
     );
   }
 
-  if (error) {
+  // A failure with nothing loaded yet replaces the feed. A failure while
+  // loading a later page keeps every page already loaded (they are still in
+  // `data`) and reports the failure inline instead, so a flaky "load more"
+  // never wipes out the rows the reader was looking at.
+  if (error && logs.length === 0) {
     return (
       <div className="flex flex-col items-start gap-2 py-6">
         <Text muted>Failed to load activity.</Text>
@@ -111,6 +115,21 @@ export function ResourceAuditFeed({
           </React.Fragment>
         ))}
       </div>
+      {error && (
+        <div className="flex items-center justify-between gap-4 border-t px-4 py-3">
+          <Text small muted>
+            The next page of activity could not be loaded.
+          </Text>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => void fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            <Button.Text>Retry</Button.Text>
+          </Button>
+        </div>
+      )}
       <AuditFeedFooter
         count={logs.length}
         noun={noun}

--- a/client/dashboard/src/components/auditlogs/subject-href.ts
+++ b/client/dashboard/src/components/auditlogs/subject-href.ts
@@ -58,6 +58,16 @@ export function subjectHref(log: AuditLog, orgSlug: string): string | null {
         : null;
     case "api_key":
       return `/${orgSlug}/api-keys`;
+    case "json_web_key_set":
+      return `/${orgSlug}/signing-keys/${log.subjectId}/overview`;
+    case "json_web_key": {
+      // A key event names the key as its subject; the set it belongs to rides
+      // along in metadata, and the Keys tab is where the key is listed.
+      const setId = log.metadata?.["json_web_key_set_id"];
+      return typeof setId === "string" && setId !== ""
+        ? `/${orgSlug}/signing-keys/${setId}/keys`
+        : null;
+    }
     default:
       return null;
   }

--- a/client/dashboard/src/components/customer-managed-keys-gate.tsx
+++ b/client/dashboard/src/components/customer-managed-keys-gate.tsx
@@ -5,11 +5,16 @@ import { useProductFeatures } from "@gram/client/react-query/productFeatures.js"
 import type { ReactNode } from "react";
 
 // CustomerManagedKeysGate is the product-feature (entitlement) gate for every
-// page under Encryption Keys and Signing Key Sets, mounted after the RBAC scope
-// gate so no protected request fires for a visitor lacking the page scope. The
-// sidebar entry is already hidden without the entitlement; this covers direct
-// URLs, including deep links to a key or key set detail page. A gated but
-// authorized organization sees only the framed refusal.
+// page under External Services, Encryption Keys and Signing Key Sets, mounted
+// after the RBAC scope gate so no protected request fires for a visitor
+// lacking the page scope. The sidebar entries are already hidden without the
+// entitlement; this covers direct URLs, including deep links to a credential,
+// key or key set detail page. A gated but authorized organization sees only
+// the framed refusal.
+//
+// A failed entitlement read is treated as not-yet-known rather than as a
+// refusal, so an entitled organization never flashes the gate; the server
+// enforces the entitlement on every endpoint regardless.
 export function CustomerManagedKeysGate({
   children,
 }: {

--- a/client/dashboard/src/lib/query-errors.ts
+++ b/client/dashboard/src/lib/query-errors.ts
@@ -1,0 +1,9 @@
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+
+// isNotNotFound is a `throwOnError` predicate for detail-page reads that treat
+// a 404 as "return to the list" rather than as a crash: only a not-found is
+// kept for the caller's own handling, and every other failure still reaches
+// the nearest error boundary the way the default query config sends it.
+export function isNotNotFound(error: unknown): boolean {
+  return !(error instanceof GramError && error.statusCode === 404);
+}

--- a/client/dashboard/src/lib/query-errors.ts
+++ b/client/dashboard/src/lib/query-errors.ts
@@ -1,9 +1,15 @@
+import { isUnauthorizedError } from "@/lib/route-errors";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 
 // isNotNotFound is a `throwOnError` predicate for detail-page reads that treat
-// a 404 as "return to the list" rather than as a crash: only a not-found is
-// kept for the caller's own handling, and every other failure still reaches
-// the nearest error boundary the way the default query config sends it.
+// a 404 as "return to the list" rather than as a crash. It keeps the dashboard
+// default's behavior for auth states (401 and 403 are handled by the cache and
+// the RBAC gates, not by the error boundary) and adds the not-found case; every
+// other failure still reaches the nearest error boundary.
 export function isNotNotFound(error: unknown): boolean {
-  return !(error instanceof GramError && error.statusCode === 404);
+  if (isUnauthorizedError(error)) return false;
+  return !(
+    error instanceof GramError &&
+    (error.statusCode === 403 || error.statusCode === 404)
+  );
 }

--- a/client/dashboard/src/pages/org/encryption-keys/CreateExternalKeySheet.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/CreateExternalKeySheet.tsx
@@ -19,6 +19,7 @@ import {
 import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
 import { useOrgRoutes } from "@/routes";
+import type { GcpKmsKey } from "@gram/client/models/components/gcpkmskey.js";
 import { useCreateGcpKmsKeyMutation } from "@gram/client/react-query/createGcpKmsKey";
 import { invalidateAllListExternalKeys } from "@gram/client/react-query/listExternalKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -41,10 +42,15 @@ export function CreateExternalKeySheet({
   open,
   onOpenChange,
   isCurrentOrganization,
+  onCreated,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isCurrentOrganization: () => boolean;
+  // Called with the new key instead of navigating to its detail page, for a
+  // caller that opened the sheet from inside another form and wants to keep
+  // that form.
+  onCreated?: (key: GcpKmsKey) => void;
 }): JSX.Element {
   const orgRoutes = useOrgRoutes();
   const queryClient = useQueryClient();
@@ -64,6 +70,10 @@ export function CreateExternalKeySheet({
       if (!isCurrentOrganization()) return;
       toast.success("Encryption key created");
       onOpenChange(false);
+      if (onCreated) {
+        onCreated(created);
+        return;
+      }
       orgRoutes.encryptionKeys.keyDetail.goTo(
         providerSlug(created.provider),
         created.id,

--- a/client/dashboard/src/pages/org/encryption-keys/CustomerManagedKeysGate.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/CustomerManagedKeysGate.tsx
@@ -1,0 +1,47 @@
+import { Page } from "@/components/page-layout";
+import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import type { ReactNode } from "react";
+
+// CustomerManagedKeysGate is the product-feature (entitlement) gate for every
+// page under Encryption Keys and Signing Key Sets, mounted after the RBAC scope
+// gate so no protected request fires for a visitor lacking the page scope. The
+// sidebar entry is already hidden without the entitlement; this covers direct
+// URLs, including deep links to a key or key set detail page. A gated but
+// authorized organization sees only the framed refusal.
+export function CustomerManagedKeysGate({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const organization = useOrganization();
+  const { data: features, isLoading: featuresLoading } = useProductFeatures(
+    { organizationId: organization.id },
+    undefined,
+    { staleTime: 30_000, throwOnError: false },
+  );
+
+  // Treat "still loading" and "the read failed" as not-yet-known so an
+  // entitled organization never flashes the gate.
+  const gated =
+    !featuresLoading &&
+    features?.customerManagedEncryptionKeysEnabled === false;
+
+  if (gated) {
+    return (
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <Text muted className="py-8 text-center">
+            Customer-managed keys are not enabled for this organization.
+          </Text>
+        </Page.Body>
+      </Page>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
@@ -1,4 +1,3 @@
-import { Page } from "@/components/page-layout";
 import { useOrganization } from "@/contexts/Auth";
 import { ResourceListPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
@@ -25,7 +24,6 @@ import {
   invalidateAllListExternalKeys,
 } from "@gram/client/react-query/listExternalKeys";
 import { useGramContext } from "@gram/client/react-query/_context.js";
-import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useVerifyGcpKmsKeyMutation } from "@gram/client/react-query/verifyGcpKmsKey";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { MoreHorizontal, Plus } from "lucide-react";
@@ -33,58 +31,28 @@ import { useState } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
 import { CreateExternalKeySheet } from "./CreateExternalKeySheet";
+import { CustomerManagedKeysGate } from "./CustomerManagedKeysGate";
 import { SigningKeysSection } from "./jwks/SigningKeysSection";
 import { ListSection } from "./ListSection";
 import { providerLabel, providerSlug } from "./providers";
 import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
+// The scope and entitlement gates sit on the route root so every page beneath
+// it (the list and each key's detail page) is covered, and so no protected
+// request fires for a visitor lacking the page scope.
 export function EncryptionKeysRoot(): JSX.Element {
-  return <Outlet />;
-}
-
-export function EncryptionKeysPage(): JSX.Element {
-  // Gate first so no protected request (product-feature read, key list) fires
-  // for a visitor lacking the page scope.
   return (
     <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <EncryptionKeysGate />
+      <CustomerManagedKeysGate>
+        <Outlet />
+      </CustomerManagedKeysGate>
     </RequireScope>
   );
 }
 
-// Product-feature (entitlement) gate, mounted only after the RBAC scope gate
-// passes. A gated-but-authorized org sees only the framed refusal, with no
-// header or toolbar.
-function EncryptionKeysGate(): JSX.Element {
+export function EncryptionKeysPage(): JSX.Element {
   const organization = useOrganization();
   const isCurrentOrganization = useIsCurrentOrganization(organization.id);
-  const { data: features, isLoading: featuresLoading } = useProductFeatures(
-    { organizationId: organization.id },
-    undefined,
-    { staleTime: 30_000, throwOnError: false },
-  );
-
-  // The sidebar entry is already hidden without the entitlement; this covers a
-  // direct URL. Treat "still loading" and "the read failed" as not-yet-known so
-  // an entitled organization never flashes the gate.
-  const gated =
-    !featuresLoading &&
-    features?.customerManagedEncryptionKeysEnabled === false;
-
-  if (gated) {
-    return (
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <Text muted className="py-8 text-center">
-            Customer-managed keys are not enabled for this organization.
-          </Text>
-        </Page.Body>
-      </Page>
-    );
-  }
 
   return (
     <EncryptionKeysOverview

--- a/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
@@ -31,7 +31,7 @@ import { useState } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
 import { CreateExternalKeySheet } from "./CreateExternalKeySheet";
-import { CustomerManagedKeysGate } from "./CustomerManagedKeysGate";
+import { CustomerManagedKeysGate } from "@/components/customer-managed-keys-gate";
 import { SigningKeysSection } from "./jwks/SigningKeysSection";
 import { ListSection } from "./ListSection";
 import { providerLabel, providerSlug } from "./providers";

--- a/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/EncryptionKeys.tsx
@@ -33,6 +33,8 @@ import { useState } from "react";
 import { Outlet } from "react-router";
 import { toast } from "sonner";
 import { CreateExternalKeySheet } from "./CreateExternalKeySheet";
+import { SigningKeysSection } from "./jwks/SigningKeysSection";
+import { ListSection } from "./ListSection";
 import { providerLabel, providerSlug } from "./providers";
 import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
 
@@ -131,19 +133,27 @@ function EncryptionKeysOverview({
           </RequireScope>
         }
       >
-        <KeyTable
-          keys={keys}
-          isLoading={isLoading}
-          isError={isError}
-          onRetry={() => void refetch()}
-          isCurrentOrganization={isCurrentOrganization}
-          detailHref={(key) =>
-            orgRoutes.encryptionKeys.keyDetail.href(
-              providerSlug(key.provider),
-              key.id,
-            )
-          }
-        />
+        <div className="flex flex-col gap-10">
+          <ListSection eyebrow="KMS Keys">
+            <KeyTable
+              keys={keys}
+              isLoading={isLoading}
+              isError={isError}
+              onRetry={() => void refetch()}
+              isCurrentOrganization={isCurrentOrganization}
+              detailHref={(key) =>
+                orgRoutes.encryptionKeys.keyDetail.href(
+                  providerSlug(key.provider),
+                  key.id,
+                )
+              }
+            />
+          </ListSection>
+          <SigningKeysSection
+            organizationId={organizationId}
+            isCurrentOrganization={isCurrentOrganization}
+          />
+        </div>
       </ResourceListPage>
 
       <CreateExternalKeySheet

--- a/client/dashboard/src/pages/org/encryption-keys/ExternalKeyDetail.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/ExternalKeyDetail.tsx
@@ -14,6 +14,7 @@ import { activeDetailTab } from "@/lib/detail-tabs";
 import { useOrgRoutes } from "@/routes";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useGetGcpKmsKey } from "@gram/client/react-query/getGcpKmsKey";
+import { isNotNotFound } from "@/lib/query-errors";
 import { Link, Navigate, useLocation, useParams } from "react-router";
 import { providerFromSlug, providerLabel } from "./providers";
 import { EXTERNAL_KEY_TABS, type ExternalKeyTab } from "./tabs";
@@ -60,8 +61,9 @@ export default function ExternalKeyDetail(): JSX.Element {
   } = useGetGcpKmsKey({ id: keyId }, undefined, {
     enabled: isGcp && keyId !== "" && canRead,
     // A missing key is handled below by returning to the list; left to the
-    // default, the 404 would surface as a crash in the error boundary.
-    throwOnError: false,
+    // default, the 404 would surface as a crash in the error boundary. Every
+    // other failure still belongs to the boundary.
+    throwOnError: isNotNotFound,
   });
 
   const activeTab = activeDetailTab(location.pathname, EXTERNAL_KEY_TABS);

--- a/client/dashboard/src/pages/org/encryption-keys/ExternalKeyDetail.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/ExternalKeyDetail.tsx
@@ -19,8 +19,17 @@ import { providerFromSlug, providerLabel } from "./providers";
 import { EXTERNAL_KEY_TABS, type ExternalKeyTab } from "./tabs";
 import { OverviewTab } from "./tabs/OverviewTab";
 import { SettingsTab } from "./tabs/SettingsTab";
+import { SigningKeysTab } from "./tabs/SigningKeysTab";
 
 const ORG_READ_SCOPES: Scope[] = ["org:read", "org:admin"];
+
+// Route keys are camelCase while tab segments are kebab-case, so the tab id has
+// to be translated before indexing the route helpers.
+const EXTERNAL_KEY_TAB_ROUTE_KEY = {
+  overview: "overview",
+  "signing-keys": "signingKeys",
+  settings: "settings",
+} as const satisfies Record<ExternalKeyTab, string>;
 
 export default function ExternalKeyDetail(): JSX.Element {
   const { provider: providerParam = "", keyId = "" } = useParams<{
@@ -50,11 +59,17 @@ export default function ExternalKeyDetail(): JSX.Element {
     isError,
   } = useGetGcpKmsKey({ id: keyId }, undefined, {
     enabled: isGcp && keyId !== "" && canRead,
+    // A missing key is handled below by returning to the list; left to the
+    // default, the 404 would surface as a crash in the error boundary.
+    throwOnError: false,
   });
 
   const activeTab = activeDetailTab(location.pathname, EXTERNAL_KEY_TABS);
   const tabHref = (tab: ExternalKeyTab) =>
-    orgRoutes.encryptionKeys.keyDetail[tab].href(providerParam, keyId);
+    orgRoutes.encryptionKeys.keyDetail[EXTERNAL_KEY_TAB_ROUTE_KEY[tab]].href(
+      providerParam,
+      keyId,
+    );
 
   const label = externalKey?.name ?? "Encryption Key";
 
@@ -122,6 +137,9 @@ export default function ExternalKeyDetail(): JSX.Element {
                 <PageTabsTrigger value="overview" asChild>
                   <Link to={tabHref("overview")}>Overview</Link>
                 </PageTabsTrigger>
+                <PageTabsTrigger value="signing-keys" asChild>
+                  <Link to={tabHref("signing-keys")}>Signing Keys</Link>
+                </PageTabsTrigger>
                 <PageTabsTrigger value="settings" asChild>
                   <Link to={tabHref("settings")}>Settings</Link>
                 </PageTabsTrigger>
@@ -138,6 +156,9 @@ export default function ExternalKeyDetail(): JSX.Element {
                 <OverviewTab key={externalKey.id} externalKey={externalKey} />
               )}
               {isLoading && <Text muted>Loading…</Text>}
+            </TabsContent>
+            <TabsContent value="signing-keys" className="mt-0">
+              <SigningKeysTab externalKeyId={keyId} />
             </TabsContent>
             <TabsContent value="settings" className="mt-0">
               {externalKey && (

--- a/client/dashboard/src/pages/org/encryption-keys/ListSection.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/ListSection.tsx
@@ -1,0 +1,35 @@
+import { Text } from "@/components/ui/Text";
+import type { ReactNode } from "react";
+
+// ListSection is one titled block on a page that stacks more than one resource
+// list: an eyebrow overline, an optional explanation, an optional action on the
+// right, and the list itself. The page keeps its single title; these are the
+// secondary headings beneath it.
+export function ListSection({
+  eyebrow,
+  description,
+  action,
+  children,
+}: {
+  eyebrow: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <div className="text-eyebrow">{eyebrow}</div>
+          {description && (
+            <Text small muted className="max-w-3xl">
+              {description}
+            </Text>
+          )}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/ListSection.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/ListSection.tsx
@@ -2,9 +2,10 @@ import { Text } from "@/components/ui/Text";
 import type { ReactNode } from "react";
 
 // ListSection is one titled block on a page that stacks more than one resource
-// list: an eyebrow overline, an optional explanation, an optional action on the
+// list: an eyebrow heading, an optional explanation, an optional action on the
 // right, and the list itself. The page keeps its single title; these are the
-// secondary headings beneath it.
+// secondary headings beneath it, so the eyebrow is a real heading for assistive
+// technology while keeping the overline styling.
 export function ListSection({
   eyebrow,
   description,
@@ -18,9 +19,9 @@ export function ListSection({
 }): JSX.Element {
   return (
     <section className="flex flex-col gap-4">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1">
-          <div className="text-eyebrow">{eyebrow}</div>
+          <h2 className="text-eyebrow">{eyebrow}</h2>
           {description && (
             <Text small muted className="max-w-3xl">
               {description}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/CreateJsonWebKeySetSheet.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/CreateJsonWebKeySetSheet.tsx
@@ -1,0 +1,156 @@
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/Sheet";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import { useOrgRoutes } from "@/routes";
+import { useCreateJsonWebKeySetMutation } from "@gram/client/react-query/createJsonWebKeySet";
+import { invalidateAllListJsonWebKeySets } from "@gram/client/react-query/listJsonWebKeySets";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ExternalKeySelect } from "./ExternalKeySelect";
+
+// CreateJsonWebKeySetSheet creates a signing key set from a KMS key. One request
+// does the whole setup: the server reads the key's public half from the
+// customer's KMS, creates the set, and publishes that key as the set's active
+// signing key, so the set is ready for verifiers as soon as the sheet closes.
+export function CreateJsonWebKeySetSheet({
+  open,
+  onOpenChange,
+  isCurrentOrganization,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [externalKeyId, setExternalKeyId] = useState("");
+
+  const createMutation = useCreateJsonWebKeySetMutation({
+    onSuccess: async (created) => {
+      if (!isCurrentOrganization()) return;
+      await invalidateAllListJsonWebKeySets(queryClient);
+      if (!isCurrentOrganization()) return;
+      toast.success("Signing key set created");
+      onOpenChange(false);
+      orgRoutes.signingKeySets.setDetail.keys.goTo(created.id);
+    },
+    onError: (error) => {
+      if (!isCurrentOrganization()) return;
+      console.error("Create signing key set failed", error);
+    },
+  });
+
+  const submitting = createMutation.isPending;
+  const submitError = createMutation.error
+    ? createMutation.error instanceof Error && createMutation.error.message
+      ? createMutation.error.message
+      : "An unexpected error occurred. Please try again."
+    : null;
+  const { reset: resetCreateMutation } = createMutation;
+
+  // Reset transient state whenever the sheet is reopened so a prior draft never
+  // leaks into a new creation.
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setExternalKeyId("");
+    resetCreateMutation();
+  }, [open, resetCreateMutation]);
+
+  const submittable = name.trim().length > 0 && externalKeyId.length > 0;
+
+  const handleSubmit = () => {
+    if (!submittable || submitting) return;
+    createMutation.mutate({
+      security: { sessionHeaderGramSession: "" },
+      request: {
+        createJSONWebKeySetForm: {
+          name: name.trim(),
+          externalKeyId,
+        },
+      },
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-[560px] flex-col sm:max-w-[560px]"
+      >
+        <SheetHeader className="px-6 pt-6 pb-0">
+          <SheetTitle className="text-lg font-semibold">
+            New Signing Key Set
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6">
+          <Text small muted>
+            A JSON Web Key Set (JWKS) is the published collection of public keys
+            that identity providers and MCP servers use to verify tokens
+            Speakeasy signs. The private half never leaves your KMS.
+          </Text>
+
+          <Stack gap={4}>
+            <Stack gap={2}>
+              <Label className="text-muted-foreground text-xs">Name</Label>
+              <Input
+                value={name}
+                onChange={setName}
+                placeholder="Production signing keys"
+              />
+            </Stack>
+
+            <ExternalKeySelect
+              value={externalKeyId}
+              onChange={setExternalKeyId}
+              disabled={submitting}
+            />
+            <Text small muted>
+              Creating the set publishes this key straight away as its active
+              signing key. Speakeasy reads the key&apos;s public half from your
+              KMS to do so, so the key&apos;s credential has to work now, not
+              later.
+            </Text>
+          </Stack>
+
+          {submitError && (
+            <Alert variant="error" dismissible={false}>
+              {submitError}
+            </Alert>
+          )}
+        </div>
+
+        <SheetFooter className="flex-row items-center justify-end gap-2 border-t px-6 py-4">
+          <Button
+            variant="secondary"
+            disabled={submitting}
+            onClick={() => onOpenChange(false)}
+          >
+            <Button.Text>Cancel</Button.Text>
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!submittable || submitting}
+            onClick={handleSubmit}
+          >
+            <Button.Text>{submitting ? "Creating…" : "Create"}</Button.Text>
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeyLink.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeyLink.tsx
@@ -1,0 +1,67 @@
+import { Text } from "@/components/ui/Text";
+import { useOrgRoutes } from "@/routes";
+import { useListExternalKeys } from "@gram/client/react-query/listExternalKeys";
+import { Link } from "react-router";
+import { providerSlug } from "../providers";
+
+// ExternalKeyLink names the KMS key behind a set or a published key and links to
+// it. Sets and keys carry only the key's id, so the name is resolved from the
+// organization's key list; one query serves every row of a table.
+//
+// A key that reads back absent is the deleted case: the server's delete guard
+// refuses while a live set or key references it, so this is only reachable for
+// a revoked key's minting key, but it is still worth saying rather than
+// rendering a link to a page that will bounce.
+export function ExternalKeyLink({
+  externalKeyId,
+}: {
+  externalKeyId: string;
+}): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  const { data, isLoading, isError } = useListExternalKeys(
+    { provider: "gcp_kms" },
+    undefined,
+    { throwOnError: false },
+  );
+
+  if (isLoading) {
+    return (
+      <Text small muted as="span">
+        Loading…
+      </Text>
+    );
+  }
+
+  // A lookup that failed says nothing about whether the key exists, so it must
+  // not be reported as deleted.
+  if (isError) {
+    return (
+      <Text small muted as="span">
+        Could not load encryption key
+      </Text>
+    );
+  }
+
+  const externalKey = data?.keys.find((key) => key.id === externalKeyId);
+  if (!externalKey) {
+    return (
+      <Text small muted as="span">
+        No longer available
+      </Text>
+    );
+  }
+
+  return (
+    <Link
+      to={orgRoutes.encryptionKeys.keyDetail.href(
+        providerSlug(externalKey.provider),
+        externalKey.id,
+      )}
+      className="underline underline-offset-2"
+    >
+      <Text small as="span">
+        {externalKey.name}
+      </Text>
+    </Link>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeyLink.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeyLink.tsx
@@ -1,6 +1,9 @@
 import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
 import { useOrgRoutes } from "@/routes";
-import { useListExternalKeys } from "@gram/client/react-query/listExternalKeys";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { buildListExternalKeysQuery } from "@gram/client/react-query/listExternalKeys";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { providerSlug } from "../providers";
 
@@ -18,13 +21,17 @@ export function ExternalKeyLink({
   externalKeyId: string;
 }): JSX.Element {
   const orgRoutes = useOrgRoutes();
-  const { data, isLoading, isError } = useListExternalKeys(
-    { provider: "gcp_kms" },
-    undefined,
-    { throwOnError: false },
-  );
+  const client = useGramContext();
+  const organization = useOrganization();
+  // Keyed by organization so a switch never shows the previous one's keys.
+  const keysQuery = buildListExternalKeysQuery(client, { provider: "gcp_kms" });
+  const { data, isPending, isError } = useQuery({
+    ...keysQuery,
+    queryKey: [...keysQuery.queryKey, { organizationId: organization.id }],
+    throwOnError: false,
+  });
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <Text small muted as="span">
         Loading…
@@ -42,7 +49,7 @@ export function ExternalKeyLink({
     );
   }
 
-  const externalKey = data?.keys.find((key) => key.id === externalKeyId);
+  const externalKey = data.keys.find((key) => key.id === externalKeyId);
   if (!externalKey) {
     return (
       <Text small muted as="span">

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeySelect.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeySelect.tsx
@@ -11,7 +11,9 @@ import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
 import { useOrganization } from "@/contexts/Auth";
 import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
-import { useListExternalKeys } from "@gram/client/react-query/listExternalKeys";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { buildListExternalKeysQuery } from "@gram/client/react-query/listExternalKeys";
+import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { CreateExternalKeySheet } from "../CreateExternalKeySheet";
@@ -48,8 +50,12 @@ export function ExternalKeySelect({
   const organization = useOrganization();
   const isCurrentOrganization = useIsCurrentOrganization(organization.id);
   const [createOpen, setCreateOpen] = useState(false);
-  const { data, isLoading, isError, refetch } = useListExternalKeys({
-    provider: "gcp_kms",
+  const client = useGramContext();
+  // Keyed by organization so a switch never offers the previous one's keys.
+  const keysQuery = buildListExternalKeysQuery(client, { provider: "gcp_kms" });
+  const { data, isPending, isError, refetch } = useQuery({
+    ...keysQuery,
+    queryKey: [...keysQuery.queryKey, { organizationId: organization.id }],
   });
   const keys = data?.keys ?? [];
 
@@ -59,11 +65,17 @@ export function ExternalKeySelect({
   // invisibly in the empty Select and be resubmitted, so clear it once the
   // live set is known. A failed request is not a live set, so a selection
   // survives a load error.
+  //
+  // The same applies to a value the caller has since marked unavailable: a key
+  // picked while the unavailable set was still loading must not stay selected
+  // once the picker says it cannot be used.
   const missing =
-    !isLoading && !isError && value !== "" && !keys.some((k) => k.id === value);
+    !isPending && !isError && value !== "" && !keys.some((k) => k.id === value);
+  const unavailableSelection =
+    value !== "" && (unavailableKeyIds?.has(value) ?? false);
   useEffect(() => {
-    if (missing) onChange("");
-  }, [missing, onChange]);
+    if (missing || unavailableSelection) onChange("");
+  }, [missing, unavailableSelection, onChange]);
 
   // Select what was just created. The list query is invalidated by the sheet,
   // so the option is there by the time this renders again.
@@ -92,7 +104,7 @@ export function ExternalKeySelect({
     );
   }
 
-  if (!isLoading && keys.length === 0) {
+  if (!isPending && keys.length === 0) {
     return (
       <div className="flex flex-col gap-1.5">
         <Label>{label}</Label>
@@ -126,11 +138,11 @@ export function ExternalKeySelect({
           <Select
             value={value}
             onValueChange={onChange}
-            disabled={isLoading || disabled}
+            disabled={isPending || disabled}
           >
             <SelectTrigger>
               <SelectValue
-                placeholder={isLoading ? "Loading…" : "Select a key"}
+                placeholder={isPending ? "Loading…" : "Select a key"}
               />
             </SelectTrigger>
             <SelectContent>
@@ -153,7 +165,7 @@ export function ExternalKeySelect({
         <Button
           size="sm"
           variant="secondary"
-          disabled={isLoading || disabled}
+          disabled={isPending || disabled}
           onClick={() => setCreateOpen(true)}
         >
           <Button.LeftIcon>

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeySelect.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/ExternalKeySelect.tsx
@@ -1,0 +1,168 @@
+import { Button } from "@/components/ui/Button";
+import { Label } from "@/components/ui/Label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
+import { useListExternalKeys } from "@gram/client/react-query/listExternalKeys";
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { CreateExternalKeySheet } from "../CreateExternalKeySheet";
+
+// ExternalKeySelect picks the KMS key a signing key set publishes from. Shared
+// by the create sheet and the publish dialog so both offer the same set and
+// explain an empty one the same way.
+//
+// A key can be registered from here rather than only from the Encryption Keys
+// list, because a set cannot exist without one and an organization's first set
+// would otherwise dead-end on an empty picker.
+//
+// Scoped to GCP: the server refuses to back a set with an AWS KMS key, and the
+// only algorithms an external key can record (RS256, ES256) are both ones the
+// server can publish, so no further filtering is needed.
+export function ExternalKeySelect({
+  value,
+  onChange,
+  label = "Encryption key",
+  disabled = false,
+  unavailableKeyIds,
+  unavailableReason = "unavailable",
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  disabled?: boolean;
+  // Keys to list but not offer, with the reason shown beside each. Listing
+  // them keeps the picker honest about which keys exist; refusing them keeps a
+  // save the server would reject from being attempted.
+  unavailableKeyIds?: ReadonlySet<string>;
+  unavailableReason?: string;
+}): JSX.Element {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  const [createOpen, setCreateOpen] = useState(false);
+  const { data, isLoading, isError, refetch } = useListExternalKeys({
+    provider: "gcp_kms",
+  });
+  const keys = data?.keys ?? [];
+
+  // The server refuses to delete a key a set still references, so a selected
+  // id normally is in the list. Still, a value the live list does not contain
+  // (a caller's stale cache, a key deleted between renders) would otherwise sit
+  // invisibly in the empty Select and be resubmitted, so clear it once the
+  // live set is known. A failed request is not a live set, so a selection
+  // survives a load error.
+  const missing =
+    !isLoading && !isError && value !== "" && !keys.some((k) => k.id === value);
+  useEffect(() => {
+    if (missing) onChange("");
+  }, [missing, onChange]);
+
+  // Select what was just created. The list query is invalidated by the sheet,
+  // so the option is there by the time this renders again.
+  const createSheet = (
+    <CreateExternalKeySheet
+      open={createOpen}
+      onOpenChange={setCreateOpen}
+      isCurrentOrganization={isCurrentOrganization}
+      onCreated={(key) => onChange(key.id)}
+    />
+  );
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Label>{label}</Label>
+        <Stack direction="horizontal" gap={2} align="center">
+          <Text small muted>
+            Failed to load encryption keys.
+          </Text>
+          <Button size="sm" variant="secondary" onClick={() => void refetch()}>
+            <Button.Text>Retry</Button.Text>
+          </Button>
+        </Stack>
+      </div>
+    );
+  }
+
+  if (!isLoading && keys.length === 0) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Label>{label}</Label>
+        <Text small muted>
+          A signing key set publishes the public half of a key in your KMS.
+          Register one now and it will be selected here.
+        </Text>
+        <div>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={disabled}
+            onClick={() => setCreateOpen(true)}
+          >
+            <Button.LeftIcon>
+              <Plus />
+            </Button.LeftIcon>
+            <Button.Text>New KMS Key</Button.Text>
+          </Button>
+        </div>
+        {createSheet}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>{label}</Label>
+      <Stack direction="horizontal" gap={2} align="center">
+        <div className="flex-1">
+          <Select
+            value={value}
+            onValueChange={onChange}
+            disabled={isLoading || disabled}
+          >
+            <SelectTrigger>
+              <SelectValue
+                placeholder={isLoading ? "Loading…" : "Select a key"}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {keys.map((key) => {
+                const unavailable = unavailableKeyIds?.has(key.id) ?? false;
+                return (
+                  <SelectItem
+                    key={key.id}
+                    value={key.id}
+                    disabled={unavailable}
+                  >
+                    {key.name} ({key.algorithm})
+                    {unavailable && ` · ${unavailableReason}`}
+                  </SelectItem>
+                );
+              })}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={isLoading || disabled}
+          onClick={() => setCreateOpen(true)}
+        >
+          <Button.LeftIcon>
+            <Plus />
+          </Button.LeftIcon>
+          <Button.Text>New</Button.Text>
+        </Button>
+      </Stack>
+      {createSheet}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
@@ -15,7 +15,7 @@ import { useOrgRoutes } from "@/routes";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useGetJsonWebKeySet } from "@gram/client/react-query/getJsonWebKeySet";
 import { isNotNotFound } from "@/lib/query-errors";
-import { CustomerManagedKeysGate } from "../CustomerManagedKeysGate";
+import { CustomerManagedKeysGate } from "@/components/customer-managed-keys-gate";
 import { Link, Navigate, Outlet, useLocation, useParams } from "react-router";
 import { JSON_WEB_KEY_SET_TABS, type JsonWebKeySetTab } from "./tabs";
 import { KeysTab } from "./tabs/KeysTab";

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
@@ -14,6 +14,8 @@ import { activeDetailTab } from "@/lib/detail-tabs";
 import { useOrgRoutes } from "@/routes";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useGetJsonWebKeySet } from "@gram/client/react-query/getJsonWebKeySet";
+import { isNotNotFound } from "@/lib/query-errors";
+import { CustomerManagedKeysGate } from "../CustomerManagedKeysGate";
 import { Link, Navigate, Outlet, useLocation, useParams } from "react-router";
 import { JSON_WEB_KEY_SET_TABS, type JsonWebKeySetTab } from "./tabs";
 import { KeysTab } from "./tabs/KeysTab";
@@ -22,8 +24,16 @@ import { SettingsTab } from "./tabs/SettingsTab";
 
 const ORG_READ_SCOPES: Scope[] = ["org:read", "org:admin"];
 
+// Same scope and entitlement gates as the Encryption Keys route root, so a deep
+// link to a set is refused the same way a deep link to a key is.
 export function SigningKeySetsRoot(): JSX.Element {
-  return <Outlet />;
+  return (
+    <RequireScope scope={ORG_READ_SCOPES} level="page">
+      <CustomerManagedKeysGate>
+        <Outlet />
+      </CustomerManagedKeysGate>
+    </RequireScope>
+  );
 }
 
 // The sets are listed on the Encryption Keys page; the bare /signing-keys URL
@@ -52,8 +62,9 @@ export default function JsonWebKeySetDetail(): JSX.Element {
   } = useGetJsonWebKeySet({ id: setId }, undefined, {
     enabled: setId !== "" && canRead,
     // A missing set is handled below by returning to the list; left to the
-    // default, the 404 would surface as a crash in the error boundary.
-    throwOnError: false,
+    // default, the 404 would surface as a crash in the error boundary. Every
+    // other failure still belongs to the boundary.
+    throwOnError: isNotNotFound,
   });
 
   const activeTab = activeDetailTab(location.pathname, JSON_WEB_KEY_SET_TABS);

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/JsonWebKeySetDetail.tsx
@@ -1,0 +1,158 @@
+import { DetailHero } from "@/components/detail-hero";
+import { Page } from "@/components/page-layout";
+import { RequireScope } from "@/components/require-scope";
+import { Heading } from "@/components/ui/Heading";
+import {
+  PageTabsList,
+  PageTabsTrigger,
+  Tabs,
+  TabsContent,
+} from "@/components/ui/Tabs";
+import { Text } from "@/components/ui/Text";
+import { useRBAC } from "@/hooks/useRBAC";
+import { activeDetailTab } from "@/lib/detail-tabs";
+import { useOrgRoutes } from "@/routes";
+import { Scope } from "@gram/client/models/components/rolegrant.js";
+import { useGetJsonWebKeySet } from "@gram/client/react-query/getJsonWebKeySet";
+import { Link, Navigate, Outlet, useLocation, useParams } from "react-router";
+import { JSON_WEB_KEY_SET_TABS, type JsonWebKeySetTab } from "./tabs";
+import { KeysTab } from "./tabs/KeysTab";
+import { OverviewTab } from "./tabs/OverviewTab";
+import { SettingsTab } from "./tabs/SettingsTab";
+
+const ORG_READ_SCOPES: Scope[] = ["org:read", "org:admin"];
+
+export function SigningKeySetsRoot(): JSX.Element {
+  return <Outlet />;
+}
+
+// The sets are listed on the Encryption Keys page; the bare /signing-keys URL
+// only exists so the detail pages have a parent segment of their own.
+export function SigningKeySetsIndex(): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  return <Navigate to={orgRoutes.encryptionKeys.href()} replace />;
+}
+
+export default function JsonWebKeySetDetail(): JSX.Element {
+  const { setId = "" } = useParams<{ setId: string }>();
+  const orgRoutes = useOrgRoutes();
+  const location = useLocation();
+
+  // The read scope gates the fetch, not just the rendering: without it the
+  // request would 403 and the not-found handling below would bounce the caller
+  // back to the list, which reads as "this set is gone" rather than "you cannot
+  // see it".
+  const { hasAnyScope, isLoading: rbacLoading } = useRBAC();
+  const canRead = hasAnyScope(ORG_READ_SCOPES);
+
+  const {
+    data: set,
+    isLoading,
+    isError,
+  } = useGetJsonWebKeySet({ id: setId }, undefined, {
+    enabled: setId !== "" && canRead,
+    // A missing set is handled below by returning to the list; left to the
+    // default, the 404 would surface as a crash in the error boundary.
+    throwOnError: false,
+  });
+
+  const activeTab = activeDetailTab(location.pathname, JSON_WEB_KEY_SET_TABS);
+  const tabHref = (tab: JsonWebKeySetTab) =>
+    orgRoutes.signingKeySets.setDetail[tab].href(setId);
+
+  const label = set?.name ?? "Signing Key Set";
+
+  // Resolve access before any not-found handling. With the fetch disabled the
+  // absence of a set says nothing about whether it exists, so the checks below
+  // would misreport it.
+  if (rbacLoading || !canRead) {
+    return (
+      <Page>
+        <Page.Header>
+          <Page.Header.Breadcrumbs />
+        </Page.Header>
+        <Page.Body>
+          <RequireScope scope={ORG_READ_SCOPES} level="page">
+            <Text muted>Loading…</Text>
+          </RequireScope>
+        </Page.Body>
+      </Page>
+    );
+  }
+
+  // The set doesn't exist or failed to load; return to the listing.
+  if (isError || (!isLoading && !set)) {
+    return <Navigate to={orgRoutes.encryptionKeys.href()} replace />;
+  }
+
+  // The bare /signing-keys/:setId URL has no tab; canonicalize to Overview.
+  if (!activeTab) {
+    return <Navigate to={tabHref("overview")} replace />;
+  }
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs substitutions={{ [setId]: label }} />
+      </Page.Header>
+      <Page.Body fullWidth noPadding className="gap-0">
+        <DetailHero>
+          <Page.Eyebrow />
+          <Text small muted>
+            Signing Key Set
+          </Text>
+          <Heading variant="h1" className="break-all normal-case">
+            {label}
+          </Heading>
+        </DetailHero>
+
+        <Tabs value={activeTab} className="flex w-full flex-1 flex-col">
+          <div className="shrink-0 border-b">
+            <div className="mx-auto max-w-[1270px] px-8">
+              <PageTabsList className="h-auto gap-6 bg-transparent p-0">
+                <PageTabsTrigger value="overview" asChild>
+                  <Link to={tabHref("overview")}>Overview</Link>
+                </PageTabsTrigger>
+                <PageTabsTrigger value="keys" asChild>
+                  <Link to={tabHref("keys")}>Keys</Link>
+                </PageTabsTrigger>
+                <PageTabsTrigger value="settings" asChild>
+                  <Link to={tabHref("settings")}>Settings</Link>
+                </PageTabsTrigger>
+              </PageTabsList>
+            </div>
+          </div>
+
+          <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
+            <TabsContent value="overview" className="mt-0">
+              {set && <OverviewTab key={set.id} set={set} />}
+              {isLoading && <Text muted>Loading…</Text>}
+            </TabsContent>
+            <TabsContent value="keys" className="mt-0">
+              {/* Keyed so the revoked toggle and any open dialog reset when
+                  navigating from one set straight to another. */}
+              {set && <KeysTab key={set.id} set={set} />}
+              {isLoading && <Text muted>Loading…</Text>}
+            </TabsContent>
+            <TabsContent value="settings" className="mt-0">
+              {set && (
+                <RequireScope
+                  scope="org:admin"
+                  level="section"
+                  fallback={
+                    <Text muted>
+                      Editing this key set requires an organization admin.
+                    </Text>
+                  }
+                >
+                  <SettingsTab key={set.id} set={set} />
+                </RequireScope>
+              )}
+              {isLoading && <Text muted>Loading…</Text>}
+            </TabsContent>
+          </div>
+        </Tabs>
+      </Page.Body>
+    </Page>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/SigningKeysSection.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/SigningKeysSection.tsx
@@ -34,7 +34,7 @@ export function SigningKeysSection({
   const client = useGramContext();
   const [createOpen, setCreateOpen] = useState(false);
   const setsQuery = buildListJsonWebKeySetsQuery(client);
-  const { data, isLoading, isError, refetch } = useQuery({
+  const { data, isPending, isError, refetch } = useQuery({
     ...setsQuery,
     queryKey: [...setsQuery.queryKey, { organizationId }],
   });
@@ -60,7 +60,7 @@ export function SigningKeysSection({
       >
         <SetTable
           sets={sets}
-          isLoading={isLoading}
+          isPending={isPending}
           isError={isError}
           onRetry={() => void refetch()}
           createButton={createButton}
@@ -78,13 +78,13 @@ export function SigningKeysSection({
 
 function SetTable({
   sets,
-  isLoading,
+  isPending,
   isError,
   onRetry,
   createButton,
 }: {
   sets: JSONWebKeySet[];
-  isLoading: boolean;
+  isPending: boolean;
   isError: boolean;
   onRetry: () => void;
   createButton: React.ReactNode;
@@ -102,7 +102,7 @@ function SetTable({
     );
   }
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <Text muted className="py-8 text-center">
         Loading…

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/SigningKeysSection.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/SigningKeysSection.tsx
@@ -1,0 +1,173 @@
+import { InlineEmptyState } from "@/components/inline-empty-state";
+import { RequireScope } from "@/components/require-scope";
+import { Button } from "@/components/ui/Button";
+import { DotRow } from "@/components/ui/DotRow";
+import { DotTable } from "@/components/ui/DotTable";
+import { Icon } from "@/components/ui/Icon";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import { HumanizeDateTime } from "@/lib/dates";
+import { useOrgRoutes } from "@/routes";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { buildListJsonWebKeySetsQuery } from "@gram/client/react-query/listJsonWebKeySets";
+import { useQuery } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { ListSection } from "../ListSection";
+import { CreateJsonWebKeySetSheet } from "./CreateJsonWebKeySetSheet";
+import { ExternalKeyLink } from "./ExternalKeyLink";
+
+const SECTION_DESCRIPTION =
+  "JSON Web Key Sets (JWKS) publish the public half of your KMS keys so identity providers and MCP servers can verify the tokens Speakeasy signs.";
+
+// SigningKeysSection is the JSON Web Key Set list, stacked beneath the KMS key
+// table on the Encryption Keys page. A set is the published face of the key
+// that backs it, which is why it lives here rather than on a page of its own.
+export function SigningKeysSection({
+  organizationId,
+  isCurrentOrganization,
+}: {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element {
+  const client = useGramContext();
+  const [createOpen, setCreateOpen] = useState(false);
+  const setsQuery = buildListJsonWebKeySetsQuery(client);
+  const { data, isLoading, isError, refetch } = useQuery({
+    ...setsQuery,
+    queryKey: [...setsQuery.queryKey, { organizationId }],
+  });
+  const sets = data?.sets ?? [];
+
+  const createButton = (
+    <RequireScope scope="org:admin" level="component">
+      <Button size="sm" onClick={() => setCreateOpen(true)}>
+        <Button.LeftIcon>
+          <Plus />
+        </Button.LeftIcon>
+        <Button.Text>New Signing Key Set</Button.Text>
+      </Button>
+    </RequireScope>
+  );
+
+  return (
+    <>
+      <ListSection
+        eyebrow="Signing Keys (JWKS)"
+        description={SECTION_DESCRIPTION}
+        action={sets.length > 0 ? createButton : undefined}
+      >
+        <SetTable
+          sets={sets}
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={() => void refetch()}
+          createButton={createButton}
+        />
+      </ListSection>
+
+      <CreateJsonWebKeySetSheet
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        isCurrentOrganization={isCurrentOrganization}
+      />
+    </>
+  );
+}
+
+function SetTable({
+  sets,
+  isLoading,
+  isError,
+  onRetry,
+  createButton,
+}: {
+  sets: JSONWebKeySet[];
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  createButton: React.ReactNode;
+}): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+
+  if (isError) {
+    return (
+      <Stack gap={3} className="py-8" align="center" justify="center">
+        <Text muted>Failed to load signing key sets.</Text>
+        <Button size="sm" variant="secondary" onClick={onRetry}>
+          <Button.Text>Retry</Button.Text>
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Text muted className="py-8 text-center">
+        Loading…
+      </Text>
+    );
+  }
+
+  if (sets.length === 0) {
+    return (
+      <InlineEmptyState
+        icon="key-round"
+        heading="No signing key sets yet"
+        description="Create a set from one of your KMS keys to start publishing public keys for token verification. The set's first key is published and activated as part of creating it."
+        action={createButton}
+      />
+    );
+  }
+
+  const headers = [
+    { label: "Name" },
+    { label: "Encryption key" },
+    { label: "Created" },
+    { label: "Updated" },
+  ];
+
+  return (
+    <DotTable headers={headers}>
+      {sets.map((set) => (
+        <DotRow
+          key={set.id}
+          icon={
+            <Icon name="key-round" className="text-muted-foreground h-5 w-5" />
+          }
+          href={orgRoutes.signingKeySets.setDetail.href(set.id)}
+          ariaLabel={`View signing key set ${set.name}`}
+        >
+          <td className="px-3 py-3">
+            <Text
+              variant="subheading"
+              as="div"
+              className="group-hover:text-primary truncate text-sm transition-colors group-hover:underline"
+            >
+              {set.name}
+            </Text>
+          </td>
+          {/* The link sits above the row link, so it has to stop the click from
+              reaching the row's own navigation. */}
+          <td
+            className="relative z-20 px-3 py-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ExternalKeyLink externalKeyId={set.externalKeyId} />
+          </td>
+          <td className="px-3 py-3">
+            <Text small muted as="div">
+              <HumanizeDateTime date={set.createdAt} />
+            </Text>
+          </td>
+          <td className="px-3 py-3">
+            <Text small muted as="div">
+              <HumanizeDateTime date={set.updatedAt} />
+            </Text>
+          </td>
+        </DotRow>
+      ))}
+    </DotTable>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
@@ -1,0 +1,287 @@
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Text } from "@/components/ui/Text";
+import { ConfirmDialog } from "@/pages/remote-identity-providers/ConfirmDialog";
+import type { JSONWebKey } from "@gram/client/models/components/jsonwebkey.js";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { useActivateJsonWebKeyMutation } from "@gram/client/react-query/activateJsonWebKey";
+import { useDeleteJsonWebKeySetMutation } from "@gram/client/react-query/deleteJsonWebKeySet";
+import {
+  buildGetJsonWebKeySetQuery,
+  invalidateAllGetJsonWebKeySet,
+} from "@gram/client/react-query/getJsonWebKeySet";
+import { useListJsonWebKeys } from "@gram/client/react-query/listJsonWebKeys";
+import { usePublishJsonWebKeyMutation } from "@gram/client/react-query/publishJsonWebKey";
+import { useRetireJsonWebKeyMutation } from "@gram/client/react-query/retireJsonWebKey";
+import { useRevokeJsonWebKeyMutation } from "@gram/client/react-query/revokeJsonWebKey";
+import { useUpdateJsonWebKeySetMutation } from "@gram/client/react-query/updateJsonWebKeySet";
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { ExternalKeySelect } from "./ExternalKeySelect";
+import { invalidateSet } from "./invalidate";
+import { keyActionCopy, type KeyLifecycleAction } from "./keyLifecycle";
+
+function errorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+// KeyActionDialog confirms and performs one lifecycle transition on a published
+// key. The three mutations are all instantiated because hooks cannot be chosen
+// per render; only the one for `action` is ever fired.
+export function KeyActionDialog({
+  action,
+  jsonWebKey,
+  onClose,
+}: {
+  action: KeyLifecycleAction;
+  jsonWebKey: JSONWebKey;
+  onClose: () => void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const copy = keyActionCopy(action);
+
+  const options = {
+    onSuccess: async () => {
+      await invalidateSet(queryClient);
+      toast.success(copy.successMessage);
+      onClose();
+    },
+  };
+  const activate = useActivateJsonWebKeyMutation(options);
+  const retire = useRetireJsonWebKeyMutation(options);
+  const revoke = useRevokeJsonWebKeyMutation(options);
+
+  const mutation = { activate, retire, revoke }[action];
+
+  return (
+    <ConfirmDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title={copy.title}
+      description={
+        <>
+          {copy.description}{" "}
+          <span className="font-mono text-xs break-all">{jsonWebKey.kid}</span>
+        </>
+      }
+      confirmLabel={copy.confirmLabel}
+      confirmVariant={copy.destructive ? "destructive-primary" : "primary"}
+      isPending={mutation.isPending}
+      error={
+        mutation.error
+          ? errorMessage(mutation.error, "The key could not be updated.")
+          : null
+      }
+      onConfirm={() =>
+        mutation.mutate({
+          security: { sessionHeaderGramSession: "" },
+          request: { id: jsonWebKey.id },
+        })
+      }
+    />
+  );
+}
+
+// DeleteSetDialog confirms and performs a set delete. Deleting withdraws every
+// key in the set at once, so the copy treats it as decommissioning a trust
+// anchor rather than removing a record.
+export function DeleteSetDialog({
+  set,
+  onClose,
+  onDeleted,
+}: {
+  set: JSONWebKeySet;
+  onClose: () => void;
+  onDeleted: () => void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const deleteMutation = useDeleteJsonWebKeySetMutation({
+    onSuccess: async () => {
+      await invalidateSet(queryClient);
+      toast.success("Signing key set deleted");
+      onClose();
+      onDeleted();
+    },
+  });
+
+  return (
+    <ConfirmDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title={`Delete "${set.name}"?`}
+      description="Every key in this set is withdrawn immediately and tokens signed with any of them stop verifying. Anything that trusts this set, such as an identity provider or MCP server verifying against its JWKS, will start rejecting those tokens. This cannot be undone; the keys themselves stay in your KMS."
+      confirmLabel="Delete key set"
+      isPending={deleteMutation.isPending}
+      error={
+        deleteMutation.error
+          ? errorMessage(
+              deleteMutation.error,
+              "The key set could not be deleted.",
+            )
+          : null
+      }
+      onConfirm={() =>
+        deleteMutation.mutate({
+          security: { sessionHeaderGramSession: "" },
+          request: { id: set.id },
+        })
+      }
+    />
+  );
+}
+
+type PublishPhase =
+  // Nothing has been written yet.
+  | "idle"
+  // The set now points at the chosen key but no key was published from it.
+  | "repointed";
+
+function publishButtonLabel(pending: boolean, phase: PublishPhase): string {
+  if (pending) return "Publishing…";
+  return phase === "repointed" ? "Retry publish" : "Publish key";
+}
+
+// PublishKeyDialog publishes a new key into a set. Publishing mints from the
+// set's current backing key, and the same KMS key cannot be published twice, so
+// in practice publishing means rotating: pick the KMS key to publish from, and
+// the set is re-pointed at it first when it differs from the current one.
+//
+// The two writes are separate requests. If the publish fails after the
+// re-point, the set is left pointing at the new key with nothing published from
+// it, so the dialog stays open, says so, and a retry only publishes.
+export function PublishKeyDialog({
+  set,
+  onClose,
+}: {
+  set: JSONWebKeySet;
+  onClose: () => void;
+}): JSX.Element {
+  const client = useGramContext();
+  const queryClient = useQueryClient();
+  // No default: the set's current backing key has almost always been published
+  // already (creation publishes it), so preselecting it would offer a publish
+  // the server refuses.
+  const [externalKeyId, setExternalKeyId] = useState("");
+  const [phase, setPhase] = useState<PublishPhase>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  // Every KMS key with a kid in the set, revoked included, is refused by the
+  // server as a duplicate, so the picker lists them but does not offer them.
+  const { data: keysData } = useListJsonWebKeys(
+    { setId: set.id, includeRevoked: true },
+    undefined,
+    { throwOnError: false },
+  );
+  const publishedKeyIds = useMemo(
+    () => new Set((keysData?.keys ?? []).map((key) => key.externalKeyId)),
+    [keysData],
+  );
+
+  const update = useUpdateJsonWebKeySetMutation();
+  const publish = usePublishJsonWebKeyMutation();
+  const pending = update.isPending || publish.isPending;
+
+  const handlePublish = async () => {
+    setError(null);
+    try {
+      if (phase === "idle") {
+        // Read the set again rather than trusting the props: the update
+        // replaces name and key together, so a stale name here would undo a
+        // rename made elsewhere since this page loaded.
+        const fresh = await queryClient.fetchQuery(
+          buildGetJsonWebKeySetQuery(client, { id: set.id }),
+        );
+        if (fresh.externalKeyId !== externalKeyId) {
+          await update.mutateAsync({
+            security: { sessionHeaderGramSession: "" },
+            request: {
+              updateJSONWebKeySetRequestBody: {
+                id: set.id,
+                name: fresh.name,
+                externalKeyId,
+              },
+            },
+          });
+          setPhase("repointed");
+          await invalidateAllGetJsonWebKeySet(queryClient);
+        }
+      }
+      await publish.mutateAsync({
+        security: { sessionHeaderGramSession: "" },
+        request: { setId: set.id },
+      });
+      await invalidateSet(queryClient);
+      toast.success("Key published");
+      onClose();
+    } catch (caught: unknown) {
+      setError(errorMessage(caught, "The key could not be published."));
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !pending) onClose();
+      }}
+    >
+      <Dialog.Content closeable={!pending}>
+        <Dialog.Header>
+          <Dialog.Title>Publish new key</Dialog.Title>
+          <Dialog.Description>
+            The new key is published as pending so verifiers can cache it before
+            it signs anything; activate it from the Keys tab once they have. If
+            the set has no active key, the new key is activated immediately.
+          </Dialog.Description>
+        </Dialog.Header>
+        <div className="flex flex-col gap-4">
+          <ExternalKeySelect
+            label="Publish from"
+            value={externalKeyId}
+            onChange={setExternalKeyId}
+            disabled={pending || phase === "repointed"}
+            unavailableKeyIds={publishedKeyIds}
+            unavailableReason="already published in this set"
+          />
+          <Text small muted>
+            A KMS key can only be published into a set once. To rotate, register
+            the new key version under Encryption Keys and choose it here; the
+            set is re-pointed at it and keys already published keep signing with
+            the key they came from.
+          </Text>
+          {phase === "repointed" && (
+            <Alert variant="warning" dismissible={false}>
+              The set now publishes from the chosen key, but no key has been
+              published from it yet. Retry to publish, or close and publish
+              later from the Keys tab.
+            </Alert>
+          )}
+          {error && (
+            <Alert variant="error" dismissible={false}>
+              {error}
+            </Alert>
+          )}
+        </div>
+        <Dialog.Footer>
+          <Button variant="tertiary" onClick={onClose} disabled={pending}>
+            <Button.Text>Cancel</Button.Text>
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void handlePublish()}
+            disabled={pending || externalKeyId === ""}
+          >
+            <Button.Text>{publishButtonLabel(pending, phase)}</Button.Text>
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
@@ -174,7 +174,7 @@ export function PublishKeyDialog({
 
   // Every KMS key with a kid in the set, revoked included, is refused by the
   // server as a duplicate, so the picker lists them but does not offer them.
-  const { data: keysData, isPending: keysPending } = useListJsonWebKeys(
+  const { data: keysData, isFetching: keysFetching } = useListJsonWebKeys(
     { setId: set.id, includeRevoked: true },
     undefined,
     { throwOnError: false },
@@ -276,10 +276,10 @@ export function PublishKeyDialog({
           <Button
             variant="primary"
             onClick={() => void handlePublish()}
-            // Publishing before the published-key list has settled could send
-            // a key the server refuses as a duplicate; a failed list still
-            // lets the server be the judge.
-            disabled={pending || keysPending || externalKeyId === ""}
+            // Publishing while the published-key list is still being read
+            // (first load or a refetch) could send a key the server refuses as
+            // a duplicate; a failed list still lets the server be the judge.
+            disabled={pending || keysFetching || externalKeyId === ""}
           >
             <Button.Text>{publishButtonLabel(pending, phase)}</Button.Text>
           </Button>

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/dialogs.tsx
@@ -174,7 +174,7 @@ export function PublishKeyDialog({
 
   // Every KMS key with a kid in the set, revoked included, is refused by the
   // server as a duplicate, so the picker lists them but does not offer them.
-  const { data: keysData } = useListJsonWebKeys(
+  const { data: keysData, isPending: keysPending } = useListJsonWebKeys(
     { setId: set.id, includeRevoked: true },
     undefined,
     { throwOnError: false },
@@ -276,7 +276,10 @@ export function PublishKeyDialog({
           <Button
             variant="primary"
             onClick={() => void handlePublish()}
-            disabled={pending || externalKeyId === ""}
+            // Publishing before the published-key list has settled could send
+            // a key the server refuses as a duplicate; a failed list still
+            // lets the server be the judge.
+            disabled={pending || keysPending || externalKeyId === ""}
           >
             <Button.Text>{publishButtonLabel(pending, phase)}</Button.Text>
           </Button>

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/invalidate.ts
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/invalidate.ts
@@ -1,0 +1,17 @@
+import { invalidateAllAuditLogs } from "@gram/client/react-query/auditLogs.js";
+import { invalidateAllGetJsonWebKeySet } from "@gram/client/react-query/getJsonWebKeySet";
+import { invalidateAllListJsonWebKeys } from "@gram/client/react-query/listJsonWebKeys";
+import { invalidateAllListJsonWebKeySets } from "@gram/client/react-query/listJsonWebKeySets";
+import type { QueryClient } from "@tanstack/react-query";
+
+// Every write to a set or one of its keys changes what the set list, the set's
+// detail, its Keys tab and its audit history show, so all of them refresh
+// together.
+export async function invalidateSet(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    invalidateAllListJsonWebKeys(queryClient),
+    invalidateAllGetJsonWebKeySet(queryClient),
+    invalidateAllListJsonWebKeySets(queryClient),
+    invalidateAllAuditLogs(queryClient),
+  ]);
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/keyLifecycle.test.ts
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/keyLifecycle.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { JSONWebKey } from "@gram/client/models/components/jsonwebkey.js";
+import {
+  availableKeyActions,
+  keyActionCopy,
+  keyAlgorithm,
+} from "./keyLifecycle";
+
+function key(publicJwk: unknown): JSONWebKey {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    organizationId: "org",
+    jsonWebKeySetId: "22222222-2222-2222-2222-222222222222",
+    externalKeyId: "33333333-3333-3333-3333-333333333333",
+    kid: "kid",
+    keyState: "active",
+    publicJwk,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+describe("availableKeyActions", () => {
+  it("mirrors the transitions the server accepts", () => {
+    expect(availableKeyActions("pending")).toEqual(["activate", "revoke"]);
+    expect(availableKeyActions("active")).toEqual(["retire", "revoke"]);
+    expect(availableKeyActions("retired")).toEqual(["activate", "revoke"]);
+    expect(availableKeyActions("revoked")).toEqual([]);
+  });
+
+  it("never offers retire to a pending key", () => {
+    expect(availableKeyActions("pending")).not.toContain("retire");
+  });
+});
+
+describe("keyAlgorithm", () => {
+  it("reads alg from the published JWK document", () => {
+    expect(keyAlgorithm(key({ kty: "RSA", alg: "RS256", use: "sig" }))).toBe(
+      "RS256",
+    );
+  });
+
+  it("falls back for a document without a usable alg", () => {
+    expect(keyAlgorithm(key({ kty: "RSA" }))).toBe("Unknown");
+    expect(keyAlgorithm(key({ alg: 42 }))).toBe("Unknown");
+    expect(keyAlgorithm(key(null))).toBe("Unknown");
+    expect(keyAlgorithm(key("RS256"))).toBe("Unknown");
+  });
+});
+
+describe("keyActionCopy", () => {
+  it("marks only revoke as destructive", () => {
+    expect(keyActionCopy("revoke").destructive).toBe(true);
+    expect(keyActionCopy("retire").destructive).toBe(false);
+    expect(keyActionCopy("activate").destructive).toBe(false);
+  });
+
+  it("warns that revoking breaks verification of outstanding tokens", () => {
+    expect(keyActionCopy("revoke").description).toMatch(/stops verifying/);
+  });
+});

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/keyLifecycle.ts
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/keyLifecycle.ts
@@ -1,0 +1,122 @@
+import type { BadgeVariant } from "@/components/ui/lib/types";
+import type {
+  JSONWebKey,
+  KeyState,
+} from "@gram/client/models/components/jsonwebkey.js";
+
+// The publish-before-sign lifecycle of a published key, as the server enforces
+// it: pending → active (activate), active → retired (retire), retired → active
+// (activate), and any state → revoked (revoke). Retire is refused for a pending
+// key, which has never signed anything to wind down from.
+
+export type KeyLifecycleAction = "activate" | "retire" | "revoke";
+
+// availableKeyActions returns the transitions the server accepts from a state,
+// in menu order. Revoked is terminal: the row is soft-deleted and only listed
+// as history.
+export function availableKeyActions(state: KeyState): KeyLifecycleAction[] {
+  switch (state) {
+    case "pending":
+      return ["activate", "revoke"];
+    case "active":
+      return ["retire", "revoke"];
+    case "retired":
+      return ["activate", "revoke"];
+    case "revoked":
+      return [];
+  }
+}
+
+export function keyStateLabel(state: KeyState): string {
+  switch (state) {
+    case "pending":
+      return "Pending";
+    case "active":
+      return "Active";
+    case "retired":
+      return "Retired";
+    case "revoked":
+      return "Revoked";
+  }
+}
+
+// keyStateDescription is the one-line meaning of a state for tooltips and
+// empty-state copy.
+export function keyStateDescription(state: KeyState): string {
+  switch (state) {
+    case "pending":
+      return "Published so verifiers can cache it, but not signing yet.";
+    case "active":
+      return "New tokens are signed with this key.";
+    case "retired":
+      return "No longer signing; still published so outstanding tokens verify.";
+    case "revoked":
+      return "Withdrawn. Tokens signed with it no longer verify.";
+  }
+}
+
+export function keyStateBadgeVariant(state: KeyState): BadgeVariant {
+  switch (state) {
+    case "pending":
+      return "information";
+    case "active":
+      return "success";
+    case "retired":
+      return "neutral";
+    case "revoked":
+      return "destructive";
+  }
+}
+
+// keyAlgorithm reads the algorithm the published JWK document advertises. The
+// document is opaque to the SDK (`any`), so the read is defensive: a document
+// without a string `alg` is rendered as unknown rather than crashing the row.
+export function keyAlgorithm(key: JSONWebKey): string {
+  const jwk: unknown = key.publicJwk;
+  if (jwk == null || typeof jwk !== "object") return "Unknown";
+  const alg = (jwk as Record<string, unknown>)["alg"];
+  return typeof alg === "string" && alg !== "" ? alg : "Unknown";
+}
+
+export type KeyActionCopy = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  destructive: boolean;
+  successMessage: string;
+};
+
+// keyActionCopy is the confirmation for each transition. Each one spells out
+// what happens to tokens already signed, because that is the consequence an
+// operator cannot see from the key row and cannot take back afterwards.
+export function keyActionCopy(action: KeyLifecycleAction): KeyActionCopy {
+  switch (action) {
+    case "activate":
+      return {
+        title: "Activate key?",
+        description:
+          "New tokens will be signed with this key. If another key is active it is retired in the same step: it stops signing but stays published, so tokens it already signed keep verifying.",
+        confirmLabel: "Activate key",
+        destructive: false,
+        successMessage: "Key activated",
+      };
+    case "retire":
+      return {
+        title: "Retire key?",
+        description:
+          "This key stops signing new tokens but stays published, so tokens it already signed keep verifying. The set has no active key until you activate another one, and nothing can be signed with it in the meantime.",
+        confirmLabel: "Retire key",
+        destructive: false,
+        successMessage: "Key retired",
+      };
+    case "revoke":
+      return {
+        title: "Revoke key?",
+        description:
+          "This withdraws the key from the published set immediately. Every token signed with it stops verifying, which breaks authentication for anything still presenting one, and the same KMS key can never be published into this set again. If you only want to stop signing, retire the key instead.",
+        confirmLabel: "Revoke key",
+        destructive: true,
+        successMessage: "Key revoked",
+      };
+  }
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs.ts
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs.ts
@@ -1,0 +1,5 @@
+// Tab set for the signing key set detail page. The resolver that turns a
+// pathname into one of these lives in @/lib/detail-tabs.
+
+export const JSON_WEB_KEY_SET_TABS = ["overview", "keys", "settings"] as const;
+export type JsonWebKeySetTab = (typeof JSON_WEB_KEY_SET_TABS)[number];

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/KeysTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/KeysTab.tsx
@@ -1,0 +1,245 @@
+import { RequireScope } from "@/components/require-scope";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { DotRow } from "@/components/ui/DotRow";
+import { DotTable } from "@/components/ui/DotTable";
+import { Icon } from "@/components/ui/Icon";
+import { Label } from "@/components/ui/Label";
+import { MoreActions, type Action } from "@/components/ui/MoreActions";
+import { Stack } from "@/components/ui/Stack";
+import { Switch } from "@/components/ui/Switch";
+import { Text } from "@/components/ui/Text";
+import { SimpleTooltip } from "@/components/ui/Tooltip";
+import { HumanizeDateTime } from "@/lib/dates";
+import type { JSONWebKey } from "@gram/client/models/components/jsonwebkey.js";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
+import { useListJsonWebKeys } from "@gram/client/react-query/listJsonWebKeys";
+import { keepPreviousData } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { KeyActionDialog, PublishKeyDialog } from "../dialogs";
+import {
+  availableKeyActions,
+  keyActionCopy,
+  keyAlgorithm,
+  keyStateBadgeVariant,
+  keyStateDescription,
+  keyStateLabel,
+  type KeyLifecycleAction,
+} from "../keyLifecycle";
+
+type PendingAction = { action: KeyLifecycleAction; key: JSONWebKey };
+
+export function KeysTab({ set }: { set: JSONWebKeySet }): JSX.Element {
+  const [includeRevoked, setIncludeRevoked] = useState(false);
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(
+    null,
+  );
+
+  const { data, isLoading, isError, refetch } = useListJsonWebKeys(
+    { setId: set.id, includeRevoked },
+    undefined,
+    // Flipping the revoked toggle changes the query key; keeping the previous
+    // rows in place avoids the table blinking to its loading state each time.
+    { placeholderData: keepPreviousData },
+  );
+  const keys = data?.keys ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <Text small muted className="max-w-3xl">
+          The public keys published in this set. Verifiers accept tokens signed
+          by any published key; only the active key signs new ones.
+        </Text>
+        <Stack direction="horizontal" gap={4} align="center">
+          <Stack direction="horizontal" gap={2} align="center">
+            <Switch
+              checked={includeRevoked}
+              onCheckedChange={setIncludeRevoked}
+              aria-labelledby="jwks-include-revoked"
+            />
+            <Label id="jwks-include-revoked">Include revoked</Label>
+          </Stack>
+          <RequireScope scope="org:admin" level="component">
+            <Button size="sm" onClick={() => setPublishOpen(true)}>
+              <Button.LeftIcon>
+                <Plus />
+              </Button.LeftIcon>
+              <Button.Text>Publish new key</Button.Text>
+            </Button>
+          </RequireScope>
+        </Stack>
+      </div>
+
+      <KeyTable
+        keys={keys}
+        includeRevoked={includeRevoked}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={() => void refetch()}
+        onAction={(action, key) => setPendingAction({ action, key })}
+      />
+
+      {publishOpen && (
+        <PublishKeyDialog set={set} onClose={() => setPublishOpen(false)} />
+      )}
+      {pendingAction && (
+        <KeyActionDialog
+          action={pendingAction.action}
+          jsonWebKey={pendingAction.key}
+          onClose={() => setPendingAction(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function KeyTable({
+  keys,
+  includeRevoked,
+  isLoading,
+  isError,
+  onRetry,
+  onAction,
+}: {
+  keys: JSONWebKey[];
+  includeRevoked: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  onAction: (action: KeyLifecycleAction, key: JSONWebKey) => void;
+}): JSX.Element {
+  if (isError) {
+    return (
+      <Stack gap={3} className="py-8" align="center" justify="center">
+        <Text muted>Failed to load keys.</Text>
+        <Button size="sm" variant="secondary" onClick={onRetry}>
+          <Button.Text>Retry</Button.Text>
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Text muted className="py-8 text-center">
+        Loading…
+      </Text>
+    );
+  }
+
+  if (keys.length === 0) {
+    return (
+      <Text muted className="py-8 text-center">
+        No published keys. Publish one to make this set usable again.
+      </Text>
+    );
+  }
+
+  const headers = [
+    { label: "Key ID" },
+    { label: "Algorithm" },
+    { label: "State" },
+    { label: "Published" },
+    { label: "Activated" },
+    { label: "Retired" },
+    ...(includeRevoked ? [{ label: "Revoked" }] : []),
+    { label: "" },
+  ];
+
+  return (
+    <DotTable headers={headers}>
+      {keys.map((key) => (
+        <DotRow
+          key={key.id}
+          icon={
+            <Icon name="key-round" className="text-muted-foreground h-5 w-5" />
+          }
+        >
+          <td className="px-3 py-3">
+            <Stack direction="horizontal" gap={1} align="center">
+              <SimpleTooltip tooltip={key.kid}>
+                <Text
+                  small
+                  as="span"
+                  className="inline-block max-w-[16ch] truncate font-mono"
+                >
+                  {key.kid}
+                </Text>
+              </SimpleTooltip>
+              <CopyButton size="xs" text={key.kid} tooltip="Copy key ID" />
+            </Stack>
+          </td>
+          <td className="px-3 py-3">
+            <Text small muted>
+              {keyAlgorithm(key)}
+            </Text>
+          </td>
+          <td className="px-3 py-3">
+            <SimpleTooltip tooltip={keyStateDescription(key.keyState)}>
+              <Badge variant={keyStateBadgeVariant(key.keyState)} size="sm">
+                {keyStateLabel(key.keyState)}
+              </Badge>
+            </SimpleTooltip>
+          </td>
+          <td className="px-3 py-3">
+            <Text small muted as="div">
+              <HumanizeDateTime date={key.createdAt} />
+            </Text>
+          </td>
+          <td className="px-3 py-3">
+            <OptionalDate date={key.activatedAt} />
+          </td>
+          <td className="px-3 py-3">
+            <OptionalDate date={key.retiredAt} />
+          </td>
+          {includeRevoked && (
+            <td className="px-3 py-3">
+              <OptionalDate date={key.revokedAt} />
+            </td>
+          )}
+          <td className="px-3 py-3 text-right">
+            <KeyRowActions jsonWebKey={key} onAction={onAction} />
+          </td>
+        </DotRow>
+      ))}
+    </DotTable>
+  );
+}
+
+function OptionalDate({ date }: { date: Date | undefined }): JSX.Element {
+  return (
+    <Text small muted as="div">
+      {date ? <HumanizeDateTime date={date} /> : "—"}
+    </Text>
+  );
+}
+
+// KeyRowActions offers only the transitions the server accepts from the key's
+// current state; a revoked key has none and renders no menu at all.
+function KeyRowActions({
+  jsonWebKey,
+  onAction,
+}: {
+  jsonWebKey: JSONWebKey;
+  onAction: (action: KeyLifecycleAction, key: JSONWebKey) => void;
+}): JSX.Element | null {
+  const actions: Action[] = availableKeyActions(jsonWebKey.keyState).map(
+    (action) => ({
+      label: keyActionCopy(action).confirmLabel,
+      destructive: keyActionCopy(action).destructive,
+      onClick: () => onAction(action, jsonWebKey),
+    }),
+  );
+
+  if (actions.length === 0) return null;
+
+  return (
+    <RequireScope scope="org:admin" level="section">
+      <MoreActions actions={actions} />
+    </RequireScope>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/KeysTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/KeysTab.tsx
@@ -38,7 +38,7 @@ export function KeysTab({ set }: { set: JSONWebKeySet }): JSX.Element {
     null,
   );
 
-  const { data, isLoading, isError, refetch } = useListJsonWebKeys(
+  const { data, isPending, isError, refetch } = useListJsonWebKeys(
     { setId: set.id, includeRevoked },
     undefined,
     // Flipping the revoked toggle changes the query key; keeping the previous
@@ -77,7 +77,7 @@ export function KeysTab({ set }: { set: JSONWebKeySet }): JSX.Element {
       <KeyTable
         keys={keys}
         includeRevoked={includeRevoked}
-        isLoading={isLoading}
+        isPending={isPending}
         isError={isError}
         onRetry={() => void refetch()}
         onAction={(action, key) => setPendingAction({ action, key })}
@@ -100,14 +100,14 @@ export function KeysTab({ set }: { set: JSONWebKeySet }): JSX.Element {
 function KeyTable({
   keys,
   includeRevoked,
-  isLoading,
+  isPending,
   isError,
   onRetry,
   onAction,
 }: {
   keys: JSONWebKey[];
   includeRevoked: boolean;
-  isLoading: boolean;
+  isPending: boolean;
   isError: boolean;
   onRetry: () => void;
   onAction: (action: KeyLifecycleAction, key: JSONWebKey) => void;
@@ -123,7 +123,7 @@ function KeyTable({
     );
   }
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <Text muted className="py-8 text-center">
         Loading…

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/OverviewTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/OverviewTab.tsx
@@ -22,8 +22,14 @@ export function OverviewTab({ set }: { set: JSONWebKeySet }): JSX.Element {
     undefined,
     { throwOnError: false },
   );
+  // The audit filter accepts at most 200 subjects. Keys come back newest
+  // first, so a set with an implausible number of them keeps its newest
+  // 199 in the feed rather than failing the request outright.
   const subjectIds = useMemo(
-    () => [set.id, ...(keysData?.keys ?? []).map((key) => key.id)],
+    () => [
+      set.id,
+      ...(keysData?.keys ?? []).slice(0, 199).map((key) => key.id),
+    ],
     [set.id, keysData],
   );
 

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/OverviewTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/OverviewTab.tsx
@@ -1,0 +1,74 @@
+import { ResourceAuditFeed } from "@/components/auditlogs/resource-audit-feed";
+import {
+  InfoField,
+  InfoFieldGrid,
+  InfoSection,
+  InfoText,
+} from "@/components/detail-fields";
+import { Text } from "@/components/ui/Text";
+import { HumanizeDateTime } from "@/lib/dates";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
+import { useListJsonWebKeys } from "@gram/client/react-query/listJsonWebKeys";
+import { useMemo } from "react";
+import { ExternalKeyLink } from "../ExternalKeyLink";
+
+export function OverviewTab({ set }: { set: JSONWebKeySet }): JSX.Element {
+  // Key events name the key as their subject, so the set's history has to ask
+  // for every key that was ever published into it, revoked ones included. The
+  // feed waits for that list to settle either way: after a failed load it still
+  // shows the set's own events rather than spinning forever.
+  const { data: keysData, isPending: keysPending } = useListJsonWebKeys(
+    { setId: set.id, includeRevoked: true },
+    undefined,
+    { throwOnError: false },
+  );
+  const subjectIds = useMemo(
+    () => [set.id, ...(keysData?.keys ?? []).map((key) => key.id)],
+    [set.id, keysData],
+  );
+
+  return (
+    <div className="flex max-w-4xl flex-col gap-8">
+      <InfoSection title="Key set">
+        <InfoFieldGrid>
+          <InfoField label="Name">
+            <InfoText>{set.name}</InfoText>
+          </InfoField>
+          <InfoField label="Created">
+            <InfoText>
+              <HumanizeDateTime date={set.createdAt} />
+            </InfoText>
+          </InfoField>
+          <InfoField label="Updated">
+            <InfoText>
+              <HumanizeDateTime date={set.updatedAt} />
+            </InfoText>
+          </InfoField>
+        </InfoFieldGrid>
+      </InfoSection>
+
+      <InfoSection title="Encryption key">
+        <Text small muted>
+          New keys are published from this KMS key. Keys already published keep
+          signing with the key they were minted from, even after the set is
+          pointed at another one.
+        </Text>
+        <InfoField label="Publishing from">
+          <ExternalKeyLink externalKeyId={set.externalKeyId} />
+        </InfoField>
+      </InfoSection>
+
+      <InfoSection title="History">
+        <Text small muted>
+          Every change to this set and to the keys published in it, newest
+          first.
+        </Text>
+        <ResourceAuditFeed
+          subjectIds={subjectIds}
+          enabled={!keysPending}
+          emptyMessage="No activity recorded for this key set yet."
+        />
+      </InfoSection>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
@@ -1,0 +1,142 @@
+import {
+  DangerSettingsSection,
+  FooterSaveButton,
+  SettingsSection,
+} from "@/components/detail/settings-section";
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { useOrgRoutes } from "@/routes";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { buildGetJsonWebKeySetQuery } from "@gram/client/react-query/getJsonWebKeySet";
+import { useUpdateJsonWebKeySetMutation } from "@gram/client/react-query/updateJsonWebKeySet";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { DeleteSetDialog } from "../dialogs";
+import { invalidateSet } from "../invalidate";
+
+export function SettingsTab({ set }: { set: JSONWebKeySet }): JSX.Element {
+  const client = useGramContext();
+  const queryClient = useQueryClient();
+  const orgRoutes = useOrgRoutes();
+  const [name, setName] = useState(set.name);
+  const [showDelete, setShowDelete] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const update = useUpdateJsonWebKeySetMutation();
+
+  const trimmed = name.trim();
+  const savable = trimmed.length > 0 && trimmed !== set.name;
+
+  const handleSave = async () => {
+    if (!savable || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // The update replaces both fields, and the backing key is changed by
+      // publishing from the Keys tab rather than here. Read the set again
+      // rather than trusting the props so a rename never reverts a re-point
+      // made elsewhere since this page loaded.
+      const fresh = await queryClient.fetchQuery(
+        buildGetJsonWebKeySetQuery(client, { id: set.id }),
+      );
+      await update.mutateAsync({
+        security: { sessionHeaderGramSession: "" },
+        request: {
+          updateJSONWebKeySetRequestBody: {
+            id: set.id,
+            name: trimmed,
+            externalKeyId: fresh.externalKeyId,
+          },
+        },
+      });
+      // The list, this set's detail (Overview + page title) and its history
+      // all show the name.
+      await invalidateSet(queryClient);
+      toast.success("Signing key set updated");
+    } catch (caught: unknown) {
+      console.error("Update signing key set failed", caught);
+      setSaveError(
+        caught instanceof Error && caught.message
+          ? caught.message
+          : "An unexpected error occurred. Please try again.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-8">
+      <SettingsSection>
+        <SettingsSection.Header>
+          <SettingsSection.Title>Key set</SettingsSection.Title>
+          <SettingsSection.Description>
+            How this set is labeled in the dashboard. Names may repeat within an
+            organization. The KMS key it publishes from is chosen when
+            publishing a new key.
+          </SettingsSection.Description>
+        </SettingsSection.Header>
+        <SettingsSection.Panel>
+          <SettingsSection.Body>
+            <div className="flex flex-col gap-1.5">
+              <Label>Name</Label>
+              <Input value={name} onChange={setName} />
+            </div>
+            {saveError && (
+              <Alert variant="error" dismissible={false}>
+                {saveError}
+              </Alert>
+            )}
+          </SettingsSection.Body>
+          <SettingsSection.Footer>
+            <SettingsSection.FooterHint>
+              {savable ? "Unsaved changes" : "No changes"}
+            </SettingsSection.FooterHint>
+            <SettingsSection.FooterActions>
+              <FooterSaveButton
+                pending={saving}
+                disabled={!savable || saving}
+                onClick={() => void handleSave()}
+              />
+            </SettingsSection.FooterActions>
+          </SettingsSection.Footer>
+        </SettingsSection.Panel>
+      </SettingsSection>
+
+      <DangerSettingsSection>
+        <DangerSettingsSection.Header>
+          <DangerSettingsSection.Title>Danger Zone</DangerSettingsSection.Title>
+          <DangerSettingsSection.Description>
+            Deleting this set withdraws every key in it. Anything that verifies
+            tokens against it stops accepting them.
+          </DangerSettingsSection.Description>
+        </DangerSettingsSection.Header>
+        <DangerSettingsSection.Panel>
+          <DangerSettingsSection.Body>
+            <div>
+              <Button
+                variant="destructive-primary"
+                onClick={() => setShowDelete(true)}
+              >
+                <Button.Text>Delete key set</Button.Text>
+              </Button>
+            </div>
+          </DangerSettingsSection.Body>
+        </DangerSettingsSection.Panel>
+      </DangerSettingsSection>
+
+      {showDelete && (
+        <DeleteSetDialog
+          set={set}
+          onClose={() => setShowDelete(false)}
+          onDeleted={() => orgRoutes.encryptionKeys.goTo()}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
@@ -57,6 +57,9 @@ export function SettingsTab({ set }: { set: JSONWebKeySet }): JSX.Element {
       // The list, this set's detail (Overview + page title) and its history
       // all show the name.
       await invalidateSet(queryClient);
+      // The server stores the trimmed name; mirror it so the input agrees with
+      // the refreshed set instead of reporting phantom unsaved changes.
+      setName(trimmed);
       toast.success("Signing key set updated");
     } catch (caught: unknown) {
       console.error("Update signing key set failed", caught);

--- a/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/jwks/tabs/SettingsTab.tsx
@@ -88,7 +88,9 @@ export function SettingsTab({ set }: { set: JSONWebKeySet }): JSX.Element {
           <SettingsSection.Body>
             <div className="flex flex-col gap-1.5">
               <Label>Name</Label>
-              <Input value={name} onChange={setName} />
+              {/* Held while saving so an edit typed mid-request cannot be
+                  overwritten when the saved name is mirrored back. */}
+              <Input value={name} onChange={setName} disabled={saving} />
             </div>
             {saveError && (
               <Alert variant="error" dismissible={false}>

--- a/client/dashboard/src/pages/org/encryption-keys/tabs.ts
+++ b/client/dashboard/src/pages/org/encryption-keys/tabs.ts
@@ -1,5 +1,9 @@
 // Tab set for the encryption key detail page. The resolver that turns a
 // pathname into one of these lives in @/lib/detail-tabs.
 
-export const EXTERNAL_KEY_TABS = ["overview", "settings"] as const;
+export const EXTERNAL_KEY_TABS = [
+  "overview",
+  "signing-keys",
+  "settings",
+] as const;
 export type ExternalKeyTab = (typeof EXTERNAL_KEY_TABS)[number];

--- a/client/dashboard/src/pages/org/encryption-keys/tabs/SigningKeysTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/tabs/SigningKeysTab.tsx
@@ -4,22 +4,43 @@ import { DotTable } from "@/components/ui/DotTable";
 import { Icon } from "@/components/ui/Icon";
 import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
 import { HumanizeDateTime } from "@/lib/dates";
 import { useOrgRoutes } from "@/routes";
+import type { JSONWebKeySet } from "@gram/client/models/components/jsonwebkeyset.js";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { buildListJsonWebKeysQuery } from "@gram/client/react-query/listJsonWebKeys";
-import { useListJsonWebKeySets } from "@gram/client/react-query/listJsonWebKeySets";
-import { useQueries } from "@tanstack/react-query";
+import { buildListJsonWebKeySetsQuery } from "@gram/client/react-query/listJsonWebKeySets";
+import { useQueries, useQuery } from "@tanstack/react-query";
 
-// SigningKeysTab lists the signing key sets that depend on this KMS key.
-// Deleting the key is refused while any of them does, so this is also where a
-// reader finds out what is holding a delete up.
-//
-// A set depends on the key in two ways, and both block deletion: the set
-// publishes new keys from it (the set's own external_key_id), or a key already
-// published in the set was minted from it and still signs with it even after
-// the set moved on to another KMS key. The second is why every set's keys are
-// read rather than only the sets currently pointed at this key.
+// How a signing key set relates to this KMS key. A set can publish new keys
+// from it, hold a key already published from it (which keeps signing with it
+// even after the set moves on to another KMS key), or only hold keys that were
+// published from it and since revoked. The first two block deleting the KMS
+// key; a revoked key is withdrawn and no longer needs it.
+type Dependent = {
+  set: JSONWebKeySet;
+  publishesFrom: boolean;
+  hasLiveKey: boolean;
+  hasRevokedKey: boolean;
+};
+
+function dependencyLabel(dependent: Dependent): string {
+  const parts: string[] = [];
+  if (dependent.publishesFrom) parts.push("Publishing key");
+  if (dependent.hasLiveKey) parts.push("Published keys");
+  if (dependent.hasRevokedKey) parts.push("Revoked keys");
+  return parts.join(", ");
+}
+
+function blocksDeletion(dependent: Dependent): boolean {
+  return dependent.publishesFrom || dependent.hasLiveKey;
+}
+
+// SigningKeysTab lists the signing key sets that have ever depended on this KMS
+// key, revoked keys included, and says which of them still block deleting it.
+// Every set's keys are read rather than only the sets currently pointed at this
+// key, because a published key pins the KMS key it was minted from.
 export function SigningKeysTab({
   externalKeyId,
 }: {
@@ -27,20 +48,33 @@ export function SigningKeysTab({
 }): JSX.Element {
   const client = useGramContext();
   const orgRoutes = useOrgRoutes();
+  const organization = useOrganization();
+  // Keyed by organization so a switch never shows the previous one's sets.
+  const setsQuery = buildListJsonWebKeySetsQuery(client);
   const {
     data: setsData,
-    isLoading: setsLoading,
+    isPending: setsPending,
     isError: setsError,
     refetch,
-  } = useListJsonWebKeySets();
+  } = useQuery({
+    ...setsQuery,
+    queryKey: [...setsQuery.queryKey, { organizationId: organization.id }],
+  });
   const sets = setsData?.sets ?? [];
 
   const keyQueries = useQueries({
-    queries: sets.map((set) =>
-      buildListJsonWebKeysQuery(client, { setId: set.id }),
-    ),
+    queries: sets.map((set) => {
+      const keysQuery = buildListJsonWebKeysQuery(client, {
+        setId: set.id,
+        includeRevoked: true,
+      });
+      return {
+        ...keysQuery,
+        queryKey: [...keysQuery.queryKey, { organizationId: organization.id }],
+      };
+    }),
   });
-  const keysLoading = keyQueries.some((query) => query.isLoading);
+  const keysPending = keyQueries.some((query) => query.isPending);
   const keysError = keyQueries.some((query) => query.isError);
 
   if (setsError || keysError) {
@@ -61,17 +95,25 @@ export function SigningKeysTab({
     );
   }
 
-  if (setsLoading || keysLoading) {
+  if (setsPending || keysPending) {
     return <Text muted>Loading…</Text>;
   }
 
-  const dependents = sets.flatMap((set, index) => {
-    const publishesFrom = set.externalKeyId === externalKeyId;
-    const hasPublishedKey = (keyQueries[index]?.data?.keys ?? []).some(
+  const dependents: Dependent[] = sets.flatMap((set, index) => {
+    const keys = (keyQueries[index]?.data?.keys ?? []).filter(
       (key) => key.externalKeyId === externalKeyId,
     );
-    if (!publishesFrom && !hasPublishedKey) return [];
-    return [{ set, publishesFrom, hasPublishedKey }];
+    const dependent: Dependent = {
+      set,
+      publishesFrom: set.externalKeyId === externalKeyId,
+      hasLiveKey: keys.some((key) => key.keyState !== "revoked"),
+      hasRevokedKey: keys.some((key) => key.keyState === "revoked"),
+    };
+    const related =
+      dependent.publishesFrom ||
+      dependent.hasLiveKey ||
+      dependent.hasRevokedKey;
+    return related ? [dependent] : [];
   });
 
   if (dependents.length === 0) {
@@ -89,27 +131,29 @@ export function SigningKeysTab({
   const headers = [
     { label: "Name" },
     { label: "Depends on this key as" },
+    { label: "Blocks deletion" },
     { label: "Created" },
   ];
 
   return (
     <div className="flex flex-col gap-4">
       <Text small muted>
-        Deleting this key is refused while any of these sets exists, because a
-        key published from it could no longer sign.
+        Deleting this key is refused while a set publishes from it or still has
+        a key published from it, because that key could no longer sign. A set
+        that only holds revoked keys from it does not block deletion.
       </Text>
       <DotTable headers={headers}>
-        {dependents.map(({ set, publishesFrom, hasPublishedKey }) => (
+        {dependents.map((dependent) => (
           <DotRow
-            key={set.id}
+            key={dependent.set.id}
             icon={
               <Icon
                 name="key-round"
                 className="text-muted-foreground h-5 w-5"
               />
             }
-            href={orgRoutes.signingKeySets.setDetail.href(set.id)}
-            ariaLabel={`View signing key set ${set.name}`}
+            href={orgRoutes.signingKeySets.setDetail.href(dependent.set.id)}
+            ariaLabel={`View signing key set ${dependent.set.name}`}
           >
             <td className="px-3 py-3">
               <Text
@@ -117,17 +161,22 @@ export function SigningKeysTab({
                 as="div"
                 className="group-hover:text-primary truncate text-sm transition-colors group-hover:underline"
               >
-                {set.name}
+                {dependent.set.name}
               </Text>
             </td>
             <td className="px-3 py-3">
               <Text small muted>
-                {dependencyLabel(publishesFrom, hasPublishedKey)}
+                {dependencyLabel(dependent)}
+              </Text>
+            </td>
+            <td className="px-3 py-3">
+              <Text small muted>
+                {blocksDeletion(dependent) ? "Yes" : "No"}
               </Text>
             </td>
             <td className="px-3 py-3">
               <Text small muted as="div">
-                <HumanizeDateTime date={set.createdAt} />
+                <HumanizeDateTime date={dependent.set.createdAt} />
               </Text>
             </td>
           </DotRow>
@@ -135,17 +184,4 @@ export function SigningKeysTab({
       </DotTable>
     </div>
   );
-}
-
-function dependencyLabel(
-  publishesFrom: boolean,
-  hasPublishedKey: boolean,
-): string {
-  if (publishesFrom && hasPublishedKey) {
-    return "Publishing key and published keys";
-  }
-  if (publishesFrom) {
-    return "Publishing key";
-  }
-  return "Published keys";
 }

--- a/client/dashboard/src/pages/org/encryption-keys/tabs/SigningKeysTab.tsx
+++ b/client/dashboard/src/pages/org/encryption-keys/tabs/SigningKeysTab.tsx
@@ -1,0 +1,151 @@
+import { Button } from "@/components/ui/Button";
+import { DotRow } from "@/components/ui/DotRow";
+import { DotTable } from "@/components/ui/DotTable";
+import { Icon } from "@/components/ui/Icon";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import { HumanizeDateTime } from "@/lib/dates";
+import { useOrgRoutes } from "@/routes";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { buildListJsonWebKeysQuery } from "@gram/client/react-query/listJsonWebKeys";
+import { useListJsonWebKeySets } from "@gram/client/react-query/listJsonWebKeySets";
+import { useQueries } from "@tanstack/react-query";
+
+// SigningKeysTab lists the signing key sets that depend on this KMS key.
+// Deleting the key is refused while any of them does, so this is also where a
+// reader finds out what is holding a delete up.
+//
+// A set depends on the key in two ways, and both block deletion: the set
+// publishes new keys from it (the set's own external_key_id), or a key already
+// published in the set was minted from it and still signs with it even after
+// the set moved on to another KMS key. The second is why every set's keys are
+// read rather than only the sets currently pointed at this key.
+export function SigningKeysTab({
+  externalKeyId,
+}: {
+  externalKeyId: string;
+}): JSX.Element {
+  const client = useGramContext();
+  const orgRoutes = useOrgRoutes();
+  const {
+    data: setsData,
+    isLoading: setsLoading,
+    isError: setsError,
+    refetch,
+  } = useListJsonWebKeySets();
+  const sets = setsData?.sets ?? [];
+
+  const keyQueries = useQueries({
+    queries: sets.map((set) =>
+      buildListJsonWebKeysQuery(client, { setId: set.id }),
+    ),
+  });
+  const keysLoading = keyQueries.some((query) => query.isLoading);
+  const keysError = keyQueries.some((query) => query.isError);
+
+  if (setsError || keysError) {
+    return (
+      <Stack gap={3} className="py-8" align="center" justify="center">
+        <Text muted>Failed to load signing key sets.</Text>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            void refetch();
+            for (const query of keyQueries) void query.refetch();
+          }}
+        >
+          <Button.Text>Retry</Button.Text>
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (setsLoading || keysLoading) {
+    return <Text muted>Loading…</Text>;
+  }
+
+  const dependents = sets.flatMap((set, index) => {
+    const publishesFrom = set.externalKeyId === externalKeyId;
+    const hasPublishedKey = (keyQueries[index]?.data?.keys ?? []).some(
+      (key) => key.externalKeyId === externalKeyId,
+    );
+    if (!publishesFrom && !hasPublishedKey) return [];
+    return [{ set, publishesFrom, hasPublishedKey }];
+  });
+
+  if (dependents.length === 0) {
+    return (
+      <Stack gap={2}>
+        <Text muted>No signing key sets use this key.</Text>
+        <Text small muted>
+          Sets that publish from this key, or that have a key published from it,
+          appear here. While any of them exists, this key cannot be deleted.
+        </Text>
+      </Stack>
+    );
+  }
+
+  const headers = [
+    { label: "Name" },
+    { label: "Depends on this key as" },
+    { label: "Created" },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Text small muted>
+        Deleting this key is refused while any of these sets exists, because a
+        key published from it could no longer sign.
+      </Text>
+      <DotTable headers={headers}>
+        {dependents.map(({ set, publishesFrom, hasPublishedKey }) => (
+          <DotRow
+            key={set.id}
+            icon={
+              <Icon
+                name="key-round"
+                className="text-muted-foreground h-5 w-5"
+              />
+            }
+            href={orgRoutes.signingKeySets.setDetail.href(set.id)}
+            ariaLabel={`View signing key set ${set.name}`}
+          >
+            <td className="px-3 py-3">
+              <Text
+                variant="subheading"
+                as="div"
+                className="group-hover:text-primary truncate text-sm transition-colors group-hover:underline"
+              >
+                {set.name}
+              </Text>
+            </td>
+            <td className="px-3 py-3">
+              <Text small muted>
+                {dependencyLabel(publishesFrom, hasPublishedKey)}
+              </Text>
+            </td>
+            <td className="px-3 py-3">
+              <Text small muted as="div">
+                <HumanizeDateTime date={set.createdAt} />
+              </Text>
+            </td>
+          </DotRow>
+        ))}
+      </DotTable>
+    </div>
+  );
+}
+
+function dependencyLabel(
+  publishesFrom: boolean,
+  hasPublishedKey: boolean,
+): string {
+  if (publishesFrom && hasPublishedKey) {
+    return "Publishing key and published keys";
+  }
+  if (publishesFrom) {
+    return "Publishing key";
+  }
+  return "Published keys";
+}

--- a/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
+++ b/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
@@ -1,5 +1,4 @@
-import { Page } from "@/components/page-layout";
-import { useOrganization } from "@/contexts/Auth";
+import { CustomerManagedKeysGate } from "@/components/customer-managed-keys-gate";
 import { ResourceListPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
 import { Dialog } from "@/components/ui/Dialog";
@@ -14,7 +13,6 @@ import {
   invalidateAllListExternalCredentials,
   useListExternalCredentials,
 } from "@gram/client/react-query/listExternalCredentials";
-import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useVerifyGcpIamCredentialMutation } from "@gram/client/react-query/verifyGcpIamCredential";
 import { Button } from "@/components/ui/Button";
 import {
@@ -33,8 +31,17 @@ import { toast } from "sonner";
 import { CreateExternalCredentialSheet } from "./CreateExternalCredentialSheet";
 import { providerLabel, providerSlug } from "./providers";
 
+// The scope and entitlement gates sit on the route root so every page beneath
+// it (the list and each credential's detail page) is covered, and so no
+// protected request fires for a visitor lacking the page scope.
 export function ExternalServicesRoot(): JSX.Element {
-  return <Outlet />;
+  return (
+    <RequireScope scope={["org:read", "org:admin"]} level="page">
+      <CustomerManagedKeysGate>
+        <Outlet />
+      </CustomerManagedKeysGate>
+    </RequireScope>
+  );
 }
 
 // The probe reports the principal it resolved, but an identity source that
@@ -47,48 +54,6 @@ function verifiedMessage(principal: string | undefined): string {
 }
 
 export function ExternalServicesPage(): JSX.Element {
-  // Gate first so no protected request (product-feature read, credential list)
-  // fires for a visitor lacking the page scope.
-  return (
-    <RequireScope scope={["org:read", "org:admin"]} level="page">
-      <ExternalServicesGate />
-    </RequireScope>
-  );
-}
-
-// Product-feature (entitlement) gate, mounted only after the RBAC scope gate
-// passes. A gated-but-authorized org sees only the framed refusal, with no
-// header or toolbar.
-function ExternalServicesGate(): JSX.Element {
-  const organization = useOrganization();
-  const { data: features, isLoading: featuresLoading } = useProductFeatures(
-    { organizationId: organization.id },
-    undefined,
-    { staleTime: 30_000, throwOnError: false },
-  );
-
-  // The sidebar entry is already hidden without the entitlement; this covers a
-  // direct URL. Treat "still loading" and "the read failed" as not-yet-known so
-  // an entitled organization never flashes the gate.
-  const gated =
-    !featuresLoading &&
-    features?.customerManagedEncryptionKeysEnabled === false;
-
-  if (gated) {
-    return (
-      <Page>
-        <Page.Header>
-          <Page.Header.Breadcrumbs />
-        </Page.Header>
-        <Page.Body>
-          <Text muted className="py-8 text-center">
-            Customer-managed keys are not enabled for this organization.
-          </Text>
-        </Page.Body>
-      </Page>
-    );
-  }
-
   return <ExternalServicesOverview />;
 }
 

--- a/client/dashboard/src/pages/remote-identity-providers/ConfirmDialog.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/ConfirmDialog.tsx
@@ -18,6 +18,7 @@ export function ConfirmDialog({
   isPending,
   impact,
   error,
+  confirmVariant = "destructive-primary",
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -36,6 +37,10 @@ export function ConfirmDialog({
   // vanishes, and the dialog it describes is still open. Callers that only need
   // "something went wrong" should keep using a toast.
   error?: string | null;
+  // Confirmations of destructive actions are the common case, so that is the
+  // default; a lifecycle step that is safe but still worth a pause (activating
+  // a key) reads wrong in red.
+  confirmVariant?: "destructive-primary" | "primary";
 }): JSX.Element {
   return (
     <Dialog
@@ -93,7 +98,7 @@ export function ConfirmDialog({
             <Button.Text>Cancel</Button.Text>
           </Button>
           <Button
-            variant="destructive-primary"
+            variant={confirmVariant}
             onClick={onConfirm}
             disabled={isPending || impact?.isLoading}
           >

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -83,6 +83,10 @@ import {
   ExternalServicesRoot,
 } from "./pages/org/external-services/ExternalServices";
 import ExternalKeyDetail from "./pages/org/encryption-keys/ExternalKeyDetail";
+import JsonWebKeySetDetail, {
+  SigningKeySetsIndex,
+  SigningKeySetsRoot,
+} from "./pages/org/encryption-keys/jwks/JsonWebKeySetDetail";
 import {
   EncryptionKeysPage,
   EncryptionKeysRoot,
@@ -1101,6 +1105,32 @@ const ORG_ROUTE_STRUCTURE = {
         component: ExternalKeyDetail,
         subPages: {
           overview: { title: "Overview", url: "overview" },
+          signingKeys: { title: "Signing Keys", url: "signing-keys" },
+          settings: { title: "Settings", url: "settings" },
+        },
+      },
+    },
+  },
+  // Signing key sets are listed on the Encryption Keys page (a set is the
+  // published face of the KMS key that backs it), but their detail pages get
+  // their own top-level path so a set id can never be mistaken for the
+  // :provider/:keyId segments of an encryption key. The index redirects to
+  // that list, which keeps the breadcrumb and command palette entry landing
+  // somewhere real. Not in the sidebar.
+  signingKeySets: {
+    title: "Signing Key Sets",
+    url: "signing-keys",
+    icon: "key-round",
+    component: SigningKeySetsRoot,
+    indexComponent: SigningKeySetsIndex,
+    subPages: {
+      setDetail: {
+        title: "Signing Key Set",
+        url: ":setId",
+        component: JsonWebKeySetDetail,
+        subPages: {
+          overview: { title: "Overview", url: "overview" },
+          keys: { title: "Keys", url: "keys" },
           settings: { title: "Settings", url: "settings" },
         },
       },

--- a/client/dashboard/src/sdk/src/funcs/auditlogsList.ts
+++ b/client/dashboard/src/sdk/src/funcs/auditlogsList.ts
@@ -123,6 +123,7 @@ async function $do(
     "cursor": payload?.cursor,
     "project_slug": payload?.project_slug,
     "subject_id": payload?.subject_id,
+    "subject_ids": payload?.subject_ids,
     "subject_type": payload?.subject_type,
   });
 

--- a/client/dashboard/src/sdk/src/models/operations/listauditlogs.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listauditlogs.ts
@@ -43,7 +43,7 @@ export type ListAuditLogsRequest = {
    */
   subjectId?: string | undefined;
   /**
-   * Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+   * Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
    */
   subjectIds?: Array<string> | undefined;
   /**

--- a/client/dashboard/src/sdk/src/models/operations/listauditlogs.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listauditlogs.ts
@@ -43,6 +43,10 @@ export type ListAuditLogsRequest = {
    */
   subjectId?: string | undefined;
   /**
+   * Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+   */
+  subjectIds?: Array<string> | undefined;
+  /**
    * Acting surface to filter audit logs to changes made through one surface, e.g. 'platform_mcp' to review agent-driven activity alone.
    */
   actingSurface?: string | undefined;
@@ -99,6 +103,7 @@ export type ListAuditLogsRequest$Outbound = {
   action?: string | undefined;
   subject_type?: string | undefined;
   subject_id?: string | undefined;
+  subject_ids?: Array<string> | undefined;
   acting_surface?: string | undefined;
   "Gram-Key"?: string | undefined;
   "Gram-Session"?: string | undefined;
@@ -116,6 +121,7 @@ export const ListAuditLogsRequest$outboundSchema: z.ZodMiniType<
     action: z.optional(z.string()),
     subjectType: z.optional(z.string()),
     subjectId: z.optional(z.string()),
+    subjectIds: z.optional(z.array(z.string())),
     actingSurface: z.optional(z.string()),
     gramKey: z.optional(z.string()),
     gramSession: z.optional(z.string()),
@@ -126,6 +132,7 @@ export const ListAuditLogsRequest$outboundSchema: z.ZodMiniType<
       actorId: "actor_id",
       subjectType: "subject_type",
       subjectId: "subject_id",
+      subjectIds: "subject_ids",
       actingSurface: "acting_surface",
       gramKey: "Gram-Key",
       gramSession: "Gram-Session",

--- a/client/dashboard/src/sdk/src/react-query/auditLogs.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/auditLogs.core.ts
@@ -85,6 +85,7 @@ export function buildAuditLogsQuery(
       action: request?.action,
       subjectType: request?.subjectType,
       subjectId: request?.subjectId,
+      subjectIds: request?.subjectIds,
       actingSurface: request?.actingSurface,
       gramKey: request?.gramKey,
       gramSession: request?.gramSession,
@@ -130,6 +131,7 @@ export function buildAuditLogsInfiniteQuery(
       action: request?.action,
       subjectType: request?.subjectType,
       subjectId: request?.subjectId,
+      subjectIds: request?.subjectIds,
       actingSurface: request?.actingSurface,
       gramKey: request?.gramKey,
       gramSession: request?.gramSession,
@@ -174,6 +176,7 @@ export function queryKeyAuditLogs(
     action?: string | undefined;
     subjectType?: string | undefined;
     subjectId?: string | undefined;
+    subjectIds?: Array<string> | undefined;
     actingSurface?: string | undefined;
     gramKey?: string | undefined;
     gramSession?: string | undefined;
@@ -190,6 +193,7 @@ export function queryKeyAuditLogsInfinite(
     action?: string | undefined;
     subjectType?: string | undefined;
     subjectId?: string | undefined;
+    subjectIds?: Array<string> | undefined;
     actingSurface?: string | undefined;
     gramKey?: string | undefined;
     gramSession?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/auditLogs.ts
+++ b/client/dashboard/src/sdk/src/react-query/auditLogs.ts
@@ -203,6 +203,7 @@ export function setAuditLogsData(
       action?: string | undefined;
       subjectType?: string | undefined;
       subjectId?: string | undefined;
+      subjectIds?: Array<string> | undefined;
       actingSurface?: string | undefined;
       gramKey?: string | undefined;
       gramSession?: string | undefined;
@@ -225,6 +226,7 @@ export function invalidateAuditLogs(
       action?: string | undefined;
       subjectType?: string | undefined;
       subjectId?: string | undefined;
+      subjectIds?: Array<string> | undefined;
       actingSurface?: string | undefined;
       gramKey?: string | undefined;
       gramSession?: string | undefined;

--- a/server/design/auditlogs/design.go
+++ b/server/design/auditlogs/design.go
@@ -130,7 +130,7 @@ var ListAuditLogsForm = Type("ListAuditLogsForm", func() {
 		Description("Subject ID to filter audit logs to a specific subject (e.g. a single assistant).")
 	})
 	Attribute("subject_ids", ArrayOf(String), func() {
-		Description("Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.")
+		Description("Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.")
 		MaxLength(200)
 	})
 	Attribute("acting_surface", String, func() {

--- a/server/design/auditlogs/design.go
+++ b/server/design/auditlogs/design.go
@@ -36,6 +36,7 @@ var _ = Service("auditlogs", func() {
 			Param("action")
 			Param("subject_type")
 			Param("subject_id")
+			Param("subject_ids")
 			Param("acting_surface")
 		})
 
@@ -127,6 +128,10 @@ var ListAuditLogsForm = Type("ListAuditLogsForm", func() {
 	})
 	Attribute("subject_id", String, func() {
 		Description("Subject ID to filter audit logs to a specific subject (e.g. a single assistant).")
+	})
+	Attribute("subject_ids", ArrayOf(String), func() {
+		Description("Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.")
+		MaxLength(200)
 	})
 	Attribute("acting_surface", String, func() {
 		Description("Acting surface to filter audit logs to changes made through one surface, e.g. 'platform_mcp' to review agent-driven activity alone.")

--- a/server/gen/auditlogs/service.go
+++ b/server/gen/auditlogs/service.go
@@ -130,8 +130,9 @@ type ListPayload struct {
 	SubjectID *string
 	// Subject IDs to filter audit logs to a set of subjects at once, e.g. a
 	// resource together with the child resources whose events name the child as
-	// the subject. Matches any listed subject regardless of subject type; combine
-	// with subject_type to pin the kind.
+	// the subject. Matches any listed subject of any subject type, except that
+	// assistant activity events stay excluded unless subject_type is 'assistant';
+	// combine with subject_type to pin the kind. Blank entries are ignored.
 	SubjectIds []string
 	// Acting surface to filter audit logs to changes made through one surface,
 	// e.g. 'platform_mcp' to review agent-driven activity alone.

--- a/server/gen/auditlogs/service.go
+++ b/server/gen/auditlogs/service.go
@@ -128,6 +128,11 @@ type ListPayload struct {
 	// Subject ID to filter audit logs to a specific subject (e.g. a single
 	// assistant).
 	SubjectID *string
+	// Subject IDs to filter audit logs to a set of subjects at once, e.g. a
+	// resource together with the child resources whose events name the child as
+	// the subject. Matches any listed subject regardless of subject type; combine
+	// with subject_type to pin the kind.
+	SubjectIds []string
 	// Acting surface to filter audit logs to changes made through one surface,
 	// e.g. 'platform_mcp' to review agent-driven activity alone.
 	ActingSurface *string

--- a/server/gen/http/auditlogs/client/cli.go
+++ b/server/gen/http/auditlogs/client/cli.go
@@ -8,12 +8,17 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+
 	auditlogs "github.com/speakeasy-api/gram/server/gen/auditlogs"
+	goa "goa.design/goa/v3/pkg"
 )
 
 // BuildListPayload builds the payload for the auditlogs list endpoint from CLI
 // flags.
-func BuildListPayload(auditlogsListCursor string, auditlogsListProjectSlug string, auditlogsListActorID string, auditlogsListAction string, auditlogsListSubjectType string, auditlogsListSubjectID string, auditlogsListActingSurface string, auditlogsListApikeyToken string, auditlogsListSessionToken string) (*auditlogs.ListPayload, error) {
+func BuildListPayload(auditlogsListCursor string, auditlogsListProjectSlug string, auditlogsListActorID string, auditlogsListAction string, auditlogsListSubjectType string, auditlogsListSubjectID string, auditlogsListSubjectIds string, auditlogsListActingSurface string, auditlogsListApikeyToken string, auditlogsListSessionToken string) (*auditlogs.ListPayload, error) {
+	var err error
 	var cursor *string
 	{
 		if auditlogsListCursor != "" {
@@ -50,6 +55,21 @@ func BuildListPayload(auditlogsListCursor string, auditlogsListProjectSlug strin
 			subjectID = &auditlogsListSubjectID
 		}
 	}
+	var subjectIds []string
+	{
+		if auditlogsListSubjectIds != "" {
+			err = json.Unmarshal([]byte(auditlogsListSubjectIds), &subjectIds)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for subjectIds, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"abc123\",\n      \"abc123\",\n      \"abc123\"\n   ]'")
+			}
+			if len(subjectIds) > 200 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("subject_ids", subjectIds, len(subjectIds), 200, false))
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	var actingSurface *string
 	{
 		if auditlogsListActingSurface != "" {
@@ -75,6 +95,7 @@ func BuildListPayload(auditlogsListCursor string, auditlogsListProjectSlug strin
 	v.Action = action
 	v.SubjectType = subjectType
 	v.SubjectID = subjectID
+	v.SubjectIds = subjectIds
 	v.ActingSurface = actingSurface
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken

--- a/server/gen/http/auditlogs/client/encode_decode.go
+++ b/server/gen/http/auditlogs/client/encode_decode.go
@@ -68,6 +68,9 @@ func EncodeListRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.R
 		if p.SubjectID != nil {
 			values.Add("subject_id", *p.SubjectID)
 		}
+		for _, value := range p.SubjectIds {
+			values.Add("subject_ids", value)
+		}
 		if p.ActingSurface != nil {
 			values.Add("acting_surface", *p.ActingSurface)
 		}

--- a/server/gen/http/auditlogs/server/encode_decode.go
+++ b/server/gen/http/auditlogs/server/encode_decode.go
@@ -42,9 +42,11 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 			action        *string
 			subjectType   *string
 			subjectID     *string
+			subjectIds    []string
 			actingSurface *string
 			apikeyToken   *string
 			sessionToken  *string
+			err           error
 		)
 		qp := r.URL.Query()
 		cursorRaw := qp.Get("cursor")
@@ -71,6 +73,10 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 		if subjectIDRaw != "" {
 			subjectID = &subjectIDRaw
 		}
+		subjectIds = qp["subject_ids"]
+		if len(subjectIds) > 200 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("subject_ids", subjectIds, len(subjectIds), 200, false))
+		}
 		actingSurfaceRaw := qp.Get("acting_surface")
 		if actingSurfaceRaw != "" {
 			actingSurface = &actingSurfaceRaw
@@ -83,7 +89,10 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
 		}
-		payload = NewListPayload(cursor, projectSlug, actorID, action, subjectType, subjectID, actingSurface, apikeyToken, sessionToken)
+		if err != nil {
+			return payload, err
+		}
+		payload = NewListPayload(cursor, projectSlug, actorID, action, subjectType, subjectID, subjectIds, actingSurface, apikeyToken, sessionToken)
 		if payload.ApikeyToken != nil {
 			if strings.Contains(*payload.ApikeyToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/auditlogs/server/types.go
+++ b/server/gen/http/auditlogs/server/types.go
@@ -780,7 +780,7 @@ func NewListFacetsGatewayErrorResponseBody(res *goa.ServiceError) *ListFacetsGat
 }
 
 // NewListPayload builds a auditlogs service list endpoint payload.
-func NewListPayload(cursor *string, projectSlug *string, actorID *string, action *string, subjectType *string, subjectID *string, actingSurface *string, apikeyToken *string, sessionToken *string) *auditlogs.ListPayload {
+func NewListPayload(cursor *string, projectSlug *string, actorID *string, action *string, subjectType *string, subjectID *string, subjectIds []string, actingSurface *string, apikeyToken *string, sessionToken *string) *auditlogs.ListPayload {
 	v := &auditlogs.ListPayload{}
 	v.Cursor = cursor
 	v.ProjectSlug = projectSlug
@@ -788,6 +788,7 @@ func NewListPayload(cursor *string, projectSlug *string, actorID *string, action
 	v.Action = action
 	v.SubjectType = subjectType
 	v.SubjectID = subjectID
+	v.SubjectIds = subjectIds
 	v.ActingSurface = actingSurface
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -658,6 +658,7 @@ func ParseEndpoint(
 		auditlogsListActionFlag        = auditlogsListFlags.String("action", "", "")
 		auditlogsListSubjectTypeFlag   = auditlogsListFlags.String("subject-type", "", "")
 		auditlogsListSubjectIDFlag     = auditlogsListFlags.String("subject-id", "", "")
+		auditlogsListSubjectIdsFlag    = auditlogsListFlags.String("subject-ids", "", "")
 		auditlogsListActingSurfaceFlag = auditlogsListFlags.String("acting-surface", "", "")
 		auditlogsListApikeyTokenFlag   = auditlogsListFlags.String("apikey-token", "", "")
 		auditlogsListSessionTokenFlag  = auditlogsListFlags.String("session-token", "", "")
@@ -7178,7 +7179,7 @@ func ParseEndpoint(
 			switch epn {
 			case "list":
 				endpoint = c.List()
-				data, err = auditlogsc.BuildListPayload(*auditlogsListCursorFlag, *auditlogsListProjectSlugFlag, *auditlogsListActorIDFlag, *auditlogsListActionFlag, *auditlogsListSubjectTypeFlag, *auditlogsListSubjectIDFlag, *auditlogsListActingSurfaceFlag, *auditlogsListApikeyTokenFlag, *auditlogsListSessionTokenFlag)
+				data, err = auditlogsc.BuildListPayload(*auditlogsListCursorFlag, *auditlogsListProjectSlugFlag, *auditlogsListActorIDFlag, *auditlogsListActionFlag, *auditlogsListSubjectTypeFlag, *auditlogsListSubjectIDFlag, *auditlogsListSubjectIdsFlag, *auditlogsListActingSurfaceFlag, *auditlogsListApikeyTokenFlag, *auditlogsListSessionTokenFlag)
 			case "list-facets":
 				endpoint = c.ListFacets()
 				data, err = auditlogsc.BuildListFacetsPayload(*auditlogsListFacetsProjectSlugFlag, *auditlogsListFacetsApikeyTokenFlag, *auditlogsListFacetsSessionTokenFlag)
@@ -11132,6 +11133,7 @@ func auditlogsListUsage() {
 	fmt.Fprint(os.Stderr, " -action STRING")
 	fmt.Fprint(os.Stderr, " -subject-type STRING")
 	fmt.Fprint(os.Stderr, " -subject-id STRING")
+	fmt.Fprint(os.Stderr, " -subject-ids JSON")
 	fmt.Fprint(os.Stderr, " -acting-surface STRING")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
@@ -11148,13 +11150,14 @@ func auditlogsListUsage() {
 	fmt.Fprintln(os.Stderr, `    -action STRING: `)
 	fmt.Fprintln(os.Stderr, `    -subject-type STRING: `)
 	fmt.Fprintln(os.Stderr, `    -subject-id STRING: `)
+	fmt.Fprintln(os.Stderr, `    -subject-ids JSON: `)
 	fmt.Fprintln(os.Stderr, `    -acting-surface STRING: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "auditlogs list --cursor \"abc123\" --project-slug \"abc123\" --actor-id \"abc123\" --action \"abc123\" --subject-type \"abc123\" --subject-id \"abc123\" --acting-surface \"abc123\" --apikey-token \"abc123\" --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "auditlogs list --cursor \"abc123\" --project-slug \"abc123\" --actor-id \"abc123\" --action \"abc123\" --subject-type \"abc123\" --subject-id \"abc123\" --subject-ids '[\n      \"abc123\",\n      \"abc123\",\n      \"abc123\"\n   ]' --acting-surface \"abc123\" --apikey-token \"abc123\" --session-token \"abc123\"")
 }
 
 func auditlogsListFacetsUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -10679,11 +10679,11 @@ paths:
                     description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
                     type: string
                 - allowEmptyValue: true
-                  description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                  description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
                   in: query
                   name: subject_ids
                   schema:
-                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
                     items:
                         type: string
                     maxItems: 200
@@ -71314,7 +71314,7 @@ components:
                     type: array
                     items:
                         type: string
-                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject of any subject type, except that assistant activity events stay excluded unless subject_type is 'assistant'; combine with subject_type to pin the kind. Blank entries are ignored.
                     maxItems: 200
                 subject_type:
                     type: string

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -10679,6 +10679,16 @@ paths:
                     description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
                     type: string
                 - allowEmptyValue: true
+                  description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                  in: query
+                  name: subject_ids
+                  schema:
+                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                    items:
+                        type: string
+                    maxItems: 200
+                    type: array
+                - allowEmptyValue: true
                   description: Acting surface to filter audit logs to changes made through one surface, e.g. 'platform_mcp' to review agent-driven activity alone.
                   in: query
                   name: acting_surface
@@ -71300,6 +71310,12 @@ components:
                 subject_id:
                     type: string
                     description: Subject ID to filter audit logs to a specific subject (e.g. a single assistant).
+                subject_ids:
+                    type: array
+                    items:
+                        type: string
+                    description: Subject IDs to filter audit logs to a set of subjects at once, e.g. a resource together with the child resources whose events name the child as the subject. Matches any listed subject regardless of subject type; combine with subject_type to pin the kind.
+                    maxItems: 200
                 subject_type:
                     type: string
                     description: Subject type to filter audit logs to a specific kind of subject. When omitted, assistant activity events are excluded; pass 'assistant' to list them.

--- a/server/internal/audit/queries.sql
+++ b/server/internal/audit/queries.sql
@@ -97,6 +97,12 @@ WHERE a.organization_id = @organization_id
     sqlc.narg(subject_id)::text IS NULL
     OR a.subject_id = sqlc.narg(subject_id)::text
   )
+  -- An empty or absent list is no filter, so a caller composing filters can
+  -- always send the parameter.
+  AND (
+    coalesce(cardinality(sqlc.narg(subject_ids)::text[]), 0) = 0
+    OR a.subject_id = ANY(sqlc.narg(subject_ids)::text[])
+  )
   -- A row written before attribution existed has no surface. Coalescing here
   -- means filtering for 'unknown' finds those rows too, instead of returning
   -- nothing and implying the organization has no unattributed history.

--- a/server/internal/audit/repo/queries.sql.go
+++ b/server/internal/audit/repo/queries.sql.go
@@ -315,12 +315,18 @@ WHERE a.organization_id = $1
     $7::text IS NULL
     OR a.subject_id = $7::text
   )
+  -- An empty or absent list is no filter, so a caller composing filters can
+  -- always send the parameter.
+  AND (
+    coalesce(cardinality($8::text[]), 0) = 0
+    OR a.subject_id = ANY($8::text[])
+  )
   -- A row written before attribution existed has no surface. Coalescing here
   -- means filtering for 'unknown' finds those rows too, instead of returning
   -- nothing and implying the organization has no unattributed history.
   AND (
-    $8::text IS NULL
-    OR COALESCE(a.acting_surface, 'unknown') = $8::text
+    $9::text IS NULL
+    OR COALESCE(a.acting_surface, 'unknown') = $9::text
   )
 ORDER BY a.seq DESC
 LIMIT 51
@@ -334,6 +340,7 @@ type ListAuditLogsParams struct {
 	Action         pgtype.Text
 	SubjectType    pgtype.Text
 	SubjectID      pgtype.Text
+	SubjectIds     []string
 	ActingSurface  pgtype.Text
 }
 
@@ -372,6 +379,7 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 		arg.Action,
 		arg.SubjectType,
 		arg.SubjectID,
+		arg.SubjectIds,
 		arg.ActingSurface,
 	)
 	if err != nil {

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -104,6 +104,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		Action:        conv.PtrToPGTextEmpty(payload.Action),
 		SubjectType:   conv.PtrToPGTextEmpty(payload.SubjectType),
 		SubjectID:     conv.PtrToPGTextEmpty(payload.SubjectID),
+		SubjectIds:    payload.SubjectIds,
 		ActingSurface: conv.PtrToPGTextEmpty(payload.ActingSurface),
 	}
 

--- a/server/internal/auditapi/impl.go
+++ b/server/internal/auditapi/impl.go
@@ -104,7 +104,7 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		Action:        conv.PtrToPGTextEmpty(payload.Action),
 		SubjectType:   conv.PtrToPGTextEmpty(payload.SubjectType),
 		SubjectID:     conv.PtrToPGTextEmpty(payload.SubjectID),
-		SubjectIds:    payload.SubjectIds,
+		SubjectIds:    normalizeSubjectIDs(payload.SubjectIds),
 		ActingSurface: conv.PtrToPGTextEmpty(payload.ActingSurface),
 	}
 
@@ -380,4 +380,17 @@ func toAuditActionFacetOptions(rows []repo.ListAuditActionFacetsRow) []*gen.Audi
 	return facetOptions(rows, func(row repo.ListAuditActionFacetsRow) (string, string, int64) {
 		return row.Value, row.DisplayName, row.Count
 	})
+}
+
+// normalizeSubjectIDs trims the subject id filter and drops blank entries so a
+// list that is empty once normalized reads as no filter rather than as a filter
+// nothing can match.
+func normalizeSubjectIDs(ids []string) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/server/internal/auditapi/list_test.go
+++ b/server/internal/auditapi/list_test.go
@@ -914,7 +914,8 @@ func TestAuditService_List_FilterBySubjectIDs(t *testing.T) {
 		require.Equal(t, "json_web_key", log.SubjectType)
 	}
 
-	// An empty list is no filter rather than a filter that matches nothing.
+	// An empty list is no filter rather than a filter that matches nothing, and
+	// blank entries do not turn it into one.
 	unfiltered, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:   nil,
 		SessionToken:  nil,
@@ -924,7 +925,7 @@ func TestAuditService_List_FilterBySubjectIDs(t *testing.T) {
 		Action:        nil,
 		SubjectType:   nil,
 		SubjectID:     nil,
-		SubjectIds:    []string{},
+		SubjectIds:    []string{"", "  "},
 		ActingSurface: nil,
 	})
 	require.NoError(t, err)

--- a/server/internal/auditapi/list_test.go
+++ b/server/internal/auditapi/list_test.go
@@ -914,9 +914,25 @@ func TestAuditService_List_FilterBySubjectIDs(t *testing.T) {
 		require.Equal(t, "json_web_key", log.SubjectType)
 	}
 
-	// An empty list is no filter rather than a filter that matches nothing, and
-	// blank entries do not turn it into one.
+	// An empty list is no filter rather than a filter that matches nothing.
 	unfiltered, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:   nil,
+		SessionToken:  nil,
+		Cursor:        nil,
+		ProjectSlug:   nil,
+		ActorID:       nil,
+		Action:        nil,
+		SubjectType:   nil,
+		SubjectID:     nil,
+		SubjectIds:    []string{},
+		ActingSurface: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, unfiltered.Logs, 4)
+
+	// Blank entries are dropped, so a list of nothing but blanks is no filter
+	// either, and a blank alongside real ids does not narrow them.
+	blanksOnly, err := ti.service.List(ctx, &gen.ListPayload{
 		ApikeyToken:   nil,
 		SessionToken:  nil,
 		Cursor:        nil,
@@ -929,5 +945,21 @@ func TestAuditService_List_FilterBySubjectIDs(t *testing.T) {
 		ActingSurface: nil,
 	})
 	require.NoError(t, err)
-	require.Len(t, unfiltered.Logs, 4)
+	require.Len(t, blanksOnly.Logs, 4)
+
+	padded, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:   nil,
+		SessionToken:  nil,
+		Cursor:        nil,
+		ProjectSlug:   nil,
+		ActorID:       nil,
+		Action:        nil,
+		SubjectType:   nil,
+		SubjectID:     nil,
+		SubjectIds:    []string{" " + setID + " ", ""},
+		ActingSurface: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, padded.Logs, 1)
+	require.Equal(t, setCreated.String(), padded.Logs[0].ID)
 }

--- a/server/internal/auditapi/list_test.go
+++ b/server/internal/auditapi/list_test.go
@@ -836,3 +836,97 @@ func deleteProject(t *testing.T, ctx context.Context, ti *testInstance, projectI
 func jsonNumber(value int) string {
 	return strconv.Itoa(value)
 }
+
+func TestAuditService_List_FilterBySubjectIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAuditService(t)
+	authCtx := testAuthContext(t, ctx)
+
+	// A parent resource plus two children whose events name the child as the
+	// subject, alongside an unrelated sibling that must stay out of the result.
+	setID := uuid.NewString()
+	firstKeyID := uuid.NewString()
+	secondKeyID := uuid.NewString()
+	otherKeyID := uuid.NewString()
+
+	seed := func(action, subjectType, subjectID string) uuid.UUID {
+		return insertAuditLog(t, ctx, ti, auditLogSeed{
+			organizationID:     authCtx.ActiveOrganizationID,
+			projectID:          uuid.NullUUID{UUID: uuid.UUID{}, Valid: false},
+			actorID:            "user:first",
+			actorType:          "user",
+			actorDisplayName:   nil,
+			actorSlug:          nil,
+			action:             action,
+			subjectID:          subjectID,
+			subjectType:        subjectType,
+			subjectDisplayName: nil,
+			subjectSlug:        nil,
+			beforeSnapshot:     nil,
+			afterSnapshot:      nil,
+			metadata:           nil,
+		})
+	}
+
+	setCreated := seed("json_web_key_set:create", "json_web_key_set", setID)
+	firstPublished := seed("json_web_key:publish", "json_web_key", firstKeyID)
+	secondPublished := seed("json_web_key:publish", "json_web_key", secondKeyID)
+	seed("json_web_key:publish", "json_web_key", otherKeyID)
+
+	result, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:   nil,
+		SessionToken:  nil,
+		Cursor:        nil,
+		ProjectSlug:   nil,
+		ActorID:       nil,
+		Action:        nil,
+		SubjectType:   nil,
+		SubjectID:     nil,
+		SubjectIds:    []string{setID, firstKeyID, secondKeyID},
+		ActingSurface: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 3)
+
+	ids := make([]string, 0, len(result.Logs))
+	for _, log := range result.Logs {
+		ids = append(ids, log.ID)
+	}
+	require.ElementsMatch(t, []string{setCreated.String(), firstPublished.String(), secondPublished.String()}, ids)
+
+	// subject_type still narrows the match: only the key rows survive.
+	keysOnly, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:   nil,
+		SessionToken:  nil,
+		Cursor:        nil,
+		ProjectSlug:   nil,
+		ActorID:       nil,
+		Action:        nil,
+		SubjectType:   new("json_web_key"),
+		SubjectID:     nil,
+		SubjectIds:    []string{setID, firstKeyID, secondKeyID},
+		ActingSurface: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, keysOnly.Logs, 2)
+	for _, log := range keysOnly.Logs {
+		require.Equal(t, "json_web_key", log.SubjectType)
+	}
+
+	// An empty list is no filter rather than a filter that matches nothing.
+	unfiltered, err := ti.service.List(ctx, &gen.ListPayload{
+		ApikeyToken:   nil,
+		SessionToken:  nil,
+		Cursor:        nil,
+		ProjectSlug:   nil,
+		ActorID:       nil,
+		Action:        nil,
+		SubjectType:   nil,
+		SubjectID:     nil,
+		SubjectIds:    []string{},
+		ActingSurface: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, unfiltered.Logs, 4)
+}


### PR DESCRIPTION
Linear: [AIS-241](https://linear.app/speakeasy/issue/AIS-241/organization-admin-ui-manage-jwks)

## Summary

Adds a **Signing Keys (JWKS)** section beneath the KMS key table on the Encryption Keys page, gated on the same `customer_managed_encryption_keys` entitlement. Organization admins can create a key set from a GCP KMS key (one request; the server publishes the first key as active), and each set gets a detail page under a new top-level `signing-keys/:setId` route with three tabs:

- **Overview**: name, the KMS key new keys are published from, and the set's audit history, including events on its keys.
- **Keys**: published keys with `kid`, algorithm, lifecycle state and timestamps, an "Include revoked" toggle, per-row activate / retire / revoke actions with consequence-specific confirmations, and a "Publish new key" flow that re-points the set at a different KMS key before publishing and explains the half-done state if the publish step fails.
- **Settings**: rename (re-reading the set first so a rename never reverts a concurrent re-point) and delete, confirmed as decommissioning a trust anchor.

The encryption key detail page gains a **Signing Keys** tab listing the sets that publish from the key or hold a key minted from it, which is what blocks deleting the key.

Key audit events name the key as their subject and carry the set id only in metadata, so `auditlogs.list` gains an optional repeated `subject_ids` filter (any subject type, composable with `subject_type`, capped at 200) and the Overview feed queries the set id plus every key id, revoked included.

Also fixes both the new and the existing encryption key detail page to return to the list on a 404 instead of surfacing it in the error boundary; the dashboard's default query config throws everything except 401/403.

The demo seed is unchanged: creating a set requires a real KMS key and credential, which cannot be seeded.

## Motivation

The JSON Web Key Sets management API shipped without a dashboard surface, so the only way to create or rotate a set was the API. This gives organization admins the full lifecycle in the same place their KMS keys already live, with every destructive step (revoke, delete) spelling out its effect on token verification. The signing key set detail route is hoisted beside `encryption-keys` rather than nested under it so a set id can never collide with the `:provider/:keyId` segments of an encryption key. The `subject_ids` audit filter exists because a per-resource feed for a parent and its children could not be expressed exactly with the single `subject_id` filter, and a client-side merge of two paginated queries has no correct ordering or termination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an organization-admin UI for JSON Web Key Sets (JWKS) under Encryption Keys with full create/publish/activate/retire/revoke/rename/delete flows. Access is gated by the `customer_managed_encryption_keys` feature (enforced on deep links via a shared gate), and a top‑level `signing-keys/:setId` route avoids collisions with `encryption-keys/:provider/:keyId`.

- Set detail adds Overview (set + key audit history), Keys (include revoked toggle; per‑row activate/retire/revoke; publish can re‑point the backing KMS key and explains partial success), and Settings (rename/delete).
- Encryption Key detail adds a Signing Keys tab listing sets that publish from the key and sets holding keys minted from it, including revoked, with a column showing which sets still block deletion.
- A shared entitlement gate now guards Encryption Keys, Signing Key Sets, and External Services route roots to block deep‑link access without the feature.
- `auditlogs.list` supports optional `subject_ids` (array, max 200; ignores blanks; assistant activity stays excluded unless `subject_type` is `assistant`); OpenAPI, client SDK, and CLI are updated.
- Detail pages redirect to the list on 404; other errors bubble to the error boundary, keeping default handling for 401/403.

Linear: AIS-241

<sup>Written for commit f603bd162d51f6940caa012287d7418ccb02c7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

