### PR TITLE
chore: centralize risk policy mutations

### DIFF
--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -53,7 +53,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
-	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
 	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
@@ -217,12 +216,24 @@ func NewService(
 ) *Service {
 	logger = logger.With(attr.SlogComponent("risk"))
 
+	var policyCacheInvalidator policycore.PolicyCacheInvalidator
+	if shadowMCPClient != nil {
+		policyCacheInvalidator = shadowMCPClient
+	}
+
 	return &Service{
-		tracer:                       tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
-		logger:                       logger,
-		db:                           db,
-		repo:                         repo.New(db),
-		policies:                     policycore.New(db),
+		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/risk"),
+		logger: logger,
+		db:     db,
+		repo:   repo.New(db),
+		policies: policycore.New(db, policycore.MutationDependencies{
+			Transactor:       db,
+			Auditor:          policyMutationAuditor{logger: auditLogger},
+			Approvals:        approvalIntake,
+			ReconcileURLs:    policycore.ReconcilePolicyURLs(reconcileShadowMCPPolicyURLs),
+			Signaler:         signaler,
+			CacheInvalidator: policyCacheInvalidator,
+		}),
 		auth:                         auth.New(logger, db, sessions, authzEngine),
 		authz:                        authzEngine,
 		signaler:                     signaler,
@@ -372,8 +383,6 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 			return nil, oops.E(oops.CodeInvalid, err, "invalid policy audience")
 		}
 	}
-	audiencePrincipalURNs := principalStrings(audiencePrincipals)
-
 	enabled := true
 	if payload.Enabled != nil {
 		enabled = *payload.Enabled
@@ -382,12 +391,6 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 	shadowMCPDisposition := conv.PtrValOr(payload.ShadowMcpDisposition, "")
 	if err := validateShadowMCPDisposition(shadowMCPDisposition, sources, action); err != nil {
 		return nil, err
-	}
-
-	if enabled && action == "block" && slices.Contains(sources, shadowmcp.SourceShadowMCP) {
-		if err := requireSingleShadowMCPBlockingPolicy(ctx, s.repo, *authCtx.ProjectID, uuid.Nil); err != nil {
-			return nil, err
-		}
 	}
 
 	var shadowMCPAllowedURLs []string
@@ -469,118 +472,47 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 		}
 	}
 
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	row, err := repo.New(dbtx).CreateRiskPolicy(ctx, repo.CreateRiskPolicyParams{
-		ID:                   id,
-		ProjectID:            *authCtx.ProjectID,
-		OrganizationID:       authCtx.ActiveOrganizationID,
-		Name:                 name,
-		PolicyType:           policyType,
-		Sources:              sources,
-		PresidioEntities:     createPolicyDetectionField(policyType, payload.PresidioEntities),
-		AnalyzerConfig:       analyzerConfig,
-		PromptInjectionRules: createPolicyDetectionField(policyType, payload.PromptInjectionRules),
-		DisabledRules:        createPolicyDetectionField(policyType, payload.DisabledRules),
-		CustomRuleIds:        createPolicyDetectionField(policyType, payload.CustomRuleIds),
-		MessageTypes:         payload.MessageTypes,
-		ScopeInclude:         conv.PtrToPGText(payload.ScopeInclude),
-		ScopeExempt:          conv.PtrToPGText(payload.ScopeExempt),
-		Enabled:              enabled,
-		Action:               action,
-		AudienceType:         audienceType,
-		ShadowMcpDisposition: conv.ToPGTextEmpty(shadowMCPDisposition),
-		AutoName:             autoName,
-		UserMessage:          conv.PtrToPGTextEmpty(payload.UserMessage),
-		Prompt:               prompt,
-		ModelConfig:          modelConfig,
-		// Create payload applies the Goa Default(5), so Score always carries a value.
-		Score: pgtype.Float8{Float64: payload.Score, Valid: true},
+	result, err := s.policies.CreatePolicy(ctx, policycore.CreateMutation{
+		Params: repo.CreateRiskPolicyParams{
+			ID:                   id,
+			ProjectID:            *authCtx.ProjectID,
+			OrganizationID:       authCtx.ActiveOrganizationID,
+			Name:                 name,
+			PolicyType:           policyType,
+			Sources:              sources,
+			PresidioEntities:     createPolicyDetectionField(policyType, payload.PresidioEntities),
+			AnalyzerConfig:       analyzerConfig,
+			PromptInjectionRules: createPolicyDetectionField(policyType, payload.PromptInjectionRules),
+			DisabledRules:        createPolicyDetectionField(policyType, payload.DisabledRules),
+			CustomRuleIds:        createPolicyDetectionField(policyType, payload.CustomRuleIds),
+			MessageTypes:         payload.MessageTypes,
+			ScopeInclude:         conv.PtrToPGText(payload.ScopeInclude),
+			ScopeExempt:          conv.PtrToPGText(payload.ScopeExempt),
+			Enabled:              enabled,
+			Action:               action,
+			AudienceType:         audienceType,
+			ShadowMcpDisposition: conv.ToPGTextEmpty(shadowMCPDisposition),
+			AutoName:             autoName,
+			UserMessage:          conv.PtrToPGTextEmpty(payload.UserMessage),
+			Prompt:               prompt,
+			ModelConfig:          modelConfig,
+			Score:                pgtype.Float8{Float64: payload.Score, Valid: true},
+		},
+		AudiencePrincipals: audiencePrincipals,
+		AllowedURLs:        shadowMCPAllowedURLs,
+		AllowedURLsSet:     payload.ShadowMcpAllowedUrls != nil,
+		BlockedURLs:        shadowMCPBlockedURLs,
+		BlockedURLsSet:     payload.ShadowMcpBlockedUrls != nil,
+		Actor: policycore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			DisplayName: authCtx.Email,
+			Slug:        nil,
+		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create risk policy").LogError(ctx, s.logger)
+		return nil, s.policyMutationError(ctx, err)
 	}
-
-	if err := syncRiskPolicyAudienceGrants(ctx, dbtx, authCtx.ActiveOrganizationID, row.ID.String(), audienceType, audiencePrincipalURNs); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "sync risk policy audience").LogError(ctx, s.logger)
-	}
-	if payload.ShadowMcpAllowedUrls != nil {
-		if err := s.reconcileShadowMCPPolicyURLs(ctx, dbtx, policybypass.ReconcilePolicyURLsInput{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PolicyID:       row.ID.String(),
-			Scope:          authz.ScopeRiskPolicyBypass,
-			DesiredURLs:    shadowMCPAllowedURLs,
-			Principals:     audiencePrincipals,
-			// No preserve set on create: the replay below re-derives every
-			// standing decision's grants over whatever this list wrote.
-			PreserveURLs: nil,
-		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "reconcile shadow mcp policy allowed urls").LogError(ctx, s.logger)
-		}
-	}
-	if payload.ShadowMcpBlockedUrls != nil {
-		// Block rules apply to everyone in the project: the grant audience is
-		// always the all-users principal, independent of the policy audience.
-		if err := s.reconcileShadowMCPPolicyURLs(ctx, dbtx, policybypass.ReconcilePolicyURLsInput{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PolicyID:       row.ID.String(),
-			Scope:          authz.ScopeRiskPolicyBlock,
-			DesiredURLs:    shadowMCPBlockedURLs,
-			Principals:     []urn.Principal{authz.AllUsersPrincipal()},
-			PreserveURLs:   nil,
-		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "reconcile shadow mcp policy blocked urls").LogError(ctx, s.logger)
-		}
-	}
-
-	// A blocking policy created after decisions were recorded must honor
-	// them: an approval's grant state is derived here, in the same
-	// transaction, so ordering never decides what a decision means. This
-	// runs after the explicit allow/block URL lists — a standing decision is
-	// the institutional record and wins a per-URL conflict with a list typed
-	// into this form; the admin re-decides to change it.
-	if s.approvalIntake != nil && enabled && action == "block" && slices.Contains(sources, shadowmcp.SourceShadowMCP) {
-		if err := s.approvalIntake.ReconcileStandingDecisionsForPolicy(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, row.ID); err != nil {
-			// An inexpressible blast radius is the caller's error, already in
-			// the boundary shape this handler returns; wrapping it would
-			// bury the explanation the admin needs.
-			var shareable *oops.ShareableError
-			if errors.As(err, &shareable) {
-				return nil, err //nolint:wrapcheck // shareable errors pass the boundary intact
-			}
-			return nil, oops.E(oops.CodeUnexpected, err, "honor standing approval decisions on policy create").LogError(ctx, s.logger)
-		}
-	}
-
-	if err := s.audit.LogRiskPolicyCreate(ctx, dbtx, audit.LogRiskPolicyCreateEvent{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		ProjectID:        *authCtx.ProjectID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName: authCtx.Email,
-		ActorSlug:        nil,
-		RiskPolicyID:     row.ID,
-		RiskPolicyName:   row.Name,
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy create").LogError(ctx, s.logger)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy create").LogError(ctx, s.logger)
-	}
-
-	if s.shadowMCPClient != nil {
-		s.shadowMCPClient.Invalidate(ctx, row.ProjectID)
-	}
-
-	if enabled {
-		_ = s.signaler.Signal(ctx, row.ProjectID)
-	}
-
-	return s.policyToType(ctx, row)
+	return s.policyToType(ctx, result.Row)
 }
 
 func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPoliciesPayload) (*gen.ListRiskPoliciesResult, error) {
@@ -951,8 +883,6 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 			return nil, oops.E(oops.CodeInvalid, err, "invalid policy audience")
 		}
 	}
-	audiencePrincipalURNs = principalStrings(audiencePrincipals)
-
 	// The disposition is immutable: accept only the policy's current effective
 	// value (so form round-trips stay valid); anything else is a posture
 	// switch, which requires delete + recreate. A policy with an explicitly
@@ -964,11 +894,6 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		return nil, oops.E(oops.CodeInvalid, nil, "cannot change the sources or action of a shadow mcp policy with a disposition; delete and recreate the policy instead")
 	}
 
-	if enabled && action == "block" && slices.Contains(sources, shadowmcp.SourceShadowMCP) {
-		if err := requireSingleShadowMCPBlockingPolicy(ctx, s.repo, *authCtx.ProjectID, current.ID); err != nil {
-			return nil, err
-		}
-	}
 	if payload.ShadowMcpDisposition != nil {
 		if effectiveDisposition == "" {
 			return nil, oops.E(oops.CodeInvalid, nil, "shadow mcp disposition requires a blocking shadow mcp policy")
@@ -1056,153 +981,48 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		return nil, err
 	}
 
-	currentAudiencePrincipalURNs, err := s.policies.AudiencePrincipalURNs(ctx, authCtx.ActiveOrganizationID, current.ID.String())
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "load risk policy audience snapshot").LogError(ctx, s.logger)
-	}
-	snapshotBefore := policyRowSnapshotWithAudience(current, currentAudiencePrincipalURNs)
-
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	row, err := repo.New(dbtx).UpdateRiskPolicy(ctx, repo.UpdateRiskPolicyParams{
-		ID:                   id,
-		ProjectID:            *authCtx.ProjectID,
-		Name:                 name,
-		Sources:              sources,
-		PresidioEntities:     presidioEntities,
-		AnalyzerConfig:       analyzerConfig,
-		PromptInjectionRules: promptInjectionRules,
-		DisabledRules:        disabledRules,
-		CustomRuleIds:        customRuleIds,
-		MessageTypes:         messageTypes,
-		ScopeInclude:         scopeInclude,
-		ScopeExempt:          scopeExempt,
-		Enabled:              enabled,
-		Action:               action,
-		AudienceType:         audienceType,
-		AutoName:             autoName,
-		UserMessage:          userMessage,
-		Prompt:               prompt,
-		ModelConfig:          modelConfig,
-		// Omit (nil) preserves the current score; the query COALESCEs to the
-		// existing column value. Never contributes to the version bump.
-		Score: conv.PtrToPGFloat8(payload.Score),
+	result, err := s.policies.UpdatePolicy(ctx, policycore.UpdateMutation{
+		Current: current,
+		Params: repo.UpdateRiskPolicyParams{
+			ID:                   id,
+			ProjectID:            *authCtx.ProjectID,
+			Name:                 name,
+			Sources:              sources,
+			PresidioEntities:     presidioEntities,
+			AnalyzerConfig:       analyzerConfig,
+			PromptInjectionRules: promptInjectionRules,
+			DisabledRules:        disabledRules,
+			CustomRuleIds:        customRuleIds,
+			MessageTypes:         messageTypes,
+			ScopeInclude:         scopeInclude,
+			ScopeExempt:          scopeExempt,
+			Enabled:              enabled,
+			Action:               action,
+			AudienceType:         audienceType,
+			AutoName:             autoName,
+			UserMessage:          userMessage,
+			Prompt:               prompt,
+			ModelConfig:          modelConfig,
+			Score:                conv.PtrToPGFloat8(payload.Score),
+		},
+		AudiencePrincipals:   audiencePrincipals,
+		AudienceChanged:      audienceUpdateRequested,
+		AllowedURLs:          shadowMCPAllowedURLs,
+		AllowedURLsSet:       payload.ShadowMcpAllowedUrls != nil,
+		BlockedURLs:          shadowMCPBlockedURLs,
+		BlockedURLsSet:       payload.ShadowMcpBlockedUrls != nil,
+		EffectiveDisposition: effectiveDisposition,
+		SupersedeDecisions:   payload.SupersedeDecisions != nil && *payload.SupersedeDecisions,
+		Actor: policycore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			DisplayName: authCtx.Email,
+			Slug:        nil,
+		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "update risk policy").LogError(ctx, s.logger)
+		return nil, s.policyMutationError(ctx, err)
 	}
-
-	if err := syncRiskPolicyAudienceGrants(ctx, dbtx, authCtx.ActiveOrganizationID, row.ID.String(), audienceType, audiencePrincipalURNs); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "sync risk policy audience").LogError(ctx, s.logger)
-	}
-
-	wasBlocking := current.Enabled && current.Action == "block" && slices.Contains(current.Sources, shadowmcp.SourceShadowMCP)
-	nowBlocking := enabled && action == "block" && slices.Contains(sources, shadowmcp.SourceShadowMCP)
-
-	// The conflict review runs exactly where the replay below does not: on a
-	// policy that was and stays blocking, this edit is the only writer of
-	// URL grant state, so it must not displace a standing decision without
-	// the caller's explicit confirmation. Standing URLs are preserved
-	// through the reconcile either way.
-	var preserveDecisionURLs map[string]struct{}
-	if s.approvalIntake != nil && wasBlocking && nowBlocking {
-		review, err := s.approvalIntake.ReviewShadowMCPPolicyURLEdit(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, current.ID, effectiveDisposition, shadowMCPAllowedURLs, shadowMCPBlockedURLs)
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "review shadow mcp policy url edit").LogError(ctx, s.logger)
-		}
-		if len(review.Conflicts) > 0 {
-			if payload.SupersedeDecisions == nil || !*payload.SupersedeDecisions {
-				names := make([]string, 0, len(review.Conflicts))
-				for _, conflict := range review.Conflicts {
-					names = append(names, conflict.TargetRaw)
-				}
-				return nil, oops.E(oops.CodeConflict, nil, "This change contradicts recorded access decisions for %s. Confirm superseding those decisions to proceed.", strings.Join(names, ", "))
-			}
-			if err := s.approvalIntake.SupersedeShadowMCPDecisions(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, review.Conflicts, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID), authCtx.Email); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "supersede contradicted decisions").LogError(ctx, s.logger)
-			}
-		}
-		if len(review.StandingURLs) > 0 {
-			preserveDecisionURLs = make(map[string]struct{}, len(review.StandingURLs))
-			for _, serverURL := range review.StandingURLs {
-				preserveDecisionURLs[serverURL] = struct{}{}
-			}
-		}
-	}
-
-	if payload.ShadowMcpAllowedUrls != nil || audienceUpdateRequested {
-		if err := s.reconcileShadowMCPPolicyURLs(ctx, dbtx, policybypass.ReconcilePolicyURLsInput{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PolicyID:       row.ID.String(),
-			Scope:          authz.ScopeRiskPolicyBypass,
-			DesiredURLs:    shadowMCPAllowedURLs,
-			Principals:     audiencePrincipals,
-			PreserveURLs:   preserveDecisionURLs,
-		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "reconcile shadow mcp policy allowed urls").LogError(ctx, s.logger)
-		}
-	}
-	if payload.ShadowMcpBlockedUrls != nil {
-		// Block rules apply to everyone in the project: the grant audience is
-		// always the all-users principal, independent of the policy audience.
-		if err := s.reconcileShadowMCPPolicyURLs(ctx, dbtx, policybypass.ReconcilePolicyURLsInput{
-			OrganizationID: authCtx.ActiveOrganizationID,
-			PolicyID:       row.ID.String(),
-			Scope:          authz.ScopeRiskPolicyBlock,
-			DesiredURLs:    shadowMCPBlockedURLs,
-			Principals:     []urn.Principal{authz.AllUsersPrincipal()},
-			PreserveURLs:   preserveDecisionURLs,
-		}); err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "reconcile shadow mcp policy blocked urls").LogError(ctx, s.logger)
-		}
-	}
-
-	// An update can transition a policy into blocking (enable it, or change
-	// its action) — the moment it starts enforcing, the standing decisions
-	// apply to it exactly as they would to a newly created one. The replay
-	// is idempotent, so firing on any transition into the blocking state is
-	// safe even when stale grants survive a disable/enable cycle.
-	if s.approvalIntake != nil && nowBlocking && !wasBlocking {
-		if err := s.approvalIntake.ReconcileStandingDecisionsForPolicy(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, row.ID); err != nil {
-			// Same shareable pass-through as the create path: the radius
-			// rejection reaches the caller with its explanation intact.
-			var shareable *oops.ShareableError
-			if errors.As(err, &shareable) {
-				return nil, err //nolint:wrapcheck // shareable errors pass the boundary intact
-			}
-			return nil, oops.E(oops.CodeUnexpected, err, "honor standing approval decisions on policy update").LogError(ctx, s.logger)
-		}
-	}
-
-	if err := s.audit.LogRiskPolicyUpdate(ctx, dbtx, audit.LogRiskPolicyUpdateEvent{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		ProjectID:        *authCtx.ProjectID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName: authCtx.Email,
-		ActorSlug:        nil,
-		RiskPolicyID:     row.ID,
-		RiskPolicyName:   row.Name,
-		SnapshotBefore:   snapshotBefore,
-		SnapshotAfter:    policyRowSnapshotWithAudience(row, audiencePrincipalURNs),
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk policy update").LogError(ctx, s.logger)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk policy update").LogError(ctx, s.logger)
-	}
-
-	if s.shadowMCPClient != nil {
-		s.shadowMCPClient.Invalidate(ctx, row.ProjectID)
-	}
-
-	_ = s.signaler.Signal(ctx, row.ProjectID)
-
-	return s.policyToType(ctx, row)
+	return s.policyToType(ctx, result.Row)
 }
 
 func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskPolicyPayload) error {
@@ -3700,10 +3520,6 @@ func buildSessionQuarantine(row repo.SessionQuarantine) *gen.SessionQuarantine {
 		ReleasedAt:     releasedAt,
 		ReleasedBy:     conv.FromPGText[string](row.ReleasedBy),
 	}
-}
-
-func policyRowSnapshotWithAudience(row repo.RiskPolicy, audiencePrincipalURNs []string) *types.RiskPolicy {
-	return policyToGoa(policycore.AuditSnapshot(policycore.Project(row, audiencePrincipalURNs, nil)))
 }
 
 func customDetectionRuleToType(row repo.RiskCustomDetectionRule) *types.RiskCustomDetectionRule {

--- a/server/internal/risk/policy_audience.go
+++ b/server/internal/risk/policy_audience.go
@@ -61,35 +61,6 @@ func riskPolicyAudiencePrincipals(audienceType string, principalURNs []string) (
 	return principals, nil
 }
 
-func principalStrings(principals []urn.Principal) []string {
-	values := make([]string, 0, len(principals))
-	for _, principal := range principals {
-		values = append(values, principal.String())
-	}
-	return values
-}
-
-func syncRiskPolicyAudienceGrants(ctx context.Context, db repo.DBTX, organizationID string, policyID string, audienceType string, principalURNs []string) error {
-	principals, err := riskPolicyAudiencePrincipals(audienceType, principalURNs)
-	if err != nil {
-		return err
-	}
-
-	if err := authz.ReplaceGrantAudience(ctx, db, authz.ResourceGrant{
-		Resource: authz.Resource{
-			OrganizationID: organizationID,
-			Scope:          authz.ScopeRiskPolicyEvaluate,
-			ResourceID:     policyID,
-		},
-		Principals: principals,
-		Selector:   authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID),
-	}); err != nil {
-		return fmt.Errorf("replace risk policy audience grants: %w", err)
-	}
-
-	return nil
-}
-
 func clearRiskPolicyAudienceGrants(ctx context.Context, db repo.DBTX, organizationID string, policyID string) error {
 	if err := authz.ReplaceGrantAudience(ctx, db, authz.ResourceGrant{
 		Resource: authz.Resource{

--- a/server/internal/risk/policy_mutation.go
+++ b/server/internal/risk/policy_mutation.go
@@ -1,0 +1,90 @@
+package risk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+type policyMutationAuditor struct {
+	logger *audit.Logger
+}
+
+func (a policyMutationAuditor) LogPolicyCreate(ctx context.Context, db repo.DBTX, event policycore.CreateAuditEvent) error {
+	if err := a.logger.LogRiskPolicyCreate(ctx, db, audit.LogRiskPolicyCreateEvent{
+		OrganizationID:   event.OrganizationID,
+		ProjectID:        event.ProjectID,
+		Actor:            event.Actor.Principal,
+		ActorDisplayName: event.Actor.DisplayName,
+		ActorSlug:        event.Actor.Slug,
+		RiskPolicyID:     event.Policy.ID,
+		RiskPolicyName:   event.Policy.Name,
+	}); err != nil {
+		return fmt.Errorf("log policy create audit: %w", err)
+	}
+	return nil
+}
+
+func (a policyMutationAuditor) LogPolicyUpdate(ctx context.Context, db repo.DBTX, event policycore.UpdateAuditEvent) error {
+	if err := a.logger.LogRiskPolicyUpdate(ctx, db, audit.LogRiskPolicyUpdateEvent{
+		OrganizationID:   event.OrganizationID,
+		ProjectID:        event.ProjectID,
+		Actor:            event.Actor.Principal,
+		ActorDisplayName: event.Actor.DisplayName,
+		ActorSlug:        event.Actor.Slug,
+		RiskPolicyID:     event.After.ID,
+		RiskPolicyName:   event.After.Name,
+		SnapshotBefore:   policyToGoa(event.Before),
+		SnapshotAfter:    policyToGoa(event.After),
+	}); err != nil {
+		return fmt.Errorf("log policy update audit: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) policyMutationError(ctx context.Context, err error) error {
+	var shareable *oops.ShareableError
+	if errors.As(err, &shareable) {
+		return shareable
+	}
+
+	var conflict *policycore.DecisionConflictError
+	if errors.As(err, &conflict) {
+		return oops.E(
+			oops.CodeConflict,
+			nil,
+			"This change contradicts recorded access decisions for %s. Confirm superseding those decisions to proceed.",
+			strings.Join(conflict.Targets, ", "),
+		)
+	}
+
+	var stale *policycore.StalePolicyError
+	if errors.As(err, &stale) {
+		return oops.E(oops.CodeConflict, err, "risk policy changed during update; reload and retry")
+	}
+
+	var blockingConflict *policycore.BlockingPolicyConflictError
+	if errors.As(err, &blockingConflict) {
+		return oops.E(
+			oops.CodeConflict,
+			nil,
+			"project already has an enabled shadow mcp blocking policy %q; disable or delete it first",
+			blockingConflict.PolicyName,
+		)
+	}
+	if errors.Is(err, policycore.ErrLoadPolicy) {
+		return oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
+	}
+
+	var mutation *policycore.MutationError
+	if errors.As(err, &mutation) {
+		return oops.E(oops.CodeUnexpected, mutation.Cause, "%s", mutation.Message).LogError(ctx, s.logger)
+	}
+	return oops.E(oops.CodeUnexpected, err, "mutate risk policy").LogError(ctx, s.logger)
+}

--- a/server/internal/risk/policy_mutation.go
+++ b/server/internal/risk/policy_mutation.go
@@ -40,8 +40,8 @@ func (a policyMutationAuditor) LogPolicyUpdate(ctx context.Context, db repo.DBTX
 		ActorSlug:        event.Actor.Slug,
 		RiskPolicyID:     event.After.ID,
 		RiskPolicyName:   event.After.Name,
-		SnapshotBefore:   policyToGoa(event.Before),
-		SnapshotAfter:    policyToGoa(event.After),
+		SnapshotBefore:   policyToGoa(policycore.AuditSnapshot(event.Before)),
+		SnapshotAfter:    policyToGoa(policycore.AuditSnapshot(event.After)),
 	}); err != nil {
 		return fmt.Errorf("log policy update audit: %w", err)
 	}

--- a/server/internal/risk/policy_mutation_test.go
+++ b/server/internal/risk/policy_mutation_test.go
@@ -1,0 +1,62 @@
+package risk
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestPolicyMutationErrorMapsCoreFailures(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{logger: testenv.NewLogger(t)}
+	cause := errors.New("database unavailable")
+
+	tests := []struct {
+		name        string
+		err         error
+		code        oops.Code
+		message     string
+		hiddenCause error
+	}{
+		{
+			name:    "stale update",
+			err:     &policycore.StalePolicyError{},
+			code:    oops.CodeConflict,
+			message: "risk policy changed during update; reload and retry",
+		},
+		{
+			name:    "blocking policy conflict",
+			err:     &policycore.BlockingPolicyConflictError{PolicyName: "existing blocker"},
+			code:    oops.CodeConflict,
+			message: `project already has an enabled shadow mcp blocking policy "existing blocker"; disable or delete it first`,
+		},
+		{
+			name:        "mutation step failure",
+			err:         &policycore.MutationError{Message: "lock risk policy", Cause: cause},
+			code:        oops.CodeUnexpected,
+			message:     "lock risk policy",
+			hiddenCause: cause,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mapped := service.policyMutationError(t.Context(), tt.err)
+			var shareable *oops.ShareableError
+			require.ErrorAs(t, mapped, &shareable)
+			require.Equal(t, tt.code, shareable.Code)
+			require.Equal(t, tt.message, shareable.Error())
+			if tt.hiddenCause != nil {
+				require.ErrorIs(t, mapped, tt.hiddenCause)
+			}
+		})
+	}
+}

--- a/server/internal/risk/policycore/core.go
+++ b/server/internal/risk/policycore/core.go
@@ -95,7 +95,11 @@ func (c *Core) ProjectWithProgress(ctx context.Context, row repo.RiskPolicy) (Po
 // AudiencePrincipalURNs returns the exact-selector audience for one policy,
 // sorted and deduplicated.
 func (c *Core) AudiencePrincipalURNs(ctx context.Context, organizationID, policyID string) ([]string, error) {
-	grants, err := authz.ListGrantsForResource(ctx, c.db, authz.Resource{
+	return audiencePrincipalURNs(ctx, c.db, organizationID, policyID)
+}
+
+func audiencePrincipalURNs(ctx context.Context, db repo.DBTX, organizationID, policyID string) ([]string, error) {
+	grants, err := authz.ListGrantsForResource(ctx, db, authz.Resource{
 		OrganizationID: organizationID,
 		Scope:          authz.ScopeRiskPolicyEvaluate,
 		ResourceID:     policyID,

--- a/server/internal/risk/policycore/core.go
+++ b/server/internal/risk/policycore/core.go
@@ -21,12 +21,17 @@ var ErrLoadPolicy = errors.New("load risk policy")
 // Core provides transport-neutral policy reads and projections. Authorization
 // remains the responsibility of the calling service.
 type Core struct {
-	db      repo.DBTX
-	queries *repo.Queries
+	db        repo.DBTX
+	queries   *repo.Queries
+	mutations *MutationDependencies
 }
 
-func New(db repo.DBTX) *Core {
-	return &Core{db: db, queries: repo.New(db)}
+func New(db repo.DBTX, mutations ...MutationDependencies) *Core {
+	core := &Core{db: db, queries: repo.New(db), mutations: nil}
+	if len(mutations) > 0 {
+		core.mutations = &mutations[0]
+	}
+	return core
 }
 
 // List returns all policies for a project with their audiences. Progress is

--- a/server/internal/risk/policycore/mutation.go
+++ b/server/internal/risk/policycore/mutation.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 
 	"github.com/google/uuid"
@@ -263,8 +262,8 @@ func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (Mutation
 		}
 		return MutationResult{}, mutationError("lock risk policy", err)
 	}
-	if !locked.UpdatedAt.Time.Equal(input.Current.UpdatedAt.Time) {
-		return MutationResult{}, &StalePolicyError{}
+	if err := requireFreshPolicy(input.Current, locked); err != nil {
+		return MutationResult{}, err
 	}
 	if input.Params.Enabled && input.Params.Action == "block" && slices.Contains(input.Params.Sources, shadowmcp.SourceShadowMCP) {
 		if err := requireSingleBlockingPolicy(ctx, queries, input.Params.ProjectID, input.Params.ID); err != nil {
@@ -388,25 +387,6 @@ func replaceAudience(ctx context.Context, db repo.DBTX, organizationID, policyID
 	return nil
 }
 
-func audiencePrincipalURNs(ctx context.Context, db repo.DBTX, organizationID, policyID string) ([]string, error) {
-	grants, err := authz.ListGrantsForResource(ctx, db, authz.Resource{
-		OrganizationID: organizationID,
-		Scope:          authz.ScopeRiskPolicyEvaluate,
-		ResourceID:     policyID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list risk policy audience grants: %w", err)
-	}
-	principalURNs := make([]string, 0, len(grants))
-	for _, grant := range grants {
-		if maps.Equal(grant.Selector, authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID)) {
-			principalURNs = append(principalURNs, grant.PrincipalUrn)
-		}
-	}
-	slices.Sort(principalURNs)
-	return slices.Compact(principalURNs), nil
-}
-
 func principalStrings(principals []urn.Principal) []string {
 	values := make([]string, 0, len(principals))
 	for _, principal := range principals {
@@ -419,11 +399,22 @@ func isBlockingShadowPolicy(row repo.RiskPolicy) bool {
 	return row.Enabled && row.Action == "block" && slices.Contains(row.Sources, shadowmcp.SourceShadowMCP)
 }
 
+func requireFreshPolicy(current, locked repo.RiskPolicy) error {
+	if !locked.UpdatedAt.Time.Equal(current.UpdatedAt.Time) {
+		return &StalePolicyError{}
+	}
+	return nil
+}
+
 func requireSingleBlockingPolicy(ctx context.Context, queries *repo.Queries, projectID, excludePolicyID uuid.UUID) error {
 	policies, err := queries.ListEnabledShadowMCPPoliciesByProject(ctx, projectID)
 	if err != nil {
 		return mutationError("list shadow mcp blocking policies", err)
 	}
+	return blockingPolicyConflict(policies, excludePolicyID)
+}
+
+func blockingPolicyConflict(policies []repo.RiskPolicy, excludePolicyID uuid.UUID) error {
 	for _, policy := range policies {
 		if policy.ID == excludePolicyID || policy.Action != "block" {
 			continue

--- a/server/internal/risk/policycore/mutation.go
+++ b/server/internal/risk/policycore/mutation.go
@@ -219,7 +219,7 @@ func (c *Core) CreatePolicy(ctx context.Context, input CreateMutation) (Mutation
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
 		Actor:          input.Actor,
-		Policy:         Project(row, audience, nil),
+		Policy:         AuditSnapshot(Project(row, audience, nil)),
 	}); err != nil {
 		return MutationResult{}, mutationError("log risk policy create", err)
 	}
@@ -350,8 +350,8 @@ func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (Mutation
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
 		Actor:          input.Actor,
-		Before:         Project(locked, currentAudience, nil),
-		After:          Project(row, audience, nil),
+		Before:         AuditSnapshot(Project(locked, currentAudience, nil)),
+		After:          AuditSnapshot(Project(row, audience, nil)),
 	}); err != nil {
 		return MutationResult{}, mutationError("log risk policy update", err)
 	}

--- a/server/internal/risk/policycore/mutation.go
+++ b/server/internal/risk/policycore/mutation.go
@@ -1,0 +1,445 @@
+package policycore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// Transactor is the transaction capability required by policy mutations.
+type Transactor interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+}
+
+// MutationAuditor records policy writes and their outbox event in the mutation
+// transaction. Transport adapters own the final audit serialization shape.
+type MutationAuditor interface {
+	LogPolicyCreate(ctx context.Context, db repo.DBTX, event CreateAuditEvent) error
+	LogPolicyUpdate(ctx context.Context, db repo.DBTX, event UpdateAuditEvent) error
+}
+
+// ApprovalCoordinator applies standing Shadow MCP decisions in the policy
+// transaction. It is intentionally narrower than the user-facing approval API.
+type ApprovalCoordinator interface {
+	ReconcileStandingDecisionsForPolicy(ctx context.Context, tx pgx.Tx, organizationID string, projectID uuid.UUID, policyID uuid.UUID) error
+	ReviewShadowMCPPolicyURLEdit(ctx context.Context, tx pgx.Tx, organizationID string, projectID uuid.UUID, policyID uuid.UUID, disposition string, desiredAllowedURLs []string, desiredBlockedURLs []string) (shadowmcp.StandingDecisionReview, error)
+	SupersedeShadowMCPDecisions(ctx context.Context, tx pgx.Tx, organizationID string, projectID uuid.UUID, conflicts []shadowmcp.StandingDecisionConflict, actor urn.Principal, actorDisplayName *string) error
+}
+
+// PolicySignaler starts best-effort policy convergence after commit.
+type PolicySignaler interface {
+	Signal(ctx context.Context, projectID uuid.UUID) error
+}
+
+// PolicyCacheInvalidator invalidates policy-derived caches after commit.
+type PolicyCacheInvalidator interface {
+	Invalidate(ctx context.Context, projectID uuid.UUID)
+}
+
+// ReconcilePolicyURLs replaces the URL grants owned by one policy.
+type ReconcilePolicyURLs func(ctx context.Context, db repo.DBTX, input policybypass.ReconcilePolicyURLsInput) error
+
+// MutationDependencies are optional for read-only Core users and required by
+// CreatePolicy and UpdatePolicy.
+type MutationDependencies struct {
+	Transactor       Transactor
+	Auditor          MutationAuditor
+	Approvals        ApprovalCoordinator
+	ReconcileURLs    ReconcilePolicyURLs
+	Signaler         PolicySignaler
+	CacheInvalidator PolicyCacheInvalidator
+}
+
+// Actor is the real user attributed to a policy mutation.
+type Actor struct {
+	Principal   urn.Principal
+	DisplayName *string
+	Slug        *string
+}
+
+// CreateAuditEvent is the transport-neutral policy-create audit contract.
+type CreateAuditEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Actor          Actor
+	Policy         Policy
+}
+
+// UpdateAuditEvent is the transport-neutral policy-update audit contract.
+type UpdateAuditEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Actor          Actor
+	Before         Policy
+	After          Policy
+}
+
+// CreateMutation is a fully validated, normalized policy create command.
+type CreateMutation struct {
+	Params             repo.CreateRiskPolicyParams
+	AudiencePrincipals []urn.Principal
+	AllowedURLs        []string
+	AllowedURLsSet     bool
+	BlockedURLs        []string
+	BlockedURLsSet     bool
+	Actor              Actor
+}
+
+// UpdateMutation is a fully validated, normalized policy update command.
+type UpdateMutation struct {
+	Current              repo.RiskPolicy
+	Params               repo.UpdateRiskPolicyParams
+	AudiencePrincipals   []urn.Principal
+	AudienceChanged      bool
+	AllowedURLs          []string
+	AllowedURLsSet       bool
+	BlockedURLs          []string
+	BlockedURLsSet       bool
+	EffectiveDisposition string
+	SupersedeDecisions   bool
+	Actor                Actor
+}
+
+// MutationResult is the committed policy row and canonical audience.
+type MutationResult struct {
+	Row                   repo.RiskPolicy
+	AudiencePrincipalURNs []string
+}
+
+// MutationError identifies the failed transaction step while retaining its
+// underlying cause for the calling transport's established error mapping.
+type MutationError struct {
+	Message string
+	Cause   error
+}
+
+func (e *MutationError) Error() string { return e.Message }
+func (e *MutationError) Unwrap() error { return e.Cause }
+
+// DecisionConflictError reports standing decisions that require explicit
+// supersession before an already-blocking policy's URL grants can change.
+type DecisionConflictError struct {
+	Targets []string
+}
+
+func (e *DecisionConflictError) Error() string {
+	return fmt.Sprintf("policy URL edit conflicts with standing decisions for %v", e.Targets)
+}
+
+// StalePolicyError reports that the row changed between preparation and lock.
+type StalePolicyError struct{}
+
+func (*StalePolicyError) Error() string { return "risk policy changed during update" }
+
+// BlockingPolicyConflictError reports the existing enabled blocking Shadow MCP
+// policy that prevents another one from being created or enabled.
+type BlockingPolicyConflictError struct {
+	PolicyName string
+}
+
+func (e *BlockingPolicyConflictError) Error() string {
+	return fmt.Sprintf("project already has an enabled shadow mcp blocking policy %q", e.PolicyName)
+}
+
+// CreatePolicy commits a fully prepared policy create and all of its domain
+// invariants in one transaction, then runs best-effort convergence effects.
+func (c *Core) CreatePolicy(ctx context.Context, input CreateMutation) (MutationResult, error) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return MutationResult{}, err
+	}
+
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return MutationResult{}, mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskPolicyMutations(ctx, input.Params.ProjectID.String()); err != nil {
+		return MutationResult{}, mutationError("lock risk policy mutations", err)
+	}
+	if input.Params.Enabled && input.Params.Action == "block" && slices.Contains(input.Params.Sources, shadowmcp.SourceShadowMCP) {
+		if err := requireSingleBlockingPolicy(ctx, queries, input.Params.ProjectID, uuid.Nil); err != nil {
+			return MutationResult{}, err
+		}
+	}
+	row, err := queries.CreateRiskPolicy(ctx, input.Params)
+	if err != nil {
+		return MutationResult{}, mutationError("create risk policy", err)
+	}
+	if err := replaceAudience(ctx, tx, row.OrganizationID, row.ID.String(), input.AudiencePrincipals); err != nil {
+		return MutationResult{}, mutationError("sync risk policy audience", err)
+	}
+
+	if input.AllowedURLsSet {
+		if err := deps.ReconcileURLs(ctx, tx, policybypass.ReconcilePolicyURLsInput{
+			OrganizationID: row.OrganizationID,
+			PolicyID:       row.ID.String(),
+			Scope:          authz.ScopeRiskPolicyBypass,
+			DesiredURLs:    input.AllowedURLs,
+			Principals:     input.AudiencePrincipals,
+			PreserveURLs:   nil,
+		}); err != nil {
+			return MutationResult{}, mutationError("reconcile shadow mcp policy allowed urls", err)
+		}
+	}
+	if input.BlockedURLsSet {
+		if err := deps.ReconcileURLs(ctx, tx, policybypass.ReconcilePolicyURLsInput{
+			OrganizationID: row.OrganizationID,
+			PolicyID:       row.ID.String(),
+			Scope:          authz.ScopeRiskPolicyBlock,
+			DesiredURLs:    input.BlockedURLs,
+			Principals:     []urn.Principal{authz.AllUsersPrincipal()},
+			PreserveURLs:   nil,
+		}); err != nil {
+			return MutationResult{}, mutationError("reconcile shadow mcp policy blocked urls", err)
+		}
+	}
+
+	if deps.Approvals != nil && isBlockingShadowPolicy(row) {
+		if err := deps.Approvals.ReconcileStandingDecisionsForPolicy(ctx, tx, row.OrganizationID, row.ProjectID, row.ID); err != nil {
+			return MutationResult{}, mutationError("honor standing approval decisions on policy create", err)
+		}
+	}
+
+	audience := principalStrings(input.AudiencePrincipals)
+	if err := deps.Auditor.LogPolicyCreate(ctx, tx, CreateAuditEvent{
+		OrganizationID: row.OrganizationID,
+		ProjectID:      row.ProjectID,
+		Actor:          input.Actor,
+		Policy:         Project(row, audience, nil),
+	}); err != nil {
+		return MutationResult{}, mutationError("log risk policy create", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return MutationResult{}, mutationError("commit risk policy create", err)
+	}
+
+	if deps.CacheInvalidator != nil {
+		deps.CacheInvalidator.Invalidate(ctx, row.ProjectID)
+	}
+	if row.Enabled {
+		_ = deps.Signaler.Signal(ctx, row.ProjectID)
+	}
+	return MutationResult{Row: row, AudiencePrincipalURNs: audience}, nil
+}
+
+// UpdatePolicy locks the current row, rejects a stale prepared command, and
+// commits the policy row, grants, standing decisions, and audit atomically.
+func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (MutationResult, error) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return MutationResult{}, err
+	}
+
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return MutationResult{}, mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskPolicyMutations(ctx, input.Params.ProjectID.String()); err != nil {
+		return MutationResult{}, mutationError("lock risk policy mutations", err)
+	}
+	locked, err := queries.GetRiskPolicyForUpdate(ctx, repo.GetRiskPolicyForUpdateParams{
+		ID: input.Params.ID, ProjectID: input.Params.ProjectID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return MutationResult{}, fmt.Errorf("%w: %w", ErrLoadPolicy, err)
+		}
+		return MutationResult{}, mutationError("lock risk policy", err)
+	}
+	if !locked.UpdatedAt.Time.Equal(input.Current.UpdatedAt.Time) {
+		return MutationResult{}, &StalePolicyError{}
+	}
+	if input.Params.Enabled && input.Params.Action == "block" && slices.Contains(input.Params.Sources, shadowmcp.SourceShadowMCP) {
+		if err := requireSingleBlockingPolicy(ctx, queries, input.Params.ProjectID, input.Params.ID); err != nil {
+			return MutationResult{}, err
+		}
+	}
+
+	currentAudience, err := audiencePrincipalURNs(ctx, tx, locked.OrganizationID, locked.ID.String())
+	if err != nil {
+		return MutationResult{}, mutationError("load risk policy audience snapshot", err)
+	}
+	row, err := queries.UpdateRiskPolicy(ctx, input.Params)
+	if err != nil {
+		return MutationResult{}, mutationError("update risk policy", err)
+	}
+	if err := replaceAudience(ctx, tx, row.OrganizationID, row.ID.String(), input.AudiencePrincipals); err != nil {
+		return MutationResult{}, mutationError("sync risk policy audience", err)
+	}
+
+	wasBlocking := isBlockingShadowPolicy(locked)
+	nowBlocking := isBlockingShadowPolicy(row)
+	var preserveDecisionURLs map[string]struct{}
+	if deps.Approvals != nil && wasBlocking && nowBlocking {
+		review, err := deps.Approvals.ReviewShadowMCPPolicyURLEdit(
+			ctx, tx, row.OrganizationID, row.ProjectID, row.ID,
+			input.EffectiveDisposition, optionalURLs(input.AllowedURLs, input.AllowedURLsSet), optionalURLs(input.BlockedURLs, input.BlockedURLsSet),
+		)
+		if err != nil {
+			return MutationResult{}, mutationError("review shadow mcp policy url edit", err)
+		}
+		if len(review.Conflicts) > 0 {
+			if !input.SupersedeDecisions {
+				targets := make([]string, 0, len(review.Conflicts))
+				for _, conflict := range review.Conflicts {
+					targets = append(targets, conflict.TargetRaw)
+				}
+				return MutationResult{}, &DecisionConflictError{Targets: targets}
+			}
+			if err := deps.Approvals.SupersedeShadowMCPDecisions(ctx, tx, row.OrganizationID, row.ProjectID, review.Conflicts, input.Actor.Principal, input.Actor.DisplayName); err != nil {
+				return MutationResult{}, mutationError("supersede contradicted decisions", err)
+			}
+		}
+		if len(review.StandingURLs) > 0 {
+			preserveDecisionURLs = make(map[string]struct{}, len(review.StandingURLs))
+			for _, serverURL := range review.StandingURLs {
+				preserveDecisionURLs[serverURL] = struct{}{}
+			}
+		}
+	}
+
+	if input.AllowedURLsSet || input.AudienceChanged {
+		if err := deps.ReconcileURLs(ctx, tx, policybypass.ReconcilePolicyURLsInput{
+			OrganizationID: row.OrganizationID,
+			PolicyID:       row.ID.String(),
+			Scope:          authz.ScopeRiskPolicyBypass,
+			DesiredURLs:    optionalURLs(input.AllowedURLs, input.AllowedURLsSet),
+			Principals:     input.AudiencePrincipals,
+			PreserveURLs:   preserveDecisionURLs,
+		}); err != nil {
+			return MutationResult{}, mutationError("reconcile shadow mcp policy allowed urls", err)
+		}
+	}
+	if input.BlockedURLsSet {
+		if err := deps.ReconcileURLs(ctx, tx, policybypass.ReconcilePolicyURLsInput{
+			OrganizationID: row.OrganizationID,
+			PolicyID:       row.ID.String(),
+			Scope:          authz.ScopeRiskPolicyBlock,
+			DesiredURLs:    input.BlockedURLs,
+			Principals:     []urn.Principal{authz.AllUsersPrincipal()},
+			PreserveURLs:   preserveDecisionURLs,
+		}); err != nil {
+			return MutationResult{}, mutationError("reconcile shadow mcp policy blocked urls", err)
+		}
+	}
+	if deps.Approvals != nil && nowBlocking && !wasBlocking {
+		if err := deps.Approvals.ReconcileStandingDecisionsForPolicy(ctx, tx, row.OrganizationID, row.ProjectID, row.ID); err != nil {
+			return MutationResult{}, mutationError("honor standing approval decisions on policy update", err)
+		}
+	}
+
+	audience := principalStrings(input.AudiencePrincipals)
+	if err := deps.Auditor.LogPolicyUpdate(ctx, tx, UpdateAuditEvent{
+		OrganizationID: row.OrganizationID,
+		ProjectID:      row.ProjectID,
+		Actor:          input.Actor,
+		Before:         Project(locked, currentAudience, nil),
+		After:          Project(row, audience, nil),
+	}); err != nil {
+		return MutationResult{}, mutationError("log risk policy update", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return MutationResult{}, mutationError("commit risk policy update", err)
+	}
+
+	if deps.CacheInvalidator != nil {
+		deps.CacheInvalidator.Invalidate(ctx, row.ProjectID)
+	}
+	_ = deps.Signaler.Signal(ctx, row.ProjectID)
+	return MutationResult{Row: row, AudiencePrincipalURNs: audience}, nil
+}
+
+func (c *Core) requireMutationDependencies() (*MutationDependencies, error) {
+	if c.mutations == nil || c.mutations.Transactor == nil || c.mutations.Auditor == nil || c.mutations.ReconcileURLs == nil || c.mutations.Signaler == nil {
+		return nil, mutationError("policy mutation dependencies are not configured", nil)
+	}
+	return c.mutations, nil
+}
+
+func replaceAudience(ctx context.Context, db repo.DBTX, organizationID, policyID string, principals []urn.Principal) error {
+	if err := authz.ReplaceGrantAudience(ctx, db, authz.ResourceGrant{
+		Resource: authz.Resource{
+			OrganizationID: organizationID,
+			Scope:          authz.ScopeRiskPolicyEvaluate,
+			ResourceID:     policyID,
+		},
+		Principals: principals,
+		Selector:   authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID),
+	}); err != nil {
+		return fmt.Errorf("replace risk policy audience grants: %w", err)
+	}
+	return nil
+}
+
+func audiencePrincipalURNs(ctx context.Context, db repo.DBTX, organizationID, policyID string) ([]string, error) {
+	grants, err := authz.ListGrantsForResource(ctx, db, authz.Resource{
+		OrganizationID: organizationID,
+		Scope:          authz.ScopeRiskPolicyEvaluate,
+		ResourceID:     policyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list risk policy audience grants: %w", err)
+	}
+	principalURNs := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		if maps.Equal(grant.Selector, authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID)) {
+			principalURNs = append(principalURNs, grant.PrincipalUrn)
+		}
+	}
+	slices.Sort(principalURNs)
+	return slices.Compact(principalURNs), nil
+}
+
+func principalStrings(principals []urn.Principal) []string {
+	values := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		values = append(values, principal.String())
+	}
+	return values
+}
+
+func isBlockingShadowPolicy(row repo.RiskPolicy) bool {
+	return row.Enabled && row.Action == "block" && slices.Contains(row.Sources, shadowmcp.SourceShadowMCP)
+}
+
+func requireSingleBlockingPolicy(ctx context.Context, queries *repo.Queries, projectID, excludePolicyID uuid.UUID) error {
+	policies, err := queries.ListEnabledShadowMCPPoliciesByProject(ctx, projectID)
+	if err != nil {
+		return mutationError("list shadow mcp blocking policies", err)
+	}
+	for _, policy := range policies {
+		if policy.ID == excludePolicyID || policy.Action != "block" {
+			continue
+		}
+		return &BlockingPolicyConflictError{PolicyName: policy.Name}
+	}
+	return nil
+}
+
+func optionalURLs(urls []string, set bool) []string {
+	if !set {
+		return nil
+	}
+	return urls
+}
+
+func mutationError(message string, cause error) error {
+	return &MutationError{Message: message, Cause: cause}
+}

--- a/server/internal/risk/policycore/mutation_test.go
+++ b/server/internal/risk/policycore/mutation_test.go
@@ -1,0 +1,56 @@
+package policycore
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+func TestRequireFreshPolicyRejectsChangedLockedRow(t *testing.T) {
+	t.Parallel()
+
+	preparedAt := time.Date(2026, time.August, 26, 1, 2, 3, 0, time.UTC)
+	current := repo.RiskPolicy{UpdatedAt: pgtype.Timestamptz{Time: preparedAt, Valid: true}}
+	locked := current
+	require.NoError(t, requireFreshPolicy(current, locked))
+
+	locked.UpdatedAt = pgtype.Timestamptz{Time: preparedAt.Add(time.Second), Valid: true}
+	err := requireFreshPolicy(current, locked)
+	var stale *StalePolicyError
+	require.ErrorAs(t, err, &stale)
+}
+
+func TestBlockingPolicyConflictExcludesCurrentPolicy(t *testing.T) {
+	t.Parallel()
+
+	currentID := uuid.New()
+	policies := []repo.RiskPolicy{
+		{ID: uuid.New(), Name: "flag-only", Action: "flag"},
+		{ID: currentID, Name: "current", Action: "block"},
+	}
+	require.NoError(t, blockingPolicyConflict(policies, currentID))
+
+	policies = append(policies, repo.RiskPolicy{ID: uuid.New(), Name: "existing blocker", Action: "block"})
+	err := blockingPolicyConflict(policies, currentID)
+	var conflict *BlockingPolicyConflictError
+	require.ErrorAs(t, err, &conflict)
+	require.Equal(t, "existing blocker", conflict.PolicyName)
+}
+
+func TestMutationErrorPreservesStepAndCause(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("database unavailable")
+	err := mutationError("lock risk policy mutations", cause)
+
+	var mutation *MutationError
+	require.ErrorAs(t, err, &mutation)
+	require.Equal(t, "lock risk policy mutations", mutation.Message)
+	require.ErrorIs(t, err, cause)
+}

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -68,6 +68,12 @@ WHERE id = @id
   AND deleted IS FALSE
 FOR UPDATE;
 
+-- name: LockRiskPolicyMutations :exec
+-- Serialize all policy writes in one project. The single enabled blocking
+-- Shadow MCP policy invariant spans multiple rows, so a row lock alone cannot
+-- protect concurrent creates or enable/disable transitions.
+SELECT pg_advisory_xact_lock(hashtextextended('risk-policy:' || @project_id::text, 0));
+
 -- name: GetRiskPolicyNameIncludingDeleted :one
 SELECT name
 FROM risk_policies

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -4444,6 +4444,18 @@ func (q *Queries) ListUserEmailsByIDs(ctx context.Context, arg ListUserEmailsByI
 	return items, nil
 }
 
+const lockRiskPolicyMutations = `-- name: LockRiskPolicyMutations :exec
+SELECT pg_advisory_xact_lock(hashtextextended('risk-policy:' || $1::text, 0))
+`
+
+// Serialize all policy writes in one project. The single enabled blocking
+// Shadow MCP policy invariant spans multiple rows, so a row lock alone cannot
+// protect concurrent creates or enable/disable transitions.
+func (q *Queries) LockRiskPolicyMutations(ctx context.Context, projectID string) error {
+	_, err := q.db.Exec(ctx, lockRiskPolicyMutations, projectID)
+	return err
+}
+
 const markContentPartsRiskAnalyzed = `-- name: MarkContentPartsRiskAnalyzed :exec
 UPDATE chat_content_parts
 SET risk_analyzed_at = clock_timestamp()

--- a/server/internal/risk/shadow_mcp_policy_setup.go
+++ b/server/internal/risk/shadow_mcp_policy_setup.go
@@ -53,24 +53,6 @@ func shadowMCPPolicyAutoName(sources []string, action string, existingNames []st
 	return name
 }
 
-// requireSingleShadowMCPBlockingPolicy rejects creating or enabling a second
-// enabled blocking shadow MCP policy in a project, so block_all and allow_all
-// postures can never conflict at enforcement time. excludePolicyID skips the
-// policy being updated; pass uuid.Nil on create.
-func requireSingleShadowMCPBlockingPolicy(ctx context.Context, queries *repo.Queries, projectID uuid.UUID, excludePolicyID uuid.UUID) error {
-	policies, err := queries.ListEnabledShadowMCPPoliciesByProject(ctx, projectID)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "list shadow mcp blocking policies")
-	}
-	for _, p := range policies {
-		if p.ID == excludePolicyID || p.Action != "block" {
-			continue
-		}
-		return oops.E(oops.CodeConflict, nil, "project already has an enabled shadow mcp blocking policy %q; disable or delete it first", p.Name)
-	}
-	return nil
-}
-
 // validateShadowMCPBlockedURLs canonicalizes the blocked-URL set of an
 // allow_all policy. Unlike the allow list there is no inventory-observed
 // requirement: blocking a server that has not been seen yet is deliberate,


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3168/featplatform-mcp-d3-risk-policies-and-exclusions

## Summary

- move prepared risk policy create and update orchestration into the transport-neutral policy core
- keep policy rows, audience grants, Shadow MCP URL grants, standing decisions, audit/outbox, and commits in one transaction
- serialize project policy writes and lock update rows before applying prepared mutations
- preserve Goa authorization, defaults, feature gates, validation, naming, error responses, and post-commit convergence behavior

## Motivation

Platform MCP policy mutations need one authoritative transaction path shared with the existing dashboard API. This stacked change builds on #5677 and removes the duplicate Goa-owned write path without exposing any Platform MCP mutation tools yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes risk policy create/update orchestration in `policycore` so the dashboard API and Platform MCP share one authoritative, serialized transaction path. Old behavior duplicated write logic in `risk.Service`; new behavior commits the policy row, audience grants, Shadow MCP URL grants, standing decisions, audit, and signals in one per-project transaction, and redacts sensitive fields in audit snapshots.

**Refactors**
- Adds `policycore` mutations `CreatePolicy`/`UpdatePolicy` with `MutationDependencies` (`Transactor`, `Auditor`, `Approvals`, `ReconcileURLs`, `Signaler`, `CacheInvalidator`), wired in `Service`.
- Serializes project writes with a per-project advisory lock and enforces a single enabled blocking Shadow MCP policy, returning a conflict when violated.
- Moves audience grant replacement, Shadow MCP URL reconciliation, and standing decision review/replay into `policycore`, including `supersede_decisions`.
- Centralizes error mapping to `oops` (stale updates, decision conflicts, not found) and adds unit tests covering those mappings; API behavior, auth, validation, and gates are unchanged.

<sup>Written for commit 369339736e50c45ff13e9b4e73833445ae055546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

