### PR TITLE
feat: emit upstream refresh and rejected MCP request metrics, enrich the matching logs

### DIFF
--- a/.changeset/remote-session-refresh-metrics.md
+++ b/.changeset/remote-session-refresh-metrics.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+New `gram.remote_session.upstream_refresh` and `mcp.request.rejected` metrics count every upstream remote session refresh attempt by outcome and trigger, and every MCP request the Session OAuth authentication gate rejects by reason, server, and surface. The matching failure logs now carry the issuer URL, outcome, user id, MCP slug, and URL needed to attribute them.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1478,7 +1478,7 @@ func newStartCommand() *cli.Command {
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			metamcp.Attach(mux, metamcp.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv))
 			remoteSessionsCache := cache.NewRedisCacheAdapter(redisClient)
-			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, db, encryptionClient, guardianPolicy, remoteSessionsCache))
+			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient)))
 			tokenexchange.Attach(mux, tokenexchange.NewService(logger, tracerProvider, db, sessionManager, authzEngine, c.String("environment")))
 			remotesessions.Attach(mux, remoteSessionsService)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -348,6 +348,12 @@ const (
 	// OAuthDeclaredAuthMethodKey records the token_endpoint_auth_method a client metadata document declares.
 	OAuthDeclaredAuthMethodKey = attribute.Key("gram.oauth.declared_auth_method")
 
+	// OAuthRefreshTriggerKey names which caller initiated an upstream remote
+	// session refresh: a lazy MCP request, the scheduled worker sweep, or a
+	// manual consent-page or admin action. Used as a metric dimension on
+	// gram.remote_session.upstream_refresh.
+	OAuthRefreshTriggerKey = attribute.Key("gram.oauth.refresh_trigger")
+
 	OAuthPresentedAuthMethodKey = attribute.Key("gram.oauth.presented_auth_method")
 	// OAuthResourceKey is the RFC 8707 resource indicator sent to an
 	// upstream authorization server during the remote-session dance.
@@ -1406,6 +1412,13 @@ func SlogOAuthFlowID(v string) slog.Attr      { return slog.String(string(OAuthF
 
 func OAuthFlowStage(v string) attribute.KeyValue { return OAuthFlowStageKey.String(v) }
 func SlogOAuthFlowStage(v string) slog.Attr      { return slog.String(string(OAuthFlowStageKey), v) }
+
+func OAuthRefreshTrigger[V ~string](v V) attribute.KeyValue {
+	return OAuthRefreshTriggerKey.String(string(v))
+}
+func SlogOAuthRefreshTrigger(v string) slog.Attr {
+	return slog.String(string(OAuthRefreshTriggerKey), v)
+}
 
 func OAuthErrorDescription(v string) attribute.KeyValue {
 	return OAuthErrorDescriptionKey.String(v)

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -304,7 +304,7 @@ func NewActivities(
 		remoteSessionRefresh = activities.NewRemoteSessionRefresh(
 			logger,
 			db,
-			remotesessions.NewRefreshService(logger, db, encryption, guardianPolicy, cacheAdapter),
+			remotesessions.NewRefreshService(logger, meterProvider, db, encryption, guardianPolicy, cacheAdapter),
 		)
 	}
 

--- a/server/internal/background/activities/remote_session_refresh.go
+++ b/server/internal/background/activities/remote_session_refresh.go
@@ -17,7 +17,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const remoteSessionRefreshKeepalive = 24 * time.Hour
@@ -123,20 +125,28 @@ func (r *RemoteSessionRefresh) Do(ctx context.Context, input RefreshRemoteSessio
 	}
 	sess := candidate.RemoteSession
 
-	result, err := r.refresher.RefreshNow(ctx, sess, "")
+	result, err := r.refresher.RefreshNow(ctx, sess, "", remotesessionmetrics.RefreshTriggerScheduled)
 	if err != nil {
-		if remotesessions.IsTokenRefreshRateLimited(err) {
-			logger.WarnContext(ctx, "scheduled remote session refresh rate limited",
-				attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
-				attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
-			)
-			return RefreshRemoteSessionResult{RateLimited: true}, nil
-		}
-		logger.WarnContext(ctx, "scheduled remote session refresh failed",
+		// The issuer URL and outcome are the ones the upstream-refresh metric
+		// recorded, so these lines join to its series; the user id is what
+		// lets "how many users are affected" be answered, since a client id is
+		// one row per provider connection, not per user.
+		args := []any{
 			attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
 			attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
-			attr.SlogError(err),
-		)
+		}
+		var failure *remotesessions.RefreshError
+		if errors.As(err, &failure) {
+			args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
+		}
+		if sess.SubjectUrn.Kind == urn.SessionSubjectKindUser {
+			args = append(args, attr.SlogUserID(sess.SubjectUrn.ID))
+		}
+		if remotesessions.IsTokenRefreshRateLimited(err) {
+			logger.WarnContext(ctx, "scheduled remote session refresh rate limited", args...)
+			return RefreshRemoteSessionResult{RateLimited: true}, nil
+		}
+		logger.WarnContext(ctx, "scheduled remote session refresh failed", append(args, attr.SlogError(err))...)
 		return RefreshRemoteSessionResult{RateLimited: false}, nil
 	}
 

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -213,6 +214,24 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // endpoint's organization could not be described, so the resulting 401 is
 // not a credential rejection.
 var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
+
+// The gram.oauth.failure_reason values the issuer gate emits on its rejection
+// logs and on the mcp.request.rejected counter, beyond the bearer-token
+// classification issuerGateFailureReason produces. Together they are a closed
+// set, so the metric dimension stays bounded.
+const (
+	// issuerGateReasonNoCredentials: no bearer token was presented at all,
+	// which is every client's first unauthenticated handshake probe and every
+	// scanner hit on a gated endpoint. Delineated from bad-credential
+	// rejections because it is by far the largest 401 population and would
+	// otherwise swamp the rejected share.
+	issuerGateReasonNoCredentials = "no_credentials"
+
+	// issuerGateReasonInvalidRemoteSession: the bearer token was accepted but
+	// a required upstream remote session for the issuer is missing or
+	// unusable, so the runtime challenged the client to reconnect.
+	issuerGateReasonInvalidRemoteSession = "invalid_remote_session"
+)
 
 func issuerGateFailureReason(err error) string {
 	switch {
@@ -455,6 +474,21 @@ func (s *Service) ApplyIssuerGate(
 		return ctx, nil, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
 	}
 
+	// The gram.mcp.url value for a rejection, rebuilt from the resolved
+	// endpoint rather than taken from the request. The post-authentication
+	// metrics use the raw request URL, query string included; here the caller
+	// is unauthenticated, and a query string any caller can vary freely would
+	// let them mint metric series. The two agree for every query-less request.
+	host := ""
+	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
+		host = requestContext.Host
+	}
+	mcpURL := host + "/" + endpoint.RouteBase + "/" + endpoint.Slug
+	surface := mcpmetrics.SurfaceHosting
+	if endpoint.MetaMcpServerID.Valid {
+		surface = mcpmetrics.SurfaceMeta
+	}
+
 	newCtx, subject, toolSelection, valErr := s.validateUserSessionToken(ctx, authToken, endpoint)
 	if subject == nil {
 		// Accept an assistant-runtime JWT, but only when the assistant
@@ -474,13 +508,21 @@ func (s *Service) ApplyIssuerGate(
 		// signature / revoked jti), but the errIssuerGateOrgLookup wrap means
 		// the token validated and the org lookup failed — an operational
 		// error, labeled distinctly so nobody chases a phantom bad token.
+		//
+		// The no-credentials probe is counted but not logged: it fires on
+		// every client's first handshake, so a warning per probe is noise.
+		reason := issuerGateReasonNoCredentials
 		if valErr != nil {
+			reason = issuerGateFailureReason(valErr)
 			endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-				attr.SlogOAuthFailureReason(issuerGateFailureReason(valErr)),
+				attr.SlogToolsetMCPSlug(endpoint.Slug),
+				attr.SlogMcpURL(mcpURL),
+				attr.SlogOAuthFailureReason(reason),
 				attr.SlogError(valErr),
 			)
 		}
+		s.metrics.RecordMCPRequestRejected(ctx, reason, mcpURL, surface)
 		return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
 	}
 
@@ -507,8 +549,11 @@ func (s *Service) ApplyIssuerGate(
 			// remotesessions.ResolveAccessToken.
 			endpoint.LogWith(s.logger).WarnContext(newCtx, "mcp issuer gate rejected: upstream remote session missing or unusable",
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-				attr.SlogOAuthFailureReason("invalid_remote_session"),
+				attr.SlogToolsetMCPSlug(endpoint.Slug),
+				attr.SlogMcpURL(mcpURL),
+				attr.SlogOAuthFailureReason(issuerGateReasonInvalidRemoteSession),
 			)
+			s.metrics.RecordMCPRequestRejected(newCtx, issuerGateReasonInvalidRemoteSession, mcpURL, surface)
 			return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:
 			return ctx, nil, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 )
 
 // HandleConsentAction serves `POST /mcp/{mcpSlug}/connect/remote-session`.
@@ -183,7 +184,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 				return oops.E(oops.CodeUnexpected, refreshErr, "refresh remote session").LogError(ctx, logger)
 			}
 		}
-		if result.Outcome == remotesessions.RefreshOutcomeSessionInactive {
+		if result.Outcome == remotesessionmetrics.RefreshOutcomeSessionInactive {
 			return oops.E(oops.CodeBadRequest, nil, "Reconnect this service before refreshing it.").LogWarn(ctx, logger)
 		}
 		http.Redirect(w, r, backURL, http.StatusSeeOther)

--- a/server/internal/mcp/issuergate_rejected_metric_test.go
+++ b/server/internal/mcp/issuergate_rejected_metric_test.go
@@ -1,0 +1,73 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+)
+
+// The issuer gate counts every request it turns away on mcp.request.rejected,
+// keyed by the endpoint's route and slug rather than the raw request URL, and
+// tells the unauthenticated handshake probe apart from a presented-but-bad
+// bearer token. Both populations 401 identically on the wire, so the counter
+// is the only place they are distinguishable.
+func TestServePublic_McpEndpoint_IssuerGated_RecordsRejectedRequests(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "endpoint-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", endpointSlug, "public", issuerID)
+
+	_, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "issuer-gated endpoint must reject the unauthenticated probe")
+
+	_, err = servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "not-a-session-token", nil)
+	require.Error(t, err, "issuer-gated endpoint must reject a malformed bearer token")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	points := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != mcpmetrics.InstrumentMCPRequestRejected {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "rejected instrument must be an int64 counter")
+			for _, dp := range sum.DataPoints {
+				points[dp.Attributes] = dp.Value
+			}
+		}
+	}
+	require.Len(t, points, 2, "the probe and the bad token must land in distinct series")
+
+	// The test request carries no request context, so the host segment is
+	// empty and the value is the route and slug alone.
+	mcpURL := "/mcp/" + endpointSlug
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.OAuthFailureReason("no_credentials"),
+		attr.McpURL(mcpURL),
+		attr.McpSurface(string(mcpmetrics.SurfaceHosting)),
+	)])
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.OAuthFailureReason("invalid_bearer_token"),
+		attr.McpURL(mcpURL),
+		attr.McpSurface(string(mcpmetrics.SurfaceHosting)),
+	)])
+}

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -13,6 +13,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 )
 
+// InstrumentMCPRequestRejected is the OTel instrument name for the counter of
+// requests the Session OAuth authentication gate rejected before dispatch.
+const InstrumentMCPRequestRejected = "mcp.request.rejected"
+
 // OAuthFlowStage is the closed set of coarse stages at which a user-facing
 // OAuth flow can terminally resolve to a non-completion outcome (failed or
 // declined). It names the handler leg where the flow ended. Kept as a bounded
@@ -57,6 +61,14 @@ type Metrics struct {
 	// remote/tunnel /x/mcp backends publish the same instrument from the
 	// proxy's request interceptor, which constructs its own [RequestCounter].
 	requestCensus *RequestCounter
+
+	// mcpRequestRejectedCounter is the unsampled census of requests the issuer
+	// gate turned away before dispatch: the population that never reaches
+	// requestCensus. It carries a per-server URL because "which server is
+	// rejecting" is the operational question; the URL is rebuilt from the
+	// resolved endpoint rather than taken from the request so an
+	// unauthenticated caller cannot mint series through the query string.
+	mcpRequestRejectedCounter metric.Int64Counter
 
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
@@ -164,10 +176,20 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 		logger.ErrorContext(context.Background(), "failed to create oauth refresh token replay served counter", attr.SlogError(err))
 	}
 
+	mcpRequestRejectedCounter, err := meter.Int64Counter(
+		InstrumentMCPRequestRejected,
+		metric.WithDescription("MCP requests rejected by the Session OAuth authentication gate before dispatch, by failure reason, server URL, and surface"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentMCPRequestRejected), attr.SlogError(err))
+	}
+
 	return &Metrics{
 		mcpToolCallCounter:                   mcpToolCallCounter,
 		mcpRequestDuration:                   mcpRequestDuration,
 		mcpInitializeCounter:                 mcpInitializeCounter,
+		mcpRequestRejectedCounter:            mcpRequestRejectedCounter,
 		requestCensus:                        NewRequestCounter(meter, logger),
 		oauthFlowStartedCounter:              oauthFlowStartedCounter,
 		oauthFlowCompletedCounter:            oauthFlowCompletedCounter,
@@ -230,6 +252,30 @@ func (m *Metrics) RecordMCPRequest(ctx context.Context, protocolVersion, method 
 	}
 
 	m.requestCensus.Record(ctx, protocolVersion, method, surface)
+}
+
+// RecordMCPRequestRejected counts one MCP request the Session OAuth
+// authentication gate turned away before dispatch. reason is the closed set
+// the gate logs under gram.oauth.failure_reason; mcpURL is the same
+// gram.mcp.url key `mcp.request.duration` and `mcp.tool.call` carry, so every
+// per-server MCP metric groups the same way; surface is the same value the
+// `mcp.request` census carries, so `rejected / (rejected + request)` is well
+// defined per surface.
+//
+// Rejected requests are absent from every other instrument: the census and
+// the duration histogram record after the gate has passed a request. This
+// counter therefore partitions traffic at the gate rather than overlapping
+// with them.
+func (m *Metrics) RecordMCPRequestRejected(ctx context.Context, reason string, mcpURL string, surface Surface) {
+	if m == nil || m.mcpRequestRejectedCounter == nil {
+		return
+	}
+
+	m.mcpRequestRejectedCounter.Add(ctx, 1, metric.WithAttributes(
+		attr.OAuthFailureReason(reason),
+		attr.McpURL(mcpURL),
+		attr.McpSurface(string(surface)),
+	))
 }
 
 // RecordMCPRequestDuration records one dispatched request's duration. The

--- a/server/internal/mcp/mcpmetrics/metrics_test.go
+++ b/server/internal/mcp/mcpmetrics/metrics_test.go
@@ -240,6 +240,38 @@ func TestRecordMCPRequestDuration_ClampsMethodLabel(t *testing.T) {
 	)
 }
 
+// TestRecordMCPRequestRejected_PinsInstrumentAndDimensions pins the wiring a
+// noop meter cannot see: the instrument name and the three attribute keys the
+// dashboard and the AIS-618 monitors query by.
+func TestRecordMCPRequestRejected_PinsInstrumentAndDimensions(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+
+	m := NewMetrics(meter, testenv.NewLogger(t))
+	m.RecordMCPRequestRejected(t.Context(), "invalid_remote_session", "mcp.example.com/mcp/demo", SurfaceMeta)
+
+	metricdatatest.AssertHasAttributes(t, collectMetric(t, reader, InstrumentMCPRequestRejected),
+		attr.OAuthFailureReason("invalid_remote_session"),
+		attr.McpURL("mcp.example.com/mcp/demo"),
+		attr.McpSurface(string(SurfaceMeta)),
+	)
+}
+
+// TestRecordMCPRequestRejected_NilSafe pins the documented contract that a
+// nil *Metrics, and one whose instrument failed to construct, are both safe
+// to record against.
+func TestRecordMCPRequestRejected_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var nilMetrics *Metrics
+	nilMetrics.RecordMCPRequestRejected(t.Context(), "no_credentials", "mcp.example.com/mcp/demo", SurfaceHosting)
+
+	empty := &Metrics{}
+	empty.RecordMCPRequestRejected(t.Context(), "no_credentials", "mcp.example.com/mcp/demo", SurfaceHosting)
+}
+
 // collectMetric drains the reader and returns the named metric, failing the
 // test when it was never recorded.
 func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {

--- a/server/internal/mcp/mcpmetrics/metrics_test.go
+++ b/server/internal/mcp/mcpmetrics/metrics_test.go
@@ -252,11 +252,17 @@ func TestRecordMCPRequestRejected_PinsInstrumentAndDimensions(t *testing.T) {
 	m := NewMetrics(meter, testenv.NewLogger(t))
 	m.RecordMCPRequestRejected(t.Context(), "invalid_remote_session", "mcp.example.com/mcp/demo", SurfaceMeta)
 
-	metricdatatest.AssertHasAttributes(t, collectMetric(t, reader, InstrumentMCPRequestRejected),
+	got := collectMetric(t, reader, InstrumentMCPRequestRejected)
+	metricdatatest.AssertHasAttributes(t, got,
 		attr.OAuthFailureReason("invalid_remote_session"),
 		attr.McpURL("mcp.example.com/mcp/demo"),
 		attr.McpSurface(string(SurfaceMeta)),
 	)
+
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "rejected instrument must be an int64 counter")
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(1), sum.DataPoints[0].Value)
 }
 
 // TestRecordMCPRequestRejected_NilSafe pins the documented contract that a

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/toolcallobserver"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	keys_gen "github.com/speakeasy-api/gram/server/gen/keys"
@@ -117,13 +118,27 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 
 func newTestMCPServiceWithCacheWrapper(t *testing.T, wrap func(cache.Cache) cache.Cache) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewMeterProvider(t), &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		MaxRequestLifetime: 0,
 	}, wrap)
+}
+
+// newTestMCPServiceWithMeterProvider wires the permissive identity resolver
+// over the caller's meter provider, for tests that assert on the metrics the
+// service records rather than the noop provider the other constructors use.
+func newTestMCPServiceWithMeterProvider(t *testing.T, meterProvider metric.MeterProvider) (context.Context, *testInstance) {
+	t.Helper()
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+		SessionTTL:         0,
+		LiveSessionCap:     0,
+		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		MaxRequestLifetime: 0,
+	}, nil)
 }
 
 // newTestMCPServiceWithDevIDP launches an in-process dev-idp instance and
@@ -177,11 +192,12 @@ func newTestMCPServiceWithGuardianOptions(t *testing.T, guardianOpts ...func(*gu
 
 func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.IdentityResolver, tunnelPublicConfig mcp.TunnelPublicConfig, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, identityResolver, tunnelPublicConfig, nil, guardianOpts...)
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewMeterProvider(t), identityResolver, tunnelPublicConfig, nil, guardianOpts...)
 }
 
 func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	t *testing.T,
+	meterProvider metric.MeterProvider,
 	identityResolver mcp.IdentityResolver,
 	tunnelPublicConfig mcp.TunnelPublicConfig,
 	wrapCache func(cache.Cache) cache.Cache,
@@ -193,7 +209,6 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	meterProvider := testenv.NewMeterProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{}, guardianOpts...)
 	require.NoError(t, err)
 

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -178,7 +178,7 @@ func NewChallengeManager(
 			cache.SuffixNone,
 		),
 		locks:     cacheImpl,
-		refresher: NewRefreshService(logger, db, enc, policy, cacheImpl),
+		refresher: NewRefreshService(logger, meterProvider, db, enc, policy, cacheImpl),
 		serverURL: serverURL,
 		revoker:   NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
 		authorizeInterceptors: []interceptors.AuthorizeInterceptor{
@@ -407,7 +407,7 @@ func (m *ChallengeManager) RefreshRemoteSession(
 		return zero, ErrRemoteSessionNotRefreshable
 	}
 
-	return m.refresher.RefreshNow(ctx, session, "")
+	return m.refresher.RefreshNow(ctx, session, "", remotesessionmetrics.RefreshTriggerManual)
 }
 
 // FallbackResourceForClient derives one client's RFC 8707 resource from its

--- a/server/internal/remotesessions/challenge_shared_grant_test.go
+++ b/server/internal/remotesessions/challenge_shared_grant_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -648,7 +649,7 @@ func TestRefreshRemoteSession_DerivesPerClientFallbackResource(t *testing.T) {
 
 	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, int64(1), refreshCount.Load())
 	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://upstream-refresh.example.com"}, captured.Load())
 }
@@ -726,7 +727,7 @@ func TestRefreshRemoteSession_StoredResourceWinsOverDerivation(t *testing.T) {
 
 	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, tokenPostCapture{HasResource: true, Resource: "https://stored-winner.example.com"}, captured.Load())
 }
 
@@ -744,7 +745,7 @@ func TestRefreshRemoteSession_AmbiguousDerivationSendsNoResource(t *testing.T) {
 
 	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, tokenPostCapture{HasResource: false, Resource: ""}, captured.Load())
 }
 
@@ -818,7 +819,7 @@ func TestRefreshRemoteSession_FindsGrantMintedByDifferentIssuer(t *testing.T) {
 
 	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "rotated-access", result.AccessToken)
 	require.Equal(t, fx.issuerA, result.Session.UserSessionIssuerID)
 	require.Equal(t, int64(1), refreshCount.Load())
@@ -840,7 +841,7 @@ func TestRefreshRemoteSession_FindsGrantAfterMintingIssuerSoftDeleted(t *testing
 
 	result, err := fx.mgr.RefreshRemoteSession(ctx, fx.subject, fx.projectID, fx.organizationID, fx.issuerB, fx.clientID)
 	require.NoError(t, err)
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "rotated-after-delete", result.AccessToken)
 	require.Equal(t, fx.issuerA, result.Session.UserSessionIssuerID)
 	require.Equal(t, int64(1), refreshCount.Load())

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -147,8 +148,11 @@ type syntheticExpiryEnv struct {
 	mgr *remotesessions.ChallengeManager
 	// refresher shares the manager's database, encryption key, and Redis lock
 	// cache, standing in for the scheduled sweep's caller in concurrency tests.
-	refresher      *remotesessions.RefreshService
-	newRefresher   func(cache.Cache) *remotesessions.RefreshService
+	refresher *remotesessions.RefreshService
+	// newRefresher builds a second RefreshService over the same database and
+	// encryption key, with the caller's meter provider and lock cache, so a
+	// test can observe recorded metrics or simulate a degraded lock cache.
+	newRefresher   func(metric.MeterProvider, cache.Cache) *remotesessions.RefreshService
 	q              *repo.Queries
 	projectID      uuid.UUID
 	organizationID string
@@ -194,7 +198,7 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 		cache.NewRedisCacheAdapter(redisClient),
 		mustURL(t, "http://localhost"),
 	)
-	refresher := remotesessions.NewRefreshService(logger, ti.conn, enc, policy, cache.NewRedisCacheAdapter(redisClient))
+	refresher := remotesessions.NewRefreshService(logger, testenv.NewMeterProvider(t), ti.conn, enc, policy, cache.NewRedisCacheAdapter(redisClient))
 
 	q := repo.New(ti.conn)
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
@@ -277,8 +281,8 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 	return ctx, syntheticExpiryEnv{
 		mgr:       mgr,
 		refresher: refresher,
-		newRefresher: func(locks cache.Cache) *remotesessions.RefreshService {
-			return remotesessions.NewRefreshService(logger, ti.conn, enc, policy, locks)
+		newRefresher: func(meterProvider metric.MeterProvider, locks cache.Cache) *remotesessions.RefreshService {
+			return remotesessions.NewRefreshService(logger, meterProvider, ti.conn, enc, policy, locks)
 		},
 		q:              q,
 		projectID:      *authCtx.ProjectID,

--- a/server/internal/remotesessions/organizationsessionhandlers.go
+++ b/server/internal/remotesessions/organizationsessionhandlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -206,7 +207,7 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgsessionsgen.Re
 	// are adopted instead of double-POSTing, and a definitive upstream
 	// invalid_grant clears only the dead refresh grant so a still-working
 	// access token remains connected.
-	result, err := s.refresher.RefreshNow(ctx, row.RemoteSession, "")
+	result, err := s.refresher.RefreshNow(ctx, row.RemoteSession, "", remotesessionmetrics.RefreshTriggerManual)
 	if err != nil {
 		// Operator-actionable failures carry a public-safe reason; surface it so
 		// the admin sees why the refresh failed instead of a generic error.
@@ -216,7 +217,7 @@ func (s *Service) RefreshSession(ctx context.Context, payload *orgsessionsgen.Re
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "refresh organization admin remote session").LogError(ctx, logger)
 	}
-	if result.Outcome == RefreshOutcomeSessionInactive {
+	if result.Outcome == remotesessionmetrics.RefreshOutcomeSessionInactive {
 		return nil, oops.E(oops.CodeNotFound, nil, "remote session was revoked while refreshing").LogWarn(ctx, logger)
 	}
 	updated := result.Session

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -150,12 +150,12 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 	var zero RefreshResult
 	q := remotesessions_repo.New(s.db)
 
-	// Loaded ahead of the lock purely to label the outcome: every return,
-	// including the concurrent-loser and inactive early exits below, carries
-	// the issuer URL. The POST itself re-reads the row after the lock so it
-	// never runs on configuration that changed while this caller waited. An
-	// active session whose client or issuer row was soft-deleted fails here
-	// and records internal_error; the refresh would fail on the same lookup
+	// Loaded ahead of the lock so the returns that never reach the POST, the
+	// concurrent-loser and inactive early exits below, still carry an issuer
+	// URL. The POST path re-reads the row after the lock and reports the
+	// issuer it actually spoke to, which wins over this label. An active
+	// session whose client or issuer row was soft-deleted fails here and
+	// records internal_error; the refresh would fail on the same lookup
 	// either way.
 	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
 	if err != nil {
@@ -165,14 +165,15 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		return zero, &RefreshError{IssuerURL: "", Outcome: outcome, err: err}
 	}
 
-	result, err := s.refresh(ctx, q, sess, callerResource)
+	result, postLockIssuerURL, err := s.refresh(ctx, q, sess, callerResource)
+	issuerURL := conv.Default(postLockIssuerURL, client.IssuerUrl)
 	if err != nil {
 		outcome := refreshOutcomeForError(ctx, err)
-		s.metrics.Record(ctx, client.IssuerUrl, trigger, outcome)
-		return zero, &RefreshError{IssuerURL: client.IssuerUrl, Outcome: outcome, err: err}
+		s.metrics.Record(ctx, issuerURL, trigger, outcome)
+		return zero, &RefreshError{IssuerURL: issuerURL, Outcome: outcome, err: err}
 	}
-	result.IssuerURL = client.IssuerUrl
-	s.metrics.Record(ctx, client.IssuerUrl, trigger, result.Outcome)
+	result.IssuerURL = issuerURL
+	s.metrics.Record(ctx, issuerURL, trigger, result.Outcome)
 	return result, nil
 }
 
@@ -219,12 +220,16 @@ func refreshOutcomeForError(ctx context.Context, err error) remotesessionmetrics
 // side of the upstream POST, and the invalid_grant clearing. RefreshNow wraps
 // it so the metric sample and the RefreshError are produced in exactly one
 // place regardless of which of the many return paths below is taken.
+//
+// The string is the issuer URL of the client row re-read after the lock,
+// the one the POST was sent to; it is empty on every return that happens
+// before that read, and RefreshNow falls back to its pre-lock label there.
 func (s *RefreshService) refresh(
 	ctx context.Context,
 	q *remotesessions_repo.Queries,
 	sess remotesessions_repo.RemoteSession,
 	callerResource string,
-) (RefreshResult, error) {
+) (RefreshResult, string, error) {
 	var zero RefreshResult
 
 	lockKey := refreshLockKey(sess.SubjectUrn, sess.RemoteSessionClientID)
@@ -242,7 +247,7 @@ func (s *RefreshService) refresh(
 		)
 	case !held:
 		if winner, ok := s.awaitRefreshedSession(ctx, q, sess); ok {
-			return winner, nil
+			return winner, "", nil
 		}
 		// A duplicate POST beats a guaranteed reconnect prompt.
 		s.logger.WarnContext(ctx, "timed out waiting on a concurrent remote session refresh; refreshing directly",
@@ -284,11 +289,11 @@ func (s *RefreshService) refresh(
 		// Revoked while we were acquiring. Refreshing anyway would rotate
 		// tokens upstream that nothing will ever hold.
 		var inactive remotesessions_repo.RemoteSession
-		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, nil
+		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, "", nil
 	case currentErr != nil:
 		// Whatever broke this read breaks the write below too, and a refresh we
 		// cannot persist leaves the stored token dead upstream.
-		return zero, fmt.Errorf("re-read active remote_session: %w", currentErr)
+		return zero, "", fmt.Errorf("re-read active remote_session: %w", currentErr)
 	}
 
 	sess = current
@@ -297,16 +302,16 @@ func (s *RefreshService) refresh(
 		if accessTokenUsable(current, time.Now()) {
 			plain, err := s.enc.Decrypt(current.AccessTokenEncrypted)
 			if err != nil {
-				return zero, fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
+				return zero, "", fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
 			}
-			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, nil
+			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil
 		}
 	}
 	if !current.RefreshTokenEncrypted.Valid || current.RefreshTokenEncrypted.String == "" {
-		return zero, ErrNoValidToken
+		return zero, "", ErrNoValidToken
 	}
 	if !refreshTokenUsable(current, time.Now()) {
-		return zero, ErrNoValidToken
+		return zero, "", ErrNoValidToken
 	}
 
 	// The persisted binding wins over the caller-derived fallback: the token
@@ -323,7 +328,7 @@ func (s *RefreshService) refresh(
 		var err error
 		resource, err = s.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
 		if err != nil {
-			return zero, fmt.Errorf("derive fallback resource: %w", err)
+			return zero, "", fmt.Errorf("derive fallback resource: %w", err)
 		}
 	}
 
@@ -331,7 +336,7 @@ func (s *RefreshService) refresh(
 	// a client secret or token endpoint rotated meanwhile must reach the POST.
 	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
 	if err != nil {
-		return zero, fmt.Errorf("load remote_session_client for refresh: %w", err)
+		return zero, "", fmt.Errorf("load remote_session_client for refresh: %w", err)
 	}
 
 	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, client, sess, resource)
@@ -345,7 +350,7 @@ func (s *RefreshService) refresh(
 				attr.SlogOAuthResource(updated.Resource.String),
 			)
 		}
-		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, nil
+		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, client.IssuerUrl, nil
 	}
 
 	var tokenRefreshErr *TokenRefreshError
@@ -358,9 +363,9 @@ func (s *RefreshService) refresh(
 		})
 		switch {
 		case err == nil:
-			return zero, refreshErr
+			return zero, client.IssuerUrl, refreshErr
 		case !errors.Is(err, pgx.ErrNoRows):
-			return zero, fmt.Errorf("clear remote session refresh token after invalid_grant: %w", err)
+			return zero, client.IssuerUrl, fmt.Errorf("clear remote session refresh token after invalid_grant: %w", err)
 		}
 		// A row that moved after our refresh attempt belongs to a concurrent
 		// winner. Re-read it below and adopt that token instead of clearing it.
@@ -371,24 +376,24 @@ func (s *RefreshService) refresh(
 		RemoteSessionClientID: sess.RemoteSessionClientID,
 	})
 	if err != nil {
-		return zero, refreshErr
+		return zero, client.IssuerUrl, refreshErr
 	}
 
 	// Nothing else moved the row, so our failure is the real state of the
 	// session rather than the losing half of a race.
 	if !latest.UpdatedAt.Time.After(sess.UpdatedAt.Time) {
-		return zero, refreshErr
+		return zero, client.IssuerUrl, refreshErr
 	}
 
 	if !accessTokenUsable(latest, time.Now()) {
-		return zero, refreshErr
+		return zero, client.IssuerUrl, refreshErr
 	}
 	plain, err := s.enc.Decrypt(latest.AccessTokenEncrypted)
 	if err != nil {
-		return zero, refreshErr
+		return zero, client.IssuerUrl, refreshErr
 	}
 
-	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, nil
+	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil
 }
 
 func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -150,21 +150,24 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 	var zero RefreshResult
 	q := remotesessions_repo.New(s.db)
 
-	// Loaded ahead of the lock so every outcome, including the concurrent-loser
-	// and inactive early exits below, carries the issuer URL. An active session
-	// whose client or issuer row was soft-deleted fails here and records
-	// internal_error; the refresh would fail on the same lookup either way.
+	// Loaded ahead of the lock purely to label the outcome: every return,
+	// including the concurrent-loser and inactive early exits below, carries
+	// the issuer URL. The POST itself re-reads the row after the lock so it
+	// never runs on configuration that changed while this caller waited. An
+	// active session whose client or issuer row was soft-deleted fails here
+	// and records internal_error; the refresh would fail on the same lookup
+	// either way.
 	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
 	if err != nil {
 		err = fmt.Errorf("load remote_session_client for refresh: %w", err)
-		outcome := refreshOutcomeForError(err)
+		outcome := refreshOutcomeForError(ctx, err)
 		s.metrics.Record(ctx, "", trigger, outcome)
 		return zero, &RefreshError{IssuerURL: "", Outcome: outcome, err: err}
 	}
 
-	result, err := s.refresh(ctx, q, client, sess, callerResource)
+	result, err := s.refresh(ctx, q, sess, callerResource)
 	if err != nil {
-		outcome := refreshOutcomeForError(err)
+		outcome := refreshOutcomeForError(ctx, err)
 		s.metrics.Record(ctx, client.IssuerUrl, trigger, outcome)
 		return zero, &RefreshError{IssuerURL: client.IssuerUrl, Outcome: outcome, err: err}
 	}
@@ -174,15 +177,23 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 }
 
 // refreshOutcomeForError maps a failed refresh onto the metric outcome set.
-// Context cancellation is checked before the transport marker because a
-// canceled POST surfaces as a transport error too, and a caller going away is
-// neither the upstream's fault nor Gram's.
-func refreshOutcomeForError(err error) remotesessionmetrics.RefreshOutcome {
+//
+// The caller going away is checked before the transport marker because an
+// aborted POST surfaces as a transport error too, and it is neither the
+// upstream's fault nor Gram's. A deadline is the caller's own only when ctx
+// itself has expired; otherwise it was the POST's internal timeout, which is
+// the upstream not answering.
+//
+// invalid_grant is checked before the status-based buckets because refresh
+// clears the grant on a definitive invalid_grant regardless of status, and
+// the metric describes what Gram did: a 429 or 5xx that also carried
+// invalid_grant left the session without a refresh grant.
+func refreshOutcomeForError(ctx context.Context, err error) remotesessionmetrics.RefreshOutcome {
 	var tokenErr *TokenRefreshError
 	switch {
 	case errors.Is(err, ErrNoValidToken):
 		return remotesessionmetrics.RefreshOutcomeNoGrant
-	case errors.Is(err, context.Canceled):
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded) && ctx.Err() != nil:
 		return remotesessionmetrics.RefreshOutcomeCanceled
 	case errors.Is(err, errRefreshUpstreamUnreachable):
 		return remotesessionmetrics.RefreshOutcomeUnreachable
@@ -191,12 +202,12 @@ func refreshOutcomeForError(err error) remotesessionmetrics.RefreshOutcome {
 		// after the POST (no token endpoint, unreadable stored values, an empty
 		// upstream response, a lost compare-and-swap) rather than by it.
 		return remotesessionmetrics.RefreshOutcomeInternalError
+	case tokenErr.invalidGrant():
+		return remotesessionmetrics.RefreshOutcomeInvalidGrant
 	case tokenErr.statusCode == http.StatusTooManyRequests:
 		return remotesessionmetrics.RefreshOutcomeRateLimited
 	case tokenErr.statusCode >= http.StatusInternalServerError:
 		return remotesessionmetrics.RefreshOutcomeUpstreamError
-	case tokenErr.invalidGrant():
-		return remotesessionmetrics.RefreshOutcomeInvalidGrant
 	case tokenErr.code == "":
 		return remotesessionmetrics.RefreshOutcomeRejectedUnparsed
 	default:
@@ -211,7 +222,6 @@ func refreshOutcomeForError(err error) remotesessionmetrics.RefreshOutcome {
 func (s *RefreshService) refresh(
 	ctx context.Context,
 	q *remotesessions_repo.Queries,
-	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow,
 	sess remotesessions_repo.RemoteSession,
 	callerResource string,
 ) (RefreshResult, error) {
@@ -315,6 +325,13 @@ func (s *RefreshService) refresh(
 		if err != nil {
 			return zero, fmt.Errorf("derive fallback resource: %w", err)
 		}
+	}
+
+	// Read after the lock: this caller may have waited on it for seconds, and
+	// a client secret or token endpoint rotated meanwhile must reach the POST.
+	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
+	if err != nil {
+		return zero, fmt.Errorf("load remote_session_client for refresh: %w", err)
 	}
 
 	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, client, sess, resource)

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -1,10 +1,11 @@
 // refreshservice.go is the single concurrency-safe entry point for refreshing
-// a remote session's upstream tokens. Three callers share it: the lazy MCP
-// resolution path (tokenservice.go), the org-admin manual refresh handler
-// (organizationsessionhandlers.go), and the scheduled pre-emptive refresh
-// activity (background worker). Sharing matters because refresh tokens rotate:
-// two callers presenting the same refresh token to a provider with reuse
-// detection (OAuth 2.0 Security BCP 4.13.2) can revoke the whole token family.
+// a remote session's upstream tokens. Four callers share it: the lazy MCP
+// resolution path (tokenservice.go), the consent page and the org-admin manual
+// refresh handler (challenge.go, organizationsessionhandlers.go), and the
+// scheduled pre-emptive refresh activity (background worker). Sharing matters
+// because refresh tokens rotate: two callers presenting the same refresh token
+// to a provider with reuse detection (OAuth 2.0 Security BCP 4.13.2) can
+// revoke the whole token family.
 
 package remotesessions
 
@@ -13,11 +14,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -25,54 +28,68 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
-// RefreshOutcome classifies how RefreshNow obtained (or failed to obtain) a
-// usable access token. Values are stable, low-cardinality strings safe for
-// metrics labels and Temporal activity results.
-type RefreshOutcome string
-
-const (
-	// RefreshOutcomeRefreshed: this caller executed the upstream refresh_token
-	// grant and persisted the rotated pair.
-	RefreshOutcomeRefreshed RefreshOutcome = "refreshed"
-	// RefreshOutcomeAdoptedConcurrentWinner: another caller refreshed the row
-	// while this one was acquiring or POSTing; its persisted token was adopted
-	// and no (or a losing) upstream call was made by this caller.
-	RefreshOutcomeAdoptedConcurrentWinner RefreshOutcome = "adopted_concurrent_winner"
-	// RefreshOutcomeSessionInactive: the row was revoked or deleted before the
-	// refresh could run. Not an error — there is simply nothing to refresh.
-	RefreshOutcomeSessionInactive RefreshOutcome = "session_inactive"
-)
-
 // RefreshResult is RefreshNow's success shape. Session and AccessToken are
-// zero/empty when Outcome is RefreshOutcomeSessionInactive.
+// zero/empty when Outcome is remotesessionmetrics.RefreshOutcomeSessionInactive.
 type RefreshResult struct {
 	Session     remotesessions_repo.RemoteSession
 	AccessToken string
-	Outcome     RefreshOutcome
+
+	// Outcome is the same closed set the upstream-refresh metric records, so
+	// a caller's log line and the metric series always agree.
+	Outcome remotesessionmetrics.RefreshOutcome
+
+	// IssuerURL is the upstream identity provider's issuer URL, the same value
+	// the upstream-refresh metric carries as its gram.oauth.issuer dimension.
+	IssuerURL string
 }
+
+// RefreshError is the error RefreshNow returns for every failed attempt. It
+// carries the issuer URL and outcome the upstream-refresh metric recorded for
+// the attempt, so a failure log can name the provider and be joined to its
+// metric series, and it wraps the underlying cause: errors.Is on
+// ErrNoValidToken and errors.As on *TokenRefreshError see through it.
+type RefreshError struct {
+	// IssuerURL is the upstream identity provider's issuer URL; empty when the
+	// attempt died before the session's client and issuer rows could be
+	// loaded.
+	IssuerURL string
+
+	// Outcome is the classification the upstream-refresh metric recorded for
+	// this attempt.
+	Outcome remotesessionmetrics.RefreshOutcome
+
+	err error
+}
+
+func (e *RefreshError) Error() string { return e.err.Error() }
+
+func (e *RefreshError) Unwrap() error { return e.err }
 
 // RefreshService owns the single-flighted refresh of a remote session. It is
 // deliberately constructible without any HTTP-serving context so the
 // background worker can hold one alongside the request-path callers.
 type RefreshService struct {
-	logger *slog.Logger
-	db     *pgxpool.Pool
-	enc    *encryption.Client
-	policy *guardian.Policy
-	locks  cache.Cache
+	logger  *slog.Logger
+	db      *pgxpool.Pool
+	enc     *encryption.Client
+	policy  *guardian.Policy
+	locks   cache.Cache
+	metrics *remotesessionmetrics.Refresh
 }
 
-func NewRefreshService(logger *slog.Logger, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, locks cache.Cache) *RefreshService {
+func NewRefreshService(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, locks cache.Cache) *RefreshService {
 	return &RefreshService{
-		logger: logger.With(attr.SlogComponent("remotesessions_refresh")),
-		db:     db,
-		enc:    enc,
-		policy: policy,
-		locks:  locks,
+		logger:  logger.With(attr.SlogComponent("remotesessions_refresh")),
+		db:      db,
+		enc:     enc,
+		policy:  policy,
+		locks:   locks,
+		metrics: remotesessionmetrics.NewRefresh(logger, meterProvider),
 	}
 }
 
@@ -121,14 +138,84 @@ func refreshLockKey(subject urn.SessionSubject, clientID uuid.UUID) string {
 // binding when one was captured at code exchange. Rows minted before the
 // resource column existed fall back to callerResource, and then to the
 // client's own derivation — one derivation rule for every refresh path.
+// trigger names the caller on the upstream-refresh metric.
 //
-// A non-nil error is either an operator-actionable *TokenRefreshError or an
-// internal infrastructure failure. A definitive invalid_grant clears only the
-// refresh grant: the existing access token remains usable until its own known
-// expiry. This keeps proactive refresh failure from forcing a reconnect.
-func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_repo.RemoteSession, callerResource string) (RefreshResult, error) {
+// Every call records exactly one upstream-refresh metric sample. A non-nil
+// error is always a *RefreshError wrapping either an operator-actionable
+// *TokenRefreshError, ErrNoValidToken, or an internal infrastructure failure.
+// A definitive invalid_grant clears only the refresh grant: the existing
+// access token remains usable until its own known expiry. This keeps
+// proactive refresh failure from forcing a reconnect.
+func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_repo.RemoteSession, callerResource string, trigger remotesessionmetrics.RefreshTrigger) (RefreshResult, error) {
 	var zero RefreshResult
 	q := remotesessions_repo.New(s.db)
+
+	// Loaded ahead of the lock so every outcome, including the concurrent-loser
+	// and inactive early exits below, carries the issuer URL. An active session
+	// whose client or issuer row was soft-deleted fails here and records
+	// internal_error; the refresh would fail on the same lookup either way.
+	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
+	if err != nil {
+		err = fmt.Errorf("load remote_session_client for refresh: %w", err)
+		outcome := refreshOutcomeForError(err)
+		s.metrics.Record(ctx, "", trigger, outcome)
+		return zero, &RefreshError{IssuerURL: "", Outcome: outcome, err: err}
+	}
+
+	result, err := s.refresh(ctx, q, client, sess, callerResource)
+	if err != nil {
+		outcome := refreshOutcomeForError(err)
+		s.metrics.Record(ctx, client.IssuerUrl, trigger, outcome)
+		return zero, &RefreshError{IssuerURL: client.IssuerUrl, Outcome: outcome, err: err}
+	}
+	result.IssuerURL = client.IssuerUrl
+	s.metrics.Record(ctx, client.IssuerUrl, trigger, result.Outcome)
+	return result, nil
+}
+
+// refreshOutcomeForError maps a failed refresh onto the metric outcome set.
+// Context cancellation is checked before the transport marker because a
+// canceled POST surfaces as a transport error too, and a caller going away is
+// neither the upstream's fault nor Gram's.
+func refreshOutcomeForError(err error) remotesessionmetrics.RefreshOutcome {
+	var tokenErr *TokenRefreshError
+	switch {
+	case errors.Is(err, ErrNoValidToken):
+		return remotesessionmetrics.RefreshOutcomeNoGrant
+	case errors.Is(err, context.Canceled):
+		return remotesessionmetrics.RefreshOutcomeCanceled
+	case errors.Is(err, errRefreshUpstreamUnreachable):
+		return remotesessionmetrics.RefreshOutcomeUnreachable
+	case !errors.As(err, &tokenErr) || tokenErr.statusCode == 0:
+		// Plain infrastructure errors, and TokenRefreshErrors raised before or
+		// after the POST (no token endpoint, unreadable stored values, an empty
+		// upstream response, a lost compare-and-swap) rather than by it.
+		return remotesessionmetrics.RefreshOutcomeInternalError
+	case tokenErr.statusCode == http.StatusTooManyRequests:
+		return remotesessionmetrics.RefreshOutcomeRateLimited
+	case tokenErr.statusCode >= http.StatusInternalServerError:
+		return remotesessionmetrics.RefreshOutcomeUpstreamError
+	case tokenErr.invalidGrant():
+		return remotesessionmetrics.RefreshOutcomeInvalidGrant
+	case tokenErr.code == "":
+		return remotesessionmetrics.RefreshOutcomeRejectedUnparsed
+	default:
+		return remotesessionmetrics.RefreshOutcomeRejected
+	}
+}
+
+// refresh is RefreshNow's body: the single-flight lock, the re-reads either
+// side of the upstream POST, and the invalid_grant clearing. RefreshNow wraps
+// it so the metric sample and the RefreshError are produced in exactly one
+// place regardless of which of the many return paths below is taken.
+func (s *RefreshService) refresh(
+	ctx context.Context,
+	q *remotesessions_repo.Queries,
+	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow,
+	sess remotesessions_repo.RemoteSession,
+	callerResource string,
+) (RefreshResult, error) {
+	var zero RefreshResult
 
 	lockKey := refreshLockKey(sess.SubjectUrn, sess.RemoteSessionClientID)
 	lockAcquiredAt := time.Now()
@@ -187,7 +274,7 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		// Revoked while we were acquiring. Refreshing anyway would rotate
 		// tokens upstream that nothing will ever hold.
 		var inactive remotesessions_repo.RemoteSession
-		return RefreshResult{Session: inactive, AccessToken: "", Outcome: RefreshOutcomeSessionInactive}, nil
+		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, nil
 	case currentErr != nil:
 		// Whatever broke this read breaks the write below too, and a refresh we
 		// cannot persist leaves the stored token dead upstream.
@@ -202,7 +289,7 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 			if err != nil {
 				return zero, fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
 			}
-			return RefreshResult{Session: current, AccessToken: plain, Outcome: RefreshOutcomeAdoptedConcurrentWinner}, nil
+			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, nil
 		}
 	}
 	if !current.RefreshTokenEncrypted.Valid || current.RefreshTokenEncrypted.String == "" {
@@ -230,7 +317,7 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		}
 	}
 
-	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, sess, resource)
+	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, client, sess, resource)
 	if refreshErr == nil {
 		// The stamp is permanent, so record which rows the backfill wrote and
 		// what it wrote — the only way to find them again if a value is wrong.
@@ -241,7 +328,7 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 				attr.SlogOAuthResource(updated.Resource.String),
 			)
 		}
-		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: RefreshOutcomeRefreshed}, nil
+		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, nil
 	}
 
 	var tokenRefreshErr *TokenRefreshError
@@ -284,7 +371,7 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		return zero, refreshErr
 	}
 
-	return RefreshResult{Session: latest, AccessToken: plain, Outcome: RefreshOutcomeAdoptedConcurrentWinner}, nil
+	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, nil
 }
 
 func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
@@ -345,6 +432,6 @@ func (s *RefreshService) awaitRefreshedSession(
 			return zero, false
 		}
 
-		return RefreshResult{Session: latest, AccessToken: plain, Outcome: RefreshOutcomeAdoptedConcurrentWinner}, true
+		return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, true
 	}
 }

--- a/server/internal/remotesessions/refreshservice_concurrent_test.go
+++ b/server/internal/remotesessions/refreshservice_concurrent_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
@@ -43,7 +43,7 @@ func TestRefreshNow_RacingLazyResolves_SingleUpstreamCall(t *testing.T) {
 
 	tokens := make([]string, concurrentRefreshCallers)
 	errs := make([]error, concurrentRefreshCallers)
-	outcomes := make([]remotesessions.RefreshOutcome, scheduled)
+	outcomes := make([]remotesessionmetrics.RefreshOutcome, scheduled)
 
 	start := make(chan struct{})
 	var wg sync.WaitGroup
@@ -56,7 +56,7 @@ func TestRefreshNow_RacingLazyResolves_SingleUpstreamCall(t *testing.T) {
 	for i := range scheduled {
 		wg.Go(func() {
 			<-start
-			result, err := env.refresher.RefreshNow(ctx, session, "")
+			result, err := env.refresher.RefreshNow(ctx, session, "", remotesessionmetrics.RefreshTriggerScheduled)
 			tokens[lazy+i], errs[lazy+i] = result.AccessToken, err
 			outcomes[i] = result.Outcome
 		})
@@ -73,7 +73,7 @@ func TestRefreshNow_RacingLazyResolves_SingleUpstreamCall(t *testing.T) {
 	}
 	for i, outcome := range outcomes {
 		require.Contains(t,
-			[]remotesessions.RefreshOutcome{remotesessions.RefreshOutcomeRefreshed, remotesessions.RefreshOutcomeAdoptedConcurrentWinner},
+			[]remotesessionmetrics.RefreshOutcome{remotesessionmetrics.RefreshOutcomeRefreshed, remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner},
 			outcome, "scheduled caller %d reported an unexpected outcome", i)
 	}
 

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 type failingAddCache struct {
@@ -44,7 +46,7 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
 	})
-	env.refresher = env.newRefresher(failingAddCache{Cache: cache.NoopCache})
+	env.refresher = env.newRefresher(testenv.NewMeterProvider(t), failingAddCache{Cache: cache.NoopCache})
 
 	session, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
 		SubjectUrn:            env.subject,
@@ -52,7 +54,7 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 	})
 	require.NoError(t, err)
 
-	result, err := env.refresher.RefreshNow(ctx, session, "")
+	result, err := env.refresher.RefreshNow(ctx, session, "", remotesessionmetrics.RefreshTriggerScheduled)
 	require.Error(t, err)
 	require.Empty(t, result.Outcome)
 	require.Empty(t, result.AccessToken)
@@ -161,7 +163,7 @@ func refreshNowAgainstUpstreamError(t *testing.T, slugSuffix string, status int,
 	})
 	require.NoError(t, err)
 
-	result, refreshErr := env.refresher.RefreshNow(ctx, session, "")
+	result, refreshErr := env.refresher.RefreshNow(ctx, session, "", remotesessionmetrics.RefreshTriggerScheduled)
 	require.Error(t, refreshErr)
 	require.Empty(t, result.Outcome)
 	require.Empty(t, result.AccessToken)

--- a/server/internal/remotesessions/refreshservice_metrics_test.go
+++ b/server/internal/remotesessions/refreshservice_metrics_test.go
@@ -1,0 +1,146 @@
+package remotesessions_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// A definitive invalid_grant records invalid_grant once with the issuer URL
+// and the caller's trigger, and the next attempt on the now-cleared grant
+// records no_grant without contacting the upstream: the AIS-616 signature the
+// dashboard expects to see. The failure error carries the same issuer and
+// outcome the metric recorded, so a log line can be joined to the series.
+func TestRefreshNow_RecordsInvalidGrantThenNoGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newSyntheticExpiryEnv(t, "refreshnow-metrics", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") != "refresh_token" {
+			_, _ = w.Write([]byte(`{"access_token":"expired-access","refresh_token":"dead-refresh"}`))
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Unknown or invalid refresh token."}`))
+	})
+
+	reader := sdkmetric.NewManualReader()
+	env.refresher = env.newRefresher(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)), cache.NoopCache)
+
+	session, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+
+	_, err = env.refresher.RefreshNow(ctx, session, "", remotesessionmetrics.RefreshTriggerScheduled)
+	var failure *remotesessions.RefreshError
+	require.ErrorAs(t, err, &failure)
+	require.Equal(t, "https://idp.example.com", failure.IssuerURL)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeInvalidGrant, failure.Outcome)
+	var tokenErr *remotesessions.TokenRefreshError
+	require.ErrorAs(t, err, &tokenErr, "the typed failure must not hide the operator-actionable cause")
+
+	cleared, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+	require.False(t, cleared.RefreshTokenEncrypted.Valid)
+
+	_, err = env.refresher.RefreshNow(ctx, cleared, "", remotesessionmetrics.RefreshTriggerManual)
+	require.ErrorIs(t, err, remotesessions.ErrNoValidToken, "the typed failure must not hide the no-grant sentinel")
+	require.ErrorAs(t, err, &failure)
+	require.Equal(t, "https://idp.example.com", failure.IssuerURL)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeNoGrant, failure.Outcome)
+
+	points := upstreamRefreshDataPoints(t, reader)
+	require.Len(t, points, 2)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.OAuthIssuer("https://idp.example.com"),
+		attr.OAuthRefreshTrigger(remotesessionmetrics.RefreshTriggerScheduled),
+		attr.Outcome(remotesessionmetrics.RefreshOutcomeInvalidGrant),
+	)])
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.OAuthIssuer("https://idp.example.com"),
+		attr.OAuthRefreshTrigger(remotesessionmetrics.RefreshTriggerManual),
+		attr.Outcome(remotesessionmetrics.RefreshOutcomeNoGrant),
+	)])
+}
+
+// A successful refresh records refreshed and hands the issuer URL back on the
+// result, the success-side counterpart of RefreshError.
+func TestRefreshNow_RecordsRefreshed(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newSyntheticExpiryEnv(t, "refreshnow-metrics-ok", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") != "refresh_token" {
+			_, _ = w.Write([]byte(`{"access_token":"expired-access","refresh_token":"live-refresh","expires_in":1}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"fresh-access","refresh_token":"rotated-refresh","expires_in":3600}`))
+	})
+
+	reader := sdkmetric.NewManualReader()
+	env.refresher = env.newRefresher(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)), cache.NoopCache)
+
+	result, err := env.refresher.RefreshNow(ctx, env.session, "", remotesessionmetrics.RefreshTriggerRequest)
+	require.NoError(t, err)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, "fresh-access", result.AccessToken)
+	require.Equal(t, "https://idp.example.com", result.IssuerURL)
+
+	points := upstreamRefreshDataPoints(t, reader)
+	require.Len(t, points, 1)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.OAuthIssuer("https://idp.example.com"),
+		attr.OAuthRefreshTrigger(remotesessionmetrics.RefreshTriggerRequest),
+		attr.Outcome(remotesessionmetrics.RefreshOutcomeRefreshed),
+	)])
+}
+
+// upstreamRefreshDataPoints drains the reader and returns the upstream-refresh
+// counter's data points keyed by their full attribute set, failing the test
+// when the instrument was never recorded.
+func upstreamRefreshDataPoints(t *testing.T, reader *sdkmetric.ManualReader) map[attribute.Set]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "gram.remote_session.upstream_refresh" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "upstream refresh instrument must be an int64 counter")
+			points := make(map[attribute.Set]int64, len(sum.DataPoints))
+			for _, dp := range sum.DataPoints {
+				points[dp.Attributes] = dp.Value
+			}
+			return points
+		}
+	}
+	t.Fatal("gram.remote_session.upstream_refresh was never recorded")
+	return nil
+}

--- a/server/internal/remotesessions/refreshservice_outcome_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_outcome_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,16 +14,24 @@ import (
 )
 
 // Pins the mapping from every failure shape RefreshNow can produce onto the
-// upstream-refresh metric's outcome set. The ordering matters at two points:
-// a canceled POST also carries the transport marker, and a 429 or 5xx must win
-// over whatever the body parsed to.
+// upstream-refresh metric's outcome set. The ordering matters at three
+// points: an aborted POST also carries the transport marker, a deadline is
+// the caller's own only when the caller's context has expired, and
+// invalid_grant wins over the 429 and 5xx buckets because the grant is
+// cleared on any status.
 func TestRefreshOutcomeForError(t *testing.T) {
 	t.Parallel()
 
+	expired, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
 	cases := []struct {
 		name string
-		err  error
-		want remotesessionmetrics.RefreshOutcome
+		// callerGone runs the case against a context whose own deadline has
+		// already passed, standing in for a caller that stopped waiting.
+		callerGone bool
+		err        error
+		want       remotesessionmetrics.RefreshOutcome
 	}{
 		{
 			name: "no refresh grant",
@@ -35,7 +44,13 @@ func TestRefreshOutcomeForError(t *testing.T) {
 			want: remotesessionmetrics.RefreshOutcomeCanceled,
 		},
 		{
-			name: "POST timed out",
+			name:       "caller's own deadline expired mid-POST",
+			callerGone: true,
+			err:        fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, context.DeadlineExceeded),
+			want:       remotesessionmetrics.RefreshOutcomeCanceled,
+		},
+		{
+			name: "POST's internal timeout with a live caller",
 			err:  fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, context.DeadlineExceeded),
 			want: remotesessionmetrics.RefreshOutcomeUnreachable,
 		},
@@ -61,11 +76,16 @@ func TestRefreshOutcomeForError(t *testing.T) {
 		},
 		{
 			name: "rate limited",
-			err:  newTokenRefreshErrorFromHTTP(http.StatusTooManyRequests, "429 Too Many Requests", []byte(`{"error":"invalid_grant"}`)),
+			err:  newTokenRefreshErrorFromHTTP(http.StatusTooManyRequests, "429 Too Many Requests", []byte(`{"error":"temporarily_unavailable"}`)),
 			want: remotesessionmetrics.RefreshOutcomeRateLimited,
 		},
 		{
-			name: "5xx wins over a parsed body",
+			name: "rate limited with no body",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusTooManyRequests, "429 Too Many Requests", nil),
+			want: remotesessionmetrics.RefreshOutcomeRateLimited,
+		},
+		{
+			name: "5xx with a parsed non-invalid_grant body",
 			err:  newTokenRefreshErrorFromHTTP(http.StatusServiceUnavailable, "503 Service Unavailable", []byte(`{"error":"temporarily_unavailable"}`)),
 			want: remotesessionmetrics.RefreshOutcomeUpstreamError,
 		},
@@ -82,6 +102,16 @@ func TestRefreshOutcomeForError(t *testing.T) {
 		{
 			name: "vendor-shaped invalid_grant",
 			err:  newTokenRefreshErrorFromHTTP(http.StatusBadRequest, "400 Bad Request", []byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`)),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+		{
+			name: "invalid_grant on a 429 still cleared the grant",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusTooManyRequests, "429 Too Many Requests", []byte(`{"error":"invalid_grant"}`)),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+		{
+			name: "invalid_grant on a 5xx still cleared the grant",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusInternalServerError, "500 Internal Server Error", []byte(`{"error":"invalid_grant"}`)),
 			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
 		},
 		{
@@ -102,6 +132,10 @@ func TestRefreshOutcomeForError(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		require.Equal(t, tc.want, refreshOutcomeForError(tc.err), tc.name)
+		ctx := t.Context()
+		if tc.callerGone {
+			ctx = expired
+		}
+		require.Equal(t, tc.want, refreshOutcomeForError(ctx, tc.err), tc.name)
 	}
 }

--- a/server/internal/remotesessions/refreshservice_outcome_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_outcome_internal_test.go
@@ -1,0 +1,107 @@
+package remotesessions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
+)
+
+// Pins the mapping from every failure shape RefreshNow can produce onto the
+// upstream-refresh metric's outcome set. The ordering matters at two points:
+// a canceled POST also carries the transport marker, and a 429 or 5xx must win
+// over whatever the body parsed to.
+func TestRefreshOutcomeForError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want remotesessionmetrics.RefreshOutcome
+	}{
+		{
+			name: "no refresh grant",
+			err:  ErrNoValidToken,
+			want: remotesessionmetrics.RefreshOutcomeNoGrant,
+		},
+		{
+			name: "caller canceled mid-POST",
+			err:  fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, context.Canceled),
+			want: remotesessionmetrics.RefreshOutcomeCanceled,
+		},
+		{
+			name: "POST timed out",
+			err:  fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, context.DeadlineExceeded),
+			want: remotesessionmetrics.RefreshOutcomeUnreachable,
+		},
+		{
+			name: "connection refused",
+			err:  fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, errors.New("dial tcp: connection refused")),
+			want: remotesessionmetrics.RefreshOutcomeUnreachable,
+		},
+		{
+			name: "database failure",
+			err:  errors.New("re-read active remote_session: connection reset"),
+			want: remotesessionmetrics.RefreshOutcomeInternalError,
+		},
+		{
+			name: "configuration error before the POST",
+			err:  newTokenRefreshError("the identity provider has no token endpoint configured", nil),
+			want: remotesessionmetrics.RefreshOutcomeInternalError,
+		},
+		{
+			name: "lost compare-and-swap after the POST",
+			err:  newTokenRefreshError("the session was rotated by another request", errRefreshNotApplied),
+			want: remotesessionmetrics.RefreshOutcomeInternalError,
+		},
+		{
+			name: "rate limited",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusTooManyRequests, "429 Too Many Requests", []byte(`{"error":"invalid_grant"}`)),
+			want: remotesessionmetrics.RefreshOutcomeRateLimited,
+		},
+		{
+			name: "5xx wins over a parsed body",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusServiceUnavailable, "503 Service Unavailable", []byte(`{"error":"temporarily_unavailable"}`)),
+			want: remotesessionmetrics.RefreshOutcomeUpstreamError,
+		},
+		{
+			name: "5xx with no body",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusBadGateway, "502 Bad Gateway", nil),
+			want: remotesessionmetrics.RefreshOutcomeUpstreamError,
+		},
+		{
+			name: "invalid_grant",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusBadRequest, "400 Bad Request", []byte(`{"error":"invalid_grant","error_description":"expired"}`)),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+		{
+			name: "vendor-shaped invalid_grant",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusBadRequest, "400 Bad Request", []byte(`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`)),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+		{
+			name: "parsed non-invalid_grant code",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusUnauthorized, "401 Unauthorized", []byte(`{"error":"invalid_client"}`)),
+			want: remotesessionmetrics.RefreshOutcomeRejected,
+		},
+		{
+			name: "unparsed 4xx body",
+			err:  newTokenRefreshErrorFromHTTP(http.StatusForbidden, "403 Forbidden", []byte(`<html>forbidden</html>`)),
+			want: remotesessionmetrics.RefreshOutcomeRejectedUnparsed,
+		},
+		{
+			name: "wrapped in context",
+			err:  fmt.Errorf("resolve access token: %w", newTokenRefreshErrorFromHTTP(http.StatusBadRequest, "400 Bad Request", []byte(`{"error":"invalid_grant"}`))),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, refreshOutcomeForError(tc.err), tc.name)
+	}
+}

--- a/server/internal/remotesessions/remotesessionmetrics/refresh.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh.go
@@ -1,0 +1,53 @@
+package remotesessionmetrics
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const meterUpstreamRefresh = "gram.remote_session.upstream_refresh"
+
+// Refresh holds the upstream-refresh instrument: an unsampled census of
+// refresh_token grant attempts against upstream identity providers, one count
+// per attempt by its outcome and by which caller triggered it.
+//
+// This is the steady-state session health signal the flow-level oauth.flow.*
+// counters do not cover: a session that connected fine and then silently
+// stopped refreshing shows up here and nowhere else.
+type Refresh struct {
+	attempts metric.Int64Counter
+}
+
+func NewRefresh(logger *slog.Logger, meterProvider metric.MeterProvider) *Refresh {
+	meter := meterProvider.Meter(meterScope)
+
+	attempts, err := meter.Int64Counter(
+		meterUpstreamRefresh,
+		metric.WithDescription("Upstream refresh_token grant attempts for Remote Sessions, by outcome and trigger. Counts attempts, not POSTs: concurrent callers single-flight and the losers record adopted_concurrent_winner."),
+		metric.WithUnit("{attempt}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterUpstreamRefresh), attr.SlogError(err))
+	}
+
+	return &Refresh{attempts: attempts}
+}
+
+// Record counts one refresh attempt by its outcome and trigger. The issuer
+// URL dimension names the actual upstream for platform administrators; empty
+// when the attempt died before the session's client and issuer rows could be
+// loaded.
+func (m *Refresh) Record(ctx context.Context, issuerURL string, trigger RefreshTrigger, outcome RefreshOutcome) {
+	if m == nil || m.attempts == nil {
+		return
+	}
+	m.attempts.Add(ctx, 1, metric.WithAttributes(
+		attr.OAuthIssuer(issuerURL),
+		attr.OAuthRefreshTrigger(trigger),
+		attr.Outcome(outcome),
+	))
+}

--- a/server/internal/remotesessions/remotesessionmetrics/refresh_outcome.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh_outcome.go
@@ -1,0 +1,84 @@
+package remotesessionmetrics
+
+// RefreshOutcome labels the upstream-refresh metric series. The values
+// partition every return from a refresh attempt, so a breakdown by outcome
+// accounts for every attempt, and they are also the outcome vocabulary the
+// remotesessions package hands back to callers and writes to logs, so a log
+// line can be joined to its metric series.
+//
+// Success and failure outcomes are kept apart from each other along the axis
+// a monitor cares about: whose fault it is. invalid_grant, rejected, and
+// rejected_unparsed are configuration or credential problems an operator can
+// act on; upstream_error, rate_limited, and unreachable are the upstream
+// having a bad minute; internal_error is a Gram bug; canceled is the caller
+// going away.
+type RefreshOutcome string
+
+const (
+	// RefreshOutcomeRefreshed: this caller executed the upstream refresh_token
+	// grant and persisted the rotated pair.
+	RefreshOutcomeRefreshed RefreshOutcome = "refreshed"
+
+	// RefreshOutcomeAdoptedConcurrentWinner: another caller refreshed the row
+	// while this one was acquiring or POSTing; its persisted token was adopted
+	// and no (or a losing) upstream call was made by this caller. N racing
+	// callers therefore record one refreshed and N-1 of these, so a sum over
+	// outcomes counts attempts, not upstream POSTs.
+	RefreshOutcomeAdoptedConcurrentWinner RefreshOutcome = "adopted_concurrent_winner"
+
+	// RefreshOutcomeSessionInactive: the row was revoked or deleted before the
+	// refresh could run. Not an error, there is simply nothing to refresh. Kept
+	// apart from no_grant so a monitor on no_grant is not polluted by
+	// revocations.
+	RefreshOutcomeSessionInactive RefreshOutcome = "session_inactive"
+
+	// RefreshOutcomeNoGrant: no upstream call was made because the session
+	// holds no refresh grant, the grant was already cleared by an earlier
+	// invalid_grant, or the grant is past its own expiry.
+	RefreshOutcomeNoGrant RefreshOutcome = "no_grant"
+
+	// RefreshOutcomeInvalidGrant: the upstream definitively rejected the grant
+	// (RFC 6749 §5.2 invalid_grant, including the vendor bodies the oautherr
+	// package recognizes) and the dead grant was cleared. Subsequent attempts
+	// on the same session record no_grant.
+	RefreshOutcomeInvalidGrant RefreshOutcome = "invalid_grant"
+
+	// RefreshOutcomeRejected: a non-5xx response whose body parsed to an RFC
+	// 6749 §5.2 code other than invalid_grant, such as invalid_client or
+	// unauthorized_client. Operator-actionable configuration errors; the grant
+	// is kept.
+	RefreshOutcomeRejected RefreshOutcome = "rejected"
+
+	// RefreshOutcomeRejectedUnparsed: a non-5xx response whose body carried no
+	// recognizable error, so nothing definitive can be concluded and the grant
+	// is kept. A sustained non-zero rate names an upstream whose error body
+	// the oautherr package does not yet recognize.
+	RefreshOutcomeRejectedUnparsed RefreshOutcome = "rejected_unparsed"
+
+	// RefreshOutcomeUpstreamError: any 5xx, regardless of body. Status wins
+	// over a parsed server_error or temporarily_unavailable body because the
+	// signal is the same either way: the upstream, not Gram's configuration,
+	// is at fault.
+	RefreshOutcomeUpstreamError RefreshOutcome = "upstream_error"
+
+	// RefreshOutcomeRateLimited: the upstream returned HTTP 429. The scheduled
+	// sweep stops contacting that provider for the rest of its pass.
+	RefreshOutcomeRateLimited RefreshOutcome = "rate_limited"
+
+	// RefreshOutcomeUnreachable: the request never produced an answer (DNS,
+	// TLS, connection refused, or the refresh POST's own timeout).
+	RefreshOutcomeUnreachable RefreshOutcome = "unreachable"
+
+	// RefreshOutcomeCanceled: the caller's context was canceled while the
+	// attempt was in flight, most often an MCP client disconnecting mid-refresh
+	// or a worker shutting down. Its own outcome so that neither unreachable
+	// (upstream health) nor internal_error (Gram faults) absorbs routine
+	// client disconnects.
+	RefreshOutcomeCanceled RefreshOutcome = "canceled"
+
+	// RefreshOutcomeInternalError: Gram could not build or persist the request.
+	// No token endpoint configured, an unreadable stored token or secret, an
+	// invalid client authentication method, an empty upstream response, a
+	// database or encryption failure, or a lost compare-and-swap on persist.
+	RefreshOutcomeInternalError RefreshOutcome = "internal_error"
+)

--- a/server/internal/remotesessions/remotesessionmetrics/refresh_outcome.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh_outcome.go
@@ -40,7 +40,9 @@ const (
 	// RefreshOutcomeInvalidGrant: the upstream definitively rejected the grant
 	// (RFC 6749 §5.2 invalid_grant, including the vendor bodies the oautherr
 	// package recognizes) and the dead grant was cleared. Subsequent attempts
-	// on the same session record no_grant.
+	// on the same session record no_grant. Recorded on any HTTP status,
+	// because the grant is cleared on any status: the outcome describes what
+	// Gram did, not the response class.
 	RefreshOutcomeInvalidGrant RefreshOutcome = "invalid_grant"
 
 	// RefreshOutcomeRejected: a non-5xx response whose body parsed to an RFC
@@ -55,25 +57,26 @@ const (
 	// the oautherr package does not yet recognize.
 	RefreshOutcomeRejectedUnparsed RefreshOutcome = "rejected_unparsed"
 
-	// RefreshOutcomeUpstreamError: any 5xx, regardless of body. Status wins
-	// over a parsed server_error or temporarily_unavailable body because the
-	// signal is the same either way: the upstream, not Gram's configuration,
-	// is at fault.
+	// RefreshOutcomeUpstreamError: a 5xx that did not carry invalid_grant. A
+	// parsed server_error or temporarily_unavailable body lands here too, as
+	// the signal is the same either way: the upstream, not Gram's
+	// configuration, is at fault.
 	RefreshOutcomeUpstreamError RefreshOutcome = "upstream_error"
 
-	// RefreshOutcomeRateLimited: the upstream returned HTTP 429. The scheduled
-	// sweep stops contacting that provider for the rest of its pass.
+	// RefreshOutcomeRateLimited: the upstream returned HTTP 429 without
+	// invalid_grant. The scheduled sweep stops contacting that provider for
+	// the rest of its pass.
 	RefreshOutcomeRateLimited RefreshOutcome = "rate_limited"
 
 	// RefreshOutcomeUnreachable: the request never produced an answer (DNS,
 	// TLS, connection refused, or the refresh POST's own timeout).
 	RefreshOutcomeUnreachable RefreshOutcome = "unreachable"
 
-	// RefreshOutcomeCanceled: the caller's context was canceled while the
-	// attempt was in flight, most often an MCP client disconnecting mid-refresh
-	// or a worker shutting down. Its own outcome so that neither unreachable
-	// (upstream health) nor internal_error (Gram faults) absorbs routine
-	// client disconnects.
+	// RefreshOutcomeCanceled: the caller's context was canceled or hit its
+	// own deadline while the attempt was in flight, most often an MCP client
+	// disconnecting mid-refresh or a worker activity timing out. Its own
+	// outcome so that neither unreachable (upstream health) nor
+	// internal_error (Gram faults) absorbs routine client disconnects.
 	RefreshOutcomeCanceled RefreshOutcome = "canceled"
 
 	// RefreshOutcomeInternalError: Gram could not build or persist the request.

--- a/server/internal/remotesessions/remotesessionmetrics/refresh_test.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-// Pins the wiring a noop meter cannot see: the instrument name and the three
-// attribute keys the dashboard and the AIS-618 monitors query by.
+// Pins the wiring a noop meter cannot see: the instrument name, the three
+// attribute keys the dashboard and the AIS-618 monitors query by, and that
+// one Record is exactly one count.
 func TestRefreshRecord_PinsInstrumentAndDimensions(t *testing.T) {
 	t.Parallel()
 
@@ -35,6 +36,11 @@ func TestRefreshRecord_PinsInstrumentAndDimensions(t *testing.T) {
 		attr.OAuthRefreshTrigger(RefreshTriggerScheduled),
 		attr.Outcome(RefreshOutcomeInvalidGrant),
 	)
+
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "upstream refresh instrument must be an int64 counter")
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(1), sum.DataPoints[0].Value)
 }
 
 // A nil receiver and a nil instrument both degrade to no-ops rather than

--- a/server/internal/remotesessions/remotesessionmetrics/refresh_test.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh_test.go
@@ -1,0 +1,50 @@
+package remotesessionmetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// Pins the wiring a noop meter cannot see: the instrument name and the three
+// attribute keys the dashboard and the AIS-618 monitors query by.
+func TestRefreshRecord_PinsInstrumentAndDimensions(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m := NewRefresh(testenv.NewLogger(t), provider)
+	m.Record(t.Context(), "https://idp.example.com/tenant-a", RefreshTriggerScheduled, RefreshOutcomeInvalidGrant)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+
+	got := rm.ScopeMetrics[0].Metrics[0]
+	require.Equal(t, meterUpstreamRefresh, got.Name)
+	metricdatatest.AssertHasAttributes(t, got,
+		attr.OAuthIssuer("https://idp.example.com/tenant-a"),
+		attr.OAuthRefreshTrigger(RefreshTriggerScheduled),
+		attr.Outcome(RefreshOutcomeInvalidGrant),
+	)
+}
+
+// A nil receiver and a nil instrument both degrade to no-ops rather than
+// panicking, per the package convention.
+func TestRefreshRecord_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var m *Refresh
+	m.Record(t.Context(), "https://idp.example.com", RefreshTriggerRequest, RefreshOutcomeRefreshed)
+
+	empty := &Refresh{attempts: nil}
+	empty.Record(t.Context(), "https://idp.example.com", RefreshTriggerRequest, RefreshOutcomeRefreshed)
+}

--- a/server/internal/remotesessions/remotesessionmetrics/refresh_trigger.go
+++ b/server/internal/remotesessions/remotesessionmetrics/refresh_trigger.go
@@ -1,0 +1,20 @@
+package remotesessionmetrics
+
+// RefreshTrigger names which caller initiated an upstream refresh attempt.
+type RefreshTrigger string
+
+const (
+	// RefreshTriggerRequest: the lazy path, where an MCP request found the
+	// stored access token expired and refreshed it inline. Every consumer of
+	// the token resolver records here, so Platform MCP readiness probes and
+	// the assistant runtime's token resolution count alongside MCP traffic.
+	RefreshTriggerRequest RefreshTrigger = "request"
+
+	// RefreshTriggerScheduled: the background worker's pre-emptive refresh
+	// sweep.
+	RefreshTriggerScheduled RefreshTrigger = "scheduled"
+
+	// RefreshTriggerManual: a person clicked refresh, on the consent page or
+	// in the organization admin view.
+	RefreshTriggerManual RefreshTrigger = "manual"
+)

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -117,7 +117,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		guardianPolicy,
 		audit.NewLogger(),
 		serverURL,
-		remotesessions.NewRefreshService(logger, conn, enc, guardianPolicy, redisCache),
+		remotesessions.NewRefreshService(logger, testenv.NewMeterProvider(t), conn, enc, guardianPolicy, redisCache),
 	)
 
 	return ctx, &testInstance{

--- a/server/internal/remotesessions/sharedcredential_test.go
+++ b/server/internal/remotesessions/sharedcredential_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -221,7 +222,7 @@ func TestRefreshRemoteSession_SiblingIssuerRefreshesSharedCredential(t *testing.
 
 	result, err := newDisconnectChallengeManager(t, ti).RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, sibling, clientID)
 	require.NoError(t, err, "a sibling issuer bound to the same client must be able to refresh the shared credential")
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "sibling-refreshed-access", result.AccessToken)
 
 	stored, err := repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
@@ -257,7 +258,7 @@ func TestRefreshRemoteSession_OrgLevelClientBindingAuthorizes(t *testing.T) {
 
 	result, err := mgr.RefreshRemoteSession(ctx, subject, *authCtx.ProjectID, authCtx.ActiveOrganizationID, usi, clientID)
 	require.NoError(t, err, "the org-level client arm of the binding probe must authorize the refresh")
-	require.Equal(t, remotesessions.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
 	require.Equal(t, "org-refreshed-access", result.AccessToken)
 
 	// The re-scoped lifecycle queries carry the same org arm: a write through

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -8,6 +8,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oautherr"
 )
 
+// errRefreshUpstreamUnreachable marks a refresh POST that never produced an
+// answer: DNS, TLS, connection refused, or the POST's own timeout. It is
+// wrapped alongside the transport error so the refresh outcome classifier can
+// tell an unreachable upstream from a Gram-side failure without inspecting
+// error text.
+var errRefreshUpstreamUnreachable = errors.New("remotesessions: upstream token endpoint unreachable")
+
 // TokenRefreshError is an operator-actionable failure of a token refresh: a
 // condition the caller can understand and act on (revoke and re-link the
 // session, fix the issuer's configuration) rather than an internal Gram fault.

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -45,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -186,18 +187,29 @@ func (m *ChallengeManager) resolveUpstreamToken(
 		// above). Both collapse to the same empty-token signal downstream and
 		// then to a byte-identical 401, so log the reason here — using the
 		// public-safe TokenRefreshError.Reason when present — instead of
-		// discarding it silently.
+		// discarding it silently. The issuer URL and outcome are the ones the
+		// upstream-refresh metric recorded, so this line joins to its series;
+		// the user id is what lets "how many users are affected" be answered,
+		// since a client id is one row per provider connection, not per user.
 		reason := "upstream token refresh failed"
 		var refreshErr *TokenRefreshError
 		if errors.As(err, &refreshErr) {
 			reason = refreshErr.Reason
 		}
-		m.logger.WarnContext(ctx, "remote session unusable: upstream token refresh failed",
+		args := []any{
 			attr.SlogRemoteSessionClientID(clientID.String()),
 			attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
 			attr.SlogOAuthFailureReason(reason),
 			attr.SlogError(err),
-		)
+		}
+		var failure *RefreshError
+		if errors.As(err, &failure) {
+			args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
+		}
+		if subject.Kind == urn.SessionSubjectKindUser {
+			args = append(args, attr.SlogUserID(subject.ID))
+		}
+		m.logger.WarnContext(ctx, "remote session unusable: upstream token refresh failed", args...)
 		return zero, nil
 	}
 
@@ -432,11 +444,11 @@ func (m *ChallengeManager) validateAndRefresh(
 		return "", sess, ErrNoValidToken
 	}
 
-	res, err := m.refresher.RefreshNow(ctx, sess, resource)
+	res, err := m.refresher.RefreshNow(ctx, sess, resource, remotesessionmetrics.RefreshTriggerRequest)
 	if err != nil {
 		return "", sess, err
 	}
-	// RefreshOutcomeSessionInactive lands here as an empty token, which the
+	// remotesessionmetrics.RefreshOutcomeSessionInactive lands here as an empty token, which the
 	// caller treats the same as "never linked".
 	return res.AccessToken, res.Session, nil
 }
@@ -445,10 +457,10 @@ func (m *ChallengeManager) validateAndRefresh(
 // endpoint and persists the new token pair on success, returning the updated
 // remote_session row and the new plaintext access token.
 //
-// It is shared by the lazy MCP resolution path (ChallengeManager) and the
-// explicit org-admin refresh handler. The upstream token POST is an external
-// call, so q must be a pool-bound querier, never a transaction-bound one — the
-// POST must not run inside an open database transaction.
+// RefreshService.RefreshNow is its only caller and supplies the session's
+// client + issuer row it already loaded. The upstream token POST is an
+// external call, so q must be a pool-bound querier, never a transaction-bound
+// one — the POST must not run inside an open database transaction.
 //
 // Operator-actionable failures (unreadable stored token, missing token
 // endpoint, an upstream rejection, no access token returned) come back as a
@@ -459,15 +471,12 @@ func refreshSessionTokens(
 	q *remotesessions_repo.Queries,
 	enc *encryption.Client,
 	policy *guardian.Policy,
+	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow,
 	sess remotesessions_repo.RemoteSession,
 	resource string,
 ) (remotesessions_repo.RemoteSession, string, error) {
 	var zero remotesessions_repo.RemoteSession
 
-	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
-	if err != nil {
-		return zero, "", fmt.Errorf("load remote_session_client for refresh: %w", err)
-	}
 	if !client.TokenEndpoint.Valid || client.TokenEndpoint.String == "" {
 		return zero, "", newTokenRefreshError("the identity provider has no token endpoint configured", nil)
 	}
@@ -512,7 +521,7 @@ func refreshSessionTokens(
 
 	resp, err := policy.PooledClient().Do(req)
 	if err != nil {
-		return zero, "", fmt.Errorf("post refresh: %w", err)
+		return zero, "", fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, err)
 	}
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -457,10 +457,11 @@ func (m *ChallengeManager) validateAndRefresh(
 // endpoint and persists the new token pair on success, returning the updated
 // remote_session row and the new plaintext access token.
 //
-// RefreshService.RefreshNow is its only caller and supplies the session's
-// client + issuer row it already loaded. The upstream token POST is an
-// external call, so q must be a pool-bound querier, never a transaction-bound
-// one — the POST must not run inside an open database transaction.
+// RefreshService is its only caller and supplies the session's client +
+// issuer row, read after the single-flight lock so the POST runs on current
+// configuration. The upstream token POST is an external call, so q must be a
+// pool-bound querier, never a transaction-bound one — the POST must not run
+// inside an open database transaction.
 //
 // Operator-actionable failures (unreadable stored token, missing token
 // endpoint, an upstream rejection, no access token returned) come back as a

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -404,7 +404,7 @@ func TestRemoteSessionRefreshActivity_SweepBackfillsNullResource(t *testing.T) {
 
 	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
 	require.NoError(t, err)
-	refresher := remotesessions.NewRefreshService(testenv.NewLogger(t), ti.conn, testenv.NewEncryptionClient(t), policy, cache.NoopCache)
+	refresher := remotesessions.NewRefreshService(testenv.NewLogger(t), testenv.NewMeterProvider(t), ti.conn, testenv.NewEncryptionClient(t), policy, cache.NoopCache)
 	activity := activities.NewRemoteSessionRefresh(testenv.NewLogger(t), ti.conn, refresher)
 
 	res, err := activity.Do(ctx, activities.RefreshRemoteSessionInput{


### PR DESCRIPTION
Resolves https://linear.app/speakeasy/issue/AIS-617/feat-emit-metrics-for-upstream-remote-session-refresh-outcomes-and

## Summary

`gram.remote_session.upstream_refresh` counts every `RefreshService.RefreshNow` call by issuer URL, trigger (`request`, `scheduled`, `manual`), and a twelve-value outcome (`refreshed`, `adopted_concurrent_winner`, `session_inactive`, `no_grant`, `invalid_grant`, `rejected`, `rejected_unparsed`, `upstream_error`, `rate_limited`, `unreachable`, `canceled`, `internal_error`). `RefreshNow` loads the client and issuer row before the single-flight lock so early exits carry the issuer, records exactly once through an outer wrapper, and returns failures as `*RefreshError` carrying the same issuer and outcome while wrapping the cause, so `errors.Is` and `errors.As` keep working. The transport error is marked so `unreachable` is classifiable, with context cancellation checked first so client disconnects land in `canceled` rather than polluting upstream health.

`mcp.request.rejected` counts requests the issuer gate turns away before dispatch, by failure reason (the existing closed set plus `no_credentials` for the unauthenticated handshake probe), server URL, and surface. The URL is rebuilt from the resolved endpoint's route and slug rather than the raw request URL: the counter records before authentication, where a query string any caller can vary would mint series.

The gate rejection logs gain `gram.toolset.mcp_slug` and `gram.mcp.url`; the lazy-path and scheduled refresh failure logs gain `gram.oauth.issuer`, `gram.outcome`, and the subject's user id.

Monitors on these instruments are deliberately out of scope (AIS-618), as is repointing the MCP Sessions dashboard, which should happen once the metrics are emitting in production.

## Motivation

Two failure sites were log-only: the upstream `refresh_token` grant in `remotesessions` and the Session OAuth authentication gate in `mcp`. Roughly half of one customer's MCP requests were rejected with 401 for two weeks without anything alerting (AIS-616). The existing metrics cover the front of the flow (`oauth.flow.*`, `gram.remote_session.upstream_authorize`, `gram.remote_session.upstream_revoke`) but not steady-state session health, and the `mcp.request` census is recorded only after the gate has passed a request, so rejected traffic was absent from every metric.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `gram.remote_session.upstream_refresh` and `mcp.request.rejected` to make upstream refresh outcomes and MCP gate rejections visible and attributable. Previously these were log-only; now we can segment by issuer/server, trigger, and reason to satisfy AIS-617.

- Adds `gram.remote_session.upstream_refresh` (counter) recording every `RefreshService.RefreshNow` attempt by `gram.oauth.issuer`, `gram.oauth.refresh_trigger` (`request|scheduled|manual`), and a closed outcome set (`refreshed`, `adopted_concurrent_winner`, `session_inactive`, `no_grant`, `invalid_grant`, `rejected`, `rejected_unparsed`, `upstream_error`, `rate_limited`, `unreachable`, `canceled`, `internal_error`). `RefreshNow` records exactly once, loads issuer pre-lock so early exits carry it, and returns `*RefreshError` that wraps the cause and carries `issuer` and `outcome`.
- Adds `mcp.request.rejected` (counter) in `@mcpmetrics` for issuer-gate rejections by `gram.oauth.failure_reason` (closed set plus `no_credentials`), `gram.mcp.url` (rebuilt from route/slug), and `gram.mcp.surface`.
- Enriches logs: issuer-gate rejections now include `gram.toolset.mcp_slug` and `gram.mcp.url`; refresh failures include `gram.oauth.issuer`, `gram.outcome`, and the subject user id. Context cancellations classify as `canceled`; transport failures as `unreachable`.

**Reviewer notes and required changes**
- Callers must construct `remotesessions.NewRefreshService(logger, meterProvider, ...)` and pass a `remotesessionmetrics.RefreshTrigger` to `RefreshNow(...)`.
- Outcome constants now live in `remotesessions/remotesessionmetrics`; use `attr.OAuthRefreshTrigger` where labeling triggers.
- No monitors ship in this PR (tracked in AIS-618).

<sup>Written for commit 7f8eb91c6159b1f84c6180b05dcfdc3b1e7e9417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

