### PR TITLE
chore: centralize risk exclusion administration

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1651,7 +1651,7 @@ func newStartCommand() *cli.Command {
 
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantChatsTools(chatService)...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantUsersTools(organizationsService)...)
-			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantRiskTools(riskService)...)
+			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantRiskTools(riskService, c.String(usersessions.JWTSigningKeyFlag))...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantDeploymentsTools(deploymentsService)...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantSkillsTools(skillsService, telemetryrepo.New(chDB))...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantPluginsTools(pluginsSvc)...)

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion.go
@@ -8,11 +8,13 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/risk"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
 type CreateRiskExclusion struct {
-	risk RiskService
+	risk     RiskService
+	redactor exclusioncore.Redactor
 }
 
 type createRiskExclusionInput struct {
@@ -24,8 +26,8 @@ type createRiskExclusionInput struct {
 	Enabled      *bool   `json:"enabled,omitempty" jsonschema:"Whether the exclusion is active. Defaults to true."`
 }
 
-func NewCreateRiskExclusionTool(riskSvc RiskService) *CreateRiskExclusion {
-	return &CreateRiskExclusion{risk: riskSvc}
+func NewCreateRiskExclusionTool(riskSvc RiskService, redactionKey string) *CreateRiskExclusion {
+	return &CreateRiskExclusion{risk: riskSvc, redactor: exclusioncore.NewRedactor(redactionKey)}
 }
 
 func (s *CreateRiskExclusion) Descriptor() core.ToolDescriptor {
@@ -147,7 +149,7 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 		return err
 	}
 	if existing != nil {
-		return core.EncodeResult(wr, toExclusionView(existing))
+		return core.EncodeResult(wr, toExclusionView(s.redactor, existing))
 	}
 
 	result, err := s.risk.CreateRiskExclusion(ctx, &risk.CreateRiskExclusionPayload{
@@ -167,5 +169,5 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 
 	// Same view as the listing so the two tools agree on shape. The model
 	// supplied this match_value itself, so nothing new is hidden from it.
-	return core.EncodeResult(wr, toExclusionView(result))
+	return core.EncodeResult(wr, toExclusionView(s.redactor, result))
 }

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
@@ -68,7 +68,7 @@ func callCreate(t *testing.T, svc RiskService, payload string) exclusionView {
 	t.Helper()
 
 	var out bytes.Buffer
-	err := NewCreateRiskExclusionTool(svc).Call(t.Context(), toolconfig.ToolCallEnv{}, strings.NewReader(payload), &out)
+	err := NewCreateRiskExclusionTool(svc, "test-redaction-key").Call(t.Context(), toolconfig.ToolCallEnv{}, strings.NewReader(payload), &out)
 	require.NoError(t, err)
 
 	var view exclusionView

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions.go
@@ -8,17 +8,16 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/risk"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
 // exclusionView is the model-facing shape of an exclusion. For the free-text
 // match types, match_value is the literal string the author wanted suppressed —
 // often the very secret or email that triggered the finding — so it is replaced
-// with a fixed marker for the same reason the risk service redacts it in audit
-// snapshots, and the same reason listRiskResultsForAgent exists at all. The
-// remaining match types and both filters are rule/source identifiers, not
-// captured content, so they stay readable: without them the model cannot tell
-// what an exclusion covers.
+// with a project-scoped keyed fingerprint. The remaining match types and both
+// filters are rule/source identifiers, not captured content, so they stay
+// readable: without them the model cannot tell what an exclusion covers.
 type exclusionView struct {
 	ID           string  `json:"id"`
 	RiskPolicyID *string `json:"risk_policy_id,omitempty"`
@@ -35,24 +34,22 @@ type listRiskExclusionsResult struct {
 	Exclusions []exclusionView `json:"exclusions"`
 }
 
-// redactMatchValue mirrors the risk service's fixed audit redaction so low-
-// entropy values cannot be recovered with an offline dictionary.
-func redactMatchValue(matchType, matchValue string) string {
+func redactMatchValue(redactor exclusioncore.Redactor, projectID, matchType, matchValue string) string {
 	if matchType != "exact" && matchType != "regex" {
 		return matchValue
 	}
 	if matchValue == "" {
 		return ""
 	}
-	return "<redacted>"
+	return redactor.Redact(projectID, "match_value", matchValue)
 }
 
-func toExclusionView(exclusion *types.RiskExclusion) exclusionView {
+func toExclusionView(redactor exclusioncore.Redactor, exclusion *types.RiskExclusion) exclusionView {
 	return exclusionView{
 		ID:           exclusion.ID,
 		RiskPolicyID: exclusion.RiskPolicyID,
 		MatchType:    exclusion.MatchType,
-		MatchValue:   redactMatchValue(exclusion.MatchType, exclusion.MatchValue),
+		MatchValue:   redactMatchValue(redactor, exclusion.ProjectID, exclusion.MatchType, exclusion.MatchValue),
 		RuleIDFilter: exclusion.RuleIDFilter,
 		SourceFilter: exclusion.SourceFilter,
 		Enabled:      exclusion.Enabled,
@@ -62,15 +59,16 @@ func toExclusionView(exclusion *types.RiskExclusion) exclusionView {
 }
 
 type ListRiskExclusions struct {
-	risk RiskService
+	risk     RiskService
+	redactor exclusioncore.Redactor
 }
 
 type listRiskExclusionsInput struct {
 	RiskPolicyID *string `json:"risk_policy_id,omitempty" jsonschema:"Only return exclusions bound to this policy ID. Omit to return every exclusion in the project (global plus policy-bound)."`
 }
 
-func NewListRiskExclusionsTool(riskSvc RiskService) *ListRiskExclusions {
-	return &ListRiskExclusions{risk: riskSvc}
+func NewListRiskExclusionsTool(riskSvc RiskService, redactionKey string) *ListRiskExclusions {
+	return &ListRiskExclusions{risk: riskSvc, redactor: exclusioncore.NewRedactor(redactionKey)}
 }
 
 func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
@@ -78,7 +76,7 @@ func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
 		SourceSlug:  "risk",
 		HandlerName: "list_risk_exclusions",
 		Name:        "platform_list_risk_exclusions",
-		Description: "List the risk exclusions configured for the current project. For exact and regex exclusions the match_value is replaced with a fixed redaction marker so suppressed secret content never enters the model context; create_risk_exclusion performs equivalence checks server-side.",
+		Description: "List the risk exclusions configured for the current project. For exact and regex exclusions, match_value is replaced with a stable project-scoped keyed fingerprint so suppressed secret content never enters the model context.",
 		InputSchema: core.BuildInputSchema[listRiskExclusionsInput](
 			core.WithPropertyFormat("risk_policy_id", "uuid"),
 		),
@@ -112,7 +110,7 @@ func (s *ListRiskExclusions) Call(ctx context.Context, _ toolconfig.ToolCallEnv,
 
 	views := make([]exclusionView, 0, len(result.Exclusions))
 	for _, exclusion := range result.Exclusions {
-		views = append(views, toExclusionView(exclusion))
+		views = append(views, toExclusionView(s.redactor, exclusion))
 	}
 
 	return core.EncodeResult(wr, listRiskExclusionsResult{Exclusions: views})

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions.go
@@ -78,7 +78,7 @@ func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
 		SourceSlug:  "risk",
 		HandlerName: "list_risk_exclusions",
 		Name:        "platform_list_risk_exclusions",
-		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists. For exact and regex exclusions the match_value is replaced with a fixed redaction marker so suppressed secret content never enters the model context.",
+		Description: "List the risk exclusions configured for the current project. For exact and regex exclusions the match_value is replaced with a fixed redaction marker so suppressed secret content never enters the model context; create_risk_exclusion performs equivalence checks server-side.",
 		InputSchema: core.BuildInputSchema[listRiskExclusionsInput](
 			core.WithPropertyFormat("risk_policy_id", "uuid"),
 		),

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions.go
@@ -2,8 +2,6 @@ package risk
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -15,8 +13,8 @@ import (
 
 // exclusionView is the model-facing shape of an exclusion. For the free-text
 // match types, match_value is the literal string the author wanted suppressed —
-// often the very secret or email that triggered the finding — so it is
-// fingerprinted here for the same reason the risk service redacts it in audit
+// often the very secret or email that triggered the finding — so it is replaced
+// with a fixed marker for the same reason the risk service redacts it in audit
 // snapshots, and the same reason listRiskResultsForAgent exists at all. The
 // remaining match types and both filters are rule/source identifiers, not
 // captured content, so they stay readable: without them the model cannot tell
@@ -37,8 +35,8 @@ type listRiskExclusionsResult struct {
 	Exclusions []exclusionView `json:"exclusions"`
 }
 
-// redactMatchValue mirrors the risk service's audit-snapshot fingerprint so the
-// same exclusion reads identically in both places.
+// redactMatchValue mirrors the risk service's fixed audit redaction so low-
+// entropy values cannot be recovered with an offline dictionary.
 func redactMatchValue(matchType, matchValue string) string {
 	if matchType != "exact" && matchType != "regex" {
 		return matchValue
@@ -46,8 +44,7 @@ func redactMatchValue(matchType, matchValue string) string {
 	if matchValue == "" {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(matchValue))
-	return "redacted:sha256:" + hex.EncodeToString(sum[:])[:12]
+	return "<redacted>"
 }
 
 func toExclusionView(exclusion *types.RiskExclusion) exclusionView {
@@ -81,7 +78,7 @@ func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
 		SourceSlug:  "risk",
 		HandlerName: "list_risk_exclusions",
 		Name:        "platform_list_risk_exclusions",
-		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists. For exact and regex exclusions the match_value is a stable sha256 fingerprint rather than the literal pattern, so suppressed secret content never enters the model context.",
+		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists. For exact and regex exclusions the match_value is replaced with a fixed redaction marker so suppressed secret content never enters the model context.",
 		InputSchema: core.BuildInputSchema[listRiskExclusionsInput](
 			core.WithPropertyFormat("risk_policy_id", "uuid"),
 		),

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
@@ -47,7 +47,7 @@ func TestExclusionViewRedactsOnlyFreeTextMatchValues(t *testing.T) {
 
 			if tt.redacted {
 				require.NotContains(t, view.MatchValue, secret)
-				require.Contains(t, view.MatchValue, "redacted:sha256:")
+				require.Equal(t, "<redacted>", view.MatchValue)
 			} else {
 				require.Equal(t, secret, view.MatchValue)
 			}

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 )
 
 // An exact or regex exclusion's match_value is the literal string someone chose
@@ -27,12 +28,13 @@ func TestExclusionViewRedactsOnlyFreeTextMatchValues(t *testing.T) {
 	}
 
 	const secret = "AKIAIOSFODNN7EXAMPLE"
+	redactor := exclusioncore.NewRedactor("test-redaction-key")
 
 	for _, tt := range tests {
 		t.Run(tt.matchType, func(t *testing.T) {
 			t.Parallel()
 
-			view := toExclusionView(&types.RiskExclusion{
+			view := toExclusionView(redactor, &types.RiskExclusion{
 				ID:           "0192bd2a-0000-7000-8000-000000000000",
 				ProjectID:    "0192bd2a-0000-7000-8000-000000000001",
 				RiskPolicyID: nil,
@@ -47,7 +49,7 @@ func TestExclusionViewRedactsOnlyFreeTextMatchValues(t *testing.T) {
 
 			if tt.redacted {
 				require.NotContains(t, view.MatchValue, secret)
-				require.Equal(t, "<redacted>", view.MatchValue)
+				require.Regexp(t, `^redacted:hmac-sha256:[0-9a-f]{16}$`, view.MatchValue)
 			} else {
 				require.Equal(t, secret, view.MatchValue)
 			}

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -194,15 +194,15 @@ func ManagedAssistantUsersTools(orgSvc platformusers.OrganizationsService) []pla
 // content never reaches the model context. The exclusion and false-positive
 // tools mutate project state; the risk service gates them on org admin and
 // audits the invoking user as the actor.
-func ManagedAssistantRiskTools(riskSvc platformrisk.RiskService) []platformtools.ExternalTool {
+func ManagedAssistantRiskTools(riskSvc platformrisk.RiskService, redactionKey string) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformrisk.NewListRiskPoliciesTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskResultsForAgentTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskResultsByChatTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewGetRiskPolicyStatusTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewGetRiskRuleBreakdownTool(riskSvc), RequiredFeature: ""},
-		{Executor: platformrisk.NewListRiskExclusionsTool(riskSvc), RequiredFeature: ""},
-		{Executor: platformrisk.NewCreateRiskExclusionTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewListRiskExclusionsTool(riskSvc, redactionKey), RequiredFeature: ""},
+		{Executor: platformrisk.NewCreateRiskExclusionTool(riskSvc, redactionKey), RequiredFeature: ""},
 		{Executor: platformrisk.NewMarkRiskResultsFalsePositiveTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewUnmarkRiskResultsFalsePositiveTool(riskSvc), RequiredFeature: ""},
 	}

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -88,7 +88,7 @@ func TestManagedAssistantUsersToolsExposesCatalog(t *testing.T) {
 func TestManagedAssistantRiskToolsExposesCatalog(t *testing.T) {
 	t.Parallel()
 
-	got := toolNames(ManagedAssistantRiskTools(nil))
+	got := toolNames(ManagedAssistantRiskTools(nil, "test-redaction-key"))
 	require.ElementsMatch(t, []string{
 		"platform_list_risk_policies",
 		"platform_list_risk_results_for_agent",
@@ -111,7 +111,7 @@ func TestManagedAssistantToolNamesFitProviderLimit(t *testing.T) {
 
 	const maxNameLen = 40
 
-	tools := ManagedAssistantRiskTools(nil)
+	tools := ManagedAssistantRiskTools(nil, "test-redaction-key")
 	tools = append(tools, ManagedAssistantLogsTools(nil)...)
 	tools = append(tools, ManagedAssistantChatsTools(nil)...)
 	tools = append(tools, ManagedAssistantUsersTools(nil)...)

--- a/server/internal/risk/exclusion.go
+++ b/server/internal/risk/exclusion.go
@@ -2,30 +2,19 @@ package risk
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"regexp"
-	"time"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	gen "github.com/speakeasy-api/gram/server/gen/risk"
 	"github.com/speakeasy-api/gram/server/gen/types"
-	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
-)
-
-const (
-	exclusionRegexMaxLength      = 512
-	exclusionMaxRegexPerScope    = 50
-	exclusionDisplayNameMaxRunes = 80
 )
 
 // parseExclusionPolicyID converts the optional risk_policy_id payload field to
@@ -43,93 +32,21 @@ func parseExclusionPolicyID(raw *string) (uuid.NullUUID, error) {
 
 // nullableText maps an optional filter string to a nullable column value:
 // empty string ("any") becomes SQL NULL.
-func nullableText(s string) pgtype.Text {
-	if s == "" {
-		return pgtype.Text{String: "", Valid: false}
-	}
-	return pgtype.Text{String: s, Valid: true}
+func nullableText(value string) pgtype.Text {
+	return pgtype.Text{String: value, Valid: value != ""}
 }
 
+// validateExclusionMatchValue retains the existing Goa/suggestion error shape
+// while sharing validation with transport-neutral exclusion administration.
 func validateExclusionMatchValue(matchType, matchValue string) error {
-	if matchValue == "" {
-		return oops.E(oops.CodeInvalid, nil, "match_value must not be empty")
-	}
-	if matchType == "regex" {
-		if len(matchValue) > exclusionRegexMaxLength {
-			return oops.E(oops.CodeInvalid, nil, "regex pattern too long (max %d characters)", exclusionRegexMaxLength)
+	if err := exclusioncore.ValidateMatchValue(matchType, matchValue); err != nil {
+		var validation *exclusioncore.ValidationError
+		if errors.As(err, &validation) {
+			return oops.E(oops.CodeInvalid, validation.Cause, "%s", validation.Message)
 		}
-		if _, err := regexp.Compile(matchValue); err != nil {
-			return oops.E(oops.CodeInvalid, err, "invalid regex pattern")
-		}
+		return oops.E(oops.CodeInvalid, err, "%s", err)
 	}
 	return nil
-}
-
-// redactExclusionValue replaces a raw exclusion pattern/filter with a stable,
-// non-reversible fingerprint. An exact match_value can be the literal sensitive
-// string the author wants suppressed (an email, a secret), so it must never
-// reach the audit log or the outbound webhook payload verbatim. The fingerprint
-// still lets update snapshots show that a value changed without revealing it.
-func redactExclusionValue(value string) string {
-	if value == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(value))
-	return "redacted:sha256:" + hex.EncodeToString(sum[:])[:12]
-}
-
-func exclusionDisplayName(matchType, matchValue string) string {
-	name := matchType + ":" + redactExclusionValue(matchValue)
-	if len([]rune(name)) > exclusionDisplayNameMaxRunes {
-		return string([]rune(name)[:exclusionDisplayNameMaxRunes])
-	}
-	return name
-}
-
-func exclusionToType(row repo.RiskExclusion) *types.RiskExclusion {
-	var policyID *string
-	if row.RiskPolicyID.Valid {
-		s := row.RiskPolicyID.UUID.String()
-		policyID = &s
-	}
-	return &types.RiskExclusion{
-		ID:           row.ID.String(),
-		ProjectID:    row.ProjectID.String(),
-		RiskPolicyID: policyID,
-		MatchType:    row.MatchType,
-		MatchValue:   row.MatchValue,
-		RuleIDFilter: row.RuleIDFilter.String,
-		SourceFilter: row.SourceFilter.String,
-		Enabled:      row.Enabled,
-		CreatedAt:    row.CreatedAt.Time.Format(time.RFC3339),
-		UpdatedAt:    row.UpdatedAt.Time.Format(time.RFC3339),
-	}
-}
-
-// exclusionAuditSnapshot is exclusionToType with the sensitive pattern/filter
-// fields redacted, for use in audit before/after snapshots that are emitted to
-// webhook consumers.
-func exclusionAuditSnapshot(row repo.RiskExclusion) *types.RiskExclusion {
-	t := exclusionToType(row)
-	t.MatchValue = redactExclusionValue(t.MatchValue)
-	t.RuleIDFilter = redactExclusionValue(t.RuleIDFilter)
-	t.SourceFilter = redactExclusionValue(t.SourceFilter)
-	return t
-}
-
-// reconcileExclusion triggers the retroactive sweep best-effort. A failed
-// trigger is logged, not fatal: the exclusion config is already committed and
-// the reconcile is idempotent, so a later trigger (or manual re-run) converges.
-func (s *Service) reconcileExclusion(ctx context.Context, projectID, exclusionID uuid.UUID) {
-	if s.reconciler == nil {
-		return
-	}
-	if err := s.reconciler.Reconcile(ctx, projectID, exclusionID); err != nil {
-		s.logger.ErrorContext(ctx, "trigger risk exclusion reconcile",
-			attr.SlogError(err),
-			attr.SlogProjectID(projectID.String()),
-		)
-	}
 }
 
 func (s *Service) ListRiskExclusions(ctx context.Context, payload *gen.ListRiskExclusionsPayload) (*gen.ListRiskExclusionsResult, error) {
@@ -145,20 +62,15 @@ func (s *Service) ListRiskExclusions(ctx context.Context, payload *gen.ListRiskE
 	if err != nil {
 		return nil, err
 	}
-
-	rows, err := s.repo.ListRiskExclusionsByProject(ctx, repo.ListRiskExclusionsByProjectParams{
-		ProjectID:    *authCtx.ProjectID,
-		RiskPolicyID: policyID,
-	})
+	exclusions, err := s.exclusions.List(ctx, *authCtx.ProjectID, policyID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list risk exclusions").LogError(ctx, s.logger)
 	}
-
-	exclusions := make([]*types.RiskExclusion, 0, len(rows))
-	for _, row := range rows {
-		exclusions = append(exclusions, exclusionToType(row))
+	result := make([]*types.RiskExclusion, 0, len(exclusions))
+	for _, exclusion := range exclusions {
+		result = append(result, exclusionToType(exclusion))
 	}
-	return &gen.ListRiskExclusionsResult{Exclusions: exclusions}, nil
+	return &gen.ListRiskExclusionsResult{Exclusions: result}, nil
 }
 
 func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRiskExclusionPayload) (*types.RiskExclusion, error) {
@@ -169,78 +81,32 @@ func (s *Service) CreateRiskExclusion(ctx context.Context, payload *gen.CreateRi
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
 	}
-
-	if err := validateExclusionMatchValue(payload.MatchType, payload.MatchValue); err != nil {
-		return nil, err
-	}
-
 	policyID, err := parseExclusionPolicyID(payload.RiskPolicyID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Confirm the parent policy exists in this project (policy-bound only).
-	if policyID.Valid {
-		if _, err := s.repo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{ID: policyID.UUID, ProjectID: *authCtx.ProjectID}); err != nil {
-			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
-		}
-	}
-
-	// Enforce the per-scope regex cap. The cap only bounds *enabled* regex
-	// exclusions (they drive matching load), so a disabled regex draft is
-	// always allowed even when the scope is already at the limit.
-	if payload.MatchType == "regex" && payload.Enabled {
-		count, err := s.repo.CountEnabledRegexExclusionsInScope(ctx, repo.CountEnabledRegexExclusionsInScopeParams{
-			ProjectID:    *authCtx.ProjectID,
-			RiskPolicyID: policyID,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").LogError(ctx, s.logger)
-		}
-		if count >= exclusionMaxRegexPerScope {
-			return nil, oops.E(oops.CodeInvalid, nil, "too many regex exclusions in scope (max %d)", exclusionMaxRegexPerScope)
-		}
-	}
-
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	row, err := repo.New(dbtx).CreateRiskExclusion(ctx, repo.CreateRiskExclusionParams{
-		ProjectID:      *authCtx.ProjectID,
-		OrganizationID: authCtx.ActiveOrganizationID,
-		RiskPolicyID:   policyID,
-		MatchType:      payload.MatchType,
-		MatchValue:     payload.MatchValue,
-		RuleIDFilter:   nullableText(payload.RuleIDFilter),
-		SourceFilter:   nullableText(payload.SourceFilter),
-		Enabled:        payload.Enabled,
+	exclusion, err := s.exclusions.Create(ctx, exclusioncore.CreateMutation{
+		Params: repo.CreateRiskExclusionParams{
+			ProjectID:      *authCtx.ProjectID,
+			OrganizationID: authCtx.ActiveOrganizationID,
+			RiskPolicyID:   policyID,
+			MatchType:      payload.MatchType,
+			MatchValue:     payload.MatchValue,
+			RuleIDFilter:   nullableText(payload.RuleIDFilter),
+			SourceFilter:   nullableText(payload.SourceFilter),
+			Enabled:        payload.Enabled,
+		},
+		Actor: exclusioncore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			DisplayName: authCtx.Email,
+			Slug:        nil,
+		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "create risk exclusion").LogError(ctx, s.logger)
+		return nil, s.exclusionError(ctx, err)
 	}
-
-	if err := s.audit.LogRiskExclusionCreate(ctx, dbtx, audit.LogRiskExclusionCreateEvent{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		ProjectID:        *authCtx.ProjectID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName: authCtx.Email,
-		ActorSlug:        nil,
-		RiskExclusionID:  row.ID,
-		DisplayName:      exclusionDisplayName(row.MatchType, row.MatchValue),
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion create").LogError(ctx, s.logger)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion create").LogError(ctx, s.logger)
-	}
-
-	s.reconcileExclusion(ctx, row.ProjectID, row.ID)
-
-	return exclusionToType(row), nil
+	return exclusionToType(exclusion), nil
 }
 
 func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRiskExclusionPayload) (*types.RiskExclusion, error) {
@@ -251,63 +117,16 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return nil, err
 	}
-
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid exclusion id")
-	}
-	if err := validateExclusionMatchValue(payload.MatchType, payload.MatchValue); err != nil {
-		return nil, err
 	}
 	policyID, err := parseExclusionPolicyID(payload.RiskPolicyID)
 	if err != nil {
 		return nil, err
 	}
-	if policyID.Valid {
-		if _, err := s.repo.GetRiskPolicy(ctx, repo.GetRiskPolicyParams{ID: policyID.UUID, ProjectID: *authCtx.ProjectID}); err != nil {
-			return nil, oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
-		}
-	}
 
-	before, err := s.repo.GetRiskExclusion(ctx, repo.GetRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID})
-	if err != nil {
-		return nil, oops.E(oops.CodeNotFound, err, "risk exclusion not found").LogError(ctx, s.logger)
-	}
-
-	// An omitted `enabled` leaves the current state untouched rather than
-	// silently re-enabling a disabled exclusion.
-	enabled := before.Enabled
-	if payload.Enabled != nil {
-		enabled = *payload.Enabled
-	}
-
-	// Enforce the per-scope regex cap when this update moves the exclusion into
-	// the enabled-regex set of a scope it wasn't already counted in (newly
-	// enabling, switching match_type to regex, or moving to another scope).
-	if payload.MatchType == "regex" && enabled {
-		wasCountedInScope := before.MatchType == "regex" && before.Enabled &&
-			before.RiskPolicyID == policyID
-		if !wasCountedInScope {
-			count, err := s.repo.CountEnabledRegexExclusionsInScope(ctx, repo.CountEnabledRegexExclusionsInScopeParams{
-				ProjectID:    *authCtx.ProjectID,
-				RiskPolicyID: policyID,
-			})
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "count regex exclusions").LogError(ctx, s.logger)
-			}
-			if count >= exclusionMaxRegexPerScope {
-				return nil, oops.E(oops.CodeInvalid, nil, "too many regex exclusions in scope (max %d)", exclusionMaxRegexPerScope)
-			}
-		}
-	}
-
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	row, err := repo.New(dbtx).UpdateRiskExclusion(ctx, repo.UpdateRiskExclusionParams{
+	exclusion, err := s.exclusions.Update(ctx, exclusioncore.UpdateMutation{
 		ID:           id,
 		ProjectID:    *authCtx.ProjectID,
 		RiskPolicyID: policyID,
@@ -315,33 +134,17 @@ func (s *Service) UpdateRiskExclusion(ctx context.Context, payload *gen.UpdateRi
 		MatchValue:   payload.MatchValue,
 		RuleIDFilter: nullableText(payload.RuleIDFilter),
 		SourceFilter: nullableText(payload.SourceFilter),
-		Enabled:      enabled,
+		Enabled:      payload.Enabled,
+		Actor: exclusioncore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			DisplayName: authCtx.Email,
+			Slug:        nil,
+		},
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "update risk exclusion").LogError(ctx, s.logger)
+		return nil, s.exclusionError(ctx, err)
 	}
-
-	if err := s.audit.LogRiskExclusionUpdate(ctx, dbtx, audit.LogRiskExclusionUpdateEvent{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		ProjectID:        *authCtx.ProjectID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName: authCtx.Email,
-		ActorSlug:        nil,
-		RiskExclusionID:  row.ID,
-		DisplayName:      exclusionDisplayName(row.MatchType, row.MatchValue),
-		SnapshotBefore:   exclusionAuditSnapshot(before),
-		SnapshotAfter:    exclusionAuditSnapshot(row),
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "log risk exclusion update").LogError(ctx, s.logger)
-	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "commit risk exclusion update").LogError(ctx, s.logger)
-	}
-
-	s.reconcileExclusion(ctx, row.ProjectID, row.ID)
-
-	return exclusionToType(row), nil
+	return exclusionToType(exclusion), nil
 }
 
 func (s *Service) DeleteRiskExclusion(ctx context.Context, payload *gen.DeleteRiskExclusionPayload) error {
@@ -352,45 +155,20 @@ func (s *Service) DeleteRiskExclusion(ctx context.Context, payload *gen.DeleteRi
 	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeOrgAdmin, ResourceKind: "", ResourceID: authCtx.ActiveOrganizationID, Dimensions: nil}); err != nil {
 		return err
 	}
-
 	id, err := uuid.Parse(payload.ID)
 	if err != nil {
 		return oops.E(oops.CodeInvalid, err, "invalid exclusion id")
 	}
-
-	before, err := s.repo.GetRiskExclusion(ctx, repo.GetRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID})
-	if err != nil {
-		return oops.E(oops.CodeNotFound, err, "risk exclusion not found").LogError(ctx, s.logger)
-	}
-
-	dbtx, err := s.db.Begin(ctx)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, s.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
-
-	if err := repo.New(dbtx).DeleteRiskExclusion(ctx, repo.DeleteRiskExclusionParams{ID: id, ProjectID: *authCtx.ProjectID}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "delete risk exclusion").LogError(ctx, s.logger)
-	}
-
-	if err := s.audit.LogRiskExclusionDelete(ctx, dbtx, audit.LogRiskExclusionDeleteEvent{
-		OrganizationID:   authCtx.ActiveOrganizationID,
-		ProjectID:        *authCtx.ProjectID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-		ActorDisplayName: authCtx.Email,
-		ActorSlug:        nil,
-		RiskExclusionID:  before.ID,
-		DisplayName:      exclusionDisplayName(before.MatchType, before.MatchValue),
+	if err := s.exclusions.Delete(ctx, exclusioncore.DeleteMutation{
+		ID:        id,
+		ProjectID: *authCtx.ProjectID,
+		Actor: exclusioncore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			DisplayName: authCtx.Email,
+			Slug:        nil,
+		},
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "log risk exclusion delete").LogError(ctx, s.logger)
+		return s.exclusionError(ctx, err)
 	}
-
-	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit risk exclusion delete").LogError(ctx, s.logger)
-	}
-
-	// Restore findings previously suppressed by this exclusion.
-	s.reconcileExclusion(ctx, *authCtx.ProjectID, id)
-
 	return nil
 }

--- a/server/internal/risk/exclusion.go
+++ b/server/internal/risk/exclusion.go
@@ -44,6 +44,8 @@ func validateExclusionMatchValue(matchType, matchValue string) error {
 		if errors.As(err, &validation) {
 			return oops.E(oops.CodeInvalid, validation.Cause, "%s", validation.Message)
 		}
+		// Keep a valid Goa error if shared validation gains another typed error
+		// instead of assuming this adapter will only ever see ValidationError.
 		return oops.E(oops.CodeInvalid, err, "%s", err)
 	}
 	return nil

--- a/server/internal/risk/exclusion_admin.go
+++ b/server/internal/risk/exclusion_admin.go
@@ -115,8 +115,9 @@ func newExclusionAfterCommit(logger *slog.Logger, reconciler RiskExclusionReconc
 		return nil
 	}
 	return func(ctx context.Context, projectID, exclusionID uuid.UUID) {
-		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second) //nolint:gosec // cancel runs in the detached goroutine below
+		reconcileBaseCtx := context.WithoutCancel(ctx)
 		go func() {
+			reconcileCtx, cancel := context.WithTimeout(reconcileBaseCtx, 10*time.Second)
 			defer cancel()
 			if err := reconciler.Reconcile(reconcileCtx, projectID, exclusionID); err != nil {
 				logger.ErrorContext(reconcileCtx, "trigger risk exclusion reconcile",

--- a/server/internal/risk/exclusion_admin.go
+++ b/server/internal/risk/exclusion_admin.go
@@ -115,8 +115,10 @@ func newExclusionAfterCommit(logger *slog.Logger, reconciler RiskExclusionReconc
 		return nil
 	}
 	return func(ctx context.Context, projectID, exclusionID uuid.UUID) {
-		if err := reconciler.Reconcile(ctx, projectID, exclusionID); err != nil {
-			logger.ErrorContext(ctx, "trigger risk exclusion reconcile",
+		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		if err := reconciler.Reconcile(reconcileCtx, projectID, exclusionID); err != nil {
+			logger.ErrorContext(reconcileCtx, "trigger risk exclusion reconcile",
 				attr.SlogError(err),
 				attr.SlogProjectID(projectID.String()),
 			)

--- a/server/internal/risk/exclusion_admin.go
+++ b/server/internal/risk/exclusion_admin.go
@@ -1,0 +1,125 @@
+package risk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+type exclusionMutationAuditor struct {
+	logger *audit.Logger
+}
+
+func (a exclusionMutationAuditor) LogExclusionCreate(ctx context.Context, db repo.DBTX, event exclusioncore.CreateAuditEvent) error {
+	if err := a.logger.LogRiskExclusionCreate(ctx, db, audit.LogRiskExclusionCreateEvent{
+		OrganizationID:   event.OrganizationID,
+		ProjectID:        event.ProjectID,
+		Actor:            event.Actor.Principal,
+		ActorDisplayName: event.Actor.DisplayName,
+		ActorSlug:        event.Actor.Slug,
+		RiskExclusionID:  event.Exclusion.ID,
+		DisplayName:      event.DisplayName,
+	}); err != nil {
+		return fmt.Errorf("log exclusion create audit: %w", err)
+	}
+	return nil
+}
+
+func (a exclusionMutationAuditor) LogExclusionUpdate(ctx context.Context, db repo.DBTX, event exclusioncore.UpdateAuditEvent) error {
+	if err := a.logger.LogRiskExclusionUpdate(ctx, db, audit.LogRiskExclusionUpdateEvent{
+		OrganizationID:   event.OrganizationID,
+		ProjectID:        event.ProjectID,
+		Actor:            event.Actor.Principal,
+		ActorDisplayName: event.Actor.DisplayName,
+		ActorSlug:        event.Actor.Slug,
+		RiskExclusionID:  event.After.ID,
+		DisplayName:      event.DisplayName,
+		SnapshotBefore:   exclusionToType(event.Before),
+		SnapshotAfter:    exclusionToType(event.After),
+	}); err != nil {
+		return fmt.Errorf("log exclusion update audit: %w", err)
+	}
+	return nil
+}
+
+func (a exclusionMutationAuditor) LogExclusionDelete(ctx context.Context, db repo.DBTX, event exclusioncore.DeleteAuditEvent) error {
+	if err := a.logger.LogRiskExclusionDelete(ctx, db, audit.LogRiskExclusionDeleteEvent{
+		OrganizationID:   event.OrganizationID,
+		ProjectID:        event.ProjectID,
+		Actor:            event.Actor.Principal,
+		ActorDisplayName: event.Actor.DisplayName,
+		ActorSlug:        event.Actor.Slug,
+		RiskExclusionID:  event.Exclusion.ID,
+		DisplayName:      event.DisplayName,
+	}); err != nil {
+		return fmt.Errorf("log exclusion delete audit: %w", err)
+	}
+	return nil
+}
+
+func exclusionToType(exclusion exclusioncore.Exclusion) *types.RiskExclusion {
+	var policyID *string
+	if exclusion.RiskPolicyID.Valid {
+		value := exclusion.RiskPolicyID.UUID.String()
+		policyID = &value
+	}
+	return &types.RiskExclusion{
+		ID:           exclusion.ID.String(),
+		ProjectID:    exclusion.ProjectID.String(),
+		RiskPolicyID: policyID,
+		MatchType:    exclusion.MatchType,
+		MatchValue:   exclusion.MatchValue,
+		RuleIDFilter: exclusion.RuleIDFilter,
+		SourceFilter: exclusion.SourceFilter,
+		Enabled:      exclusion.Enabled,
+		CreatedAt:    exclusion.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:    exclusion.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+func (s *Service) exclusionError(ctx context.Context, err error) error {
+	var validation *exclusioncore.ValidationError
+	if errors.As(err, &validation) {
+		return oops.E(oops.CodeInvalid, validation.Cause, "%s", validation.Message)
+	}
+	var regexLimit *exclusioncore.RegexLimitError
+	if errors.As(err, &regexLimit) {
+		return oops.E(oops.CodeInvalid, nil, "%s", regexLimit)
+	}
+	if errors.Is(err, exclusioncore.ErrPolicyNotFound) {
+		return oops.E(oops.CodeNotFound, err, "risk policy not found").LogError(ctx, s.logger)
+	}
+	if errors.Is(err, exclusioncore.ErrExclusionNotFound) {
+		return oops.E(oops.CodeNotFound, err, "risk exclusion not found").LogError(ctx, s.logger)
+	}
+	var mutation *exclusioncore.MutationError
+	if errors.As(err, &mutation) {
+		return oops.E(oops.CodeUnexpected, mutation.Cause, "%s", mutation.Message).LogError(ctx, s.logger)
+	}
+	return oops.E(oops.CodeUnexpected, err, "administer risk exclusion").LogError(ctx, s.logger)
+}
+
+func newExclusionAfterCommit(logger *slog.Logger, reconciler RiskExclusionReconciler) exclusioncore.AfterCommit {
+	if reconciler == nil {
+		return nil
+	}
+	return func(ctx context.Context, projectID, exclusionID uuid.UUID) {
+		if err := reconciler.Reconcile(ctx, projectID, exclusionID); err != nil {
+			logger.ErrorContext(ctx, "trigger risk exclusion reconcile",
+				attr.SlogError(err),
+				attr.SlogProjectID(projectID.String()),
+			)
+		}
+	}
+}

--- a/server/internal/risk/exclusion_admin.go
+++ b/server/internal/risk/exclusion_admin.go
@@ -115,13 +115,15 @@ func newExclusionAfterCommit(logger *slog.Logger, reconciler RiskExclusionReconc
 		return nil
 	}
 	return func(ctx context.Context, projectID, exclusionID uuid.UUID) {
-		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		defer cancel()
-		if err := reconciler.Reconcile(reconcileCtx, projectID, exclusionID); err != nil {
-			logger.ErrorContext(reconcileCtx, "trigger risk exclusion reconcile",
-				attr.SlogError(err),
-				attr.SlogProjectID(projectID.String()),
-			)
-		}
+		reconcileCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second) //nolint:gosec // cancel runs in the detached goroutine below
+		go func() {
+			defer cancel()
+			if err := reconciler.Reconcile(reconcileCtx, projectID, exclusionID); err != nil {
+				logger.ErrorContext(reconcileCtx, "trigger risk exclusion reconcile",
+					attr.SlogError(err),
+					attr.SlogProjectID(projectID.String()),
+				)
+			}
+		}()
 	}
 }

--- a/server/internal/risk/exclusion_admin_test.go
+++ b/server/internal/risk/exclusion_admin_test.go
@@ -1,0 +1,67 @@
+package risk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type blockingExclusionReconciler struct {
+	entered chan error
+	release chan struct{}
+}
+
+func (r *blockingExclusionReconciler) Reconcile(ctx context.Context, _, _ uuid.UUID) error {
+	_, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		r.entered <- context.DeadlineExceeded
+	} else {
+		r.entered <- ctx.Err()
+	}
+	<-r.release
+	return nil
+}
+
+func TestExclusionAfterCommitDetachesAndReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &blockingExclusionReconciler{
+		entered: make(chan error, 1),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-reconciler.release:
+		default:
+			close(reconciler.release)
+		}
+	})
+	logger := testenv.NewLogger(t)
+	afterCommit := newExclusionAfterCommit(logger, reconciler)
+
+	requestCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	returned := make(chan struct{})
+	go func() {
+		afterCommit(requestCtx, uuid.New(), uuid.New())
+		close(returned)
+	}()
+
+	select {
+	case err := <-reconciler.entered:
+		require.NoError(t, err, "reconcile context must ignore request cancellation and remain bounded")
+	case <-time.After(time.Second):
+		require.FailNow(t, "reconciler was not invoked")
+	}
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		require.FailNow(t, "after-commit hook waited for reconciliation")
+	}
+	close(reconciler.release)
+}

--- a/server/internal/risk/exclusioncore/core.go
+++ b/server/internal/risk/exclusioncore/core.go
@@ -20,7 +20,6 @@ const (
 	RegexMaxLength      = 512
 	MaxRegexPerScope    = 50
 	displayNameMaxRunes = 80
-	redactedValue       = "<redacted>"
 )
 
 var (
@@ -70,6 +69,7 @@ type MutationDependencies struct {
 	Transactor  Transactor
 	Auditor     MutationAuditor
 	AfterCommit AfterCommit
+	Redactor    Redactor
 }
 
 type Core struct {
@@ -143,25 +143,19 @@ func ValidateMatchValue(matchType, matchValue string) error {
 	return nil
 }
 
-func RedactValue(value string) string {
-	if value == "" {
-		return ""
-	}
-	return redactedValue
-}
-
-func DisplayName(exclusion Exclusion) string {
-	name := exclusion.MatchType + ":" + RedactValue(exclusion.MatchValue)
+func DisplayName(redactor Redactor, exclusion Exclusion) string {
+	name := exclusion.MatchType + ":" + redactor.Redact(exclusion.ProjectID.String(), "match_value", exclusion.MatchValue)
 	if len([]rune(name)) > displayNameMaxRunes {
 		return string([]rune(name)[:displayNameMaxRunes])
 	}
 	return name
 }
 
-func AuditSnapshot(exclusion Exclusion) Exclusion {
-	exclusion.MatchValue = RedactValue(exclusion.MatchValue)
-	exclusion.RuleIDFilter = RedactValue(exclusion.RuleIDFilter)
-	exclusion.SourceFilter = RedactValue(exclusion.SourceFilter)
+func AuditSnapshot(redactor Redactor, exclusion Exclusion) Exclusion {
+	projectID := exclusion.ProjectID.String()
+	exclusion.MatchValue = redactor.Redact(projectID, "match_value", exclusion.MatchValue)
+	exclusion.RuleIDFilter = redactor.Redact(projectID, "rule_id_filter", exclusion.RuleIDFilter)
+	exclusion.SourceFilter = redactor.Redact(projectID, "source_filter", exclusion.SourceFilter)
 	return exclusion
 }
 
@@ -274,8 +268,8 @@ func (c *Core) Create(ctx context.Context, input CreateMutation) (Exclusion, err
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
 		Actor:          input.Actor,
-		Exclusion:      AuditSnapshot(exclusion),
-		DisplayName:    DisplayName(exclusion),
+		Exclusion:      AuditSnapshot(deps.Redactor, exclusion),
+		DisplayName:    DisplayName(deps.Redactor, exclusion),
 	}); err != nil {
 		return Exclusion{}, mutationError("log risk exclusion create", err)
 	}
@@ -323,9 +317,9 @@ func (c *Core) Toggle(ctx context.Context, input ToggleMutation) (Exclusion, err
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
 		Actor:          input.Actor,
-		Before:         AuditSnapshot(beforeExclusion),
-		After:          AuditSnapshot(afterExclusion),
-		DisplayName:    DisplayName(afterExclusion),
+		Before:         AuditSnapshot(deps.Redactor, beforeExclusion),
+		After:          AuditSnapshot(deps.Redactor, afterExclusion),
+		DisplayName:    DisplayName(deps.Redactor, afterExclusion),
 	}); err != nil {
 		return Exclusion{}, mutationError("log risk exclusion toggle", err)
 	}
@@ -405,9 +399,9 @@ func (c *Core) Update(ctx context.Context, input UpdateMutation) (Exclusion, err
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
 		Actor:          input.Actor,
-		Before:         AuditSnapshot(beforeExclusion),
-		After:          AuditSnapshot(afterExclusion),
-		DisplayName:    DisplayName(afterExclusion),
+		Before:         AuditSnapshot(deps.Redactor, beforeExclusion),
+		After:          AuditSnapshot(deps.Redactor, afterExclusion),
+		DisplayName:    DisplayName(deps.Redactor, afterExclusion),
 	}); err != nil {
 		return Exclusion{}, mutationError("log risk exclusion update", err)
 	}
@@ -450,8 +444,8 @@ func (c *Core) Delete(ctx context.Context, input DeleteMutation) error {
 		OrganizationID: before.OrganizationID,
 		ProjectID:      before.ProjectID,
 		Actor:          input.Actor,
-		Exclusion:      AuditSnapshot(exclusion),
-		DisplayName:    DisplayName(exclusion),
+		Exclusion:      AuditSnapshot(deps.Redactor, exclusion),
+		DisplayName:    DisplayName(deps.Redactor, exclusion),
 	}); err != nil {
 		return mutationError("log risk exclusion delete", err)
 	}
@@ -465,7 +459,7 @@ func (c *Core) Delete(ctx context.Context, input DeleteMutation) error {
 }
 
 func (c *Core) requireMutationDependencies() (*MutationDependencies, error) {
-	if c.mutations == nil || c.mutations.Transactor == nil || c.mutations.Auditor == nil {
+	if c.mutations == nil || c.mutations.Transactor == nil || c.mutations.Auditor == nil || !c.mutations.Redactor.Configured() {
 		return nil, mutationError("risk exclusion mutation dependencies are not configured", nil)
 	}
 	return c.mutations, nil

--- a/server/internal/risk/exclusioncore/core.go
+++ b/server/internal/risk/exclusioncore/core.go
@@ -2,12 +2,11 @@ package exclusioncore
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -21,6 +20,7 @@ const (
 	RegexMaxLength      = 512
 	MaxRegexPerScope    = 50
 	displayNameMaxRunes = 80
+	redactedValue       = "<redacted>"
 )
 
 var (
@@ -134,7 +134,7 @@ func ValidateMatchValue(matchType, matchValue string) error {
 	if matchType != "regex" {
 		return nil
 	}
-	if len(matchValue) > RegexMaxLength {
+	if utf8.RuneCountInString(matchValue) > RegexMaxLength {
 		return &ValidationError{Message: fmt.Sprintf("regex pattern too long (max %d characters)", RegexMaxLength), Cause: nil}
 	}
 	if _, err := regexp.Compile(matchValue); err != nil {
@@ -147,8 +147,7 @@ func RedactValue(value string) string {
 	if value == "" {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(value))
-	return "redacted:sha256:" + hex.EncodeToString(sum[:])[:12]
+	return redactedValue
 }
 
 func DisplayName(exclusion Exclusion) string {
@@ -188,8 +187,17 @@ type CreateMutation struct {
 	Actor  Actor
 }
 
+// ToggleMutation changes only an exclusion's enabled state. It is the mutation
+// contract for transports that do not permit editing exclusion definitions.
+type ToggleMutation struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+	Enabled   bool
+	Actor     Actor
+}
+
 // UpdateMutation is a fully parsed exclusion replacement. Nil Enabled preserves
-// the authoritative locked row's current value.
+// the authoritative locked row's current value for Goa compatibility.
 type UpdateMutation struct {
 	ID           uuid.UUID
 	ProjectID    uuid.UUID
@@ -278,6 +286,69 @@ func (c *Core) Create(ctx context.Context, input CreateMutation) (Exclusion, err
 		deps.AfterCommit(ctx, row.ProjectID, row.ID)
 	}
 	return exclusion, nil
+}
+
+func (c *Core) Toggle(ctx context.Context, input ToggleMutation) (Exclusion, error) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return Exclusion{}, err
+	}
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return Exclusion{}, mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskExclusionMutations(ctx, input.ProjectID.String()); err != nil {
+		return Exclusion{}, mutationError("lock risk exclusion mutations", err)
+	}
+	before, err := queries.GetRiskExclusionForUpdate(ctx, repo.GetRiskExclusionForUpdateParams{ID: input.ID, ProjectID: input.ProjectID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Exclusion{}, fmt.Errorf("%w: %w", ErrExclusionNotFound, err)
+		}
+		return Exclusion{}, mutationError("lock risk exclusion", err)
+	}
+	if err := enforceRegexLimit(ctx, queries, input.ProjectID, before.RiskPolicyID, uuid.NullUUID{UUID: input.ID, Valid: true}, before.MatchType, input.Enabled); err != nil {
+		return Exclusion{}, err
+	}
+	row, err := queries.UpdateRiskExclusion(ctx, toggleUpdateParams(before, input.Enabled))
+	if err != nil {
+		return Exclusion{}, mutationError("toggle risk exclusion", err)
+	}
+	beforeExclusion := Project(before)
+	afterExclusion := Project(row)
+	if err := deps.Auditor.LogExclusionUpdate(ctx, tx, UpdateAuditEvent{
+		OrganizationID: row.OrganizationID,
+		ProjectID:      row.ProjectID,
+		Actor:          input.Actor,
+		Before:         AuditSnapshot(beforeExclusion),
+		After:          AuditSnapshot(afterExclusion),
+		DisplayName:    DisplayName(afterExclusion),
+	}); err != nil {
+		return Exclusion{}, mutationError("log risk exclusion toggle", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Exclusion{}, mutationError("commit risk exclusion toggle", err)
+	}
+	if deps.AfterCommit != nil {
+		deps.AfterCommit(ctx, row.ProjectID, row.ID)
+	}
+	return afterExclusion, nil
+}
+
+func toggleUpdateParams(before repo.RiskExclusion, enabled bool) repo.UpdateRiskExclusionParams {
+	return repo.UpdateRiskExclusionParams{
+		ID:           before.ID,
+		ProjectID:    before.ProjectID,
+		RiskPolicyID: before.RiskPolicyID,
+		MatchType:    before.MatchType,
+		MatchValue:   before.MatchValue,
+		RuleIDFilter: before.RuleIDFilter,
+		SourceFilter: before.SourceFilter,
+		Enabled:      enabled,
+	}
 }
 
 func (c *Core) Update(ctx context.Context, input UpdateMutation) (Exclusion, error) {

--- a/server/internal/risk/exclusioncore/core.go
+++ b/server/internal/risk/exclusioncore/core.go
@@ -1,0 +1,441 @@
+package exclusioncore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	RegexMaxLength      = 512
+	MaxRegexPerScope    = 50
+	displayNameMaxRunes = 80
+)
+
+var (
+	ErrPolicyNotFound    = errors.New("risk policy not found")
+	ErrExclusionNotFound = errors.New("risk exclusion not found")
+)
+
+// Exclusion is the transport-neutral representation of a persisted exclusion.
+type Exclusion struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	RiskPolicyID   uuid.NullUUID
+	MatchType      string
+	MatchValue     string
+	RuleIDFilter   string
+	SourceFilter   string
+	Enabled        bool
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// Actor is the real user attributed to an exclusion mutation.
+type Actor struct {
+	Principal   urn.Principal
+	DisplayName *string
+	Slug        *string
+}
+
+// Transactor is the transaction capability required by exclusion mutations.
+type Transactor interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+}
+
+// MutationAuditor records exclusion writes and their outbox event atomically.
+type MutationAuditor interface {
+	LogExclusionCreate(ctx context.Context, db repo.DBTX, event CreateAuditEvent) error
+	LogExclusionUpdate(ctx context.Context, db repo.DBTX, event UpdateAuditEvent) error
+	LogExclusionDelete(ctx context.Context, db repo.DBTX, event DeleteAuditEvent) error
+}
+
+// AfterCommit triggers best-effort historical reconciliation after commit.
+type AfterCommit func(ctx context.Context, projectID, exclusionID uuid.UUID)
+
+// MutationDependencies are optional for read-only Core users and required by writes.
+type MutationDependencies struct {
+	Transactor  Transactor
+	Auditor     MutationAuditor
+	AfterCommit AfterCommit
+}
+
+type Core struct {
+	db        repo.DBTX
+	queries   *repo.Queries
+	mutations *MutationDependencies
+}
+
+func New(db repo.DBTX, mutations ...MutationDependencies) *Core {
+	core := &Core{db: db, queries: repo.New(db), mutations: nil}
+	if len(mutations) > 0 {
+		core.mutations = &mutations[0]
+	}
+	return core
+}
+
+// List returns a project's exclusions, optionally filtered to one policy.
+func (c *Core) List(ctx context.Context, projectID uuid.UUID, policyID uuid.NullUUID) ([]Exclusion, error) {
+	rows, err := c.queries.ListRiskExclusionsByProject(ctx, repo.ListRiskExclusionsByProjectParams{
+		ProjectID:    projectID,
+		RiskPolicyID: policyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list risk exclusions: %w", err)
+	}
+	out := make([]Exclusion, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, Project(row))
+	}
+	return out, nil
+}
+
+func Project(row repo.RiskExclusion) Exclusion {
+	return Exclusion{
+		ID:             row.ID,
+		ProjectID:      row.ProjectID,
+		OrganizationID: row.OrganizationID,
+		RiskPolicyID:   row.RiskPolicyID,
+		MatchType:      row.MatchType,
+		MatchValue:     row.MatchValue,
+		RuleIDFilter:   valueOrEmpty(row.RuleIDFilter),
+		SourceFilter:   valueOrEmpty(row.SourceFilter),
+		Enabled:        row.Enabled,
+		CreatedAt:      row.CreatedAt.Time,
+		UpdatedAt:      row.UpdatedAt.Time,
+	}
+}
+
+// ValidationError separates a stable client message from its technical cause.
+type ValidationError struct {
+	Message string
+	Cause   error
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+func (e *ValidationError) Unwrap() error { return e.Cause }
+
+func ValidateMatchValue(matchType, matchValue string) error {
+	if matchValue == "" {
+		return &ValidationError{Message: "match_value must not be empty", Cause: nil}
+	}
+	if matchType != "regex" {
+		return nil
+	}
+	if len(matchValue) > RegexMaxLength {
+		return &ValidationError{Message: fmt.Sprintf("regex pattern too long (max %d characters)", RegexMaxLength), Cause: nil}
+	}
+	if _, err := regexp.Compile(matchValue); err != nil {
+		return &ValidationError{Message: "invalid regex pattern", Cause: err}
+	}
+	return nil
+}
+
+func RedactValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return "redacted:sha256:" + hex.EncodeToString(sum[:])[:12]
+}
+
+func DisplayName(exclusion Exclusion) string {
+	name := exclusion.MatchType + ":" + RedactValue(exclusion.MatchValue)
+	if len([]rune(name)) > displayNameMaxRunes {
+		return string([]rune(name)[:displayNameMaxRunes])
+	}
+	return name
+}
+
+func AuditSnapshot(exclusion Exclusion) Exclusion {
+	exclusion.MatchValue = RedactValue(exclusion.MatchValue)
+	exclusion.RuleIDFilter = RedactValue(exclusion.RuleIDFilter)
+	exclusion.SourceFilter = RedactValue(exclusion.SourceFilter)
+	return exclusion
+}
+
+// MutationError identifies the failed transaction step.
+type MutationError struct {
+	Message string
+	Cause   error
+}
+
+func (e *MutationError) Error() string { return e.Message }
+func (e *MutationError) Unwrap() error { return e.Cause }
+
+// RegexLimitError reports an enabled regex scope at capacity.
+type RegexLimitError struct{}
+
+func (*RegexLimitError) Error() string {
+	return fmt.Sprintf("too many regex exclusions in scope (max %d)", MaxRegexPerScope)
+}
+
+// CreateMutation is a fully parsed exclusion create command.
+type CreateMutation struct {
+	Params repo.CreateRiskExclusionParams
+	Actor  Actor
+}
+
+// UpdateMutation is a fully parsed exclusion replacement. Nil Enabled preserves
+// the authoritative locked row's current value.
+type UpdateMutation struct {
+	ID           uuid.UUID
+	ProjectID    uuid.UUID
+	RiskPolicyID uuid.NullUUID
+	MatchType    string
+	MatchValue   string
+	RuleIDFilter pgtype.Text
+	SourceFilter pgtype.Text
+	Enabled      *bool
+	Actor        Actor
+}
+
+type DeleteMutation struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+	Actor     Actor
+}
+
+type CreateAuditEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Actor          Actor
+	Exclusion      Exclusion
+	DisplayName    string
+}
+
+type UpdateAuditEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Actor          Actor
+	Before         Exclusion
+	After          Exclusion
+	DisplayName    string
+}
+
+type DeleteAuditEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Actor          Actor
+	Exclusion      Exclusion
+	DisplayName    string
+}
+
+func (c *Core) Create(ctx context.Context, input CreateMutation) (Exclusion, error) {
+	if err := ValidateMatchValue(input.Params.MatchType, input.Params.MatchValue); err != nil {
+		return Exclusion{}, err
+	}
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return Exclusion{}, err
+	}
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return Exclusion{}, mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskExclusionMutations(ctx, input.Params.ProjectID.String()); err != nil {
+		return Exclusion{}, mutationError("lock risk exclusion mutations", err)
+	}
+	if err := ensurePolicy(ctx, queries, input.Params.ProjectID, input.Params.RiskPolicyID); err != nil {
+		return Exclusion{}, err
+	}
+	if err := enforceRegexLimit(ctx, queries, input.Params.ProjectID, input.Params.RiskPolicyID, uuid.NullUUID{UUID: uuid.Nil, Valid: false}, input.Params.MatchType, input.Params.Enabled); err != nil {
+		return Exclusion{}, err
+	}
+	row, err := queries.CreateRiskExclusion(ctx, input.Params)
+	if err != nil {
+		return Exclusion{}, mutationError("create risk exclusion", err)
+	}
+	exclusion := Project(row)
+	if err := deps.Auditor.LogExclusionCreate(ctx, tx, CreateAuditEvent{
+		OrganizationID: row.OrganizationID,
+		ProjectID:      row.ProjectID,
+		Actor:          input.Actor,
+		Exclusion:      AuditSnapshot(exclusion),
+		DisplayName:    DisplayName(exclusion),
+	}); err != nil {
+		return Exclusion{}, mutationError("log risk exclusion create", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Exclusion{}, mutationError("commit risk exclusion create", err)
+	}
+	if deps.AfterCommit != nil {
+		deps.AfterCommit(ctx, row.ProjectID, row.ID)
+	}
+	return exclusion, nil
+}
+
+func (c *Core) Update(ctx context.Context, input UpdateMutation) (Exclusion, error) {
+	if err := ValidateMatchValue(input.MatchType, input.MatchValue); err != nil {
+		return Exclusion{}, err
+	}
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return Exclusion{}, err
+	}
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return Exclusion{}, mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskExclusionMutations(ctx, input.ProjectID.String()); err != nil {
+		return Exclusion{}, mutationError("lock risk exclusion mutations", err)
+	}
+	if err := ensurePolicy(ctx, queries, input.ProjectID, input.RiskPolicyID); err != nil {
+		return Exclusion{}, err
+	}
+	before, err := queries.GetRiskExclusionForUpdate(ctx, repo.GetRiskExclusionForUpdateParams{ID: input.ID, ProjectID: input.ProjectID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Exclusion{}, fmt.Errorf("%w: %w", ErrExclusionNotFound, err)
+		}
+		return Exclusion{}, mutationError("lock risk exclusion", err)
+	}
+	enabled := before.Enabled
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+	if err := enforceRegexLimit(ctx, queries, input.ProjectID, input.RiskPolicyID, uuid.NullUUID{UUID: input.ID, Valid: true}, input.MatchType, enabled); err != nil {
+		return Exclusion{}, err
+	}
+	row, err := queries.UpdateRiskExclusion(ctx, repo.UpdateRiskExclusionParams{
+		ID:           input.ID,
+		ProjectID:    input.ProjectID,
+		RiskPolicyID: input.RiskPolicyID,
+		MatchType:    input.MatchType,
+		MatchValue:   input.MatchValue,
+		RuleIDFilter: input.RuleIDFilter,
+		SourceFilter: input.SourceFilter,
+		Enabled:      enabled,
+	})
+	if err != nil {
+		return Exclusion{}, mutationError("update risk exclusion", err)
+	}
+	beforeExclusion := Project(before)
+	afterExclusion := Project(row)
+	if err := deps.Auditor.LogExclusionUpdate(ctx, tx, UpdateAuditEvent{
+		OrganizationID: row.OrganizationID,
+		ProjectID:      row.ProjectID,
+		Actor:          input.Actor,
+		Before:         AuditSnapshot(beforeExclusion),
+		After:          AuditSnapshot(afterExclusion),
+		DisplayName:    DisplayName(afterExclusion),
+	}); err != nil {
+		return Exclusion{}, mutationError("log risk exclusion update", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Exclusion{}, mutationError("commit risk exclusion update", err)
+	}
+	if deps.AfterCommit != nil {
+		deps.AfterCommit(ctx, row.ProjectID, row.ID)
+	}
+	return afterExclusion, nil
+}
+
+func (c *Core) Delete(ctx context.Context, input DeleteMutation) error {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return err
+	}
+	tx, err := deps.Transactor.Begin(ctx)
+	if err != nil {
+		return mutationError("begin transaction", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	queries := repo.New(tx)
+	if err := queries.LockRiskExclusionMutations(ctx, input.ProjectID.String()); err != nil {
+		return mutationError("lock risk exclusion mutations", err)
+	}
+	before, err := queries.GetRiskExclusionForUpdate(ctx, repo.GetRiskExclusionForUpdateParams{ID: input.ID, ProjectID: input.ProjectID})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: %w", ErrExclusionNotFound, err)
+		}
+		return mutationError("lock risk exclusion", err)
+	}
+	if err := queries.DeleteRiskExclusion(ctx, repo.DeleteRiskExclusionParams{ID: input.ID, ProjectID: input.ProjectID}); err != nil {
+		return mutationError("delete risk exclusion", err)
+	}
+	exclusion := Project(before)
+	if err := deps.Auditor.LogExclusionDelete(ctx, tx, DeleteAuditEvent{
+		OrganizationID: before.OrganizationID,
+		ProjectID:      before.ProjectID,
+		Actor:          input.Actor,
+		Exclusion:      AuditSnapshot(exclusion),
+		DisplayName:    DisplayName(exclusion),
+	}); err != nil {
+		return mutationError("log risk exclusion delete", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return mutationError("commit risk exclusion delete", err)
+	}
+	if deps.AfterCommit != nil {
+		deps.AfterCommit(ctx, before.ProjectID, before.ID)
+	}
+	return nil
+}
+
+func (c *Core) requireMutationDependencies() (*MutationDependencies, error) {
+	if c.mutations == nil || c.mutations.Transactor == nil || c.mutations.Auditor == nil {
+		return nil, mutationError("risk exclusion mutation dependencies are not configured", nil)
+	}
+	return c.mutations, nil
+}
+
+func ensurePolicy(ctx context.Context, queries *repo.Queries, projectID uuid.UUID, policyID uuid.NullUUID) error {
+	if !policyID.Valid {
+		return nil
+	}
+	if _, err := queries.GetRiskPolicyForUpdate(ctx, repo.GetRiskPolicyForUpdateParams{ID: policyID.UUID, ProjectID: projectID}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: %w", ErrPolicyNotFound, err)
+		}
+		return mutationError("load risk policy", err)
+	}
+	return nil
+}
+
+func enforceRegexLimit(ctx context.Context, queries *repo.Queries, projectID uuid.UUID, policyID, excludeID uuid.NullUUID, matchType string, enabled bool) error {
+	if matchType != "regex" || !enabled {
+		return nil
+	}
+	count, err := queries.CountEnabledRegexExclusionsInScope(ctx, repo.CountEnabledRegexExclusionsInScopeParams{
+		ProjectID: projectID, RiskPolicyID: policyID, ExcludeID: excludeID,
+	})
+	if err != nil {
+		return mutationError("count regex exclusions", err)
+	}
+	if count >= MaxRegexPerScope {
+		return &RegexLimitError{}
+	}
+	return nil
+}
+
+func valueOrEmpty(value pgtype.Text) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}
+
+func mutationError(message string, cause error) error {
+	return &MutationError{Message: message, Cause: cause}
+}

--- a/server/internal/risk/exclusioncore/core_test.go
+++ b/server/internal/risk/exclusioncore/core_test.go
@@ -1,0 +1,96 @@
+package exclusioncore
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+func TestValidateMatchValue(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateMatchValue("exact", "value"))
+	require.NoError(t, ValidateMatchValue("regex", `^value$`))
+
+	var validationErr *ValidationError
+	err := ValidateMatchValue("exact", "")
+	require.ErrorAs(t, err, &validationErr)
+	require.Equal(t, "match_value must not be empty", validationErr.Message)
+	require.NoError(t, validationErr.Cause)
+
+	err = ValidateMatchValue("regex", strings.Repeat("x", RegexMaxLength+1))
+	require.ErrorAs(t, err, &validationErr)
+	require.Equal(t, "regex pattern too long (max 512 characters)", validationErr.Message)
+
+	err = ValidateMatchValue("regex", "[")
+	require.ErrorAs(t, err, &validationErr)
+	require.Equal(t, "invalid regex pattern", validationErr.Message)
+	require.Error(t, validationErr.Cause)
+}
+
+func TestAuditSnapshotRedactsSensitiveFields(t *testing.T) {
+	t.Parallel()
+
+	exclusion := Exclusion{
+		ID:             uuid.New(),
+		ProjectID:      uuid.New(),
+		OrganizationID: "<ORG_ID>",
+		RiskPolicyID:   uuid.NullUUID{},
+		MatchType:      "exact",
+		MatchValue:     "sensitive-value",
+		RuleIDFilter:   "sensitive-rule",
+		SourceFilter:   "sensitive-source",
+		Enabled:        true,
+		CreatedAt:      time.Time{},
+		UpdatedAt:      time.Time{},
+	}
+
+	snapshot := AuditSnapshot(exclusion)
+	require.Equal(t, RedactValue("sensitive-value"), snapshot.MatchValue)
+	require.Equal(t, RedactValue("sensitive-rule"), snapshot.RuleIDFilter)
+	require.Equal(t, RedactValue("sensitive-source"), snapshot.SourceFilter)
+	require.NotContains(t, DisplayName(exclusion), exclusion.MatchValue)
+
+	// Redaction returns a copy; the caller's response projection stays intact.
+	require.Equal(t, "sensitive-value", exclusion.MatchValue)
+	require.Equal(t, "sensitive-rule", exclusion.RuleIDFilter)
+	require.Equal(t, "sensitive-source", exclusion.SourceFilter)
+}
+
+func TestProjectPreservesReadShape(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, time.August, 25, 1, 2, 3, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Hour)
+	policyID := uuid.New()
+	row := repo.RiskExclusion{
+		ID:             uuid.New(),
+		ProjectID:      uuid.New(),
+		OrganizationID: "<ORG_ID>",
+		RiskPolicyID:   uuid.NullUUID{UUID: policyID, Valid: true},
+		MatchType:      "rule_id",
+		MatchValue:     "rule",
+		RuleIDFilter:   pgtype.Text{String: "filter", Valid: true},
+		SourceFilter:   pgtype.Text{},
+		Enabled:        true,
+		CreatedAt:      pgtype.Timestamptz{Time: createdAt, Valid: true},
+		UpdatedAt:      pgtype.Timestamptz{Time: updatedAt, Valid: true},
+		DeletedAt:      pgtype.Timestamptz{},
+		Deleted:        false,
+	}
+
+	got := Project(row)
+	require.Equal(t, row.ID, got.ID)
+	require.Equal(t, policyID, got.RiskPolicyID.UUID)
+	require.True(t, got.RiskPolicyID.Valid)
+	require.Equal(t, "filter", got.RuleIDFilter)
+	require.Empty(t, got.SourceFilter)
+	require.Equal(t, createdAt, got.CreatedAt)
+	require.Equal(t, updatedAt, got.UpdatedAt)
+}

--- a/server/internal/risk/exclusioncore/core_test.go
+++ b/server/internal/risk/exclusioncore/core_test.go
@@ -52,14 +52,21 @@ func TestAuditSnapshotRedactsSensitiveFields(t *testing.T) {
 		UpdatedAt:      time.Time{},
 	}
 
-	snapshot := AuditSnapshot(exclusion)
-	require.Equal(t, "<redacted>", snapshot.MatchValue)
-	require.Equal(t, "<redacted>", snapshot.RuleIDFilter)
-	require.Equal(t, "<redacted>", snapshot.SourceFilter)
+	redactor := NewRedactor("test-redaction-key")
+	snapshot := AuditSnapshot(redactor, exclusion)
+	require.Regexp(t, `^redacted:hmac-sha256:[0-9a-f]{16}$`, snapshot.MatchValue)
+	require.Regexp(t, `^redacted:hmac-sha256:[0-9a-f]{16}$`, snapshot.RuleIDFilter)
+	require.Regexp(t, `^redacted:hmac-sha256:[0-9a-f]{16}$`, snapshot.SourceFilter)
 	require.NotEqual(t, exclusion.MatchValue, snapshot.MatchValue)
 	require.NotEqual(t, exclusion.RuleIDFilter, snapshot.RuleIDFilter)
 	require.NotEqual(t, exclusion.SourceFilter, snapshot.SourceFilter)
-	require.Equal(t, "exact:<redacted>", DisplayName(exclusion))
+	require.Equal(t, snapshot.MatchValue, AuditSnapshot(redactor, exclusion).MatchValue)
+	require.NotEqual(t, snapshot.MatchValue, snapshot.RuleIDFilter, "field domains must not collide")
+	require.Equal(t, "exact:"+snapshot.MatchValue, DisplayName(redactor, exclusion))
+
+	otherProject := exclusion
+	otherProject.ProjectID = uuid.New()
+	require.NotEqual(t, snapshot.MatchValue, AuditSnapshot(redactor, otherProject).MatchValue)
 
 	// Redaction returns a copy; the caller's response projection stays intact.
 	require.Equal(t, "sensitive-value", exclusion.MatchValue)

--- a/server/internal/risk/exclusioncore/core_test.go
+++ b/server/internal/risk/exclusioncore/core_test.go
@@ -17,6 +17,7 @@ func TestValidateMatchValue(t *testing.T) {
 
 	require.NoError(t, ValidateMatchValue("exact", "value"))
 	require.NoError(t, ValidateMatchValue("regex", `^value$`))
+	require.NoError(t, ValidateMatchValue("regex", strings.Repeat("é", RegexMaxLength)))
 
 	var validationErr *ValidationError
 	err := ValidateMatchValue("exact", "")
@@ -52,15 +53,44 @@ func TestAuditSnapshotRedactsSensitiveFields(t *testing.T) {
 	}
 
 	snapshot := AuditSnapshot(exclusion)
-	require.Equal(t, RedactValue("sensitive-value"), snapshot.MatchValue)
-	require.Equal(t, RedactValue("sensitive-rule"), snapshot.RuleIDFilter)
-	require.Equal(t, RedactValue("sensitive-source"), snapshot.SourceFilter)
-	require.NotContains(t, DisplayName(exclusion), exclusion.MatchValue)
+	require.Equal(t, "<redacted>", snapshot.MatchValue)
+	require.Equal(t, "<redacted>", snapshot.RuleIDFilter)
+	require.Equal(t, "<redacted>", snapshot.SourceFilter)
+	require.NotEqual(t, exclusion.MatchValue, snapshot.MatchValue)
+	require.NotEqual(t, exclusion.RuleIDFilter, snapshot.RuleIDFilter)
+	require.NotEqual(t, exclusion.SourceFilter, snapshot.SourceFilter)
+	require.Equal(t, "exact:<redacted>", DisplayName(exclusion))
 
 	// Redaction returns a copy; the caller's response projection stays intact.
 	require.Equal(t, "sensitive-value", exclusion.MatchValue)
 	require.Equal(t, "sensitive-rule", exclusion.RuleIDFilter)
 	require.Equal(t, "sensitive-source", exclusion.SourceFilter)
+}
+
+func TestToggleUpdateParamsPreservesDefinition(t *testing.T) {
+	t.Parallel()
+
+	before := repo.RiskExclusion{
+		ID:             uuid.New(),
+		ProjectID:      uuid.New(),
+		OrganizationID: "<ORG_ID>",
+		RiskPolicyID:   uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		MatchType:      "regex",
+		MatchValue:     "^value$",
+		RuleIDFilter:   pgtype.Text{String: "rule", Valid: true},
+		SourceFilter:   pgtype.Text{String: "source", Valid: true},
+		Enabled:        false,
+	}
+
+	params := toggleUpdateParams(before, true)
+	require.Equal(t, before.ID, params.ID)
+	require.Equal(t, before.ProjectID, params.ProjectID)
+	require.Equal(t, before.RiskPolicyID, params.RiskPolicyID)
+	require.Equal(t, before.MatchType, params.MatchType)
+	require.Equal(t, before.MatchValue, params.MatchValue)
+	require.Equal(t, before.RuleIDFilter, params.RuleIDFilter)
+	require.Equal(t, before.SourceFilter, params.SourceFilter)
+	require.True(t, params.Enabled)
 }
 
 func TestProjectPreservesReadShape(t *testing.T) {

--- a/server/internal/risk/exclusioncore/redaction.go
+++ b/server/internal/risk/exclusioncore/redaction.go
@@ -1,0 +1,48 @@
+package exclusioncore
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/speakeasy-api/gram/server/internal/inv"
+)
+
+const (
+	exclusionRedactionDomain = "gram/risk/exclusion-redaction/v1"
+	redactedValuePrefix      = "redacted:hmac-sha256:"
+)
+
+// Redactor produces stable project-scoped fingerprints without exposing values
+// to offline dictionary attacks. Field names domain-separate match values from
+// filters even when their literal content is identical.
+type Redactor struct {
+	key []byte
+}
+
+func NewRedactor(keyMaterial string) Redactor {
+	inv.Require("risk exclusion redactor", "key material is configured", keyMaterial != "")
+
+	derive := hmac.New(sha256.New, []byte(keyMaterial))
+	_, _ = derive.Write([]byte(exclusionRedactionDomain))
+	return Redactor{key: derive.Sum(nil)}
+}
+
+func (r Redactor) Configured() bool {
+	return len(r.key) > 0
+}
+
+func (r Redactor) Redact(projectID, field, value string) string {
+	if value == "" {
+		return ""
+	}
+	inv.Require("risk exclusion redactor", "derived key is configured", len(r.key) > 0)
+
+	mac := hmac.New(sha256.New, r.key)
+	_, _ = mac.Write([]byte(projectID))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(field))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(value))
+	return redactedValuePrefix + hex.EncodeToString(mac.Sum(nil))[:16]
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -241,6 +241,7 @@ func NewService(
 			Transactor:  db,
 			Auditor:     exclusionMutationAuditor{logger: auditLogger},
 			AfterCommit: newExclusionAfterCommit(logger, reconciler),
+			Redactor:    exclusioncore.NewRedactor(jwtSecret),
 		}),
 		auth:                         auth.New(logger, db, sessions, authzEngine),
 		authz:                        authzEngine,

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -53,6 +53,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
 	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
@@ -96,6 +97,7 @@ type Service struct {
 	db                           *pgxpool.Pool
 	repo                         *repo.Queries
 	policies                     *policycore.Core
+	exclusions                   *exclusioncore.Core
 	auth                         *auth.Auth
 	authz                        *authz.Engine
 	signaler                     RiskAnalysisSignaler
@@ -163,6 +165,7 @@ func NewObserver(
 		db:                           db,
 		repo:                         repo.New(db),
 		policies:                     policycore.New(db),
+		exclusions:                   exclusioncore.New(db),
 		auth:                         nil,
 		authz:                        nil,
 		signaler:                     signaler,
@@ -233,6 +236,11 @@ func NewService(
 			ReconcileURLs:    policycore.ReconcilePolicyURLs(reconcileShadowMCPPolicyURLs),
 			Signaler:         signaler,
 			CacheInvalidator: policyCacheInvalidator,
+		}),
+		exclusions: exclusioncore.New(db, exclusioncore.MutationDependencies{
+			Transactor:  db,
+			Auditor:     exclusionMutationAuditor{logger: auditLogger},
+			AfterCommit: newExclusionAfterCommit(logger, reconciler),
 		}),
 		auth:                         auth.New(logger, db, sessions, authzEngine),
 		authz:                        authzEngine,
@@ -1056,6 +1064,9 @@ func (s *Service) DeleteRiskPolicy(ctx context.Context, payload *gen.DeleteRiskP
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	q := repo.New(dbtx)
+	if err := q.LockRiskExclusionMutations(ctx, authCtx.ProjectID.String()); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock risk exclusion mutations").LogError(ctx, s.logger)
+	}
 	if err := q.DeleteRiskPolicy(ctx, repo.DeleteRiskPolicyParams{
 		ID:        id,
 		ProjectID: *authCtx.ProjectID,
@@ -2872,7 +2883,7 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 		"type": "object",
 		"properties": map[string]any{
 			"match_type":     map[string]any{"type": "string", "enum": []string{"exact", "regex", "rule_id", "source", "entity_type"}},
-			"match_value":    map[string]any{"type": "string", "minLength": 1, "maxLength": exclusionRegexMaxLength},
+			"match_value":    map[string]any{"type": "string", "minLength": 1, "maxLength": exclusioncore.RegexMaxLength},
 			"rule_id_filter": map[string]any{"type": "string", "maxLength": 200},
 			"source_filter":  map[string]any{"type": "string", "maxLength": 200},
 		},

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1529,6 +1529,19 @@ WHERE id = @id
   AND project_id = @project_id
   AND deleted IS FALSE;
 
+-- name: GetRiskExclusionForUpdate :one
+SELECT *
+FROM risk_exclusions
+WHERE id = @id
+  AND project_id = @project_id
+  AND deleted IS FALSE
+FOR UPDATE;
+
+-- name: LockRiskExclusionMutations :exec
+-- Serialize exclusion writes per project. Regex limits span rows and include the
+-- empty global scope, so row locks alone cannot protect the count-and-write.
+SELECT pg_advisory_xact_lock(hashtextextended('risk-exclusion:' || @project_id::text, 0));
+
 -- name: GetRiskExclusionForReconcile :one
 -- Fetches an exclusion regardless of deleted/enabled state so the reconcile
 -- sweep can decide whether to apply (enabled) or only reverse (deleted/disabled).
@@ -1562,14 +1575,16 @@ ORDER BY created_at;
 
 -- name: CountEnabledRegexExclusionsInScope :one
 -- Enforces the per-scope regex cap. Counts enabled regex exclusions sharing the
--- same scope (same risk_policy_id, treating NULL/global as its own bucket).
+-- same scope (same risk_policy_id, treating NULL/global as its own bucket),
+-- optionally excluding the row currently being updated.
 SELECT COUNT(*)::BIGINT
 FROM risk_exclusions
 WHERE project_id = @project_id
   AND match_type = 'regex'
   AND enabled IS TRUE
   AND deleted IS FALSE
-  AND risk_policy_id IS NOT DISTINCT FROM sqlc.narg(risk_policy_id);
+  AND risk_policy_id IS NOT DISTINCT FROM sqlc.narg(risk_policy_id)
+  AND (sqlc.narg(exclude_id)::uuid IS NULL OR id <> sqlc.narg(exclude_id));
 
 -- name: UpdateRiskExclusion :one
 UPDATE risk_exclusions

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -348,17 +348,20 @@ WHERE project_id = $1
   AND enabled IS TRUE
   AND deleted IS FALSE
   AND risk_policy_id IS NOT DISTINCT FROM $2
+  AND ($3::uuid IS NULL OR id <> $3)
 `
 
 type CountEnabledRegexExclusionsInScopeParams struct {
 	ProjectID    uuid.UUID
 	RiskPolicyID uuid.NullUUID
+	ExcludeID    uuid.NullUUID
 }
 
 // Enforces the per-scope regex cap. Counts enabled regex exclusions sharing the
-// same scope (same risk_policy_id, treating NULL/global as its own bucket).
+// same scope (same risk_policy_id, treating NULL/global as its own bucket),
+// optionally excluding the row currently being updated.
 func (q *Queries) CountEnabledRegexExclusionsInScope(ctx context.Context, arg CountEnabledRegexExclusionsInScopeParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countEnabledRegexExclusionsInScope, arg.ProjectID, arg.RiskPolicyID)
+	row := q.db.QueryRow(ctx, countEnabledRegexExclusionsInScope, arg.ProjectID, arg.RiskPolicyID, arg.ExcludeID)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
@@ -2004,6 +2007,41 @@ type GetRiskExclusionForReconcileParams struct {
 // bounded to a tenant) even though the caller is an internal activity.
 func (q *Queries) GetRiskExclusionForReconcile(ctx context.Context, arg GetRiskExclusionForReconcileParams) (RiskExclusion, error) {
 	row := q.db.QueryRow(ctx, getRiskExclusionForReconcile, arg.ID, arg.ProjectID)
+	var i RiskExclusion
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.OrganizationID,
+		&i.RiskPolicyID,
+		&i.MatchType,
+		&i.MatchValue,
+		&i.RuleIDFilter,
+		&i.SourceFilter,
+		&i.Enabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
+const getRiskExclusionForUpdate = `-- name: GetRiskExclusionForUpdate :one
+SELECT id, project_id, organization_id, risk_policy_id, match_type, match_value, rule_id_filter, source_filter, enabled, created_at, updated_at, deleted_at, deleted
+FROM risk_exclusions
+WHERE id = $1
+  AND project_id = $2
+  AND deleted IS FALSE
+FOR UPDATE
+`
+
+type GetRiskExclusionForUpdateParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+}
+
+func (q *Queries) GetRiskExclusionForUpdate(ctx context.Context, arg GetRiskExclusionForUpdateParams) (RiskExclusion, error) {
+	row := q.db.QueryRow(ctx, getRiskExclusionForUpdate, arg.ID, arg.ProjectID)
 	var i RiskExclusion
 	err := row.Scan(
 		&i.ID,
@@ -4445,6 +4483,17 @@ func (q *Queries) ListUserEmailsByIDs(ctx context.Context, arg ListUserEmailsByI
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockRiskExclusionMutations = `-- name: LockRiskExclusionMutations :exec
+SELECT pg_advisory_xact_lock(hashtextextended('risk-exclusion:' || $1::text, 0))
+`
+
+// Serialize exclusion writes per project. Regex limits span rows and include the
+// empty global scope, so row locks alone cannot protect the count-and-write.
+func (q *Queries) LockRiskExclusionMutations(ctx context.Context, projectID string) error {
+	_, err := q.db.Exec(ctx, lockRiskExclusionMutations, projectID)
+	return err
 }
 
 const lockRiskPolicyMutations = `-- name: LockRiskPolicyMutations :exec


### PR DESCRIPTION
Linear: https://linear.app/speakeasy/issue/AGE-3168/featplatform-mcp-d3-risk-policies-and-exclusions

> Stacked on #5680.

## Summary

- Move exclusion creation, updates, and deletion behind a transport-neutral core.
- Serialize project exclusion mutations and use locked reads so the enabled-regex cap is enforced atomically.
- Keep audit snapshots redacted and transactional, run reconciliation after commit, and regenerate the SQLc bindings.

## Motivation

Share exclusion administration with the upcoming Platform MCP transport while preserving existing Goa behavior and closing races around the enabled-regex cap. This change does not require a schema migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes risk exclusion administration in a transport-neutral core and replaces unkeyed sha256 fingerprints with keyed HMAC-SHA256 redaction for free-text values. Writes are serialized per project and reconciliation runs after commit in a detached, bounded goroutine so requests no longer wait.

- Linked Linear: AGE-3168 (D3) — shares exclusion admin across transports.

**Refactors**
- Adds `server/internal/risk/exclusioncore` with list/create/update/delete/toggle, shared validation, auditing, and an after-commit reconcile callback.
- Goa service delegates to the core via an auditor adapter and keeps existing API error shapes.
- Introduces `GetRiskExclusionForUpdate` and `LockRiskExclusionMutations`; policy deletes acquire the same lock.
- Redaction is HMAC-SHA256 keyed from the JWT signing key and scoped per project and field, used by both platform tools and audit snapshots.
- Runs reconciliation post-commit in a detached goroutine with a short timeout that ignores request cancellation.

**Bug Fixes**
- Excludes the row being updated when enforcing the per-scope enabled-regex cap.
- Locks policy and exclusion existence checks and returns not found under lock.
- Keeps the current enabled state on updates when `enabled` is omitted.

<sup>Written for commit 6b3036c1fabd60217d5e88c906ab1fecfd23458c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

