### PR TITLE
chore: trace skill insight query phases

### DIFF
--- a/server/internal/skillefficacy/impl.go
+++ b/server/internal/skillefficacy/impl.go
@@ -15,6 +15,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
@@ -148,7 +150,7 @@ func (s *Service) QueryInsights(ctx context.Context, payload *gen.QueryInsightsP
 	}
 	var rows []telemetryrepo.SkillInsightBucket
 	if len(responseSkillIDs) > 0 {
-		rows, err = s.insights.QuerySkillInsights(ctx, telemetryrepo.QuerySkillInsightsParams{
+		rows, err = s.querySkillInsights(ctx, "skillEfficacy.queryInsights.main", telemetryrepo.QuerySkillInsightsParams{
 			OrganizationID:  authCtx.ActiveOrganizationID,
 			ProjectID:       authCtx.ProjectID.String(),
 			SkillIDs:        skillIDs,
@@ -232,7 +234,7 @@ func (s *Service) attachRegressionSignals(ctx context.Context, logger *slog.Logg
 		versionIDs = append(versionIDs, versionID)
 	}
 	windowEnd := time.Now().UTC()
-	rows, err := s.insights.QuerySkillInsights(ctx, telemetryrepo.QuerySkillInsightsParams{
+	rows, err := s.querySkillInsights(ctx, "skillEfficacy.queryInsights.regression", telemetryrepo.QuerySkillInsightsParams{
 		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: authCtx.ProjectID.String(), SkillIDs: regressionSkillIDs,
 		SkillVersionIDs: versionIDs, From: windowEnd.Add(-config.TrendWindow), To: windowEnd,
 		IntervalSeconds: int64(config.TrendWindow.Seconds()),
@@ -259,6 +261,26 @@ func (s *Service) attachRegressionSignals(ctx context.Context, logger *slog.Logg
 		}
 	}
 	return nil
+}
+
+func (s *Service) querySkillInsights(ctx context.Context, spanName string, params telemetryrepo.QuerySkillInsightsParams) ([]telemetryrepo.SkillInsightBucket, error) {
+	ctx, span := s.tracer.Start(ctx, spanName, trace.WithAttributes(
+		attribute.Int("skill.insights.skill_count", len(params.SkillIDs)),
+		attribute.Int("skill.insights.skill_version_count", len(params.SkillVersionIDs)),
+		attribute.Int64("skill.insights.window_seconds", int64(params.To.Sub(params.From).Seconds())),
+		attribute.Int64("skill.insights.interval_seconds", params.IntervalSeconds),
+	))
+	defer span.End()
+
+	rows, err := s.insights.QuerySkillInsights(ctx, params)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.Int("skill.insights.bucket_count", len(rows)))
+	return rows, nil
 }
 
 func (s *Service) requireProjectAccess(ctx context.Context, scope authz.Scope) (*contextvalues.AuthContext, *slog.Logger, error) {

--- a/server/internal/skillefficacy/impl.go
+++ b/server/internal/skillefficacy/impl.go
@@ -276,7 +276,7 @@ func (s *Service) querySkillInsights(ctx context.Context, spanName string, param
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return nil, err
+		return nil, fmt.Errorf("query skill insights: %w", err)
 	}
 
 	span.SetAttributes(attribute.Int("skill.insights.bucket_count", len(rows)))


### PR DESCRIPTION
## Why?

The skill insights endpoint performs a main analytics query and a regression query sequentially, but production traces currently attribute both to one handler span. That prevents us from identifying which phase is responsible for the remaining latency after the query optimization in #5625.

Relates to [DNO-811](https://linear.app/speakeasy/issue/DNO-811/skill-activation-counts-take-1-minute-to-load).

## What?

Add distinct OpenTelemetry spans for the main and regression insight queries. Each span records aggregate query shape and result size attributes, plus error status, without including organization, project, skill, or version identifiers.

## Notes

This changes observability only. It does not change endpoint behavior, database queries, or schemas.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds separate OpenTelemetry spans for the skill insights main query and regression query so we can attribute latency to each phase. Previously both phases were under one handler span; this supports DNO-811 and does not change endpoint behavior.

**New Features**
- Names spans `skillEfficacy.queryInsights.main` and `skillEfficacy.queryInsights.regression`.
- Adds span attributes for skill count, version count, window seconds, and interval seconds.
- Wraps query errors and marks the span as error on failure; records `bucket_count` on success.
- Omits organization, project, skill, and version identifiers from span attributes.

<sup>Written for commit 730b08c13d3b1403e5b05258bc66b615cc98d95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

