### PR TITLE
fix: delete demo org API keys on reseed

### DIFF
--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -223,9 +223,9 @@ func SnapshotClickHouse(ctx context.Context, ch driver.Conn, orgID string, proje
 }
 
 // TamperDemoRows plants stray rows inside the demo scope — a duplicated chat
-// in Postgres and a duplicated telemetry row in ClickHouse — so a subsequent
-// seed run can be shown to clean up unexpected demo-org data, not merely
-// re-assert its own rows.
+// and a visitor-minted API key in Postgres, a duplicated telemetry row in
+// ClickHouse — so a subsequent seed run can be shown to clean up unexpected
+// demo-org data, not merely re-assert its own rows.
 func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID string, projectID string) error {
 	// Generated columns (e.g. chats.deleted) cannot be written, so the
 	// duplicated row is built column by column from the non-generated set.
@@ -261,6 +261,19 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 	}
 	if tag.RowsAffected() != 1 {
 		return fmt.Errorf("tamper postgres chat: expected 1 row inserted, got %d", tag.RowsAffected())
+	}
+
+	// The seed itself never inserts an API key, so this row cannot be cloned
+	// from an existing one: it stands in for a key a demo visitor minted with
+	// the org:admin grants every demo session holds. Nothing in the demo
+	// project's FK cascade reaches api_keys, so only an explicit scoped delete
+	// removes it.
+	if _, err := db.Exec(ctx, `
+		INSERT INTO api_keys (organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes)
+		VALUES ($1, $2::uuid, 'user_demo_tamper', 'tampered visitor key', 'gram_demo', 'DEMO-TAMPER-HASH', ARRAY['producer'])`,
+		orgID, projectID,
+	); err != nil {
+		return fmt.Errorf("tamper postgres api key: %w", err)
 	}
 
 	err = ch.Exec(ctx, fmt.Sprintf(`

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -263,14 +263,21 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 		return fmt.Errorf("tamper postgres chat: expected 1 row inserted, got %d", tag.RowsAffected())
 	}
 
-	// The seed itself never inserts an API key, so this row cannot be cloned
-	// from an existing one: it stands in for a key a demo visitor minted with
-	// the org:admin grants every demo session holds. Nothing in the demo
-	// project's FK cascade reaches api_keys, so only an explicit scoped delete
-	// removes it.
+	// The seed itself never inserts an API key or a LiteLLM instance, so these
+	// rows cannot be cloned from existing ones: they stand in for what a demo
+	// visitor creates with the org:admin grants every demo session holds. The
+	// projects delete only SET NULLs api_keys.project_id, so the key needs an
+	// explicit scoped delete — and litellm_instances.api_key_id is ON DELETE
+	// RESTRICT, so the instance must be deleted before the key or the whole
+	// reseed aborts on the FK.
 	if _, err := db.Exec(ctx, `
-		INSERT INTO api_keys (organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes)
-		VALUES ($1, $2::uuid, 'user_demo_tamper', 'tampered visitor key', 'gram_demo', 'DEMO-TAMPER-HASH', ARRAY['producer'])`,
+		WITH key AS (
+			INSERT INTO api_keys (organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes)
+			VALUES ($1, $2::uuid, 'user_demo_tamper', 'tampered visitor key', 'gram_demo', 'DEMO-TAMPER-HASH', ARRAY['producer'])
+			RETURNING organization_id, project_id, id
+		)
+		INSERT INTO litellm_instances (organization_id, project_id, api_key_id, created_by_user_id, name)
+		SELECT organization_id, project_id, id, 'user_demo_tamper', 'tampered visitor instance' FROM key`,
 		orgID, projectID,
 	); err != nil {
 		return fmt.Errorf("tamper postgres api key: %w", err)

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -352,12 +352,15 @@ BEGIN
   DELETE FROM deployment_logs WHERE project_id = proj_a;
   DELETE FROM deployments WHERE organization_id = demo_org;
   DELETE FROM assets WHERE project_id = proj_a;
-  -- api_keys does not reference projects, so the projects delete below does
-  -- not cascade to it. Demo visitors hold org:admin (authz.DemoScopeGrants)
-  -- and can mint keys; without this delete those keys outlive every reseed and
-  -- keep working long after the session that created them is gone. The local
-  -- tenant's own key is reinserted by RunLocalFixtures immediately after this
-  -- script runs.
+  -- api_keys.project_id is ON DELETE SET NULL, so the projects delete below
+  -- only orphans the row — the key keeps authenticating, scoped to the org.
+  -- Demo visitors hold org:admin (authz.DemoScopeGrants) and can mint keys, so
+  -- without this delete those keys outlive every reseed and keep working long
+  -- after the session that created them is gone. The local tenant's own key is
+  -- reinserted by RunLocalFixtures immediately after this script runs.
+  -- litellm_instances.api_key_id is ON DELETE RESTRICT, so an instance a
+  -- visitor created would abort the run here; it goes first.
+  DELETE FROM litellm_instances WHERE organization_id = demo_org;
   DELETE FROM api_keys WHERE organization_id = demo_org;
   DELETE FROM projects WHERE organization_id = demo_org;
 

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -27,6 +27,17 @@
 --                per-chat owner comes from demo.chat_owner_idx(n), mirrored
 --                in the ClickHouse seed's arrayElement calls)
 
+-- ensure_demo_org() does the whole delete-and-reinsert as ONE statement, and
+-- the shared pool caps statements at 60s (newDBClient) — which the prod-sized
+-- demo org now exceeds, failing the daily run with SQLSTATE 57014. 3x that
+-- ceiling is enough headroom for the current seed to grow into while still
+-- failing the daily run fast if it ever wedges. SET LOCAL, not
+-- SET: the script is applied as a single multi-statement simple query, so it
+-- runs in one implicit transaction and the setting reverts when that ends —
+-- including on failure, so a raised timeout can never escape onto a pooled
+-- connection.
+SET LOCAL statement_timeout = '180s';
+
 CREATE SCHEMA IF NOT EXISTS demo;
 
 -- Deterministic RFC-compliant UUID from a name. Plain md5(...)::uuid leaves

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -341,6 +341,13 @@ BEGIN
   DELETE FROM deployment_logs WHERE project_id = proj_a;
   DELETE FROM deployments WHERE organization_id = demo_org;
   DELETE FROM assets WHERE project_id = proj_a;
+  -- api_keys does not reference projects, so the projects delete below does
+  -- not cascade to it. Demo visitors hold org:admin (authz.DemoScopeGrants)
+  -- and can mint keys; without this delete those keys outlive every reseed and
+  -- keep working long after the session that created them is gone. The local
+  -- tenant's own key is reinserted by RunLocalFixtures immediately after this
+  -- script runs.
+  DELETE FROM api_keys WHERE organization_id = demo_org;
   DELETE FROM projects WHERE organization_id = demo_org;
 
   -- Single project: the demo org intentionally has exactly one project so
@@ -1344,6 +1351,13 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
   ) x;
   IF stray > 0 THEN
     RAISE EXCEPTION 'demo seed postflight: % demo-org rows reference non-demo users', stray;
+  END IF;
+
+  -- The seed never creates API keys: any row left here was minted by a demo
+  -- visitor and would grant programmatic access that survives the reseed.
+  SELECT count(*) INTO stray FROM api_keys WHERE organization_id = demo_org;
+  IF stray > 0 THEN
+    RAISE EXCEPTION 'demo seed postflight: % api keys survived the reseed', stray;
   END IF;
 
   RAISE NOTICE 'demo seed ok: % chats, % findings, % members, % tools',


### PR DESCRIPTION
Two fixes to the daily demo org reseed.

## API keys survived the reseed

API keys created inside the shared demo org were never removed, so they kept working indefinitely.

`api_keys.project_id` is `ON DELETE SET NULL`, so the seed's `DELETE FROM projects WHERE organization_id = demo_org` — which cascades most demo data away — only orphaned the row. The key kept authenticating, scoped to the org. Demo sessions hold every user-visible scope including `org:admin` (`authz.DemoScopeGrants`), so any visitor can mint a key. The stated safety argument for allowing demo writes at all is that the daily reseed reverts them; that argument did not hold for this table.

- `postgres.sql`: scoped `DELETE FROM api_keys WHERE organization_id = demo_org` alongside the other org-scoped deletes.
- `postgres.sql`: postflight assert — the seed never inserts an API key, so any surviving row is visitor-minted and fails the run.
- `postgres.sql`: `litellm_instances` is deleted first — `litellm_instances.api_key_id` is `ON DELETE RESTRICT`, so an instance a visitor created would abort the whole reseed on the FK.
- `demoseedtest.go`: `TamperDemoRows` plants a visitor-style key and a LiteLLM instance on it between the two seed runs. The existing tamper rows are clones of seeded rows, which cannot cover tables the seed never writes.

## Statement timeout

The scheduled run has started failing with `ERROR: canceling statement due to statement timeout (SQLSTATE 57014)`. `ensure_demo_org()` does the whole delete-and-reinsert as one statement, and the shared pool caps statements at 60s (`newDBClient`), which the demo org has now outgrown.

`SET LOCAL statement_timeout = '180s'` at the top of the script — 3x the pool default, enough headroom to grow into while still failing fast if a run wedges. `SET LOCAL` rather than `SET`: the script is applied as a single multi-statement simple query, so it runs in one implicit transaction and the setting reverts when that ends, including on failure — a raised timeout can never escape onto a pooled connection.

## Testing

`mise run test:server -tags=demoseed_safety ./internal/demoseed/...` passes.

- Verified the API-key coverage is real: with the new delete commented out, the run fails with `demo seed postflight: 1 api keys survived the reseed`.
- Verified the ordering coverage is real: with the `litellm_instances` delete removed, the run fails with `violates foreign key constraint "litellm_instances_api_key_tenant_fkey"` (SQLSTATE 23503).
- Verified the timeout applies: a temporary probe inside `ensure_demo_org()` reports `statement_timeout=3min`.

Local dev is unaffected — `RunLocalFixtures` upserts the local key by id immediately after the script runs.

## Follow-up

Only `api_keys` was audited here. Other org-scoped tables outside the demo project's FK cascade may have the same gap and deserve a sweep in a separate change.
