### PR TITLE
feat: CIMD support for the platform MCP authorization server

### DIFF
--- a/.changeset/platform-mcp-cimd.md
+++ b/.changeset/platform-mcp-cimd.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The Platform MCP authorization server now accepts OAuth Client ID Metadata Documents (CIMD) alongside dynamic client registration. A client that presents a URL-shaped `client_id` has its metadata document fetched, validated, and cached against the stored client row, so agents that prefer CIMD over dynamic registration can connect instead of failing at `/authorize` with no fallback. Loopback redirect URIs match ignoring the port for such clients, as RFC 8252 requires for native apps that bind an ephemeral port per run, and the consent screen shows the document's origin next to the client name.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -138,6 +138,11 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		Signer:        sessiontokens.NewSigner(config.JWTSigningKey),
 		Encryption:    config.Encryption,
 		Telemetry:     oauthTelemetry,
+		Logger:        config.Logger,
+		// Backs the inbound CIMD document fetcher's SSRF protection; without
+		// it the authorization server serves DCR only.
+		GuardianPolicy: config.GuardianPolicy,
+		MeterProvider:  config.MeterProvider,
 	})
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create local Platform MCP OAuth service: %w", err)
@@ -460,6 +465,11 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		Signer:        sessiontokens.NewSigner(config.JWTSigningKey),
 		Encryption:    config.Encryption,
 		Telemetry:     oauthTelemetry,
+		Logger:        config.Logger,
+		// Backs the inbound CIMD document fetcher's SSRF protection; without
+		// it the authorization server serves DCR only.
+		GuardianPolicy: config.GuardianPolicy,
+		MeterProvider:  config.MeterProvider,
 	})
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create platform mcp oauth service: %w", err)

--- a/server/internal/platformmcp/oauth/state.go
+++ b/server/internal/platformmcp/oauth/state.go
@@ -43,6 +43,43 @@ type Client struct {
 	RedirectURIs    []string
 	SecretExpiresAt *time.Time
 	RevokedAt       *time.Time
+
+	// MetadataURI is set when the row came from a Client ID Metadata
+	// Document rather than RFC 7591 dynamic registration. The draft
+	// requires the client_id to equal the document URL, so this doubles as
+	// the CIMD discriminator: a non-empty value means the client is public
+	// by construction and its metadata is a cache of a remote document.
+	MetadataURI string
+	// CacheExpiresAt and ETag carry the stored document's cache state back
+	// to the resolver so it can decide between serving the row, sending a
+	// conditional refresh, and refetching unconditionally.
+	CacheExpiresAt *time.Time
+	ETag           string
+}
+
+// IsCIMD reports whether this client was resolved from a Client ID Metadata
+// Document. CIMD clients are public: the draft forbids symmetric secrets, and
+// the client_id_metadata_uri CHECK constraints enforce that in the database.
+func (c Client) IsCIMD() bool { return c.MetadataURI != "" }
+
+// UpsertCIMDClientInput carries a freshly fetched metadata document into the
+// client registry. ClientID is the document URL, which is also what is stored
+// as the metadata URI.
+type UpsertCIMDClientInput struct {
+	ClientID     string
+	Name         string
+	RedirectURIs []string
+	CacheTTL     time.Duration
+	ETag         string
+}
+
+// TouchCIMDCacheInput refreshes cache bookkeeping after a 304 Not Modified.
+// The stored name and redirect URIs are current by definition of the 304, so
+// they are not part of the input.
+type TouchCIMDCacheInput struct {
+	ClientID string
+	CacheTTL time.Duration
+	ETag     string
 }
 
 type Connection struct {
@@ -121,6 +158,15 @@ type Store interface {
 	RegisterClient(ctx context.Context, client Client) error
 	GetClient(ctx context.Context, clientID string) (Client, error)
 	RevokeClient(ctx context.Context, clientID string, now time.Time) error
+	// UpsertClientFromCIMD writes a client resolved from a metadata
+	// document, replacing the mutable metadata and the cache columns. It
+	// returns ErrNotFound when the client_id is already held by a
+	// secret-bearing registration or a revoked row, neither of which a
+	// document may rewrite.
+	UpsertClientFromCIMD(ctx context.Context, input UpsertCIMDClientInput) (Client, error)
+	// TouchClientCIMDCache moves the cache stamp, expiry, and validator on
+	// an existing CIMD row after a 304, with the same guards.
+	TouchClientCIMDCache(ctx context.Context, input TouchCIMDCacheInput) (Client, error)
 	RegisterConnection(ctx context.Context, connection Connection) error
 	GetConnection(ctx context.Context, organizationID, subject, clientID string) (Connection, error)
 	AuthorizeConnection(ctx context.Context, input AuthorizeConnectionInput) (Connection, error)
@@ -183,6 +229,46 @@ func (s *InMemoryStore) GetClient(_ context.Context, clientID string) (Client, e
 	if client.RevokedAt != nil {
 		return Client{}, ErrRevoked
 	}
+	return client, nil
+}
+
+func (s *InMemoryStore) UpsertClientFromCIMD(_ context.Context, input UpsertCIMDClientInput) (Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.clients[input.ClientID]; ok && (existing.SecretHash != "" || existing.RevokedAt != nil) {
+		// Mirrors the guarded DO UPDATE in Postgres: a document may never
+		// rewrite a secret-bearing registration or resurrect a revoked row.
+		return Client{}, ErrNotFound
+	}
+	expiresAt := time.Now().Add(input.CacheTTL)
+	client := Client{
+		ID:              input.ClientID,
+		SecretHash:      "",
+		Name:            input.Name,
+		RedirectURIs:    input.RedirectURIs,
+		SecretExpiresAt: nil,
+		RevokedAt:       nil,
+		MetadataURI:     input.ClientID,
+		CacheExpiresAt:  &expiresAt,
+		ETag:            input.ETag,
+	}
+	s.clients[input.ClientID] = client
+	return client, nil
+}
+
+func (s *InMemoryStore) TouchClientCIMDCache(_ context.Context, input TouchCIMDCacheInput) (Client, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	client, ok := s.clients[input.ClientID]
+	if !ok || !client.IsCIMD() || client.SecretHash != "" || client.RevokedAt != nil {
+		return Client{}, ErrNotFound
+	}
+	expiresAt := time.Now().Add(input.CacheTTL)
+	client.CacheExpiresAt = &expiresAt
+	client.ETag = input.ETag
+	s.clients[input.ClientID] = client
 	return client, nil
 }
 

--- a/server/internal/platformmcp/oauth_client_resolver.go
+++ b/server/internal/platformmcp/oauth_client_resolver.go
@@ -1,0 +1,289 @@
+// Client resolution seam for the Platform MCP authorization server. Every
+// handler that resolves a registered client from a presented client_id —
+// authorize, organization selection, connect, token — funnels through
+// resolveClient, so inbound CIMD resolution and the layers around it
+// (admission control and document caching) have exactly one home instead of
+// per-handler branches.
+//
+// This mirrors internal/mcp/client_resolver.go, which does the same job for
+// the hosted, issuer-gated authorization server. The two share the resolver,
+// the validator, and the admission vocabulary but not their storage: hosted
+// clients hang off a project's issuer, platform clients are global because
+// registration happens before browser authentication and organization
+// selection.
+
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
+)
+
+// platformCIMDAdmissionMode is the admission policy this authorization
+// server applies to URL-shaped client_ids. Unlike a hosted issuer, it is a
+// compile-time constant: Platform MCP has one, first-party authorization
+// server with no per-tenant configuration surface to hang a mode off.
+//
+// Open is the deliberate choice. Client identity is not the security
+// boundary here — every flow still passes IDP login, organization
+// selection, the live org:admin recheck in gateAndAuthorize, and explicit
+// user consent — and dynamic client registration on this same server is
+// already open to anyone, so admitting spec-valid documents adds no trust
+// that DCR does not already grant. CIMD is in fact the stronger of the two:
+// the client_id is a fetchable URL bound to an origin we can show the user,
+// rather than an opaque identifier chosen anonymously.
+//
+// Decisions are counted under the same cimd.admission.decisions instrument
+// the hosted AS uses, so tightening this to ModePresets later is a constant
+// change informed by real data rather than a guess. ModePresets on this
+// server denies anything outside the curated catalog: there is no
+// per-issuer custom URL table to consult.
+const platformCIMDAdmissionMode = admission.ModeOpen
+
+// clientMetadataResolver is the subset of *cimd.Resolver this package uses,
+// declared as an interface so tests can host documents on an httptest
+// server without a guardian policy.
+type clientMetadataResolver interface {
+	Resolve(ctx context.Context, clientID string, cache cimd.CacheState) (*cimd.CacheResult, error)
+}
+
+// errCIMDFetchFailed marks a transport-level document fetch failure. The
+// wrapped cause may name internal network conditions (guardian SSRF denials,
+// DNS errors), so handlers must log it and render a generic OAuth error
+// rather than echoing it to the client.
+var errCIMDFetchFailed = errors.New("cimd document fetch failed")
+
+// clientResolveMode selects how resolveClient treats a URL-shaped client_id.
+type clientResolveMode string
+
+const (
+	// lookupClientOnly resolves strictly from the store. Used by every leg
+	// after authorize: the row was persisted there, and a mid-flow request
+	// must keep working even if the document host is briefly unreachable.
+	lookupClientOnly clientResolveMode = "lookup_only"
+
+	// resolveClientCIMD additionally treats a URL-shaped client_id as a
+	// Client ID Metadata Document reference: the stored row is read for its
+	// cache state, the document fetched and validated when that cache has
+	// lapsed, and the row lazily upserted. Authorize-time only.
+	resolveClientCIMD clientResolveMode = "resolve_cimd"
+)
+
+// resolveClient resolves the registered client behind a presented client_id.
+// Error contract, in the order callers should check:
+//
+//   - *admission.DenialError: policy refused this client_id before any fetch
+//     ran; render invalid_client with the error's own Description
+//     (resolveClientCIMD only)
+//   - *oauthwire.Error: a CIMD spec/policy rejection with a client-safe code
+//     and description (resolveClientCIMD only)
+//   - errCIMDFetchFailed: document fetch failure; log it, render generic
+//     (resolveClientCIMD only)
+//   - platformoauth.ErrNotFound / ErrRevoked: unknown or revoked client
+//   - anything else: infrastructure failure
+func (s *OAuthHTTP) resolveClient(ctx context.Context, clientID string, mode clientResolveMode) (platformoauth.Client, error) {
+	if mode != resolveClientCIMD || s.cimd == nil || !cimd.IsClientIDURL(clientID) {
+		client, err := s.store.GetClient(ctx, clientID)
+		if err != nil {
+			return platformoauth.Client{}, fmt.Errorf("lookup platform client: %w", err)
+		}
+		return client, nil
+	}
+
+	// Admission runs before the resolver, so a denied client_id costs a map
+	// lookup — no outbound request, no fetch timeout.
+	if err := s.admitCIMDClient(ctx, clientID); err != nil {
+		return platformoauth.Client{}, err
+	}
+
+	// The persisted row doubles as the document cache, so it is read before
+	// the fetch rather than only written after one. A miss is the ordinary
+	// first-contact case, not an error. Only a CIMD row is a cache: a
+	// secret-bearing registration sharing this client_id must still force a
+	// fetch, and the upsert's guard will refuse to rewrite it anyway.
+	var cache cimd.CacheState
+	cached, err := s.store.GetClient(ctx, clientID)
+	switch {
+	case err == nil:
+		if cached.IsCIMD() && cached.CacheExpiresAt != nil {
+			cache = cimd.CacheState{ExpiresAt: *cached.CacheExpiresAt, ETag: cached.ETag}
+		}
+	case errors.Is(err, platformoauth.ErrNotFound):
+	default:
+		return platformoauth.Client{}, fmt.Errorf("lookup cimd platform client: %w", err)
+	}
+
+	result, err := s.cimd.Resolve(ctx, clientID, cache)
+	if err != nil {
+		// Fail closed on every refresh failure, leaving the cached row as it
+		// was: -02 §5.1 says a fetch failure SHOULD abort the authorization
+		// request, so an expired document is never served stale to keep a
+		// flow alive. A spec rejection is already client-safe; anything else
+		// may name internal network conditions.
+		if _, ok := errors.AsType[*oauthwire.Error](err); ok {
+			return platformoauth.Client{}, fmt.Errorf("resolve cimd client: %w", err)
+		}
+		return platformoauth.Client{}, fmt.Errorf("%w: %w", errCIMDFetchFailed, err)
+	}
+
+	switch result.Outcome {
+	case cimd.CacheOutcomeCached:
+		return cached, nil
+	case cimd.CacheOutcomeNotModified:
+		client, err := s.store.TouchClientCIMDCache(ctx, platformoauth.TouchCIMDCacheInput{ClientID: clientID, CacheTTL: result.TTL, ETag: result.ETag})
+		if err != nil {
+			// No such updatable row means it stopped being a CIMD row
+			// between the read and the write (revoked, or replaced by a
+			// secret-bearing registration); the caller renders that as an
+			// unknown client rather than serving what the 304 was about.
+			return platformoauth.Client{}, fmt.Errorf("refresh cimd client cache: %w", err)
+		}
+		return client, nil
+	case cimd.CacheOutcomeRefreshed:
+		client, err := s.store.UpsertClientFromCIMD(ctx, platformoauth.UpsertCIMDClientInput{
+			ClientID:     clientID,
+			Name:         result.Document.ClientName,
+			RedirectURIs: result.Document.RedirectURIs,
+			CacheTTL:     result.TTL,
+			ETag:         result.ETag,
+		})
+		if err != nil {
+			return platformoauth.Client{}, fmt.Errorf("upsert cimd client: %w", err)
+		}
+		return client, nil
+	default:
+		return platformoauth.Client{}, fmt.Errorf("unknown cimd resolve outcome %q", result.Outcome)
+	}
+}
+
+// admitCIMDClient enforces platformCIMDAdmissionMode against a presented
+// URL-shaped client_id, before any document is fetched. Returns nil when the
+// client is admitted and a *admission.DenialError when policy denies it.
+func (s *OAuthHTTP) admitCIMDClient(ctx context.Context, clientID string) error {
+	decision := admission.Evaluate(platformCIMDAdmissionMode, clientID)
+	if decision.Outcome == admission.OutcomeCheckCustom {
+		// The branch that asks the caller to consult an issuer's own URL
+		// rows. Platform MCP has no such table — it is a single first-party
+		// server, not a per-tenant one — so a catalog miss is final.
+		decision = admission.Decision{Outcome: admission.OutcomeDeny, Admit: "", Denial: admission.DenialNotListed}
+	}
+
+	if decision.Outcome == admission.OutcomeAdmit {
+		s.cimdAdmission.RecordAdmitted(ctx, platformCIMDAdmissionMode, decision.Admit)
+		return nil
+	}
+
+	// Recorded before the enforcement check, so a reporting mode produces
+	// the same counter series an enforcing one would.
+	s.cimdAdmission.RecordDenied(ctx, platformCIMDAdmissionMode, decision.Denial)
+
+	// The presented client_id goes in the log and never in a metric
+	// dimension: it is attacker-chosen and unbounded on this surface.
+	logAttrs := []any{
+		attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+		attr.SlogCIMDAdmissionMode(platformCIMDAdmissionMode),
+		attr.SlogCIMDAdmissionOutcome(decision.Denial),
+	}
+	if !platformCIMDAdmissionMode.Enforces() {
+		s.logger.InfoContext(ctx, "cimd admission would deny", logAttrs...)
+		return nil
+	}
+	s.logger.InfoContext(ctx, "cimd admission denied", logAttrs...)
+	return &admission.DenialError{Mode: platformCIMDAdmissionMode, Reason: decision.Denial}
+}
+
+// truncateClientIDForLog bounds a presented client_id for logging. The value
+// is attacker-chosen on the unauthenticated OAuth surface and is logged at
+// points that run before any length validation, so an oversized client_id
+// could otherwise inflate every line it appears on.
+func truncateClientIDForLog(clientID string) string {
+	if len(clientID) <= admission.MaxClientIDLength {
+		return clientID
+	}
+	return clientID[:admission.MaxClientIDLength] + "…(truncated)"
+}
+
+// clientRedirectAllowed reports whether a request's redirect_uri matches one
+// registered on the client. The rule is exact string matching (RFC 9700
+// §4.1.3) with exactly one exception, applied to CIMD-resolved clients only:
+// when both the registered and requested URIs are RFC 8252 §7.3 loopback
+// redirects, the port is ignored. RFC 8252 requires the AS to allow variable
+// loopback ports for native apps — Claude Code binds an OS-assigned
+// ephemeral port per invocation — and RFC 9700 preserves that carve-out. The
+// port is the ONLY component allowed to vary: every other component must
+// match in escaped form, and neither side may carry userinfo. Dynamically
+// registered clients keep byte-exact matching.
+func clientRedirectAllowed(client platformoauth.Client, requested string) bool {
+	if slices.Contains(client.RedirectURIs, requested) {
+		return true
+	}
+	if !client.IsCIMD() {
+		return false
+	}
+
+	// Fragments disqualify the exception on either side: RFC 6749 §3.1.2
+	// forbids fragments in redirect URIs, and url.Parse cannot distinguish
+	// an absent fragment from an explicit empty one ("...#") — URL.String()
+	// drops the latter, which would let a malformed registered URI match a
+	// fragment-less request.
+	if strings.Contains(requested, "#") {
+		return false
+	}
+	requestedURL, err := url.Parse(requested)
+	if err != nil || requestedURL.User != nil || !cimd.IsLoopbackRedirectURI(requestedURL) {
+		return false
+	}
+	for _, registered := range client.RedirectURIs {
+		if strings.Contains(registered, "#") {
+			continue
+		}
+		registeredURL, err := url.Parse(registered)
+		if err != nil || registeredURL.User != nil || !cimd.IsLoopbackRedirectURI(registeredURL) {
+			continue
+		}
+		if loopbackRedirectEqualIgnoringPort(registeredURL, requestedURL) {
+			return true
+		}
+	}
+	return false
+}
+
+// loopbackRedirectEqualIgnoringPort reports whether two parsed loopback
+// redirect URIs are identical except for the port. Rebuilding each URI with
+// the port stripped and the host lowercased, then comparing the resulting
+// strings, covers every remaining component in escaped form — scheme, host,
+// path, and query — so a percent-encoding variant (e.g. /%63allback for a
+// registered /callback) cannot slip through the variable-port exception.
+// Callers must have rejected fragments on both sides already.
+func loopbackRedirectEqualIgnoringPort(a, b *url.URL) bool {
+	stripPort := func(u *url.URL) string {
+		c := *u
+		c.Host = strings.ToLower(c.Hostname())
+		return c.String()
+	}
+	return stripPort(a) == stripPort(b)
+}
+
+// clientIDOrigin is the host a CIMD client's metadata document was fetched
+// from, for display on the consent page. Empty for a dynamically registered
+// client, whose identifier says nothing about who it belongs to.
+func clientIDOrigin(client platformoauth.Client) string {
+	if !client.IsCIMD() {
+		return ""
+	}
+	parsed, err := url.Parse(client.MetadataURI)
+	if err != nil {
+		return ""
+	}
+	return parsed.Host
+}

--- a/server/internal/platformmcp/oauth_client_resolver.go
+++ b/server/internal/platformmcp/oauth_client_resolver.go
@@ -115,8 +115,16 @@ func (s *OAuthHTTP) resolveClient(ctx context.Context, clientID string, mode cli
 	cached, err := s.store.GetClient(ctx, clientID)
 	switch {
 	case err == nil:
-		if cached.IsCIMD() && cached.CacheExpiresAt != nil {
-			cache = cimd.CacheState{ExpiresAt: *cached.CacheExpiresAt, ETag: cached.ETag}
+		if cached.IsCIMD() {
+			// The two columns are independent: a host may serve an ETag with
+			// no freshness directives at all, and clearing only the expiry
+			// is a request to revalidate now, not to discard what
+			// revalidation needs. Dropping the validator here would turn
+			// every such refresh into an unconditional fetch.
+			cache.ETag = cached.ETag
+			if cached.CacheExpiresAt != nil {
+				cache.ExpiresAt = *cached.CacheExpiresAt
+			}
 		}
 	case errors.Is(err, platformoauth.ErrNotFound):
 	default:
@@ -171,6 +179,16 @@ func (s *OAuthHTTP) resolveClient(ctx context.Context, clientID string, mode cli
 // client is admitted and a *admission.DenialError when policy denies it.
 func (s *OAuthHTTP) admitCIMDClient(ctx context.Context, clientID string) error {
 	decision := admission.Evaluate(platformCIMDAdmissionMode, clientID)
+	if len(clientID) > admission.MaxClientIDLength {
+		// Evaluate applies this bound itself in the modes that consult the
+		// catalog, but not in the open mode this server runs, where every
+		// URL-shaped value is admitted. Applying it here regardless keeps an
+		// unbounded, attacker-chosen string from becoming the parameter of
+		// an indexed store lookup on an unauthenticated endpoint — the same
+		// reason the bound exists in the admission package at all. The
+		// resolver would reject it too, but only after the read.
+		decision = admission.Decision{Outcome: admission.OutcomeDeny, Admit: "", Denial: admission.DenialOversized}
+	}
 	if decision.Outcome == admission.OutcomeCheckCustom {
 		// The branch that asks the caller to consult an issuer's own URL
 		// rows. Platform MCP has no such table — it is a single first-party

--- a/server/internal/platformmcp/oauth_page.html
+++ b/server/internal/platformmcp/oauth_page.html
@@ -262,6 +262,10 @@
         <dl class="info">
           <dt>Application</dt>
           <dd>{{.ClientName}}</dd>
+          {{if .ClientIDOrigin}}
+          <dt>Verified origin</dt>
+          <dd>{{.ClientIDOrigin}}</dd>
+          {{end}}
           <dt>Organization</dt>
           <dd>{{.OrganizationName}}</dd>
           <dt>Will redirect to</dt>

--- a/server/internal/platformmcp/oauthhttp.go
+++ b/server/internal/platformmcp/oauthhttp.go
@@ -11,23 +11,29 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
 )
 
@@ -47,9 +53,17 @@ var (
 )
 
 type oauthPageData struct {
-	Title            string
-	Kind             string
+	Title string
+	Kind  string
+	// ClientName is attacker-chosen for any CIMD-resolved client: it comes
+	// from a document served at a URL the client picked. ClientIDOrigin is
+	// the trust anchor that name lacks — the host the document was fetched
+	// from, which the client cannot fake without controlling it — so the
+	// consent page shows both whenever a client arrived by CIMD. It is
+	// empty for dynamically registered clients, which have no origin to
+	// vouch for them at all.
 	ClientName       string
+	ClientIDOrigin   string
 	OrganizationName string
 	Organizations    []OrganizationOption
 	RedirectURI      string
@@ -110,6 +124,13 @@ type OAuthHTTP struct {
 	audience      string
 	telemetry     OAuthTelemetry
 	now           func() time.Time
+	logger        *slog.Logger
+	// cimd resolves URL-shaped client_ids against their Client ID Metadata
+	// Documents. Nil disables inbound CIMD entirely: such a client_id then
+	// falls through to an ordinary registry lookup and is rejected as
+	// unknown, and the AS metadata stops advertising support.
+	cimd          clientMetadataResolver
+	cimdAdmission *admission.Metrics
 }
 
 type OAuthHTTPConfig struct {
@@ -124,6 +145,11 @@ type OAuthHTTPConfig struct {
 	Signer        *sessiontokens.Signer
 	Encryption    *encryption.Client
 	Telemetry     OAuthTelemetry
+	Logger        *slog.Logger
+	// GuardianPolicy backs the CIMD document fetcher's SSRF protection.
+	// Nil leaves inbound CIMD disabled.
+	GuardianPolicy *guardian.Policy
+	MeterProvider  metric.MeterProvider
 }
 
 func NewOAuthHTTP(config OAuthHTTPConfig) (*OAuthHTTP, error) {
@@ -133,6 +159,20 @@ func NewOAuthHTTP(config OAuthHTTPConfig) (*OAuthHTTP, error) {
 	credentials, err := NewCredentialCodec(config.Encryption)
 	if err != nil {
 		return nil, err
+	}
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	meterProvider := config.MeterProvider
+	if meterProvider == nil {
+		meterProvider = noop.NewMeterProvider()
+	}
+	// A nil guardian policy leaves resolver nil, which disables inbound
+	// CIMD rather than fetching documents through an unguarded client.
+	var resolver clientMetadataResolver
+	if config.GuardianPolicy != nil {
+		resolver = cimd.NewResolver(config.GuardianPolicy, meterProvider, logger)
 	}
 	baseURL := *config.BaseURL
 	issuer, err := url.JoinPath(baseURL.String(), "platform-mcp")
@@ -154,6 +194,9 @@ func NewOAuthHTTP(config OAuthHTTPConfig) (*OAuthHTTP, error) {
 		audience:      issuer,
 		telemetry:     config.Telemetry,
 		now:           time.Now,
+		logger:        logger,
+		cimd:          resolver,
+		cimdAdmission: admission.NewMetrics(meterProvider, logger),
 	}, nil
 }
 
@@ -203,6 +246,12 @@ func (s *OAuthHTTP) AuthorizationServerHandler() http.Handler {
 			"grant_types_supported":                 usersessions.SupportedGrantTypes,
 			"token_endpoint_auth_methods_supported": usersessions.SupportedAuthMethods,
 			"code_challenge_methods_supported":      usersessions.SupportedCodeChallengeMethods,
+			// Advertised only when a document can actually be resolved and
+			// the admission mode admits something. Advertising support while
+			// admitting nothing would route spec-compliant clients into a
+			// guaranteed-failure flow instead of letting them fall back to
+			// dynamic client registration.
+			"client_id_metadata_document_supported": s.cimd != nil && platformCIMDAdmissionMode != admission.ModeDisabled,
 		})
 	})
 }
@@ -263,8 +312,18 @@ func (s *OAuthHTTP) AuthorizeHandler() http.Handler {
 			writeRequestOAuthError(w, http.StatusBadRequest, err)
 			return
 		}
-		client, err := s.store.GetClient(r.Context(), request.ClientID)
-		if err != nil || !s.clientRedirectAllowed(client, request.RedirectURI) {
+		// URL-shaped client_ids resolve via CIMD here (admission-gated,
+		// inside the resolver). Every resolution failure renders inline per
+		// RFC 6749 §4.1.2.1 — the redirect_uri of an unresolved client
+		// cannot be trusted — and a document fetch failure aborts the
+		// request per draft-ietf-oauth-client-id-metadata-document-02 §5.1
+		// (fail closed, no stale fallback).
+		client, err := s.resolveClient(r.Context(), request.ClientID, resolveClientCIMD)
+		if err != nil {
+			s.writeClientResolutionError(w, r.Context(), request.ClientID, err)
+			return
+		}
+		if !clientRedirectAllowed(client, request.RedirectURI) {
 			writeOAuthError(w, http.StatusUnauthorized, "invalid_client", "unknown client_id or redirect_uri")
 			return
 		}
@@ -364,7 +423,10 @@ func (s *OAuthHTTP) organizationSelectionGet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	client, err := s.store.GetClient(r.Context(), challenge.ClientID)
+	// Lookup only: authorize already resolved and persisted any CIMD row,
+	// and a mid-flow leg must keep working even if the document host has
+	// since become unreachable.
+	client, err := s.resolveClient(r.Context(), challenge.ClientID, lookupClientOnly)
 	if err != nil {
 		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", "authorization client is unavailable")
 		return
@@ -470,7 +532,10 @@ func (s *OAuthHTTP) connectGet(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, http.StatusUnauthorized, "invalid_request", "authorization state is invalid or incomplete")
 		return
 	}
-	client, err := s.store.GetClient(r.Context(), challenge.ClientID)
+	// Lookup only: authorize already resolved and persisted any CIMD row,
+	// and a mid-flow leg must keep working even if the document host has
+	// since become unreachable.
+	client, err := s.resolveClient(r.Context(), challenge.ClientID, lookupClientOnly)
 	if err != nil {
 		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", "authorization client is unavailable")
 		return
@@ -484,6 +549,7 @@ func (s *OAuthHTTP) connectGet(w http.ResponseWriter, r *http.Request) {
 		Title:            "Connect Platform MCP",
 		Kind:             "connect",
 		ClientName:       client.Name,
+		ClientIDOrigin:   clientIDOrigin(client),
 		OrganizationName: organization.Name,
 		RedirectURI:      challenge.RedirectURI,
 		State:            challenge.ID,
@@ -942,8 +1008,34 @@ func (s *OAuthHTTP) url(segment string) string {
 	return s.issuer + "/" + segment
 }
 
-func (s *OAuthHTTP) clientRedirectAllowed(client platformoauth.Client, redirectURI string) bool {
-	return slices.Contains(client.RedirectURIs, redirectURI)
+// writeClientResolutionError maps the resolveClient error contract onto the
+// wire. Called before any redirect_uri is trusted, so every case renders
+// inline rather than redirecting (RFC 6749 §4.1.2.1).
+func (s *OAuthHTTP) writeClientResolutionError(w http.ResponseWriter, ctx context.Context, clientID string, err error) {
+	if admissionErr, ok := errors.AsType[*admission.DenialError](err); ok {
+		// Policy, not a spec violation, and it carries its own actionable
+		// description. Already logged inside admitCIMDClient.
+		writeOAuthError(w, http.StatusUnauthorized, "invalid_client", admissionErr.Description())
+		return
+	}
+	if oauthErr, ok := errors.AsType[*oauthwire.Error](err); ok {
+		writeOAuthError(w, http.StatusBadRequest, oauthErr.Code, oauthErr.Description)
+		return
+	}
+	if errors.Is(err, errCIMDFetchFailed) {
+		// The cause may name internal network conditions (SSRF denials, DNS
+		// failures); log it and keep the wire response generic. A fetch
+		// failure is transient from the client's perspective, so signal
+		// retry-later rather than a permanent invalid_client that would make
+		// SDKs stop retrying.
+		s.logger.InfoContext(ctx, "cimd document fetch failed",
+			attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+			attr.SlogError(err),
+		)
+		writeOAuthError(w, http.StatusServiceUnavailable, "temporarily_unavailable", "failed to fetch client metadata document")
+		return
+	}
+	writeOAuthError(w, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 }
 
 func clientCredentials(r *http.Request) (string, string) {

--- a/server/internal/platformmcp/oauthhttp.go
+++ b/server/internal/platformmcp/oauthhttp.go
@@ -236,7 +236,7 @@ func (s *OAuthHTTP) ProtectedResourceHandler() http.Handler {
 
 func (s *OAuthHTTP) AuthorizationServerHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{
+		metadata := map[string]any{
 			"issuer":                                s.issuer,
 			"authorization_endpoint":                s.url("authorize"),
 			"token_endpoint":                        s.url("token"),
@@ -246,13 +246,18 @@ func (s *OAuthHTTP) AuthorizationServerHandler() http.Handler {
 			"grant_types_supported":                 usersessions.SupportedGrantTypes,
 			"token_endpoint_auth_methods_supported": usersessions.SupportedAuthMethods,
 			"code_challenge_methods_supported":      usersessions.SupportedCodeChallengeMethods,
-			// Advertised only when a document can actually be resolved and
-			// the admission mode admits something. Advertising support while
-			// admitting nothing would route spec-compliant clients into a
-			// guaranteed-failure flow instead of letting them fall back to
-			// dynamic client registration.
-			"client_id_metadata_document_supported": s.cimd != nil && platformCIMDAdmissionMode != admission.ModeDisabled,
-		})
+		}
+		// Advertised only when a document can actually be resolved and the
+		// admission mode admits something, and omitted rather than sent as
+		// false otherwise: an absent member is how RFC 8414 metadata says
+		// "unsupported", and it is what the hosted authorization server
+		// emits. Advertising support while admitting nothing would route
+		// spec-compliant clients into a guaranteed-failure flow instead of
+		// letting them fall back to dynamic client registration.
+		if s.cimd != nil && platformCIMDAdmissionMode != admission.ModeDisabled {
+			metadata["client_id_metadata_document_supported"] = true
+		}
+		writeJSON(w, http.StatusOK, metadata)
 	})
 }
 

--- a/server/internal/platformmcp/oauthhttp_cimd_test.go
+++ b/server/internal/platformmcp/oauthhttp_cimd_test.go
@@ -1,0 +1,352 @@
+// Integration tests for inbound CIMD (Client ID Metadata Documents) on the
+// Platform MCP authorization server: a URL-shaped client_id presented to
+// /platform-mcp/authorize is resolved by fetching the metadata document from
+// an httptest TLS server the guardian policy is told to trust.
+
+package platformmcp
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	platformoauth "github.com/speakeasy-api/gram/server/internal/platformmcp/oauth"
+	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+)
+
+type cimdDocServer struct {
+	srv      *httptest.Server
+	clientID string
+
+	mu           sync.Mutex
+	doc          map[string]any
+	etag         string
+	cacheControl string
+	status       int
+
+	// requests counts every request the document host received, so a test
+	// can assert that a cached resolve costs no upstream call.
+	requests atomic.Int64
+}
+
+func (ds *cimdDocServer) set(t *testing.T, mutate func(ds *cimdDocServer)) {
+	t.Helper()
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	mutate(ds)
+}
+
+func startCIMDDocServer(t *testing.T) *cimdDocServer {
+	t.Helper()
+
+	ds := &cimdDocServer{
+		srv:          nil,
+		clientID:     "",
+		mu:           sync.Mutex{},
+		doc:          nil,
+		etag:         "",
+		cacheControl: "",
+		status:       0,
+		requests:     atomic.Int64{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/client.json", func(w http.ResponseWriter, r *http.Request) {
+		ds.requests.Add(1)
+		conditional := r.Header.Get("If-None-Match")
+
+		ds.mu.Lock()
+		defer ds.mu.Unlock()
+
+		// Failure injection wins over revalidation: a host that has started
+		// erroring does so whether or not the request was conditional.
+		if ds.status != 0 {
+			http.Error(w, "document host failure", ds.status)
+			return
+		}
+		if ds.cacheControl != "" {
+			w.Header().Set("Cache-Control", ds.cacheControl)
+		}
+		if ds.etag != "" && conditional == ds.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		if ds.etag != "" {
+			w.Header().Set("ETag", ds.etag)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ds.doc); err != nil {
+			t.Errorf("encode cimd document: %v", err)
+		}
+	})
+	ds.srv = httptest.NewTLSServer(mux)
+	t.Cleanup(ds.srv.Close)
+
+	ds.clientID = ds.srv.URL + "/oauth/client.json"
+	ds.doc = map[string]any{
+		"client_id":                  ds.clientID,
+		"client_name":                "CIMD Platform Client",
+		"redirect_uris":              []any{"http://127.0.0.1:33418/callback"},
+		"token_endpoint_auth_method": "none",
+	}
+	return ds
+}
+
+func (ds *cimdDocServer) certPool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(ds.srv.Certificate())
+	return pool
+}
+
+// newTestCIMDOAuthHTTP builds a document server plus a Platform MCP
+// authorization server whose guardian policy trusts that server's TLS
+// certificate. The policy is the unsafe variant because the document host is
+// a loopback httptest server, which the default policy's SSRF rules refuse.
+func newTestCIMDOAuthHTTP(t *testing.T) (*OAuthHTTP, *cimdDocServer) {
+	t.Helper()
+
+	ds := startCIMDDocServer(t)
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{}, guardian.WithTLSRootCAs(ds.certPool()))
+	require.NoError(t, err)
+
+	base, err := url.Parse("https://gram.example")
+	require.NoError(t, err)
+	service, err := NewOAuthHTTP(OAuthHTTPConfig{
+		BaseURL:        base,
+		Cache:          &memoryCache{values: map[string]any{}},
+		Store:          platformoauth.NewInMemoryStore(),
+		Identity:       testIdentity{},
+		Gate:           allowGate{},
+		Authorizer:     allowAuthorizer{},
+		Organizations:  testOrganizationSelector{organizations: []OrganizationOption{{ID: "org-1", Name: "Organization one"}}},
+		Signer:         sessiontokens.NewSigner("test-key"),
+		Encryption:     testCIMDEncryption(t),
+		GuardianPolicy: policy,
+	})
+	require.NoError(t, err)
+	return service, ds
+}
+
+func testCIMDEncryption(t *testing.T) *encryption.Client {
+	t.Helper()
+
+	client, err := encryption.NewWithBytes(make([]byte, 32))
+	require.NoError(t, err)
+	return client
+}
+
+func doCIMDAuthorize(t *testing.T, service *OAuthHTTP, clientID, redirectURI string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	query := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
+		"code_challenge_method": {"S256"},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/platform-mcp/authorize?"+query.Encode(), nil)
+	response := httptest.NewRecorder()
+	service.AuthorizeHandler().ServeHTTP(response, request)
+	return response
+}
+
+func TestCIMDAuthorize_ResolvesAndPersistsClient(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+
+	response := doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback")
+	require.Equal(t, http.StatusFound, response.Code)
+	require.Contains(t, response.Header().Get("Location"), "https://idp.example/authorize")
+
+	client, err := service.store.GetClient(t.Context(), ds.clientID)
+	require.NoError(t, err)
+	require.True(t, client.IsCIMD())
+	require.Equal(t, ds.clientID, client.MetadataURI)
+	require.Equal(t, "CIMD Platform Client", client.Name)
+	require.Empty(t, client.SecretHash, "a CIMD client is public by construction")
+	require.Equal(t, int64(1), ds.requests.Load())
+}
+
+func TestCIMDAuthorize_ServesCachedDocumentWithoutRefetching(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	ds.set(t, func(ds *cimdDocServer) { ds.cacheControl = "max-age=600" })
+
+	require.Equal(t, http.StatusFound, doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback").Code)
+	require.Equal(t, http.StatusFound, doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback").Code)
+
+	require.Equal(t, int64(1), ds.requests.Load(), "second authorize must be served from the stored row")
+}
+
+func TestCIMDAuthorize_LoopbackRedirectPortMayVary(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+
+	// RFC 8252 §7.3: a native client binds an OS-assigned ephemeral port per
+	// invocation, so the port registered in the document cannot be matched
+	// byte-exactly.
+	response := doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:51099/callback")
+	require.Equal(t, http.StatusFound, response.Code)
+
+	// Every other component still has to match.
+	response = doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:51099/other")
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client"`)
+}
+
+func TestCIMDAuthorize_NonLoopbackRedirectStaysExact(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	// Same-origin with the document URL, as Gram's origin-binding policy
+	// requires, and https rather than http so it is not an RFC 8252 §7.3
+	// loopback redirect: the variable-port exception must not apply.
+	ds.set(t, func(ds *cimdDocServer) {
+		ds.doc["redirect_uris"] = []any{ds.srv.URL + "/callback"}
+	})
+
+	docURL, err := url.Parse(ds.srv.URL)
+	require.NoError(t, err)
+	otherPort := *docURL
+	otherPort.Host = docURL.Hostname() + ":" + docURL.Port() + "9"
+	otherPort.Path = "/callback"
+
+	response := doCIMDAuthorize(t, service, ds.clientID, otherPort.String())
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client"`)
+}
+
+func TestCIMDAuthorize_DocumentFetchFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	ds.set(t, func(ds *cimdDocServer) { ds.status = http.StatusInternalServerError })
+
+	response := doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback")
+	require.Equal(t, http.StatusServiceUnavailable, response.Code)
+	require.Contains(t, response.Body.String(), `"temporarily_unavailable"`)
+	require.NotContains(t, response.Body.String(), ds.srv.URL, "the wire response must not echo transport detail")
+}
+
+func TestCIMDAuthorize_DocumentClientIDMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	ds.set(t, func(ds *cimdDocServer) { ds.doc["client_id"] = "https://elsewhere.example/oauth/client.json" })
+
+	response := doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback")
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client_metadata"`)
+}
+
+func TestCIMDAuthorize_ConfidentialDocumentRejected(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	ds.set(t, func(ds *cimdDocServer) {
+		ds.doc["token_endpoint_auth_method"] = "client_secret_basic"
+	})
+
+	response := doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback")
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client_metadata"`)
+}
+
+func TestCIMDToken_ClientPresentingSecretRejected(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	require.Equal(t, http.StatusFound, doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback").Code)
+
+	// A CIMD client is public: presenting credentials means something other
+	// than the legitimate client is talking, so the token leg must refuse it
+	// rather than treating the secret as absent.
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {ds.clientID},
+		"client_secret": {"not-a-real-secret"},
+		"code":          {"whatever"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/platform-mcp/token", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response := httptest.NewRecorder()
+	service.TokenHandler().ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client"`)
+}
+
+func TestAuthorizationServerMetadata_AdvertisesCIMDOnlyWhenResolvable(t *testing.T) {
+	t.Parallel()
+
+	withCIMD, _ := newTestCIMDOAuthHTTP(t)
+	require.True(t, authorizationServerMetadataFlag(t, withCIMD), "a resolvable AS advertises CIMD support")
+
+	// No guardian policy means no resolver: advertising support would route
+	// spec-compliant clients into a guaranteed-failure flow instead of
+	// letting them fall back to dynamic client registration.
+	require.False(t, authorizationServerMetadataFlag(t, newTestOAuthHTTP(t)))
+}
+
+func authorizationServerMetadataFlag(t *testing.T, service *OAuthHTTP) bool {
+	t.Helper()
+
+	response := httptest.NewRecorder()
+	service.AuthorizationServerHandler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/platform-mcp", nil))
+	require.Equal(t, http.StatusOK, response.Code)
+
+	var metadata struct {
+		Supported bool `json:"client_id_metadata_document_supported"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &metadata))
+	return metadata.Supported
+}
+
+// notModifiedResolver stands in for the document fetcher on the one branch
+// the httptest server cannot reach from a handler test: the cache floor is
+// five minutes, so a stored document cannot be made stale mid-test to force
+// a conditional request.
+type notModifiedResolver struct {
+	ttl  time.Duration
+	etag string
+}
+
+func (r notModifiedResolver) Resolve(_ context.Context, _ string, _ cimd.CacheState) (*cimd.CacheResult, error) {
+	return &cimd.CacheResult{Outcome: cimd.CacheOutcomeNotModified, Document: nil, ETag: r.etag, TTL: r.ttl}, nil
+}
+
+func TestCIMDResolve_NotModifiedRefreshesStoredCacheOnly(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	require.Equal(t, http.StatusFound, doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback").Code)
+
+	service.cimd = notModifiedResolver{ttl: 30 * time.Minute, etag: `"v2"`}
+	client, err := service.resolveClient(t.Context(), ds.clientID, resolveClientCIMD)
+	require.NoError(t, err)
+
+	// A 304 confirms the stored document, so only the validator and the
+	// expiry move; the metadata it vouches for is left alone.
+	require.Equal(t, `"v2"`, client.ETag)
+	require.Equal(t, "CIMD Platform Client", client.Name)
+	require.Equal(t, []string{"http://127.0.0.1:33418/callback"}, client.RedirectURIs)
+	require.NotNil(t, client.CacheExpiresAt)
+}

--- a/server/internal/platformmcp/oauthhttp_cimd_test.go
+++ b/server/internal/platformmcp/oauthhttp_cimd_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 )
 
 type cimdDocServer struct {
@@ -244,6 +245,24 @@ func TestCIMDAuthorize_DocumentFetchFailureIsRetryable(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, response.Code)
 	require.Contains(t, response.Body.String(), `"temporarily_unavailable"`)
 	require.NotContains(t, response.Body.String(), ds.srv.URL, "the wire response must not echo transport detail")
+
+	// Retryable means the next attempt actually works: the failure left no
+	// negative cache behind, so a recovered host resolves normally.
+	ds.set(t, func(ds *cimdDocServer) { ds.status = 0 })
+	require.Equal(t, http.StatusFound, doCIMDAuthorize(t, service, ds.clientID, "http://127.0.0.1:33418/callback").Code)
+	require.Equal(t, int64(2), ds.requests.Load())
+}
+
+func TestCIMDAuthorize_OversizedClientIDDeniedBeforeAnyLookup(t *testing.T) {
+	t.Parallel()
+
+	service, ds := newTestCIMDOAuthHTTP(t)
+	oversized := ds.srv.URL + "/oauth/" + strings.Repeat("x", admission.MaxClientIDLength) + ".json"
+
+	response := doCIMDAuthorize(t, service, oversized, "http://127.0.0.1:33418/callback")
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+	require.Contains(t, response.Body.String(), `"invalid_client"`)
+	require.Zero(t, ds.requests.Load(), "an oversized client_id must not reach the document host")
 }
 
 func TestCIMDAuthorize_DocumentClientIDMismatchRejected(t *testing.T) {
@@ -313,11 +332,16 @@ func authorizationServerMetadataFlag(t *testing.T, service *OAuthHTTP) bool {
 	service.AuthorizationServerHandler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/platform-mcp", nil))
 	require.Equal(t, http.StatusOK, response.Code)
 
+	// Absence is how RFC 8414 metadata says "unsupported", so the member is
+	// decoded as a pointer: a literal false would be a different answer.
 	var metadata struct {
-		Supported bool `json:"client_id_metadata_document_supported"`
+		Supported *bool `json:"client_id_metadata_document_supported"`
 	}
 	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &metadata))
-	return metadata.Supported
+	if metadata.Supported == nil {
+		return false
+	}
+	return *metadata.Supported
 }
 
 // notModifiedResolver stands in for the document fetcher on the one branch

--- a/server/internal/platformmcp/oauthstore.go
+++ b/server/internal/platformmcp/oauthstore.go
@@ -69,7 +69,56 @@ func (s *PostgresOAuthStore) GetClient(ctx context.Context, clientID string) (pl
 	if err != nil {
 		return platformoauth.Client{}, mapOAuthReadError(err)
 	}
-	return platformoauth.Client{ID: row.ClientID, SecretHash: row.ClientSecretHash.String, Name: row.ClientName, RedirectURIs: row.RedirectUris, SecretExpiresAt: timePointer(row.ClientSecretExpiresAt)}, nil
+	return oauthClientFromRow(row), nil
+}
+
+func (s *PostgresOAuthStore) UpsertClientFromCIMD(ctx context.Context, input platformoauth.UpsertCIMDClientInput) (platformoauth.Client, error) {
+	if s == nil || s.db == nil || input.ClientID == "" || input.Name == "" || len(input.RedirectURIs) == 0 {
+		return platformoauth.Client{}, platformoauth.ErrNotFound
+	}
+	row, err := platformrepo.New(s.db).UpsertPlatformMCPOAuthClientFromCIMD(ctx, platformrepo.UpsertPlatformMCPOAuthClientFromCIMDParams{
+		ClientID:             input.ClientID,
+		ClientName:           input.Name,
+		RedirectUris:         input.RedirectURIs,
+		CacheTtlSeconds:      input.CacheTTL.Seconds(),
+		ClientIDMetadataEtag: text(input.ETag),
+	})
+	if err != nil {
+		// No rows means the guarded DO UPDATE refused the write: the
+		// client_id is held by a secret-bearing registration or a revoked
+		// row. Both are "no such CIMD client" to the caller.
+		return platformoauth.Client{}, mapOAuthReadError(err)
+	}
+	return oauthClientFromRow(row), nil
+}
+
+func (s *PostgresOAuthStore) TouchClientCIMDCache(ctx context.Context, input platformoauth.TouchCIMDCacheInput) (platformoauth.Client, error) {
+	if s == nil || s.db == nil || input.ClientID == "" {
+		return platformoauth.Client{}, platformoauth.ErrNotFound
+	}
+	row, err := platformrepo.New(s.db).UpdatePlatformMCPOAuthClientCIMDCache(ctx, platformrepo.UpdatePlatformMCPOAuthClientCIMDCacheParams{
+		ClientID:             input.ClientID,
+		CacheTtlSeconds:      input.CacheTTL.Seconds(),
+		ClientIDMetadataEtag: text(input.ETag),
+	})
+	if err != nil {
+		return platformoauth.Client{}, mapOAuthReadError(err)
+	}
+	return oauthClientFromRow(row), nil
+}
+
+func oauthClientFromRow(row platformrepo.PlatformMcpOauthClient) platformoauth.Client {
+	return platformoauth.Client{
+		ID:              row.ClientID,
+		SecretHash:      row.ClientSecretHash.String,
+		Name:            row.ClientName,
+		RedirectURIs:    row.RedirectUris,
+		SecretExpiresAt: timePointer(row.ClientSecretExpiresAt),
+		RevokedAt:       timePointer(row.RevokedAt),
+		MetadataURI:     row.ClientIDMetadataUri.String,
+		CacheExpiresAt:  timePointer(row.ClientIDMetadataCacheExpiresAt),
+		ETag:            row.ClientIDMetadataEtag.String,
+	}
 }
 
 func (s *PostgresOAuthStore) RevokeClient(ctx context.Context, clientID string, now time.Time) error {

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -24,6 +24,80 @@ FROM platform_mcp_oauth_clients
 WHERE client_id = @client_id
   AND revoked_at IS NULL;
 
+-- name: UpsertPlatformMCPOAuthClientFromCIMD :one
+-- Lazy upsert for a client resolved from a Client ID Metadata Document at
+-- authorize time. For CIMD rows the document URL IS the client_id, so the
+-- conflict target is the same unique index that serves DCR lookups. On
+-- refresh the mutable metadata (client_name, redirect_uris) and every cache
+-- column are replaced wholesale, including the ETag, which is set to NULL
+-- when the response carried no usable validator so the next refresh is
+-- unconditional rather than replaying a stale one.
+--
+-- The cache expiry is derived from the database clock rather than the
+-- application's, so it can never land before the client_id_metadata_fetched_at
+-- written in the same statement.
+--
+-- The DO UPDATE is guarded so it can never touch a secret-bearing DCR row
+-- that happens to share the client_id, nor resurrect a revoked one:
+-- rewriting the former would trip the client_id_metadata_uri CHECK
+-- constraints with an opaque 500, and the latter would undo an operator's
+-- revocation. Either collision surfaces as no-rows, which the resolver maps
+-- to invalid_client.
+INSERT INTO platform_mcp_oauth_clients (
+    client_id,
+    client_secret_hash,
+    client_name,
+    redirect_uris,
+    client_secret_expires_at,
+    client_id_metadata_uri,
+    client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at,
+    client_id_metadata_etag
+) VALUES (
+    @client_id,
+    NULL,
+    @client_name,
+    @redirect_uris,
+    NULL,
+    @client_id,
+    clock_timestamp(),
+    clock_timestamp() + make_interval(secs => @cache_ttl_seconds::double precision),
+    sqlc.narg('client_id_metadata_etag')
+)
+ON CONFLICT (client_id)
+DO UPDATE SET
+    client_name = EXCLUDED.client_name,
+    redirect_uris = EXCLUDED.redirect_uris,
+    client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
+    client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at = EXCLUDED.client_id_metadata_cache_expires_at,
+    client_id_metadata_etag = EXCLUDED.client_id_metadata_etag,
+    updated_at = clock_timestamp()
+WHERE platform_mcp_oauth_clients.client_secret_hash IS NULL
+  AND platform_mcp_oauth_clients.revoked_at IS NULL
+RETURNING *;
+
+-- name: UpdatePlatformMCPOAuthClientCIMDCache :one
+-- Refreshes the cache bookkeeping on a CIMD-resolved client whose document
+-- host answered 304 Not Modified. The stored client_name and redirect_uris
+-- are current by definition of the 304, so they are deliberately untouched;
+-- only the fetch stamp, the expiry, and the validator move.
+--
+-- The guards mirror UpsertPlatformMCPOAuthClientFromCIMD's, so this statement
+-- can never push a row into violating the client_id_metadata_uri CHECK
+-- constraints; such a collision surfaces as no-rows, which the resolver maps
+-- to invalid_client.
+UPDATE platform_mcp_oauth_clients
+SET client_id_metadata_fetched_at = clock_timestamp(),
+    client_id_metadata_cache_expires_at = clock_timestamp() + make_interval(secs => @cache_ttl_seconds::double precision),
+    client_id_metadata_etag = sqlc.narg('client_id_metadata_etag'),
+    updated_at = clock_timestamp()
+WHERE client_id = @client_id
+  AND client_id_metadata_uri IS NOT NULL
+  AND client_secret_hash IS NULL
+  AND revoked_at IS NULL
+RETURNING *;
+
 -- name: GetPlatformMCPOAuthClientForUpdate :one
 SELECT *
 FROM platform_mcp_oauth_clients

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -5662,6 +5662,146 @@ func (q *Queries) UpdatePlatformMCPDistributionPublication(ctx context.Context, 
 	return i, err
 }
 
+const updatePlatformMCPOAuthClientCIMDCache = `-- name: UpdatePlatformMCPOAuthClientCIMDCache :one
+UPDATE platform_mcp_oauth_clients
+SET client_id_metadata_fetched_at = clock_timestamp(),
+    client_id_metadata_cache_expires_at = clock_timestamp() + make_interval(secs => $1::double precision),
+    client_id_metadata_etag = $2,
+    updated_at = clock_timestamp()
+WHERE client_id = $3
+  AND client_id_metadata_uri IS NOT NULL
+  AND client_secret_hash IS NULL
+  AND revoked_at IS NULL
+RETURNING id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, revoked_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at
+`
+
+type UpdatePlatformMCPOAuthClientCIMDCacheParams struct {
+	CacheTtlSeconds      float64
+	ClientIDMetadataEtag pgtype.Text
+	ClientID             string
+}
+
+// Refreshes the cache bookkeeping on a CIMD-resolved client whose document
+// host answered 304 Not Modified. The stored client_name and redirect_uris
+// are current by definition of the 304, so they are deliberately untouched;
+// only the fetch stamp, the expiry, and the validator move.
+//
+// The guards mirror UpsertPlatformMCPOAuthClientFromCIMD's, so this statement
+// can never push a row into violating the client_id_metadata_uri CHECK
+// constraints; such a collision surfaces as no-rows, which the resolver maps
+// to invalid_client.
+func (q *Queries) UpdatePlatformMCPOAuthClientCIMDCache(ctx context.Context, arg UpdatePlatformMCPOAuthClientCIMDCacheParams) (PlatformMcpOauthClient, error) {
+	row := q.db.QueryRow(ctx, updatePlatformMCPOAuthClientCIMDCache, arg.CacheTtlSeconds, arg.ClientIDMetadataEtag, arg.ClientID)
+	var i PlatformMcpOauthClient
+	err := row.Scan(
+		&i.ID,
+		&i.ClientID,
+		&i.ClientSecretHash,
+		&i.ClientName,
+		&i.RedirectUris,
+		&i.ClientIDIssuedAt,
+		&i.ClientSecretExpiresAt,
+		&i.RevokedAt,
+		&i.ClientIDMetadataUri,
+		&i.ClientIDMetadataFetchedAt,
+		&i.ClientIDMetadataCacheExpiresAt,
+		&i.ClientIDMetadataEtag,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertPlatformMCPOAuthClientFromCIMD = `-- name: UpsertPlatformMCPOAuthClientFromCIMD :one
+INSERT INTO platform_mcp_oauth_clients (
+    client_id,
+    client_secret_hash,
+    client_name,
+    redirect_uris,
+    client_secret_expires_at,
+    client_id_metadata_uri,
+    client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at,
+    client_id_metadata_etag
+) VALUES (
+    $1,
+    NULL,
+    $2,
+    $3,
+    NULL,
+    $1,
+    clock_timestamp(),
+    clock_timestamp() + make_interval(secs => $4::double precision),
+    $5
+)
+ON CONFLICT (client_id)
+DO UPDATE SET
+    client_name = EXCLUDED.client_name,
+    redirect_uris = EXCLUDED.redirect_uris,
+    client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
+    client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    client_id_metadata_cache_expires_at = EXCLUDED.client_id_metadata_cache_expires_at,
+    client_id_metadata_etag = EXCLUDED.client_id_metadata_etag,
+    updated_at = clock_timestamp()
+WHERE platform_mcp_oauth_clients.client_secret_hash IS NULL
+  AND platform_mcp_oauth_clients.revoked_at IS NULL
+RETURNING id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, revoked_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at
+`
+
+type UpsertPlatformMCPOAuthClientFromCIMDParams struct {
+	ClientID             string
+	ClientName           string
+	RedirectUris         []string
+	CacheTtlSeconds      float64
+	ClientIDMetadataEtag pgtype.Text
+}
+
+// Lazy upsert for a client resolved from a Client ID Metadata Document at
+// authorize time. For CIMD rows the document URL IS the client_id, so the
+// conflict target is the same unique index that serves DCR lookups. On
+// refresh the mutable metadata (client_name, redirect_uris) and every cache
+// column are replaced wholesale, including the ETag, which is set to NULL
+// when the response carried no usable validator so the next refresh is
+// unconditional rather than replaying a stale one.
+//
+// The cache expiry is derived from the database clock rather than the
+// application's, so it can never land before the client_id_metadata_fetched_at
+// written in the same statement.
+//
+// The DO UPDATE is guarded so it can never touch a secret-bearing DCR row
+// that happens to share the client_id, nor resurrect a revoked one:
+// rewriting the former would trip the client_id_metadata_uri CHECK
+// constraints with an opaque 500, and the latter would undo an operator's
+// revocation. Either collision surfaces as no-rows, which the resolver maps
+// to invalid_client.
+func (q *Queries) UpsertPlatformMCPOAuthClientFromCIMD(ctx context.Context, arg UpsertPlatformMCPOAuthClientFromCIMDParams) (PlatformMcpOauthClient, error) {
+	row := q.db.QueryRow(ctx, upsertPlatformMCPOAuthClientFromCIMD,
+		arg.ClientID,
+		arg.ClientName,
+		arg.RedirectUris,
+		arg.CacheTtlSeconds,
+		arg.ClientIDMetadataEtag,
+	)
+	var i PlatformMcpOauthClient
+	err := row.Scan(
+		&i.ID,
+		&i.ClientID,
+		&i.ClientSecretHash,
+		&i.ClientName,
+		&i.RedirectUris,
+		&i.ClientIDIssuedAt,
+		&i.ClientSecretExpiresAt,
+		&i.RevokedAt,
+		&i.ClientIDMetadataUri,
+		&i.ClientIDMetadataFetchedAt,
+		&i.ClientIDMetadataCacheExpiresAt,
+		&i.ClientIDMetadataEtag,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const upsertPlatformMCPReadinessAssistant = `-- name: UpsertPlatformMCPReadinessAssistant :one
 INSERT INTO platform_mcp_readiness (
     organization_id,


### PR DESCRIPTION
Closes AGE-3332. Follows #5633, which added the storage this uses.

## Problem

The Platform MCP authorization server accepted dynamically registered clients only. A client that discovers CIMD support and commits to a URL-shaped `client_id` had nowhere to go: MCP clients pick CIMD over dynamic registration at metadata-discovery time and do not fall back to registration when `/authorize` rejects them, so the flow just ends. That is what went wrong in a live demo of Platform MCP.

## What changes

A URL-shaped `client_id` presented to `/platform-mcp/authorize` is now resolved by fetching its Client ID Metadata Document, validating it, and lazily upserting the client. The heavy lifting is reused, not rewritten: the fetch/validate/cache-policy resolver, the document validator, the admission vocabulary, and the loopback-redirect rule all come from `usersessions/cimd`, which already backs the hosted authorization server.

- **New resolution seam** (`oauth_client_resolver.go`), mirroring `internal/mcp/client_resolver.go`. Every leg that resolves a client goes through it: `/authorize` resolves CIMD, and the later legs (organization selection, connect, token) are lookup-only so a mid-flow request survives a briefly unreachable document host.
- **The stored row is the document cache.** A warm client costs no upstream request; a 304 moves only the validator and the expiry, leaving the metadata it vouches for alone.
- **Fail closed on refresh failure** (draft-02 §5.1): an expired document is never served stale to keep a flow alive. A fetch failure renders `503 temporarily_unavailable` (transient, so SDKs keep retrying) with the transport detail kept in the logs, since it can name SSRF denials and DNS conditions.
- **Store methods** `UpsertClientFromCIMD` / `TouchClientCIMDCache`, on Postgres and the in-memory contract implementation. Both are guarded so a document can never rewrite a secret-bearing registration or resurrect a revoked row — that surfaces as `invalid_client`, never a 500 from a CHECK violation.
- **Loopback redirect URIs match ignoring the port for CIMD clients only** (RFC 8252 §7.3): native clients bind an OS-assigned ephemeral port per invocation. Every other component still matches in escaped form, neither side may carry userinfo or a fragment, and dynamically registered clients keep byte-exact matching.
- **The AS metadata advertises `client_id_metadata_document_supported`** only when a resolver actually exists. Advertising support while unable to honour it would route spec-compliant clients into a guaranteed-failure flow instead of letting them use dynamic registration.
- **The consent page shows the document's origin** next to the client name, which is attacker-chosen for any CIMD client.

## Admission policy

`platformCIMDAdmissionMode` is a compile-time constant rather than per-tenant configuration: this is a single first-party authorization server with no issuer row to hang a mode off. It is set to open, deliberately.

Client identity is not the security boundary here. Every flow still passes IDP login, organization selection, the live `org:admin` recheck in `gateAndAuthorize`, and explicit user consent — and dynamic registration on this same server is already open to anyone, so admitting spec-valid documents grants nothing DCR does not already grant. CIMD is in fact the stronger of the two, since the `client_id` is a fetchable URL bound to an origin we can show the user rather than an opaque identifier chosen anonymously.

Decisions are counted on the same `cimd.admission.decisions` instrument the hosted server uses, so tightening to `presets` later is a constant change informed by real data. The `check_custom` branch folds to a denial, since there is no per-issuer allow-list table on this server.

## Testing

Ten new tests in `oauthhttp_cimd_test.go` drive real documents from an httptest TLS server the guardian policy is told to trust: resolve-and-persist, cache hit costs no fetch, 304 refreshes cache bookkeeping only, loopback port variance accepted, non-loopback stays exact, fetch failure is retryable and leaks no transport detail, `client_id` mismatch and confidential auth methods rejected, a CIMD client presenting a secret refused at the token leg, and the metadata flag appearing only when a resolver exists.

`internal/platformmcp` and `internal/mcp` are green; `mise lint:server` is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Client ID Metadata Document (CIMD) support to the Platform MCP authorization server so URL-shaped client_id values at /platform-mcp/authorize resolve, cache, and persist instead of failing; this unblocks CIMD-capable clients (AGE-3332).

- New Features
- `/platform-mcp/authorize` resolves CIMD and lazily upserts; later legs read from storage only.
- The stored client row is the document cache; 304 refreshes only ETag/expiry; no stale serving; fetch failures return 503 temporarily_unavailable.
- Bounds URL-shaped client_id length before any lookup; oversized inputs are denied without contacting the document host.
- Admission is compile-time open and decisions are metered; CIMD fetching is SSRF-protected and only enabled when a `GuardianPolicy` is provided.
- Loopback redirect URIs accept varying ports for CIMD clients only; all other redirects remain exact.
- Token endpoint rejects credentials for CIMD clients, which are always public.
- Authorization server metadata advertises `client_id_metadata_document_supported` only when resolvable and omits the flag otherwise.
- Consent page shows the document origin host next to the client name.
- Guarded store and SQL upsert/refresh APIs prevent overwriting secret-bearing or revoked registrations (Postgres and in-memory).

- Migration
- To enable inbound CIMD, pass a `GuardianPolicy` when constructing the service (optionally `Logger` and `MeterProvider`); otherwise the server remains DCR-only.
- No changes are required for existing dynamically registered clients.
- Clients should retry on `temporarily_unavailable` responses during authorize.

<sup>Written for commit 1110ccded3bb8ad3b848c84590f048bb5209a27e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

