### PR TITLE
feat: portable /~ redirect paths through login and signup

### DIFF
--- a/client/dashboard/src/contexts/AuthProvider.test.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -7,10 +7,24 @@ const mocks = vi.hoisted(() => ({
   group: vi.fn(),
 }));
 
-vi.mock("@/contexts/Sdk", () => ({
-  useSlugs: () => ({ orgSlug: undefined, projectSlug: undefined }),
-  useIsPlatformAdminRef: () => ({ current: false }),
-}));
+// Slugs derived from the live router location, as the real hook derives them
+// from the URL: the portable-path tests below navigate mid-render, and a
+// frozen orgSlug would send the post-navigation render down the wrong gate.
+vi.mock("@/contexts/Sdk", async () => {
+  const { useLocation } = await import("react-router");
+  return {
+    useSlugs: () => {
+      const parts = useLocation().pathname.split("/").filter(Boolean) as Array<
+        string | undefined
+      >;
+      return {
+        orgSlug: parts[0],
+        projectSlug: parts[1] === "projects" ? parts[2] : undefined,
+      };
+    },
+    useIsPlatformAdminRef: () => ({ current: false }),
+  };
+});
 
 // The route table pulls in every page; the provider only reads the org-level
 // path list from it.
@@ -60,13 +74,25 @@ function gatedSession(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function renderGate() {
+// Renders outside AuthProvider so it stays visible whichever gate wins,
+// exposing where the provider's redirects finally settled.
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location">
+      {location.pathname + location.search + location.hash}
+    </div>
+  );
+};
+
+function renderGate(initialPath = "/") {
   return render(
     <TelemetryStateProvider
       telemetry={telemetry}
       featureFlagsInitiallyAvailable
     >
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <LocationProbe />
         <AuthProvider>
           <div data-testid="app" />
         </AuthProvider>
@@ -136,5 +162,96 @@ describe("AuthProvider organization telemetry group", () => {
     renderGate();
 
     expect(registeredOrgGroups()).toEqual([]);
+  });
+});
+
+// Portable "/~" paths let external links (marketing CTAs, docs) deep-link
+// into the app without knowing the visitor's org or project slugs. They match
+// no route, so AuthProvider must resolve them before route matching runs.
+describe("AuthProvider portable paths", () => {
+  const PROJECT_ORG = {
+    id: "org-3",
+    name: "Acme",
+    slug: "acme",
+    projects: [{ slug: "proj-a" }, { slug: "proj-b" }],
+  };
+
+  function portableSession(overrides: Record<string, unknown> = {}) {
+    return gatedSession({
+      organizations: [PROJECT_ORG],
+      organization: PROJECT_ORG,
+      activeOrganizationId: PROJECT_ORG.id,
+      whitelisted: true,
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("bounces a logged-out visitor through login with the destination", () => {
+    mocks.sessionData.mockReturnValue({
+      session: null,
+      error: new Error("unauthorized"),
+      status: "error",
+    });
+
+    renderGate("/~/toolsets?tab=all");
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/login?redirect=%2F~%2Ftoolsets%3Ftab%3Dall",
+    );
+  });
+
+  it("sends a session with no organization to sign-up with the destination", () => {
+    mocks.sessionData.mockReturnValue(
+      portableSession({ activeOrganizationId: "" }),
+    );
+
+    renderGate("/~/toolsets");
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/sign-up?redirect=%2F~%2Ftoolsets",
+    );
+  });
+
+  it("expands into the active org and first project", () => {
+    mocks.sessionData.mockReturnValue(portableSession());
+
+    renderGate("/~/toolsets?tab=all");
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/acme/projects/proj-a/toolsets?tab=all",
+    );
+    expect(screen.getByTestId("app")).toBeTruthy();
+  });
+
+  it("prefers the last-visited project", () => {
+    localStorage.setItem("preferredProject", "proj-b");
+    mocks.sessionData.mockReturnValue(portableSession());
+
+    renderGate("/~/toolsets");
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/acme/projects/proj-b/toolsets",
+    );
+  });
+
+  it("leaves ordinary paths alone", () => {
+    mocks.sessionData.mockReturnValue(portableSession());
+
+    renderGate("/acme/projects/proj-a/toolsets");
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/acme/projects/proj-a/toolsets",
+    );
+    expect(screen.getByTestId("app")).toBeTruthy();
   });
 });

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -26,6 +26,7 @@ import {
   useSearchParams,
 } from "react-router";
 import { orgRoutePaths } from "@/routes";
+import { isPortablePath, resolvePortablePath } from "@/lib/portable-path";
 import { safeRedirectPath, UNAUTHENTICATED_PATHS } from "@/lib/session-expired";
 import { useSlugs } from "./Sdk";
 import {
@@ -117,7 +118,18 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     return <AppLoadingShell />;
   }
 
+  // A portable "/~" path (an external link that cannot know the viewer's
+  // slugs) matches no route, so the gates below must resolve it before route
+  // matching gets a say. Logged out it bounces through login carrying the
+  // full destination — the same shape LoginCheck produces for slugged paths.
+  const portableRedirect = isPortablePath(location.pathname)
+    ? encodeURIComponent(location.pathname + location.search + location.hash)
+    : undefined;
+
   if (error || !session || !session.session) {
+    if (portableRedirect) {
+      return <Navigate to={`/login?redirect=${portableRedirect}`} replace />;
+    }
     return (
       <SessionContext.Provider value={emptySession}>
         {children}
@@ -153,11 +165,27 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   }
 
   if (!session.activeOrganizationId) {
+    if (portableRedirect) {
+      return <Navigate to={`/sign-up?redirect=${portableRedirect}`} replace />;
+    }
     return (
       <SessionContext.Provider value={session}>
         {children}
       </SessionContext.Provider>
     );
+  }
+
+  // Fully authenticated: expand "/~" into the active org and the project the
+  // user last visited, keeping the destination's own query and hash.
+  if (session.organization) {
+    const resolved = resolvePortablePath(
+      location,
+      session.organization,
+      localStorage.getItem(PREFERRED_PROJECT_KEY),
+    );
+    if (resolved) {
+      return <Navigate to={resolved} replace />;
+    }
   }
 
   // Skip all slug-based redirect logic for exempt paths

--- a/client/dashboard/src/lib/portable-path.test.ts
+++ b/client/dashboard/src/lib/portable-path.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { isPortablePath, resolvePortablePath } from "./portable-path";
+
+const ORG = {
+  slug: "acme",
+  projects: [{ slug: "proj-a" }, { slug: "proj-b" }],
+};
+
+const loc = (pathname: string, search = "", hash = "") => ({
+  pathname,
+  search,
+  hash,
+});
+
+describe("isPortablePath", () => {
+  it("matches the bare prefix and nested paths", () => {
+    expect(isPortablePath("/~")).toBe(true);
+    expect(isPortablePath("/~/toolsets")).toBe(true);
+  });
+
+  it("rejects ordinary and lookalike paths", () => {
+    expect(isPortablePath("/")).toBe(false);
+    expect(isPortablePath("/acme/projects/default")).toBe(false);
+    // "~foo" could be a real (if odd) first segment; only the exact "~"
+    // segment is the placeholder.
+    expect(isPortablePath("/~foo/toolsets")).toBe(false);
+  });
+});
+
+describe("resolvePortablePath", () => {
+  it("returns undefined for non-portable paths", () => {
+    expect(resolvePortablePath(loc("/acme/toolsets"), ORG)).toBeUndefined();
+  });
+
+  it("expands into the org and first project", () => {
+    expect(resolvePortablePath(loc("/~/toolsets"), ORG)).toBe(
+      "/acme/projects/proj-a/toolsets",
+    );
+  });
+
+  it("expands the bare prefix to the project home", () => {
+    expect(resolvePortablePath(loc("/~"), ORG)).toBe("/acme/projects/proj-a");
+  });
+
+  it("prefers the last-visited project when it still exists", () => {
+    expect(resolvePortablePath(loc("/~/toolsets"), ORG, "proj-b")).toBe(
+      "/acme/projects/proj-b/toolsets",
+    );
+  });
+
+  it("ignores a preferred project that is no longer visible", () => {
+    expect(resolvePortablePath(loc("/~/toolsets"), ORG, "gone")).toBe(
+      "/acme/projects/proj-a/toolsets",
+    );
+  });
+
+  it("keeps the destination's query and hash", () => {
+    expect(
+      resolvePortablePath(loc("/~/toolsets", "?tab=all", "#top"), ORG),
+    ).toBe("/acme/projects/proj-a/toolsets?tab=all#top");
+  });
+
+  it("falls back to the org home when no project is visible", () => {
+    const org = { slug: "acme", projects: [] };
+    expect(resolvePortablePath(loc("/~/toolsets", "?tab=all"), org)).toBe(
+      "/acme?tab=all",
+    );
+  });
+});

--- a/client/dashboard/src/lib/portable-path.ts
+++ b/client/dashboard/src/lib/portable-path.ts
@@ -14,7 +14,7 @@
  * alphanumerics and dashes) and needs no escaping in a URL.
  */
 
-export const PORTABLE_PATH_PREFIX = "/~";
+const PORTABLE_PATH_PREFIX = "/~";
 
 export function isPortablePath(pathname: string): boolean {
   return (

--- a/client/dashboard/src/lib/portable-path.ts
+++ b/client/dashboard/src/lib/portable-path.ts
@@ -1,0 +1,56 @@
+/**
+ * Portable dashboard paths.
+ *
+ * A path beginning with `/~` stands for `/<orgSlug>/projects/<projectSlug>`
+ * for whichever organization and project the viewer ends up in. External
+ * surfaces — marketing-site CTAs, docs, emails — cannot know a visitor's
+ * slugs, but the post-login `?redirect=` param carries paths verbatim, so a
+ * placeholder segment lets a single URL work for every visitor:
+ *
+ *   app.getgram.ai/~/toolsets  →  /acme/projects/default/toolsets
+ *
+ * The placeholder is resolved client-side by AuthProvider once the session is
+ * known. `~` cannot collide with a real org slug (slugs are lowercase
+ * alphanumerics and dashes) and needs no escaping in a URL.
+ */
+
+export const PORTABLE_PATH_PREFIX = "/~";
+
+export function isPortablePath(pathname: string): boolean {
+  return (
+    pathname === PORTABLE_PATH_PREFIX ||
+    pathname.startsWith(`${PORTABLE_PATH_PREFIX}/`)
+  );
+}
+
+type OrganizationWithProjects = {
+  slug: string;
+  projects: Array<{ slug: string }>;
+};
+
+/**
+ * Expands a portable path into a concrete one for the given organization,
+ * preferring the project the user last visited. Returns undefined when the
+ * path is not portable. An organization whose visible project list is empty
+ * (project-level access can be filtered away) resolves to the org home, since
+ * the remainder of the path is project-scoped and cannot render anywhere else.
+ */
+export function resolvePortablePath(
+  location: { pathname: string; search: string; hash: string },
+  organization: OrganizationWithProjects,
+  preferredProjectSlug?: string | null,
+): string | undefined {
+  if (!isPortablePath(location.pathname)) return undefined;
+
+  const project =
+    (preferredProjectSlug != null &&
+      organization.projects.find((p) => p.slug === preferredProjectSlug)) ||
+    organization.projects[0];
+
+  if (!project) {
+    return `/${organization.slug}${location.search}${location.hash}`;
+  }
+
+  const rest = location.pathname.slice(PORTABLE_PATH_PREFIX.length);
+  return `/${organization.slug}/projects/${project.slug}${rest}${location.search}${location.hash}`;
+}

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -444,12 +444,12 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 				ActorEmail:     userInfo.Email,
 			})
 			if err != nil {
-				return s.redirectSignupError(ctx, err)
+				return s.redirectSignupError(ctx, payload, err)
 			}
 
 			session.ActiveOrganizationID = org.ID
 			if err := s.sessions.StoreSession(ctx, session); err != nil {
-				return s.redirectSignupError(ctx, err)
+				return s.redirectSignupError(ctx, payload, err)
 			}
 
 			if err := s.trialNotifier.TrialStarted(ctx, org.ID); err != nil {
@@ -1325,12 +1325,19 @@ func (s *Service) persistProvisionedOrganization(
 // the blanket zero-org redirect in the dashboard's app layout and lands on
 // /register — making that split persist would mean storing the flow origin on
 // the session, which is not worth it for this path.
-func (s *Service) redirectSignupError(ctx context.Context, err error) (*gen.CallbackResult, error) {
+func (s *Service) redirectSignupError(ctx context.Context, payload *gen.CallbackPayload, err error) (*gen.CallbackResult, error) {
 	s.logger.ErrorContext(ctx, "signup provisioning failed", attr.SlogError(err), attr.SlogReason(string(authErrInit)))
 
 	base := strings.TrimRight(s.cfg.SignInRedirectURL, "/")
+	location := fmt.Sprintf("%s/sign-up?signin_error=%s", base, authErrInit)
+	// Keep the destination on the retry: /sign-up threads ?redirect= back
+	// through the next login attempt, so a signup that arrived with one (e.g.
+	// a marketing CTA deep link) still lands there once provisioning succeeds.
+	if dest := s.destinationFromState(payload); dest != "" {
+		location += "&redirect=" + url.QueryEscape(dest)
+	}
 	return &gen.CallbackResult{
-		Location:      fmt.Sprintf("%s/sign-up?signin_error=%s", base, authErrInit),
+		Location:      location,
 		SessionToken:  "",
 		SessionCookie: "",
 	}, nil
@@ -1375,11 +1382,7 @@ func (s *Service) captureSignupTelemetry(ctx context.Context, email, orgName str
 }
 
 func (s *Service) dispositionFromState(payload *gen.CallbackPayload) string {
-	state := decodeStateParam(payload)
-	if state == nil {
-		return ""
-	}
-	parsed, err := url.Parse(safeRedirectPath(state.FinalDestinationURL, s.siteOrigin))
+	parsed, err := url.Parse(s.destinationFromState(payload))
 	if err != nil {
 		return ""
 	}
@@ -1585,11 +1588,7 @@ func (s *Service) callbackRedirectURL(
 	ctx context.Context,
 	payload *gen.CallbackPayload,
 ) string {
-	var location string
-
-	if state := decodeStateParam(payload); state != nil {
-		location = safeRedirectPath(state.FinalDestinationURL, s.siteOrigin)
-	}
+	location := s.destinationFromState(payload)
 
 	if location != "" {
 		msg := fmt.Sprintf("Found destination URL in state: '%s'", location)
@@ -1599,4 +1598,14 @@ func (s *Service) callbackRedirectURL(
 	}
 
 	return s.cfg.SignInRedirectURL
+}
+
+// destinationFromState extracts the sanitized post-login destination carried
+// through the IDP round trip, or "" when the state holds none worth honoring.
+func (s *Service) destinationFromState(payload *gen.CallbackPayload) string {
+	state := decodeStateParam(payload)
+	if state == nil {
+		return ""
+	}
+	return safeRedirectPath(state.FinalDestinationURL, s.siteOrigin)
 }

--- a/server/internal/auth/redirect_signup_error_test.go
+++ b/server/internal/auth/redirect_signup_error_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	gen "github.com/speakeasy-api/gram/server/gen/auth"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -24,7 +25,7 @@ func TestService_redirectSignupError(t *testing.T) {
 		},
 	}
 
-	result, err := svc.redirectSignupError(t.Context(), errors.New("provisioning failed"))
+	result, err := svc.redirectSignupError(t.Context(), nil, errors.New("provisioning failed"))
 	require.NoError(t, err, "signup failures are reported by redirect, not by error")
 	require.Equal(t, "http://localhost:3000/dashboard/sign-up?signin_error=init_error", result.Location)
 	require.Empty(t, result.SessionToken)
@@ -44,7 +45,51 @@ func TestService_redirectSignupError_TrimsTrailingSlash(t *testing.T) {
 		},
 	}
 
-	result, err := svc.redirectSignupError(t.Context(), errors.New("provisioning failed"))
+	result, err := svc.redirectSignupError(t.Context(), nil, errors.New("provisioning failed"))
 	require.NoError(t, err)
 	require.Equal(t, "http://localhost:3000/dashboard/sign-up?signin_error=init_error", result.Location)
+}
+
+// TestService_redirectSignupError_PreservesDestination confirms the retry page
+// keeps the post-login destination that the failed attempt carried through the
+// IDP round trip: /sign-up threads ?redirect= into the next login attempt, so
+// dropping it here would strand a deep-linked signup on the dashboard root.
+func TestService_redirectSignupError_PreservesDestination(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		logger: testenv.NewLogger(t),
+		cfg: AuthConfigurations{
+			SignInRedirectURL: "http://localhost:3000",
+		},
+	}
+
+	state := encodeStateParam("/~/toolsets?tab=all", "nonce")
+	payload := &gen.CallbackPayload{Code: "code", State: &state}
+
+	result, err := svc.redirectSignupError(t.Context(), payload, errors.New("provisioning failed"))
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:3000/sign-up?signin_error=init_error&redirect=%2F~%2Ftoolsets%3Ftab%3Dall", result.Location)
+}
+
+// TestService_redirectSignupError_DropsForeignDestination confirms an
+// off-origin destination smuggled into the unsigned state param is discarded
+// rather than echoed back into the retry URL.
+func TestService_redirectSignupError_DropsForeignDestination(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		logger: testenv.NewLogger(t),
+		cfg: AuthConfigurations{
+			SignInRedirectURL: "http://localhost:3000",
+		},
+		siteOrigin: parseSiteOrigin("http://localhost:3000"),
+	}
+
+	state := encodeStateParam("https://evil.example/phish", "nonce")
+	payload := &gen.CallbackPayload{Code: "code", State: &state}
+
+	result, err := svc.redirectSignupError(t.Context(), payload, errors.New("provisioning failed"))
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:3000/sign-up?signin_error=init_error", result.Location)
 }


### PR DESCRIPTION
The post-login ?redirect= param already survives the full IDP round trip, but external surfaces (marketing CTAs, docs, emails) cannot know a visitor's org or project slugs, and a slug-less path was silently dropped by the dashboard's post-auth routing.

A path beginning with /~ now stands for /<orgSlug>/projects/<projectSlug>, resolved by AuthProvider once the session is known: logged-out visitors bounce through /login carrying the destination, sessions with no org go to /sign-up with it, and authenticated users land on the expanded path in their active org and last-visited project.

Server side, a signup provisioning failure now keeps the destination on the /sign-up retry URL instead of dropping it, and the state-destination extraction is factored into one helper.


Claude-Session: https://claude.ai/code/session_016QyHEZKFqUUjovz2yvcLNv