### PR TITLE
chore: bound local infra memory so one worktree cannot OOM the host

### DIFF
--- a/.mise-tasks/stop/_default
+++ b/.mise-tasks/stop/_default
@@ -1,11 +1,38 @@
 #!/usr/bin/env bash
 
-#MISE description="Stop all development processes with pitchfork"
+#MISE description="Stop this worktree's development processes and infra containers"
+#MISE dir="{{ config_root }}"
 #MISE raw=true
 
 set -e
 
+# --keep-infra: stop only the pitchfork daemons, leave the containers running.
+# For the case where you want to restart the app against a warm database.
+keep_infra=0
+for arg in "$@"; do
+    case "$arg" in
+        --keep-infra) keep_infra=1 ;;
+        *) echo "unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
 pitchfork stop --all-local
+
+# `stop`, not `down`: this is the pause, `mise nuke` is the destroy. Containers
+# and volumes survive, so `./zero` comes back up warm.
+#
+# Stopping them at all matters because compose.yml is instantiated once per
+# worktree. Leaving a stack up after you have stopped working in its worktree
+# costs ~1.5 GB and a Temporal server polling in the background, indefinitely
+# and per worktree -- the accumulation across several worktrees is what pushes
+# the host into swap. `--profile "*"` so the tunnel and litellm containers are
+# included; without it they are invisible to compose and stay up.
+#
+# The shared stack (compose.shared.yml: Presidio, LGTM) is deliberately left
+# alone -- other worktrees are using it.
+if [ "$keep_infra" -eq 0 ]; then
+    docker compose --profile "*" stop
+fi
 
 gum style \
   --foreground 9 --border-foreground 9 --border rounded \

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -33,12 +33,21 @@
 # Bound to 127.0.0.1: Presidio is an unauthenticated PII-analysis service and
 # only ever called by local host processes, so it must not be reachable on the
 # host's external interfaces.
+#
+# Both services carry a `mem_limit`. They are the two largest containers on the
+# machine (Presidio loads a ~1 GB spaCy model; the LGTM bundle runs Grafana,
+# Tempo, Loki and Prometheus in one image), and unlike the per-worktree stack
+# neither has a soft cap of its own to fall back on. Being shared singletons
+# they are not multiplied by worktree count, but they are also never torn down
+# by a worktree's teardown -- they simply accumulate retention until something
+# on the host gives. The cgroup limit makes that failure land on the container.
 name: gram-shared
 
 services:
   gram-presidio:
     image: mcr.microsoft.com/presidio-analyzer:2.2.362
     restart: unless-stopped
+    mem_limit: 2g
     ports:
       - "127.0.0.1:5050:3000"
     healthcheck:
@@ -58,6 +67,7 @@ services:
   lgtm:
     image: grafana/otel-lgtm:0.30.1@sha256:bb182ac3174a20923fa58f00d1790fa71eb06cc0150078c0b0e8feb9e6611492
     restart: unless-stopped
+    mem_limit: 2g
     # Bound to 127.0.0.1 for the same reason as Presidio: every one of these
     # APIs is unauthenticated, and this container now holds every worktree's
     # traces and metrics. All consumers are local host processes

--- a/compose.yml
+++ b/compose.yml
@@ -6,10 +6,30 @@
 # LGTM observability stack.
 name: ${COMPOSE_PROJECT_NAME:-gram}
 
+# Memory ceilings (`mem_limit`) are deliberate and belong on EVERY service here.
+# Several services already carry a *soft* cap tuned to their runtime -- Temporal's
+# GOMEMLIMIT, the Pub/Sub emulator's -Xmx, ClickHouse's max_server_memory_usage.
+# Those are best-effort: the GC or the query planner aims to stay under them, and
+# a leak, a runaway merge or an oversized allocation sails straight past. Nothing
+# below them was an actual floor.
+#
+# That gap is only a nuisance with one stack running. This file is instantiated
+# once per worktree (see COMPOSE_PROJECT_NAME above), so with several worktrees
+# live the unbounded tail is multiplied by N, and the failure lands on the host:
+# macOS has no OOM killer worth the name, so it swaps instead, and the desktop
+# thrashes long before Docker notices anything is wrong.
+#
+# `mem_limit` is a cgroup limit, so the kernel kills the one offending container
+# and leaves the rest of the machine alone. Each value is the service's soft cap
+# plus headroom for allocator slack and off-heap memory -- set them ABOVE the
+# soft cap, never equal to it, or the OOM killer fires during normal operation
+# instead of the GC.
+
 services:
   gram-db:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
+    mem_limit: 1g
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -30,6 +50,7 @@ services:
   gram-cache:
     image: redis:6.2-alpine
     restart: unless-stopped
+    mem_limit: 256m
     volumes:
       - cache_data:/var/lib/gram-cache/data
     ports:
@@ -42,6 +63,7 @@ services:
     # CLI 1.8.1 embeds Server 1.31.2 and UI 2.50.1.
     image: temporalio/temporal:1.8.1
     restart: unless-stopped
+    mem_limit: 768m
     ports:
       - "${TEMPORAL_PORT}:7233"
       - "${TEMPORAL_WEB_PORT}:8233"
@@ -100,6 +122,7 @@ services:
     profiles: [litellm]
     image: ghcr.io/berriai/litellm:v1.94.0@sha256:65d84a2282137b4dc73bbe184650a7c807177c533e4223b3bfbc87963fe3fabe
     restart: unless-stopped
+    mem_limit: 1g
     command: ["--config", "/app/config.yaml", "--port", "4000"]
     environment:
       OPENROUTER_API_KEY: ${OPENROUTER_DEV_KEY}
@@ -121,6 +144,7 @@ services:
     build:
       context: ./local/clickhouse
     restart: unless-stopped
+    mem_limit: 2g
     ports:
       - "${CLICKHOUSE_HTTP_PORT}:8123"
       - "${CLICKHOUSE_NATIVE_PORT}:9440"
@@ -139,6 +163,7 @@ services:
   pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
     restart: unless-stopped
+    mem_limit: 512m
     environment:
       # The emulator is a JVM app (cloud-pubsub-emulator-all.jar) launched with
       # no -Xmx, so its default max heap is 1/4 of container-visible RAM -- the
@@ -163,6 +188,7 @@ services:
     profiles: [local-registry]
     image: postgres:17
     restart: unless-stopped
+    mem_limit: 512m
     environment:
       POSTGRES_USER: mcp_registry
       POSTGRES_PASSWORD: mcp_registry
@@ -181,6 +207,7 @@ services:
     build:
       context: https://github.com/crystaldba/postgres-mcp.git#07eb329c8c48e49640e0d1b5b35465d4d024c3ee
     restart: unless-stopped
+    mem_limit: 512m
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -198,8 +225,9 @@ services:
 
   tunnel-agent:
     profiles: [tunnel]
-    image: golang:1.26.4-bookworm
+    image: golang:1.26.5-bookworm
     restart: unless-stopped
+    mem_limit: 1g
     network_mode: "service:tunnel-postgres-mcp"
     working_dir: /workspace
     volumes:


### PR DESCRIPTION
## Summary

Adds `mem_limit` to every service in `compose.yml` and `compose.shared.yml`, fixes a permanently crash-looping container, and makes `mise stop` release the containers it started.

- **`mem_limit` on all 11 services.** Values sit *above* each service's existing soft cap rather than equal to it, leaving headroom for allocator slack and off-heap memory — ClickHouse gets 2g against its 1GiB `max_server_memory_usage` because mark cache, uncompressed cache and merge buffers allocate outside that accounting; Temporal gets 768m against `GOMEMLIMIT=256MiB`. Setting a cgroup limit equal to a soft cap fires the OOM killer during normal operation instead of the GC.
- **`tunnel-agent`: `golang:1.26.4-bookworm` → `1.26.5-bookworm`.** `go.mod` requires `go >= 1.26.5` and the image runs with `GOTOOLCHAIN=local`, so `go run ./tunnel/cmd/tunnel-agent` failed immediately on every start. Combined with `restart: unless-stopped` that is an unbounded crash loop — one per worktree with the `tunnel` profile enabled, each respawning roughly every 25s indefinitely.
- **`mise stop` now stops this worktree's containers.** `stop`, not `down`, so volumes survive and the next `./zero` comes back warm; `--keep-infra` opts out for the restart-app-against-a-warm-DB case. Uses `--profile "*"` so the `tunnel` and `litellm` containers are included — without it they are invisible to compose and stay up. The shared stack is deliberately left running, since other worktrees depend on it.

## Motivation

`compose.yml` is instantiated once per worktree via `COMPOSE_PROJECT_NAME`, so any unbounded memory tail is multiplied by the number of live worktrees. Several of the services already carry a soft cap tuned to their runtime — Temporal's `GOMEMLIMIT`, the Pub/Sub emulator's `-Xmx`, ClickHouse's `max_server_memory_usage` — but those are best-effort: the GC or the query planner *aims* to stay under them, and a leak or an oversized allocation sails straight past. Nothing underneath them was an actual floor.

With one stack up that gap is a nuisance. With five it is a machine-level failure, because it lands on the host rather than on a container: macOS has no OOM killer worth the name, so it swaps, and the desktop thrashes long before Docker reports anything wrong. A cgroup limit moves that failure back inside the VM, where the kernel kills the one offending container and leaves everything else alone.

The other two changes are the same problem from the opposite direction — sources of load that nothing was bounding. `mise stop` previously stopped only the pitchfork daemons, so a worktree you had finished with kept its full stack (~1.5GB and a polling Temporal server) running indefinitely; teardown only ever happened at `wt` worktree removal, via the existing `pre-remove` → `mise run nuke --keep-shared` hook. And a `tunnel-agent` that can never start successfully burns CPU forever without ever being noticed, because a crash-looping container looks the same as a healthy one in `docker ps` unless you read the status column.

Local developer infrastructure only — no shipped package behaviour changes, hence no changeset.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds memory for all local infra containers with Docker `mem_limit` so one worktree can’t OOM the host, fixes the `tunnel-agent` crash loop, and changes `mise stop` to pause this worktree’s containers. This keeps failures inside a single container and avoids host-wide swap storms.

- Set limits on all services in `compose.yml`, with values above existing soft caps to allow allocator and off-heap headroom.
- Added limits to shared `gram-presidio` and `lgtm` in `compose.shared.yml` to bound always-on singletons.
- Bumped `tunnel-agent` from `golang:1.26.4-bookworm` to `golang:1.26.5-bookworm` to satisfy `go >= 1.26.5` and stop the restart loop.
- `mise stop` now runs `docker compose --profile "*"` `stop` instead of leaving containers running; volumes persist, `--keep-infra` keeps infra up, and the shared stack remains untouched.

<sup>Written for commit 95f084b93ec2e82ffdc26c589fd8be7d547d4843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

