### PR TITLE
chore: share local pubsub emulator across worktrees

### DIFF
--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -61,6 +61,11 @@ suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"
 
+# Pub/Sub resource paths include the project ID. Giving each worktree its
+# Compose project ID keeps identical topic and subscription IDs isolated when
+# every worktree connects to one shared emulator.
+mise set --file mise.local.toml "GRAM_GCP_PROJECT_ID=${compose_project}"
+
 # The LGTM stack is shared across every worktree (compose.shared.yml), so all of
 # their traces and metrics land in one Tempo/Prometheus. Tagging each worktree's
 # telemetry with its compose project is what keeps those signals apart — without

--- a/.mise-tasks/git/worksync.sh
+++ b/.mise-tasks/git/worksync.sh
@@ -61,6 +61,20 @@ else
   echo "✅ Added ${added} env var declaration(s) to mise.local.toml."
 fi
 
+# Pub/Sub now uses one emulator on its default port. A generated host declaration
+# contains the port template copied from mise.toml, which proves the host and
+# port were emitted together by zero:remap-ports. Reset only that generated pair;
+# explicit endpoints remain untouched.
+if grep -E '^PUBSUB_EMULATOR_HOST[[:space:]]*=' mise.local.toml \
+     | grep -qF '{{env.PUBSUB_EMULATOR_PORT}}'; then
+  for key in PUBSUB_EMULATOR_HOST PUBSUB_EMULATOR_PORT; do
+    if grep -qE "^${key}[[:space:]]*=" mise.local.toml; then
+      mise unset --file mise.local.toml "$key"
+    fi
+  done
+  echo "✅ Reset auto-generated Pub/Sub emulator endpoint to the shared default."
+fi
+
 # Presidio moved to the shared stack (compose.shared.yml) and must use the
 # default port so every worktree reaches the single shared copy. A pre-existing
 # worktree may still carry the old auto-generated remap for it, which we reset
@@ -107,15 +121,22 @@ if grep -E '^OTEL_EXPORTER_OTLP_ENDPOINT[[:space:]]*=' mise.local.toml \
   echo "✅ Reset auto-generated LGTM ports to the shared defaults."
 fi
 
-# With one LGTM serving every worktree, a worktree that does not tag its
-# telemetry is indistinguishable from every other worktree on the same commit.
-# `git:workinit` writes this for new worktrees; add it here for the ones created
-# before the stack was shared. Only ever filled in when absent, so a
-# hand-customised value survives.
-if ! grep -qE '^OTEL_RESOURCE_ATTRIBUTES[[:space:]]*=' mise.local.toml; then
-  worktree_project=$(mise set --file mise.local.toml 2>/dev/null \
-    | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
-  if [ -n "$worktree_project" ]; then
+# Shared singleton services need a worktree dimension. `git:workinit` writes
+# both values for new worktrees; add them here for older worktrees. Only fill
+# absent values so hand-customised configuration survives.
+worktree_project=$(mise set --file mise.local.toml 2>/dev/null \
+  | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
+if [ -n "$worktree_project" ]; then
+  # Pub/Sub resource paths include the project ID, so this isolates identical
+  # topic and subscription IDs inside the shared emulator.
+  if ! grep -qE '^GRAM_GCP_PROJECT_ID[[:space:]]*=' mise.local.toml; then
+    mise set --file mise.local.toml "GRAM_GCP_PROJECT_ID=${worktree_project}"
+    echo "✅ Namespaced this worktree's Pub/Sub resources under ${worktree_project}."
+  fi
+
+  # Without this label, telemetry from same-commit worktrees is
+  # indistinguishable in the shared LGTM stack.
+  if ! grep -qE '^OTEL_RESOURCE_ATTRIBUTES[[:space:]]*=' mise.local.toml; then
     mise set --file mise.local.toml \
       "OTEL_RESOURCE_ATTRIBUTES=worktree=${worktree_project}"
     echo "✅ Tagged this worktree's telemetry as worktree=${worktree_project}."

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -111,9 +111,10 @@ docker ps -a --filter "label=com.docker.compose.service=pubsub-emulator" --filte
   | awk '$1 != "gram-shared" { print $2 }' \
   | xargs -r docker rm -f > /dev/null 2>&1 || true
 
-# Pub/Sub is required by the local streams processes. Start its shared singleton
-# first and fail infra startup if it cannot bind or launch.
-docker compose -f compose.shared.yml -p gram-shared up -d pubsub-emulator || exit 1
+# Pub/Sub is required by the local streams processes. Wait for its TCP
+# healthcheck so a container that starts and immediately exits cannot let
+# infrastructure startup report success.
+docker compose -f compose.shared.yml -p gram-shared up -d --wait --wait-timeout 30 pubsub-emulator || exit 1
 
 # Presidio and LGTM are shared too, but neither is a synchronous startup
 # dependency. A transient image pull or cold model must not take down this

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -45,7 +45,7 @@ if [ -n "$host_arch" ]; then
         if grep -qxF "$key" <<< "$local_tags"$'\n'"$local_digests"; then
             cached_imgs+=("$img")
         fi
-    done < <(docker compose config --images 2>/dev/null | sort -u)
+    done < <({ docker compose config --images; docker compose -f compose.shared.yml -p gram-shared config --images; } 2>/dev/null | sort -u)
     # `docker pull` honors an exported DOCKER_DEFAULT_PLATFORM, so while it is
     # set the pull just re-fetches the same foreign-arch variant and the
     # warning would never clear — tell the user to unset it first.
@@ -80,14 +80,12 @@ if [ -n "$host_arch" ]; then
     fi
 fi
 
-# This worktree's own stack, first — with --remove-orphans. A pre-existing
-# worktree (and the main tree) still runs a gram-presidio container under its own
-# project that compose.yml no longer declares; removing it here, BEFORE asserting
-# the shared analyzer below, frees the old host port (5050 on the main tree,
-# which never remapped it) so the shared `up` can bind it in this same run
-# instead of losing the port to the stale container and only converging next
-# time. Profile-gated services (litellm, tunnel, local-registry) stay declared in
-# compose.yml and are not treated as orphans.
+# This worktree's own stack, first — with --remove-orphans. Pre-existing
+# worktrees can still run Pub/Sub or Presidio containers that compose.yml no
+# longer declares. Removing this worktree's copies before asserting the shared
+# services frees fixed ports in the main tree and removes obsolete remapped
+# copies elsewhere. Profile-gated services (litellm, tunnel, local-registry)
+# remain declared in compose.yml and are not treated as orphans.
 docker compose up -d --remove-orphans || exit 1
 
 # One-time migration: free host port 5050 for the shared analyzer. Before the
@@ -104,13 +102,24 @@ docker ps -a --filter "label=com.docker.compose.service=gram-presidio" --filter 
   | awk '$1 != "gram-shared" { print $2 }' \
   | xargs -r docker rm -f > /dev/null 2>&1 || true
 
-# Presidio analyzer, shared across all worktrees under a fixed project name so a
-# worktree's COMPOSE_PROJECT_NAME cannot fork it into a second copy. Bringing it
-# up is idempotent, so every worktree can safely (re)assert it here. A failure
-# here (e.g. a transient pull of the ~1 GB image) must NOT take down this
-# worktree's own databases, so warn and continue rather than aborting.
-docker compose -f compose.shared.yml -p gram-shared up -d \
-  || echo "⚠️  Shared Presidio analyzer failed to start; continuing. PII scanning stays degraded until it is up." >&2
+# One-time migration: the main tree previously bound its per-worktree Pub/Sub
+# emulator to the shared port. Remove only a non-shared emulator actually
+# publishing 8088. Sibling worktrees on remapped ports keep running until their
+# next git:worksync/infra:start migration.
+docker ps -a --filter "label=com.docker.compose.service=pubsub-emulator" --filter "publish=8088" \
+  --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
+  | awk '$1 != "gram-shared" { print $2 }' \
+  | xargs -r docker rm -f > /dev/null 2>&1 || true
+
+# Pub/Sub is required by the local streams processes. Start its shared singleton
+# first and fail infra startup if it cannot bind or launch.
+docker compose -f compose.shared.yml -p gram-shared up -d pubsub-emulator || exit 1
+
+# Presidio and LGTM are shared too, but neither is a synchronous startup
+# dependency. A transient image pull or cold model must not take down this
+# worktree's databases, so warn and continue.
+docker compose -f compose.shared.yml -p gram-shared up -d gram-presidio lgtm \
+  || echo "⚠️  Optional shared Presidio/LGTM services failed to start; continuing with degraded PII scanning or observability." >&2
 
 # Best-effort readiness for the shared analyzer. `up -d` returns once the
 # container is created, not once its ~1 GB spaCy model has loaded, so poll the

--- a/.mise-tasks/nuke.sh
+++ b/.mise-tasks/nuke.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-# --keep-shared: leave the shared stack (compose.shared.yml: Presidio) running.
-# Worktree removal passes this — other worktrees depend on the shared services.
+# --keep-shared: leave compose.shared.yml services running. Worktree removal
+# passes this because other worktrees depend on those singletons.
 keep_shared=0
 for arg in "$@"; do
     case "$arg" in
@@ -23,10 +23,9 @@ fi
 
 docker compose --profile "*" down --volumes --remove-orphans
 
-# The shared Presidio analyzer lives under a fixed project (compose.shared.yml).
-# nuke means "destroy all infra", so tear it down too — `./zero` recreates it.
-# Note this affects every worktree that shares it, hence --keep-shared for
-# worktree removal.
+# Shared services live under a fixed project. Nuke means "destroy all infra", so
+# tear them down too; `./zero` recreates them. This affects every worktree,
+# hence --keep-shared for worktree removal.
 if [ "$keep_shared" -eq 0 ]; then
     docker compose -f compose.shared.yml -p gram-shared down --volumes --remove-orphans
 fi

--- a/.mise-tasks/zero/remap-ports.mts
+++ b/.mise-tasks/zero/remap-ports.mts
@@ -40,6 +40,7 @@ import { checkPort } from "get-port-please";
  */
 const SHARED_PORT_ENV_VARS = new Set([
   "PRESIDIO_PORT",
+  "PUBSUB_EMULATOR_PORT",
   // The LGTM stack is shared too, so every worktree must reach Grafana, Tempo,
   // Loki, Prometheus and the OTLP receivers on the same default host port.
   // OTEL_EXPORTER_OTLP_ENDPOINT is derived from OTLP_GRPC_PORT and is skipped

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -1,41 +1,51 @@
 # Shared infra — one copy across ALL git worktrees.
 #
-# The Presidio analyzer is a stateless /analyze HTTP service: it holds no
-# per-worktree state and loads a ~1 GB spaCy model, so running one copy per
-# worktree wasted the most memory of anything in the stack. It lives here under
-# a FIXED project name instead of the per-worktree `COMPOSE_PROJECT_NAME` used
-# by compose.yml.
+# Pub/Sub is stateful, but its fully-qualified resource paths include a project
+# ID. `git:workinit` gives every worktree a unique GRAM_GCP_PROJECT_ID, so one
+# emulator can safely host identical topic and subscription IDs for all trees.
 #
-# The LGTM observability stack lives here for the same reason. It used to be
-# per-worktree, on the grounds that same-commit worktrees emit identical
-# Prometheus series and intermixed traces. That is true only while the signals
-# are indistinguishable — so instead of paying ~560 MB per worktree for a second
-# copy (the single most expensive container in the stack, and the main reason
-# several concurrent worktrees exhausted host memory), every worktree now tags
-# its telemetry with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
-# `git:workinit` writes that; `mise.toml` holds the main tree's default. Filter
-# by the `worktree` label in Grafana to get one worktree's signals back.
+# Presidio is stateless and expensive to duplicate. LGTM separates intermixed
+# telemetry with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
+# `git:workinit` writes both worktree dimensions; `mise.toml` holds the main
+# tree defaults.
 #
-# Always manage this file with an explicit fixed project so a worktree's
-# COMPOSE_PROJECT_NAME cannot fork it into a second copy:
+# Always manage this file under its fixed project:
 #
 #   docker compose -f compose.shared.yml -p gram-shared up -d
 #   docker compose -f compose.shared.yml -p gram-shared down
 #
-# The host port is a hardcoded literal, NOT ${PRESIDIO_PORT}. As a single
-# shared singleton it must land on the same fixed host port no matter which
-# worktree starts it — interpolating per-worktree env would let a worktree that
-# still carries a stale PRESIDIO_PORT remap (not yet cleaned by git:worksync)
-# recreate this container republished on a different port, fragmenting the
-# shared stack for everyone else. Keep this literal in sync with PRESIDIO_PORT's
-# default in mise.toml (5050), which is what every worktree's app connects to.
+# Host ports are hardcoded literals, not interpolated per-worktree variables.
+# This prevents a worktree carrying stale remapped ports from republishing a
+# shared container elsewhere and fragmenting the stack. Keep the literals in
+# sync with mise.toml: Pub/Sub 8088, Presidio 5050, LGTM 13000/13200/13100/9099,
+# and OTLP 4317/4318.
 #
-# Bound to 127.0.0.1: Presidio is an unauthenticated PII-analysis service and
-# only ever called by local host processes, so it must not be reachable on the
-# host's external interfaces.
+# Every port is bound to 127.0.0.1. These unauthenticated local development
+# services are consumed only by host processes and must not be externally
+# reachable.
 name: gram-shared
 
 services:
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
+    restart: unless-stopped
+    environment:
+      # The emulator is a JVM app launched without -Xmx, so its default maximum
+      # heap is one quarter of the whole Docker VM. This shared local instance
+      # does not need an unbounded multi-gigabyte ceiling.
+      JAVA_TOOL_OPTIONS: -Xmx128m
+    ports:
+      - "127.0.0.1:8088:8085"
+    command:
+      [
+        "gcloud",
+        "beta",
+        "emulators",
+        "pubsub",
+        "start",
+        "--host-port=0.0.0.0:8085",
+      ]
+
   gram-presidio:
     image: mcr.microsoft.com/presidio-analyzer:2.2.362
     restart: unless-stopped

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -45,6 +45,12 @@ services:
         "start",
         "--host-port=0.0.0.0:8085",
       ]
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/8085"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 2s
 
   gram-presidio:
     image: mcr.microsoft.com/presidio-analyzer:2.2.362

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,9 @@
 # Per-worktree infra. `git:workinit` sets a unique COMPOSE_PROJECT_NAME (and
 # `zero:remap-ports` remaps the host ports) so each worktree gets its own stack
 # — postgres, clickhouse, temporal, etc. — without colliding.
-# Services that hold no per-worktree state live in compose.shared.yml instead
-# and run as a single copy for the whole machine: the Presidio analyzer and the
-# LGTM observability stack.
+# Services shared safely through explicit worktree namespaces live in
+# compose.shared.yml and run once for the whole machine: Pub/Sub, Presidio, and
+# the LGTM observability stack.
 name: ${COMPOSE_PROJECT_NAME:-gram}
 
 services:
@@ -135,29 +135,6 @@ services:
       nofile:
         soft: 262144
         hard: 262144
-
-  pubsub-emulator:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
-    restart: unless-stopped
-    environment:
-      # The emulator is a JVM app (cloud-pubsub-emulator-all.jar) launched with
-      # no -Xmx, so its default max heap is 1/4 of container-visible RAM -- the
-      # whole Docker VM, several GB. An emulator serving one developer never
-      # needs that, and the unbounded ceiling is what makes N worktrees
-      # dangerous. `gcloud beta emulators pubsub start` has no pass-through flag
-      # for JVM options, so set the cap through the JVM's own env var.
-      JAVA_TOOL_OPTIONS: -Xmx128m
-    ports:
-      - "${PUBSUB_EMULATOR_PORT}:8085"
-    command:
-      [
-        "gcloud",
-        "beta",
-        "emulators",
-        "pubsub",
-        "start",
-        "--host-port=0.0.0.0:8085",
-      ]
 
   mcp-registry-db:
     profiles: [local-registry]

--- a/infra/cmd/infra/demo.go
+++ b/infra/cmd/infra/demo.go
@@ -28,6 +28,11 @@ func newDemoCommand() *cli.Command {
 			Usage:   "Host to use for the PubSub emulator",
 			EnvVars: []string{"PUBSUB_EMULATOR_HOST"},
 		},
+		&cli.StringFlag{
+			Name:    "gcp-project-id",
+			Usage:   "Google Cloud project ID",
+			EnvVars: []string{"GRAM_GCP_PROJECT_ID"},
+		},
 
 		&cli.BoolFlag{
 			Name:    "with-otel-tracing",
@@ -60,13 +65,15 @@ func newDemoCommand() *cli.Command {
 			slog.SetDefault(logger)
 
 			var err error
-			var projectID string
+			projectID := c.String("gcp-project-id")
 			opts := []option.ClientOption{option.WithLogger(logger)}
 			switch {
 			case c.String("pubsub-emulator-host") != "":
 				opts = append(opts, option.WithEndpoint(c.String("pubsub-emulator-host")), option.WithoutAuthentication())
-				projectID = "my-project-id"
-			default:
+				if projectID == "" {
+					projectID = "my-project-id"
+				}
+			case projectID == "":
 				projectID, err = metadata.ProjectIDWithContext(ctx)
 				if err != nil {
 					return fmt.Errorf("failed to get google cloud project id: %w", err)

--- a/mise.toml
+++ b/mise.toml
@@ -375,7 +375,8 @@ GRAM_SVIX_API_KEY = { default = "unset" }
 ################
 ## GCP config ##
 ################
-## Typically this variable is omitted and the GCP SDK will detect project ID
-## from the environment. However, for local development, it can be set to a
-## static value.
+## The Pub/Sub emulator namespaces resources by project ID. The main tree keeps
+## this stable default; git:workinit overrides it with the worktree's unique
+## Compose project so one shared emulator can isolate identical topic and
+## subscription IDs from concurrent worktrees.
 GRAM_GCP_PROJECT_ID = "local-dev-project"


### PR DESCRIPTION
## Summary

- move the local Pub/Sub emulator from the per-worktree Compose stack into the fixed shared stack
- namespace emulator topics and subscriptions with each worktree's generated project ID
- stop remapping the shared endpoint and migrate generated worktree settings and obsolete containers
- make shared Pub/Sub a required infrastructure dependency while keeping Presidio and LGTM best-effort

## Motivation

Running one JVM-backed emulator per worktree duplicates memory and local infrastructure without providing stronger isolation. Pub/Sub resource paths already include a project ID, so assigning each worktree a unique local project preserves independent topics and subscriptions while every worktree uses one emulator process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares the Pub/Sub emulator across all worktrees and makes it a required dependency at infra startup. Previously each worktree ran its own emulator and startup didn’t wait; now all worktrees use one emulator on 127.0.0.1:8088, startup waits for its health, and topics/subscriptions are isolated by `GRAM_GCP_PROJECT_ID`. Presidio and LGTM remain shared but optional.

**Migration**
- Run `mise run git:worksync` to reset auto-generated `PUBSUB_EMULATOR_HOST`/`PUBSUB_EMULATOR_PORT` and backfill `GRAM_GCP_PROJECT_ID`.
- Run `mise run infra:start` to remove old per-worktree Pub/Sub containers and start the shared emulator; this waits up to 30s for health and exits on failure.
- Ensure `GRAM_GCP_PROJECT_ID` is set; `git:workinit` writes it and `git:worksync` backfills it.
- Stop remapping `PUBSUB_EMULATOR_PORT`; `zero:remap-ports` now treats it as shared.

<sup>Written for commit 50306371668b00cd304e52c4800a3487878842eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

