### PR TITLE
chore: share Temporal across worktrees

### DIFF
--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -61,16 +61,19 @@ suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"
 
+# Temporal runs once for the whole machine. A namespace per Compose project
+# isolates workflow IDs, schedules, and task queues across worktrees.
+mise set --file mise.local.toml "TEMPORAL_NAMESPACE=${compose_project}"
+
 # Pub/Sub resource paths include the project ID. Giving each worktree its
 # Compose project ID keeps identical topic and subscription IDs isolated when
 # every worktree connects to one shared emulator.
 mise set --file mise.local.toml "GRAM_GCP_PROJECT_ID=${compose_project}"
 
-# The LGTM stack is shared across every worktree (compose.shared.yml), so all of
-# their traces and metrics land in one Tempo/Prometheus. Tagging each worktree's
-# telemetry with its compose project is what keeps those signals apart — without
-# it, two worktrees on the same commit emit identical Prometheus series. The
-# OTel SDK reads this env var directly, so nothing in the Go code has to know.
+# Temporal, Pub/Sub, and LGTM are shared across every worktree
+# (compose.shared.yml). The namespace and project ID above isolate state; this
+# label keeps traces and metrics separate too. The OTel SDK reads it directly,
+# so nothing in the Go code has to know.
 mise set --file mise.local.toml "OTEL_RESOURCE_ATTRIBUTES=worktree=${compose_project}"
 
 remap=$(mise run zero:remap-ports --format flat --file -)

--- a/.mise-tasks/git/worksync.sh
+++ b/.mise-tasks/git/worksync.sh
@@ -121,12 +121,34 @@ if grep -E '^OTEL_EXPORTER_OTLP_ENDPOINT[[:space:]]*=' mise.local.toml \
   echo "✅ Reset auto-generated LGTM ports to the shared defaults."
 fi
 
+# Temporal now runs in the shared stack. Old worktrees have generated remaps for
+# both published ports and TEMPORAL_ADDRESS; reset those to the fixed shared
+# endpoint. The address template proves the values came from zero:remap-ports,
+# so explicit custom Temporal endpoints remain untouched.
+if grep -E '^TEMPORAL_ADDRESS[[:space:]]*=' mise.local.toml \
+     | grep -qF '{{env.TEMPORAL_PORT}}'; then
+  for key in TEMPORAL_ADDRESS TEMPORAL_PORT TEMPORAL_WEB_PORT; do
+    if grep -qE "^${key}[[:space:]]*=" mise.local.toml; then
+      mise unset --file mise.local.toml "$key"
+    fi
+  done
+  echo "✅ Reset auto-generated Temporal ports to the shared defaults."
+fi
+
 # Shared singleton services need a worktree dimension. `git:workinit` writes
-# both values for new worktrees; add them here for older worktrees. Only fill
-# absent values so hand-customised configuration survives.
+# all three values for new worktrees; add them here for older worktrees. Preserve
+# custom configuration except Temporal's old `default` value: sharing that
+# namespace across worktrees defeats the isolation this migration establishes.
 worktree_project=$(mise set --file mise.local.toml 2>/dev/null \
   | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
 if [ -n "$worktree_project" ]; then
+  # Workflow IDs, schedules, and task queues are namespace-scoped in Temporal.
+  if ! grep -qE '^TEMPORAL_NAMESPACE[[:space:]]*=' mise.local.toml \
+     || grep -qE '^TEMPORAL_NAMESPACE[[:space:]]*=[[:space:]]*"default"[[:space:]]*$' mise.local.toml; then
+    mise set --file mise.local.toml "TEMPORAL_NAMESPACE=${worktree_project}"
+    echo "✅ Namespaced this worktree's Temporal state under ${worktree_project}."
+  fi
+
   # Pub/Sub resource paths include the project ID, so this isolates identical
   # topic and subscription IDs inside the shared emulator.
   if ! grep -qE '^GRAM_GCP_PROJECT_ID[[:space:]]*=' mise.local.toml; then

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -81,11 +81,11 @@ if [ -n "$host_arch" ]; then
 fi
 
 # This worktree's own stack, first — with --remove-orphans. Pre-existing
-# worktrees can still run Pub/Sub or Presidio containers that compose.yml no
-# longer declares. Removing this worktree's copies before asserting the shared
-# services frees fixed ports in the main tree and removes obsolete remapped
-# copies elsewhere. Profile-gated services (litellm, tunnel, local-registry)
-# remain declared in compose.yml and are not treated as orphans.
+# worktrees can still run Temporal, Pub/Sub, or Presidio containers that
+# compose.yml no longer declares. Removing this worktree's copies before
+# asserting the shared services frees fixed ports in the main tree and removes
+# obsolete remapped copies elsewhere. Profile-gated services (litellm, tunnel,
+# local-registry) remain declared in compose.yml and are not treated as orphans.
 docker compose up -d --remove-orphans || exit 1
 
 # One-time migration: free host port 5050 for the shared analyzer. Before the
@@ -111,10 +111,35 @@ docker ps -a --filter "label=com.docker.compose.service=pubsub-emulator" --filte
   | awk '$1 != "gram-shared" { print $2 }' \
   | xargs -r docker rm -f > /dev/null 2>&1 || true
 
-# Pub/Sub is required by the local streams processes. Wait for its TCP
-# healthcheck so a container that starts and immediately exits cannot let
-# infrastructure startup report success.
-docker compose -f compose.shared.yml -p gram-shared up -d --wait --wait-timeout 30 pubsub-emulator || exit 1
+# One-time migration: Temporal now runs under the shared project too. Remove
+# only a non-shared Temporal container publishing the fixed gRPC port. Sibling
+# worktrees on remapped ports keep running until their next
+# git:worksync/infra:start migration.
+docker ps -a --filter "label=com.docker.compose.service=gram-temporal" --filter "publish=7233" \
+  --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
+  | awk '$1 != "gram-shared" { print $2 }' \
+  | xargs -r docker rm -f > /dev/null 2>&1 || true
+
+# Pub/Sub is required by the local streams processes, and Temporal is required
+# by seeding and every background worker. Wait for both healthchecks so a
+# container that starts and immediately exits cannot let infrastructure startup
+# report success.
+docker compose -f compose.shared.yml -p gram-shared up -d --wait --wait-timeout 30 \
+  pubsub-emulator gram-temporal || exit 1
+
+# The shared Temporal server starts with the main tree's `default` namespace.
+# Every worktree gets a distinct TEMPORAL_NAMESPACE from git:workinit; create it
+# idempotently before any seed or daemon can submit workflows. The second
+# describe handles two concurrent starts racing to create the same namespace.
+if ! docker compose -f compose.shared.yml -p gram-shared exec -T gram-temporal \
+     temporal operator namespace describe --namespace "$TEMPORAL_NAMESPACE" > /dev/null 2>&1; then
+  echo "Creating Temporal namespace ${TEMPORAL_NAMESPACE}..."
+  docker compose -f compose.shared.yml -p gram-shared exec -T gram-temporal \
+    temporal operator namespace create --namespace "$TEMPORAL_NAMESPACE" > /dev/null 2>&1 \
+    || docker compose -f compose.shared.yml -p gram-shared exec -T gram-temporal \
+      temporal operator namespace describe --namespace "$TEMPORAL_NAMESPACE" > /dev/null \
+    || exit 1
+fi
 
 # Presidio and LGTM are shared too, but neither is a synchronous startup
 # dependency. A transient image pull or cold model must not take down this
@@ -249,13 +274,3 @@ wait_for "Postgres" gram-db \
 wait_for "ClickHouse" clickhouse \
     docker compose exec -T clickhouse clickhouse-client --user "$CLICKHOUSE_USERNAME" --password "$CLICKHOUSE_PASSWORD" -q "SELECT 1"
 
-# Temporal is the last of the three to become usable, and the first thing that
-# needs it is `mise run seed`, whose deployment step starts a workflow. Without
-# this probe seed fails with `error starting deployment: context deadline
-# exceeded` — a 10s timeout on a Temporal that isn't serving yet — which on a
-# cold worktree leaves the stack up but only partially seeded.
-#
-# `cluster health` hangs rather than erroring when the dev-server's SQLite
-# persistence is wedged, so it relies on run_bounded to cap each attempt.
-wait_for "Temporal" gram-temporal \
-    docker compose exec -T gram-temporal temporal operator cluster health

--- a/.mise-tasks/zero/cleanup.sh
+++ b/.mise-tasks/zero/cleanup.sh
@@ -5,12 +5,13 @@
 
 set -e
 
-# Restart Temporal container to clear any SQLite locks from previous runs
-# The health check doesn't catch SQLite lock issues, so we restart unconditionally
-if docker compose ps gram-temporal --status running -q 2>/dev/null | grep -q .; then
-    echo "Restarting Temporal container..."
-    docker compose restart gram-temporal
-    until docker compose exec -T gram-temporal temporal operator cluster health 2>/dev/null; do
+# Restart the shared Temporal container to clear SQLite locks from previous
+# runs. This affects every worktree, so zero keeps it interactive-only.
+shared_compose=(docker compose -f compose.shared.yml -p gram-shared)
+if "${shared_compose[@]}" ps gram-temporal --status running -q 2>/dev/null | grep -q .; then
+    echo "Restarting shared Temporal container..."
+    "${shared_compose[@]}" restart gram-temporal
+    until "${shared_compose[@]}" exec -T gram-temporal temporal operator cluster health 2>/dev/null; do
         echo "Waiting for Temporal to be healthy..."
         sleep 2
     done

--- a/.mise-tasks/zero/remap-ports.mts
+++ b/.mise-tasks/zero/remap-ports.mts
@@ -41,10 +41,12 @@ import { checkPort } from "get-port-please";
 const SHARED_PORT_ENV_VARS = new Set([
   "PRESIDIO_PORT",
   "PUBSUB_EMULATOR_PORT",
-  // The LGTM stack is shared too, so every worktree must reach Grafana, Tempo,
-  // Loki, Prometheus and the OTLP receivers on the same default host port.
-  // OTEL_EXPORTER_OTLP_ENDPOINT is derived from OTLP_GRPC_PORT and is skipped
-  // along with it, so it keeps its mise.toml default as well.
+  "TEMPORAL_PORT",
+  "TEMPORAL_WEB_PORT",
+  // Temporal and the LGTM stack are shared, so every worktree must reach them
+  // on the same default host ports. TEMPORAL_ADDRESS and
+  // OTEL_EXPORTER_OTLP_ENDPOINT are derived from skipped ports and therefore
+  // keep their mise.toml defaults too.
   "GRAFANA_PORT",
   "TEMPO_HTTP_PORT",
   "LOKI_HTTP_PORT",

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -184,6 +184,7 @@ await pokeDockerService(
   "gram-temporal",
   "Temporal",
   `http://localhost:${temporalWebPort}`,
+  true,
 );
 
 const grafanaPort = process.env["GRAFANA_PORT"] ?? "13000";

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -1,13 +1,18 @@
 # Shared infra — one copy across ALL git worktrees.
 #
-# Pub/Sub is stateful, but its fully-qualified resource paths include a project
-# ID. `git:workinit` gives every worktree a unique GRAM_GCP_PROJECT_ID, so one
-# emulator can safely host identical topic and subscription IDs for all trees.
+# Temporal is stateful and shared. `git:workinit` gives every worktree a unique
+# TEMPORAL_NAMESPACE, so identical workflow IDs and task queues remain isolated.
+# The default namespace belongs to the main tree.
+#
+# Pub/Sub is stateful too, but its fully-qualified resource paths include a
+# project ID. `git:workinit` gives every worktree a unique GRAM_GCP_PROJECT_ID,
+# so one emulator can safely host identical topic and subscription IDs for all
+# trees.
 #
 # Presidio is stateless and expensive to duplicate. LGTM separates intermixed
 # telemetry with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
-# `git:workinit` writes both worktree dimensions; `mise.toml` holds the main
-# tree defaults.
+# `git:workinit` writes all worktree dimensions; `mise.toml` holds the main tree
+# defaults.
 #
 # Always manage this file under its fixed project:
 #
@@ -17,8 +22,8 @@
 # Host ports are hardcoded literals, not interpolated per-worktree variables.
 # This prevents a worktree carrying stale remapped ports from republishing a
 # shared container elsewhere and fragmenting the stack. Keep the literals in
-# sync with mise.toml: Pub/Sub 8088, Presidio 5050, LGTM 13000/13200/13100/9099,
-# and OTLP 4317/4318.
+# sync with mise.toml: Temporal 7233/8233, Pub/Sub 8088, Presidio 5050, LGTM
+# 13000/13200/13100/9099, and OTLP 4317/4318.
 #
 # Every port is bound to 127.0.0.1. These unauthenticated local development
 # services are consumed only by host processes and must not be externally
@@ -26,6 +31,69 @@
 name: gram-shared
 
 services:
+  gram-temporal:
+    # The CLI image, not temporalio/server: as of 1.31 the server image no
+    # longer bundles the `temporal` binary that `server start-dev` needs.
+    # CLI 1.8.1 embeds Server 1.31.2 and UI 2.50.1.
+    image: temporalio/temporal:1.8.1
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:7233:7233"
+      - "127.0.0.1:8233:8233"
+    environment:
+      # The dev server is a single Go process, so its footprint is governed by
+      # the Go runtime rather than by cgroup limits. GOMEMLIMIT is a soft heap
+      # ceiling the GC actively works to stay under, which is what caps memory
+      # in sandboxes where `deploy.resources.limits` cannot be applied.
+      GOMEMLIMIT: 256MiB
+      # Per-P allocator caches and GC workers scale with core count; the dev
+      # server never needs the whole host.
+      GOMAXPROCS: 4
+    entrypoint: ["temporal"]
+    command: [
+        "server",
+        "start-dev",
+        "--ip",
+        "0.0.0.0",
+        "--ui-ip",
+        "0.0.0.0",
+        "--namespace",
+        "default",
+        "--db-filename",
+        "/home/temporal/dev.db",
+        # Temporal's history cache is count-bounded by default (128k mutable
+        # state entries host-wide), which puts no ceiling on bytes. Switch it to
+        # a size-based limit so the live heap stays bounded and GOMEMLIMIT does
+        # not turn into GC thrash. 1.31 dropped the shard-level cache, so
+        # hostLevelCacheMaxSizeBytes is the only size knob left.
+        "--dynamic-config-value",
+        "history.cacheSizeBasedLimit=true",
+        "--dynamic-config-value",
+        "history.hostLevelCacheMaxSizeBytes=67108864",
+        "--dynamic-config-value",
+        "history.eventsCacheMaxSizeBytes=2097152",
+        "--dynamic-config-value",
+        'history.cacheTTL="5m"',
+        "--dynamic-config-value",
+        'history.eventsCacheTTL="5m"',
+        # Worktrees share this server but use separate namespaces. One worker
+        # per namespace still does not need the default four task queue
+        # partitions, each of which carries its own manager and buffers.
+        "--dynamic-config-value",
+        "matching.numTaskqueueReadPartitions=1",
+        "--dynamic-config-value",
+        "matching.numTaskqueueWritePartitions=1",
+      ]
+    volumes:
+      # The fixed project keeps persistence independent of whichever worktree
+      # starts the shared stack first.
+      - temporal_data:/home/temporal
+    healthcheck:
+      test: ["CMD", "temporal", "operator", "cluster", "health"]
+      interval: 5s
+      timeout: 30s
+      retries: 5
+
   pubsub-emulator:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators@sha256:1b083a6a9647024a98d4f38c2b51906a0f61ca36adcba11672b8933544962efe
     restart: unless-stopped
@@ -103,5 +171,7 @@ services:
       retries: 12
 
 volumes:
+  temporal_data:
+    driver: local
   lgtm_data:
     driver: local

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -35,7 +35,7 @@ services:
     # The CLI image, not temporalio/server: as of 1.31 the server image no
     # longer bundles the `temporal` binary that `server start-dev` needs.
     # CLI 1.8.1 embeds Server 1.31.2 and UI 2.50.1.
-    image: temporalio/temporal:1.8.1
+    image: temporalio/temporal:1.8.1@sha256:59561b9ef060eaeb1f46cb6a1842d6cbdd8a393eb3b6d315ecef5fe2f0b1d7a6
     restart: unless-stopped
     ports:
       - "127.0.0.1:7233:7233"

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,9 @@
-# Per-worktree infra. `git:workinit` sets a unique COMPOSE_PROJECT_NAME (and
-# `zero:remap-ports` remaps the host ports) so each worktree gets its own stack
-# — postgres, clickhouse, temporal, etc. — without colliding.
+# Per-worktree infra. `git:workinit` sets a unique COMPOSE_PROJECT_NAME and
+# `zero:remap-ports` remaps the host ports, so each worktree gets its own
+# Postgres, Redis, and ClickHouse without colliding.
 # Services shared safely through explicit worktree namespaces live in
-# compose.shared.yml and run once for the whole machine: Pub/Sub, Presidio, and
-# the LGTM observability stack.
+# compose.shared.yml and run once for the whole machine: Temporal, Pub/Sub,
+# Presidio, and the LGTM observability stack.
 name: ${COMPOSE_PROJECT_NAME:-gram}
 
 services:
@@ -35,66 +35,6 @@ services:
     ports:
       - "${GRAM_REDIS_CACHE_PORT}:35299"
     command: redis-server --port 35299 --requirepass xi9XILbY
-
-  gram-temporal:
-    # The CLI image, not temporalio/server: as of 1.31 the server image no
-    # longer bundles the `temporal` binary that `server start-dev` needs.
-    # CLI 1.8.1 embeds Server 1.31.2 and UI 2.50.1.
-    image: temporalio/temporal:1.8.1
-    restart: unless-stopped
-    ports:
-      - "${TEMPORAL_PORT}:7233"
-      - "${TEMPORAL_WEB_PORT}:8233"
-    environment:
-      # The dev server is a single Go process, so its footprint is governed by
-      # the Go runtime rather than by cgroup limits. GOMEMLIMIT is a soft heap
-      # ceiling the GC actively works to stay under, which is what caps memory
-      # in sandboxes where `deploy.resources.limits` cannot be applied.
-      GOMEMLIMIT: 256MiB
-      # Per-P allocator caches and GC workers scale with core count; the dev
-      # server never needs the whole host.
-      GOMAXPROCS: 4
-    entrypoint: ["temporal"]
-    command: [
-        "server",
-        "start-dev",
-        "--ip",
-        "${TEMPORAL_IP:-0.0.0.0}",
-        "--ui-ip",
-        "${TEMPORAL_IP:-0.0.0.0}",
-        "--namespace",
-        "default",
-        "--db-filename",
-        "/home/temporal/dev.db",
-        # Temporal's history cache is count-bounded by default (128k mutable
-        # state entries host-wide), which puts no ceiling on bytes. Switch it to
-        # a size-based limit so the live heap stays bounded and GOMEMLIMIT does
-        # not turn into GC thrash. 1.31 dropped the shard-level cache, so
-        # hostLevelCacheMaxSizeBytes is the only size knob left.
-        "--dynamic-config-value",
-        "history.cacheSizeBasedLimit=true",
-        "--dynamic-config-value",
-        "history.hostLevelCacheMaxSizeBytes=67108864",
-        "--dynamic-config-value",
-        "history.eventsCacheMaxSizeBytes=2097152",
-        "--dynamic-config-value",
-        'history.cacheTTL="5m"',
-        "--dynamic-config-value",
-        'history.eventsCacheTTL="5m"',
-        # A single local worker does not need the default 4 task queue
-        # partitions, each of which carries its own manager and buffers.
-        "--dynamic-config-value",
-        "matching.numTaskqueueReadPartitions=1",
-        "--dynamic-config-value",
-        "matching.numTaskqueueWritePartitions=1",
-      ]
-    volumes:
-      - temporal_data:/home/temporal
-    healthcheck:
-      test: ["CMD", "temporal", "operator", "cluster", "health"]
-      interval: 5s
-      timeout: 30s
-      retries: 5
 
   litellm:
     profiles: [litellm]
@@ -196,8 +136,6 @@ volumes:
   postgres_data:
     driver: local
   cache_data:
-    driver: local
-  temporal_data:
     driver: local
   clickhouse_data:
     driver: local


### PR DESCRIPTION
## Summary

- move the local Temporal dev server from the per-worktree Compose stack into the fixed shared stack
- assign each worktree a Temporal namespace and create it idempotently through the CLI inside the shared container
- migrate existing worktree port overrides and update startup, cleanup, and status tooling for the shared service

## Motivation

Running a Temporal server per worktree duplicates a stateful service and consumes unnecessary resources. A single machine-wide server keeps the local stack lighter, while namespace-scoped workflows, schedules, task queues, and workflow IDs preserve worktree isolation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share Temporal across all worktrees via the shared Docker stack. Previously each worktree ran its own Temporal with remapped ports; now one server runs on 127.0.0.1:7233/8233 and each worktree uses its own namespace for isolation. The shared service is pinned to `temporalio/temporal:1.8.1` (with digest) for reproducible dev.

**Migration**
- `git:worksync` unsets auto-generated `TEMPORAL_ADDRESS`, `TEMPORAL_PORT`, and `TEMPORAL_WEB_PORT`; custom endpoints are preserved.
- `git:workinit`/`git:worksync` set `TEMPORAL_NAMESPACE` to the worktree’s `COMPOSE_PROJECT_NAME` and migrate older `"default"` namespaces.
- `infra:start` removes any per-worktree Temporal publishing 7233, starts shared `gram-temporal` and Pub/Sub with health checks, and creates the namespace idempotently.
- `compose.shared.yml` now hosts pinned `gram-temporal`; `compose.yml` no longer declares it; zero tooling treats Temporal ports as shared and restarts the shared container interactively.

<sup>Written for commit a2d21bc77d5a437f4d0e070f243b293ccd27ce35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

