### PR TITLE
chore: share ClickHouse across worktrees

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -749,7 +749,7 @@ jobs:
     if: needs.changes.outputs.migrations == 'true' && github.event_name == 'pull_request'
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:25.8.3
+        image: clickhouse/clickhouse-server:26.7.5.10@sha256:800e82865530eb2f1c4bc1b960e43b435fd9b2d83b4bd04a2564a5cfd88fdb6e
         env:
           CLICKHOUSE_USER: gram
           CLICKHOUSE_PASSWORD: gram

--- a/.mise-tasks/clickhouse/rebuild.sh
+++ b/.mise-tasks/clickhouse/rebuild.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-#MISE description="Rebuild the local ClickHouse image to pick up config changes (users.d, config.d)"
+
+#MISE description="Restart the shared ClickHouse server to reload mounted configuration"
 
 set -e
 
-docker compose up -d --build clickhouse
-
-until curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${CLICKHOUSE_HTTP_PORT}/?user=${CLICKHOUSE_USERNAME}&password=${CLICKHOUSE_PASSWORD}&query=SELECT+1" | grep -q 200; do
-    echo "Waiting for ClickHouse to be ready..."
-    sleep 1
-done
-
-echo "ClickHouse rebuilt and ready."
+echo "⚠️  Restarting shared ClickHouse interrupts every worktree." >&2
+docker compose -f compose.shared.yml -p gram-shared up -d --force-recreate \
+    --wait --wait-timeout 30 clickhouse
+echo "Shared ClickHouse restarted and healthy."

--- a/.mise-tasks/git/workboot.sh
+++ b/.mise-tasks/git/workboot.sh
@@ -27,12 +27,9 @@ echo $$ > "$marker"
 rm -f "$failed"
 trap 'code=$?; rm -f "$marker"; [ "$code" -eq 0 ] || echo "$code" > "$failed"' EXIT
 
-# Re-booting a worktree whose stack is already running fails for a reason that
-# has nothing to do with the worktree: `mise run start` kills the previous
-# daemons, pitchfork records the kill as a daemon failure, `start` reports
-# failure, and `zero` never reaches `mise run seed` -- leaving the org on the
-# demo gate. Stop cleanly first so a retry is a real retry. No-op on a fresh
-# worktree, where nothing is running yet.
+# Re-booting a worktree whose stack is already running can make pitchfork treat
+# intentional replacement of old daemons as a failure. Stop cleanly first so a
+# retry is a real retry. No-op on a fresh worktree.
 mise run stop || true
 
 # INFRA_READINESS_TIMEOUT is raised from its 30s default because a new worktree
@@ -46,23 +43,4 @@ mise run stop || true
 # synchronously (only background Temporal risk activities do, and they already
 # retry), and infra:start treats the wait as advisory anyway. An interactive
 # `./zero` keeps the wait so its success message stays honest.
-if INFRA_READINESS_TIMEOUT=300 PRESIDIO_READINESS_TIMEOUT=0 ./zero --agent; then
-    exit 0
-fi
-
-# `mise run seed` is `zero`'s last step, and the one that fills the org with
-# data and lifts it off the demo gate -- a boot that stops here leaves a
-# dashboard that looks broken. It talks only to Postgres and ClickHouse (no
-# server, no dev-idp handshake), so the remaining failure mode is a database
-# still settling on a cold volume. Retry the seed alone -- if `zero` failed
-# earlier than seeding, these retries fail too and the boot is reported failed
-# anyway.
-for delay in 15 30 60; do
-    sleep "$delay"
-    echo "Retrying seed after a ${delay}s wait..."
-    if mise run seed; then
-        exit 0
-    fi
-done
-
-exit 1
+INFRA_READINESS_TIMEOUT=300 PRESIDIO_READINESS_TIMEOUT=0 ./zero --agent

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -57,6 +57,11 @@ if ! mise run install:aube --offline; then
   mise run install:aube
 fi
 
+copied_compose_project=$(mise set --file mise.local.toml 2>/dev/null \
+  | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
+copied_clickhouse_database=$(mise set --file mise.local.toml 2>/dev/null \
+  | awk '$1 == "CLICKHOUSE_DATABASE" { print $2 }')
+
 suffix=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 compose_project="gram-infra-${suffix}"
 mise set --file mise.local.toml "COMPOSE_PROJECT_NAME=${compose_project}"
@@ -69,6 +74,54 @@ mise set --file mise.local.toml "TEMPORAL_NAMESPACE=${compose_project}"
 # Compose project ID keeps identical topic and subscription IDs isolated when
 # every worktree connects to one shared emulator.
 mise set --file mise.local.toml "GRAM_GCP_PROJECT_ID=${compose_project}"
+# Shared ClickHouse isolates worktrees by database. Preserve a copied explicit
+# override, but replace legacy `default` and source-derived namespaces with this
+# worktree's namespace.
+source_clickhouse_database=$(printf '%s' "$copied_compose_project" \
+  | tr '[:upper:]-' '[:lower:]_' \
+  | tr -c 'a-z0-9_' '_')
+clickhouse_database="$copied_clickhouse_database"
+if [ "$clickhouse_database" = "$source_clickhouse_database" ] || [ "$clickhouse_database" = "default" ]; then
+  clickhouse_database=
+fi
+if [ -z "$clickhouse_database" ]; then
+  clickhouse_database=$(printf '%s' "$compose_project" \
+    | tr '[:upper:]-' '[:lower:]_' \
+    | tr -c 'a-z0-9_' '_')
+fi
+if [[ ! "$clickhouse_database" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "Error: generated ClickHouse database '$clickhouse_database' is not a safe identifier." >&2
+  exit 1
+fi
+
+# Move the declaration after copied base config, then redeclare both dependent
+# URLs after it. mise interpolation is precedence- and order-sensitive.
+mise unset --file mise.local.toml CLICKHOUSE_DATABASE >/dev/null 2>&1 || true
+mise set --file mise.local.toml "CLICKHOUSE_DATABASE=${clickhouse_database}"
+generated_clickhouse_urls=0
+for key in GRAM_CLICKHOUSE_URL GRAM_CLICKHOUSE_GOMIGRATE_URL; do
+  value=$(mise set --file mise.local.toml 2>/dev/null \
+    | awk -v key="$key" '$1 == key { print $2 }')
+  case "$value" in
+    *'{{env.CLICKHOUSE_'*)
+      mise unset --file mise.local.toml "$key" >/dev/null 2>&1 || true
+      generated_clickhouse_urls=1
+      ;;
+    "") ;;
+    *) continue ;;
+  esac
+  if [ "$key" = "GRAM_CLICKHOUSE_URL" ]; then
+    mise set --file mise.local.toml \
+      'GRAM_CLICKHOUSE_URL=clickhouse://{{env.CLICKHOUSE_USERNAME}}:{{env.CLICKHOUSE_PASSWORD}}@{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}/{{env.CLICKHOUSE_DATABASE}}?secure=true&skip_verify=true'
+  else
+    mise set --file mise.local.toml \
+      'GRAM_CLICKHOUSE_GOMIGRATE_URL=clickhouse://{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}?database={{env.CLICKHOUSE_DATABASE}}&username={{env.CLICKHOUSE_USERNAME}}&password={{env.CLICKHOUSE_PASSWORD}}&secure=true&skip_verify=true&x-multi-statement=true'
+  fi
+done
+if [ "$generated_clickhouse_urls" -eq 1 ]; then
+  mise unset --file mise.local.toml CLICKHOUSE_HTTP_PORT >/dev/null 2>&1 || true
+  mise unset --file mise.local.toml CLICKHOUSE_NATIVE_PORT >/dev/null 2>&1 || true
+fi
 
 # Temporal, Pub/Sub, and LGTM are shared across every worktree
 # (compose.shared.yml). The namespace and project ID above isolate state; this

--- a/.mise-tasks/git/worksync.sh
+++ b/.mise-tasks/git/worksync.sh
@@ -44,6 +44,61 @@ if grep -E '^GRAM_ADMIN_SERVER_URL[[:space:]]*=' mise.local.toml \
   echo "✅ Cleared the stale admin origin declaration(s); re-mapped below."
 fi
 
+# ClickHouse moved from per-worktree ports to a shared server. A generated URL
+# contains mise's CLICKHOUSE_* interpolation marker; that is the evidence needed
+# to remove the paired generated ports without touching manually pinned
+# endpoints. The old volume is intentionally retained by infra:start.
+generated_clickhouse_urls=0
+for key in GRAM_CLICKHOUSE_URL GRAM_CLICKHOUSE_GOMIGRATE_URL; do
+  if grep -E "^${key}[[:space:]]*=" mise.local.toml \
+       | grep -qF '{{env.CLICKHOUSE_'; then
+    mise unset --file mise.local.toml "$key"
+    generated_clickhouse_urls=1
+  fi
+done
+if [ "$generated_clickhouse_urls" -eq 1 ]; then
+  for key in CLICKHOUSE_HTTP_PORT CLICKHOUSE_NATIVE_PORT; do
+    if grep -qE "^${key}[[:space:]]*=" mise.local.toml; then
+      mise unset --file mise.local.toml "$key"
+    fi
+  done
+  echo "✅ Reset auto-generated ClickHouse ports and URLs to shared defaults."
+fi
+
+# Preserve an explicit non-default database override. Otherwise derive the
+# namespace from COMPOSE_PROJECT_NAME.
+clickhouse_database=$(mise set --file mise.local.toml 2>/dev/null \
+  | awk '$1 == "CLICKHOUSE_DATABASE" { print $2 }')
+if [ "$clickhouse_database" = "default" ]; then
+  clickhouse_database=
+fi
+if [ -z "$clickhouse_database" ]; then
+  worktree_project=$(mise set --file mise.local.toml 2>/dev/null \
+    | awk '$1 == "COMPOSE_PROJECT_NAME" { print $2 }')
+  clickhouse_database=$(printf '%s' "$worktree_project" \
+    | tr '[:upper:]-' '[:lower:]_' \
+    | tr -c 'a-z0-9_' '_')
+fi
+if [[ ! "$clickhouse_database" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "Error: generated ClickHouse database '$clickhouse_database' is not a safe identifier." >&2
+  exit 1
+fi
+mise unset --file mise.local.toml CLICKHOUSE_DATABASE >/dev/null 2>&1 || true
+mise set --file mise.local.toml "CLICKHOUSE_DATABASE=${clickhouse_database}"
+
+for key in GRAM_CLICKHOUSE_URL GRAM_CLICKHOUSE_GOMIGRATE_URL; do
+  if grep -qE "^${key}[[:space:]]*=" mise.local.toml; then
+    continue
+  fi
+  if [ "$key" = "GRAM_CLICKHOUSE_URL" ]; then
+    mise set --file mise.local.toml \
+      'GRAM_CLICKHOUSE_URL=clickhouse://{{env.CLICKHOUSE_USERNAME}}:{{env.CLICKHOUSE_PASSWORD}}@{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}/{{env.CLICKHOUSE_DATABASE}}?secure=true&skip_verify=true'
+  else
+    mise set --file mise.local.toml \
+      'GRAM_CLICKHOUSE_GOMIGRATE_URL=clickhouse://{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}?database={{env.CLICKHOUSE_DATABASE}}&username={{env.CLICKHOUSE_USERNAME}}&password={{env.CLICKHOUSE_PASSWORD}}&secure=true&skip_verify=true&x-multi-statement=true'
+  fi
+done
+
 echo "⏳ Syncing port mappings..."
 added=0
 remap=$(mise run zero:remap-ports --preserve --format flat --file -)

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -80,45 +80,48 @@ if [ -n "$host_arch" ]; then
     fi
 fi
 
-# This worktree's own stack, first — with --remove-orphans. Pre-existing
-# worktrees can still run Temporal, Pub/Sub, or Presidio containers that
-# compose.yml no longer declares. Removing this worktree's copies before
-# asserting the shared services frees fixed ports in the main tree and removes
-# obsolete remapped copies elsewhere. Profile-gated services (litellm, tunnel,
-# local-registry) remain declared in compose.yml and are not treated as orphans.
+# Remove a stale singleton that still owns a fixed shared port. The read loop is
+# portable to Bash 3.2 on macOS; BSD xargs has no -r/--no-run-if-empty.
+remove_non_shared_container_on_port() {
+  local service="$1" port="$2"
+  docker ps -a --filter "label=com.docker.compose.service=${service}" --filter "publish=${port}" \
+    --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
+    | awk '$1 != "gram-shared" { print $2 }' \
+    | while IFS= read -r container_id; do
+        [ -n "$container_id" ] && docker rm -f "$container_id"
+      done > /dev/null 2>&1
+}
+
+# Remove obsolete fixed-port ClickHouse containers before gram-shared binds
+# 8123. Remapped containers are removed below as compose orphans; old volumes
+# remain available as rollback data.
+remove_non_shared_container_on_port clickhouse 8123 || true
+
+# ClickHouse is a hard dependency of migrations and local/demo seed.
+docker compose -f compose.shared.yml -p gram-shared up -d --wait --wait-timeout 30 clickhouse || exit 1
+
+# Database identifiers cannot be parameterized in CREATE DATABASE. Validate the
+# effective name before quoting it, including explicit overrides.
+clickhouse_database="${CLICKHOUSE_DATABASE:-default}"
+if [[ ! "$clickhouse_database" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "❌ Invalid CLICKHOUSE_DATABASE '$clickhouse_database'; expected [a-z][a-z0-9_]*." >&2
+  exit 1
+fi
+docker compose -f compose.shared.yml -p gram-shared exec -T clickhouse \
+  clickhouse-client --user gram --password gram --database default \
+  --query "CREATE DATABASE IF NOT EXISTS \`${clickhouse_database}\`" || exit 1
+
+# Start this worktree's remaining services after ClickHouse is ready.
 docker compose up -d --remove-orphans || exit 1
 
-# One-time migration: free host port 5050 for the shared analyzer. Before the
-# shared stack existed, the main tree ran its own gram-presidio bound to 5050
-# under its own compose project (the main tree never remaps PRESIDIO_PORT). The
-# --remove-orphans above only touches THIS worktree's project, so that stale
-# container would keep 5050 and block the shared `up` below. Remove ONLY the
-# non-`gram-shared` container that actually holds 5050 — scoping by the port
-# keeps this from touching a sibling worktree's still-in-use analyzer bound to
-# its own remapped port, which the sibling's app is still pointed at until it
-# runs `git:worksync`. Idempotent: once migrated there is nothing to remove.
-docker ps -a --filter "label=com.docker.compose.service=gram-presidio" --filter "publish=5050" \
-  --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
-  | awk '$1 != "gram-shared" { print $2 }' \
-  | xargs -r docker rm -f > /dev/null 2>&1 || true
+# Free fixed ports held by obsolete non-shared singleton containers. Remapped
+# sibling worktrees keep running until their own git:worksync/infra:start.
+remove_non_shared_container_on_port gram-presidio 5050 || true
+remove_non_shared_container_on_port pubsub-emulator 8088 || true
 
-# One-time migration: the main tree previously bound its per-worktree Pub/Sub
-# emulator to the shared port. Remove only a non-shared emulator actually
-# publishing 8088. Sibling worktrees on remapped ports keep running until their
-# next git:worksync/infra:start migration.
-docker ps -a --filter "label=com.docker.compose.service=pubsub-emulator" --filter "publish=8088" \
-  --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
-  | awk '$1 != "gram-shared" { print $2 }' \
-  | xargs -r docker rm -f > /dev/null 2>&1 || true
-
-# One-time migration: Temporal now runs under the shared project too. Remove
-# only a non-shared Temporal container publishing the fixed gRPC port. Sibling
-# worktrees on remapped ports keep running until their next
-# git:worksync/infra:start migration.
-docker ps -a --filter "label=com.docker.compose.service=gram-temporal" --filter "publish=7233" \
-  --format '{{.Label "com.docker.compose.project"}} {{.ID}}' 2>/dev/null \
-  | awk '$1 != "gram-shared" { print $2 }' \
-  | xargs -r docker rm -f > /dev/null 2>&1 || true
+# Temporal now runs under the shared project too. Remove only a non-shared
+# container publishing the fixed gRPC port; remapped siblings keep running.
+remove_non_shared_container_on_port gram-temporal 7233 || true
 
 # Pub/Sub is required by the local streams processes, and Temporal is required
 # by seeding and every background worker. Wait for both healthchecks so a
@@ -267,10 +270,3 @@ wait_for() {
 # Use psql to wait for the database to be ready
 wait_for "Postgres" gram-db \
     docker compose exec -T gram-db psql -U "$DB_USER" -d "$DB_NAME" -c "SELECT 1"
-
-# ClickHouse takes longer than Postgres to accept queries. Migrations run
-# immediately after infra starts, so without waiting here the first ClickHouse
-# migration can fail with a connection EOF.
-wait_for "ClickHouse" clickhouse \
-    docker compose exec -T clickhouse clickhouse-client --user "$CLICKHOUSE_USERNAME" --password "$CLICKHOUSE_PASSWORD" -q "SELECT 1"
-

--- a/.mise-tasks/nuke.sh
+++ b/.mise-tasks/nuke.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-# --keep-shared: leave compose.shared.yml services running. Worktree removal
-# passes this because other worktrees depend on those singletons.
+# --keep-shared: leave shared containers and volumes running. Worktree removal
+# still drops this worktree's ClickHouse database before its local stack.
 keep_shared=0
 for arg in "$@"; do
     case "$arg" in
@@ -21,11 +21,30 @@ if pitchfork supervisor status &> /dev/null; then
     pitchfork clean || true
 fi
 
+# Main-tree default is never dropped; worktrees remove only their selected
+# validated namespace.
+clickhouse_database="${CLICKHOUSE_DATABASE:-default}"
+if [[ ! "$clickhouse_database" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    echo "invalid CLICKHOUSE_DATABASE '$clickhouse_database'; refusing to use it in DROP DATABASE" >&2
+    exit 1
+fi
+if [ "$clickhouse_database" != "default" ]; then
+    drop_cmd=(
+        docker compose -f compose.shared.yml -p gram-shared exec -T clickhouse
+        clickhouse-client --user gram --password gram --database default
+        --query "DROP DATABASE IF EXISTS \`${clickhouse_database}\`"
+    )
+    if [ "$keep_shared" -eq 1 ]; then
+        "${drop_cmd[@]}"
+    else
+        "${drop_cmd[@]}" 2>/dev/null || true
+    fi
+fi
+
 docker compose --profile "*" down --volumes --remove-orphans
 
-# Shared services live under a fixed project. Nuke means "destroy all infra", so
-# tear them down too; `./zero` recreates them. This affects every worktree,
-# hence --keep-shared for worktree removal.
+# Full nuke destroys the fixed shared ClickHouse, Temporal, Pub/Sub, Presidio,
+# and LGTM stack. This affects every worktree, hence --keep-shared on removal.
 if [ "$keep_shared" -eq 0 ]; then
     docker compose -f compose.shared.yml -p gram-shared down --volumes --remove-orphans
 fi

--- a/.mise-tasks/zero/remap-ports.mts
+++ b/.mise-tasks/zero/remap-ports.mts
@@ -39,6 +39,8 @@ import { checkPort } from "get-port-please";
  * keep their mise.toml defaults too.
  */
 const SHARED_PORT_ENV_VARS = new Set([
+  "CLICKHOUSE_HTTP_PORT",
+  "CLICKHOUSE_NATIVE_PORT",
   "PRESIDIO_PORT",
   "PUBSUB_EMULATOR_PORT",
   "TEMPORAL_PORT",

--- a/.mise-tasks/zero/summary.mts
+++ b/.mise-tasks/zero/summary.mts
@@ -200,6 +200,7 @@ await pokeDockerService(
   "clickhouse",
   "ClickHouse",
   `http://localhost:${clickhouseHTTPPort}`,
+  true,
 );
 
 const devIdpPort = process.env["GRAM_DEVIDP_PORT"] ?? "35291";

--- a/compose.shared.yml
+++ b/compose.shared.yml
@@ -1,18 +1,16 @@
 # Shared infra — one copy across ALL git worktrees.
 #
+# ClickHouse is shared at the server and volume level. Each worktree uses its
+# own validated database name, so table and migration state stay isolated.
+#
 # Temporal is stateful and shared. `git:workinit` gives every worktree a unique
 # TEMPORAL_NAMESPACE, so identical workflow IDs and task queues remain isolated.
 # The default namespace belongs to the main tree.
 #
-# Pub/Sub is stateful too, but its fully-qualified resource paths include a
-# project ID. `git:workinit` gives every worktree a unique GRAM_GCP_PROJECT_ID,
-# so one emulator can safely host identical topic and subscription IDs for all
-# trees.
-#
-# Presidio is stateless and expensive to duplicate. LGTM separates intermixed
-# telemetry with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
-# `git:workinit` writes all worktree dimensions; `mise.toml` holds the main tree
-# defaults.
+# Pub/Sub resource paths include a per-worktree project ID, allowing one shared
+# emulator to host identical topic and subscription IDs for every worktree.
+# Presidio is stateless and expensive to duplicate. LGTM separates telemetry
+# with OTEL_RESOURCE_ATTRIBUTES=worktree=$COMPOSE_PROJECT_NAME.
 #
 # Always manage this file under its fixed project:
 #
@@ -22,7 +20,8 @@
 # Host ports are hardcoded literals, not interpolated per-worktree variables.
 # This prevents a worktree carrying stale remapped ports from republishing a
 # shared container elsewhere and fragmenting the stack. Keep the literals in
-# sync with mise.toml: Temporal 7233/8233, Pub/Sub 8088, Presidio 5050, LGTM
+# sync with mise.toml: ClickHouse 8123/9440, Temporal 7233/8233, Pub/Sub 8088,
+# Presidio 5050, LGTM
 # 13000/13200/13100/9099, and OTLP 4317/4318.
 #
 # Every port is bound to 127.0.0.1. These unauthenticated local development
@@ -120,6 +119,44 @@ services:
       retries: 15
       start_period: 2s
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:26.7.5.10@sha256:800e82865530eb2f1c4bc1b960e43b435fd9b2d83b4bd04a2564a5cfd88fdb6e
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8123:8123"
+      - "127.0.0.1:9440:9440"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: gram
+      CLICKHOUSE_PASSWORD: gram
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - ./local/clickhouse/config.d/config.xml:/etc/clickhouse-server/config.d/gram-config.xml:ro
+      - ./local/clickhouse/config.d/limits.xml:/etc/clickhouse-server/config.d/gram-limits.xml:ro
+      - ./local/clickhouse/config.d/ssl.xml:/etc/clickhouse-server/config.d/gram-ssl.xml:ro
+      - ./local/clickhouse/users.d/dev_profile.xml:/etc/clickhouse-server/users.d/gram-dev-profile.xml:ro
+      - ./local/clickhouse/certs:/etc/clickhouse-server/certs:ro
+      - clickhouse_data:/var/lib/clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "clickhouse-client",
+          "--user",
+          "gram",
+          "--password",
+          "gram",
+          "--query",
+          "SELECT 1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+
   gram-presidio:
     image: mcr.microsoft.com/presidio-analyzer:2.2.362
     restart: unless-stopped
@@ -172,6 +209,8 @@ services:
 
 volumes:
   temporal_data:
+    driver: local
+  clickhouse_data:
     driver: local
   lgtm_data:
     driver: local

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,7 @@
 # Per-worktree infra. `git:workinit` sets a unique COMPOSE_PROJECT_NAME and
-# `zero:remap-ports` remaps the host ports, so each worktree gets its own
-# Postgres, Redis, and ClickHouse without colliding.
-# Services shared safely through explicit worktree namespaces live in
-# compose.shared.yml and run once for the whole machine: Temporal, Pub/Sub,
-# Presidio, and the LGTM observability stack.
+# `zero:remap-ports` remaps host ports so each worktree gets isolated Postgres
+# and Redis services. Namespace-safe services live once in compose.shared.yml:
+# ClickHouse, Temporal, Pub/Sub, Presidio, and LGTM.
 name: ${COMPOSE_PROJECT_NAME:-gram}
 
 services:
@@ -56,25 +54,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
-
-  clickhouse:
-    build:
-      context: ./local/clickhouse
-    restart: unless-stopped
-    ports:
-      - "${CLICKHOUSE_HTTP_PORT}:8123"
-      - "${CLICKHOUSE_NATIVE_PORT}:9440"
-    environment:
-      CLICKHOUSE_DB: default
-      CLICKHOUSE_USER: gram
-      CLICKHOUSE_PASSWORD: gram
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-    volumes:
-      - clickhouse_data:/var/lib/clickhouse
-    ulimits:
-      nofile:
-        soft: 262144
-        hard: 262144
 
   mcp-registry-db:
     profiles: [local-registry]
@@ -136,8 +115,6 @@ volumes:
   postgres_data:
     driver: local
   cache_data:
-    driver: local
-  clickhouse_data:
     driver: local
   mcp_registry_data:
     driver: local

--- a/examples/clickhouse/docker-compose.yml
+++ b/examples/clickhouse/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.7.5.10@sha256:800e82865530eb2f1c4bc1b960e43b435fd9b2d83b4bd04a2564a5cfd88fdb6e
     container_name: clickhouse-dev
     ports:
       - "8124:8123" # HTTP interface

--- a/local/clickhouse/Dockerfile
+++ b/local/clickhouse/Dockerfile
@@ -1,5 +1,0 @@
-FROM clickhouse/clickhouse-server:25.8.3
-
-COPY config.d /etc/clickhouse-server/config.d
-COPY users.d /etc/clickhouse-server/users.d
-COPY certs /etc/clickhouse-server/certs

--- a/local/clickhouse/config.d/limits.xml
+++ b/local/clickhouse/config.d/limits.xml
@@ -5,25 +5,18 @@
          auto ratio (90% of visible RAM) or a compose cgroup limit: cgroup limits are not
          enforced in every environment, in which case ClickHouse sees the whole host's RAM.
 
-         Sized for N concurrent worktrees, not one: each worktree runs its own ClickHouse, so
-         this budget is multiplied by however many stacks are up. 1 GiB is ample for the
-         local dataset (dev seed plus whatever a test run writes) and keeps six worktrees
-         under 6 GiB of ClickHouse headroom instead of 12 GiB. It is also the floor that
-         boots: 512 MiB fails startup with BAD_ARGUMENTS on the background-pool constraint
-         described below, which the <background_pool_size> setting does not rescue — that
-         override is a no-op here (system.settings reports 20 while 8 is enforced), so the
-         effective pool tracks this cap rather than the value written below. -->
+         This singleton serves every worktree. Their queries, caches, and background work
+         share this 1 GiB budget. A 512 MiB cap does not boot because it violates the
+         background-pool constraint described below. -->
     <max_server_memory_usage>1073741824</max_server_memory_usage> <!-- 1 GiB -->
 
     <!-- Reduce cache sizes relative to available RAM -->
     <cache_size_to_ram_max_ratio>0.20</cache_size_to_ram_max_ratio>
 
-    <!-- Reduce background thread pools so ClickHouse doesn't spawn too many workers.
-         The constraint that bounds this: startup fails with BAD_ARGUMENTS unless
-         background_pool_size * background_merges_mutations_concurrency_ratio is at least
-         number_of_free_entries_in_pool_to_execute_mutation (default 20). Note that
-         background_pool_size is not actually honoured from this file (see above), so raising
-         it is not a way to buy room under a smaller memory cap. -->
+    <!-- Keep the merge/mutation pool large enough to satisfy ClickHouse's startup check:
+         background_pool_size * background_merges_mutations_concurrency_ratio must be at
+         least number_of_free_entries_in_pool_to_execute_mutation (default 20). Reduce the
+         scheduling pool separately to limit idle development workers. -->
     <background_pool_size>20</background_pool_size>
     <background_schedule_pool_size>2</background_schedule_pool_size>
 </clickhouse>

--- a/mise.toml
+++ b/mise.toml
@@ -96,7 +96,7 @@ CLICKHOUSE_DATABASE = "default"
 CLICKHOUSE_INSECURE = true
 GRAM_CLICKHOUSE_URL = "clickhouse://{{env.CLICKHOUSE_USERNAME}}:{{env.CLICKHOUSE_PASSWORD}}@{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}/{{env.CLICKHOUSE_DATABASE}}?secure=true&skip_verify=true"
 ## golang-migrate requires username/password as query parameters instead of in the URL
-GRAM_CLICKHOUSE_GOMIGRATE_URL = "clickhouse://{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}/{{env.CLICKHOUSE_DATABASE}}?username={{env.CLICKHOUSE_USERNAME}}&password={{env.CLICKHOUSE_PASSWORD}}&secure=true&skip_verify=true&x-multi-statement=true"
+GRAM_CLICKHOUSE_GOMIGRATE_URL = "clickhouse://{{env.CLICKHOUSE_HOST}}:{{env.CLICKHOUSE_NATIVE_PORT}}?database={{env.CLICKHOUSE_DATABASE}}&username={{env.CLICKHOUSE_USERNAME}}&password={{env.CLICKHOUSE_PASSWORD}}&secure=true&skip_verify=true&x-multi-statement=true"
 
 ############################
 ## Temporal configuration ##

--- a/server/clickhouse/local/golang_migrate/README.md
+++ b/server/clickhouse/local/golang_migrate/README.md
@@ -41,6 +41,6 @@ The script will automatically use the configured migration engine.
 Note that golang-migrate requires a different URL format than Atlas:
 
 - **Atlas**: `clickhouse://user:password@host:port/database?params`
-- **golang-migrate**: `clickhouse://host:port/database?username=user&password=pass&params`
+- **golang-migrate**: `clickhouse://host:port?database=database&username=user&password=pass&params`
 
 This is handled automatically by using the `GRAM_CLICKHOUSE_GOMIGRATE_URL` environment variable for golang-migrate.

--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -19,7 +19,7 @@ type ClickhouseClientFunc func(t *testing.T) (clickhouse.Conn, error)
 // from migration files. Returns a container reference and a function to create
 // test connections. The per-test connection is automatically closed via t.Cleanup.
 func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseContainer, ClickhouseClientFunc, error) {
-	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:25.8.3",
+	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:26.7.5.10@sha256:800e82865530eb2f1c4bc1b960e43b435fd9b2d83b4bd04a2564a5cfd88fdb6e",
 		clickhousecontainer.WithUsername("gram"),
 		clickhousecontainer.WithPassword("gram"),
 		clickhousecontainer.WithInitScripts(rootPath("clickhouse", "schema.sql")),

--- a/zero
+++ b/zero
@@ -206,6 +206,9 @@ mise clickhouse:migrate
 
 mise run zero:devidp
 
+echo -e "\n⏳ Seeding the worktree databases"
+mise run seed
+
 echo -e "\n✅ All set up!"
 
 # Use local:start if it's defined, otherwise fall back to the default start task.
@@ -235,7 +238,6 @@ if $started; then
     wait "$server_cache_pid" || true
 
     mise run "$start_task"
-    mise run seed
 else
     # Nothing will consume the cache, so stop paying for it: without this the
     # build runs to completion in the background of a `./zero` the user


### PR DESCRIPTION
## Summary

- run one fixed-port ClickHouse server and volume for all worktrees while isolating data and migration state by validated per-worktree databases
- use ClickHouse 26.7.5.10 across local Compose, tests, examples, and migration CI, pinned by tag and multi-architecture image digest
- mount local server configuration and certificates read-only on the official ClickHouse image
- migrate worktree initialization, synchronization, startup, cleanup, seed ordering, and connection URLs to the shared namespace model
- make ClickHouse startup, status, cleanup, and configuration reloads operate only on the shared singleton

## Motivation

Per-worktree ClickHouse containers duplicate the server and its storage even though development only needs schema and data isolation. Sharing the server reduces local resource use while database namespaces preserve independent migrations, fixtures, and cleanup. A shared-only lifecycle keeps the implementation small and avoids persistent mode-switching state in worktree configuration.
