### PR TITLE
chore: document plugin collaborator permission

### DIFF
--- a/docs/plugins/publishing.md
+++ b/docs/plugins/publishing.md
@@ -50,7 +50,7 @@ Or with a collaborator:
 
 6. **Store connection.** The `plugin_github_connections` row is upserted with `(project_id, installation_id, repo_owner, repo_name)`.
 
-7. **Add collaborator.** If a GitHub username was provided, `AddCollaborator()` grants `push` permission to the repo.
+7. **Add collaborator.** If a GitHub username was provided, `AddCollaborator()` grants `pull` permission to the repo.
 
 > **Keys are minted before the GitHub push.** If the push fails, the keys are discarded and not persisted to the database. On retry the flow starts over.
 


### PR DESCRIPTION
## Why?

The plugin publishing documentation says optional collaborators receive push access, while the implementation grants read-only pull access.

## What?

Update the documented collaborator permission to match the implementation.

## Notes

Documentation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates plugin publishing docs to state that `AddCollaborator()` grants pull (read-only) permission, not push. This aligns the docs with actual behavior and clarifies that optional collaborators cannot push to the repo.

<sup>Written for commit b01542cc4d1d7c9f7ee1c0b67d5873337e8a6612. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

