### PR TITLE
mig: add ClickHouse billing meter readings table

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260825112511_billing-meter-readings.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260825112511_billing-meter-readings.down.sql
@@ -1,0 +1,2 @@
+-- reverse: create "billing_meter_readings" table
+DROP TABLE `billing_meter_readings`;

--- a/server/clickhouse/local/golang_migrate/20260825112511_billing-meter-readings.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260825112511_billing-meter-readings.up.sql
@@ -1,0 +1,22 @@
+-- create "billing_meter_readings" table
+CREATE TABLE `billing_meter_readings` (
+  `id` UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+  `organization_id` String COMMENT 'Organization that owns the workload.',
+  `project_id` UUID COMMENT 'Project that owns the workload.',
+  `meter_id` LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+  `operation_id` String COMMENT 'Domain operation that produced the reading.',
+  `unit` LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+  `value` Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'ClickHouse ingestion time and ReplacingMergeTree version.',
+  `corrects_reading_id` Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+  `reading_kind` LowCardinality(String) MATERIALIZED if(isNull(corrects_reading_id), 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+  `attributes` Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+  `tokenizer_codec` LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+  CONSTRAINT `identity_valid` CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id)),
+  CONSTRAINT `value_kind_valid` CHECK (isNull(corrects_reading_id) AND value > 0) OR (isNotNull(corrects_reading_id) AND value != 0),
+  CONSTRAINT `correction_id_valid` CHECK isNull(corrects_reading_id) OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
+  CONSTRAINT `measurement_valid` CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
+  INDEX `idx_billing_meter_readings_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1
+) ENGINE = ReplacingMergeTree(inserted_at)
+PRIMARY KEY (`organization_id`, `meter_id`, `project_id`) ORDER BY (`organization_id`, `meter_id`, `project_id`, `id`) PARTITION BY (cityHash64(toString(id)) % 64) SETTINGS index_granularity = 8192 COMMENT 'Raw immutable s-token usage ledger with stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:QdT9YmGqh/gOzyw9PvU2YecmL/UUr8y3F+VGu/r9HFo=
+h1:5xIpaQ7Q8fdToRy0Oo/pKMul9rY3feKkJPdKQWhjIJg=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -91,3 +91,4 @@ h1:QdT9YmGqh/gOzyw9PvU2YecmL/UUr8y3F+VGu/r9HFo=
 20260817165153_add-risk-findings-suppression-reason.up.sql h1:janOxO76sl27TabZZDLDtpq3/+t8GpigxITjcj+GsNQ=
 20260821180408_add-risk-findings-event-kind.up.sql h1:QkhOhO7Q4cfBVkbhvAatxmHdTbZtDm9MQ7+78USDRFQ=
 20260824192251_otel-event-feed-tables.up.sql h1:n3KFSIcdJXiqHRQQCAjkrD5Ux0dAsqJ1Ar9R7rM31qI=
+20260825112511_billing-meter-readings.up.sql h1:27Ts5n4EmmxCSfPKF89JmZBaixYgLQ0xvqoE/4yAGOM=

--- a/server/clickhouse/migrations/20260825112504_billing-meter-readings.sql
+++ b/server/clickhouse/migrations/20260825112504_billing-meter-readings.sql
@@ -1,0 +1,22 @@
+-- Create "billing_meter_readings" table
+CREATE TABLE `billing_meter_readings` (
+  `id` UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+  `organization_id` String COMMENT 'Organization that owns the workload.',
+  `project_id` UUID COMMENT 'Project that owns the workload.',
+  `meter_id` LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+  `operation_id` String COMMENT 'Domain operation that produced the reading.',
+  `unit` LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+  `value` Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'ClickHouse ingestion time and ReplacingMergeTree version.',
+  `corrects_reading_id` Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+  `reading_kind` LowCardinality(String) MATERIALIZED if(isNull(corrects_reading_id), 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+  `attributes` Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+  `tokenizer_codec` LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+  CONSTRAINT `identity_valid` CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id)),
+  CONSTRAINT `value_kind_valid` CHECK (isNull(corrects_reading_id) AND value > 0) OR (isNotNull(corrects_reading_id) AND value != 0),
+  CONSTRAINT `correction_id_valid` CHECK isNull(corrects_reading_id) OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
+  CONSTRAINT `measurement_valid` CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
+  INDEX `idx_billing_meter_readings_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1
+) ENGINE = ReplacingMergeTree(inserted_at)
+PRIMARY KEY (`organization_id`, `meter_id`, `project_id`) ORDER BY (`organization_id`, `meter_id`, `project_id`, `id`) PARTITION BY (cityHash64(toString(id)) % 64) SETTINGS index_granularity = 8192 COMMENT 'Raw immutable s-token usage ledger with stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:UEPn6rvO3RUhV/B5oL+/FLaqpF9xE5k18ASwjVAPd5U=
+h1:M4tHi9jHBtmcZtIR3cr05p4sMRVrpl9gYWBBQqKfg7k=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -96,3 +96,4 @@ h1:UEPn6rvO3RUhV/B5oL+/FLaqpF9xE5k18ASwjVAPd5U=
 20260817165146_add-risk-findings-suppression-reason.sql h1:0MOXyO3mr5+cUxRk4azh2z18RYgUIIOYRoLPIPSUEbU=
 20260821180402_add-risk-findings-event-kind.sql h1:1NyIucg2KfdbPn1PqiPfLpzMf62hgy7Zogmk0uuZzu0=
 20260824192245_otel-event-feed-tables.sql h1:fC4u4OnBq3d3Dwcq7VmWp4J8YwSSNXUKfhA55C04ZkQ=
+20260825112504_billing-meter-readings.sql h1:tQBQtUvTVevKBYdP539VUMePWX/XYBS9FWYQvsDvZ0M=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1179,6 +1179,37 @@ SELECT
 FROM telemetry_logs
 GROUP BY gram_project_id, attribute_key;
 
+-- Raw usage ledger only. Meter definitions, pricing, billability, aggregation,
+-- finalized billing-cycle records, and reconciliation live in transactional models.
+-- Outbox and Pub/Sub delivery is at least once. Producers keep each deterministic
+-- id's payload stable. Readers must use FINAL or equivalent id deduplication
+-- before summing. Adjustments use distinct ids and never update originals.
+CREATE TABLE IF NOT EXISTS billing_meter_readings (
+    id UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+    organization_id String COMMENT 'Organization that owns the workload.',
+    project_id UUID COMMENT 'Project that owns the workload.',
+    meter_id LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+    operation_id String COMMENT 'Domain operation that produced the reading.',
+    unit LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+    value Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+    occurred_at DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed.',
+    inserted_at DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'ClickHouse ingestion time and ReplacingMergeTree version.',
+    corrects_reading_id Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+    reading_kind LowCardinality(String) MATERIALIZED if(isNull(corrects_reading_id), 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+    attributes Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+    tokenizer_codec LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+    CONSTRAINT identity_valid CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id)),
+    CONSTRAINT value_kind_valid CHECK (isNull(corrects_reading_id) AND value > 0) OR (isNotNull(corrects_reading_id) AND value != 0),
+    CONSTRAINT correction_id_valid CHECK isNull(corrects_reading_id) OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
+    CONSTRAINT measurement_valid CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
+    INDEX idx_billing_meter_readings_occurred_at occurred_at TYPE minmax GRANULARITY 1
+) ENGINE = ReplacingMergeTree(inserted_at)
+PARTITION BY cityHash64(toString(id)) % 64
+PRIMARY KEY (organization_id, meter_id, project_id)
+ORDER BY (organization_id, meter_id, project_id, id)
+SETTINGS index_granularity = 8192
+COMMENT 'Raw immutable s-token usage ledger with stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
+
 CREATE TABLE IF NOT EXISTS authz_challenges (
     -- Identity
     id UUID DEFAULT generateUUIDv7() COMMENT 'Unique identifier for the challenge entry.',


### PR DESCRIPTION
Closes DNO-964

## Summary

- Adds the raw `billing_meter_readings` ClickHouse ledger from #5692 with synchronized Atlas and local golang-migrate migrations.
- Derives an explicit `reading_kind`, promotes the existing tokenizer codec attribute to a typed materialized column, and orders the key by organization, meter, project, then stable reading ID.
- Adds cheap row-local checks for required identities, usage-versus-adjustment values, correction IDs, unit, and tokenizer while retaining the Go consumer's poison-message validation.
- Preserves stable-ID hash partitioning and the requirement that billing reads use `FINAL` or equivalent ID deduplication.
- Leaves the raw ledger without a TTL until durable finalized s-token billing-cycle records exist outside ClickHouse.
- Defers meter-definition version, produced time, source, and adjustment reason until the wire contract and producers carry authoritative values. Meter catalog, pricing, billability, aggregation rules, finalized cycles, and reconciliation remain transactional concerns.

## Motivation

Land a deployable raw usage ledger independently from application and infrastructure integration without pretending it is the complete billing model or inventing values absent from the current producer contract.
