### PR TITLE
fix: keep the login page off the mode-switch backdrop

### DIFF
--- a/client/dashboard/src/components/mode-switch-stage.tsx
+++ b/client/dashboard/src/components/mode-switch-stage.tsx
@@ -70,14 +70,18 @@ export function ModeSwitchProvider({
 
   return (
     <ModeSwitchContext.Provider value={{ ...state, switchTo }}>
-      {/* Ink behind the whole chrome: the panes are opaque, so this only shows
-          during a switch — the dark screen the tab cards and the starfield sit
-          on. pointer-events-none because it is positioned and would otherwise
-          swallow clicks on the panes' non-positioned content. */}
-      <div
-        aria-hidden="true"
-        className="bg-surface-tertiary-fixed-dark pointer-events-none fixed inset-0 z-0"
-      />
+      {/* Ink behind the whole chrome: the dark screen the tab cards and the
+          starfield sit on. Only while a switch is in flight — the provider is
+          above the router, so an always-on backdrop would black out routes
+          without an opaque pane of their own, such as login. pointer-events-none
+          because it is positioned and would otherwise swallow clicks on the
+          panes' non-positioned content. */}
+      {state.phase !== "idle" && (
+        <div
+          aria-hidden="true"
+          className="bg-surface-tertiary-fixed-dark pointer-events-none fixed inset-0 z-0"
+        />
+      )}
       {/* Win95 screensaver behind the grid: only while a switch is in flight,
           raked toward whichever card is being opened. */}
       {state.phase !== "idle" && state.from && state.to && (


### PR DESCRIPTION
## Summary

The mode-switch backdrop — the dark full-screen ink the tab cards and starfield sit on — now renders only while a switch is in flight, gated on `state.phase !== "idle"` like the starfield already was.

## Motivation

`ModeSwitchProvider` is mounted above the router so its animation state survives the mid-switch route swap, which also means everything it renders is present on every route. The backdrop is `fixed inset-0`, and inside the app chrome it is invisible because the panes above it are opaque. The login page has no opaque pane of its own, so the backdrop showed through and turned its background black.

Gating on the animation phase is the smaller fix than giving the login page an opaque background: the backdrop only has a job during the shrink/hold/zoom beats, and outside them there is nothing for it to sit behind.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the mode-switch backdrop off non-switching routes so the login page no longer shows a black background. Previously the backdrop was always mounted; now it only appears during an in-flight switch to match the starfield.

- Preserves `pointer-events-none`, fixed positioning, and z-index.
- No visual change on routes with opaque panes; fixes routes without one (e.g., login).
- Starfield and switch animation timing remain unchanged.

<sup>Written for commit 3ec5b675c299a2690e12f02c5c6513ff678c3d88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

