### PR TITLE
fix: register VerifyCustomDomainV2 activity on the worker

### DIFF
--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -416,6 +416,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.SetOpenRouterSpendCap)
 	temporalWorker.RegisterActivity(activities.ReconcilePaygOpenRouterChatKey)
 	temporalWorker.RegisterActivity(activities.VerifyCustomDomain)
+	temporalWorker.RegisterActivity(activities.VerifyCustomDomainV2)
 	temporalWorker.RegisterActivity(activities.CustomDomainIngress)
 	temporalWorker.RegisterActivity(activities.ReconcileCustomDomain)
 	temporalWorker.RegisterActivity(activities.SignalCustomDomainReconcile)


### PR DESCRIPTION
PR #5690 added the VerifyCustomDomainV2 activity and the registration workflow executes it, but the worker never registered it — every verification pass fails with ActivityNotRegisteredError and pending domains poll until the 24h deadline without ever verifying. Registers the activity; in-flight registration workflows pick it up on their next retry after deploy.