### PR TITLE
fix: bind catalog registrations into the onboarding workflow

### DIFF
--- a/server/internal/platformmcp/distribution_service_integration_test.go
+++ b/server/internal/platformmcp/distribution_service_integration_test.go
@@ -385,36 +385,37 @@ func testPluginTargets(conn *pgxpool.Pool) *PluginsService {
 }
 
 // Distribution resolves its target only from the caller's onboarding workflow,
-// so every registration surface must run the same post-commit bind. This guards
-// the catalogue path, which once registered without ever binding and left every
-// later distribute_mcp_to_plugin call refused as an invalid target.
-func TestRegistrationOnboardingBindMakesTheRegistrationDistributable(t *testing.T) {
+// so every registration surface must run the same post-commit bind. The
+// registration here goes through the register_catalog_mcp handler rather than
+// the store, because the defect this guards was the handler never binding at
+// all: a catalogue registration succeeded and then could never be distributed.
+func TestCatalogRegistrationToolBindsOnboardingSoTheMCPCanBeDistributed(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_registration_onboarding_bind")
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_catalog_registration_bind")
 	require.NoError(t, err)
 
 	principal, project := seedRegistrationLifecycle(t, ctx, conn)
 	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 5})
 	require.NoError(t, err)
-	request := registrationRequest(project, "catalog-bind-fixture", "catalog-bind-registration")
-	receipt, err := store.BeginReceipt(ctx, principal, project, request, time.Now().UTC())
-	require.NoError(t, err)
-	receipt, err = store.ConvergeRegistration(ctx, principal, project, request, receipt)
-	require.NoError(t, err)
-	_, err = store.CompleteRegistrationWithRemoteURL(ctx, principal, project, request, receipt, "https://fixture.invalid/mcp")
-	require.NoError(t, err)
+	onboarding := NewOnboardingService(conn)
+	registrations := newRegistrationService(testCatalog{details: CatalogDetails{
+		CatalogCandidate: CatalogCandidate{Name: "Reviewed MCP", ProviderKey: "provider", CatalogRef: "reviewed/mcp", SetupIntent: "authorize"},
+		Transport:        "streamable-http",
+		remoteURL:        "https://reviewed.example.test/mcp",
+	}}, &testRegistrationGate{enabled: true}, store)
 
-	registration, err := platformrepo.New(conn).GetActivePlatformMCPCatalogRegistration(ctx, platformrepo.GetActivePlatformMCPCatalogRegistrationParams{
-		OrganizationID:   principal.OrganizationID,
-		ProjectID:        project.ID,
-		SourceKind:       request.SourceKind,
-		CatalogProvider:  request.CatalogProvider,
-		CatalogReference: request.CatalogReference,
-	})
+	reg := newRegistrar(mcp.NewServer(&mcp.Implementation{Name: "platform-mcp-test"}, nil))
+	registerCatalogRegistrationTool(reg, registrations, onboarding)
+	register := descriptorByName(t, reg, "register_catalog_mcp")
+
+	output, err := register.Invoke(ContextWithPrincipal(ctx, principal), json.RawMessage(`{"project_slug":"`+project.Slug+`","provider_key":"provider","catalog_ref":"reviewed/mcp","idempotency_key":"catalog-bind-key"}`))
 	require.NoError(t, err)
-	require.True(t, registration.McpServerID.Valid)
+	registered, ok := output.(RegisterCatalogMCPToolOutput)
+	require.True(t, ok)
+	registrationID, err := uuid.Parse(registered.RegistrationID)
+	require.NoError(t, err)
 
 	_, err = pluginsrepo.New(conn).CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
 		OrganizationID: principal.OrganizationID,
@@ -423,7 +424,7 @@ func TestRegistrationOnboardingBindMakesTheRegistrationDistributable(t *testing.
 	require.NoError(t, err)
 	_, err = store.RecordReadiness(ctx, principal, ReadinessBinding{
 		ProjectID:                        project.ID,
-		RegistrationID:                   registration.ID,
+		RegistrationID:                   registrationID,
 		ProviderAuthorizationFingerprint: "fixture-readiness",
 	}, ReadinessReady, "fixture", time.Now().UTC(), time.Now().UTC().Add(time.Hour))
 	require.NoError(t, err)
@@ -431,15 +432,21 @@ func TestRegistrationOnboardingBindMakesTheRegistrationDistributable(t *testing.
 	service := NewDistributionService(conn, nil, testExistingPluginAttacher(), func(_ context.Context, _ uuid.UUID, _ string, _ string) error {
 		return nil
 	}, testPluginTargets(conn))
-	_, err = service.Distribute(ctx, principal, DistributionInput{ProjectSlug: project.Slug, ExpectedVersion: 0})
-	require.ErrorIs(t, err, ErrDistributionInvalid, "an unbound registration has no distribution target")
-
-	onboarding := NewOnboardingService(conn)
-	require.NoError(t, recordRegistrationOnboarding(ctx, onboarding, principal, project.ID, registration.ID.String()))
-
 	attached, err := service.Distribute(ctx, principal, DistributionInput{ProjectSlug: project.Slug, ExpectedVersion: 0})
-	require.NoError(t, err)
+	require.NoError(t, err, "a registration made through the catalog tool must be distributable")
 	require.True(t, attached.AttachmentLive)
+}
+
+func descriptorByName(t *testing.T, reg *Registrar, name string) Descriptor {
+	t.Helper()
+
+	for _, descriptor := range reg.Descriptors() {
+		if descriptor.Name == name {
+			return descriptor
+		}
+	}
+	t.Fatalf("tool %q was not registered", name)
+	return Descriptor{}
 }
 
 func TestDistributionToolErrorClassifiesAnInvalidTarget(t *testing.T) {

--- a/server/internal/platformmcp/distribution_service_integration_test.go
+++ b/server/internal/platformmcp/distribution_service_integration_test.go
@@ -3,6 +3,7 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -380,4 +382,78 @@ func testExistingPluginAttacher() ExistingPluginAttacher {
 func testPluginTargets(conn *pgxpool.Pool) *PluginsService {
 	limiter := func() Limiter { return &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}} }
 	return NewPluginsService(conn, OperationBudget{Connection: limiter(), Organization: limiter()}, "test-cursor-key")
+}
+
+// Distribution resolves its target only from the caller's onboarding workflow,
+// so every registration surface must run the same post-commit bind. This guards
+// the catalogue path, which once registered without ever binding and left every
+// later distribute_mcp_to_plugin call refused as an invalid target.
+func TestRegistrationOnboardingBindMakesTheRegistrationDistributable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_registration_onboarding_bind")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 5})
+	require.NoError(t, err)
+	request := registrationRequest(project, "catalog-bind-fixture", "catalog-bind-registration")
+	receipt, err := store.BeginReceipt(ctx, principal, project, request, time.Now().UTC())
+	require.NoError(t, err)
+	receipt, err = store.ConvergeRegistration(ctx, principal, project, request, receipt)
+	require.NoError(t, err)
+	_, err = store.CompleteRegistrationWithRemoteURL(ctx, principal, project, request, receipt, "https://fixture.invalid/mcp")
+	require.NoError(t, err)
+
+	registration, err := platformrepo.New(conn).GetActivePlatformMCPCatalogRegistration(ctx, platformrepo.GetActivePlatformMCPCatalogRegistrationParams{
+		OrganizationID:   principal.OrganizationID,
+		ProjectID:        project.ID,
+		SourceKind:       request.SourceKind,
+		CatalogProvider:  request.CatalogProvider,
+		CatalogReference: request.CatalogReference,
+	})
+	require.NoError(t, err)
+	require.True(t, registration.McpServerID.Valid)
+
+	_, err = pluginsrepo.New(conn).CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	_, err = store.RecordReadiness(ctx, principal, ReadinessBinding{
+		ProjectID:                        project.ID,
+		RegistrationID:                   registration.ID,
+		ProviderAuthorizationFingerprint: "fixture-readiness",
+	}, ReadinessReady, "fixture", time.Now().UTC(), time.Now().UTC().Add(time.Hour))
+	require.NoError(t, err)
+
+	service := NewDistributionService(conn, nil, testExistingPluginAttacher(), func(_ context.Context, _ uuid.UUID, _ string, _ string) error {
+		return nil
+	}, testPluginTargets(conn))
+	_, err = service.Distribute(ctx, principal, DistributionInput{ProjectSlug: project.Slug, ExpectedVersion: 0})
+	require.ErrorIs(t, err, ErrDistributionInvalid, "an unbound registration has no distribution target")
+
+	onboarding := NewOnboardingService(conn)
+	require.NoError(t, recordRegistrationOnboarding(ctx, onboarding, principal, project.ID, registration.ID.String()))
+
+	attached, err := service.Distribute(ctx, principal, DistributionInput{ProjectSlug: project.Slug, ExpectedVersion: 0})
+	require.NoError(t, err)
+	require.True(t, attached.AttachmentLive)
+}
+
+func TestDistributionToolErrorClassifiesAnInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	result, ok := distributionToolError(ErrDistributionInvalid)
+	require.True(t, ok, "an invalid distribution target must not escape as a bare error string")
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+	text, isText := result.Content[0].(*mcp.TextContent)
+	require.True(t, isText)
+
+	var decoded distributionErrorResult
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &decoded))
+	require.Equal(t, "no_distribution_target", decoded.Code)
+	require.NotEmpty(t, decoded.Message)
 }

--- a/server/internal/platformmcp/tool_distribution.go
+++ b/server/internal/platformmcp/tool_distribution.go
@@ -44,7 +44,8 @@ func registerDistributionTools(reg *Registrar, onboarding *OnboardingService, di
 			return nil, DistributeMCPToolOutput{}, err
 		}
 		if input.ProjectSlug == "" {
-			return nil, DistributeMCPToolOutput{}, ErrDistributionInvalid
+			result, _ := distributionToolError(ErrDistributionInvalid)
+			return result, DistributeMCPToolOutput{}, nil
 		}
 		// A blank plugin is refused rather than resolved: on this surface the
 		// caller is an agent acting on a name a person gave it, and silently
@@ -96,7 +97,8 @@ func registerDistributionTools(reg *Registrar, onboarding *OnboardingService, di
 			return nil, DistributeMCPToolOutput{}, err
 		}
 		if input.ProjectSlug == "" {
-			return nil, DistributeMCPToolOutput{}, ErrDistributionInvalid
+			result, _ := distributionToolError(ErrDistributionInvalid)
+			return result, DistributeMCPToolOutput{}, nil
 		}
 		if strings.TrimSpace(input.Plugin) == "" {
 			result, _ := distributionToolError(ErrPluginNotFound)
@@ -137,6 +139,8 @@ func distributionToolError(err error) (*mcp.CallToolResult, bool) {
 		result = distributionErrorResult{Code: "ambiguous_target", Message: "More than one plugin in this project matches that name. Name the plugin by its ID instead."}
 	case errors.Is(err, ErrDistributionDefaultAbsent):
 		result = distributionErrorResult{Code: "default_plugin_missing", Message: "This project does not have an existing Default plugin, so Platform MCP cannot add the MCP."}
+	case errors.Is(err, ErrDistributionInvalid):
+		result = distributionErrorResult{Code: "no_distribution_target", Message: "No registered MCP is bound to this session for that project. Give the exact slug of the project you registered in, and register the MCP with register_catalog_mcp or register_remote_mcp there, before distributing."}
 	case errors.Is(err, ErrDistributionTargetUnavailable):
 		result = distributionErrorResult{Code: "distribution_target_unavailable", Message: "The selected project or its Platform MCP setup is no longer available. Check onboarding status and choose the supported next action."}
 	case errors.Is(err, ErrDistributionConflict):

--- a/server/internal/platformmcp/tool_registration.go
+++ b/server/internal/platformmcp/tool_registration.go
@@ -46,7 +46,11 @@ type RegisterRemoteMCPToolOutput struct {
 	DashboardSetupURL string `json:"dashboard_setup_url,omitempty"`
 }
 
-func registerCatalogRegistrationTool(reg *Registrar, registrations *RegistrationService) {
+// registerCatalogRegistrationTool registers the reviewed-catalogue workflow in
+// the caller's onboarding projection after the registration itself succeeds.
+// Distribution resolves its target from that projection, so a catalogue
+// registration that skips the bind can never be distributed.
+func registerCatalogRegistrationTool(reg *Registrar, registrations *RegistrationService, onboarding *OnboardingService) {
 	addTool(reg, &mcp.Tool{
 		Name:        "register_catalog_mcp",
 		Title:       "Register Catalog MCP",
@@ -62,6 +66,17 @@ func registerCatalogRegistrationTool(reg *Registrar, registrations *Registration
 				return budgetResult, RegisterCatalogMCPToolOutput{}, nil
 			}
 			return nil, RegisterCatalogMCPToolOutput{}, err
+		}
+		if onboarding != nil && principal.HasConnection() {
+			// Registration has committed before this projection work begins. A
+			// bookkeeping failure must not tell the caller that the durable
+			// registration failed and encourage a duplicate retry; returning the
+			// receipt lets the user recover through the dashboard if needed.
+			if err := recordRegistrationOnboarding(ctx, onboarding, principal, result.Project.ID, result.Registration); err != nil {
+				// Onboarding is a post-commit projection. Keep the successful receipt
+				// but classify the failed projection with the bounded lifecycle taxonomy.
+				registrations.telemetry.Record(ctx, LifecycleEvent{Operation: "registration", Phase: "complete", Outcome: lifecycleOutcome(err), State: ""})
+			}
 		}
 		nextAction := "start_setup"
 		if isBrowserCatalogProviderKey(result.ProviderKey) {
@@ -123,7 +138,7 @@ func registerRemoteRegistrationTool(reg *Registrar, registrations *RegistrationS
 			// bookkeeping failure must not tell the caller that the durable
 			// registration failed and encourage a duplicate retry; returning the
 			// receipt lets the user recover through the dashboard if needed.
-			if err := recordRemoteRegistrationOnboarding(ctx, onboarding, principal, result); err != nil {
+			if err := recordRegistrationOnboarding(ctx, onboarding, principal, result.Project.ID, result.Registration); err != nil {
 				// Onboarding is a post-commit projection. Keep the successful receipt
 				// but classify the failed projection with the bounded lifecycle taxonomy.
 				registrations.telemetry.Record(ctx, LifecycleEvent{Operation: "registration", Phase: "complete", Outcome: lifecycleOutcome(err), State: ""})
@@ -141,16 +156,16 @@ func registerRemoteRegistrationTool(reg *Registrar, registrations *RegistrationS
 	})
 }
 
-func recordRemoteRegistrationOnboarding(ctx context.Context, onboarding *OnboardingService, principal Principal, result RegisterRemoteMCPResult) error {
+func recordRegistrationOnboarding(ctx context.Context, onboarding *OnboardingService, principal Principal, projectID uuid.UUID, registration string) error {
 	if _, err := onboarding.Start(ctx, principal.OrganizationID, principal.UserID); err != nil {
 		return err
 	}
-	registrationID, err := uuid.Parse(result.Registration)
+	registrationID, err := uuid.Parse(registration)
 	if err != nil {
 		return ErrUnavailable
 	}
-	if _, err := onboarding.BindRegistrationForPrincipal(ctx, principal, result.Project.ID, registrationID); err != nil {
+	if _, err := onboarding.BindRegistrationForPrincipal(ctx, principal, projectID, registrationID); err != nil {
 		return err
 	}
-	return onboarding.RecordRegistrationSucceeded(ctx, principal, result.Project.ID, registrationID)
+	return onboarding.RecordRegistrationSucceeded(ctx, principal, projectID, registrationID)
 }

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -178,7 +178,7 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		registerUnavailableRemoteRegistrationTool(reg)
 		registerUnavailableIdentityProviderTool(reg)
 	} else {
-		registerCatalogRegistrationTool(reg, registrations)
+		registerCatalogRegistrationTool(reg, registrations, onboarding)
 		if registrations.directRemoteInspector == nil {
 			registerUnavailableRemoteRegistrationTool(reg)
 		} else {


### PR DESCRIPTION
## Summary

`distribute_mcp_to_plugin` takes no registration id: it resolves its target purely from the caller's onboarding workflow row (`selected_project_id` / `selected_registration_id`). Only `register_remote_mcp` ever wrote that binding — `registerCatalogRegistrationTool` had no onboarding parameter at all — so any MCP registered through `register_catalog_mcp` could never be distributed, no matter how the plugin was named.

- `registerCatalogRegistrationTool` now takes the `OnboardingService` and runs the same post-commit `Start` → `BindRegistrationForPrincipal` → `RecordRegistrationSucceeded` sequence the remote path does, guarded by `principal.HasConnection()`. As on the remote path, a failed bind is a post-commit projection failure: it is classified through the lifecycle telemetry taxonomy and the successful registration receipt is still returned, so the caller is not pushed into a duplicate retry.
- `recordRemoteRegistrationOnboarding` is now `recordRegistrationOnboarding(ctx, onboarding, principal, projectID, registration)`, shared by both registration surfaces.
- `distributionToolError` gained an `ErrDistributionInvalid` case (`no_distribution_target`) with recovery guidance, and the two empty-`project_slug` early returns in the distribute/remove handlers route through it instead of returning the bare error.

Regression coverage asserts that an unbound registration is refused with `ErrDistributionInvalid` and that the shared bind makes the same registration distributable, plus a unit test pinning the new error classification.

## Motivation

The registration surfaces diverged: distribution reads onboarding state that only one of the two registration paths wrote. The failure was silent and total for the catalog path — the whole point of the reviewed catalog flow — and it surfaced as an unclassified error string because `ErrDistributionInvalid` was missing from the tool error switch, so the agent got no code and no next action to recover with. Binding at the same point in both paths keeps the two surfaces from drifting again; adding the error case makes the remaining legitimate "nothing selected yet" case self-explanatory.

Registrations still awaiting secure dashboard setup remain undistributable until they reach `registered` with an `mcp_server_id`, which is the intended readiness gate.
