### PR TITLE
fix: declare the wire form of subject counts in tool output schemas

### DIFF
--- a/server/internal/platformmcp/descriptor.go
+++ b/server/internal/platformmcp/descriptor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -218,6 +219,11 @@ func addResource(r *Registrar, resource *mcp.Resource, meta ResourceMeta, read f
 // that reads as a restriction while restricting nothing.
 func addTool[In, Out any](r *Registrar, tool *mcp.Tool, meta ToolMeta, handler mcp.ToolHandlerFor[In, Out]) {
 	if meta.servesAudience(AudienceExternal) {
+		// Declared here rather than left to the SDK: the SDK infers the output
+		// schema from the Go type alone and cannot see a custom MarshalJSON.
+		if tool.OutputSchema == nil {
+			tool.OutputSchema = inferOutputSchema[Out](tool.Name)
+		}
 		mcp.AddTool(r.server, tool, handler)
 	}
 
@@ -293,6 +299,37 @@ func resolveInputSchema[In any](name string) *jsonschema.Resolved {
 		panic(fmt.Sprintf("platformmcp: resolve input schema for %q: %v", name, err))
 	}
 	return resolved
+}
+
+// wireTypeSchemas overrides schema inference for types whose JSON form does not
+// match their Go shape. Inference reflects on the Go type and cannot see a
+// custom MarshalJSON, so a type that serializes as something other than its
+// struct has to say so here.
+var wireTypeSchemas = map[reflect.Type]*jsonschema.Schema{
+	reflect.TypeFor[SubjectCount](): subjectCountSchema,
+}
+
+// inferOutputSchema derives the schema the tool advertises for its result,
+// honouring wireTypeSchemas. A tool with an untyped result gets no schema at
+// all, which is what the SDK would have done for it.
+func inferOutputSchema[Out any](name string) *jsonschema.Schema {
+	target := reflect.TypeFor[Out]()
+	if target == reflect.TypeFor[any]() {
+		return nil
+	}
+	// Pointer results describe the pointed-to value, matching how the SDK
+	// derives the schema it would otherwise have inferred.
+	if target.Kind() == reflect.Pointer {
+		target = target.Elem()
+	}
+	schema, err := jsonschema.ForType(target, &jsonschema.ForOptions{
+		IgnoreInvalidTypes: false,
+		TypeSchemas:        wireTypeSchemas,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("platformmcp: infer output schema for %q: %v", name, err))
+	}
+	return schema
 }
 
 // validateAgainstSchema applies the tool's declared contract to a direct call.

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -1,8 +1,10 @@
 package platformmcp
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -155,4 +157,58 @@ func TestExternalEndpointServesOnlyExternallyAdmittedTools(t *testing.T) {
 		}
 	}
 	require.Positive(t, withheld, "the catalogue withholds at least one tool from the external endpoint, so this test can fail")
+}
+
+// A tool whose result carries a SubjectCount must advertise that field as it
+// serializes — a number or the suppression label — not as the Go struct it is
+// reflected from. Asserted against a real session's tools/list rather than the
+// inference helper, so dropping the schema in addTool fails here too.
+func TestAdvertisedOutputSchemaMatchesTheSubjectCountWireForm(t *testing.T) {
+	t.Parallel()
+
+	// Registered directly rather than through newServer: with no dependencies
+	// the deployment substitutes the "diagnostics are not enabled" stubs, whose
+	// results carry no subject count. The handler is never called here — only
+	// the schema the registration advertises is under test.
+	server := newTestMCPServer()
+	registerDiagnosticsTools(newRegistrar(server), nil)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(t.Context(), serverTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "subject-count-test", Version: "0.0.1"}, nil)
+	session, err := client.Connect(t.Context(), clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	tools, err := session.ListTools(t.Context(), nil)
+	require.NoError(t, err)
+
+	var advertised any
+	for _, tool := range tools.Tools {
+		if tool.Name == "get_project_overview" {
+			advertised = tool.OutputSchema
+		}
+	}
+	require.NotNil(t, advertised, "the external endpoint advertises an output schema for get_project_overview")
+
+	encodedSchema, err := json.Marshal(advertised)
+	require.NoError(t, err)
+	var schema jsonschema.Schema
+	require.NoError(t, json.Unmarshal(encodedSchema, &schema))
+	resolved, err := schema.Resolve(nil)
+	require.NoError(t, err)
+
+	// Zero is reported exactly, three is suppressed, and twenty-five is
+	// reported exactly: the three shapes active_users takes on the wire.
+	for _, count := range []SubjectCount{NewSubjectCount(0), NewSubjectCount(3), NewSubjectCount(25)} {
+		encoded, err := json.Marshal(GetProjectOverviewOutput{ActiveUsers: count})
+		require.NoError(t, err)
+
+		var decoded any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.NoError(t, resolved.Validate(decoded), "output %s", encoded)
+	}
 }

--- a/server/internal/platformmcp/privacy.go
+++ b/server/internal/platformmcp/privacy.go
@@ -82,6 +82,17 @@ func (c *SubjectCount) UnmarshalJSON(data []byte) error {
 // override a tool would advertise an object, and a client that validates
 // results against the declared schema rejects the entire result.
 var subjectCountSchema = &jsonschema.Schema{
-	Types:       []string{"integer", "string"},
 	Description: `count of people: a number, or "` + subjectSuppressedLabel + `" when the exact count is withheld`,
+	// Spelled out as the two values MarshalJSON can produce rather than as the
+	// looser "integer or string": the label is the only string this ever emits,
+	// and a client reading the schema should learn which one to expect.
+	AnyOf: []*jsonschema.Schema{
+		{Type: "integer", Minimum: &subjectCountMinimum},
+		{Const: &subjectSuppressedConst},
+	},
 }
+
+var (
+	subjectCountMinimum        = float64(0)
+	subjectSuppressedConst any = subjectSuppressedLabel
+)

--- a/server/internal/platformmcp/privacy.go
+++ b/server/internal/platformmcp/privacy.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 // SubjectSuppressionThreshold is the smallest subject count a diagnostic will
@@ -72,4 +74,14 @@ func (c *SubjectCount) UnmarshalJSON(data []byte) error {
 	}
 	c.value = SubjectSuppressionThreshold - 1
 	return nil
+}
+
+// subjectCountSchema describes SubjectCount as it serializes rather than as it
+// is shaped in Go. Schema inference reflects on the type — a struct — while
+// MarshalJSON emits a number or the suppression label, so without this
+// override a tool would advertise an object, and a client that validates
+// results against the declared schema rejects the entire result.
+var subjectCountSchema = &jsonschema.Schema{
+	Types:       []string{"integer", "string"},
+	Description: `count of people: a number, or "` + subjectSuppressedLabel + `" when the exact count is withheld`,
 }

--- a/server/internal/platformmcp/privacy_test.go
+++ b/server/internal/platformmcp/privacy_test.go
@@ -88,3 +88,25 @@ func TestSubjectCount_ReportedValueRoundTrips(t *testing.T) {
 	require.False(t, decoded.Suppressed())
 	require.Equal(t, int64(42), decoded.value)
 }
+
+// The bug this guards: the advertised output schema is inferred from the Go
+// type, which is a struct, while the value on the wire is a number or the
+// suppression label. A client that validates results against the declared
+// schema rejected the entire result.
+func TestSubjectCountOutputSchemaMatchesTheWireForm(t *testing.T) {
+	t.Parallel()
+
+	schema := inferOutputSchema[GetProjectOverviewOutput]("get_project_overview")
+	require.NotNil(t, schema)
+	resolved, err := schema.Resolve(nil)
+	require.NoError(t, err)
+
+	for _, count := range []SubjectCount{NewSubjectCount(0), NewSubjectCount(3), NewSubjectCount(25)} {
+		encoded, err := json.Marshal(GetProjectOverviewOutput{ActiveUsers: count})
+		require.NoError(t, err)
+
+		var decoded any
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.NoError(t, resolved.Validate(decoded), "output %s", encoded)
+	}
+}

--- a/server/internal/platformmcp/privacy_test.go
+++ b/server/internal/platformmcp/privacy_test.go
@@ -88,25 +88,3 @@ func TestSubjectCount_ReportedValueRoundTrips(t *testing.T) {
 	require.False(t, decoded.Suppressed())
 	require.Equal(t, int64(42), decoded.value)
 }
-
-// The bug this guards: the advertised output schema is inferred from the Go
-// type, which is a struct, while the value on the wire is a number or the
-// suppression label. A client that validates results against the declared
-// schema rejected the entire result.
-func TestSubjectCountOutputSchemaMatchesTheWireForm(t *testing.T) {
-	t.Parallel()
-
-	schema := inferOutputSchema[GetProjectOverviewOutput]("get_project_overview")
-	require.NotNil(t, schema)
-	resolved, err := schema.Resolve(nil)
-	require.NoError(t, err)
-
-	for _, count := range []SubjectCount{NewSubjectCount(0), NewSubjectCount(3), NewSubjectCount(25)} {
-		encoded, err := json.Marshal(GetProjectOverviewOutput{ActiveUsers: count})
-		require.NoError(t, err)
-
-		var decoded any
-		require.NoError(t, json.Unmarshal(encoded, &decoded))
-		require.NoError(t, resolved.Validate(decoded), "output %s", encoded)
-	}
-}


### PR DESCRIPTION
AGE-3339

## Summary

`SubjectCount` is a struct with an unexported field and a custom `MarshalJSON` that emits either a number or the string `"less_than_5"`. The MCP SDK infers a tool's output schema by reflecting on the Go result type, so every tool returning a subject count advertised `active_users` as an `object` while sending an integer or a string. Nothing in the package overrode that schema.

This declares the wire form explicitly:

- `subjectCountSchema` in `privacy.go` describes the type as it serializes — `{"types": ["integer", "string"]}` — and lives next to the type whose `MarshalJSON` it mirrors.
- `descriptor.go` gains `wireTypeSchemas` and `inferOutputSchema[Out]`, and `addTool` sets `tool.OutputSchema` before handing the tool to the SDK when the caller left it nil. Registration already funnels through `addTool`, so every current and future tool picks this up without a per-tool override. Tools with an untyped result still declare no output schema, matching what the SDK did for them; pointer results unwrap the same way the SDK unwraps them.
- A test marshals a real `GetProjectOverviewOutput` at a reported count, a suppressed count, and zero, and validates each against the advertised schema.

Only `GetProjectOverviewOutput` and `QueryMCPMetricsOutput` carry a `SubjectCount` today, both as value fields.

## Motivation

A client that validates tool results against the declared output schema — which strict MCP clients do — rejected the whole result, not just the offending field:

```
validating /properties/active_users: type: 25 has type "integer", want "object"
```

That takes out `get_project_overview`, `get_mcp_diagnostics`, and `query_mcp_metrics` entirely: the usage and diagnostics surface is unreadable from an agent, so the numbers it computes correctly never reach anyone.

The fix goes at the registration choke point rather than on the three affected tools. The mismatch is a property of the type, not of any one tool, and the same trap waits for the next type that marshals to something other than its Go shape — `wireTypeSchemas` gives that a single place to be declared. Removing the map entry makes the new test fail with the exact error above, so the guard is anchored to the reported symptom.
