### PR TITLE
fix: keep redirect on auth cross-links and stop double login page load

### DIFF
--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -1,6 +1,7 @@
 import { handleError } from "@/lib/errors";
 import {
   isGramSessionUnauthorizedError,
+  isSessionInfoQueryKey,
   isUnauthorizedError,
 } from "@/lib/route-errors";
 import { redirectToLoginOnUnauthorized } from "@/lib/session-expired";
@@ -40,9 +41,16 @@ const createQueryClient = () =>
     // listing a proxied MCP server's tools) 401 when the *upstream* wants
     // credentials, which their hooks handle inline — redirecting on those loops
     // the page through /login forever since the Gram session is still valid.
+    // The session bootstrap (auth.info) is excluded: its 401 is the expected
+    // "logged out" answer and AuthProvider already routes it to /login in-SPA.
+    // Hard-navigating for it too reloaded the login page on every logged-out
+    // visit — Loading…, login screen, full reload, Loading…, login screen.
     queryCache: new QueryCache({
-      onError: (error) => {
-        if (isGramSessionUnauthorizedError(error)) {
+      onError: (error, query) => {
+        if (
+          isGramSessionUnauthorizedError(error) &&
+          !isSessionInfoQueryKey(query.queryKey)
+        ) {
           redirectToLoginOnUnauthorized();
         }
       },

--- a/client/dashboard/src/lib/route-errors.test.ts
+++ b/client/dashboard/src/lib/route-errors.test.ts
@@ -2,8 +2,10 @@ import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { describe, expect, it } from "vitest";
 import {
   isGramSessionUnauthorizedError,
+  isSessionInfoQueryKey,
   isUnauthorizedError,
 } from "./route-errors";
+import { queryKeySessionInfo } from "@gram/client/react-query/sessionInfo.core.js";
 
 function gramError(status: number): GramError {
   return new GramError("request failed", {
@@ -50,5 +52,21 @@ describe("isGramSessionUnauthorizedError", () => {
       false,
     );
     expect(isGramSessionUnauthorizedError(null)).toBe(false);
+  });
+});
+
+describe("isSessionInfoQueryKey", () => {
+  it("matches the generated auth.info query key", () => {
+    expect(isSessionInfoQueryKey(queryKeySessionInfo({}))).toBe(true);
+    expect(
+      isSessionInfoQueryKey(queryKeySessionInfo({ gramSession: "abc" })),
+    ).toBe(true);
+  });
+
+  it("rejects other queries' keys", () => {
+    expect(
+      isSessionInfoQueryKey(["@gram/client", "toolsets", "list", {}]),
+    ).toBe(false);
+    expect(isSessionInfoQueryKey([])).toBe(false);
   });
 });

--- a/client/dashboard/src/lib/route-errors.ts
+++ b/client/dashboard/src/lib/route-errors.ts
@@ -1,4 +1,5 @@
 import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { queryKeySessionInfo } from "@gram/client/react-query/sessionInfo.core.js";
 
 function getHttpStatusCode(error: unknown): number | undefined {
   if (error instanceof GramError) {
@@ -40,6 +41,22 @@ export function isUnauthorizedError(error: unknown): boolean {
  */
 export function isGramSessionUnauthorizedError(error: unknown): boolean {
   return error instanceof GramError && error.statusCode === 401;
+}
+
+// The static part of the auth.info query key; the final element is the
+// per-call parameters object and never participates in the match.
+const SESSION_INFO_KEY_PREFIX = queryKeySessionInfo({}).slice(0, -1);
+
+/**
+ * True for the session-bootstrap query (auth.info). Its 401 is the expected
+ * "logged out" answer — AuthProvider renders the logged-out tree and
+ * LoginCheck redirects in-SPA — so the global 401 handler must not also
+ * force a full-page navigation for it. Reacting to both produced a double
+ * page load on every logged-out visit: SPA-rendered login screen, then a
+ * hard reload of the same screen.
+ */
+export function isSessionInfoQueryKey(queryKey: readonly unknown[]): boolean {
+  return SESSION_INFO_KEY_PREFIX.every((part, i) => queryKey[i] === part);
 }
 
 const UUID_PATTERN =

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  authPageHref,
   openSafeExternalUrl,
   safeExternalHttpUrl,
   safeSameOriginPath,
@@ -117,5 +118,30 @@ describe("safeSameOriginUrl", () => {
     "//evil.example/path",
   ])("rejects the unsafe redirect %s", (raw) => {
     expect(safeSameOriginUrl(raw)).toBeNull();
+  });
+});
+
+describe("authPageHref", () => {
+  it("returns the bare page with no destination", () => {
+    expect(authPageHref("/login", null)).toBe("/login");
+    expect(authPageHref("/sign-up", undefined)).toBe("/sign-up");
+  });
+
+  it("carries a path-form destination, query included", () => {
+    expect(authPageHref("/sign-up", "/~/watchdog?range=7d")).toBe(
+      "/sign-up?redirect=%2F~%2Fwatchdog%3Frange%3D7d",
+    );
+  });
+
+  it("normalizes an absolute same-origin destination to a path", () => {
+    const absolute = new URL("/~/watchdog?range=7d", window.location.origin)
+      .href;
+    expect(authPageHref("/login", absolute)).toBe(
+      "/login?redirect=%2F~%2Fwatchdog%3Frange%3D7d",
+    );
+  });
+
+  it("drops a foreign-origin destination", () => {
+    expect(authPageHref("/login", "https://evil.example/phish")).toBe("/login");
   });
 });

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -68,3 +68,19 @@ export function safeSameOriginPath(
   const url = new URL(href);
   return `${url.pathname}${url.search}${url.hash}`;
 }
+
+/**
+ * Href for the cross-links between the login and sign-up pages. The two pages
+ * hand unauthenticated visitors back and forth, and a bare link would drop
+ * the ?redirect= destination the visitor arrived with — a deep link from the
+ * marketing site would silently forget where it was headed. Carries the
+ * destination normalized to a same-origin path; accepts either the path form
+ * (Login holds one) or the absolute form (SignUp holds one).
+ */
+export function authPageHref(
+  page: "/login" | "/sign-up",
+  redirectTo: string | null | undefined,
+): string {
+  const path = safeSameOriginPath(redirectTo);
+  return path ? `${page}?redirect=${encodeURIComponent(path)}` : page;
+}

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -1,5 +1,5 @@
+import { authPageHref } from "@/lib/safe-external-url";
 import { buildLoginRedirectURL, cn } from "@/lib/utils";
-import { useRoutes } from "@/routes";
 import { Link } from "react-router";
 import { AUTH_BUTTON_CLASSES, AUTH_PILLARS } from "./auth-constants";
 import { SigninErrorNotice } from "./auth-errors";
@@ -9,7 +9,6 @@ export function LoginPanel({
 }: {
   redirectTo: string | null;
 }): JSX.Element {
-  const routes = useRoutes();
   const handleLogin = () => {
     window.location.href = buildLoginRedirectURL(redirectTo);
   };
@@ -52,7 +51,7 @@ export function LoginPanel({
       <p className="mt-2 text-[14px] text-(--muted-strong)">
         No account?{" "}
         <Link
-          to={routes.signUp.href()}
+          to={authPageHref("/sign-up", redirectTo)}
           className="text-(--link) underline hover:text-(--focus)"
         >
           Sign-up for a 14-day trial.

--- a/client/dashboard/src/pages/login/components/signup-panel.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.tsx
@@ -1,4 +1,5 @@
 import { useTelemetry } from "@/contexts/Telemetry";
+import { authPageHref } from "@/lib/safe-external-url";
 import { buildLoginRedirectURL, cn } from "@/lib/utils";
 import { useForm } from "@tanstack/react-form";
 import { Link } from "react-router";
@@ -245,7 +246,7 @@ export function SignUpPanel({
       <p className="mt-2 text-[14px] text-(--muted-strong)">
         Already have an account?{" "}
         <Link
-          to="/login"
+          to={authPageHref("/login", redirectTo)}
           className="text-(--link) underline hover:text-(--focus)"
         >
           Log in


### PR DESCRIPTION
## Summary

Two follow-ups to #5688 (portable `/~` redirect paths), both found while verifying the marketing-CTA flow in production:

- **Login/sign-up cross-links now carry the redirect destination.** The "Sign-up for a 14-day trial." link on `/login` and the "Log in" link on `/sign-up` were bare paths, so a visitor who arrived with `?redirect=…` and switched pages lost the destination before authenticating. Both links now build their href through a shared `authPageHref` helper that normalizes the destination to a same-origin path (dropping any foreign origin smuggled into the param) and re-encodes it.
- **Logged-out visits no longer load the login page twice.** The expected 401 from the `auth.info` session bootstrap was handled by two mechanisms at once: `AuthProvider`/`LoginCheck` redirected to `/login` in-SPA, and the global query-cache 401 handler then hard-navigated to the same URL (its unauthenticated-path skip list covers `/login` but not `/` or protected deep links). The result was a visible double render: Loading…, login screen, full reload, Loading…, login screen. The query-cache handler now ignores the `auth.info` query — `AuthProvider` owns that error path — matched by its query key via a new `isSessionInfoQueryKey`. Mid-session expiry keeps its hard redirect via every other query's 401, unchanged.

## Motivation

The marketing site's "explore platform" CTA relies on `?redirect=` surviving the whole signup/login journey. In practice the most common new-user path — land on `/login`, click through to sign-up — dropped the destination, and every logged-out visit flashed the login page twice. With these fixes the destination survives page switches on either side of auth, and a logged-out visit renders one loading state and one login screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QyHEZKFqUUjovz2yvcLNv

---
_Generated by [Claude Code](https://claude.ai/code/session_016QyHEZKFqUUjovz2yvcLNv)_