### PR TITLE
fix: handle missing self-serve subscriptions in admin billing

### DIFF
--- a/client/admin/src/pages/organization/Billing.test.tsx
+++ b/client/admin/src/pages/organization/Billing.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { GramAdminError } from "@/lib/gramAdminApi";
 import { routeTree } from "@/routeTree.gen";
 import { anOrganization } from "@/test/fixtures";
 import { renderRouteTree } from "@/test/harness";
@@ -141,6 +142,20 @@ async function renderBilling(): Promise<QueryClient> {
 }
 
 describe("Billing", () => {
+  it("shows an empty state when the organization has no subscription", async () => {
+    mocks.getStripeSubscription.mockRejectedValue(
+      new GramAdminError(404, null, "gram admin 404"),
+    );
+
+    await renderBilling();
+
+    expect(
+      await screen.findByText("This organization has no Stripe subscription."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(mocks.getPaygBillingSummary).not.toHaveBeenCalled();
+  });
+
   it("renders exact current-cycle usage and payment state", async () => {
     await renderBilling();
 

--- a/server/internal/usage/stripe_subscription.go
+++ b/server/internal/usage/stripe_subscription.go
@@ -180,10 +180,6 @@ func canManageStripeSubscriptionLifecycle(status string) bool {
 }
 
 func (s *Service) getStripeBillingState(ctx context.Context, organizationID string) (repo.BillingMetadatum, *stripeclient.SubscriptionState, error) {
-	if s.stripeClient == nil {
-		return repo.BillingMetadatum{}, nil, oops.E(oops.CodeUnavailable, nil, "self-serve billing is temporarily unavailable").LogWarn(ctx, s.logger)
-	}
-
 	metadata, err := repo.New(s.db).GetBillingMetadata(ctx, organizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
@@ -192,6 +188,9 @@ func (s *Service) getStripeBillingState(ctx context.Context, organizationID stri
 		return repo.BillingMetadatum{}, nil, oops.E(oops.CodeUnexpected, err, "failed to get billing metadata").LogError(ctx, s.logger)
 	case !metadata.StripeCustomerID.Valid || !metadata.StripeSubscriptionID.Valid:
 		return repo.BillingMetadatum{}, nil, oops.E(oops.CodeNotFound, nil, "the organization does not have a Stripe subscription").LogWarn(ctx, s.logger)
+	}
+	if s.stripeClient == nil {
+		return repo.BillingMetadatum{}, nil, oops.E(oops.CodeUnavailable, nil, "self-serve billing is temporarily unavailable").LogWarn(ctx, s.logger)
 	}
 
 	state, err := s.stripeClient.GetSubscription(ctx, metadata.StripeSubscriptionID.String)

--- a/server/internal/usage/stripe_subscription_test.go
+++ b/server/internal/usage/stripe_subscription_test.go
@@ -96,6 +96,16 @@ func TestGetStripeSubscriptionReturnsNotFoundWithoutSubscription(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeNotFound)
 }
 
+func TestGetStripeSubscriptionForOrganizationReturnsNotFoundWithoutSubscriptionWhenStripeUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	ti.service.stripeClient = nil
+	_, err := ti.service.GetStripeSubscriptionForOrganization(t.Context(), ti.orgID)
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
 func TestCreateStripePortalSessionRequiresOrganizationAdmin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- check billing metadata before requiring a configured Stripe client
- return the expected missing-subscription response for organizations without self-serve billing
- cover the backend response and admin billing empty state with regression tests

## Test plan

- `mise run test:server ./internal/usage -run 'TestGetStripeSubscription(ForOrganizationReturnsNotFoundWithoutSubscriptionWhenStripeUnavailable|ReturnsNotFoundWithoutSubscription)$' -count=1`
- `aube run -F admin test -- src/pages/organization/Billing.test.tsx`
- `git diff --check`
