### PR TITLE
feat: show completed trial history

### DIFF
--- a/.changeset/admin-completed-trial-history.md
+++ b/.changeset/admin-completed-trial-history.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Show completed trial status, tier, lifecycle date, and original end date on the organization overview.

--- a/client/admin/src/pages/organization/TrialFacts.test.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.test.tsx
@@ -145,9 +145,16 @@ describe("TrialFacts", () => {
       vi.advanceTimersByTime(75_000);
     });
 
-    expect(screen.getByText("Expired")).toBeTruthy();
+    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
+      "Expired",
+    );
     expect(screen.queryByText("Remaining")).toBeNull();
-    expect(screen.queryByText("Running")).toBeNull();
+    expect(
+      screen.getByText("Original end").nextElementSibling?.textContent,
+    ).toBe(new Date(end).toLocaleDateString());
+    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+      "Enterprise",
+    );
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -203,35 +210,77 @@ describe("TrialFacts", () => {
       />,
     );
 
-    expect(screen.getByText("Trial state not recognised")).toBeTruthy();
+    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
+      "Unknown",
+    );
   });
 
-  it.each(["converted", "demoted", "expired"] as const)(
-    "does not show completed lifecycle dates for %s trials",
-    (trialState) => {
-      const converted = "2026-05-01T00:00:00Z";
-      const demoted = "2026-05-02T00:00:00Z";
+  it.each([
+    ["converted", "Converted", "Conversion date"],
+    ["demoted", "Demoted", "Demotion date"],
+    ["expired", "Expired", undefined],
+  ] as const)(
+    "shows completed %s trial history without a countdown",
+    (trialState, stateLabel, lifecycleLabel) => {
+      const end = "2026-04-30T23:00:00Z";
+      const converted = "2026-05-01T23:00:00Z";
+      const demoted = "2026-05-02T23:00:00Z";
       render(
         <TrialFacts
           org={anOrganization({
             trial_state: trialState,
+            trial_tier: "enterprise",
+            trial_ends_at: end,
             trial_converted_at: converted,
             trial_demoted_at: demoted,
           })}
         />,
       );
 
+      expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
+        stateLabel,
+      );
+      expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+        "Enterprise",
+      );
       expect(
-        screen.getByText(
-          trialState === "converted"
-            ? "Converted"
-            : trialState === "demoted"
-              ? "Demoted"
-              : "Expired",
-        ),
-      ).toBeTruthy();
-      expect(screen.queryByText(converted)).toBeNull();
-      expect(screen.queryByText(demoted)).toBeNull();
+        screen.getByText("Original end").nextElementSibling?.textContent,
+      ).toBe(new Date(end).toLocaleDateString());
+
+      if (lifecycleLabel) {
+        const lifecycleDate = trialState === "converted" ? converted : demoted;
+        expect(
+          screen.getByText(lifecycleLabel).nextElementSibling?.textContent,
+        ).toBe(new Date(lifecycleDate).toLocaleDateString());
+      }
+      expect(screen.queryByText("Remaining")).toBeNull();
+      expect(screen.queryByText("Conversion date") !== null).toBe(
+        trialState === "converted",
+      );
+      expect(screen.queryByText("Demotion date") !== null).toBe(
+        trialState === "demoted",
+      );
+    },
+  );
+
+  it.each(["converted", "demoted", "expired"] as const)(
+    "shows missing %s history as unknown",
+    (trialState) => {
+      render(<TrialFacts org={anOrganization({ trial_state: trialState })} />);
+
+      expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+        "Unknown",
+      );
+      expect(
+        screen.getByText("Original end").nextElementSibling?.textContent,
+      ).toBe("Unknown");
+      if (trialState !== "expired") {
+        expect(
+          screen.getByText(
+            trialState === "converted" ? "Conversion date" : "Demotion date",
+          ).nextElementSibling?.textContent,
+        ).toBe("Unknown");
+      }
     },
   );
 });

--- a/client/admin/src/pages/organization/TrialFacts.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useRef, useState, type JSX } from "react";
 
-import { Trial } from "@/components/Trial";
 import { useOnUnmount } from "@/hooks/useOnUnmount";
 import type { AdminOrganization } from "@/lib/gramAdminApi";
 import { formatTrialTimeRemaining } from "@/lib/trialDates";
@@ -10,6 +9,25 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 const MAX_TIMEOUT_MS = 2_147_483_647;
+
+function stateLabel(state: unknown): string {
+  switch (state) {
+    case "running":
+    case "ending_soon":
+      return "Live";
+    case "converted":
+      return "Converted";
+    case "demoted":
+      return "Demoted";
+    case "expired":
+      return "Expired";
+    case undefined:
+    case null:
+      return "No trial";
+    default:
+      return "Unknown";
+  }
+}
 
 function nextRemainingChange(remaining: number): number {
   if (remaining > 72 * HOUR_MS) {
@@ -88,13 +106,31 @@ export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
 
   const expired = live && !Number.isNaN(endTime) && endTime <= now.getTime();
 
-  // Completed states retain their existing compact presentation. Their stored
-  // conversion and demotion dates are intentionally not presented yet.
-  if (!live) return <Trial org={org} />;
+  if (!live || expired) {
+    // Keep each lifecycle date beside its state branch. Conversion and demotion
+    // timestamps are both present on the wire, so selecting one generically
+    // would make it too easy to silently show the other event.
+    const lifecycleFact =
+      org.trial_state === "converted"
+        ? { label: "Conversion date", date: org.trial_converted_at }
+        : org.trial_state === "demoted"
+          ? { label: "Demotion date", date: org.trial_demoted_at }
+          : undefined;
+    const label = expired ? TRIAL_LABELS.expired : stateLabel(org.trial_state);
 
-  // A live server state can become locally elapsed before the next refresh.
-  // Keep its presentation consistent and detach the countdown immediately.
-  if (expired) return <Trial org={{ ...org, trial_state: "expired" }} />;
+    return (
+      <div className="space-y-1 text-sm">
+        <Fact label="State">{label}</Fact>
+        <Fact label="Tier">{tierLabel(org.trial_tier)}</Fact>
+        {lifecycleFact && (
+          <Fact label={lifecycleFact.label}>
+            {dateLabel(lifecycleFact.date)}
+          </Fact>
+        )}
+        <Fact label="Original end">{dateLabel(org.trial_ends_at)}</Fact>
+      </div>
+    );
+  }
 
   const remaining = formatTrialTimeRemaining(org.trial_ends_at, now);
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3148/see-a-trials-real-state-on-the-organization-page

## Summary

Adds completed-trial history to organization details. Converted and demoted trials show their lifecycle date and original trial end, while expired trials show the original end; completed states never show a countdown.

## Motivation

Operators need to distinguish how a trial ended and retain its original deadline after the live countdown is no longer relevant.
