### PR TITLE
feat: show live trial details

### DIFF
--- a/.changeset/admin-live-trial-overview.md
+++ b/.changeset/admin-live-trial-overview.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Show live trial state, tier, UTC end date, and automatically updating time remaining on the organization overview.

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -229,6 +229,9 @@ export type AdminOrganization = {
   free_trial_ends_at?: string;
   trial_state?: TrialState;
   trial_ends_at?: string;
+  trial_tier?: string;
+  trial_converted_at?: string;
+  trial_demoted_at?: string;
   member_count: number;
   created_at: string;
   updated_at: string;

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -48,12 +48,11 @@ const ORG = anOrganization({
   free_trial_started_at: "2026-02-01T00:00:00Z",
   free_trial_ends_at: "2026-11-12T00:00:00Z",
   trial_state: "running",
-  trial_ends_at: "2026-05-06T00:00:00Z",
+  trial_ends_at: "2099-05-06T00:00:00Z",
+  trial_tier: "enterprise",
 });
 
-// The trial is a date without a clock wherever it is read. UTC, because that is
-// the zone the API states these dates in and the zone they are rendered in;
-// see `utils.test.ts`.
+// Most record dates use the shared UTC date formatter.
 function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { timeZone: "UTC" });
 }
@@ -155,7 +154,7 @@ afterEach(() => {
 });
 
 describe("Overview", () => {
-  it("reads the trial exactly the way the row does", async () => {
+  it("shows live trial facts without changing the shared row display", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
@@ -163,16 +162,17 @@ describe("Overview", () => {
     const trialEndsAt = ORG.trial_ends_at;
     if (!trialEndsAt) throw new Error("the record under test needs a trial");
 
-    const trial = await screen.findByText("Trial");
-    // Written out, not built from the component. The same string is asserted
-    // against the list's cell, which is the only way two pages that could
-    // drift apart are held together.
-    expect(valueBeside("Trial").textContent).toBe(
-      `Running ends ${shortDate(trialEndsAt)}`,
-    );
+    await screen.findByText("Trial");
+    const facts = valueBeside("Trial");
     expect(
-      trial.parentElement?.querySelector('[data-slot="badge"]'),
-    ).toBeTruthy();
+      within(facts).getByText("State").nextElementSibling?.textContent,
+    ).toBe("Running");
+    expect(
+      within(facts).getByText("Tier").nextElementSibling?.textContent,
+    ).toBe("Enterprise");
+    expect(
+      within(facts).getByText("Ends").nextElementSibling?.textContent,
+    ).toBe(new Date(trialEndsAt).toLocaleDateString());
 
     // The defaulted pair is gone from the page, not merely unread: an operator
     // who sees "Free trial ends" reads a date no organization ever earned.
@@ -180,7 +180,7 @@ describe("Overview", () => {
     expect(screen.queryByText("Free trial ends")).toBeNull();
   });
 
-  it("reads a dash for an organization that never trialled", async () => {
+  it("keeps No trial visible for an organization that never trialled", async () => {
     mocks.getOrganization.mockResolvedValue({
       ...ORG,
       trial_state: "none",
@@ -194,7 +194,7 @@ describe("Overview", () => {
     // `free_trial_ends_at` still dates this record, which is the whole reason
     // the page was moved off it.
     expect(ORG.free_trial_ends_at).toBeTruthy();
-    expect(valueBeside("Trial").textContent).toBe("-No trial");
+    expect(valueBeside("Trial").textContent).toBe("No trial");
   });
 
   it("reads a date as the server's day, not the reader's", async () => {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -4,7 +4,7 @@ import { useParams } from "@tanstack/react-router";
 
 import { useConfirmDialog } from "@/components/ConfirmDialog";
 import { CopyValue } from "@/components/CopyValue";
-import { Trial } from "@/components/Trial";
+import { TrialFacts } from "@/pages/organization/TrialFacts";
 import {
   Select,
   SelectContent,
@@ -222,7 +222,7 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
           </Select>
         </Row>
         <Row label="Trial">
-          <Trial org={org} />
+          <TrialFacts org={org} />
         </Row>
       </Group>
 

--- a/client/admin/src/pages/organization/TrialFacts.test.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.test.tsx
@@ -1,0 +1,237 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { anOrganization } from "@/test/fixtures";
+
+import { TrialFacts } from "./TrialFacts";
+
+const END = "2026-05-06T01:01:00Z";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("TrialFacts", () => {
+  it.each([
+    ["running", "Running"],
+    ["ending_soon", "Ending soon"],
+  ] as const)("shows the live %s trial facts", (trialState, stateLabel) => {
+    vi.stubEnv("TZ", "America/Los_Angeles");
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:30Z");
+
+    render(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: trialState,
+          trial_tier: "enterprise",
+          trial_ends_at: END,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
+      stateLabel,
+    );
+    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+      "Enterprise",
+    );
+    expect(screen.getByText("Ends").nextElementSibling?.textContent).toBe(
+      new Date(END).toLocaleDateString(),
+    );
+    expect(screen.getByText("Remaining").nextElementSibling?.textContent).toBe(
+      "1 hour 1 minute",
+    );
+  });
+
+  it("keeps No trial visible", () => {
+    render(<TrialFacts org={anOrganization({ trial_state: "none" })} />);
+
+    expect(screen.getByText("No trial")).toBeTruthy();
+  });
+
+  it("does not expose an unknown stored tier", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:30Z");
+
+    render(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: "running",
+          trial_tier: "future_internal_tier",
+          trial_ends_at: END,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+      "Unknown",
+    );
+    expect(screen.queryByText("future_internal_tier")).toBeNull();
+  });
+
+  it("updates on end-relative minute boundaries and cleans up its timer", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:30.500Z");
+    const view = render(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: "running",
+          trial_tier: "enterprise",
+          trial_ends_at: "2026-05-06T01:01:45Z",
+        })}
+      />,
+    );
+
+    const remaining = () =>
+      screen.getByText("Remaining").nextElementSibling?.textContent;
+    expect(remaining()).toBe("1 hour 2 minutes");
+
+    act(() => {
+      vi.advanceTimersByTime(14_499);
+    });
+    expect(remaining()).toBe("1 hour 2 minutes");
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(remaining()).toBe("1 hour 1 minute");
+    expect(vi.getTimerCount()).toBe(1);
+
+    view.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([
+    ["2026-05-09T00:00:30Z", "4 days", "72 hours"],
+    ["2026-05-07T00:00:30Z", "25 hours", "24 hours"],
+  ])("updates at the formatter boundary ending at %s", (end, before, after) => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:00Z");
+    render(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: "running",
+          trial_ends_at: end,
+        })}
+      />,
+    );
+
+    const remaining = () =>
+      screen.getByText("Remaining").nextElementSibling?.textContent;
+    expect(remaining()).toBe(before);
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(remaining()).toBe(after);
+  });
+
+  it("switches a live trial to expired at its exact end", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:30Z");
+    const end = "2026-05-06T00:01:45Z";
+    render(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: "running",
+          trial_tier: "enterprise",
+          trial_ends_at: end,
+        })}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(75_000);
+    });
+
+    expect(screen.getByText("Expired")).toBeTruthy();
+    expect(screen.queryByText("Remaining")).toBeNull();
+    expect(screen.queryByText("Running")).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("refreshes a stale clock when transitioning into a live trial", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:00Z");
+    const view = render(
+      <TrialFacts org={anOrganization({ trial_state: "converted" })} />,
+    );
+    vi.setSystemTime("2026-05-06T00:30:00Z");
+
+    view.rerender(
+      <TrialFacts
+        org={anOrganization({
+          trial_state: "running",
+          trial_ends_at: "2026-05-06T01:00:00Z",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Remaining").nextElementSibling?.textContent).toBe(
+      "30 minutes",
+    );
+  });
+
+  it.each([undefined, "not-a-date"])(
+    "shows an unknown live end for %s",
+    (end) => {
+      vi.useFakeTimers();
+      render(
+        <TrialFacts
+          org={anOrganization({
+            trial_state: "running",
+            trial_ends_at: end,
+          })}
+        />,
+      );
+
+      expect(screen.getByText("Ends").nextElementSibling?.textContent).toBe(
+        "Unknown",
+      );
+      expect(
+        screen.getByText("Remaining").nextElementSibling?.textContent,
+      ).toBe("Unknown");
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("labels an unknown future trial state safely", () => {
+    render(
+      <TrialFacts
+        org={anOrganization({ trial_state: "future_state" as "running" })}
+      />,
+    );
+
+    expect(screen.getByText("Trial state not recognised")).toBeTruthy();
+  });
+
+  it.each(["converted", "demoted", "expired"] as const)(
+    "does not show completed lifecycle dates for %s trials",
+    (trialState) => {
+      const converted = "2026-05-01T00:00:00Z";
+      const demoted = "2026-05-02T00:00:00Z";
+      render(
+        <TrialFacts
+          org={anOrganization({
+            trial_state: trialState,
+            trial_converted_at: converted,
+            trial_demoted_at: demoted,
+          })}
+        />,
+      );
+
+      expect(
+        screen.getByText(
+          trialState === "converted"
+            ? "Converted"
+            : trialState === "demoted"
+              ? "Demoted"
+              : "Expired",
+        ),
+      ).toBeTruthy();
+      expect(screen.queryByText(converted)).toBeNull();
+      expect(screen.queryByText(demoted)).toBeNull();
+    },
+  );
+});

--- a/client/admin/src/pages/organization/TrialFacts.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useRef, useState, type JSX } from "react";
+
+import { Trial } from "@/components/Trial";
+import { useOnUnmount } from "@/hooks/useOnUnmount";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+import { formatTrialTimeRemaining } from "@/lib/trialDates";
+import { TRIAL_LABELS } from "@/lib/trialLabels";
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+function nextRemainingChange(remaining: number): number {
+  if (remaining > 72 * HOUR_MS) {
+    return Math.max(72 * HOUR_MS, (Math.ceil(remaining / DAY_MS) - 1) * DAY_MS);
+  }
+  if (remaining > 24 * HOUR_MS) {
+    return (Math.ceil(remaining / HOUR_MS) - 1) * HOUR_MS;
+  }
+  return (Math.ceil(remaining / MINUTE_MS) - 1) * MINUTE_MS;
+}
+
+function tierLabel(tier: string | undefined): string {
+  return tier === "enterprise" ? "Enterprise" : "Unknown";
+}
+
+function dateLabel(iso: string | undefined): string {
+  if (!iso) return "Unknown";
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? "Unknown" : date.toLocaleDateString();
+}
+
+function Fact({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[7rem_1fr] gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+// Detail-only trial facts. List and peek surfaces deliberately keep using the
+// compact Trial component; this view has room for exact and changing facts.
+export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
+  const live =
+    org.trial_state === "running" || org.trial_state === "ending_soon";
+  const [now, setNow] = useState(() => new Date());
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const end = new Date(org.trial_ends_at ?? "");
+  const endTime = end.getTime();
+
+  const attachRemainingTime = useCallback(
+    (node: HTMLSpanElement | null) => {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+      if (!node) return;
+
+      const tick = () => {
+        const currentTime = Date.now();
+        setNow(new Date(currentTime));
+
+        const remaining = endTime - currentTime;
+        if (Number.isNaN(endTime) || remaining <= 0) return;
+
+        const delay = remaining - nextRemainingChange(remaining);
+        timer.current = setTimeout(tick, Math.min(delay, MAX_TIMEOUT_MS));
+      };
+
+      // The component may have spent time in a completed state with no timer.
+      // Refresh before scheduling whenever the countdown is attached.
+      tick();
+    },
+    [endTime],
+  );
+
+  useOnUnmount(() => clearTimeout(timer.current));
+
+  if (org.trial_state === "none" || !org.trial_state) {
+    return <span className="text-muted-foreground text-sm">No trial</span>;
+  }
+
+  const expired = live && !Number.isNaN(endTime) && endTime <= now.getTime();
+
+  // Completed states retain their existing compact presentation. Their stored
+  // conversion and demotion dates are intentionally not presented yet.
+  if (!live) return <Trial org={org} />;
+
+  // A live server state can become locally elapsed before the next refresh.
+  // Keep its presentation consistent and detach the countdown immediately.
+  if (expired) return <Trial org={{ ...org, trial_state: "expired" }} />;
+
+  const remaining = formatTrialTimeRemaining(org.trial_ends_at, now);
+
+  return (
+    <div className="space-y-1 text-sm">
+      <Fact label="State">{TRIAL_LABELS[org.trial_state] ?? "Unknown"}</Fact>
+      <Fact label="Tier">{tierLabel(org.trial_tier)}</Fact>
+      <Fact label="Ends">{dateLabel(org.trial_ends_at)}</Fact>
+      <Fact label="Remaining">
+        <span ref={attachRemainingTime}>{remaining ?? "Unknown"}</span>
+      </Fact>
+    </div>
+  );
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3148/see-a-trials-real-state-on-the-organization-page

## Summary

Shows factual live-trial state, tier, end date, and adaptive remaining time on organization detail pages while preserving the compact shared list and peek display. The countdown updates at end-relative boundaries, handles stale or invalid data safely, and cleans up timers; organizations without a trial retain a visible `No trial` row.

## Motivation

Operators need the real live-trial state and time remaining on the detail page without changing existing list, peek, callout, or extension behavior.
