### PR TITLE
feat: platform-MCP session recall tools (list_my_sessions, continue_session)

### DIFF
--- a/.changeset/session-recall-platform-mcp-tools.md
+++ b/.changeset/session-recall-platform-mcp-tools.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Add list_my_sessions and continue_session platform-MCP tools: owner-scoped recall of captured coding-agent sessions as a redacted handoff digest, recorded as a chat_session:recall audit event with a lineage edge.

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -36,6 +36,7 @@ export const AUDIT_ACTIONS = [
   "chat_session:access",
   "chat_session:handoff_export",
   "chat_session:move",
+  "chat_session:recall",
   "custom_domains:create",
   "custom_domains:delete",
   "custom_domains:update",
@@ -327,6 +328,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "exported chat session handoff";
     case "chat_session:move":
       return "moved chat session";
+    case "chat_session:recall":
+      return "recalled chat session";
 
     case "custom_domains:create":
       return "added custom domain";

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -797,7 +797,8 @@ function SubViewBar({ title, onBack }: { title: string; onBack: () => void }) {
 }
 
 // SessionLinksSection lists session-lineage edges touching this chat: moves
-// out of it ("Moved to …") and moves that produced it ("Derived from …").
+// and recalls out of it ("Moved to …", "Recalled into …") and moves that
+// produced it ("Derived from …").
 // Presence-gated — chats with no edges render nothing, so there is no feature
 // flag and no empty state.
 function SessionLinksSection({
@@ -873,15 +874,25 @@ function SessionLinksSection({
           ),
         )}
         {outbound.map((link, i) =>
-          row(
-            `out-${i}-${link.createdAt.toISOString()}`,
-            <>Moved to {formatPlatform(link.targetHarness)}</>,
-            link.createdAt,
-            hop(link.childChatId, link.childCaptured),
-            link.childCaptured
-              ? (link.childTitle ?? undefined)
-              : "not yet captured",
-          ),
+          // Recall edges never carry a child chat (the continuation is
+          // unknowable at recall time), so there is nothing to hop to and
+          // "not yet captured" would wrongly imply one is expected.
+          link.kind === "recall"
+            ? row(
+                `out-${i}-${link.createdAt.toISOString()}`,
+                <>Recalled into a later session</>,
+                link.createdAt,
+                undefined,
+              )
+            : row(
+                `out-${i}-${link.createdAt.toISOString()}`,
+                <>Moved to {formatPlatform(link.targetHarness)}</>,
+                link.createdAt,
+                hop(link.childChatId, link.childCaptured),
+                link.childCaptured
+                  ? (link.childTitle ?? undefined)
+                  : "not yet captured",
+              ),
         )}
       </div>
     </div>

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -18,7 +18,13 @@ import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
 import { useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { ArrowUpRight, CircleDashed, GitBranch, Pin } from "lucide-react";
+import {
+  ArrowUpRight,
+  CircleDashed,
+  GitBranch,
+  History,
+  Pin,
+} from "lucide-react";
 import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 import { formatPlatform } from "@/lib/formatPlatform";
@@ -121,6 +127,20 @@ function SessionLineageIcons({
           <CircleDashed
             className="size-3.5"
             aria-label="Moved, continuation not yet captured"
+          />
+        </SimpleTooltip>
+      )}
+      {summary.recalledCount > 0 && (
+        <SimpleTooltip
+          tooltip={
+            summary.recalledCount === 1
+              ? "Recalled into a later session"
+              : `Recalled into ${summary.recalledCount} later sessions`
+          }
+        >
+          <History
+            className="size-3.5"
+            aria-label="Recalled into a later session"
           />
         </SimpleTooltip>
       )}

--- a/client/dashboard/src/pages/chatLogs/sessionLinks.ts
+++ b/client/dashboard/src/pages/chatLogs/sessionLinks.ts
@@ -7,6 +7,10 @@ export interface LineageSummary {
   /** Harnesses this session was moved to whose continuation is not captured
    * (or not visible to the caller — deliberately indistinguishable). */
   danglingIn: string[];
+  /** Times this session was recalled into a later session. Recall edges never
+   * carry a child chat (the continuation is unknowable at recall time), so
+   * they are distinct recall events rather than dangling moves. */
+  recalledCount: number;
   /** Whether this session is itself the continuation of an earlier one. */
   derived: boolean;
 }
@@ -20,11 +24,14 @@ export function summarizeLineage(
   const summary: LineageSummary = {
     continuedIn: [],
     danglingIn: [],
+    recalledCount: 0,
     derived: false,
   };
   for (const link of links) {
     if (link.parentChatId === chatId) {
-      if (link.childCaptured) {
+      if (link.kind === "recall") {
+        summary.recalledCount += 1;
+      } else if (link.childCaptured) {
         summary.continuedIn.push(link.targetHarness);
       } else {
         summary.danglingIn.push(link.targetHarness);
@@ -37,6 +44,7 @@ export function summarizeLineage(
   if (
     summary.continuedIn.length === 0 &&
     summary.danglingIn.length === 0 &&
+    summary.recalledCount === 0 &&
     !summary.derived
   ) {
     return undefined;

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -221,9 +221,9 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		// Metered separately and lower: this is the only read that reaches
-		// personal data, so exhausting it must not be possible by spending the
-		// ordinary diagnostic allowance.
+		// Metered separately and lower: personal-data reads (this and session
+		// recall below, each on its own budget) must not be fundable by
+		// spending the ordinary diagnostic allowance.
 		SensitiveDiagnostics: platformmcp.OperationBudget{
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
@@ -543,9 +543,9 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
-		// Metered separately and lower: this is the only read that reaches
-		// personal data, so exhausting it must not be possible by spending the
-		// ordinary diagnostic allowance.
+		// Metered separately and lower: personal-data reads (this and session
+		// recall below, each on its own budget) must not be fundable by
+		// spending the ordinary diagnostic allowance.
 		SensitiveDiagnostics: platformmcp.OperationBudget{
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -35,6 +35,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp/localfixture"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp/remotesessionprovider"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp/setupcorpus"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -77,6 +78,10 @@ type platformMCPConfig struct {
 	// what a project overview's active-user count measures. Shared with the
 	// telemetry service so both surfaces answer from the same source.
 	SessionCapture platformmcp.FeatureChecker
+	// SessionPortability gates the session-recall tools (list_my_sessions /
+	// continue_session). Sibling of SessionCapture: capture records sessions,
+	// portability serves them back as redacted handoff digests.
+	SessionPortability platformmcp.FeatureChecker
 	// TelemetryDrilldown is the row-level half of the same read model. Nil
 	// withholds the drill-down tools while leaving the overview-first entry
 	// points serving.
@@ -223,6 +228,12 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// Session recall serves whole-transcript digests, so it is metered on
+		// its own low allowance that no other budget can fund.
+		SensitiveSessionRecall: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.SessionRecallConnectionLimitName, ratelimit.PerMinute(platformmcp.SessionRecallsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SessionRecallOrganizationLimitName, ratelimit.PerMinute(platformmcp.SessionRecallsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// The second drill-down cap: what a connection may accumulate over ten
 		// minutes, rather than how often it may call. Both buckets refill over
 		// that window, so a caller paging steadily under the per-minute rate
@@ -293,6 +304,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
+	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -314,6 +326,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		skillAuthoring,
 		diagnostics,
 		pluginInventory,
+		sessionRecall,
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -537,6 +550,12 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsConnectionLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.SensitiveDiagnosticsOrganizationLimitName, ratelimit.PerMinute(platformmcp.SensitiveDiagnosticQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		// Session recall serves whole-transcript digests, so it is metered on
+		// its own low allowance that no other budget can fund.
+		SensitiveSessionRecall: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.SessionRecallConnectionLimitName, ratelimit.PerMinute(platformmcp.SessionRecallsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.SessionRecallOrganizationLimitName, ratelimit.PerMinute(platformmcp.SessionRecallsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// The second drill-down cap: what a connection may accumulate over ten
 		// minutes, rather than how often it may call. Both buckets refill over
 		// that window, so a caller paging steadily under the per-minute rate
@@ -596,6 +615,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
+	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
 	runtime := platformmcp.NewRuntimeWithLifecycle(
 		config.Logger,
 		authenticator,
@@ -614,6 +634,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		skillAuthoring,
 		diagnostics,
 		pluginInventory,
+		sessionRecall,
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -825,6 +825,7 @@ func newStartCommand() *cli.Command {
 			logsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureLogs)
 			toolIOLogsEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureToolIOLogs)
 			sessionCaptureEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureSessionCapture)
+			sessionPortabilityEnabled := newFeatureChecker(logger, productFeatures, productfeatures.FeatureSessionPortability)
 			challengeLoggingEnabled := authz.ChallengeLoggingEnabled(newFeatureChecker(logger, productFeatures, productfeatures.FeatureAuthzChallengeLogging))
 			roleClient, err := newAccessRoleProvider(ctx, logger, guardianPolicy, c)
 			if err != nil {
@@ -1545,6 +1546,7 @@ func newStartCommand() *cli.Command {
 				Telemetry:              telemetryrepo.New(chDB),
 				TelemetryDrilldown:     telemetryrepo.New(chDB),
 				SessionCapture:         platformmcp.FeatureChecker(sessionCaptureEnabled),
+				SessionPortability:     platformmcp.FeatureChecker(sessionPortabilityEnabled),
 				LocalFixture:           platformFixture,
 			})
 			if err != nil {

--- a/server/internal/audit/chatsessions.go
+++ b/server/internal/audit/chatsessions.go
@@ -147,6 +147,84 @@ func (l *Logger) LogChatSessionMove(ctx context.Context, dbtx repo.DBTX, event L
 	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.ChatSessionV1})
 }
 
+const ActionChatSessionRecall Action = "chat_session:recall"
+
+type LogChatSessionRecallEvent struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+
+	Actor urn.Principal
+
+	ChatSessionURN urn.ChatSession
+	ChatTitle      string
+	// OwnerUserID mirrors LogChatSessionAccessEvent: auxiliary context naming
+	// whose session was recalled, not the audit subject.
+	OwnerUserID string //nolint:glint // owner user id is auxiliary context, not the audit subject (which is ChatSessionURN)
+
+	// SourceSessionID is the native harness session id the recalled chat was
+	// captured from, when known.
+	SourceSessionID string //nolint:glint // native harness session id, not a Gram resource with a URN
+
+	// The remaining fields describe the digest that was served — counts and
+	// sizes only. Like the handoff-export event this entry records that content
+	// left, not what it said.
+	RedactToolPayloads bool
+	FindingsMasked     int
+	UnanalyzedMessages int
+	DigestBytes        int
+	TurnsIncluded      int
+	TurnsDropped       int
+}
+
+// LogChatSessionRecall records that a captured agent session was recalled as a
+// redacted handoff digest so work can continue in another harness (session
+// portability). The digest itself never lands in the audit log — the entry is
+// deliberately content-free. Callers record the recall's lineage edge
+// (chat_session_links) in the same transaction and pass that dbtx here so the
+// edge and the governance record commit together.
+func (l *Logger) LogChatSessionRecall(ctx context.Context, dbtx repo.DBTX, event LogChatSessionRecallEvent) error {
+	action := ActionChatSessionRecall
+
+	meta := map[string]any{
+		"redact_tool_payloads": event.RedactToolPayloads,
+		"findings_masked":      event.FindingsMasked,
+		"unanalyzed_messages":  event.UnanalyzedMessages,
+		"digest_bytes":         event.DigestBytes,
+		"turns_included":       event.TurnsIncluded,
+		"turns_dropped":        event.TurnsDropped,
+	}
+	if event.SourceSessionID != "" {
+		meta["source_session_id"] = event.SourceSessionID
+	}
+	metadata, err := marshalAuditPayload(meta)
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: event.ProjectID, Valid: event.ProjectID != uuid.Nil},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.ToPGTextEmpty(""),
+		ActorSlug:        conv.ToPGTextEmpty(""),
+
+		Action: string(action),
+
+		SubjectID:          event.ChatSessionURN.ID.String(),
+		SubjectType:        string(subjectTypeChatSession),
+		SubjectDisplayName: conv.ToPGTextEmpty(event.ChatTitle),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OwnerUserID),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.ChatSessionV1})
+}
+
 const ActionChatSessionHandoffExport Action = "chat_session:handoff_export"
 
 type LogChatSessionHandoffExportEvent struct {

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -299,7 +299,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 		PlatformMCPReadTools: assistant_platform_mcp_adapter.ExternalTools(
 			platformmcp.NewRuntimeWithLifecycle(
 				logger, nil, nil, platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine), "", "",
-				platformmcp.NewPostgresReader(logger, conn), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+				platformmcp.NewPostgresReader(logger, conn), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 				platformmcp.CatalogDescriptor{},
 			).AssistantTools(),
 			platformmcp.NewLiveOrgAdminAuthorizer(conn, authzEngine),

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -17,7 +17,7 @@ import (
 func TestEveryRegisteredToolDeclaresAnAudience(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 	descriptors := registrar.Descriptors()
 	require.NotEmpty(t, descriptors, "the deployment registers tools even when every dependency is absent")
 
@@ -170,7 +170,7 @@ func names(descriptors []Descriptor) []string {
 func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := map[string]bool{}
 	for _, descriptor := range registrar.For(AudienceAssistant) {
@@ -178,12 +178,16 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	}
 
 	// Named-plugin distribution is intentionally unavailable until
-	// compatibility deployment.
+	// compatibility deployment. Session recall is external-only in v1: the
+	// shared project-assistant surface must not serve user-personal
+	// cross-project transcripts.
 	for _, name := range []string{
 		"distribute_mcp_to_plugin",
 		"remove_mcp_from_plugin",
 		"list_plugins",
 		"get_plugin",
+		"list_my_sessions",
+		"continue_session",
 	} {
 		require.False(t, admitted[name], "tool %q needs a connection or is rollout-gated and must not be admitted to the assistant", name)
 	}
@@ -222,7 +226,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 func TestExternalEndpointServesOnlyExternallyAdmittedTools(t *testing.T) {
 	t.Parallel()
 
-	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	server, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 
 	admitted := make(map[string]bool)
 	for _, descriptor := range registrar.For(AudienceExternal) {

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -10,22 +10,24 @@ import (
 )
 
 const (
-	CatalogConnectionLimitName        = "platform-mcp-catalog-connection"
-	CatalogOrganizationLimitName      = "platform-mcp-catalog-organization"
-	RegistrationConnectionLimitName   = "platform-mcp-registration-connection"
-	RegistrationOrganizationLimitName = "platform-mcp-registration-organization"
-	HandoffConnectionLimitName        = "platform-mcp-handoff-connection"
-	HandoffOrganizationLimitName      = "platform-mcp-handoff-organization"
-	SetupConnectionLimitName          = "platform-mcp-setup-connection"
-	SetupOrganizationLimitName        = "platform-mcp-setup-organization"
-	RepairConnectionLimitName         = "platform-mcp-repair-connection"
-	RepairOrganizationLimitName       = "platform-mcp-repair-organization"
-	DocsConnectionLimitName           = "platform-mcp-docs-connection"
-	DocsOrganizationLimitName         = "platform-mcp-docs-organization"
-	SkillsConnectionLimitName         = "platform-mcp-skills-connection"
-	SkillsOrganizationLimitName       = "platform-mcp-skills-organization"
-	LifecycleConnectionLimitName      = "platform-mcp-lifecycle-connection"
-	LifecycleOrganizationLimitName    = "platform-mcp-lifecycle-organization"
+	CatalogConnectionLimitName         = "platform-mcp-catalog-connection"
+	CatalogOrganizationLimitName       = "platform-mcp-catalog-organization"
+	RegistrationConnectionLimitName    = "platform-mcp-registration-connection"
+	RegistrationOrganizationLimitName  = "platform-mcp-registration-organization"
+	HandoffConnectionLimitName         = "platform-mcp-handoff-connection"
+	HandoffOrganizationLimitName       = "platform-mcp-handoff-organization"
+	SetupConnectionLimitName           = "platform-mcp-setup-connection"
+	SetupOrganizationLimitName         = "platform-mcp-setup-organization"
+	RepairConnectionLimitName          = "platform-mcp-repair-connection"
+	RepairOrganizationLimitName        = "platform-mcp-repair-organization"
+	DocsConnectionLimitName            = "platform-mcp-docs-connection"
+	DocsOrganizationLimitName          = "platform-mcp-docs-organization"
+	SkillsConnectionLimitName          = "platform-mcp-skills-connection"
+	SkillsOrganizationLimitName        = "platform-mcp-skills-organization"
+	LifecycleConnectionLimitName       = "platform-mcp-lifecycle-connection"
+	LifecycleOrganizationLimitName     = "platform-mcp-lifecycle-organization"
+	SessionRecallConnectionLimitName   = "platform-mcp-session-recall-connection"
+	SessionRecallOrganizationLimitName = "platform-mcp-session-recall-organization"
 )
 
 const (
@@ -58,6 +60,13 @@ const (
 	// meter the volume rather than the calls.
 	DrilldownRowsPerConnectionPerWindow          = 1000
 	DrilldownMetricQueriesPerConnectionPerWindow = 20
+
+	// SessionRecallsPer* bound continue_session. Metered separately and lower
+	// than every other read: each allowed call serves an entire session
+	// transcript as a digest, so this allowance must not be fundable by
+	// spending any other budget.
+	SessionRecallsPerConnectionPerMinute   = 10
+	SessionRecallsPerOrganizationPerMinute = 100
 )
 
 // DrilldownVolumeWindow is the interval the drill-down volume caps refill over.
@@ -175,6 +184,9 @@ type OperationBudgets struct {
 	// Diagnostics so exhausting it is not possible by spending the summary
 	// allowance, and so it can be tightened on its own.
 	SensitiveDiagnostics OperationBudget
+	// SensitiveSessionRecall meters continue_session — the only operation that
+	// serves whole-transcript content — on its own low allowance.
+	SensitiveSessionRecall OperationBudget
 	// DrilldownVolume meters what the drill-downs return rather than how often
 	// they are called: rows and spans against one bucket, metric queries
 	// against another, both per connection over DrilldownVolumeWindow.
@@ -230,5 +242,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2438,6 +2438,108 @@ WHERE m.id = @mcp_server_id
   AND m.project_id = @project_id
   AND m.deleted IS FALSE;
 
+-- Session recall (list_my_sessions / continue_session). Every read below
+-- fuses tenancy and ownership into the row filter — organization, owner
+-- user_id, not-deleted, and the personal-account exclusion — rather than
+-- fetching then authorizing. An unresolved actor (empty user_id) matches no
+-- rows because chats.user_id is never the empty string: fail-closed.
+-- Personal-account sessions are excluded from BOTH list and continue:
+-- personal-account ownership attribution is partly device-bridge-inferred,
+-- which is acceptable for titles but not for transcripts (see the
+-- ListOwnedChatSessionMeta warning in agent/queries.sql). The predicate
+-- (ua.id IS NULL OR ua.account_type <> 'personal') also drops rows whose
+-- account_type is NULL — the comparison evaluates to NULL — and that is
+-- deliberate: an unclassified account might be personal, so it gets the
+-- same fail-closed treatment.
+
+-- name: ListOwnedChatSessionsForRecall :many
+SELECT c.id, c.external_chat_id, c.title, c.summary, c.cwd, c.updated_at, c.project_id, p.name AS project_name, p.slug AS project_slug
+FROM chats c
+JOIN projects p ON p.id = c.project_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE c.organization_id = @organization_id
+  AND c.user_id = @user_id::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+ORDER BY c.updated_at DESC
+LIMIT @row_limit;
+
+-- name: GetOwnedChatForRecall :one
+SELECT c.id, c.external_chat_id, c.title, c.cwd, c.updated_at, c.project_id
+FROM chats c
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE c.id = @chat_id
+  AND c.organization_id = @organization_id
+  AND c.user_id = @user_id::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal');
+
+-- name: ListOwnedChatTranscriptMessagesForRecall :many
+-- Latest generation only: compaction/edit rewrites bump chat_messages.generation
+-- and the digest must reflect the current conversation view, not superseded
+-- rows. chat_messages.project_id is NULL on old rows — always filtered, so
+-- pre-project-stamp rows fail closed rather than leaking across tenants.
+-- Newest rows first under @row_limit so the cap keeps the end of a long
+-- session — the part a handoff digest is about — and the service restores
+-- chronological order. Content is never truncated here: finding-span
+-- verification compares exact bytes, so per-message bounding happens after
+-- masking, not at the read.
+SELECT cm.id, cm.seq, cm.created_at, cm.role, cm.content, cm.content_asset_url, cm.tool_calls, cm.tool_call_id, cm.tool_urn, cm.source, cm.risk_analyzed_at
+FROM chat_messages cm
+JOIN chats c ON c.id = cm.chat_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE cm.chat_id = @chat_id
+  AND cm.project_id = @project_id
+  AND c.organization_id = @organization_id
+  AND c.user_id = @user_id::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND cm.generation = (
+    SELECT COALESCE(MAX(generation), 0)
+    FROM chat_messages
+    WHERE chat_id = @chat_id
+      AND project_id = @project_id
+  )
+ORDER BY cm.created_at DESC, cm.seq DESC
+LIMIT @row_limit;
+
+-- name: ListRiskFindingSpansForRecall :many
+-- Findings that drive inline masking of the recall digest. Message-anchored
+-- rows only (the digest does not render content parts), with the canonical
+-- suppression filters from risk's ListRiskResultsByChatFound: found, not
+-- excluded, not swept as false positive, policy still enabled and not deleted.
+SELECT rr.chat_message_id, rr.source, rr.rule_id, rr.match, rr.spans, rr.start_pos, rr.end_pos
+FROM risk_results rr
+JOIN chat_messages cm ON cm.id = rr.chat_message_id
+JOIN chats c ON c.id = cm.chat_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+WHERE cm.chat_id = @chat_id
+  AND rr.project_id = @project_id
+  AND c.organization_id = @organization_id
+  AND c.user_id = @user_id::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
+ORDER BY cm.created_at ASC, cm.seq ASC, rr.id ASC;
+
+-- name: InsertChatSessionRecallLink :exec
+-- Sibling of agent's InsertChatSessionLink with kind='recall'. A v1 recall
+-- edge always has a NULL child: the OAuth principal carries no harness
+-- session id, so the continuation is unknowable at recall time and each
+-- recall records a distinct event. The ON CONFLICT clause is therefore inert
+-- today (the partial unique index only covers non-NULL children) and kept
+-- verbatim for forward safety.
+INSERT INTO chat_session_links (
+  project_id, organization_id, parent_chat_id, child_chat_id,
+  parent_session_id, child_session_id, kind, target_harness, source_surface,
+  actor_email, device_serial, device_hostname
+) VALUES (
+  @project_id, @organization_id, @parent_chat_id, @child_chat_id,
+  @parent_session_id, @child_session_id, 'recall', @target_harness, @source_surface,
+  @actor_email, @device_serial, @device_hostname
+)
+ON CONFLICT (project_id, parent_chat_id, child_chat_id) WHERE child_chat_id IS NOT NULL DO NOTHING;
 -- Plugin inventory. Plugins are the unit an administrator installs and reasons
 -- about, so this surface reads them directly rather than inferring them from
 -- distribution targets. Membership is derived from plugin_servers and

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2508,6 +2508,9 @@ LIMIT @row_limit;
 -- rows only (the digest does not render content parts), with the canonical
 -- suppression filters from risk's ListRiskResultsByChatFound: found, not
 -- excluded, not swept as false positive, policy still enabled and not deleted.
+-- Latest generation only, matching the transcript read: findings on
+-- superseded generations mask nothing the digest renders, so loading them
+-- would only let long, repeatedly compacted sessions inflate the scan.
 SELECT rr.chat_message_id, rr.source, rr.rule_id, rr.match, rr.spans, rr.start_pos, rr.end_pos
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
@@ -2520,6 +2523,12 @@ WHERE cm.chat_id = @chat_id
   AND c.user_id = @user_id::text
   AND c.deleted IS FALSE
   AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND cm.generation = (
+    SELECT COALESCE(MAX(generation), 0)
+    FROM chat_messages
+    WHERE chat_id = @chat_id
+      AND project_id = @project_id
+  )
   AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
 ORDER BY cm.created_at ASC, cm.seq ASC, rr.id ASC;
 

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const attachPlatformMCPOperationReceiptRegistration = `-- name: AttachPlatformMCPOperationReceiptRegistration :one
@@ -1838,6 +1839,46 @@ func (q *Queries) GetLatestRedeemedPlatformMCPSetupHandoff(ctx context.Context, 
 		&i.InvalidatedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getOwnedChatForRecall = `-- name: GetOwnedChatForRecall :one
+SELECT c.id, c.external_chat_id, c.title, c.cwd, c.updated_at, c.project_id
+FROM chats c
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE c.id = $1
+  AND c.organization_id = $2
+  AND c.user_id = $3::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+`
+
+type GetOwnedChatForRecallParams struct {
+	ChatID         uuid.UUID
+	OrganizationID string
+	UserID         string
+}
+
+type GetOwnedChatForRecallRow struct {
+	ID             uuid.UUID
+	ExternalChatID pgtype.Text
+	Title          pgtype.Text
+	Cwd            pgtype.Text
+	UpdatedAt      pgtype.Timestamptz
+	ProjectID      uuid.UUID
+}
+
+func (q *Queries) GetOwnedChatForRecall(ctx context.Context, arg GetOwnedChatForRecallParams) (GetOwnedChatForRecallRow, error) {
+	row := q.db.QueryRow(ctx, getOwnedChatForRecall, arg.ChatID, arg.OrganizationID, arg.UserID)
+	var i GetOwnedChatForRecallRow
+	err := row.Scan(
+		&i.ID,
+		&i.ExternalChatID,
+		&i.Title,
+		&i.Cwd,
+		&i.UpdatedAt,
+		&i.ProjectID,
 	)
 	return i, err
 }
@@ -3677,6 +3718,56 @@ func (q *Queries) HasPlatformMCPSelectedUseEvidence(ctx context.Context, arg Has
 	return exists, err
 }
 
+const insertChatSessionRecallLink = `-- name: InsertChatSessionRecallLink :exec
+INSERT INTO chat_session_links (
+  project_id, organization_id, parent_chat_id, child_chat_id,
+  parent_session_id, child_session_id, kind, target_harness, source_surface,
+  actor_email, device_serial, device_hostname
+) VALUES (
+  $1, $2, $3, $4,
+  $5, $6, 'recall', $7, $8,
+  $9, $10, $11
+)
+ON CONFLICT (project_id, parent_chat_id, child_chat_id) WHERE child_chat_id IS NOT NULL DO NOTHING
+`
+
+type InsertChatSessionRecallLinkParams struct {
+	ProjectID       uuid.UUID
+	OrganizationID  string
+	ParentChatID    uuid.UUID
+	ChildChatID     uuid.NullUUID
+	ParentSessionID string
+	ChildSessionID  pgtype.Text
+	TargetHarness   string
+	SourceSurface   pgtype.Text
+	ActorEmail      pgtype.Text
+	DeviceSerial    pgtype.Text
+	DeviceHostname  pgtype.Text
+}
+
+// Sibling of agent's InsertChatSessionLink with kind='recall'. A v1 recall
+// edge always has a NULL child: the OAuth principal carries no harness
+// session id, so the continuation is unknowable at recall time and each
+// recall records a distinct event. The ON CONFLICT clause is therefore inert
+// today (the partial unique index only covers non-NULL children) and kept
+// verbatim for forward safety.
+func (q *Queries) InsertChatSessionRecallLink(ctx context.Context, arg InsertChatSessionRecallLinkParams) error {
+	_, err := q.db.Exec(ctx, insertChatSessionRecallLink,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.ParentChatID,
+		arg.ChildChatID,
+		arg.ParentSessionID,
+		arg.ChildSessionID,
+		arg.TargetHarness,
+		arg.SourceSurface,
+		arg.ActorEmail,
+		arg.DeviceSerial,
+		arg.DeviceHostname,
+	)
+	return err
+}
+
 const invalidateActivePlatformMCPSetupHandoffs = `-- name: InvalidateActivePlatformMCPSetupHandoffs :execrows
 UPDATE platform_mcp_setup_handoffs
 SET invalidated_at = clock_timestamp(),
@@ -3787,6 +3878,171 @@ func (q *Queries) IsPlatformMCPNewModelEligible(ctx context.Context, organizatio
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
+}
+
+const listOwnedChatSessionsForRecall = `-- name: ListOwnedChatSessionsForRecall :many
+
+SELECT c.id, c.external_chat_id, c.title, c.summary, c.cwd, c.updated_at, c.project_id, p.name AS project_name, p.slug AS project_slug
+FROM chats c
+JOIN projects p ON p.id = c.project_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE c.organization_id = $1
+  AND c.user_id = $2::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+ORDER BY c.updated_at DESC
+LIMIT $3
+`
+
+type ListOwnedChatSessionsForRecallParams struct {
+	OrganizationID string
+	UserID         string
+	RowLimit       int32
+}
+
+type ListOwnedChatSessionsForRecallRow struct {
+	ID             uuid.UUID
+	ExternalChatID pgtype.Text
+	Title          pgtype.Text
+	Summary        pgtype.Text
+	Cwd            pgtype.Text
+	UpdatedAt      pgtype.Timestamptz
+	ProjectID      uuid.UUID
+	ProjectName    string
+	ProjectSlug    string
+}
+
+// Session recall (list_my_sessions / continue_session). Every read below
+// fuses tenancy and ownership into the row filter — organization, owner
+// user_id, not-deleted, and the personal-account exclusion — rather than
+// fetching then authorizing. An unresolved actor (empty user_id) matches no
+// rows because chats.user_id is never the empty string: fail-closed.
+// Personal-account sessions are excluded from BOTH list and continue:
+// personal-account ownership attribution is partly device-bridge-inferred,
+// which is acceptable for titles but not for transcripts (see the
+// ListOwnedChatSessionMeta warning in agent/queries.sql). The predicate
+// (ua.id IS NULL OR ua.account_type <> 'personal') also drops rows whose
+// account_type is NULL — the comparison evaluates to NULL — and that is
+// deliberate: an unclassified account might be personal, so it gets the
+// same fail-closed treatment.
+func (q *Queries) ListOwnedChatSessionsForRecall(ctx context.Context, arg ListOwnedChatSessionsForRecallParams) ([]ListOwnedChatSessionsForRecallRow, error) {
+	rows, err := q.db.Query(ctx, listOwnedChatSessionsForRecall, arg.OrganizationID, arg.UserID, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedChatSessionsForRecallRow
+	for rows.Next() {
+		var i ListOwnedChatSessionsForRecallRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ExternalChatID,
+			&i.Title,
+			&i.Summary,
+			&i.Cwd,
+			&i.UpdatedAt,
+			&i.ProjectID,
+			&i.ProjectName,
+			&i.ProjectSlug,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOwnedChatTranscriptMessagesForRecall = `-- name: ListOwnedChatTranscriptMessagesForRecall :many
+SELECT cm.id, cm.seq, cm.created_at, cm.role, cm.content, cm.content_asset_url, cm.tool_calls, cm.tool_call_id, cm.tool_urn, cm.source, cm.risk_analyzed_at
+FROM chat_messages cm
+JOIN chats c ON c.id = cm.chat_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+WHERE cm.chat_id = $1
+  AND cm.project_id = $2
+  AND c.organization_id = $3
+  AND c.user_id = $4::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND cm.generation = (
+    SELECT COALESCE(MAX(generation), 0)
+    FROM chat_messages
+    WHERE chat_id = $1
+      AND project_id = $2
+  )
+ORDER BY cm.created_at DESC, cm.seq DESC
+LIMIT $5
+`
+
+type ListOwnedChatTranscriptMessagesForRecallParams struct {
+	ChatID         uuid.UUID
+	ProjectID      uuid.NullUUID
+	OrganizationID string
+	UserID         string
+	RowLimit       int32
+}
+
+type ListOwnedChatTranscriptMessagesForRecallRow struct {
+	ID              uuid.UUID
+	Seq             int64
+	CreatedAt       pgtype.Timestamptz
+	Role            string
+	Content         string
+	ContentAssetUrl pgtype.Text
+	ToolCalls       []byte
+	ToolCallID      pgtype.Text
+	ToolUrn         urn.Tool
+	Source          pgtype.Text
+	RiskAnalyzedAt  pgtype.Timestamptz
+}
+
+// Latest generation only: compaction/edit rewrites bump chat_messages.generation
+// and the digest must reflect the current conversation view, not superseded
+// rows. chat_messages.project_id is NULL on old rows — always filtered, so
+// pre-project-stamp rows fail closed rather than leaking across tenants.
+// Newest rows first under @row_limit so the cap keeps the end of a long
+// session — the part a handoff digest is about — and the service restores
+// chronological order. Content is never truncated here: finding-span
+// verification compares exact bytes, so per-message bounding happens after
+// masking, not at the read.
+func (q *Queries) ListOwnedChatTranscriptMessagesForRecall(ctx context.Context, arg ListOwnedChatTranscriptMessagesForRecallParams) ([]ListOwnedChatTranscriptMessagesForRecallRow, error) {
+	rows, err := q.db.Query(ctx, listOwnedChatTranscriptMessagesForRecall,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedChatTranscriptMessagesForRecallRow
+	for rows.Next() {
+		var i ListOwnedChatTranscriptMessagesForRecallRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Seq,
+			&i.CreatedAt,
+			&i.Role,
+			&i.Content,
+			&i.ContentAssetUrl,
+			&i.ToolCalls,
+			&i.ToolCallID,
+			&i.ToolUrn,
+			&i.Source,
+			&i.RiskAnalyzedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listPlatformMCPClientConnectionsForUpdate = `-- name: ListPlatformMCPClientConnectionsForUpdate :many
@@ -4671,6 +4927,77 @@ func (q *Queries) ListPlatformMCPSubjectConnections(ctx context.Context, arg Lis
 			&i.AuthorizedAt,
 			&i.ReauthorizedAt,
 			&i.Ready,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRiskFindingSpansForRecall = `-- name: ListRiskFindingSpansForRecall :many
+SELECT rr.chat_message_id, rr.source, rr.rule_id, rr.match, rr.spans, rr.start_pos, rr.end_pos
+FROM risk_results rr
+JOIN chat_messages cm ON cm.id = rr.chat_message_id
+JOIN chats c ON c.id = cm.chat_id
+LEFT JOIN user_accounts ua ON ua.id = c.user_account_id
+JOIN risk_policies rp ON rp.id = rr.risk_policy_id AND rp.deleted IS FALSE AND rp.enabled IS TRUE
+WHERE cm.chat_id = $1
+  AND rr.project_id = $2
+  AND c.organization_id = $3
+  AND c.user_id = $4::text
+  AND c.deleted IS FALSE
+  AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
+ORDER BY cm.created_at ASC, cm.seq ASC, rr.id ASC
+`
+
+type ListRiskFindingSpansForRecallParams struct {
+	ChatID         uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	UserID         string
+}
+
+type ListRiskFindingSpansForRecallRow struct {
+	ChatMessageID uuid.NullUUID
+	Source        string
+	RuleID        pgtype.Text
+	Match         pgtype.Text
+	Spans         []byte
+	StartPos      pgtype.Int4
+	EndPos        pgtype.Int4
+}
+
+// Findings that drive inline masking of the recall digest. Message-anchored
+// rows only (the digest does not render content parts), with the canonical
+// suppression filters from risk's ListRiskResultsByChatFound: found, not
+// excluded, not swept as false positive, policy still enabled and not deleted.
+func (q *Queries) ListRiskFindingSpansForRecall(ctx context.Context, arg ListRiskFindingSpansForRecallParams) ([]ListRiskFindingSpansForRecallRow, error) {
+	rows, err := q.db.Query(ctx, listRiskFindingSpansForRecall,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.UserID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRiskFindingSpansForRecallRow
+	for rows.Next() {
+		var i ListRiskFindingSpansForRecallRow
+		if err := rows.Scan(
+			&i.ChatMessageID,
+			&i.Source,
+			&i.RuleID,
+			&i.Match,
+			&i.Spans,
+			&i.StartPos,
+			&i.EndPos,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -4951,6 +4951,12 @@ WHERE cm.chat_id = $1
   AND c.user_id = $4::text
   AND c.deleted IS FALSE
   AND (ua.id IS NULL OR ua.account_type <> 'personal')
+  AND cm.generation = (
+    SELECT COALESCE(MAX(generation), 0)
+    FROM chat_messages
+    WHERE chat_id = $1
+      AND project_id = $2
+  )
   AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
 ORDER BY cm.created_at ASC, cm.seq ASC, rr.id ASC
 `
@@ -4976,6 +4982,9 @@ type ListRiskFindingSpansForRecallRow struct {
 // rows only (the digest does not render content parts), with the canonical
 // suppression filters from risk's ListRiskResultsByChatFound: found, not
 // excluded, not swept as false positive, policy still enabled and not deleted.
+// Latest generation only, matching the transcript read: findings on
+// superseded generations mask nothing the digest renders, so loading them
+// would only let long, repeatedly compacted sessions inflate the scan.
 func (q *Queries) ListRiskFindingSpansForRecall(ctx context.Context, arg ListRiskFindingSpansForRecallParams) ([]ListRiskFindingSpansForRecallRow, error) {
 	rows, err := q.db.Query(ctx, listRiskFindingSpansForRecall,
 		arg.ChatID,

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -119,18 +119,18 @@ func NewRuntime(logger *slog.Logger, authenticator Authenticator, gate Gate, aut
 }
 
 func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService) *Runtime {
-	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	return NewRuntimeWithLifecycle(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 }
 
 // NewRuntimeWithLifecycle wires the Platform MCP onboarding lifecycle. Catalogue
 // selection remains server-validated: callers receive only search/inspect
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
-func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, candidate CatalogDescriptor) *Runtime {
+func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, candidate)
+	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, candidate)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/session_recall.go
+++ b/server/internal/platformmcp/session_recall.go
@@ -1,0 +1,700 @@
+package platformmcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/risk/maskdisplay"
+	"github.com/speakeasy-api/gram/server/internal/scanners"
+	"github.com/speakeasy-api/gram/server/internal/sessionhandoff"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// Sentinel refusals for the session-recall tools. Both map to structured
+// refusal payloads at the tool boundary rather than protocol errors.
+var (
+	errSessionRecallDisabled = errors.New("platform mcp session recall disabled")
+	// errSessionNotFound covers unknown ids AND ids owned by someone else with
+	// one message, so a caller cannot probe whether another user's session
+	// exists (GetMCP precedent).
+	errSessionNotFound = errors.New("platform mcp session not found")
+)
+
+// recallTargetHarness is the target recorded on the recall lineage edge: the
+// continuation happens wherever the Platform MCP client runs, which is the
+// only name the server can honestly record.
+const recallTargetHarness = "platform-mcp"
+
+// recallMessageRowCap bounds how many transcript rows one recall reads — the
+// newest rows, since a handoff digest is about where the session ended up. At
+// the renderer's 24 KiB recent-turns budget, rows beyond this many would only
+// be dropped again after being materialized; the cap also bounds worst-case
+// read volume against sessions holding many inline-threshold-sized messages.
+const recallMessageRowCap = 240
+
+// recallDigestByteCap is the hard bound on the serialized digest — a backstop
+// over the renderer's own per-section bounds, so no renderer regression can
+// ever return an unbounded document (2x the recent-turns budget, leaving room
+// for the bounded fixed sections).
+const recallDigestByteCap = 48 << 10
+
+// recallDigestTruncationMarker terminates a digest cut by recallDigestByteCap,
+// so a truncated document is never mistaken for a complete one.
+const recallDigestTruncationMarker = "\n\n[digest truncated: size cap reached]"
+
+// SessionRecallService serves the session-portability recall tools: listing
+// the caller's own captured coding-agent sessions and rendering one as a
+// redacted handoff digest so its work can continue in the current harness.
+//
+// Every read fuses tenancy and ownership into the SQL row filter (the queries
+// carry organization + owner user_id + not-deleted + the personal-account
+// exclusion), so there is no fetch-then-authorize step anywhere in this file.
+type SessionRecallService struct {
+	logger      *slog.Logger
+	db          *pgxpool.Pool
+	repo        *platformrepo.Queries
+	auditor     *audit.Logger
+	portability FeatureChecker
+	budget      OperationBudget
+}
+
+// NewSessionRecallService composes the recall entry points. A nil dependency
+// leaves the service invalid, which registers the unavailable stubs rather
+// than tools that always fail.
+func NewSessionRecallService(logger *slog.Logger, db *pgxpool.Pool, repo *platformrepo.Queries, auditor *audit.Logger, portability FeatureChecker, budget OperationBudget) *SessionRecallService {
+	return &SessionRecallService{
+		logger:      logger,
+		db:          db,
+		repo:        repo,
+		auditor:     auditor,
+		portability: portability,
+		budget:      budget,
+	}
+}
+
+func (s *SessionRecallService) valid() bool {
+	return s != nil && s.logger != nil && s.db != nil && s.repo != nil && s.auditor != nil && s.portability != nil && s.budget.valid()
+}
+
+type ListMySessionsInput struct {
+	Limit int `json:"limit,omitempty" jsonschema:"maximum number of sessions to return; server clamps this to 100"`
+}
+
+// RecallableSession is one captured session the caller owns — metadata only,
+// never transcript content.
+type RecallableSession struct {
+	SessionID   string `json:"session_id"`
+	ChatID      string `json:"chat_id"`
+	Title       string `json:"title,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	ProjectName string `json:"project_name"`
+	ProjectSlug string `json:"project_slug"`
+	Cwd         string `json:"cwd,omitempty"`
+	LastActive  string `json:"last_active"`
+}
+
+type ListMySessionsOutput struct {
+	Sessions []RecallableSession `json:"sessions"`
+}
+
+type ContinueSessionInput struct {
+	SessionID string `json:"session_id" jsonschema:"the session to recall — a session id from list_my_sessions"`
+}
+
+// ContinueSessionOutput carries the digest plus its fidelity as structured
+// fields; fidelity is never folded into the markdown prose.
+type ContinueSessionOutput struct {
+	Digest          string   `json:"digest"`
+	SourceSessionID string   `json:"source_session_id"`
+	ChatID          string   `json:"chat_id"`
+	NotCarriedOver  []string `json:"not_carried_over"`
+	Notes           []string `json:"notes"`
+}
+
+func (s *SessionRecallService) ListMySessions(ctx context.Context, principal Principal, input ListMySessionsInput) (ListMySessionsOutput, error) {
+	if !s.valid() {
+		return ListMySessionsOutput{Sessions: nil}, ErrUnavailable
+	}
+	if err := s.requirePortability(ctx, principal); err != nil {
+		return ListMySessionsOutput{Sessions: nil}, err
+	}
+	limit := boundedLimit(input.Limit)
+	rows, err := s.repo.ListOwnedChatSessionsForRecall(ctx, platformrepo.ListOwnedChatSessionsForRecallParams{
+		OrganizationID: principal.OrganizationID,
+		UserID:         principal.UserID,
+		RowLimit:       int32(limit), // #nosec G115 -- boundedLimit caps the value at 100.
+	})
+	if err != nil {
+		return ListMySessionsOutput{Sessions: nil}, fmt.Errorf("list owned sessions for recall: %w", err)
+	}
+	sessions := make([]RecallableSession, 0, len(rows))
+	for _, row := range rows {
+		sessions = append(sessions, RecallableSession{
+			SessionID:   sessionIDForChat(row.ExternalChatID, row.ID),
+			ChatID:      row.ID.String(),
+			Title:       conv.FromPGTextOrEmpty[string](row.Title),
+			Summary:     conv.FromPGTextOrEmpty[string](row.Summary),
+			ProjectName: row.ProjectName,
+			ProjectSlug: row.ProjectSlug,
+			Cwd:         conv.FromPGTextOrEmpty[string](row.Cwd),
+			LastActive:  row.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		})
+	}
+	return ListMySessionsOutput{Sessions: sessions}, nil
+}
+
+func (s *SessionRecallService) ContinueSession(ctx context.Context, principal Principal, input ContinueSessionInput) (ContinueSessionOutput, error) {
+	empty := ContinueSessionOutput{Digest: "", SourceSessionID: "", ChatID: "", NotCarriedOver: nil, Notes: nil}
+	if !s.valid() {
+		return empty, ErrUnavailable
+	}
+	if err := s.requirePortability(ctx, principal); err != nil {
+		return empty, err
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return empty, err
+	}
+	sessionID := strings.TrimSpace(input.SessionID)
+	if sessionID == "" {
+		return empty, fmt.Errorf("session_id is required")
+	}
+	// Session ids resolve through the same derivation the capture paths use —
+	// never by string-matching the raw id against a chat column.
+	chatID := chat.SessionIDToChatID(sessionID)
+
+	row, err := s.repo.GetOwnedChatForRecall(ctx, platformrepo.GetOwnedChatForRecallParams{
+		ChatID:         chatID,
+		OrganizationID: principal.OrganizationID,
+		UserID:         principal.UserID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return empty, errSessionNotFound
+	}
+	if err != nil {
+		return empty, fmt.Errorf("resolve owned session for recall: %w", err)
+	}
+
+	messages, err := s.repo.ListOwnedChatTranscriptMessagesForRecall(ctx, platformrepo.ListOwnedChatTranscriptMessagesForRecallParams{
+		ChatID:         chatID,
+		ProjectID:      uuid.NullUUID{UUID: row.ProjectID, Valid: true},
+		OrganizationID: principal.OrganizationID,
+		UserID:         principal.UserID,
+		RowLimit:       recallMessageRowCap,
+	})
+	if err != nil {
+		return empty, fmt.Errorf("read session transcript for recall: %w", err)
+	}
+	// The query serves the newest rows first so the cap keeps the session's
+	// tail; everything downstream expects chronological order.
+	cappedRead := len(messages) == recallMessageRowCap
+	slices.Reverse(messages)
+	findings, err := s.repo.ListRiskFindingSpansForRecall(ctx, platformrepo.ListRiskFindingSpansForRecallParams{
+		ChatID:         chatID,
+		ProjectID:      row.ProjectID,
+		OrganizationID: principal.OrganizationID,
+		UserID:         principal.UserID,
+	})
+	if err != nil {
+		return empty, fmt.Errorf("read risk findings for recall: %w", err)
+	}
+
+	masks := maskFindingSpans(messages, findings)
+	extract := turnsFromRows(messages, masks.content)
+
+	sourceSessionID := sessionIDForChat(row.ExternalChatID, row.ID)
+	handoff := sessionhandoff.Render(&sessionhandoff.Transcript{
+		Session: sessionhandoff.SessionMeta{
+			Title:        conv.FromPGTextOrEmpty[string](row.Title),
+			SessionID:    sourceSessionID,
+			ChatID:       chatID.String(),
+			Source:       valueOrUnknown(extract.source),
+			Cwd:          conv.FromPGTextOrEmpty[string](row.Cwd),
+			LastActivity: row.UpdatedAt.Time,
+		},
+		Turns: extract.turns,
+	}, sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+	if cappedRead {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, fmt.Sprintf("only the most recent %d messages were considered", recallMessageRowCap))
+	}
+	if extract.offloaded > 0 {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, fmt.Sprintf("%d large messages were offloaded to asset storage and are not included", extract.offloaded))
+	}
+	if extract.unanalyzed > 0 {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, fmt.Sprintf("%d messages are awaiting risk analysis; their content was withheld", extract.unanalyzed))
+	}
+	if masks.withheld > 0 {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, fmt.Sprintf("%d messages had findings that could not be masked precisely; their content was withheld", masks.withheld))
+	}
+	if extract.undecodedToolCalls > 0 {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, fmt.Sprintf("%d messages had tool activity that could not be decoded", extract.undecodedToolCalls))
+	}
+	digest, digestTruncated := truncateDigest(handoff.Markdown)
+	if digestTruncated {
+		handoff.Fidelity.Warnings = append(handoff.Fidelity.Warnings, "the digest exceeded the size cap and was truncated")
+	}
+
+	// The lineage edge and the governance record commit together BEFORE the
+	// digest is returned: failing to record the recall refuses the call rather
+	// than serving unrecorded content.
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return empty, oops.E(oops.CodeUnexpected, err, "record session recall").LogError(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	if err := platformrepo.New(dbtx).InsertChatSessionRecallLink(ctx, platformrepo.InsertChatSessionRecallLinkParams{
+		ProjectID:      row.ProjectID,
+		OrganizationID: principal.OrganizationID,
+		ParentChatID:   chatID,
+		// The OAuth principal carries no harness session id, so the
+		// continuation is unknowable at recall time: every recall records a
+		// distinct NULL-child edge. The digest byline's lineage marker is the
+		// retroactive correlation path.
+		ChildChatID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ParentSessionID: sessionID,
+		ChildSessionID:  conv.ToPGTextEmpty(""),
+		TargetHarness:   recallTargetHarness,
+		SourceSurface:   conv.ToPGText(string(principal.surface())),
+		// The OAuth path carries no email; the audit event's actor names the
+		// user.
+		ActorEmail:     conv.ToPGTextEmpty(""),
+		DeviceSerial:   conv.ToPGTextEmpty(""),
+		DeviceHostname: conv.ToPGTextEmpty(""),
+	}); err != nil {
+		return empty, oops.E(oops.CodeUnexpected, err, "record session recall link").LogError(ctx, s.logger)
+	}
+
+	if err := s.auditor.LogChatSessionRecall(ctx, dbtx, audit.LogChatSessionRecallEvent{
+		OrganizationID:     principal.OrganizationID,
+		ProjectID:          row.ProjectID,
+		Actor:              urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+		ChatSessionURN:     urn.NewChatSession(chatID),
+		ChatTitle:          conv.FromPGTextOrEmpty[string](row.Title),
+		OwnerUserID:        principal.UserID,
+		SourceSessionID:    sourceSessionID,
+		RedactToolPayloads: true,
+		FindingsMasked:     masks.neutralized,
+		UnanalyzedMessages: extract.unanalyzed,
+		DigestBytes:        len(digest),
+		TurnsIncluded:      handoff.TurnsIncluded,
+		TurnsDropped:       handoff.TurnsDropped,
+	}); err != nil {
+		return empty, oops.E(oops.CodeUnexpected, err, "record session recall").LogError(ctx, s.logger)
+	}
+
+	if err := dbtx.Commit(ctx); err != nil {
+		return empty, oops.E(oops.CodeUnexpected, err, "record session recall").LogError(ctx, s.logger)
+	}
+
+	return ContinueSessionOutput{
+		Digest:          digest,
+		SourceSessionID: sourceSessionID,
+		ChatID:          chatID.String(),
+		NotCarriedOver:  handoff.Fidelity.Missing,
+		Notes:           handoff.Fidelity.Warnings,
+	}, nil
+}
+
+// requirePortability fails closed: an error resolving the feature refuses the
+// call rather than defaulting the feature on.
+func (s *SessionRecallService) requirePortability(ctx context.Context, principal Principal) error {
+	enabled, err := s.portability(ctx, principal.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("resolve session portability feature: %w", err)
+	}
+	if !enabled {
+		return errSessionRecallDisabled
+	}
+	return nil
+}
+
+// sessionIDForChat prefers the harness-native session id the capture pipeline
+// recorded, falling back to the chat uuid (which IS the session id for chats
+// captured under a UUID session id).
+func sessionIDForChat(externalChatID pgtype.Text, chatID uuid.UUID) string {
+	if id := conv.FromPGTextOrEmpty[string](externalChatID); id != "" {
+		return id
+	}
+	return chatID.String()
+}
+
+func valueOrUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// findingSpanEntry mirrors one element of the risk_results.spans JSONB column
+// ({match,field,path,start_pos,end_pos} per the schema comment). Declared
+// locally so this package does not depend on the risk-analysis activity
+// package that writes it.
+type findingSpanEntry struct {
+	Match    string `json:"match"`
+	Field    string `json:"field"`
+	Path     string `json:"path"`
+	StartPos int    `json:"start_pos"`
+	EndPos   int    `json:"end_pos"`
+}
+
+// withheldContentPlaceholder replaces a message's entire prose when a finding
+// targeting it cannot be masked precisely — the fail-closed alternative to
+// serving content known to carry an un-applied finding.
+const withheldContentPlaceholder = "[content withheld: a risk finding could not be masked precisely]"
+
+// unanalyzedContentPlaceholder replaces a message's prose while its risk
+// analysis is still pending — the sweep is asynchronous and risk_analyzed_at
+// can be reset to NULL on an update, so prose without a completed analysis has
+// unknown findings and must not be served. Distinct from
+// withheldContentPlaceholder so the two withhold causes stay distinguishable.
+const unanalyzedContentPlaceholder = "[content withheld: risk analysis pending]"
+
+type contentMaskSpan struct {
+	start   int
+	end     int
+	display string
+	// match is the finding's recorded matched text. Offsets alone cannot be
+	// trusted: an in-range span over content that drifted since the scan
+	// would mask unrelated bytes while the actual finding survives elsewhere,
+	// so applyContentMasks refuses any span whose selected bytes differ.
+	match string
+}
+
+// findingMasks is maskFindingSpans's result: the substitute content per
+// affected message, the number of finding spans neutralized (masked in place
+// or covered by a whole-message withholding), and how many messages had their
+// prose withheld because a finding could not be masked precisely.
+type findingMasks struct {
+	content     map[uuid.UUID]string
+	neutralized int
+	withheld    int
+}
+
+// maskFindingSpans replaces every content-anchored finding span with
+// maskdisplay.Display's partial-mask form — byte-identical with what the
+// dashboard already shows masked, so the digest never reveals more than
+// existing UI. Fail-closed: a message with any finding that cannot be applied
+// exactly (undecodable or absent span data, offsets that don't fit the
+// content, overlapping spans, spans anchored somewhere other than the content
+// column) has its entire prose replaced by withheldContentPlaceholder rather
+// than served with a known finding unmasked.
+func maskFindingSpans(rows []platformrepo.ListOwnedChatTranscriptMessagesForRecallRow, findings []platformrepo.ListRiskFindingSpansForRecallRow) findingMasks {
+	out := findingMasks{content: nil, neutralized: 0, withheld: 0}
+	if len(findings) == 0 {
+		return out
+	}
+	type messageSpans struct {
+		spans       []contentMaskSpan
+		unappliable int
+	}
+	byMessage := make(map[uuid.UUID]*messageSpans)
+	for _, finding := range findings {
+		if !finding.ChatMessageID.Valid {
+			continue
+		}
+		ms := byMessage[finding.ChatMessageID.UUID]
+		if ms == nil {
+			ms = &messageSpans{spans: nil, unappliable: 0}
+			byMessage[finding.ChatMessageID.UUID] = ms
+		}
+		ruleID := conv.FromPGTextOrEmpty[string](finding.RuleID)
+		var entries []findingSpanEntry
+		if len(finding.Spans) > 0 && json.Unmarshal(finding.Spans, &entries) != nil {
+			// Span data exists but cannot be read.
+			ms.unappliable++
+			continue
+		}
+		if len(entries) == 0 {
+			if !finding.StartPos.Valid || !finding.EndPos.Valid {
+				// A finding with no span data at all cannot be masked.
+				ms.unappliable++
+				continue
+			}
+			// Legacy rows carry only the primary span.
+			entries = []findingSpanEntry{{
+				Match:    conv.FromPGTextOrEmpty[string](finding.Match),
+				Field:    "",
+				Path:     "",
+				StartPos: int(finding.StartPos.Int32),
+				EndPos:   int(finding.EndPos.Int32),
+			}}
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Field, "tool.") {
+				// Spans anchored in tool-call structures are never rendered:
+				// tool payloads are redacted unconditionally.
+				continue
+			}
+			switch scanners.FindingSurface(finding.Source, entry.Field, entry.Path) {
+			case scanners.SurfaceContent:
+				expected := entry.Match
+				if expected == "" {
+					// Older span entries omit the per-span match; the
+					// finding's primary match is the same text for them.
+					expected = conv.FromPGTextOrEmpty[string](finding.Match)
+				}
+				ms.spans = append(ms.spans, contentMaskSpan{
+					start:   entry.StartPos,
+					end:     entry.EndPos,
+					display: maskdisplay.Display(finding.Source, ruleID, entry.Match),
+					match:   expected,
+				})
+			case scanners.SurfaceDerived, scanners.SurfaceNone:
+				// Derived metadata (a tool name, an account email, a judge
+				// verdict): the offsets index no rendered text, and the
+				// dashboard shows these findings without masking prose.
+			default:
+				// json_path (offsets index a `.get(...)`-extracted sub-value,
+				// not the outer content) or an unrecognized attribution:
+				// cannot be applied precisely.
+				ms.unappliable++
+			}
+		}
+	}
+	out.content = make(map[uuid.UUID]string, len(byMessage))
+	for _, row := range rows {
+		ms, ok := byMessage[row.ID]
+		if !ok || (len(ms.spans) == 0 && ms.unappliable == 0) {
+			continue
+		}
+		if ms.unappliable == 0 {
+			if content, ok := applyContentMasks(row.Content, ms.spans); ok {
+				out.content[row.ID] = content
+				out.neutralized += len(ms.spans)
+				continue
+			}
+		}
+		out.content[row.ID] = withheldContentPlaceholder
+		out.neutralized += ms.unappliable + len(ms.spans)
+		out.withheld++
+	}
+	return out
+}
+
+// applyContentMasks rebuilds content with every span replaced by its display
+// form. Fail-closed: ok is false when any span cannot be applied exactly —
+// offsets outside the content, an empty or inverted range, spans that
+// partially overlap, or selected bytes that differ from the finding's
+// recorded match (in-range but stale offsets). Identical (start,end)
+// duplicates from separate findings target the same region and collapse into
+// one replacement.
+func applyContentMasks(content string, spans []contentMaskSpan) (string, bool) {
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end < spans[j].end
+	})
+	applied := make([]contentMaskSpan, 0, len(spans))
+	for _, span := range spans {
+		if span.start < 0 || span.end <= span.start || span.end > len(content) {
+			return "", false
+		}
+		if span.match == "" || content[span.start:span.end] != span.match {
+			return "", false
+		}
+		if n := len(applied); n > 0 {
+			prev := applied[n-1]
+			if span.start == prev.start && span.end == prev.end {
+				continue
+			}
+			if span.start < prev.end {
+				return "", false
+			}
+		}
+		applied = append(applied, span)
+	}
+	var b strings.Builder
+	b.Grow(len(content))
+	last := 0
+	for _, span := range applied {
+		b.WriteString(content[last:span.start])
+		b.WriteString(span.display)
+		last = span.end
+	}
+	b.WriteString(content[last:])
+	return b.String(), true
+}
+
+// transcriptTurns is what turnsFromRows extracts from the stored message rows.
+type transcriptTurns struct {
+	turns []sessionhandoff.Turn
+	// offloaded counts messages whose body lives in asset storage and is not
+	// included in the digest.
+	offloaded int
+	// unanalyzed counts messages risk analysis had not yet completed for;
+	// their prose is withheld (replaced by unanalyzedContentPlaceholder).
+	unanalyzed int
+	// undecodedToolCalls counts assistant messages whose recorded tool_calls
+	// payload carried tool activity that could not be decoded, so the digest
+	// is missing their tool names and touched files.
+	undecodedToolCalls int
+	// source is the latest message's capture surface, empty when none recorded.
+	source string
+}
+
+// turnsFromRows adapts chronological transcript rows to the renderer's neutral
+// turn model, substituting findings-masked content where available. Prose from
+// rows whose risk analysis has not completed is withheld (fail closed: its
+// findings are unknown); tool-call names from such rows still render, because
+// the recall path redacts tool payloads unconditionally and names come from
+// the tool_calls column, not the unanalyzed prose.
+func turnsFromRows(rows []platformrepo.ListOwnedChatTranscriptMessagesForRecallRow, masked map[uuid.UUID]string) transcriptTurns {
+	out := transcriptTurns{turns: make([]sessionhandoff.Turn, 0, len(rows)), offloaded: 0, unanalyzed: 0, undecodedToolCalls: 0, source: ""}
+	for _, row := range rows {
+		if row.Role == "system" {
+			continue
+		}
+		if source := strings.TrimSpace(conv.FromPGTextOrEmpty[string](row.Source)); source != "" {
+			// Rows are chronological, so the last non-empty source wins.
+			out.source = source
+		}
+		content := row.Content
+		if replacement, ok := masked[row.ID]; ok {
+			content = replacement
+		}
+		offloadedBody := content == "" && conv.FromPGTextOrEmpty[string](row.ContentAssetUrl) != ""
+		unanalyzed := !offloadedBody && content != "" && !row.RiskAnalyzedAt.Valid
+		if offloadedBody {
+			out.offloaded++
+		} else if unanalyzed {
+			out.unanalyzed++
+		}
+		at := row.CreatedAt.Time
+		switch row.Role {
+		case "user":
+			if offloadedBody {
+				continue
+			}
+			if text := chat.StripLeadingEnvelopes(content); strings.TrimSpace(text) != "" {
+				if unanalyzed {
+					text = unanalyzedContentPlaceholder
+				}
+				out.turns = append(out.turns, sessionhandoff.Turn{Role: "user", Text: text, ToolName: "", ToolInput: "", ToolResult: "", At: at})
+			}
+		case "assistant":
+			if !offloadedBody && strings.TrimSpace(content) != "" {
+				text := content
+				if unanalyzed {
+					text = unanalyzedContentPlaceholder
+				}
+				out.turns = append(out.turns, sessionhandoff.Turn{Role: "assistant", Text: text, ToolName: "", ToolInput: "", ToolResult: "", At: at})
+			}
+			calls, undecoded := decodeToolCalls(row.ToolCalls)
+			if undecoded {
+				out.undecodedToolCalls++
+			}
+			for _, call := range calls {
+				out.turns = append(out.turns, sessionhandoff.Turn{Role: "assistant", Text: "", ToolName: call.name, ToolInput: call.input, ToolResult: "", At: at})
+			}
+		case "tool":
+			if offloadedBody || content == "" {
+				continue
+			}
+			out.turns = append(out.turns, sessionhandoff.Turn{Role: "tool", Text: "", ToolName: "", ToolInput: "", ToolResult: content, At: at})
+		}
+	}
+	return out
+}
+
+type recalledToolCall struct {
+	name  string
+	input string
+}
+
+// decodeToolCalls extracts the tool invocations from a chat_messages.tool_calls
+// JSONB payload ([{id,type,function:{name,arguments}}]), unwrapping one level
+// of string encoding for payloads stored as a JSON string containing the
+// array. A malformed payload never fails the recall, but undecoded reports
+// when the payload carried tool activity that yielded no calls, so the
+// fidelity report can say tool context was lost instead of dropping it
+// silently.
+func decodeToolCalls(raw []byte) (calls []recalledToolCall, undecoded bool) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		var quoted string
+		if err := json.Unmarshal(raw, &quoted); err != nil {
+			return nil, true
+		}
+		if strings.TrimSpace(quoted) == "" {
+			return nil, false
+		}
+		if err := json.Unmarshal([]byte(quoted), &elements); err != nil {
+			return nil, true
+		}
+	}
+	out := make([]recalledToolCall, 0, len(elements))
+	skipped := 0
+	for _, element := range elements {
+		var call struct {
+			Function struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			} `json:"function"`
+		}
+		// Elements decode independently: one malformed entry means that
+		// call's activity was lost — the valid calls around it still render,
+		// and the loss reports.
+		if json.Unmarshal(element, &call) != nil || call.Function.Name == "" {
+			skipped++
+			continue
+		}
+		out = append(out, recalledToolCall{name: call.Function.Name, input: toolArgumentsText(call.Function.Arguments)})
+	}
+	return out, skipped > 0
+}
+
+// toolArgumentsText normalizes the OpenAI-style arguments value, which capture
+// stores as a JSON string containing the marshaled input, to the inner JSON
+// text. The recall path renders with tool payloads redacted, so this text
+// never reaches the digest; it rides on the neutral turn model for renderers
+// that do serve payloads.
+func toolArgumentsText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var quoted string
+	if err := json.Unmarshal(raw, &quoted); err == nil {
+		return quoted
+	}
+	return string(raw)
+}
+
+// truncateDigest enforces recallDigestByteCap on the rendered digest — a
+// backstop over the renderer's own bounds. The cut lands on a rune boundary
+// and the marker is appended within the cap, so the result is valid UTF-8 and
+// never exceeds recallDigestByteCap bytes.
+func truncateDigest(digest string) (string, bool) {
+	if len(digest) <= recallDigestByteCap {
+		return digest, false
+	}
+	keep := recallDigestByteCap - len(recallDigestTruncationMarker)
+	for keep > 0 && !utf8.RuneStart(digest[keep]) {
+		keep--
+	}
+	return digest[:keep] + recallDigestTruncationMarker, true
+}

--- a/server/internal/platformmcp/session_recall.go
+++ b/server/internal/platformmcp/session_recall.go
@@ -454,9 +454,12 @@ func maskFindingSpans(rows []platformrepo.ListOwnedChatTranscriptMessagesForReca
 					expected = conv.FromPGTextOrEmpty[string](finding.Match)
 				}
 				ms.spans = append(ms.spans, contentMaskSpan{
-					start:   entry.StartPos,
-					end:     entry.EndPos,
-					display: maskdisplay.Display(finding.Source, ruleID, entry.Match),
+					start: entry.StartPos,
+					end:   entry.EndPos,
+					// The resolved match, not entry.Match: a span entry with
+					// no per-span match would otherwise render an empty
+					// display, deleting the bytes instead of masking them.
+					display: maskdisplay.Display(finding.Source, ruleID, expected),
 					match:   expected,
 				})
 			case scanners.SurfaceDerived, scanners.SurfaceNone:

--- a/server/internal/platformmcp/session_recall_integration_test.go
+++ b/server/internal/platformmcp/session_recall_integration_test.go
@@ -171,6 +171,12 @@ func TestSessionRecallListReturnsOnlyOwnedSessions(t *testing.T) {
 	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, "ses_"+uuid.NewString(), "personal account session", uuid.NullUUID{UUID: personalAccountID, Valid: true})
 	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, "ses_"+uuid.NewString(), "unclassified account session", uuid.NullUUID{UUID: unclassifiedAccountID, Valid: true})
 
+	// A deleted chat the caller owns: the c.deleted IS FALSE predicate must
+	// drop it from the list and refuse a direct continue.
+	deletedSession := "ses_" + uuid.NewString()
+	deletedChatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, deletedSession, "deleted own session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+	require.NoError(t, testrepo.New(conn).SoftDeleteChatFixture(ctx, deletedChatID))
+
 	out, err := svc.ListMySessions(ctx, principal, ListMySessionsInput{Limit: 0})
 	require.NoError(t, err)
 	require.Len(t, out.Sessions, 2)
@@ -184,6 +190,10 @@ func TestSessionRecallListReturnsOnlyOwnedSessions(t *testing.T) {
 	require.Equal(t, ownedSession, byChatID[ownedChatID.String()].SessionID, "the harness-native session id is served, not the chat uuid")
 	require.Equal(t, "fix flaky auth test", byChatID[ownedChatID.String()].Title)
 	require.Equal(t, project.Slug, byChatID[ownedChatID.String()].ProjectSlug)
+	require.NotContains(t, byChatID, deletedChatID.String())
+
+	_, err = svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: deletedSession})
+	require.ErrorIs(t, err, errSessionNotFound, "a deleted own session refuses exactly like a foreign one")
 }
 
 // Cases 2, 3, and 4: the digest carries the lineage byline and the

--- a/server/internal/platformmcp/session_recall_integration_test.go
+++ b/server/internal/platformmcp/session_recall_integration_test.go
@@ -175,7 +175,7 @@ func TestSessionRecallListReturnsOnlyOwnedSessions(t *testing.T) {
 	// drop it from the list and refuse a direct continue.
 	deletedSession := "ses_" + uuid.NewString()
 	deletedChatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, deletedSession, "deleted own session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
-	require.NoError(t, testrepo.New(conn).SoftDeleteChatFixture(ctx, deletedChatID))
+	require.NoError(t, testrepo.New(conn).ForceSoftDeleteChat(ctx, deletedChatID))
 
 	out, err := svc.ListMySessions(ctx, principal, ListMySessionsInput{Limit: 0})
 	require.NoError(t, err)

--- a/server/internal/platformmcp/session_recall_integration_test.go
+++ b/server/internal/platformmcp/session_recall_integration_test.go
@@ -1,0 +1,460 @@
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/risk/maskdisplay"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func newRecallService(t *testing.T, conn *pgxpool.Pool, enabled *bool) *SessionRecallService {
+	t.Helper()
+	return NewSessionRecallService(testenv.NewLogger(t), conn, platformrepo.New(conn), audit.NewLogger(), func(_ context.Context, _ string) (bool, error) {
+		return *enabled, nil
+	}, allowBudget())
+}
+
+// seedRecallChat inserts a captured chat the way hook ingest records one: the
+// chat id derives from the session id, and the session id is stored as the
+// external chat id.
+func seedRecallChat(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID, userID, sessionID, title string, userAccountID uuid.NullUUID) uuid.UUID {
+	t.Helper()
+	chatID := chat.SessionIDToChatID(sessionID)
+	_, err := testrepo.New(conn).SeedCapturedAgentChatFixture(ctx, testrepo.SeedCapturedAgentChatFixtureParams{
+		ID:             chatID,
+		ProjectID:      projectID,
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+		ExternalChatID: conv.ToPGText(sessionID),
+		Title:          conv.ToPGText(title),
+		Cwd:            conv.ToPGText("/home/dev/code/api"),
+		UserAccountID:  userAccountID,
+	})
+	require.NoError(t, err)
+	return chatID
+}
+
+type recallMessageSeed struct {
+	role            string
+	content         string
+	at              time.Time
+	generation      int32
+	toolCalls       string
+	source          string
+	analyzed        bool
+	contentAssetURL string
+}
+
+func seedRecallMessage(t *testing.T, ctx context.Context, conn *pgxpool.Pool, chatID, projectID uuid.UUID, seed recallMessageSeed) uuid.UUID {
+	t.Helper()
+	var toolCalls []byte
+	if seed.toolCalls != "" {
+		toolCalls = []byte(seed.toolCalls)
+	}
+	analyzedAt := pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	if seed.analyzed {
+		analyzedAt = conv.ToPGTimestamptz(seed.at.Add(time.Minute))
+	}
+	id, err := testrepo.New(conn).SeedCapturedAgentChatMessageFixture(ctx, testrepo.SeedCapturedAgentChatMessageFixtureParams{
+		ChatID:          chatID,
+		ProjectID:       uuid.NullUUID{UUID: projectID, Valid: true},
+		Role:            seed.role,
+		Content:         seed.content,
+		Generation:      seed.generation,
+		ToolCalls:       toolCalls,
+		Source:          conv.ToPGTextEmpty(seed.source),
+		ContentAssetUrl: conv.ToPGTextEmpty(seed.contentAssetURL),
+		RiskAnalyzedAt:  analyzedAt,
+		CreatedAt:       conv.ToPGTimestamptz(seed.at),
+	})
+	require.NoError(t, err)
+	return id
+}
+
+// seedRecallFinding records one open finding against a message, under an
+// enabled policy, with the given content span.
+func seedRecallFinding(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID string, messageID uuid.UUID, source, ruleID, match string, start, end int) {
+	t.Helper()
+	policyID, err := testrepo.New(conn).SeedRiskPolicyFixture(ctx, testrepo.SeedRiskPolicyFixtureParams{
+		ProjectID:      projectID,
+		OrganizationID: organizationID,
+		Name:           "recall test policy " + uuid.NewString()[:8],
+		Sources:        []string{source},
+	})
+	require.NoError(t, err)
+	spans := `[{"match":"` + match + `","field":"content","start_pos":` + itoa(start) + `,"end_pos":` + itoa(end) + `}]`
+	_, err = testrepo.New(conn).SeedRiskResultFixture(ctx, testrepo.SeedRiskResultFixtureParams{
+		ProjectID:      projectID,
+		OrganizationID: organizationID,
+		RiskPolicyID:   policyID,
+		ChatMessageID:  uuid.NullUUID{UUID: messageID, Valid: true},
+		Source:         source,
+		RuleID:         conv.ToPGText(ruleID),
+		Match:          conv.ToPGText(match),
+		StartPos:       pgtype.Int4{Int32: int32(start), Valid: true}, // #nosec G115 -- test offsets are tiny.
+		EndPos:         pgtype.Int4{Int32: int32(end), Valid: true},   // #nosec G115 -- test offsets are tiny.
+		Spans:          []byte(spans),
+	})
+	require.NoError(t, err)
+}
+
+// seedRecallUserAccount inserts a provider account row; accountType is the
+// raw column value, so an invalid pgtype.Text seeds an unclassified (NULL
+// account_type) account.
+func seedRecallUserAccount(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, accountType pgtype.Text) uuid.UUID {
+	t.Helper()
+	id, err := testrepo.New(conn).SeedUserAccountFixture(ctx, testrepo.SeedUserAccountFixtureParams{
+		OrganizationID:      organizationID,
+		ExternalAccountUuid: "acct-" + uuid.NewString(),
+		AccountType:         accountType,
+	})
+	require.NoError(t, err)
+	return id
+}
+
+func countRecallLinks(t *testing.T, ctx context.Context, conn *pgxpool.Pool, parentChatID uuid.UUID) int64 {
+	t.Helper()
+	count, err := testrepo.New(conn).CountChatSessionLinksByKindFixture(ctx, testrepo.CountChatSessionLinksByKindFixtureParams{
+		ParentChatID: parentChatID,
+		Kind:         "recall",
+	})
+	require.NoError(t, err)
+	return count
+}
+
+// Case 1: the list serves exactly the principal's own non-deleted sessions on
+// non-personal accounts — a foreign owner, an unattributed (empty user_id)
+// chat, a personal-account chat, and an unclassified-account (NULL
+// account_type) chat are all excluded.
+func TestSessionRecallListReturnsOnlyOwnedSessions(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_list")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	ownedSession := "ses_" + uuid.NewString()
+	ownedChatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, ownedSession, "fix flaky auth test", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	teamAccountID := seedRecallUserAccount(t, ctx, conn, principal.OrganizationID, conv.ToPGText("team"))
+	personalAccountID := seedRecallUserAccount(t, ctx, conn, principal.OrganizationID, conv.ToPGText("personal"))
+	unclassifiedAccountID := seedRecallUserAccount(t, ctx, conn, principal.OrganizationID, conv.ToPGTextEmpty(""))
+
+	teamSession := uuid.NewString()
+	teamChatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, teamSession, "team account session", uuid.NullUUID{UUID: teamAccountID, Valid: true})
+
+	// None of these may appear in the listing. The unclassified (NULL
+	// account_type) account is excluded deliberately: it might be personal,
+	// and personal attribution is not transcript-grade.
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, "user_"+uuid.NewString(), "ses_"+uuid.NewString(), "not yours", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, "", "ses_"+uuid.NewString(), "unattributed", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, "ses_"+uuid.NewString(), "personal account session", uuid.NullUUID{UUID: personalAccountID, Valid: true})
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, "ses_"+uuid.NewString(), "unclassified account session", uuid.NullUUID{UUID: unclassifiedAccountID, Valid: true})
+
+	out, err := svc.ListMySessions(ctx, principal, ListMySessionsInput{Limit: 0})
+	require.NoError(t, err)
+	require.Len(t, out.Sessions, 2)
+
+	byChatID := map[string]RecallableSession{}
+	for _, session := range out.Sessions {
+		byChatID[session.ChatID] = session
+	}
+	require.Contains(t, byChatID, ownedChatID.String())
+	require.Contains(t, byChatID, teamChatID.String())
+	require.Equal(t, ownedSession, byChatID[ownedChatID.String()].SessionID, "the harness-native session id is served, not the chat uuid")
+	require.Equal(t, "fix flaky auth test", byChatID[ownedChatID.String()].Title)
+	require.Equal(t, project.Slug, byChatID[ownedChatID.String()].ProjectSlug)
+}
+
+// Cases 2, 3, and 4: the digest carries the lineage byline and the
+// findings-masked content but never the raw match; the lineage edge and the
+// content-free audit record commit together; and a repeat recall records a
+// second distinct NULL-child edge.
+func TestSessionRecallContinueMasksAndRecords(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_continue")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	sessionID := "ses_" + uuid.NewString()
+	chatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, sessionID, "fix flaky auth test", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	// AWS's documented example key id — the one fake the secret scanners
+	// (and GitHub push protection) recognize as fake; a novel AKIA string
+	// blocks the push.
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+	userContent := "Fix the login flow. My token is " + secret + " — rotate it."
+	base := time.Now().UTC().Add(-time.Hour)
+	userMessageID := seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: userContent, at: base, generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "assistant", content: "Working on it.", at: base.Add(time.Minute), generation: 0,
+		toolCalls: `[{"id":"call_1","type":"function","function":{"name":"Edit","arguments":"{\"file_path\":\"/repo/auth/login.go\"}"}}]`,
+		source:    "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "tool", content: "edit applied", at: base.Add(2 * time.Minute), generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "assistant", content: "Done. The login flow now refreshes tokens.", at: base.Add(3 * time.Minute), generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: "also check the signup page", at: base.Add(4 * time.Minute), generation: 0, toolCalls: "", source: "claude-code", analyzed: false, contentAssetURL: "",
+	})
+
+	start := strings.Index(userContent, secret)
+	seedRecallFinding(t, ctx, conn, project.ID, principal.OrganizationID, userMessageID, "gitleaks", "secret.aws_access_token", secret, start, start+len(secret))
+
+	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionChatSessionRecall)
+	require.NoError(t, err)
+
+	out, err := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.NoError(t, err)
+
+	// Case 2: byline lineage markers, masked span, no raw match, and nothing
+	// derived from tool inputs — the files-touched section is omitted under
+	// redaction and unanalyzed prose is withheld.
+	require.Contains(t, out.Digest, "source session "+sessionID)
+	require.Contains(t, out.Digest, "gram chat "+chatID.String())
+	masked := maskdisplay.Display("gitleaks", "secret.aws_access_token", secret)
+	require.Contains(t, out.Digest, masked, "the digest shows exactly the dashboard's partial-mask form")
+	require.NotContains(t, out.Digest, secret)
+	require.Contains(t, out.Digest, "- → Edit\n", "tool names are retained without input summaries")
+	require.NotContains(t, out.Digest, "/repo/auth/login.go", "paths come from tool inputs, which redaction must not read")
+	require.Contains(t, out.Digest, unanalyzedContentPlaceholder, "unanalyzed prose is withheld, not served")
+	require.Equal(t, sessionID, out.SourceSessionID)
+	require.Equal(t, chatID.String(), out.ChatID)
+	require.Contains(t, out.NotCarriedOver, "tool inputs and outputs (redacted; tool names retained)")
+	require.Contains(t, out.NotCarriedOver, "files touched (derived from tool inputs, which are redacted)")
+	require.Contains(t, out.Notes, "1 messages are awaiting risk analysis; their content was withheld")
+
+	// Case 3: one NULL-child recall edge and one content-free audit record,
+	// committed together.
+	edge, err := testrepo.New(conn).GetChatSessionLinkByParentFixture(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, "recall", edge.Kind)
+	require.False(t, edge.ChildChatID.Valid, "a v1 recall edge always has a NULL child")
+	require.Equal(t, sessionID, edge.ParentSessionID)
+	require.Equal(t, "platform-mcp", edge.TargetHarness)
+	require.Equal(t, principal.OrganizationID, edge.OrganizationID)
+	require.Equal(t, project.ID, edge.ProjectID)
+
+	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionChatSessionRecall)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionChatSessionRecall)
+	require.NoError(t, err)
+	require.Equal(t, chatID.String(), record.SubjectID)
+	require.Equal(t, "chat_session", record.SubjectType)
+	require.Equal(t, project.ID, record.ProjectID.UUID)
+	require.Equal(t, principal.UserID, record.ActorID)
+	metadata, err := audittest.DecodeAuditData(record.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, true, metadata["redact_tool_payloads"])
+	require.EqualValues(t, 1, metadata["findings_masked"])
+	require.EqualValues(t, 1, metadata["unanalyzed_messages"])
+	require.EqualValues(t, len(out.Digest), metadata["digest_bytes"])
+	require.EqualValues(t, 6, metadata["turns_included"])
+	require.EqualValues(t, 0, metadata["turns_dropped"])
+	require.Equal(t, sessionID, metadata["source_session_id"])
+	require.NotContains(t, string(record.Metadata), secret, "the audit record is content-free")
+
+	// Case 4: each recall is a distinct event — a second continue inserts a
+	// second NULL-child edge rather than deduplicating.
+	_, err = svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, countRecallLinks(t, ctx, conn, chatID))
+}
+
+// Case 4b: a finding whose offsets cannot be applied exactly withholds the
+// whole message rather than serving prose known to carry an unmasked finding,
+// and the fidelity notes say so.
+func TestSessionRecallContinueWithholdsWhenFindingCannotBeMasked(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_withheld")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	sessionID := "ses_" + uuid.NewString()
+	chatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, sessionID, "stale offsets session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	base := time.Now().UTC().Add(-time.Hour)
+	content := "prose with a finding the offsets no longer locate"
+	messageID := seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: content, at: base, generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	// Offsets beyond the content: the mask cannot be applied exactly.
+	seedRecallFinding(t, ctx, conn, project.ID, principal.OrganizationID, messageID, "gitleaks", "secret.generic", "stale", 1000, 1006)
+
+	out, err := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.NoError(t, err)
+
+	require.NotContains(t, out.Digest, content, "prose with an un-applied finding must never be served")
+	require.Contains(t, out.Digest, withheldContentPlaceholder)
+	require.Contains(t, out.Notes, "1 messages had findings that could not be masked precisely; their content was withheld")
+}
+
+// Case 5: with the feature disabled both tools refuse, and a refused continue
+// writes neither the edge nor the audit record.
+func TestSessionRecallRefusesWhenFeatureDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_disabled")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := false
+	svc := newRecallService(t, conn, &enabled)
+
+	sessionID := "ses_" + uuid.NewString()
+	chatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, sessionID, "gated session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionChatSessionRecall)
+	require.NoError(t, err)
+
+	_, err = svc.ListMySessions(ctx, principal, ListMySessionsInput{Limit: 0})
+	require.ErrorIs(t, err, errSessionRecallDisabled)
+	_, err = svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.ErrorIs(t, err, errSessionRecallDisabled)
+
+	require.EqualValues(t, 0, countRecallLinks(t, ctx, conn, chatID))
+	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionChatSessionRecall)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+// Case 6: another user's session, a personal-account session, an
+// unclassified-account session, and an unknown id all refuse with the same
+// not-found sentinel — no existence leak.
+func TestSessionRecallContinueHidesForeignAndUnknownSessions(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_not_found")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	foreignSession := "ses_" + uuid.NewString()
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, "user_"+uuid.NewString(), foreignSession, "not yours", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	personalAccountID := seedRecallUserAccount(t, ctx, conn, principal.OrganizationID, conv.ToPGText("personal"))
+	personalSession := "ses_" + uuid.NewString()
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, personalSession, "personal account session", uuid.NullUUID{UUID: personalAccountID, Valid: true})
+
+	unclassifiedAccountID := seedRecallUserAccount(t, ctx, conn, principal.OrganizationID, conv.ToPGTextEmpty(""))
+	unclassifiedSession := "ses_" + uuid.NewString()
+	seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, unclassifiedSession, "unclassified account session", uuid.NullUUID{UUID: unclassifiedAccountID, Valid: true})
+
+	_, foreignErr := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: foreignSession})
+	require.ErrorIs(t, foreignErr, errSessionNotFound)
+	_, personalErr := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: personalSession})
+	require.ErrorIs(t, personalErr, errSessionNotFound)
+	_, unclassifiedErr := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: unclassifiedSession})
+	require.ErrorIs(t, unclassifiedErr, errSessionNotFound, "an unclassified (NULL account_type) account gets the personal-account fail-closed treatment")
+	_, unknownErr := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: uuid.NewString()})
+	require.ErrorIs(t, unknownErr, errSessionNotFound)
+	require.Equal(t, foreignErr.Error(), unknownErr.Error(), "an existing foreign session and an unknown id are indistinguishable")
+}
+
+// Case 7: only the latest generation renders — superseded rows from before a
+// compaction or edit never reach the digest.
+// A session longer than the row cap reads only its newest rows: the evicted
+// head never reaches the digest and the fidelity notes say the view is
+// partial.
+func TestSessionRecallContinueCapsRowRead(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_rowcap")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	sessionID := "ses_" + uuid.NewString()
+	chatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, sessionID, "very long session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	base := time.Now().UTC().Add(-24 * time.Hour)
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: "EVICTED-HEAD original ask", at: base, generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	for i := range recallMessageRowCap {
+		seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+			role: "user", content: "filler turn " + strconv.Itoa(i), at: base.Add(time.Duration(i+1) * time.Minute), generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+		})
+	}
+
+	out, err := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.NoError(t, err)
+	require.NotContains(t, out.Digest, "EVICTED-HEAD", "rows beyond the cap are never read")
+	require.Contains(t, out.Notes, fmt.Sprintf("only the most recent %d messages were considered", recallMessageRowCap))
+}
+
+func TestSessionRecallContinueServesLatestGenerationOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_session_recall_generation")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	enabled := true
+	svc := newRecallService(t, conn, &enabled)
+
+	sessionID := "ses_" + uuid.NewString()
+	chatID := seedRecallChat(t, ctx, conn, project.ID, principal.OrganizationID, principal.UserID, sessionID, "compacted session", uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+
+	base := time.Now().UTC().Add(-time.Hour)
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: "SUPERSEDED-GENERATION-ZERO ask", at: base, generation: 0, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "user", content: "current generation ask", at: base.Add(time.Minute), generation: 1, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+	seedRecallMessage(t, ctx, conn, chatID, project.ID, recallMessageSeed{
+		role: "assistant", content: "current generation answer", at: base.Add(2 * time.Minute), generation: 1, toolCalls: "", source: "claude-code", analyzed: true, contentAssetURL: "",
+	})
+
+	out, err := svc.ContinueSession(ctx, principal, ContinueSessionInput{SessionID: sessionID})
+	require.NoError(t, err)
+	require.Contains(t, out.Digest, "current generation ask")
+	require.Contains(t, out.Digest, "current generation answer")
+	require.NotContains(t, out.Digest, "SUPERSEDED-GENERATION-ZERO")
+}

--- a/server/internal/platformmcp/skills_integration_test.go
+++ b/server/internal/platformmcp/skills_integration_test.go
@@ -344,7 +344,7 @@ func newSkillsVerticalFixture(t *testing.T, ctx context.Context, name string, op
 
 	runtime := NewRuntimeWithLifecycle(
 		logger, &testAuthenticator{principal: principal}, testGate{enabled: true}, &testAuthorizer{},
-		"", "test-cursor-key", nil, nil, nil, nil, nil, nil, nil, nil, skillsSurface, nil, nil, CatalogDescriptor{},
+		"", "test-cursor-key", nil, nil, nil, nil, nil, nil, nil, nil, skillsSurface, nil, nil, nil, CatalogDescriptor{},
 	)
 	server := httptest.NewServer(runtime.Handler())
 	t.Cleanup(server.Close)

--- a/server/internal/platformmcp/skills_test.go
+++ b/server/internal/platformmcp/skills_test.go
@@ -618,7 +618,7 @@ func TestSkillsToolsAreDeclaredWithAndWithoutTheirDependencies(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, test.build(), nil, nil, CatalogDescriptor{})
+			_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, test.build(), nil, nil, nil, CatalogDescriptor{})
 
 			registered := make(map[string]Descriptor, len(wanted))
 			for _, descriptor := range registrar.Descriptors() {

--- a/server/internal/platformmcp/tool_client_admission_test.go
+++ b/server/internal/platformmcp/tool_client_admission_test.go
@@ -13,7 +13,7 @@ import (
 func TestSetClientAdmissionRequiresConfirmationAndAValidMode(t *testing.T) {
 	t.Parallel()
 
-	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
 	descriptors := registrar.For(AudienceAssistant)
 	var found bool
 	for _, descriptor := range descriptors {

--- a/server/internal/platformmcp/tool_session_recall.go
+++ b/server/internal/platformmcp/tool_session_recall.go
@@ -1,0 +1,109 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// SessionRecaller is the narrow boundary the session-recall tools call through,
+// so unit tests can model the service without a database.
+type SessionRecaller interface {
+	ListMySessions(ctx context.Context, principal Principal, input ListMySessionsInput) (ListMySessionsOutput, error)
+	ContinueSession(ctx context.Context, principal Principal, input ContinueSessionInput) (ContinueSessionOutput, error)
+}
+
+func registerSessionRecallTools(reg *Registrar, svc SessionRecaller) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_my_sessions",
+		Title:       "List My Sessions",
+		Description: "List your own captured coding-agent sessions in this organization — titles, summaries, project, working directory, and last activity. Never returns other users' sessions and never returns transcript content; use continue_session to recall one.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListMySessionsInput) (*mcp.CallToolResult, ListMySessionsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, ListMySessionsOutput{}, err
+		}
+		if svc == nil {
+			return nil, ListMySessionsOutput{}, ErrUnavailable
+		}
+		output, err := svc.ListMySessions(ctx, principal, input)
+		if err != nil {
+			if result, ok := sessionRecallToolResult(err); ok {
+				return result, ListMySessionsOutput{}, nil
+			}
+			return nil, ListMySessionsOutput{}, fmt.Errorf("list my sessions: %w", err)
+		}
+		return nil, output, nil
+	})
+
+	// Deliberately NOT read-only: every successful call writes a lineage edge
+	// and an audit event, and the description says so.
+	addTool(reg, &mcp.Tool{
+		Name:        "continue_session",
+		Title:       "Continue Session",
+		Description: "Render a redacted handoff digest of one of your own previous sessions so its work can continue here. Sensitive values found by risk scanning appear masked, and tool inputs/outputs are omitted (tool names are retained). Every call records a lineage edge and an entry in the organization's audit log. This is not a transcript or log reader, and it cannot access other users' sessions.",
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ContinueSessionInput) (*mcp.CallToolResult, ContinueSessionOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, ContinueSessionOutput{}, err
+		}
+		if svc == nil {
+			return nil, ContinueSessionOutput{}, ErrUnavailable
+		}
+		output, err := svc.ContinueSession(ctx, principal, input)
+		if err != nil {
+			if result, ok := sessionRecallToolResult(err); ok {
+				return result, ContinueSessionOutput{}, nil
+			}
+			return nil, ContinueSessionOutput{}, fmt.Errorf("continue session: %w", err)
+		}
+		return nil, output, nil
+	})
+}
+
+// sessionRecallToolResult maps the recall sentinels to structured refusal
+// payloads, deferring everything else to the shared budget mapper.
+func sessionRecallToolResult(err error) (*mcp.CallToolResult, bool) {
+	var payload any
+	switch {
+	case errors.Is(err, errSessionRecallDisabled):
+		payload = featureUnavailableResult{
+			Code:    unavailableCode,
+			Feature: "session_portability",
+			Message: "Session recall is not enabled for this organization.",
+		}
+	case errors.Is(err, errSessionNotFound):
+		payload = operationBudgetResult{
+			Code:    "not_found",
+			Message: "This session was not found among your own captured sessions. Use list_my_sessions to see the sessions you can continue.",
+		}
+	default:
+		return operationBudgetToolResult(err)
+	}
+	content, marshalErr := json.Marshal(payload)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
+}
+
+// Each stub declares the audiences its live counterpart declares, so the tools
+// do not appear on and disappear from a surface as the rollout flips.
+func registerUnavailableSessionRecallTools(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_my_sessions",
+		Title:       "List My Sessions",
+		Description: "List your own captured coding-agent sessions. Session recall is not available in the current rollout.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, unavailableTool("session_recall"))
+	addTool(reg, &mcp.Tool{
+		Name:        "continue_session",
+		Title:       "Continue Session",
+		Description: "Recall one of your own previous sessions as a redacted handoff digest. Session recall is not available in the current rollout.",
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, unavailableTool("session_recall"))
+}

--- a/server/internal/platformmcp/tool_session_recall_test.go
+++ b/server/internal/platformmcp/tool_session_recall_test.go
@@ -302,6 +302,32 @@ func TestMaskFindingSpansWithholdsOnMissingMatchText(t *testing.T) {
 	require.Equal(t, withheldContentPlaceholder, masks.content[messageID])
 }
 
+// A span entry that omits its per-span match still masks with the finding's
+// primary match: the display must render the partial-mask form of that
+// resolved text, never an empty replacement that silently deletes the bytes.
+func TestMaskFindingSpansUsesResolvedMatchForDisplay(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "aaaaSECRETbbbb"
+	spans := `[{"field":"content","start_pos":4,"end_pos":10}]`
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Match:         pgtype.Text{String: "SECRET", Valid: true},
+			Spans:         []byte(spans),
+		}},
+	)
+
+	require.Equal(t, 0, masks.withheld)
+	expected := "aaaa" + maskdisplay.Display("gitleaks", "secret.generic", "SECRET") + "bbbb"
+	require.Equal(t, expected, masks.content[messageID], "the mask renders the resolved match's display form, not an empty replacement")
+}
+
 func TestMaskFindingSpansCollapsesIdenticalDuplicateSpans(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/tool_session_recall_test.go
+++ b/server/internal/platformmcp/tool_session_recall_test.go
@@ -1,0 +1,627 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/risk/maskdisplay"
+)
+
+type fakeSessionRecaller struct {
+	listOutput     ListMySessionsOutput
+	listErr        error
+	continueOutput ContinueSessionOutput
+	continueErr    error
+
+	lastPrincipal Principal
+	lastContinue  ContinueSessionInput
+}
+
+func (f *fakeSessionRecaller) ListMySessions(_ context.Context, principal Principal, _ ListMySessionsInput) (ListMySessionsOutput, error) {
+	f.lastPrincipal = principal
+	return f.listOutput, f.listErr
+}
+
+func (f *fakeSessionRecaller) ContinueSession(_ context.Context, principal Principal, input ContinueSessionInput) (ContinueSessionOutput, error) {
+	f.lastPrincipal = principal
+	f.lastContinue = input
+	return f.continueOutput, f.continueErr
+}
+
+func sessionRecallRegistrar(svc SessionRecaller) *Registrar {
+	registrar := newRegistrar(newTestMCPServer())
+	registerSessionRecallTools(registrar, svc)
+	return registrar
+}
+
+func TestListMySessionsToolServesSessions(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeSessionRecaller{listOutput: ListMySessionsOutput{Sessions: []RecallableSession{{
+		SessionID:   "ses_abc",
+		ChatID:      uuid.NewString(),
+		Title:       "fix flaky auth test",
+		Summary:     "",
+		ProjectName: "Default",
+		ProjectSlug: "default",
+		Cwd:         "/home/dev/code/api",
+		LastActive:  "2026-08-20T10:00:00Z",
+	}}}}
+	registrar := sessionRecallRegistrar(fake)
+
+	principal := registrationServicePrincipal()
+	result, err := descriptorByName(t, registrar, "list_my_sessions").Invoke(
+		ContextWithPrincipal(t.Context(), principal),
+		json.RawMessage(`{}`),
+	)
+
+	require.NoError(t, err)
+	output, ok := result.(ListMySessionsOutput)
+	require.True(t, ok)
+	require.Len(t, output.Sessions, 1)
+	require.Equal(t, "ses_abc", output.Sessions[0].SessionID)
+	require.Equal(t, principal, fake.lastPrincipal)
+}
+
+func TestContinueSessionToolServesDigest(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeSessionRecaller{continueOutput: ContinueSessionOutput{
+		Digest:          "# Session handoff — fix flaky auth test\n",
+		SourceSessionID: "ses_abc",
+		ChatID:          uuid.NewString(),
+		NotCarriedOver:  []string{"assistant thinking (not captured)"},
+		Notes:           nil,
+	}}
+	registrar := sessionRecallRegistrar(fake)
+
+	result, err := descriptorByName(t, registrar, "continue_session").Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"session_id":"ses_abc"}`),
+	)
+
+	require.NoError(t, err)
+	output, ok := result.(ContinueSessionOutput)
+	require.True(t, ok)
+	require.Equal(t, "ses_abc", output.SourceSessionID)
+	require.Equal(t, "ses_abc", fake.lastContinue.SessionID)
+}
+
+func TestSessionRecallToolsRefuseWhenFeatureDisabled(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeSessionRecaller{listErr: errSessionRecallDisabled, continueErr: errSessionRecallDisabled}
+	registrar := sessionRecallRegistrar(fake)
+	ctx := ContextWithPrincipal(t.Context(), registrationServicePrincipal())
+
+	for name, arguments := range map[string]string{
+		"list_my_sessions": `{}`,
+		"continue_session": `{"session_id":"ses_abc"}`,
+	} {
+		_, err := descriptorByName(t, registrar, name).Invoke(ctx, json.RawMessage(arguments))
+		var refusal *ToolRefusalError
+		require.ErrorAs(t, err, &refusal, "tool %q must refuse with a structured payload", name)
+		require.JSONEq(t, `{"code":"feature_unavailable","feature":"session_portability","message":"Session recall is not enabled for this organization."}`, refusal.Payload)
+	}
+}
+
+func TestContinueSessionToolRefusesUnknownSession(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeSessionRecaller{continueErr: errSessionNotFound}
+	registrar := sessionRecallRegistrar(fake)
+
+	_, err := descriptorByName(t, registrar, "continue_session").Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"session_id":"ses_missing"}`),
+	)
+
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	require.JSONEq(t, `{"code":"not_found","message":"This session was not found among your own captured sessions. Use list_my_sessions to see the sessions you can continue."}`, refusal.Payload)
+}
+
+func TestContinueSessionToolMapsBudgetErrors(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeSessionRecaller{continueErr: ErrOperationRateLimited}
+	registrar := sessionRecallRegistrar(fake)
+
+	_, err := descriptorByName(t, registrar, "continue_session").Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"session_id":"ses_abc"}`),
+	)
+
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	require.Contains(t, refusal.Payload, `"rate_limited"`)
+}
+
+func TestSessionRecallStubsRefuse(t *testing.T) {
+	t.Parallel()
+
+	registrar := newRegistrar(newTestMCPServer())
+	registerUnavailableSessionRecallTools(registrar)
+	ctx := ContextWithPrincipal(t.Context(), registrationServicePrincipal())
+
+	for name, arguments := range map[string]string{
+		"list_my_sessions": `{}`,
+		"continue_session": `{"session_id":"ses_abc"}`,
+	} {
+		descriptor := descriptorByName(t, registrar, name)
+		require.Equal(t, externalOnly, descriptor.Meta.Audiences, "stub for %q must declare the live tool's audiences", name)
+		_, err := descriptor.Invoke(ctx, json.RawMessage(arguments))
+		var refusal *ToolRefusalError
+		require.ErrorAs(t, err, &refusal)
+		require.JSONEq(t, `{"code":"feature_unavailable","feature":"session_recall","message":"This is not switched on for your organization yet."}`, refusal.Payload)
+	}
+}
+
+func TestSessionRecallToolsRequirePrincipal(t *testing.T) {
+	t.Parallel()
+
+	registrar := sessionRecallRegistrar(&fakeSessionRecaller{})
+
+	for name, arguments := range map[string]string{
+		"list_my_sessions": `{}`,
+		"continue_session": `{"session_id":"ses_abc"}`,
+	} {
+		_, err := descriptorByName(t, registrar, name).Invoke(t.Context(), json.RawMessage(arguments))
+		require.ErrorIs(t, err, ErrUnauthorized, "tool %q must refuse a principal-less call", name)
+	}
+}
+
+func recallMessageRow(id uuid.UUID, role, content string) platformrepo.ListOwnedChatTranscriptMessagesForRecallRow {
+	return platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{
+		ID:             id,
+		Role:           role,
+		Content:        content,
+		CreatedAt:      pgtype.Timestamptz{Time: time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC), InfinityModifier: pgtype.Finite, Valid: true},
+		RiskAnalyzedAt: pgtype.Timestamptz{Time: time.Date(2026, 8, 20, 11, 0, 0, 0, time.UTC), InfinityModifier: pgtype.Finite, Valid: true},
+	}
+}
+
+func TestMaskFindingSpansReplacesEverySpan(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "token AKIAIOSFODNN7EXAMPLE and email dev@acme.example end"
+	tokenStart := strings.Index(content, "AKIA")
+	emailStart := strings.Index(content, "dev@")
+	spans := `[
+		{"match":"AKIAIOSFODNN7EXAMPLE","field":"content","start_pos":` + itoa(tokenStart) + `,"end_pos":` + itoa(tokenStart+20) + `},
+		{"match":"dev@acme.example","field":"","start_pos":` + itoa(emailStart) + `,"end_pos":` + itoa(emailStart+16) + `}
+	]`
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.aws_access_token", Valid: true},
+			Match:         pgtype.Text{String: "AKIAIOSFODNN7EXAMPLE", Valid: true},
+			Spans:         []byte(spans),
+		}},
+	)
+
+	require.Equal(t, 2, masks.neutralized)
+	require.Equal(t, 0, masks.withheld)
+	tokenMask := maskdisplay.Display("gitleaks", "secret.aws_access_token", "AKIAIOSFODNN7EXAMPLE")
+	emailMask := maskdisplay.Display("gitleaks", "secret.aws_access_token", "dev@acme.example")
+	require.Equal(t, "token "+tokenMask+" and email "+emailMask+" end", masks.content[messageID])
+	require.NotContains(t, masks.content[messageID], "AKIAIOSFODNN7EXAMPLE")
+}
+
+func TestMaskFindingSpansWithholdsOnOverlapAndHostileOffsets(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "aaaaSECRETbbbb"
+	spans := `[
+		{"match":"SECRET","field":"content","start_pos":4,"end_pos":10},
+		{"match":"SECRETbb","field":"content","start_pos":4,"end_pos":12},
+		{"match":"out of range","field":"content","start_pos":100,"end_pos":120},
+		{"match":"negative","field":"content","start_pos":-3,"end_pos":2}
+	]`
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Spans:         []byte(spans),
+		}},
+	)
+
+	// Overlapping and out-of-range offsets cannot all be honored, so the
+	// whole message is withheld rather than served with a finding unmasked.
+	require.Equal(t, 1, masks.withheld)
+	require.Equal(t, 4, masks.neutralized)
+	require.Equal(t, withheldContentPlaceholder, masks.content[messageID])
+	require.NotContains(t, masks.content[messageID], "SECRET")
+}
+
+// Offsets that land in range but select different bytes than the finding's
+// recorded match mean the content drifted since the scan — masking those
+// bytes would leave the actual finding served elsewhere in the message, so
+// the whole message is withheld.
+func TestMaskFindingSpansWithholdsOnStaleOffsets(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "aaaaDRIFTYbbbb SECRET moved here"
+	spans := `[{"match":"SECRET","field":"content","start_pos":4,"end_pos":10}]`
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Spans:         []byte(spans),
+		}},
+	)
+
+	require.Equal(t, 1, masks.withheld)
+	require.Equal(t, withheldContentPlaceholder, masks.content[messageID])
+	require.NotContains(t, masks.content[messageID], "SECRET")
+}
+
+// A content span with no recorded match text anywhere (neither in the span
+// entry nor the finding's primary match) cannot be verified against the
+// content, so it withholds rather than masking on trust.
+func TestMaskFindingSpansWithholdsOnMissingMatchText(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "aaaaSECRETbbbb"
+	spans := `[{"field":"content","start_pos":4,"end_pos":10}]`
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Spans:         []byte(spans),
+		}},
+	)
+
+	require.Equal(t, 1, masks.withheld)
+	require.Equal(t, withheldContentPlaceholder, masks.content[messageID])
+}
+
+func TestMaskFindingSpansCollapsesIdenticalDuplicateSpans(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "aaaaSECRETbbbb"
+	rows := []platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)}
+	span := `[{"match":"SECRET","field":"content","start_pos":4,"end_pos":10}]`
+	finding := func(rule string) platformrepo.ListRiskFindingSpansForRecallRow {
+		return platformrepo.ListRiskFindingSpansForRecallRow{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: rule, Valid: true},
+			Spans:         []byte(span),
+		}
+	}
+
+	// Two policies flagging the same region mask it once — never a withhold.
+	masks := maskFindingSpans(rows, []platformrepo.ListRiskFindingSpansForRecallRow{finding("secret.generic"), finding("secret.other")})
+
+	require.Equal(t, 0, masks.withheld)
+	require.Equal(t, 2, masks.neutralized)
+	require.NotContains(t, masks.content[messageID], "SECRET")
+	require.True(t, strings.HasPrefix(masks.content[messageID], "aaaa"))
+	require.True(t, strings.HasSuffix(masks.content[messageID], "bbbb"))
+}
+
+func TestMaskFindingSpansWithholdsOnUnappliableSpanData(t *testing.T) {
+	t.Parallel()
+
+	content := "prose that carries a finding somewhere"
+	cases := map[string]platformrepo.ListRiskFindingSpansForRecallRow{
+		// A .get(...) span's offsets index the extracted sub-value, not the
+		// outer content.
+		"nested path": {Spans: []byte(`[{"match":"SECRET","field":"content","path":"config.token","start_pos":0,"end_pos":6}]`)},
+		// An unrecognized field could anchor anywhere.
+		"unknown field": {Spans: []byte(`[{"match":"SECRET","field":"mystery","start_pos":0,"end_pos":6}]`)},
+		// Span data that exists but cannot be decoded.
+		"undecodable spans": {Spans: []byte(`{"not":"an array"}`)},
+		// A finding with no span data at all cannot be masked.
+		"no span data": {Spans: nil},
+	}
+	for name, finding := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			messageID := uuid.New()
+			finding.ChatMessageID = uuid.NullUUID{UUID: messageID, Valid: true}
+			finding.Source = "gitleaks"
+			finding.RuleID = pgtype.Text{String: "secret.generic", Valid: true}
+
+			masks := maskFindingSpans(
+				[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+				[]platformrepo.ListRiskFindingSpansForRecallRow{finding},
+			)
+
+			require.Equal(t, 1, masks.withheld)
+			require.Equal(t, 1, masks.neutralized)
+			require.Equal(t, withheldContentPlaceholder, masks.content[messageID])
+		})
+	}
+}
+
+func TestMaskFindingSpansKeepsMultibyteContentIntact(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	prefix := "héllo wörld — "
+	secret := "SECRETVALUE123"
+	content := prefix + secret + " — döne"
+	start := strings.Index(content, secret)
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Spans:         []byte(`[{"match":"` + secret + `","field":"content","start_pos":` + itoa(start) + `,"end_pos":` + itoa(start+len(secret)) + `}]`),
+		}},
+	)
+
+	require.Equal(t, 1, masks.neutralized)
+	require.Equal(t, 0, masks.withheld)
+	display := maskdisplay.Display("gitleaks", "secret.generic", secret)
+	require.Equal(t, prefix+display+" — döne", masks.content[messageID])
+}
+
+func TestMaskFindingSpansFallsBackToPrimarySpan(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "the secret is HUSH42 today"
+	start := strings.Index(content, "HUSH42")
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "user", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Match:         pgtype.Text{String: "HUSH42", Valid: true},
+			Spans:         nil,
+			StartPos:      pgtype.Int4{Int32: int32(start), Valid: true},
+			EndPos:        pgtype.Int4{Int32: int32(start + 6), Valid: true},
+		}},
+	)
+
+	require.Equal(t, 1, masks.neutralized)
+	require.Equal(t, 0, masks.withheld)
+	require.NotContains(t, masks.content[messageID], "HUSH42")
+}
+
+func TestMaskFindingSpansIgnoresToolFieldSpans(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	content := "prose without the matched value"
+
+	masks := maskFindingSpans(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "assistant", content)},
+		[]platformrepo.ListRiskFindingSpansForRecallRow{{
+			ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+			Source:        "gitleaks",
+			RuleID:        pgtype.Text{String: "secret.generic", Valid: true},
+			Spans: []byte(`[
+				{"match":"SECRET","field":"tool.args","start_pos":0,"end_pos":6},
+				{"match":"delete_all","field":"tool.name","start_pos":0,"end_pos":10}
+			]`),
+		}},
+	)
+
+	// A tool-field span's offsets index the tool payload, not the content
+	// column, and tool payloads are redacted unconditionally anyway.
+	require.Equal(t, 0, masks.neutralized)
+	require.Equal(t, 0, masks.withheld)
+	require.Empty(t, masks.content)
+}
+
+// Derived-source findings (a flagged tool name, an account email, a judge
+// verdict) are persisted with empty field and zero offsets: their match is
+// derived metadata, not a slice of the prose, so the prose serves unmasked —
+// same as the dashboard — rather than being withheld.
+func TestMaskFindingSpansServesDerivedFindingsUnmasked(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{"destructive_tool", "shadow_mcp", "llm_judge"} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			messageID := uuid.New()
+			masks := maskFindingSpans(
+				[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{recallMessageRow(messageID, "assistant", "prose the finding does not anchor into")},
+				[]platformrepo.ListRiskFindingSpansForRecallRow{{
+					ChatMessageID: uuid.NullUUID{UUID: messageID, Valid: true},
+					Source:        source,
+					RuleID:        pgtype.Text{String: "rule.derived", Valid: true},
+					Match:         pgtype.Text{String: "derived-metadata", Valid: true},
+					Spans:         []byte(`[{"match":"derived-metadata","field":"","start_pos":0,"end_pos":0}]`),
+				}},
+			)
+
+			require.Equal(t, 0, masks.neutralized)
+			require.Equal(t, 0, masks.withheld)
+			require.Empty(t, masks.content)
+		})
+	}
+}
+
+func TestTurnsFromRowsAdaptsTranscript(t *testing.T) {
+	t.Parallel()
+
+	userID, assistantID, toolID, systemID, offloadedID, unanalyzedID := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	userRow := recallMessageRow(userID, "user", "<message-context>surface: claude-code</message-context>Fix the login flow")
+	userRow.Source = pgtype.Text{String: "claude-code", Valid: true}
+
+	assistantRow := recallMessageRow(assistantID, "assistant", "Working on it.")
+	assistantRow.ToolCalls = []byte(`[
+		{"id":"call_1","type":"function","function":{"name":"Edit","arguments":"{\"file_path\":\"/repo/auth/login.go\"}"}},
+		{"id":"call_2","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"go test ./...\"}"}}
+	]`)
+
+	toolRow := recallMessageRow(toolID, "tool", "edit applied")
+
+	systemRow := recallMessageRow(systemID, "system", "system prompt that must not surface")
+
+	offloadedRow := recallMessageRow(offloadedID, "user", "")
+	offloadedRow.ContentAssetUrl = pgtype.Text{String: "https://assets.example/blob", Valid: true}
+
+	unanalyzedRow := recallMessageRow(unanalyzedID, "user", "also check signup")
+	unanalyzedRow.RiskAnalyzedAt = pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+
+	extract := turnsFromRows([]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{
+		userRow, assistantRow, toolRow, systemRow, offloadedRow, unanalyzedRow,
+	}, nil)
+
+	require.Equal(t, 1, extract.offloaded)
+	require.Equal(t, 1, extract.unanalyzed)
+	require.Equal(t, "claude-code", extract.source)
+
+	require.Len(t, extract.turns, 6)
+	require.Equal(t, "user", extract.turns[0].Role)
+	require.Equal(t, "Fix the login flow", extract.turns[0].Text, "harness envelopes are stripped from user prose")
+	require.Equal(t, "Working on it.", extract.turns[1].Text)
+	require.Equal(t, "Edit", extract.turns[2].ToolName)
+	require.JSONEq(t, `{"file_path":"/repo/auth/login.go"}`, extract.turns[2].ToolInput, "arguments are unquoted to the inner JSON text")
+	require.Equal(t, "Bash", extract.turns[3].ToolName)
+	require.Equal(t, "edit applied", extract.turns[4].ToolResult)
+	require.Equal(t, unanalyzedContentPlaceholder, extract.turns[5].Text,
+		"prose without a completed risk analysis is withheld, not served with a warning")
+}
+
+// truncateDigest is the hard backstop over the renderer's per-section bounds:
+// the returned document never exceeds the cap, cuts on a rune boundary, and
+// always ends with the explicit truncation marker.
+func TestTruncateDigestEnforcesHardCap(t *testing.T) {
+	t.Parallel()
+
+	small, truncated := truncateDigest("short digest")
+	require.False(t, truncated)
+	require.Equal(t, "short digest", small)
+
+	// Multibyte content across the cut point must back off to a rune start:
+	// with a 3-byte rune the cap arithmetic lands the cut mid-rune, so the
+	// back-off branch is actually exercised.
+	huge := strings.Repeat("€", recallDigestByteCap)
+	capped, truncated := truncateDigest(huge)
+	require.True(t, truncated)
+	require.LessOrEqual(t, len(capped), recallDigestByteCap)
+	require.True(t, strings.HasSuffix(capped, recallDigestTruncationMarker))
+	require.True(t, utf8.ValidString(capped), "truncation must not split a rune")
+}
+
+func TestTurnsFromRowsUnwrapsStringEncodedToolCalls(t *testing.T) {
+	t.Parallel()
+
+	array := `[{"id":"call_1","type":"function","function":{"name":"Edit","arguments":"{\"file_path\":\"/repo/auth/login.go\"}"}}]`
+	// The whole array stored double-encoded, as a JSON string.
+	wrapped, err := json.Marshal(array)
+	require.NoError(t, err)
+
+	row := recallMessageRow(uuid.New(), "assistant", "Working on it.")
+	row.ToolCalls = wrapped
+
+	extract := turnsFromRows([]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{row}, nil)
+
+	require.Equal(t, 0, extract.undecodedToolCalls)
+	require.Len(t, extract.turns, 2)
+	require.Equal(t, "Edit", extract.turns[1].ToolName)
+	require.JSONEq(t, `{"file_path":"/repo/auth/login.go"}`, extract.turns[1].ToolInput)
+}
+
+// Which tool_calls payload shapes count as lost tool activity: payloads that
+// carry entries but decode to no usable calls are counted (never dropped
+// silently), while genuinely empty payloads are not.
+func TestTurnsFromRowsCountsUndecodableToolCalls(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		payload       []byte
+		wantUndecoded int
+	}{
+		"not an array":         {payload: []byte(`{"not":"an array"}`), wantUndecoded: 1},
+		"entries lack names":   {payload: []byte(`[{"id":"call_1"}]`), wantUndecoded: 1},
+		"garbage":              {payload: []byte(`not json at all`), wantUndecoded: 1},
+		"absent":               {payload: nil, wantUndecoded: 0},
+		"json null":            {payload: []byte(`null`), wantUndecoded: 0},
+		"empty array":          {payload: []byte(`[]`), wantUndecoded: 0},
+		"wrapped empty array":  {payload: []byte(`"[]"`), wantUndecoded: 0},
+		"wrapped empty string": {payload: []byte(`""`), wantUndecoded: 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			row := recallMessageRow(uuid.New(), "assistant", "Working on it.")
+			row.ToolCalls = tc.payload
+
+			extract := turnsFromRows([]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{row}, nil)
+
+			require.Equal(t, tc.wantUndecoded, extract.undecodedToolCalls)
+			require.Len(t, extract.turns, 1, "only the prose turn survives")
+			require.Empty(t, extract.turns[0].ToolName)
+		})
+	}
+}
+
+// A payload mixing valid and malformed entries keeps the valid calls in the
+// digest while still reporting the malformed ones as lost tool activity.
+func TestTurnsFromRowsKeepsValidCallsAmongMalformed(t *testing.T) {
+	t.Parallel()
+
+	row := recallMessageRow(uuid.New(), "assistant", "Working on it.")
+	row.ToolCalls = []byte(`[
+		{"id":"call_1","type":"function","function":{"name":"Edit","arguments":"{}"}},
+		{"id":"call_2","type":"function","function":{"arguments":"{}"}},
+		42
+	]`)
+
+	extract := turnsFromRows([]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{row}, nil)
+
+	require.Equal(t, 1, extract.undecodedToolCalls)
+	require.Len(t, extract.turns, 2)
+	require.Equal(t, "Edit", extract.turns[1].ToolName)
+}
+
+func TestTurnsFromRowsSubstitutesMaskedContent(t *testing.T) {
+	t.Parallel()
+
+	messageID := uuid.New()
+	row := recallMessageRow(messageID, "user", "raw secret content")
+
+	extract := turnsFromRows(
+		[]platformrepo.ListOwnedChatTranscriptMessagesForRecallRow{row},
+		map[uuid.UUID]string{messageID: "masked content"},
+	)
+
+	require.Len(t, extract.turns, 1)
+	require.Equal(t, "masked content", extract.turns[0].Text)
+}
+
+func itoa(v int) string {
+	return strconv.Itoa(v)
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -148,7 +148,7 @@ type operationBudgetResult struct {
 // registrar alongside the server so another admitted audience — the project
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
-func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -266,6 +266,11 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 		registerUnavailablePluginTools(reg)
 	} else {
 		registerPluginTools(reg, plugins)
+	}
+	if !sessionRecall.valid() {
+		registerUnavailableSessionRecallTools(reg)
+	} else {
+		registerSessionRecallTools(reg, sessionRecall)
 	}
 	if feedback == nil {
 		addTool(reg, &mcp.Tool{

--- a/server/internal/sessionhandoff/render.go
+++ b/server/internal/sessionhandoff/render.go
@@ -1,0 +1,431 @@
+// Package sessionhandoff renders a captured Gram chat transcript into a
+// deterministic markdown handoff digest — the document served to a harness
+// that wants to continue a previous session's work. No LLM sits in this path:
+// the same transcript always renders the same digest, which is what makes the
+// FidelityReport trustworthy.
+//
+// The renderer is a stdlib-only port of the device-agent handoff renderer
+// (core/sessionport, ADR-0018 session portability), adapted to transcripts
+// recalled from Gram's capture store rather than a harness's native session
+// file.
+package sessionhandoff
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// DefaultBudget bounds the "what has happened so far" section, in bytes of
+// rendered output (a rough proxy for tokens). The task statement and the
+// final assistant message are always included on top of it.
+const DefaultBudget = 24 << 10
+
+// emptyRecentMarker stands in for the recent-turns section when nothing fits
+// or nothing was recorded. Its length is the effective minimum budget: a
+// positive Options.Budget below it is raised so the section never exceeds its
+// documented bound just to hold the marker.
+const emptyRecentMarker = "(nothing recorded)\n"
+
+// maxSummaryLine bounds one-line tool summaries inside the handoff.
+const maxSummaryLine = 120
+
+// maxTitleRunes bounds the rendered title's rune length.
+const maxTitleRunes = 96
+
+// maxContextSection bounds the Original-task and Where-things-stand sections
+// in bytes. Both render outside the recent-turns budget, so without their own
+// bound a single huge message would blow the document past every advertised
+// limit.
+const maxContextSection = 4 << 10
+
+// maxMetaField bounds caller-supplied byline fields and extracted file paths
+// in bytes — all of them render outside the recent-turns budget and none is
+// trustworthy-length input.
+const maxMetaField = 512
+
+// SessionMeta identifies the captured session a transcript came from.
+type SessionMeta struct {
+	// Title is the session's display title (chats.title), resolved by the
+	// caller. Empty falls back to SessionID in the rendered document.
+	Title string
+
+	// SessionID is the harness-native session identifier the capture pipeline
+	// recorded (external_chat_id), falling back to the chat uuid.
+	SessionID string
+
+	// ChatID is the Gram chat uuid the transcript was recalled from.
+	ChatID string
+
+	// Source is the harness that produced the session (a capture surface slug
+	// such as "claude-code").
+	Source string
+
+	// Cwd is the working directory the session ran in, when recorded.
+	Cwd string
+
+	// LastActivity is when the chat was last updated.
+	LastActivity time.Time
+}
+
+// Turn is one step of the neutral transcript.
+type Turn struct {
+	// Role is "user", "assistant", or "tool" (a tool result).
+	Role string
+
+	// Text is the turn's prose, when it has any.
+	Text string
+
+	// ToolName and ToolInput describe a tool invocation requested by the
+	// assistant. Both are verbatim strings — the renderer decides how to
+	// compress or redact them.
+	ToolName  string
+	ToolInput string
+
+	// ToolResult carries a tool turn's output, verbatim.
+	ToolResult string
+
+	// At is the turn's timestamp, zero when not recorded.
+	At time.Time
+}
+
+// Transcript is a fully assembled session recall.
+type Transcript struct {
+	Session SessionMeta
+	Turns   []Turn
+}
+
+// FidelityReport states what the handoff does not carry. It is surfaced as
+// structured fields next to the digest: the product promise is "continue with
+// your full context", never "identical session".
+type FidelityReport struct {
+	// Missing lists content categories absent from the handoff.
+	Missing []string
+
+	// Warnings lists degradations short of missing content.
+	Warnings []string
+}
+
+// Handoff is a rendered handoff document plus the honesty report that goes
+// with it.
+type Handoff struct {
+	Markdown string
+	Fidelity FidelityReport
+
+	// TurnsIncluded and TurnsDropped account for the recent-turns section
+	// numerically — how many transcript turns fit the budget and how many fell
+	// outside it — so callers can record content-free counters (audit) without
+	// re-parsing the FidelityReport's prose.
+	TurnsIncluded int
+	TurnsDropped  int
+}
+
+// Options controls how Render compresses and redacts the transcript.
+type Options struct {
+	// Budget bounds the recent-turns section in bytes; <= 0 uses
+	// DefaultBudget, and positive values are raised to the length of the
+	// section's empty-state marker so the bound always holds.
+	Budget int
+
+	// RedactToolPayloads drops tool inputs and outputs from the digest,
+	// keeping tool names only. The files-touched section is omitted too: it is
+	// derived from tool inputs, which redaction must not read.
+	RedactToolPayloads bool
+}
+
+// Render produces the handoff document for a recalled transcript.
+func Render(t *Transcript, opts Options) Handoff {
+	budget := opts.Budget
+	if budget <= 0 {
+		budget = DefaultBudget
+	}
+	if budget < len(emptyRecentMarker) {
+		budget = len(emptyRecentMarker)
+	}
+
+	fidelity := FidelityReport{
+		// The capture pipeline never records assistant thinking, and it
+		// stores each turn's final assistant message only.
+		Missing: []string{
+			"assistant thinking (not captured)",
+			"intermediate assistant messages within turns (capture records each turn's final message only)",
+		},
+		Warnings: []string{
+			"rendered from Gram's captured transcript, not the harness's native session file; lower fidelity than a device-local move",
+		},
+	}
+	if opts.RedactToolPayloads {
+		fidelity.Missing = append(fidelity.Missing,
+			"tool inputs and outputs (redacted; tool names retained)",
+			"files touched (derived from tool inputs, which are redacted)",
+		)
+	}
+	if t.Session.Cwd == "" {
+		fidelity.Warnings = append(fidelity.Warnings, "working directory was not captured for this session")
+	}
+	if len(t.Turns) == 0 {
+		fidelity.Warnings = append(fidelity.Warnings, "transcript is empty; handoff carries metadata only")
+	}
+
+	firstPrompt := firstUserText(t.Turns)
+	if bounded := clip(firstPrompt, maxContextSection); bounded != firstPrompt {
+		firstPrompt = bounded
+		fidelity.Warnings = append(fidelity.Warnings, "the original task statement was too large and appears clipped")
+	}
+	lastAssistant := lastAssistantText(t.Turns)
+	if bounded := clip(lastAssistant, maxContextSection); bounded != lastAssistant {
+		lastAssistant = bounded
+		fidelity.Warnings = append(fidelity.Warnings, "the final assistant message was too large and appears clipped")
+	}
+
+	recent, dropped, clipped := renderRecent(t.Turns, budget, opts.RedactToolPayloads)
+	if dropped > 0 {
+		fidelity.Missing = append(fidelity.Missing, fmt.Sprintf("%d earlier turns beyond the handoff budget", dropped))
+	}
+	if clipped {
+		// The turn is present but shortened, so this is a degradation
+		// rather than absent content — either way the report must say so.
+		fidelity.Warnings = append(fidelity.Warnings, "the most recent turn was too large for the handoff budget and appears clipped")
+	}
+
+	// Under redaction the section is omitted entirely (and reported missing
+	// above) rather than derived from inputs the caller asked us not to read.
+	var files []string
+	if !opts.RedactToolPayloads {
+		files = filesTouched(t.Turns)
+	}
+
+	var b strings.Builder
+	title := t.Session.Title
+	if title == "" {
+		title = t.Session.SessionID
+	}
+	fmt.Fprintf(&b, "# Session handoff — %s\n\n", truncateTitle(title))
+	// The source session id is the lineage marker: it lands in the
+	// continuation's own context/transcript, so a continuation whose new id
+	// nobody could know at recall time can still be tied back to its origin
+	// later. The gram chat uuid rides next to it for the same reason.
+	fmt.Fprintf(&b, "Recalled from %s · source session %s · gram chat %s · project: %s · last active %s · via Gram\n\n",
+		clip(t.Session.Source, maxMetaField), clip(t.Session.SessionID, maxMetaField), t.Session.ChatID,
+		clip(valueOr(t.Session.Cwd, "(unknown)"), maxMetaField), t.Session.LastActivity.Format("2006-01-02 15:04 MST"))
+
+	b.WriteString("## Original task\n\n")
+	b.WriteString(valueOr(firstPrompt, "(no user prompt recorded)"))
+	b.WriteString("\n\n")
+
+	b.WriteString("## What has happened so far\n\n")
+	if recent == "" {
+		b.WriteString(emptyRecentMarker)
+	} else {
+		b.WriteString(recent)
+	}
+	b.WriteString("\n")
+
+	if len(files) > 0 {
+		b.WriteString("## Files touched\n\n")
+		for _, f := range files {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("## Where things stand\n\n")
+	b.WriteString(valueOr(lastAssistant, "(no assistant message recorded)"))
+	b.WriteString("\n\n")
+
+	b.WriteString("## Instruction\n\n")
+	b.WriteString("This context was recalled from a previous session. Treat it as background for the current conversation: confirm your understanding of where that work stood in one short paragraph, then continue with the user's current request.\n")
+
+	return Handoff{
+		Markdown:      b.String(),
+		Fidelity:      fidelity,
+		TurnsIncluded: len(t.Turns) - dropped,
+		TurnsDropped:  dropped,
+	}
+}
+
+// renderRecent walks turns newest-first, accumulating rendered entries until
+// the byte budget is exhausted, then restores chronological order. It returns
+// the section body, how many turns fell outside the budget, and whether the
+// newest turn had to be clipped to fit — every way this drops content, so the
+// FidelityReport can account for all of them.
+func renderRecent(turns []Turn, budget int, redactToolPayloads bool) (body string, dropped int, clipped bool) {
+	var entries []string
+	used := 0
+	included := 0
+	for i := len(turns) - 1; i >= 0; i-- {
+		entry := renderTurn(turns[i], redactToolPayloads)
+		if entry == "" {
+			included++ // skipped-by-content turns don't count as lost
+			continue
+		}
+		if used+len(entry) > budget {
+			// Guard on entries, not included: a leading run of content-empty
+			// turns (empty or redacted tool results) must not suppress the
+			// newest real turn.
+			if len(entries) > 0 {
+				return joinReversed(entries), len(turns) - included, clipped
+			}
+			// Keep that newest turn, but bound it — one oversized turn
+			// must not blow the budget the section advertises.
+			entry = strings.TrimRight(clip(entry, budget-1), "\n") + "\n"
+			clipped = true
+		}
+		entries = append(entries, entry)
+		used += len(entry)
+		included++
+	}
+	return joinReversed(entries), 0, clipped
+}
+
+func joinReversed(entries []string) string {
+	var b strings.Builder
+	for i := len(entries) - 1; i >= 0; i-- {
+		b.WriteString(entries[i])
+	}
+	return b.String()
+}
+
+// renderTurn renders one turn: prose verbatim, tool traffic as one-liners.
+// Under redaction, tool invocations keep their name only and tool results are
+// dropped entirely.
+func renderTurn(t Turn, redactToolPayloads bool) string {
+	switch {
+	case t.ToolName != "":
+		if redactToolPayloads {
+			return fmt.Sprintf("- → %s\n", t.ToolName)
+		}
+		return fmt.Sprintf("- → %s %s\n", t.ToolName, summarize(t.ToolInput))
+	case t.ToolResult != "":
+		if redactToolPayloads {
+			return ""
+		}
+		return fmt.Sprintf("- → result: %s\n", summarize(t.ToolResult))
+	case strings.TrimSpace(t.Text) != "":
+		role := "User"
+		if t.Role == "assistant" {
+			role = "Assistant"
+		}
+		return fmt.Sprintf("**%s:** %s\n\n", role, strings.TrimSpace(t.Text))
+	default:
+		return ""
+	}
+}
+
+// summarize compresses a tool payload onto one bounded line.
+func summarize(s string) string {
+	return clip(strings.Join(strings.Fields(s), " "), maxSummaryLine)
+}
+
+// clip bounds s to maxBytes bytes — ellipsis included, so the result never
+// exceeds maxBytes — cutting back to a rune boundary so a multi-byte payload
+// can never leave invalid UTF-8 in the document.
+func clip(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	const ellipsis = "…"
+	keep := maxBytes - len(ellipsis)
+	if keep <= 0 {
+		return ""
+	}
+	for keep > 0 && !utf8.RuneStart(s[keep]) {
+		keep--
+	}
+	return s[:keep] + ellipsis
+}
+
+// filesTouched extracts file paths from tool inputs — the JSON keys the
+// known harness tool schemas use for their file arguments. Best-effort by
+// design: it feeds a context list, not an audit.
+func filesTouched(turns []Turn) []string {
+	seen := make(map[string]bool)
+	var files []string
+	for _, t := range turns {
+		if t.ToolInput == "" {
+			continue
+		}
+		var input map[string]any
+		if err := json.Unmarshal([]byte(t.ToolInput), &input); err != nil {
+			continue
+		}
+		for _, key := range []string{"file_path", "path", "filename", "notebook_path"} {
+			if v, ok := input[key].(string); ok && strings.TrimSpace(v) != "" {
+				v = clip(v, maxMetaField)
+				if !seen[v] {
+					seen[v] = true
+					files = append(files, v)
+				}
+			}
+		}
+	}
+	const maxFiles = 20
+	if len(files) > maxFiles {
+		files = append(files[:maxFiles], fmt.Sprintf("… and %d more", len(files)-maxFiles))
+	}
+	return files
+}
+
+func firstUserText(turns []Turn) string {
+	for _, t := range turns {
+		if t.Role == "user" && strings.TrimSpace(t.Text) != "" && isSubstantivePrompt(t.Text) {
+			return strings.TrimSpace(t.Text)
+		}
+	}
+	return ""
+}
+
+func lastAssistantText(turns []Turn) string {
+	for i := len(turns) - 1; i >= 0; i-- {
+		if turns[i].Role == "assistant" && strings.TrimSpace(turns[i].Text) != "" {
+			return strings.TrimSpace(turns[i].Text)
+		}
+	}
+	return ""
+}
+
+func valueOr(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+// isSubstantivePrompt filters harness-generated user records (command
+// wrappers, context envelopes) so the original-task section reflects what the
+// human actually asked.
+func isSubstantivePrompt(text string) bool {
+	text = strings.TrimSpace(text)
+	return text != "" && !isEnvelope(text)
+}
+
+// isEnvelope reports whether text opens with an XML-ish element that closes
+// again inside the same prompt — the shape every harness envelope has
+// (<command-name>…</command-name>, <local-command-stdout>…). Requiring the
+// close tag keeps prose that merely starts with a bracket ("<div> renders
+// wrong") as a usable title.
+func isEnvelope(text string) bool {
+	if !strings.HasPrefix(text, "<") {
+		return false
+	}
+	name := text[1:]
+	end := strings.IndexAny(name, " \t\r\n>")
+	if end <= 0 {
+		return false
+	}
+	name = name[:end]
+	return strings.Contains(text, "</"+name+">")
+}
+
+// truncateTitle collapses whitespace and bounds the rune length of the
+// rendered title.
+func truncateTitle(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if utf8.RuneCountInString(s) <= maxTitleRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxTitleRunes-1]) + "…"
+}

--- a/server/internal/sessionhandoff/render.go
+++ b/server/internal/sessionhandoff/render.go
@@ -170,6 +170,11 @@ func Render(t *Transcript, opts Options) Handoff {
 	}
 
 	firstPrompt := firstUserText(t.Turns)
+	if firstPrompt == "" && len(t.Turns) > 0 {
+		// The section renders a placeholder; say so instead of letting the
+		// caller overstate what the handoff carries.
+		fidelity.Warnings = append(fidelity.Warnings, "no substantive user prompt was recorded; the original task is not stated")
+	}
 	if bounded := clip(firstPrompt, maxContextSection); bounded != firstPrompt {
 		firstPrompt = bounded
 		fidelity.Warnings = append(fidelity.Warnings, "the original task statement was too large and appears clipped")

--- a/server/internal/sessionhandoff/render_test.go
+++ b/server/internal/sessionhandoff/render_test.go
@@ -1,0 +1,244 @@
+package sessionhandoff_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/sessionhandoff"
+)
+
+func sampleTranscript() *sessionhandoff.Transcript {
+	return &sessionhandoff.Transcript{
+		Session: sessionhandoff.SessionMeta{
+			Title:        "quokka-ledger cutover",
+			SessionID:    "0f4a3b2c-1111-4222-8333-444455556666",
+			ChatID:       "b6c2f2b8-7777-4888-9999-aaaabbbbcccc",
+			Source:       "claude-code",
+			Cwd:          "/tmp/quokka",
+			LastActivity: time.Date(2026, 8, 1, 10, 1, 0, 0, time.UTC),
+		},
+		Turns: []sessionhandoff.Turn{
+			{Role: "user", Text: "Map the banyan scheduler jobs blocking the quokka-ledger cutover."},
+			{Role: "assistant", Text: "Three jobs block the cutover."},
+			{Role: "assistant", ToolName: "Edit", ToolInput: `{"file_path":"/tmp/quokka/scheduler.go","old":"a","new":"b"}`},
+			{Role: "tool", ToolResult: "edited ok\nsecond line detail"},
+			{Role: "assistant", Text: "hedgehog-sweep needs --lease-mode=advisory; README update remains."},
+		},
+	}
+}
+
+// section returns the body of a "## name" section of the handoff.
+func section(t *testing.T, markdown, name string) string {
+	t.Helper()
+	_, after, ok := strings.Cut(markdown, "## "+name+"\n\n")
+	require.True(t, ok, "handoff has no %q section\n---\n%s", name, markdown)
+	if before, _, cut := strings.Cut(after, "\n## "); cut {
+		return before
+	}
+	return after
+}
+
+func TestRenderHandoffStructure(t *testing.T) {
+	t.Parallel()
+	h := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: false})
+
+	for _, want := range []string{
+		"# Session handoff — quokka-ledger cutover",
+		"Recalled from claude-code · source session 0f4a3b2c-1111-4222-8333-444455556666 · gram chat b6c2f2b8-7777-4888-9999-aaaabbbbcccc · project: /tmp/quokka · last active 2026-08-01 10:01 UTC · via Gram",
+		"## Original task",
+		"Map the banyan scheduler jobs blocking the quokka-ledger cutover.",
+		"## What has happened so far",
+		"- → Edit ",
+		"- → result: edited ok second line detail",
+		"## Files touched",
+		"- /tmp/quokka/scheduler.go",
+		"## Where things stand",
+		"hedgehog-sweep needs --lease-mode=advisory; README update remains.",
+		"## Instruction",
+	} {
+		require.Contains(t, h.Markdown, want)
+	}
+	require.NotEmpty(t, h.Fidelity.Missing)
+	require.Contains(t, h.Fidelity.Missing[0], "thinking")
+}
+
+func TestRenderBudgetTruncates(t *testing.T) {
+	t.Parallel()
+	tr := &sessionhandoff.Transcript{
+		Session: sampleTranscript().Session,
+		Turns:   nil,
+	}
+	tr.Turns = append(tr.Turns, sessionhandoff.Turn{Role: "user", Text: "the original ask about flotilla"})
+	for i := range 40 {
+		tr.Turns = append(tr.Turns, sessionhandoff.Turn{
+			Role: "assistant", Text: fmt.Sprintf("filler turn %02d %s", i, strings.Repeat("pad ", 100)),
+		})
+	}
+	tr.Turns = append(tr.Turns, sessionhandoff.Turn{Role: "assistant", Text: "final state: kelp-reader rename done"})
+
+	h := sessionhandoff.Render(tr, sessionhandoff.Options{Budget: 2048, RedactToolPayloads: false})
+
+	require.Contains(t, h.Markdown, "the original ask about flotilla", "the original task must survive any budget")
+	require.Contains(t, h.Markdown, "final state: kelp-reader rename done", "the last assistant message must survive any budget")
+	require.NotContains(t, h.Markdown, "filler turn 01", "early filler turns must fall outside a small budget")
+	var truncated bool
+	for _, m := range h.Fidelity.Missing {
+		if strings.Contains(m, "beyond the handoff budget") {
+			truncated = true
+		}
+	}
+	require.True(t, truncated, "fidelity must report budget truncation, got %+v", h.Fidelity)
+}
+
+// A positive budget smaller than the section's empty-state marker is raised
+// to the marker's length, so the documented bound holds whether the section
+// carries the marker or a clipped newest turn.
+func TestRenderTinyBudgetStaysBounded(t *testing.T) {
+	t.Parallel()
+	const marker = "(nothing recorded)\n"
+
+	empty := &sessionhandoff.Transcript{Session: sampleTranscript().Session, Turns: nil}
+	h := sessionhandoff.Render(empty, sessionhandoff.Options{Budget: 1, RedactToolPayloads: false})
+	require.Contains(t, h.Markdown, marker, "the empty-state marker must render whole")
+
+	h = sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 1, RedactToolPayloads: false})
+	body := section(t, h.Markdown, "What has happened so far")
+	require.LessOrEqual(t, len(body), len(marker), "section exceeds the effective minimum budget:\n%s", body)
+}
+
+// The capture path emits content-empty turns (a tool result whose content
+// renders empty, or any tool result under redaction). Those must not consume
+// the "keep at least one turn" allowance and leave the section blank when the
+// newest real turn overflows the budget.
+func TestRenderKeepsNewestTurnBehindEmptyOnes(t *testing.T) {
+	t.Parallel()
+	big := "narwhal-index rebuild is " + strings.Repeat("still running ", 40)
+	tr := &sessionhandoff.Transcript{
+		Session: sampleTranscript().Session,
+		Turns: []sessionhandoff.Turn{
+			{Role: "user", Text: "start the narwhal-index rebuild"},
+			{Role: "assistant", Text: big},
+			{Role: "tool", ToolResult: ""},
+			{Role: "tool", ToolResult: ""},
+		},
+	}
+
+	const budget = 100
+	h := sessionhandoff.Render(tr, sessionhandoff.Options{Budget: budget, RedactToolPayloads: false})
+	body := section(t, h.Markdown, "What has happened so far")
+
+	require.NotContains(t, body, "(nothing recorded)", "empty trailing turns suppressed the newest real turn")
+	require.Contains(t, body, "narwhal-index rebuild is", "newest real turn missing from section")
+	require.LessOrEqual(t, len(body), budget, "section is over the budget:\n%s", body)
+
+	// Clipping that turn drops content, so the report has to admit it —
+	// a FidelityReport is only worth anything if it never overstates.
+	var warned bool
+	for _, w := range h.Fidelity.Warnings {
+		if strings.Contains(w, "clipped") {
+			warned = true
+		}
+	}
+	require.True(t, warned, "clipping the newest turn must be reported, got %+v", h.Fidelity)
+}
+
+// Tool payloads are cut to a byte bound; the cut must land on a rune boundary
+// so a multi-byte payload cannot leave invalid UTF-8 in the document.
+func TestSummarizeCutsOnRuneBoundary(t *testing.T) {
+	t.Parallel()
+	tr := &sessionhandoff.Transcript{
+		Session: sampleTranscript().Session,
+		Turns: []sessionhandoff.Turn{{
+			Role: "assistant", ToolName: "Edit",
+			ToolInput: strings.Repeat("ü", 300),
+		}},
+	}
+
+	md := sessionhandoff.Render(tr, sessionhandoff.Options{Budget: 0, RedactToolPayloads: false}).Markdown
+	require.True(t, utf8.ValidString(md), "handoff contains invalid UTF-8 after truncating a multi-byte payload")
+	for line := range strings.SplitSeq(section(t, md, "What has happened so far"), "\n") {
+		// maxSummaryLine (120) plus the "- → Edit " prefix.
+		require.LessOrEqual(t, len(line), 120+len("- → Edit "), "summary line is over the bound: %q", line)
+	}
+}
+
+func TestRenderRedactionFlag(t *testing.T) {
+	t.Parallel()
+	redacted := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+
+	require.Contains(t, redacted.Markdown, "- → Edit\n", "redacted tool line must carry the name only")
+	require.NotContains(t, redacted.Markdown, `"old":"a"`, "tool input must not survive redaction")
+	require.NotContains(t, redacted.Markdown, "- → result:", "tool result lines must be dropped under redaction")
+	require.NotContains(t, redacted.Markdown, "edited ok", "tool result content must not survive redaction")
+	require.NotContains(t, redacted.Markdown, "/tmp/quokka/scheduler.go", "no tool-input-derived value may survive redaction")
+	require.Contains(t, redacted.Fidelity.Missing, "tool inputs and outputs (redacted; tool names retained)")
+
+	plain := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: false})
+
+	require.Contains(t, plain.Markdown, `- → Edit {"file_path":"/tmp/quokka/scheduler.go","old":"a","new":"b"}`)
+	require.Contains(t, plain.Markdown, "- → result: edited ok second line detail")
+	require.NotContains(t, plain.Fidelity.Missing, "tool inputs and outputs (redacted; tool names retained)")
+}
+
+func TestRenderFidelitySeed(t *testing.T) {
+	t.Parallel()
+	h := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: false})
+
+	require.Equal(t, []string{
+		"assistant thinking (not captured)",
+		"intermediate assistant messages within turns (capture records each turn's final message only)",
+	}, h.Fidelity.Missing)
+	require.Contains(t, h.Fidelity.Warnings,
+		"rendered from Gram's captured transcript, not the harness's native session file; lower fidelity than a device-local move")
+
+	redacted := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+	require.Equal(t, []string{
+		"assistant thinking (not captured)",
+		"intermediate assistant messages within turns (capture records each turn's final message only)",
+		"tool inputs and outputs (redacted; tool names retained)",
+		"files touched (derived from tool inputs, which are redacted)",
+	}, redacted.Fidelity.Missing)
+}
+
+func TestRenderBylineLineageMarkers(t *testing.T) {
+	t.Parallel()
+	tr := sampleTranscript()
+	md := sessionhandoff.Render(tr, sessionhandoff.Options{Budget: 0, RedactToolPayloads: true}).Markdown
+
+	require.Contains(t, md, "source session "+tr.Session.SessionID, "the lineage marker must ride in the byline verbatim")
+	require.Contains(t, md, "gram chat "+tr.Session.ChatID)
+	require.Contains(t, md, "· via Gram")
+}
+
+func TestRenderWarnsWhenCwdMissing(t *testing.T) {
+	t.Parallel()
+	tr := sampleTranscript()
+	tr.Session.Cwd = ""
+
+	h := sessionhandoff.Render(tr, sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+	require.Contains(t, h.Fidelity.Warnings, "working directory was not captured for this session")
+	require.Contains(t, h.Markdown, "project: (unknown)")
+
+	withCwd := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+	require.NotContains(t, withCwd.Fidelity.Warnings, "working directory was not captured for this session")
+}
+
+func TestRenderFilesTouchedUnderRedaction(t *testing.T) {
+	t.Parallel()
+	h := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: true})
+
+	// Paths are parsed from raw tool inputs, which redaction must not read —
+	// the section is omitted and reported missing instead.
+	require.NotContains(t, h.Markdown, "## Files touched")
+	require.NotContains(t, h.Markdown, "/tmp/quokka/scheduler.go")
+	require.Contains(t, h.Fidelity.Missing, "files touched (derived from tool inputs, which are redacted)")
+
+	unredacted := sessionhandoff.Render(sampleTranscript(), sessionhandoff.Options{Budget: 0, RedactToolPayloads: false})
+	require.Contains(t, section(t, unredacted.Markdown, "Files touched"), "- /tmp/quokka/scheduler.go")
+	require.NotContains(t, unredacted.Fidelity.Missing, "files touched (derived from tool inputs, which are redacted)")
+}

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -529,13 +529,6 @@ SELECT blob_url, consumed_at
 FROM session_handoff_links
 WHERE token = @token;
 
--- name: SoftDeleteChatFixture :exec
--- Test-only fixture: tombstones a chat. The deleted column is generated from
--- deleted_at, so a soft delete has to set the timestamp.
-UPDATE chats
-SET deleted_at = clock_timestamp()
-WHERE id = @id;
-
 -- name: SeedCapturedAgentChatFixture :one
 -- Test-only fixture: inserts the chat row a captured agent session hangs off,
 -- with the harness-native session id stored as external_chat_id and an

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -529,6 +529,13 @@ SELECT blob_url, consumed_at
 FROM session_handoff_links
 WHERE token = @token;
 
+-- name: SoftDeleteChatFixture :exec
+-- Test-only fixture: tombstones a chat. The deleted column is generated from
+-- deleted_at, so a soft delete has to set the timestamp.
+UPDATE chats
+SET deleted_at = clock_timestamp()
+WHERE id = @id;
+
 -- name: SeedCapturedAgentChatFixture :one
 -- Test-only fixture: inserts the chat row a captured agent session hangs off,
 -- with the harness-native session id stored as external_chat_id and an

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -529,6 +529,53 @@ SELECT blob_url, consumed_at
 FROM session_handoff_links
 WHERE token = @token;
 
+-- name: SeedCapturedAgentChatFixture :one
+-- Test-only fixture: inserts the chat row a captured agent session hangs off,
+-- with the harness-native session id stored as external_chat_id and an
+-- optional personal/team account attribution.
+INSERT INTO chats (id, project_id, organization_id, user_id, external_chat_id, title, cwd, user_account_id)
+VALUES (@id, @project_id, @organization_id, @user_id, sqlc.narg(external_chat_id), @title, sqlc.narg(cwd), sqlc.narg(user_account_id))
+RETURNING id;
+
+-- name: SeedCapturedAgentChatMessageFixture :one
+-- Test-only fixture: inserts a captured transcript row with the full recall
+-- shape — generation, tool_calls, capture source, asset offload marker, and
+-- risk-analysis completion — at a deterministic created_at.
+INSERT INTO chat_messages (chat_id, project_id, role, content, generation, tool_calls, source, content_asset_url, risk_analyzed_at, created_at)
+VALUES (@chat_id, @project_id, @role, @content, @generation, sqlc.narg(tool_calls), sqlc.narg(source), sqlc.narg(content_asset_url), sqlc.narg(risk_analyzed_at), @created_at)
+RETURNING id;
+
+-- name: SeedUserAccountFixture :one
+-- Test-only fixture: inserts a minimal provider account row so chats can be
+-- attributed to a team or personal account.
+INSERT INTO user_accounts (organization_id, external_account_uuid, account_type)
+VALUES (@organization_id, @external_account_uuid, @account_type)
+RETURNING id;
+
+-- name: SeedRiskPolicyFixture :one
+-- Test-only fixture: inserts an enabled standard risk policy.
+INSERT INTO risk_policies (project_id, organization_id, name, sources, version)
+VALUES (@project_id, @organization_id, @name, @sources, 1)
+RETURNING id;
+
+-- name: SeedRiskResultFixture :one
+-- Test-only fixture: records one open finding against a chat message, with the
+-- primary span mirrored into the spans JSONB set.
+INSERT INTO risk_results (project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, match, start_pos, end_pos, spans)
+VALUES (@project_id, @organization_id, @risk_policy_id, 1, @chat_message_id, @source, TRUE, @rule_id, @match, @start_pos, @end_pos, sqlc.narg(spans))
+RETURNING id;
+
+-- name: GetChatSessionLinkByParentFixture :one
+-- Test-only inspection of a recorded session-lineage edge from its parent end.
+SELECT kind, child_chat_id, parent_session_id, target_harness, organization_id, project_id
+FROM chat_session_links
+WHERE parent_chat_id = @parent_chat_id;
+
+-- name: CountChatSessionLinksByKindFixture :one
+SELECT COUNT(*)
+FROM chat_session_links
+WHERE parent_chat_id = @parent_chat_id
+  AND kind = @kind;
 -- name: ForceSoftDeleteRemoteSessionIssuerFixture :exec
 -- Tombstones a remote session issuer regardless of its clients. Production
 -- deletes refuse while a live client references it, so this is the only way to

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1908,19 +1908,6 @@ func (q *Queries) SetWorkosLastEventIDFixture(ctx context.Context, arg SetWorkos
 	return err
 }
 
-const softDeleteChatFixture = `-- name: SoftDeleteChatFixture :exec
-UPDATE chats
-SET deleted_at = clock_timestamp()
-WHERE id = $1
-`
-
-// Test-only fixture: tombstones a chat. The deleted column is generated from
-// deleted_at, so a soft delete has to set the timestamp.
-func (q *Queries) SoftDeleteChatFixture(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, softDeleteChatFixture, id)
-	return err
-}
-
 const updateChatMessageCreatedAt = `-- name: UpdateChatMessageCreatedAt :exec
 UPDATE chat_messages
 SET created_at = $1

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1908,6 +1908,19 @@ func (q *Queries) SetWorkosLastEventIDFixture(ctx context.Context, arg SetWorkos
 	return err
 }
 
+const softDeleteChatFixture = `-- name: SoftDeleteChatFixture :exec
+UPDATE chats
+SET deleted_at = clock_timestamp()
+WHERE id = $1
+`
+
+// Test-only fixture: tombstones a chat. The deleted column is generated from
+// deleted_at, so a soft delete has to set the timestamp.
+func (q *Queries) SoftDeleteChatFixture(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, softDeleteChatFixture, id)
+	return err
+}
+
 const updateChatMessageCreatedAt = `-- name: UpdateChatMessageCreatedAt :exec
 UPDATE chat_messages
 SET created_at = $1

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -24,6 +24,25 @@ func (q *Queries) CorruptDeviceIntegrationCredentialsFixture(ctx context.Context
 	return err
 }
 
+const countChatSessionLinksByKindFixture = `-- name: CountChatSessionLinksByKindFixture :one
+SELECT COUNT(*)
+FROM chat_session_links
+WHERE parent_chat_id = $1
+  AND kind = $2
+`
+
+type CountChatSessionLinksByKindFixtureParams struct {
+	ParentChatID uuid.UUID
+	Kind         string
+}
+
+func (q *Queries) CountChatSessionLinksByKindFixture(ctx context.Context, arg CountChatSessionLinksByKindFixtureParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countChatSessionLinksByKindFixture, arg.ParentChatID, arg.Kind)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countFunctionsAccess = `-- name: CountFunctionsAccess :one
 SELECT count(id)
 FROM functions_access
@@ -449,6 +468,36 @@ type ForceSoftDeleteUserSessionIssuerParams struct {
 func (q *Queries) ForceSoftDeleteUserSessionIssuer(ctx context.Context, arg ForceSoftDeleteUserSessionIssuerParams) error {
 	_, err := q.db.Exec(ctx, forceSoftDeleteUserSessionIssuer, arg.ID, arg.ProjectID)
 	return err
+}
+
+const getChatSessionLinkByParentFixture = `-- name: GetChatSessionLinkByParentFixture :one
+SELECT kind, child_chat_id, parent_session_id, target_harness, organization_id, project_id
+FROM chat_session_links
+WHERE parent_chat_id = $1
+`
+
+type GetChatSessionLinkByParentFixtureRow struct {
+	Kind            string
+	ChildChatID     uuid.NullUUID
+	ParentSessionID string
+	TargetHarness   string
+	OrganizationID  string
+	ProjectID       uuid.UUID
+}
+
+// Test-only inspection of a recorded session-lineage edge from its parent end.
+func (q *Queries) GetChatSessionLinkByParentFixture(ctx context.Context, parentChatID uuid.UUID) (GetChatSessionLinkByParentFixtureRow, error) {
+	row := q.db.QueryRow(ctx, getChatSessionLinkByParentFixture, parentChatID)
+	var i GetChatSessionLinkByParentFixtureRow
+	err := row.Scan(
+		&i.Kind,
+		&i.ChildChatID,
+		&i.ParentSessionID,
+		&i.TargetHarness,
+		&i.OrganizationID,
+		&i.ProjectID,
+	)
+	return i, err
 }
 
 const getDeploymentFunctionInfraOverrides = `-- name: GetDeploymentFunctionInfraOverrides :many
@@ -1381,6 +1430,82 @@ func (q *Queries) ScrubDeploymentFunctionMachineSpecs(ctx context.Context, deplo
 	return err
 }
 
+const seedCapturedAgentChatFixture = `-- name: SeedCapturedAgentChatFixture :one
+INSERT INTO chats (id, project_id, organization_id, user_id, external_chat_id, title, cwd, user_account_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id
+`
+
+type SeedCapturedAgentChatFixtureParams struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	UserID         pgtype.Text
+	ExternalChatID pgtype.Text
+	Title          pgtype.Text
+	Cwd            pgtype.Text
+	UserAccountID  uuid.NullUUID
+}
+
+// Test-only fixture: inserts the chat row a captured agent session hangs off,
+// with the harness-native session id stored as external_chat_id and an
+// optional personal/team account attribution.
+func (q *Queries) SeedCapturedAgentChatFixture(ctx context.Context, arg SeedCapturedAgentChatFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedCapturedAgentChatFixture,
+		arg.ID,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.ExternalChatID,
+		arg.Title,
+		arg.Cwd,
+		arg.UserAccountID,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedCapturedAgentChatMessageFixture = `-- name: SeedCapturedAgentChatMessageFixture :one
+INSERT INTO chat_messages (chat_id, project_id, role, content, generation, tool_calls, source, content_asset_url, risk_analyzed_at, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+RETURNING id
+`
+
+type SeedCapturedAgentChatMessageFixtureParams struct {
+	ChatID          uuid.UUID
+	ProjectID       uuid.NullUUID
+	Role            string
+	Content         string
+	Generation      int32
+	ToolCalls       []byte
+	Source          pgtype.Text
+	ContentAssetUrl pgtype.Text
+	RiskAnalyzedAt  pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+}
+
+// Test-only fixture: inserts a captured transcript row with the full recall
+// shape — generation, tool_calls, capture source, asset offload marker, and
+// risk-analysis completion — at a deterministic created_at.
+func (q *Queries) SeedCapturedAgentChatMessageFixture(ctx context.Context, arg SeedCapturedAgentChatMessageFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedCapturedAgentChatMessageFixture,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.Role,
+		arg.Content,
+		arg.Generation,
+		arg.ToolCalls,
+		arg.Source,
+		arg.ContentAssetUrl,
+		arg.RiskAnalyzedAt,
+		arg.CreatedAt,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const seedOpenRouterSpendRangeFixture = `-- name: SeedOpenRouterSpendRangeFixture :exec
 INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
 SELECT
@@ -1478,6 +1603,92 @@ func (q *Queries) SeedPublishOutboxRow(ctx context.Context, arg SeedPublishOutbo
 	var i SeedPublishOutboxRowRow
 	err := row.Scan(&i.ID, &i.PublicID)
 	return i, err
+}
+
+const seedRiskPolicyFixture = `-- name: SeedRiskPolicyFixture :one
+INSERT INTO risk_policies (project_id, organization_id, name, sources, version)
+VALUES ($1, $2, $3, $4, 1)
+RETURNING id
+`
+
+type SeedRiskPolicyFixtureParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	Name           string
+	Sources        []string
+}
+
+// Test-only fixture: inserts an enabled standard risk policy.
+func (q *Queries) SeedRiskPolicyFixture(ctx context.Context, arg SeedRiskPolicyFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedRiskPolicyFixture,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.Name,
+		arg.Sources,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedRiskResultFixture = `-- name: SeedRiskResultFixture :one
+INSERT INTO risk_results (project_id, organization_id, risk_policy_id, risk_policy_version, chat_message_id, source, found, rule_id, match, start_pos, end_pos, spans)
+VALUES ($1, $2, $3, 1, $4, $5, TRUE, $6, $7, $8, $9, $10)
+RETURNING id
+`
+
+type SeedRiskResultFixtureParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	RiskPolicyID   uuid.UUID
+	ChatMessageID  uuid.NullUUID
+	Source         string
+	RuleID         pgtype.Text
+	Match          pgtype.Text
+	StartPos       pgtype.Int4
+	EndPos         pgtype.Int4
+	Spans          []byte
+}
+
+// Test-only fixture: records one open finding against a chat message, with the
+// primary span mirrored into the spans JSONB set.
+func (q *Queries) SeedRiskResultFixture(ctx context.Context, arg SeedRiskResultFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedRiskResultFixture,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.RiskPolicyID,
+		arg.ChatMessageID,
+		arg.Source,
+		arg.RuleID,
+		arg.Match,
+		arg.StartPos,
+		arg.EndPos,
+		arg.Spans,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedUserAccountFixture = `-- name: SeedUserAccountFixture :one
+INSERT INTO user_accounts (organization_id, external_account_uuid, account_type)
+VALUES ($1, $2, $3)
+RETURNING id
+`
+
+type SeedUserAccountFixtureParams struct {
+	OrganizationID      string
+	ExternalAccountUuid string
+	AccountType         pgtype.Text
+}
+
+// Test-only fixture: inserts a minimal provider account row so chats can be
+// attributed to a team or personal account.
+func (q *Queries) SeedUserAccountFixture(ctx context.Context, arg SeedUserAccountFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, seedUserAccountFixture, arg.OrganizationID, arg.ExternalAccountUuid, arg.AccountType)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const setDeploymentFunctionInfraOverrides = `-- name: SetDeploymentFunctionInfraOverrides :exec


### PR DESCRIPTION
## What

Two platform-MCP tools that bring session portability to users without the device agent, as the pull model: from inside any agent connected to the platform MCP server, recall one of your own captured coding-agent sessions and continue it in the current conversation.

- `list_my_sessions` — the calling user's captured sessions (titles, summaries, project, last activity). Owner-matched via the OAuth principal; read-only.
- `continue_session` — renders a redacted handoff digest of one owned session from its captured transcript and returns it as the tool result. Every call writes a `chat_session_links` lineage edge (`kind='recall'`, NULL child) plus a content-free `chat_session:recall` audit event in one transaction, before the digest is returned — if governance recording fails, the recall refuses.

Gated on the `session_portability` product feature. `externalOnly` audience, org-wide scope with ownership fused into every query.

## How

- **New leaf package `server/internal/sessionhandoff`** — a stdlib-only port of the device agent's deterministic handoff renderer (ADR 0018 document shape), with a `RedactToolPayloads` option and fidelity entries specific to captured-transcript rendering.
- **Owner-fused queries** in `platformmcp/queries.sql`: every read carries org + `chats.user_id = principal` + not-deleted + personal-account exclusion in the row filter — never fetch-then-authorize, and no change to `chat.load`'s existing auth boundary.
- **Redact-inline**: prose is masked span-by-span with the same `maskdisplay` formatter the dashboard uses over `risk_results` spans, so the digest can never reveal more than existing UI; tool inputs/outputs are dropped unconditionally (names retained).
- **Lineage UI**: recall edges render as "Recalled into a later session" in the Agent Sessions icons and detail panel instead of misreading as a move.

## Review flags (deliberate calls, please push back if wrong)

- **Redact-inline over refuse-on-findings** for analyzed content. ~~Unanalyzed-prose inclusion with a fidelity warning~~ — tightened per review: prose without a completed risk analysis is now withheld with its own placeholder.
- ~~`filesTouched` reads un-redacted tool inputs~~ — tightened per review: the files-touched section is omitted under redaction and reported in fidelity.
- **Bounds** (added per review): transcript reads are capped at the newest 240 rows, out-of-budget sections are clipped, and the serialized digest has a 48 KiB hard cap with an explicit truncation marker.
- Personal-account sessions are excluded from both tools — stricter than `getSessionMeta`'s titles-only inclusion.
- No migration: `kind` is free text and v1 recall edges always have a NULL child. A future non-NULL-child recall would require widening the partial unique index to include `kind`.
- v1 records the destination as unknowable (NULL child); the digest byline carries greppable source markers for future retroactive correlation.

## Testing

- Renderer: ported device-agent test cases plus redaction/fidelity/byline cases.
- platformmcp: unit tests (tool descriptors, masking, row→turn adapter), descriptor audience invariants, and a 7-case integration test (ownership isolation, masking matches `maskdisplay` exactly, edge+audit atomicity, repeat-recall semantics, feature-gate refusal without side effects, no-existence-leak not-found, latest-generation-only).
- Full local verification: `build:server`, `lint:server`, 1103 tests across the affected packages, dashboard type-check + vitest (audit-actions mirror), `hk fix` clean.

Linear: DNO-969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GS7R3576TM43jKcNvvFf9T
