### PR TITLE
fix: reject meta mcp members that front the same backend

### DIFF
--- a/.changeset/meta-mcp-member-backend-uniqueness.md
+++ b/.changeset/meta-mcp-member-backend-uniqueness.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+A meta MCP server can no longer hold two members that front the same backend. `meta_mcp.addMember` rejects an MCP server whose remote, tunneled, toolset, or unproxied backend a live member of that gateway already serves, and `mcpServers.update` rejects repointing an attached server onto a backend one of its co-members already fronts. Both return an invalid-argument error; attaching the same MCP server twice keeps returning the existing conflict error.

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -601,6 +601,10 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
+	if err := verifyMetaMcpBackendUniqueness(ctx, dbtx, *authCtx.ProjectID, serverID, existing, ids, logger); err != nil {
+		return nil, err
+	}
+
 	// Resolve name: nil = leave existing; non-nil = trim and require non-empty.
 	name := existing.Name
 	if payload.Name != nil {
@@ -1160,6 +1164,44 @@ func verifyTunneledPublicConsent(ctx context.Context, dbtx pgx.Tx, projectID uui
 		return fmt.Errorf("tunneled MCP servers cannot be public until the tunnel source enables public serving")
 	}
 	return nil
+}
+
+// verifyMetaMcpBackendUniqueness rejects repointing a server onto a backend a
+// co-member of one of its meta MCP servers already fronts, the state
+// metamcp.AddMetaMcpMember refuses at attach time. The two paths share no
+// lock, so a simultaneous attach of the colliding member can still slip past.
+func verifyMetaMcpBackendUniqueness(
+	ctx context.Context,
+	dbtx pgx.Tx,
+	projectID uuid.UUID,
+	serverID uuid.UUID,
+	existing repo.McpServer,
+	ids serverIDs,
+	logger *slog.Logger,
+) error {
+	if ids.RemoteMcpServerID == existing.RemoteMcpServerID &&
+		ids.TunneledMcpServerID == existing.TunneledMcpServerID &&
+		ids.ToolsetID == existing.ToolsetID &&
+		ids.UnproxiedMcpServerID == existing.UnproxiedMcpServerID {
+		return nil
+	}
+
+	metaName, err := metamcprepo.New(dbtx).FindMetaMCPSiblingSharingBackend(ctx, metamcprepo.FindMetaMCPSiblingSharingBackendParams{
+		McpServerID:          serverID,
+		ProjectID:            projectID,
+		RemoteMcpServerID:    ids.RemoteMcpServerID,
+		TunneledMcpServerID:  ids.TunneledMcpServerID,
+		ToolsetID:            ids.ToolsetID,
+		UnproxiedMcpServerID: ids.UnproxiedMcpServerID,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "check meta mcp members sharing a backend").LogError(ctx, logger)
+	default:
+		return oops.E(oops.CodeInvalid, nil, "another member of meta mcp server %q already fronts this backend", metaName).LogError(ctx, logger)
+	}
 }
 
 func backendFilterCount(ids ...uuid.NullUUID) int {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -1201,7 +1201,7 @@ func verifyMetaMcpBackendUniqueness(
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "check meta mcp members sharing a backend").LogError(ctx, logger)
 	default:
-		return oops.E(oops.CodeInvalid, nil, "another member of meta mcp server %q already fronts this backend", metaName).LogError(ctx, logger)
+		return oops.E(oops.CodeConflict, nil, "another member of meta mcp server %q already fronts this backend", metaName).LogError(ctx, logger)
 	}
 }
 

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -1168,8 +1168,9 @@ func verifyTunneledPublicConsent(ctx context.Context, dbtx pgx.Tx, projectID uui
 
 // verifyMetaMcpBackendUniqueness rejects repointing a server onto a backend a
 // co-member of one of its meta MCP servers already fronts, the state
-// metamcp.AddMetaMcpMember refuses at attach time. The two paths share no
-// lock, so a simultaneous attach of the colliding member can still slip past.
+// metamcp.AddMetaMcpMember refuses at attach time. Running after the server
+// lock leaves nowhere to also take the meta lock without inverting that path's
+// meta-then-server order, so a simultaneous attach can still slip past.
 func verifyMetaMcpBackendUniqueness(
 	ctx context.Context,
 	dbtx pgx.Tx,

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -920,6 +920,57 @@ func TestUpdateMcpServer_RejectsBackendSharedWithMetaMcpSibling(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestUpdateMcpServer_PreExistingSharedBackendStaysEditable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sharedBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	first := seedMcpServerForBackend(t, ctx, ti, "first server", sharedBackend)
+	second := seedMcpServerForBackend(t, ctx, ti, "second server", sharedBackend)
+
+	meta, err := metamcprepo.New(ti.conn).CreateMetaMCPServer(ctx, metamcprepo.CreateMetaMCPServerParams{
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		ProjectID:           *authCtx.ProjectID,
+		Name:                "legacy collision holder",
+		UserSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+	require.NoError(t, err)
+
+	// Straight through the repo: a violating pair predating the guard, which
+	// nothing backfills.
+	for _, memberID := range []string{first, second} {
+		_, err = metamcprepo.New(ti.conn).CreateMetaMCPMember(ctx, metamcprepo.CreateMetaMCPMemberParams{
+			ProjectID:       *authCtx.ProjectID,
+			MetaMcpServerID: meta.ID,
+			McpServerID:     uuid.MustParse(memberID),
+			SortOrder:       0,
+		})
+		require.NoError(t, err)
+	}
+
+	// Every update payload carries a backend id, so only the unchanged-backend
+	// short-circuit keeps edits to such a pair from failing forever.
+	newName := "renamed second server"
+	updated, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                second,
+		Name:              &newName,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &sharedBackend,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.Name)
+	require.Equal(t, newName, *updated.Name)
+}
+
 func seedMcpServerForBackend(t *testing.T, ctx context.Context, ti *testInstance, name, remoteMcpServerID string) string {
 	t.Helper()
 

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
@@ -858,4 +859,81 @@ func TestUpdateMcpServer_AlreadyUnproxiedAllowsNonStaffRename(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updated.Name)
 	require.Equal(t, newName, *updated.Name)
+}
+
+func TestUpdateMcpServer_RejectsBackendSharedWithMetaMcpSibling(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sharedBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	ownBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	sibling := seedMcpServerForBackend(t, ctx, ti, "sibling server", sharedBackend)
+	subject := seedMcpServerForBackend(t, ctx, ti, "subject server", ownBackend)
+
+	meta, err := metamcprepo.New(ti.conn).CreateMetaMCPServer(ctx, metamcprepo.CreateMetaMCPServerParams{
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		ProjectID:           *authCtx.ProjectID,
+		Name:                "collision holder",
+		UserSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+	require.NoError(t, err)
+
+	for _, memberID := range []string{sibling, subject} {
+		_, err = metamcprepo.New(ti.conn).CreateMetaMCPMember(ctx, metamcprepo.CreateMetaMCPMemberParams{
+			ProjectID:       *authCtx.ProjectID,
+			MetaMcpServerID: meta.ID,
+			McpServerID:     uuid.MustParse(memberID),
+			SortOrder:       0,
+		})
+		require.NoError(t, err)
+	}
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                subject,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &sharedBackend,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	requireOopsCode(t, err, oops.CodeInvalid)
+
+	// A backend no sibling fronts is still free to move to.
+	freeBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                subject,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &freeBackend,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+}
+
+func seedMcpServerForBackend(t *testing.T, ctx context.Context, ti *testInstance, name, remoteMcpServerID string) string {
+	t.Helper()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              name,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteMcpServerID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+
+	return created.ID
 }

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -903,7 +903,7 @@ func TestUpdateMcpServer_RejectsBackendSharedWithMetaMcpSibling(t *testing.T) {
 		ToolsetID:         nil,
 		Visibility:        types.McpServerVisibility("disabled"),
 	})
-	requireOopsCode(t, err, oops.CodeInvalid)
+	requireOopsCode(t, err, oops.CodeConflict)
 
 	// A backend no sibling fronts is still free to move to.
 	freeBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()

--- a/server/internal/metamcp/addmetamcpmember_test.go
+++ b/server/internal/metamcp/addmetamcpmember_test.go
@@ -176,7 +176,7 @@ func TestAddMetaMcpMember_RejectsSecondServerOnSameBackend(t *testing.T) {
 				McpServerID:      second.String(),
 				SortOrder:        nil,
 			})
-			requireOopsCode(t, err, oops.CodeInvalid)
+			requireOopsCode(t, err, oops.CodeConflict)
 		})
 	}
 }

--- a/server/internal/metamcp/addmetamcpmember_test.go
+++ b/server/internal/metamcp/addmetamcpmember_test.go
@@ -191,7 +191,7 @@ func TestAddMetaMcpMember_AllowsDistinctBackends(t *testing.T) {
 
 	meta := seedMetaMcpServer(t, ctx, ti, "distinct backend host")
 
-	// One server per backend kind: every member leaves two of the three
+	// One server per backend kind: every member leaves three of the four
 	// backend columns null, so a null-matching guard would reject these.
 	servers := []uuid.UUID{
 		seedMcpServer(t, ctx, ti.conn, *authCtx.ProjectID),
@@ -201,6 +201,9 @@ func TestAddMetaMcpMember_AllowsDistinctBackends(t *testing.T) {
 		}),
 		seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, mcpserversrepo.CreateMCPServerParams{
 			ToolsetID: conv.ToNullUUID(seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID)),
+		}),
+		seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, mcpserversrepo.CreateMCPServerParams{
+			UnproxiedMcpServerID: conv.ToNullUUID(seedUnproxiedBackend(t, ctx, ti.conn, *authCtx.ProjectID)),
 		}),
 	}
 

--- a/server/internal/metamcp/addmetamcpmember_test.go
+++ b/server/internal/metamcp/addmetamcpmember_test.go
@@ -123,6 +123,143 @@ func TestAddMetaMcpMember_ServerMayJoinMultipleMetas(t *testing.T) {
 	}
 }
 
+func TestAddMetaMcpMember_RejectsSecondServerOnSameBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	tests := []struct {
+		name    string
+		backend mcpserversrepo.CreateMCPServerParams
+	}{
+		{
+			name:    "remote",
+			backend: mcpserversrepo.CreateMCPServerParams{RemoteMcpServerID: conv.ToNullUUID(seedRemoteBackend(t, ctx, ti.conn, *authCtx.ProjectID))},
+		},
+		{
+			name:    "tunnel",
+			backend: mcpserversrepo.CreateMCPServerParams{TunneledMcpServerID: conv.ToNullUUID(seedTunnelBackend(t, ctx, ti.conn, *authCtx.ProjectID))},
+		},
+		{
+			name:    "toolset",
+			backend: mcpserversrepo.CreateMCPServerParams{ToolsetID: conv.ToNullUUID(seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			meta := seedMetaMcpServer(t, ctx, ti, "shared backend host "+tt.name)
+			backend := tt.backend
+			first := seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, backend)
+			second := seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, backend)
+
+			_, err := ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+				SessionToken:     nil,
+				ApikeyToken:      nil,
+				ProjectSlugInput: nil,
+				MetaMcpServerID:  meta.ID,
+				McpServerID:      first.String(),
+				SortOrder:        nil,
+			})
+			require.NoError(t, err)
+
+			_, err = ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+				SessionToken:     nil,
+				ApikeyToken:      nil,
+				ProjectSlugInput: nil,
+				MetaMcpServerID:  meta.ID,
+				McpServerID:      second.String(),
+				SortOrder:        nil,
+			})
+			requireOopsCode(t, err, oops.CodeInvalid)
+		})
+	}
+}
+
+func TestAddMetaMcpMember_AllowsDistinctBackends(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	meta := seedMetaMcpServer(t, ctx, ti, "distinct backend host")
+
+	// One server per backend kind: every member leaves two of the three
+	// backend columns null, so a null-matching guard would reject these.
+	servers := []uuid.UUID{
+		seedMcpServer(t, ctx, ti.conn, *authCtx.ProjectID),
+		seedMcpServer(t, ctx, ti.conn, *authCtx.ProjectID),
+		seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, mcpserversrepo.CreateMCPServerParams{
+			TunneledMcpServerID: conv.ToNullUUID(seedTunnelBackend(t, ctx, ti.conn, *authCtx.ProjectID)),
+		}),
+		seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, mcpserversrepo.CreateMCPServerParams{
+			ToolsetID: conv.ToNullUUID(seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID)),
+		}),
+	}
+
+	for _, serverID := range servers {
+		_, err := ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+			SessionToken:     nil,
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+			MetaMcpServerID:  meta.ID,
+			McpServerID:      serverID.String(),
+			SortOrder:        nil,
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestAddMetaMcpMember_RemovedMemberFreesBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	meta := seedMetaMcpServer(t, ctx, ti, "freed backend host")
+	backend := mcpserversrepo.CreateMCPServerParams{
+		RemoteMcpServerID: conv.ToNullUUID(seedRemoteBackend(t, ctx, ti.conn, *authCtx.ProjectID)),
+	}
+	first := seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, backend)
+	second := seedMcpServerFronting(t, ctx, ti.conn, *authCtx.ProjectID, backend)
+
+	member, err := ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  meta.ID,
+		McpServerID:      first.String(),
+		SortOrder:        nil,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ti.service.RemoveMetaMcpMember(ctx, &gen.RemoveMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		ID:               member.ID,
+	}))
+
+	_, err = ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  meta.ID,
+		McpServerID:      second.String(),
+		SortOrder:        nil,
+	})
+	require.NoError(t, err)
+}
+
 func TestAddMetaMcpMember_RejectsForeignProjectServer(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -532,6 +532,24 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 		return nil, oops.E(oops.CodeUnexpected, err, "lock mcp server").LogError(ctx, logger)
 	}
 
+	// The meta lock above serializes concurrent adds, so this sees every
+	// committed member.
+	sharing, err := txRepo.CountMetaMCPMembersSharingBackend(ctx, repo.CountMetaMCPMembersSharingBackendParams{
+		MetaMcpServerID:      metaID,
+		ProjectID:            *authCtx.ProjectID,
+		McpServerID:          mcpServerID,
+		RemoteMcpServerID:    server.RemoteMcpServerID,
+		TunneledMcpServerID:  server.TunneledMcpServerID,
+		ToolsetID:            server.ToolsetID,
+		UnproxiedMcpServerID: server.UnproxiedMcpServerID,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count meta mcp members sharing a backend").LogError(ctx, logger)
+	}
+	if sharing > 0 {
+		return nil, oops.E(oops.CodeInvalid, nil, "another member of this meta mcp server already fronts the same backend").LogError(ctx, logger)
+	}
+
 	member, err := txRepo.CreateMetaMCPMember(ctx, repo.CreateMetaMCPMemberParams{
 		ProjectID:       *authCtx.ProjectID,
 		MetaMcpServerID: metaID,

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -547,7 +547,7 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 		return nil, oops.E(oops.CodeUnexpected, err, "count meta mcp members sharing a backend").LogError(ctx, logger)
 	}
 	if sharing > 0 {
-		return nil, oops.E(oops.CodeInvalid, nil, "another member of this meta mcp server already fronts the same backend").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeConflict, nil, "another member of this meta mcp server already fronts the same backend").LogError(ctx, logger)
 	}
 
 	member, err := txRepo.CreateMetaMCPMember(ctx, repo.CreateMetaMCPMemberParams{

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -124,6 +124,58 @@ VALUES (
 )
 RETURNING *;
 
+-- name: CountMetaMCPMembersSharingBackend :one
+-- Count live members of @meta_mcp_server_id, other than @mcp_server_id, that
+-- front one of the given backends. Two mcp_servers rows may name the same
+-- backend, and a meta MCP server holding both would serve identical tools
+-- under two slugs with nothing to route between them.
+--
+-- A null argument never matches: `column = NULL` evaluates to NULL, so an
+-- unset backend kind cannot pair with a member's null column.
+SELECT count(*)
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = @meta_mcp_server_id
+  AND m.project_id = @project_id
+  AND m.deleted IS FALSE
+  AND m.mcp_server_id <> @mcp_server_id
+  AND (s.remote_mcp_server_id = sqlc.narg('remote_mcp_server_id')
+    OR s.tunneled_mcp_server_id = sqlc.narg('tunneled_mcp_server_id')
+    OR s.toolset_id = sqlc.narg('toolset_id')
+    OR s.unproxied_mcp_server_id = sqlc.narg('unproxied_mcp_server_id'));
+
+-- name: FindMetaMCPSiblingSharingBackend :one
+-- Same rule as CountMetaMCPMembersSharingBackend, asked from the member
+-- server's side: name a meta MCP server where @mcp_server_id already sits
+-- alongside a live co-member fronting one of the given backends. Guards a
+-- backend repoint on an already-attached server.
+SELECT meta.name
+FROM meta_mcp_server_members mine
+JOIN meta_mcp_server_members sibling
+  ON sibling.meta_mcp_server_id = mine.meta_mcp_server_id
+ AND sibling.project_id = mine.project_id
+ AND sibling.deleted IS FALSE
+ AND sibling.mcp_server_id <> mine.mcp_server_id
+JOIN mcp_servers s
+  ON s.id = sibling.mcp_server_id
+ AND s.project_id = sibling.project_id
+ AND s.deleted IS FALSE
+JOIN meta_mcp_servers meta
+  ON meta.id = mine.meta_mcp_server_id
+ AND meta.project_id = mine.project_id
+ AND meta.deleted IS FALSE
+WHERE mine.mcp_server_id = @mcp_server_id
+  AND mine.project_id = @project_id
+  AND mine.deleted IS FALSE
+  AND (s.remote_mcp_server_id = sqlc.narg('remote_mcp_server_id')
+    OR s.tunneled_mcp_server_id = sqlc.narg('tunneled_mcp_server_id')
+    OR s.toolset_id = sqlc.narg('toolset_id')
+    OR s.unproxied_mcp_server_id = sqlc.narg('unproxied_mcp_server_id'))
+LIMIT 1;
+
 -- name: GetMetaMCPMember :one
 SELECT *
 FROM meta_mcp_server_members

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -12,6 +12,55 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countMetaMCPMembersSharingBackend = `-- name: CountMetaMCPMembersSharingBackend :one
+SELECT count(*)
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = $1
+  AND m.project_id = $2
+  AND m.deleted IS FALSE
+  AND m.mcp_server_id <> $3
+  AND (s.remote_mcp_server_id = $4
+    OR s.tunneled_mcp_server_id = $5
+    OR s.toolset_id = $6
+    OR s.unproxied_mcp_server_id = $7)
+`
+
+type CountMetaMCPMembersSharingBackendParams struct {
+	MetaMcpServerID      uuid.UUID
+	ProjectID            uuid.UUID
+	McpServerID          uuid.UUID
+	RemoteMcpServerID    uuid.NullUUID
+	TunneledMcpServerID  uuid.NullUUID
+	ToolsetID            uuid.NullUUID
+	UnproxiedMcpServerID uuid.NullUUID
+}
+
+// Count live members of @meta_mcp_server_id, other than @mcp_server_id, that
+// front one of the given backends. Two mcp_servers rows may name the same
+// backend, and a meta MCP server holding both would serve identical tools
+// under two slugs with nothing to route between them.
+//
+// A null argument never matches: `column = NULL` evaluates to NULL, so an
+// unset backend kind cannot pair with a member's null column.
+func (q *Queries) CountMetaMCPMembersSharingBackend(ctx context.Context, arg CountMetaMCPMembersSharingBackendParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countMetaMCPMembersSharingBackend,
+		arg.MetaMcpServerID,
+		arg.ProjectID,
+		arg.McpServerID,
+		arg.RemoteMcpServerID,
+		arg.TunneledMcpServerID,
+		arg.ToolsetID,
+		arg.UnproxiedMcpServerID,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createMetaMCPMember = `-- name: CreateMetaMCPMember :one
 INSERT INTO meta_mcp_server_members (
     project_id,
@@ -282,6 +331,59 @@ func (q *Queries) DeleteMetaMCPServer(ctx context.Context, arg DeleteMetaMCPServ
 		&i.Deleted,
 	)
 	return i, err
+}
+
+const findMetaMCPSiblingSharingBackend = `-- name: FindMetaMCPSiblingSharingBackend :one
+SELECT meta.name
+FROM meta_mcp_server_members mine
+JOIN meta_mcp_server_members sibling
+  ON sibling.meta_mcp_server_id = mine.meta_mcp_server_id
+ AND sibling.project_id = mine.project_id
+ AND sibling.deleted IS FALSE
+ AND sibling.mcp_server_id <> mine.mcp_server_id
+JOIN mcp_servers s
+  ON s.id = sibling.mcp_server_id
+ AND s.project_id = sibling.project_id
+ AND s.deleted IS FALSE
+JOIN meta_mcp_servers meta
+  ON meta.id = mine.meta_mcp_server_id
+ AND meta.project_id = mine.project_id
+ AND meta.deleted IS FALSE
+WHERE mine.mcp_server_id = $1
+  AND mine.project_id = $2
+  AND mine.deleted IS FALSE
+  AND (s.remote_mcp_server_id = $3
+    OR s.tunneled_mcp_server_id = $4
+    OR s.toolset_id = $5
+    OR s.unproxied_mcp_server_id = $6)
+LIMIT 1
+`
+
+type FindMetaMCPSiblingSharingBackendParams struct {
+	McpServerID          uuid.UUID
+	ProjectID            uuid.UUID
+	RemoteMcpServerID    uuid.NullUUID
+	TunneledMcpServerID  uuid.NullUUID
+	ToolsetID            uuid.NullUUID
+	UnproxiedMcpServerID uuid.NullUUID
+}
+
+// Same rule as CountMetaMCPMembersSharingBackend, asked from the member
+// server's side: name a meta MCP server where @mcp_server_id already sits
+// alongside a live co-member fronting one of the given backends. Guards a
+// backend repoint on an already-attached server.
+func (q *Queries) FindMetaMCPSiblingSharingBackend(ctx context.Context, arg FindMetaMCPSiblingSharingBackendParams) (string, error) {
+	row := q.db.QueryRow(ctx, findMetaMCPSiblingSharingBackend,
+		arg.McpServerID,
+		arg.ProjectID,
+		arg.RemoteMcpServerID,
+		arg.TunneledMcpServerID,
+		arg.ToolsetID,
+		arg.UnproxiedMcpServerID,
+	)
+	var name string
+	err := row.Scan(&name)
+	return name, err
 }
 
 const getMetaMCPMember = `-- name: GetMetaMCPMember :one

--- a/server/internal/metamcp/setup_test.go
+++ b/server/internal/metamcp/setup_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
+	unproxiedmcprepo "github.com/speakeasy-api/gram/server/internal/unproxiedmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -219,6 +220,23 @@ func seedToolsetBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, o
 	require.NoError(t, err)
 
 	return toolset.ID
+}
+
+// seedUnproxiedBackend inserts an unproxied_mcp_servers row.
+func seedUnproxiedBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	server, err := unproxiedmcprepo.New(conn).CreateServer(ctx, unproxiedmcprepo.CreateServerParams{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		Name:        pgtype.Text{String: "", Valid: false},
+		Slug:        conv.ToPGText("unproxied-" + uuid.NewString()),
+		Url:         "https://vendor.example.com/mcp",
+		Description: pgtype.Text{String: "", Valid: false},
+	})
+	require.NoError(t, err)
+
+	return server.ID
 }
 
 // seedOtherProject creates an additional project in the caller's organization.

--- a/server/internal/metamcp/setup_test.go
+++ b/server/internal/metamcp/setup_test.go
@@ -29,6 +29,8 @@ import (
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -146,30 +148,77 @@ func seedUserSessionIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 func seedMcpServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
 	t.Helper()
 
+	return seedMcpServerFronting(t, ctx, conn, projectID, mcpserversrepo.CreateMCPServerParams{
+		RemoteMcpServerID: conv.ToNullUUID(seedRemoteBackend(t, ctx, conn, projectID)),
+	})
+}
+
+// seedMcpServerFronting creates an mcp_server row on the caller's chosen
+// backend so tests can point two servers at one backend.
+func seedMcpServerFronting(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, backend mcpserversrepo.CreateMCPServerParams) uuid.UUID {
+	t.Helper()
+
+	mcpServerID, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	backend.ID = mcpServerID
+	backend.ProjectID = projectID
+	backend.Name = conv.ToPGText("member mcp server")
+	backend.Slug = conv.ToPGText("member-mcp-server-" + uuid.NewString())
+	backend.UserSessionIssuerID = conv.ToNullUUID(seedUserSessionIssuer(t, ctx, conn, projectID))
+	backend.Visibility = "disabled"
+
+	frontend, err := mcpserversrepo.New(conn).CreateMCPServer(ctx, backend)
+	require.NoError(t, err)
+
+	return frontend.ID
+}
+
+// seedRemoteBackend inserts a remote_mcp_servers row.
+func seedRemoteBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
 	server := remotemcptest.SeedServer(t, ctx, conn, remotemcprepo.CreateServerParams{
 		ProjectID:     projectID,
 		TransportType: "streamable-http",
 		Url:           "https://test.example.com/mcp/" + uuid.NewString(),
 	})
 
-	issuerID := seedUserSessionIssuer(t, ctx, conn, projectID)
+	return server.ID
+}
 
-	mcpServerID, err := uuid.NewV7()
-	require.NoError(t, err)
-	frontend, err := mcpserversrepo.New(conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
-		ID:                  mcpServerID,
-		ProjectID:           projectID,
-		Name:                conv.ToPGText("member mcp server"),
-		Slug:                conv.ToPGText("member-mcp-server-" + uuid.NewString()),
-		EnvironmentID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		UserSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
-		RemoteMcpServerID:   uuid.NullUUID{UUID: server.ID, Valid: true},
-		ToolsetID:           uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		Visibility:          "disabled",
+// seedTunnelBackend inserts a tunneled_mcp_servers row.
+func seedTunnelBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	server, err := tunneledmcprepo.New(conn).CreateServer(ctx, tunneledmcprepo.CreateServerParams{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		Name:      "tunnel " + uuid.NewString(),
+		KeyHash:   "key-hash-" + uuid.NewString(),
+		KeyPrefix: "key-prefix",
 	})
 	require.NoError(t, err)
 
-	return frontend.ID
+	return server.ID
+}
+
+// seedToolsetBackend inserts a toolsets row.
+func seedToolsetBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	slug := "toolset-" + uuid.NewString()[:8]
+	toolset, err := toolsetsrepo.New(conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		McpSlug:        conv.ToPGText(slug),
+		McpEnabled:     true,
+	})
+	require.NoError(t, err)
+
+	return toolset.ID
 }
 
 // seedOtherProject creates an additional project in the caller's organization.


### PR DESCRIPTION
AGE-3291

## Summary

A meta MCP server can no longer hold two members that front the same backend.

- `meta_mcp.addMember` now counts live members of the gateway, other than the candidate itself, whose `mcp_servers` row names the candidate's backend, and rejects the attach with an invalid-argument error when there is one. It covers every backend kind an `mcp_servers` row can take — remote, tunneled, toolset, unproxied — since two members sharing a toolset or a tunnel is as meaningless as two sharing a remote server. The check runs under the `FOR UPDATE` lock `AddMetaMcpMember` already takes on the meta row, so concurrent adds to one gateway serialize behind it.
- `mcpServers.update` can repoint an attached server's backend and recreate the same collision after the fact, so it gets the mirror check: when the update actually changes a backend reference, it refuses to move the server onto a backend one of its co-members already fronts, naming the gateway in the error. The two paths take no common lock, so a simultaneous attach of the colliding member can still slip past; the guard is a correctness affordance for the API, not a database invariant.
- The candidate's own `mcp_server_id` is excluded from both queries, so the existing live-unique index keeps owning the "same server attached twice" case and this error stays specific to the different-server case.

The two new queries pass each backend id as a nullable argument and compare with `=`, never `IS NOT DISTINCT FROM`: a null argument yields NULL rather than matching a member's null column, so a remote-backed candidate cannot collide with a toolset-backed member. Tests cover the three shared-backend rejections, mixed backend kinds still attaching cleanly, and a removed member freeing its backend for a re-add.

## Motivation

`meta_mcp_server_members.mcp_server_id` points at `mcp_servers`, which has a hard XOR over `remote_mcp_server_id` / `tunneled_mcp_server_id` / `toolset_id` / `unproxied_mcp_server_id` — but nothing stops two different `mcp_servers` rows from naming the same one. Attaching both to a gateway produces two members with different slugs serving identical tools, and routing has no basis to prefer one over the other.

Per Brian on where this belongs:

> it wouldn't really make sense (I don't think?) to include mcp_servers A -> remote_mcp_servers R along with mcp_servers B -> remote_mcp_servers R in the same meta mcp server. that can be something we enforce when constructing them

> application code-wise, not database-wise […] We can/should enforce that sort of logic at app layer

Enforcing at the app layer rather than with a partial unique index keeps it out of the schema, where the rule would have to be expressed four times over and could not produce a useful error message.
