### PR TITLE
feat: allow promotion codes in Stripe checkout

### DIFF
--- a/.changeset/stripe-checkout-promotion-codes.md
+++ b/.changeset/stripe-checkout-promotion-codes.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Allow customers to enter Stripe promotion codes during pay-as-you-go checkout.

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -516,6 +516,7 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	}
 
 	params := new(stripesdk.CheckoutSessionCreateParams)
+	params.AllowPromotionCodes = new(true)
 	params.CancelURL = stripesdk.String(input.CancelURL)
 	params.ClientReferenceID = stripesdk.String(input.OrganizationID)
 	params.Customer = stripesdk.String(input.CustomerID)

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -442,6 +442,7 @@ func TestCreateCheckoutSessionBuildsMeteredSubscription(t *testing.T) {
 	require.Equal(t, "cus_test", stripesdk.StringValue(params.Customer))
 	require.Equal(t, expiresAt.Unix(), stripesdk.Int64Value(params.ExpiresAt))
 	require.Equal(t, "<ORG_ID>", stripesdk.StringValue(params.ClientReferenceID))
+	require.True(t, stripesdk.BoolValue(params.AllowPromotionCodes))
 	require.Equal(t, "subscription", stripesdk.StringValue(params.Mode))
 	require.Equal(t, "always", stripesdk.StringValue(params.PaymentMethodCollection))
 	require.Equal(t, "https://app.example.test/the-customer/billing", stripesdk.StringValue(params.SuccessURL))


### PR DESCRIPTION
## Summary

Enable customer-entered promotion codes on hosted Stripe Checkout sessions for pay-as-you-go billing, with coverage for the generated Checkout parameters.

## Motivation

Allow billing administrators to redeem Stripe-managed promotions during self-serve checkout without adding discount handling to the dashboard or Gram API.
