### PR TITLE
feat: select gateway upstream credentials per member at consent time

### DIFF
--- a/.changeset/gateway-per-member-credential-selection.md
+++ b/.changeset/gateway-per-member-credential-selection.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Qualify a gateway endpoint's upstream credentials to the member they belong to, by resolving the member at consent time from its OAuth protected-resource metadata.

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -125,7 +125,16 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		}
 		// Not endpoint.UpstreamResource: under multi-binding that may belong
 		// to a different client's upstream; ambiguity derives "" (no resource).
-		clientResource, rerr := s.remoteChallengeMgr.FallbackResourceForClient(ctx, client.ID)
+		// A gateway's members carry their own issuers while the client is bound
+		// to the gateway's, so the stored derivation finds nothing there and
+		// consent-time discovery resolves the member instead.
+		var clientResource string
+		var rerr error
+		if endpoint.MetaMcpServerID.Valid {
+			clientResource, rerr = s.resolveGatewayMemberResource(ctx, logger, endpoint, client.IssuerURL)
+		} else {
+			clientResource, rerr = s.remoteChallengeMgr.FallbackResourceForClient(ctx, client.ID)
+		}
 		if rerr != nil {
 			return oops.E(oops.CodeUnexpected, rerr, "derive client upstream resource").LogError(ctx, logger)
 		}

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -126,13 +126,23 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		// Not endpoint.UpstreamResource: under multi-binding that may belong
 		// to a different client's upstream; ambiguity derives "" (no resource).
 		// A gateway's members carry their own issuers while the client is bound
-		// to the gateway's, so the stored derivation finds nothing there and
-		// consent-time discovery resolves the member instead.
+		// to the gateway's, so the stored derivation usually finds nothing there
+		// and consent-time discovery resolves the member instead.
 		var clientResource string
 		var rerr error
 		if endpoint.MetaMcpServerID.Valid {
-			clientResource, rerr = s.resolveGatewayMemberResource(ctx, logger, endpoint, client.IssuerURL)
-		} else {
+			// Member visibility is judged against the consent subject, exactly
+			// like the runtime request the minted session will make.
+			memberCtx, cerr := s.contextForSessionSubject(ctx, endpoint, subject, "consent:"+challengeState.ID, challengeState.ClientID)
+			if cerr != nil {
+				return oops.E(oops.CodeUnexpected, cerr, "stamp consent subject context").LogError(ctx, logger)
+			}
+			clientResource, rerr = s.resolveGatewayMemberResource(memberCtx, logger, endpoint, client.IssuerURL)
+		}
+		// Discovery wins wherever it resolves; the stored derivation still
+		// answers for a client bound to a member's own issuer, and returns ""
+		// itself whenever it is ambiguous, so it can never be worse than "".
+		if rerr == nil && clientResource == "" {
 			clientResource, rerr = s.remoteChallengeMgr.FallbackResourceForClient(ctx, client.ID)
 		}
 		if rerr != nil {

--- a/server/internal/mcp/authnchallenge_consent_action_test.go
+++ b/server/internal/mcp/authnchallenge_consent_action_test.go
@@ -201,6 +201,15 @@ func seedMultiClientConsentEndpoint(t *testing.T) (context.Context, consentActio
 // upstream authorize redirect URL.
 func postConnectAction(t *testing.T, fx consentActionFixture, clientID uuid.UUID) *url.URL {
 	t.Helper()
+	return postConnectActionAs(t, nil, fx, clientID)
+}
+
+// postConnectActionAs is postConnectAction with the request context under test
+// control, so a consent can be driven with a specific grant set. A nil context
+// leaves the request on its own background context, which is what an
+// unauthenticated browser POST carries.
+func postConnectActionAs(t *testing.T, ctx context.Context, fx consentActionFixture, clientID uuid.UUID) *url.URL {
+	t.Helper()
 
 	form := url.Values{}
 	form.Set("state", fx.stateID)
@@ -209,6 +218,9 @@ func postConnectAction(t *testing.T, fx consentActionFixture, clientID uuid.UUID
 	form.Set("client_id", clientID.String())
 
 	req := httptest.NewRequest(http.MethodPost, "/mcp/"+fx.endpoint.Slug+"/connect/remote-session", strings.NewReader(form.Encode()))
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	require.NoError(t, fx.ti.service.ServeConsentAction(w, req, fx.endpoint))

--- a/server/internal/mcp/authnchallenge_consent_gateway_credentials_test.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_credentials_test.go
@@ -232,6 +232,52 @@ func TestGatewayCredentials_DetachedMemberDoesNotContestAnother(t *testing.T) {
 	require.Equal(t, removed.accessToken, got, "the stale credential stays bound to the member it was minted for")
 }
 
+// A reconnect whose discovery misses must not un-qualify a grant that already
+// names its member. The resource column is the routing key, and nothing
+// re-derives it for a gateway-bound client afterwards — the refresh backfill
+// derives from the client's own issuer bindings, which a gateway consent does
+// not create — so an overwrite would be permanent.
+func TestGatewayCredentials_ReconnectDoesNotUnqualifyAStoredResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-reconnect-gw")
+
+	var captured atomic.Value
+	as := newConsentExchangeAS(t, &captured, "token-reconnect")
+	advertising := &atomic.Bool{}
+	advertising.Store(true)
+	member := newToggleableGatewayMemberUpstream(t, advertising, as.URL).URL + "/mcp"
+	seeded := createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-reconnect-member", member, 0)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-reconnect", as.URL, []uuid.UUID{fx.shared})
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 1, "the member must be a probe candidate, or this asserts nothing")
+
+	mgr := newConsentCallbackManager(t, fx.ti)
+	gw := connectedGateway{fx: fx, metaServerID: metaServerID, mgr: mgr, members: nil}
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, client))
+	require.Equal(t, member, activeResource(t, ctx, gw, client), "the first connect qualifies the grant")
+
+	// The member stops advertising and the subject reconnects.
+	advertising.Store(false)
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "the reconnect must derive nothing, or this asserts nothing")
+	completeRemoteLogin(t, mgr, loc)
+
+	require.Equal(t, member, activeResource(t, ctx, gw, client), "a transient discovery miss must not un-qualify a stored grant")
+
+	// And a resolvable reconnect still rebinds: preserving is not freezing.
+	advertising.Store(true)
+	other := newGatewayMemberUpstream(t, as.URL).URL + "/mcp"
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-reconnect-moved", other, 1)
+	_, err := metamcp_repo.New(fx.ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{ID: seeded.memberID, ProjectID: fx.projectID})
+	require.NoError(t, err)
+	require.Equal(t, []string{other}, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID))
+
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, client))
+	require.Equal(t, other, activeResource(t, ctx, gw, client), "a non-empty resolution still rebinds the grant")
+}
+
 // Trailing-slash spellings must survive the round trip: consent trims the
 // member URL before recording it while the backend keeps its stored spelling,
 // so the two only meet because routing trims too. A second member is present

--- a/server/internal/mcp/authnchallenge_consent_gateway_credentials_test.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_credentials_test.go
@@ -1,0 +1,276 @@
+// The point of consent-time member resolution is that a later request to one
+// gateway member forwards that member's credential and no other. These tests
+// carry a real gateway all the way through — consent, authorize, code
+// exchange, persisted remote_sessions rows — and then hand the result to the
+// production routing decision, so the feature is asserted end to end rather
+// than at the redirect it starts with.
+
+package mcp_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// connectedGatewayMember is one member of a gateway whose client has completed
+// the whole OAuth round trip.
+type connectedGatewayMember struct {
+	upstreamURL string
+	accessToken string
+	clientID    uuid.UUID
+	seeded      gatewayMember
+	// exchanged holds what this member's authorization server saw on the
+	// token POST.
+	exchanged *atomic.Value
+}
+
+// connectedGateway is a gateway with count remote members, each behind its own
+// live authorization server, each with a connected client.
+type connectedGateway struct {
+	fx           consentActionFixture
+	metaServerID uuid.UUID
+	mgr          *remotesessions.ChallengeManager
+	members      []connectedGatewayMember
+}
+
+// resolveTokens runs the production credential resolver for the gateway's
+// issuer and subject — the same map the serving path routes from.
+func (g connectedGateway) resolveTokens(t *testing.T, ctx context.Context) map[uuid.UUID]remotesessions.UpstreamToken {
+	t.Helper()
+	tokens, err := g.mgr.ResolveAccessTokens(ctx, g.fx.projectID, g.fx.orgID, g.fx.shared, g.fx.subject)
+	require.NoError(t, err)
+	return tokens
+}
+
+// route drives the real routeUpstreamToken for one backend's upstream
+// resource. Nothing here is stubbed: the map comes from the database and the
+// selection rule is the one the proxy uses.
+func (g connectedGateway) route(t *testing.T, ctx context.Context, tokens map[uuid.UUID]remotesessions.UpstreamToken, upstreamResource string) (string, error) {
+	t.Helper()
+	token, err := mcp.RouteUpstreamTokenForTest(ctx, g.fx.ti.logger, tokens, upstreamResource)
+	if err != nil {
+		return "", fmt.Errorf("route upstream token: %w", err)
+	}
+	return token, nil
+}
+
+// connectGateway seeds a gateway with count remote members and drives each
+// member's client through consent, the authorize redirect, and the code
+// exchange, so every credential is persisted the way production writes it.
+//
+// discoverable=false makes every member answer 404 at the well-known path,
+// reproducing the pre-change state where no grant carries a resource.
+func connectGateway(t *testing.T, prefix string, count int, discoverable bool) (context.Context, connectedGateway) {
+	t.Helper()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, prefix+"-gw")
+
+	captured := make([]atomic.Value, count)
+	members := make([]connectedGatewayMember, 0, count)
+	for i := range count {
+		name := fmt.Sprintf("%s-%d", prefix, i)
+		accessToken := "token-" + name
+		as := newConsentExchangeAS(t, &captured[i], accessToken)
+
+		upstream := newUpstreamWithoutMetadata(t).URL + "/mcp"
+		if discoverable {
+			upstream = newGatewayMemberUpstream(t, as.URL).URL + "/mcp"
+		}
+
+		members = append(members, connectedGatewayMember{
+			upstreamURL: upstream,
+			accessToken: accessToken,
+			clientID:    createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, name, as.URL, []uuid.UUID{fx.shared}),
+			seeded:      createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, name+"-member", upstream, int32(i)),
+			exchanged:   &captured[i],
+		})
+	}
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), count)
+
+	// Every member exists before any client connects, so consent always sees
+	// the whole gateway.
+	mgr := newConsentCallbackManager(t, fx.ti)
+	for _, member := range members {
+		completeRemoteLogin(t, mgr, postConnectAction(t, fx, member.clientID))
+	}
+
+	return ctx, connectedGateway{fx: fx, metaServerID: metaServerID, mgr: mgr, members: members}
+}
+
+// activeResource reads the RFC 8707 resource persisted on a subject's
+// credential straight from the database.
+func activeResource(t *testing.T, ctx context.Context, gw connectedGateway, clientID uuid.UUID) string {
+	t.Helper()
+	sess, err := remotesessions_repo.New(gw.fx.ti.conn).GetActiveRemoteSession(ctx, remotesessions_repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            gw.fx.subject,
+		RemoteSessionClientID: clientID,
+	})
+	require.NoError(t, err)
+	return sess.Resource.String
+}
+
+// The resolved member must survive the whole chain — consent form, login
+// state, token exchange, remote_sessions row — because everything downstream
+// routes off the persisted value, not off what consent sent.
+func TestGatewayCredentials_ConsentResolutionPersistsOnTheGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, gw := connectGateway(t, "aim87-persist", 2, true)
+
+	for _, member := range gw.members {
+		require.Equal(t, consentExchangeCapture{HasResource: true, Resource: member.upstreamURL}, member.exchanged.Load(),
+			"the code exchange must carry the member as its RFC 8707 resource indicator")
+		require.Equal(t, member.upstreamURL, activeResource(t, ctx, gw, member.clientID),
+			"remote_sessions.resource must name the member the client authorized for")
+	}
+	require.NotEqual(t, activeResource(t, ctx, gw, gw.members[0].clientID), activeResource(t, ctx, gw, gw.members[1].clientID),
+		"two members must not share a resource")
+	require.NotEqual(t, gw.fx.endpoint.UpstreamResource, activeResource(t, ctx, gw, gw.members[0].clientID),
+		"the endpoint-level resource must never reach a grant")
+}
+
+// The feature's whole purpose: with grants qualified per member, a request to
+// each member selects that member's own credential.
+func TestGatewayCredentials_EachMemberSelectsItsOwnCredential(t *testing.T) {
+	t.Parallel()
+
+	ctx, gw := connectGateway(t, "aim87-select", 3, true)
+
+	tokens := gw.resolveTokens(t, ctx)
+	require.Len(t, tokens, 3)
+
+	for _, member := range gw.members {
+		got, err := gw.route(t, ctx, tokens, member.upstreamURL)
+		require.NoError(t, err, "member %s must resolve a credential", member.upstreamURL)
+		require.Equal(t, member.accessToken, got, "member %s must receive its own credential", member.upstreamURL)
+	}
+
+	// A backend nobody consented to gets nothing rather than somebody else's.
+	got, err := gw.route(t, ctx, tokens, "https://aim87-select-unknown.example.com/mcp")
+	require.Error(t, err)
+	require.Empty(t, got)
+}
+
+// The negative that gives the positive its meaning: the same three-member
+// gateway whose members advertise no metadata records unqualified grants, and
+// then no member can be served at all. This is the state before consent-time
+// resolution, and it fails closed rather than forwarding an arbitrary token.
+func TestGatewayCredentials_UnqualifiedGrantsFailClosedForEveryMember(t *testing.T) {
+	t.Parallel()
+
+	ctx, gw := connectGateway(t, "aim87-unqualified", 3, false)
+
+	for _, member := range gw.members {
+		require.Equal(t, consentExchangeCapture{HasResource: false, Resource: ""}, member.exchanged.Load(), "no resource indicator is sent when discovery misses")
+		require.Empty(t, activeResource(t, ctx, gw, member.clientID), "a member that advertises nothing cannot qualify its grant")
+	}
+
+	tokens := gw.resolveTokens(t, ctx)
+	require.Len(t, tokens, 3)
+
+	for _, member := range gw.members {
+		got, err := gw.route(t, ctx, tokens, member.upstreamURL)
+		require.Error(t, err, "member %s must not be served from an unqualified credential", member.upstreamURL)
+		require.Empty(t, got)
+	}
+}
+
+// The v1 limitation AIM-87 names, pinned so it cannot regress silently: a lone
+// credential is forwarded even to a member it was not minted for. It is why
+// qualification matters as soon as a gateway holds a second member.
+func TestGatewayCredentials_LoneUnqualifiedCredentialIsStillForwarded(t *testing.T) {
+	t.Parallel()
+
+	ctx, gw := connectGateway(t, "aim87-lone", 1, false)
+
+	tokens := gw.resolveTokens(t, ctx)
+	require.Len(t, tokens, 1)
+
+	got, err := gw.route(t, ctx, tokens, "https://aim87-lone-other.example.com/mcp")
+	require.NoError(t, err)
+	require.Equal(t, gw.members[0].accessToken, got, "documented v1 limitation: a single credential is forwarded unqualified")
+}
+
+// Membership changes after a grant is recorded. The recorded resource is the
+// member's identity, not its membership, so a detached member's credential
+// stays bound to that member and never becomes another member's.
+func TestGatewayCredentials_DetachedMemberDoesNotContestAnother(t *testing.T) {
+	t.Parallel()
+
+	ctx, gw := connectGateway(t, "aim87-churn", 3, true)
+
+	removed := gw.members[1]
+	_, err := metamcp_repo.New(gw.fx.ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{
+		ID:        removed.seeded.memberID,
+		ProjectID: gw.fx.projectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, gw.fx.ti.conn, gw.fx.projectID, gw.metaServerID), 2)
+
+	tokens := gw.resolveTokens(t, ctx)
+	require.Len(t, tokens, 3, "detaching a member does not revoke the subject's credential")
+
+	for _, member := range []connectedGatewayMember{gw.members[0], gw.members[2]} {
+		got, err := gw.route(t, ctx, tokens, member.upstreamURL)
+		require.NoError(t, err)
+		require.Equal(t, member.accessToken, got, "the surviving members keep their own credentials")
+	}
+
+	got, err := gw.route(t, ctx, tokens, removed.upstreamURL)
+	require.NoError(t, err)
+	require.Equal(t, removed.accessToken, got, "the stale credential stays bound to the member it was minted for")
+}
+
+// Trailing-slash spellings must survive the round trip: consent trims the
+// member URL before recording it while the backend keeps its stored spelling,
+// so the two only meet because routing trims too. A second member is present
+// so the selection is a real choice rather than the lone-credential rule.
+func TestGatewayCredentials_TrailingSlashSpellingsSelectTheSameCredential(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-slash-gw")
+
+	var slashCaptured, plainCaptured atomic.Value
+	slashAS := newConsentExchangeAS(t, &slashCaptured, "token-slash")
+	plainAS := newConsentExchangeAS(t, &plainCaptured, "token-plain")
+
+	// Advertised with a trailing slash, stored without; the member's own URL
+	// carries one too.
+	slashed := newGatewayMemberUpstream(t, slashAS.URL+"/").URL + "/mcp/"
+	plain := newGatewayMemberUpstream(t, plainAS.URL).URL + "/mcp"
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-slash-member", slashed, 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-slash-plain", plain, 1)
+
+	slashClient := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-slash", slashAS.URL, []uuid.UUID{fx.shared})
+	plainClient := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-plain", plainAS.URL, []uuid.UUID{fx.shared})
+
+	mgr := newConsentCallbackManager(t, fx.ti)
+	gw := connectedGateway{fx: fx, metaServerID: metaServerID, mgr: mgr, members: nil}
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, slashClient))
+	completeRemoteLogin(t, mgr, postConnectAction(t, fx, plainClient))
+
+	require.Equal(t, strings.TrimRight(slashed, "/"), activeResource(t, ctx, gw, slashClient), "the grant records the trimmed form resolveUpstreamResource derives")
+
+	tokens := gw.resolveTokens(t, ctx)
+	require.Len(t, tokens, 2)
+
+	// The backend's own resource is its stored URL, slash and all.
+	got, err := gw.route(t, ctx, tokens, slashed)
+	require.NoError(t, err)
+	require.Equal(t, "token-slash", got, "the member's slashed URL must still select its own credential")
+
+	got, err = gw.route(t, ctx, tokens, plain)
+	require.NoError(t, err)
+	require.Equal(t, "token-plain", got)
+}

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
 
 const (
@@ -60,8 +61,7 @@ func (s *Service) resolveGatewayMemberResource(
 	endpoint *ResolvedMcpEndpoint,
 	issuerURL string,
 ) (string, error) {
-	want := strings.TrimRight(issuerURL, "/")
-	if want == "" {
+	if strings.TrimSpace(issuerURL) == "" {
 		return "", nil
 	}
 
@@ -107,7 +107,13 @@ func (s *Service) resolveGatewayMemberResource(
 				return nil
 			}
 			for _, authorizationServer := range doc.AuthorizationServers {
-				if strings.TrimRight(authorizationServer, "/") == want {
+				// Canonical, not literal: the entry is written by the upstream
+				// while the issuer URL is Gram's stored spelling, so the two
+				// disagree on trailing slash, default port, and host case for
+				// one authorization server. A literal compare both misses real
+				// members and lets two members behind one authorization server
+				// slip past the ambiguity guard on a spelling difference.
+				if remotesessions.IssuerURLsCanonicallyEqual(authorizationServer, issuerURL) {
 					matches[i] = strings.TrimRight(row.UpstreamUrl, "/")
 					break
 				}

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource.go
@@ -1,0 +1,135 @@
+// Per-member credential selection for gateway endpoints. A caller
+// authenticates once at a gateway, so every upstream credential they hold
+// hangs off the gateway's user_session_issuer and the per-client derivation
+// that qualifies a normal endpoint's grants derives nothing. This resolves the
+// member a connecting client belongs to at consent time — by probing each
+// member's RFC 9728 protected-resource metadata for the client's authorization
+// server — and records that member's URL as the grant's RFC 8707 resource, so
+// routeUpstreamToken can route by it unchanged.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
+)
+
+const (
+	// gatewayResourceProbeTimeout bounds one member's probe. Tighter than the
+	// discovery helper's own budget on purpose: this runs inside a consent
+	// click, so a member that is slow is a member that does not resolve.
+	gatewayResourceProbeTimeout = 3 * time.Second
+
+	// gatewayResourceProbeBudget bounds the whole fan-out however many members
+	// the gateway holds, so consent latency stays independent of membership
+	// size. Members left unprobed when it expires simply do not match.
+	gatewayResourceProbeBudget = 6 * time.Second
+
+	// gatewayResourceProbeConcurrency caps in-flight probes. A gateway's
+	// members are distinct upstreams, so the cap bounds what a single consent
+	// click reads as against other people's servers.
+	gatewayResourceProbeConcurrency = 4
+)
+
+// resolveGatewayMemberResource returns the upstream URL of the one gateway
+// member whose protected-resource metadata names issuerURL as an authorization
+// server, or "" when the member cannot be identified unambiguously.
+//
+// Fails closed, never guesses: no match, several matches, unavailable metadata,
+// and probe errors all derive "", which the connect arm treats exactly as an
+// underivable resource. Two limits fall out of the discovery approach and are
+// accepted for v1 — tunneled members advertise no metadata document and so are
+// never resolvable this way, and one authorization server fronting two members
+// of the same gateway is ambiguous by construction, because a grant records one
+// resource per (subject, client).
+//
+// The returned error is a database fault only; the connect arm turns it into a
+// failed consent rather than minting an unqualified grant.
+func (s *Service) resolveGatewayMemberResource(
+	ctx context.Context,
+	logger *slog.Logger,
+	endpoint *ResolvedMcpEndpoint,
+	issuerURL string,
+) (string, error) {
+	want := strings.TrimRight(issuerURL, "/")
+	if want == "" {
+		return "", nil
+	}
+
+	rows, err := metamcprepo.New(s.db).ListServableMetaMCPMemberUpstreams(ctx, metamcprepo.ListServableMetaMCPMemberUpstreamsParams{
+		MetaMcpServerID: endpoint.MetaMcpServerID.UUID,
+		ProjectID:       endpoint.ProjectID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list gateway member upstreams: %w", err)
+	}
+	if len(rows) == 0 {
+		return "", nil
+	}
+
+	budgetCtx, cancel := context.WithTimeout(ctx, gatewayResourceProbeBudget)
+	defer cancel()
+
+	// Index-addressed so each probe writes its own slot and one unreachable
+	// member neither blocks nor discards another's result.
+	matches := make([]string, len(rows))
+
+	// A plain Group: a probe failure is one member not resolving, not a reason
+	// to cancel the others.
+	group := &errgroup.Group{}
+	group.SetLimit(gatewayResourceProbeConcurrency)
+	for i, row := range rows {
+		group.Go(func() error {
+			if budgetCtx.Err() != nil {
+				return nil
+			}
+			probeCtx, cancelOne := context.WithTimeout(budgetCtx, gatewayResourceProbeTimeout)
+			defer cancelOne()
+
+			doc, _, probeErr := wellknown.DiscoverProtectedResourceMetadata(probeCtx, s.guardianPolicy, row.UpstreamUrl)
+			if probeErr != nil {
+				// Debug: a member without OAuth answers 404 here, which is the
+				// common case and not a fault.
+				logger.DebugContext(ctx, "gateway member advertises no usable protected resource metadata",
+					attr.SlogMcpServerID(row.McpServerID.String()),
+					attr.SlogResourceURI(row.UpstreamUrl),
+					attr.SlogError(probeErr),
+				)
+				return nil
+			}
+			for _, authorizationServer := range doc.AuthorizationServers {
+				if strings.TrimRight(authorizationServer, "/") == want {
+					matches[i] = strings.TrimRight(row.UpstreamUrl, "/")
+					break
+				}
+			}
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	resource := ""
+	for _, match := range matches {
+		switch {
+		case match == "", match == resource:
+		case resource == "":
+			resource = match
+		default:
+			logger.WarnContext(ctx, "gateway members share an authorization server; credential cannot be qualified to one member",
+				attr.SlogMetaMcpServerID(endpoint.MetaMcpServerID.UUID.String()),
+				attr.SlogOAuthIssuer(issuerURL),
+			)
+			return "", nil
+		}
+	}
+	return resource, nil
+}

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource.go
@@ -11,6 +11,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -19,6 +20,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
@@ -32,7 +35,7 @@ const (
 
 	// gatewayResourceProbeBudget bounds the whole fan-out however many members
 	// the gateway holds, so consent latency stays independent of membership
-	// size. Members left unprobed when it expires simply do not match.
+	// size. Members left unprobed when it expires are unknown, not absent.
 	gatewayResourceProbeBudget = 6 * time.Second
 
 	// gatewayResourceProbeConcurrency caps in-flight probes. A gateway's
@@ -41,20 +44,35 @@ const (
 	gatewayResourceProbeConcurrency = 4
 )
 
+// gatewayMemberProbe is one member's outcome. A conclusive probe either found
+// the member claiming the issuer (resource set) or proved it claims nothing;
+// an inconclusive one leaves the member unknown, and one unknown member is
+// enough that no other member's claim can be called unique.
+type gatewayMemberProbe struct {
+	resource     string
+	inconclusive bool
+}
+
 // resolveGatewayMemberResource returns the upstream URL of the one gateway
 // member whose protected-resource metadata names issuerURL as an authorization
 // server, or "" when the member cannot be identified unambiguously.
 //
-// Fails closed, never guesses: no match, several matches, unavailable metadata,
-// and probe errors all derive "", which the connect arm treats exactly as an
-// underivable resource. Two limits fall out of the discovery approach and are
-// accepted for v1 — tunneled members advertise no metadata document and so are
-// never resolvable this way, and one authorization server fronting two members
-// of the same gateway is ambiguous by construction, because a grant records one
-// resource per (subject, client).
+// Fails closed, never guesses: no match, several matches, and any member whose
+// metadata could not be read all derive "", which the connect arm treats
+// exactly as an underivable resource. Metadata that could not be read is the
+// load-bearing case — a member that is slow, unreachable, or simply never
+// probed makes no claim only because nobody asked, so treating it as absent
+// would hand a rival member a unique match it did not earn. A 404 is the
+// opposite: the member answered, and answered that it speaks no OAuth.
 //
-// The returned error is a database fault only; the connect arm turns it into a
-// failed consent rather than minting an unqualified grant.
+// Two limits fall out of the discovery approach and are accepted for v1 —
+// tunneled members advertise no metadata document and so are never resolvable
+// this way, and one authorization server fronting two members of the same
+// gateway is ambiguous by construction, because a grant records one resource
+// per (subject, client).
+//
+// The returned error is a database or grant-load fault only; the connect arm
+// turns it into a failed consent rather than minting an unqualified grant.
 func (s *Service) resolveGatewayMemberResource(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -72,7 +90,12 @@ func (s *Service) resolveGatewayMemberResource(
 	if err != nil {
 		return "", fmt.Errorf("list gateway member upstreams: %w", err)
 	}
-	if len(rows) == 0 {
+
+	candidates, err := s.authorizedGatewayMemberUpstreams(ctx, endpoint, rows)
+	if err != nil {
+		return "", err
+	}
+	if len(candidates) == 0 {
 		return "", nil
 	}
 
@@ -81,15 +104,16 @@ func (s *Service) resolveGatewayMemberResource(
 
 	// Index-addressed so each probe writes its own slot and one unreachable
 	// member neither blocks nor discards another's result.
-	matches := make([]string, len(rows))
+	probes := make([]gatewayMemberProbe, len(candidates))
 
 	// A plain Group: a probe failure is one member not resolving, not a reason
 	// to cancel the others.
 	group := &errgroup.Group{}
 	group.SetLimit(gatewayResourceProbeConcurrency)
-	for i, row := range rows {
+	for i, row := range candidates {
 		group.Go(func() error {
 			if budgetCtx.Err() != nil {
+				probes[i].inconclusive = true
 				return nil
 			}
 			probeCtx, cancelOne := context.WithTimeout(budgetCtx, gatewayResourceProbeTimeout)
@@ -97,12 +121,26 @@ func (s *Service) resolveGatewayMemberResource(
 
 			doc, _, probeErr := wellknown.DiscoverProtectedResourceMetadata(probeCtx, s.guardianPolicy, row.UpstreamUrl)
 			if probeErr != nil {
+				probes[i].inconclusive = !conclusiveProbeMiss(probeErr)
 				// Debug: a member without OAuth answers 404 here, which is the
 				// common case and not a fault.
 				logger.DebugContext(ctx, "gateway member advertises no usable protected resource metadata",
 					attr.SlogMcpServerID(row.McpServerID.String()),
 					attr.SlogResourceURI(row.UpstreamUrl),
 					attr.SlogError(probeErr),
+				)
+				return nil
+			}
+			// RFC 9728 §3.3: a document naming some other resource is the
+			// host's, not this member's — on a shared multi-tenant host the
+			// path-style probe 404s and the origin-style fallback returns a
+			// neighbour's document, whose authorization servers this member
+			// never declared.
+			if doc.Resource != "" && !remotesessions.IssuerURLsCanonicallyEqual(doc.Resource, row.UpstreamUrl) {
+				logger.DebugContext(ctx, "gateway member protected resource metadata names another resource",
+					attr.SlogMcpServerID(row.McpServerID.String()),
+					attr.SlogResourceURI(row.UpstreamUrl),
+					attr.SlogOAuthResource(doc.Resource),
 				)
 				return nil
 			}
@@ -114,7 +152,7 @@ func (s *Service) resolveGatewayMemberResource(
 				// members and lets two members behind one authorization server
 				// slip past the ambiguity guard on a spelling difference.
 				if remotesessions.IssuerURLsCanonicallyEqual(authorizationServer, issuerURL) {
-					matches[i] = strings.TrimRight(row.UpstreamUrl, "/")
+					probes[i].resource = strings.TrimRight(row.UpstreamUrl, "/")
 					break
 				}
 			}
@@ -123,12 +161,25 @@ func (s *Service) resolveGatewayMemberResource(
 	}
 	_ = group.Wait()
 
+	for _, probe := range probes {
+		if probe.inconclusive {
+			logger.WarnContext(ctx, "a gateway member's protected resource metadata could not be read; credential cannot be qualified to one member",
+				attr.SlogMetaMcpServerID(endpoint.MetaMcpServerID.UUID.String()),
+				attr.SlogOAuthIssuer(issuerURL),
+			)
+			return "", nil
+		}
+	}
+
 	resource := ""
-	for _, match := range matches {
+	for _, probe := range probes {
 		switch {
-		case match == "", match == resource:
+		// Two members may front one URL: remote_mcp_servers is unique on
+		// (project_id, slug), not on url. routeUpstreamToken keys on the
+		// destination URL, so a token minted for it serves either member.
+		case probe.resource == "", probe.resource == resource:
 		case resource == "":
-			resource = match
+			resource = probe.resource
 		default:
 			logger.WarnContext(ctx, "gateway members share an authorization server; credential cannot be qualified to one member",
 				attr.SlogMetaMcpServerID(endpoint.MetaMcpServerID.UUID.String()),
@@ -138,4 +189,61 @@ func (s *Service) resolveGatewayMemberResource(
 		}
 	}
 	return resource, nil
+}
+
+// authorizedGatewayMemberUpstreams drops the members the connecting subject
+// holds no mcp:connect on, as resolveMetaMemberSnapshot does for the serving
+// path. A member the caller cannot reach must neither claim their credential
+// — the resolved URL is echoed to them and sent to the authorization server —
+// nor contest the claim of a member they can.
+func (s *Service) authorizedGatewayMemberUpstreams(
+	ctx context.Context,
+	endpoint *ResolvedMcpEndpoint,
+	rows []metamcprepo.ListServableMetaMCPMemberUpstreamsRow,
+) ([]metamcprepo.ListServableMetaMCPMemberUpstreamsRow, error) {
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	ctx, err := s.authz.PrepareContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load access grants: %w", err)
+	}
+
+	authorized := make([]metamcprepo.ListServableMetaMCPMemberUpstreamsRow, 0, len(rows))
+	for _, row := range rows {
+		// Only proxy backends reach here, so mcp:connect is keyed on the
+		// mcp_servers id (see grantResourceIdForMcpServer). Any visibility
+		// other than the two known values fails closed.
+		switch row.McpServerVisibility {
+		case mcpservers.VisibilityPublic:
+		case mcpservers.VisibilityPrivate:
+			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, row.McpServerID.String(), endpoint.ProjectID.String())); err != nil {
+				continue
+			}
+		default:
+			continue
+		}
+		authorized = append(authorized, row)
+	}
+	return authorized, nil
+}
+
+// conclusiveProbeMiss reports whether a failed probe proves the member claims
+// no authorization server at all. Only an answer does: a 404 (the common
+// shape for a member without OAuth), a member URL that cannot be probed, a
+// host network policy forbids, and a document that is not RFC 9728. Every
+// other failure — timeout, transport, unexpected status, or anything the
+// discovery helper did not type — leaves the member's claim unknown.
+func conclusiveProbeMiss(err error) bool {
+	discoveryErr, ok := errors.AsType[*wellknown.ProtectedResourceDiscoveryError](err)
+	if !ok {
+		return false
+	}
+	switch discoveryErr.Code() {
+	case "not_found", "invalid_url", "host_blocked", "malformed":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
@@ -1,0 +1,294 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+)
+
+// consentTestTenant reads the project and organization the test service's auth
+// context was seeded with.
+func consentTestTenant(t *testing.T, ctx context.Context) (uuid.UUID, string) {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	return *authCtx.ProjectID, authCtx.ActiveOrganizationID
+}
+
+// newGatewayMemberUpstream serves an RFC 9728 protected-resource document
+// naming authorizationServers, at every well-known candidate the discovery
+// helper probes.
+func newGatewayMemberUpstream(t *testing.T, authorizationServers ...string) *httptest.Server {
+	t.Helper()
+	quoted := make([]string, 0, len(authorizationServers))
+	for _, as := range authorizationServers {
+		quoted = append(quoted, `"`+as+`"`)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-protected-resource") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"authorization_servers":[` + strings.Join(quoted, ",") + `]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newHangingUpstream never answers, releasing only when the probe's own
+// deadline cancels the request.
+func newHangingUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newUnreachableUpstreamURL returns a URL whose listener is already closed, so
+// a probe against it fails immediately.
+func newUnreachableUpstreamURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+// createGatewayMember attaches a remote-backed member, on its own user session
+// issuer as a gateway member has in production, to metaServerID.
+func createGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug, serverURL string, sortOrder int32) {
+	t.Helper()
+
+	remoteServer, err := remotemcp_repo.New(conn).CreateServer(ctx, remotemcp_repo.CreateServerParams{
+		ID:            uuid.New(),
+		ProjectID:     projectID,
+		TransportType: "sse",
+		Url:           serverURL,
+	})
+	require.NoError(t, err)
+
+	mcpServer, err := mcpservers_repo.New(conn).CreateMCPServer(ctx, mcpservers_repo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           projectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		RemoteMcpServerID:   conv.ToNullUUID(remoteServer.ID),
+		Visibility:          "public",
+		UserSessionIssuerID: conv.ToNullUUID(createUserSessionIssuer(t, ctx, conn, projectID)),
+	})
+	require.NoError(t, err)
+
+	_, err = metamcp_repo.New(conn).CreateMetaMCPMember(ctx, metamcp_repo.CreateMetaMCPMemberParams{
+		ProjectID:       projectID,
+		MetaMcpServerID: metaServerID,
+		McpServerID:     mcpServer.ID,
+		SortOrder:       sortOrder,
+	})
+	require.NoError(t, err)
+}
+
+// createGatewayMetaServer creates the meta_mcp_servers row a gateway endpoint
+// resolves through.
+func createGatewayMetaServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, organizationID, name string, userSessionIssuerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	metaServer, err := metamcp_repo.New(conn).CreateMetaMCPServer(ctx, metamcp_repo.CreateMetaMCPServerParams{
+		OrganizationID:      organizationID,
+		ProjectID:           projectID,
+		Name:                name,
+		UserSessionIssuerID: conv.ToNullUUID(userSessionIssuerID),
+	})
+	require.NoError(t, err)
+	return metaServer.ID
+}
+
+// seedGatewayConsentEndpoint builds a gateway endpoint over one shared user
+// session issuer, so every client the consent screen offers hangs off the
+// gateway rather than off any member.
+func seedGatewayConsentEndpoint(t *testing.T, slug string) (context.Context, consentActionFixture, uuid.UUID) {
+	t.Helper()
+
+	ctx, ti := newTestMCPService(t)
+	projectID, orgID := consentTestTenant(t, ctx)
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	metaServerID := createGatewayMetaServer(t, ctx, ti.conn, projectID, orgID, slug, shared)
+	endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, slug)
+	endpoint.MetaMcpServerID = conv.ToNullUUID(metaServerID)
+
+	return ctx, consentActionFixture{
+		ti:        ti,
+		endpoint:  endpoint,
+		stateID:   stateID,
+		projectID: projectID,
+		orgID:     orgID,
+		shared:    shared,
+		subject:   subject,
+		clientA:   uuid.Nil,
+		clientB:   uuid.Nil,
+		clientC:   uuid.Nil,
+		clientD:   uuid.Nil,
+	}, metaServerID
+}
+
+// Each client's credential is qualified to the member whose protected-resource
+// metadata names that client's authorization server — not to an arbitrary
+// member, and not to nothing.
+func TestServeConsentAction_GatewayConnectResolvesMemberByAuthorizationServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-resolve")
+
+	asA := "https://aim87-a-as.example.com"
+	asB := "https://aim87-b-as.example.com"
+	memberA := newGatewayMemberUpstream(t, asA)
+	memberB := newGatewayMemberUpstream(t, asB)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-member-a", memberA.URL+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-member-b", memberB.URL+"/mcp", 1)
+
+	clientA := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-a", asA, []uuid.UUID{fx.shared})
+	clientB := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-b", asB, []uuid.UUID{fx.shared})
+
+	locA := postConnectAction(t, fx, clientA)
+	require.Equal(t, memberA.URL+"/mcp", locA.Query().Get("resource"))
+	require.Equal(t, memberA.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, locA.Query().Get("state")).Resource)
+
+	locB := postConnectAction(t, fx, clientB)
+	require.Equal(t, memberB.URL+"/mcp", locB.Query().Get("resource"))
+	require.Equal(t, memberB.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, locB.Query().Get("state")).Resource)
+}
+
+// No member claims the client's authorization server: fail closed rather than
+// qualify the credential to a member it does not belong to.
+func TestServeConsentAction_GatewayConnectNoMatchingMemberSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-nomatch")
+
+	member := newGatewayMemberUpstream(t, "https://aim87-other-as.example.com")
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-nomatch-member", member.URL+"/mcp", 0)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-nomatch", "https://aim87-unclaimed-as.example.com", []uuid.UUID{fx.shared})
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "no member claims this client's authorization server — send no resource")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// One authorization server fronting two members of the same gateway is
+// unsupported in v1: a grant records one resource per (subject, client), so an
+// ambiguous match fails closed.
+func TestServeConsentAction_GatewayConnectAmbiguousMembersSendNoResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-ambiguous")
+
+	shared := "https://aim87-shared-as.example.com"
+	memberA := newGatewayMemberUpstream(t, shared)
+	memberB := newGatewayMemberUpstream(t, shared)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-ambiguous-a", memberA.URL+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-ambiguous-b", memberB.URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-ambiguous", shared, []uuid.UUID{fx.shared})
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "two members behind one authorization server are ambiguous — send no resource")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// An unreachable member must not take the rest of the gateway down with it.
+func TestServeConsentAction_GatewayConnectProbeFailureLeavesOtherMembersResolvable(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-probefail")
+
+	as := "https://aim87-healthy-as.example.com"
+	healthy := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-broken-member", newUnreachableUpstreamURL(t)+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-healthy-member", healthy.URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-probefail", as, []uuid.UUID{fx.shared})
+
+	loc := postConnectAction(t, fx, client)
+	require.Equal(t, healthy.URL+"/mcp", loc.Query().Get("resource"))
+	require.Equal(t, healthy.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// A member that never answers is bounded by the per-probe deadline, so consent
+// resolves on the healthy member well inside the fan-out budget.
+func TestServeConsentAction_GatewayConnectHangingMemberIsBounded(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-hang")
+
+	as := "https://aim87-live-as.example.com"
+	healthy := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hanging-member", newHangingUpstream(t).URL+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-live-member", healthy.URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-hang", as, []uuid.UUID{fx.shared})
+
+	started := time.Now()
+	loc := postConnectAction(t, fx, client)
+	require.Equal(t, healthy.URL+"/mcp", loc.Query().Get("resource"))
+	require.Less(t, time.Since(started), 5*time.Second, "the per-probe deadline, not the discovery helper's own budget, must bound one hung member")
+}
+
+// The gateway path is additive: an endpoint that is not a gateway keeps
+// deriving its resource from the client's own attached MCP servers, even with
+// a gateway in the project whose member would otherwise claim the client.
+func TestServeConsentAction_NonGatewayEndpointKeepsPerClientDerivation(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	projectID, orgID := consentTestTenant(t, ctx)
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	issuerA := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, issuerA, "aim87-direct-srv", consentUpstreamA)
+
+	as := "https://aim87-direct-as.example.com"
+	metaServerID := createGatewayMetaServer(t, ctx, ti.conn, projectID, orgID, "aim87-unused-gw", shared)
+	member := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, ti.conn, projectID, metaServerID, "aim87-unused-member", member.URL+"/mcp", 0)
+
+	endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, "aim87-non-gateway")
+	fx := consentActionFixture{
+		ti:        ti,
+		endpoint:  endpoint,
+		stateID:   stateID,
+		projectID: projectID,
+		orgID:     orgID,
+		shared:    shared,
+		subject:   subject,
+		clientA:   uuid.Nil,
+		clientB:   uuid.Nil,
+		clientC:   uuid.Nil,
+		clientD:   uuid.Nil,
+	}
+	client := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "aim87-direct", as, []uuid.UUID{shared, issuerA})
+
+	loc := postConnectAction(t, fx, client)
+	require.Equal(t, consentUpstreamA, loc.Query().Get("resource"), "a non-gateway endpoint must keep the stored per-client derivation")
+	require.Equal(t, consentUpstreamA, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -35,12 +38,27 @@ func consentTestTenant(t *testing.T, ctx context.Context) (uuid.UUID, string) {
 
 // newGatewayMemberUpstream serves an RFC 9728 protected-resource document
 // naming authorizationServers, at every well-known candidate the discovery
-// helper probes.
+// helper probes. The document omits the optional `resource` field, which is
+// the shape a member that makes no claim about its own identity returns.
 func newGatewayMemberUpstream(t *testing.T, authorizationServers ...string) *httptest.Server {
+	t.Helper()
+	return newGatewayMemberUpstreamDeclaring(t, "", authorizationServers...)
+}
+
+// newGatewayMemberUpstreamDeclaring is newGatewayMemberUpstream with the
+// document's RFC 9728 `resource` field under test control, so a document that
+// names a resource other than the member serving it can be seeded. That is
+// what a shared multi-tenant host returns from its origin-style location when
+// the member's own path-style probe 404s.
+func newGatewayMemberUpstreamDeclaring(t *testing.T, declaredResource string, authorizationServers ...string) *httptest.Server {
 	t.Helper()
 	quoted := make([]string, 0, len(authorizationServers))
 	for _, as := range authorizationServers {
 		quoted = append(quoted, `"`+as+`"`)
+	}
+	resourceField := ""
+	if declaredResource != "" {
+		resourceField = `"resource":"` + declaredResource + `",`
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-protected-resource") {
@@ -48,8 +66,34 @@ func newGatewayMemberUpstream(t *testing.T, authorizationServers ...string) *htt
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"authorization_servers":[` + strings.Join(quoted, ",") + `]}`))
+		_, _ = w.Write([]byte(`{` + resourceField + `"authorization_servers":[` + strings.Join(quoted, ",") + `]}`))
 	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newGatewayMemberUpstreamDeclaringSelf serves a document whose resource field
+// names this server's own URL plus path — the compliant shape. path may carry
+// a trailing slash the member's stored URL does not, so the positive case only
+// passes under the same canonicalisation the authorization-server match uses.
+func newGatewayMemberUpstreamDeclaringSelf(t *testing.T, path string, authorizationServers ...string) *httptest.Server {
+	t.Helper()
+	quoted := make([]string, 0, len(authorizationServers))
+	for _, as := range authorizationServers {
+		quoted = append(quoted, `"`+as+`"`)
+	}
+	var self atomic.Value
+	self.Store("")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-protected-resource") {
+			http.NotFound(w, r)
+			return
+		}
+		declared, _ := self.Load().(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"` + declared + `","authorization_servers":[` + strings.Join(quoted, ",") + `]}`))
+	}))
+	self.Store(srv.URL + path)
 	t.Cleanup(srv.Close)
 	return srv
 }
@@ -60,6 +104,23 @@ func newHangingUpstream(t *testing.T) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newToggleableGatewayMemberUpstream advertises its authorization server only
+// while advertising is set, so one member can stop being discoverable between
+// a connect and a reconnect.
+func newToggleableGatewayMemberUpstream(t *testing.T, advertising *atomic.Bool, authorizationServer string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !advertising.Load() || !strings.HasPrefix(r.URL.Path, "/.well-known/oauth-protected-resource") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"authorization_servers":["` + authorizationServer + `"]}`))
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -354,27 +415,43 @@ func TestServeConsentAction_GatewayConnectAmbiguousMembersSendNoResource(t *test
 	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
 }
 
-// An unreachable member must not take the rest of the gateway down with it.
-func TestServeConsentAction_GatewayConnectProbeFailureLeavesOtherMembersResolvable(t *testing.T) {
+// A member Gram could not reach has not said it claims nothing — nobody could
+// ask it. A member that answers 404 has. Only the second may be treated as
+// making no claim, and the pair is what separates the two.
+func TestServeConsentAction_GatewayConnectUnreachableMemberPoisonsButA404DoesNot(t *testing.T) {
 	t.Parallel()
 
 	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-probefail")
 
 	as := "https://aim87-healthy-as.example.com"
 	healthy := newGatewayMemberUpstream(t, as)
-	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-broken-member", newUnreachableUpstreamURL(t)+"/mcp", 0)
+	unreachable := createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-broken-member", newUnreachableUpstreamURL(t)+"/mcp", 0)
 	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-healthy-member", healthy.URL+"/mcp", 1)
 
 	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-probefail", as, []uuid.UUID{fx.shared})
 
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2, "both members must be probe candidates, or this asserts nothing")
+
 	loc := postConnectAction(t, fx, client)
-	require.Equal(t, healthy.URL+"/mcp", loc.Query().Get("resource"))
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a member whose metadata could not be read leaves every other member's claim unproven")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+
+	// Same gateway, same healthy member: swap the silent member for one that
+	// answers 404 and the resolution goes through.
+	_, err := metamcp_repo.New(fx.ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{ID: unreachable.memberID, ProjectID: fx.projectID})
+	require.NoError(t, err)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-quiet-member", newUpstreamWithoutMetadata(t).URL+"/mcp", 2)
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2, "the 404 member must be a probe candidate, or this asserts nothing")
+
+	loc = postConnectAction(t, fx, client)
+	require.Equal(t, healthy.URL+"/mcp", loc.Query().Get("resource"), "a member without OAuth answers 404, and an answer is not an absence")
 	require.Equal(t, healthy.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
 }
 
-// A member that never answers is bounded by the per-probe deadline, so consent
-// resolves on the healthy member well inside the fan-out budget.
-func TestServeConsentAction_GatewayConnectHangingMemberIsBounded(t *testing.T) {
+// A member that never answers is bounded by the per-probe deadline — and,
+// having never answered, leaves the healthy member's claim unproven.
+func TestServeConsentAction_GatewayConnectHangingMemberIsBoundedAndPoisons(t *testing.T) {
 	t.Parallel()
 
 	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-hang")
@@ -386,10 +463,137 @@ func TestServeConsentAction_GatewayConnectHangingMemberIsBounded(t *testing.T) {
 
 	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-hang", as, []uuid.UUID{fx.shared})
 
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2, "both members must be probe candidates, or this asserts nothing")
+
 	started := time.Now()
 	loc := postConnectAction(t, fx, client)
-	require.Equal(t, healthy.URL+"/mcp", loc.Query().Get("resource"))
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a member that never answers is unknown, not absent")
 	require.Less(t, time.Since(started), 5*time.Second, "the per-probe deadline, not the discovery helper's own budget, must bound one hung member")
+}
+
+// The attack the inconclusive rule exists for. Any member may write any
+// authorization server into its own document, so a member that names one it
+// does not own becomes the unique match the moment the true owner cannot
+// answer — and the resolved URL is where the subject's upstream token goes.
+func TestServeConsentAction_GatewayConnectHostileMemberCannotClaimAnAbsentMembersIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-hostile")
+
+	as := "https://aim87-hostile-as.example.com"
+	// The authorization server's true owner, made unable to answer.
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hostile-owner", newHangingUpstream(t).URL+"/mcp", 0)
+	claimant := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hostile-claimant", claimant.URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-hostile", as, []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2, "both members must be probe candidates, or this asserts nothing")
+
+	loc := postConnectAction(t, fx, client)
+	require.NotEqual(t, claimant.URL+"/mcp", loc.Query().Get("resource"), "the claimant must not receive the subject's upstream token")
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "an unanswered member makes the claimant's match non-unique")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// Starvation, which is the ambiguity guard's cheapest bypass: rows arrive in
+// member-controlled sort_order, so a claimant placed first answers inside the
+// first wave while enough silent members behind it exhaust the whole fan-out
+// budget before the authorization server's true owner is ever reached. The
+// budget must bound latency without ever turning "we ran out of time" into a
+// confident match.
+func TestServeConsentAction_GatewayConnectBudgetExhaustionSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-budget")
+
+	as := "https://aim87-budget-as.example.com"
+	claimant := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-budget-claimant", claimant.URL+"/mcp", 0)
+	// Two full waves at the concurrency cap, each bounded by the per-probe
+	// deadline, is the whole budget.
+	for i := range 8 {
+		createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-budget-hang-"+strconv.Itoa(i), newHangingUpstream(t).URL+"/mcp", int32(i+1))
+	}
+	owner := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-budget-owner", owner.URL+"/mcp", 9)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-budget", as, []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 10, "every member must be a probe candidate, or this asserts nothing")
+
+	started := time.Now()
+	loc := postConnectAction(t, fx, client)
+	require.NotEqual(t, claimant.URL+"/mcp", loc.Query().Get("resource"), "the claimant must not win by outlasting the owner's turn")
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a starved fan-out has not established that any claim is unique")
+	require.Less(t, time.Since(started), 10*time.Second, "the fan-out budget, not the member count, must bound consent latency")
+}
+
+// A shared multi-tenant host answers the origin-style location with its own
+// document. Honouring that document's authorization servers matches a member
+// on an issuer it never declared, so a document naming some other resource is
+// not the member's to speak with.
+func TestServeConsentAction_GatewayConnectSkipsDocumentNamingAnotherResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-declared")
+
+	as := "https://aim87-declared-as.example.com"
+	neighbour := newGatewayMemberUpstreamDeclaring(t, "https://aim87-declared-neighbour.example.com/mcp", as)
+	borrowed := createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-declared-borrowed", neighbour.URL+"/mcp", 0)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-declared", as, []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 1, "the member must be a probe candidate, or this asserts nothing")
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a document naming another resource does not speak for this member")
+
+	// A member whose document names itself is honoured, spelling differences
+	// included — the comparison is the same canonical one the match uses.
+	_, err := metamcp_repo.New(fx.ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{ID: borrowed.memberID, ProjectID: fx.projectID})
+	require.NoError(t, err)
+	own := newGatewayMemberUpstreamDeclaringSelf(t, "/mcp/", as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-declared-own", own.URL+"/mcp", 1)
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 1, "the self-declaring member must be the only candidate")
+
+	loc = postConnectAction(t, fx, client)
+	require.Equal(t, own.URL+"/mcp", loc.Query().Get("resource"), "a member that names itself keeps its claim")
+	require.Equal(t, own.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// A private member the connecting subject holds no mcp:connect on must not be
+// probed, matched, or echoed back in the redirect's resource parameter — the
+// same visibility rule the serving path applies to the member list.
+func TestServeConsentAction_GatewayConnectExcludesMembersTheSubjectCannotConnectTo(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-rbac")
+
+	as := "https://aim87-rbac-as.example.com"
+	private := newGatewayMemberUpstream(t, as)
+	member := createGatewayMemberWithVisibility(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-rbac-private", private.URL+"/mcp", 0, "private")
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-rbac", as, []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 1, "the member must be a probe candidate, or this asserts nothing")
+
+	loc := postConnectActionAs(t, authztest.WithExactGrants(t, ctx), fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a member the subject cannot connect to must not claim their credential")
+
+	// The same member, the same probe, the same document: only the grant differs.
+	granted := authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeMCPConnect,
+		Selector: authz.NewSelector(authz.ScopeMCPConnect, member.mcpServerID.String()),
+	})
+	loc = postConnectActionAs(t, granted, fx, client)
+	require.Equal(t, private.URL+"/mcp", loc.Query().Get("resource"), "mcp:connect on the member is what makes it selectable")
+	require.Equal(t, private.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
 }
 
 // The gateway path is additive: an endpoint that is not a gateway keeps
@@ -627,12 +831,13 @@ func TestServeConsentAction_GatewayConnectKeepsDistinctIssuersApart(t *testing.T
 	require.False(t, hasResource, "scheme and path case distinguish authorization servers")
 }
 
-// Flagged narrowing, pinned deliberately: on a gateway there is no fallback to
-// the stored per-client derivation. The same client, in the same project, with
-// the same bindings, derives a resource through a non-gateway endpoint and
-// none through the gateway when discovery misses. Widening this is a product
-// decision, not an accident — this test is what would notice it changing.
-func TestServeConsentAction_GatewayConnectDoesNotFallBackToStoredDerivation(t *testing.T) {
+// Precedence, pinned in both directions: on a gateway, consent-time discovery
+// answers where it can and the stored per-client derivation answers where it
+// cannot. A client bound to both the gateway's issuer and a member's own
+// issuer derives through either endpoint, so a discovery miss no longer costs
+// it the resource it had — and a discovery hit still overrides what the
+// derivation would have said.
+func TestServeConsentAction_GatewayConnectFallsBackToStoredDerivation(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -645,7 +850,7 @@ func TestServeConsentAction_GatewayConnectDoesNotFallBackToStoredDerivation(t *t
 	metaServerID := createGatewayMetaServer(t, ctx, ti.conn, projectID, orgID, "aim87-fallback-gw", shared)
 	// Live, servable, and simply not advertising OAuth — the "metadata
 	// unavailable at consent" case.
-	createGatewayMember(t, ctx, ti.conn, projectID, metaServerID, "aim87-fallback-member", newUpstreamWithoutMetadata(t).URL+"/mcp", 0)
+	quiet := createGatewayMember(t, ctx, ti.conn, projectID, metaServerID, "aim87-fallback-member", newUpstreamWithoutMetadata(t).URL+"/mcp", 0)
 
 	newFixture := func(slug string) consentActionFixture {
 		endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, slug)
@@ -671,10 +876,23 @@ func TestServeConsentAction_GatewayConnectDoesNotFallBackToStoredDerivation(t *t
 	direct := newFixture("aim87-fallback-direct")
 	require.Equal(t, consentUpstreamA, postConnectAction(t, direct, client).Query().Get("resource"), "the stored derivation does answer for this client")
 
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, ti.conn, projectID, metaServerID), 1, "the member must be a probe candidate, or this asserts nothing")
+
 	gateway := newFixture("aim87-fallback-gateway")
 	gateway.endpoint.MetaMcpServerID = conv.ToNullUUID(metaServerID)
 	loc := postConnectAction(t, gateway, client)
-	_, hasResource := loc.Query()["resource"]
-	require.False(t, hasResource, "a gateway consent derives from discovery only; a missed probe sends no resource")
-	require.Empty(t, mintedRemoteLoginState(t, ctx, gateway, loc.Query().Get("state")).Resource)
+	require.Equal(t, consentUpstreamA, loc.Query().Get("resource"), "a discovery miss on a gateway must not cost the client the resource it derives everywhere else")
+	require.Equal(t, consentUpstreamA, mintedRemoteLoginState(t, ctx, gateway, loc.Query().Get("state")).Resource)
+
+	// Swap the silent member for one that claims the client's authorization
+	// server: the same client, the same bindings, now resolved by discovery.
+	_, err := metamcp_repo.New(ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{ID: quiet.memberID, ProjectID: projectID})
+	require.NoError(t, err)
+	claimed := newGatewayMemberUpstream(t, "https://aim87-fallback-as.example.com")
+	createGatewayMember(t, ctx, ti.conn, projectID, metaServerID, "aim87-fallback-claimed", claimed.URL+"/mcp", 1)
+	require.Equal(t, []string{claimed.URL + "/mcp"}, gatewayMemberUpstreamURLs(t, ctx, ti.conn, projectID, metaServerID))
+
+	loc = postConnectAction(t, gateway, client)
+	require.Equal(t, claimed.URL+"/mcp", loc.Query().Get("resource"), "discovery outranks the stored derivation wherever it resolves")
+	require.Equal(t, claimed.URL+"/mcp", mintedRemoteLoginState(t, ctx, gateway, loc.Query().Get("state")).Resource)
 }

--- a/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
+++ b/server/internal/mcp/authnchallenge_consent_gateway_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,9 @@ import (
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	tunneledmcp_repo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
+	unproxiedmcp_repo "github.com/speakeasy-api/gram/server/internal/unproxiedmcp/repo"
 )
 
 // consentTestTenant reads the project and organization the test service's auth
@@ -61,6 +65,17 @@ func newHangingUpstream(t *testing.T) *httptest.Server {
 	return srv
 }
 
+// newUpstreamWithoutMetadata answers 404 everywhere, as an upstream that does
+// not speak OAuth does. Its probe fails cleanly rather than hanging.
+func newUpstreamWithoutMetadata(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // newUnreachableUpstreamURL returns a URL whose listener is already closed, so
 // a probe against it fails immediately.
 func newUnreachableUpstreamURL(t *testing.T) string {
@@ -73,9 +88,23 @@ func newUnreachableUpstreamURL(t *testing.T) string {
 	return url
 }
 
+// gatewayMember identifies a seeded member so a test can disable, detach, or
+// tombstone it after the fact.
+type gatewayMember struct {
+	mcpServerID uuid.UUID
+	memberID    uuid.UUID
+}
+
 // createGatewayMember attaches a remote-backed member, on its own user session
 // issuer as a gateway member has in production, to metaServerID.
-func createGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug, serverURL string, sortOrder int32) {
+func createGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug, serverURL string, sortOrder int32) gatewayMember {
+	t.Helper()
+	return createGatewayMemberWithVisibility(t, ctx, conn, projectID, metaServerID, slug, serverURL, sortOrder, "public")
+}
+
+// createGatewayMemberWithVisibility is createGatewayMember with the member
+// server's visibility under test control, so a disabled member can be seeded.
+func createGatewayMemberWithVisibility(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug, serverURL string, sortOrder int32, visibility string) gatewayMember {
 	t.Helper()
 
 	remoteServer, err := remotemcp_repo.New(conn).CreateServer(ctx, remotemcp_repo.CreateServerParams{
@@ -92,18 +121,123 @@ func createGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, 
 		Name:                conv.ToPGText(slug),
 		Slug:                conv.ToPGText(slug),
 		RemoteMcpServerID:   conv.ToNullUUID(remoteServer.ID),
+		Visibility:          visibility,
+		UserSessionIssuerID: conv.ToNullUUID(createUserSessionIssuer(t, ctx, conn, projectID)),
+	})
+	require.NoError(t, err)
+
+	return gatewayMember{mcpServerID: mcpServer.ID, memberID: attachGatewayMember(t, ctx, conn, projectID, metaServerID, mcpServer.ID, sortOrder)}
+}
+
+// attachGatewayMember writes the meta_mcp_server_members row joining an
+// existing mcp_server to a gateway.
+func attachGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID, mcpServerID uuid.UUID, sortOrder int32) uuid.UUID {
+	t.Helper()
+	member, err := metamcp_repo.New(conn).CreateMetaMCPMember(ctx, metamcp_repo.CreateMetaMCPMemberParams{
+		ProjectID:       projectID,
+		MetaMcpServerID: metaServerID,
+		McpServerID:     mcpServerID,
+		SortOrder:       sortOrder,
+	})
+	require.NoError(t, err)
+	return member.ID
+}
+
+// createTunneledGatewayMember attaches a tunneled-backed member: a real member
+// class in v0 that advertises no metadata document of its own.
+func createTunneledGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug string, sortOrder int32) gatewayMember {
+	t.Helper()
+
+	tunneled, err := tunneledmcp_repo.New(conn).CreateServer(ctx, tunneledmcp_repo.CreateServerParams{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		Name:      slug,
+		KeyHash:   uuid.NewString(),
+		KeyPrefix: "gram_tunnel_test",
+	})
+	require.NoError(t, err)
+
+	mcpServer, err := mcpservers_repo.New(conn).CreateMCPServer(ctx, mcpservers_repo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           projectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		TunneledMcpServerID: conv.ToNullUUID(tunneled.ID),
 		Visibility:          "public",
 		UserSessionIssuerID: conv.ToNullUUID(createUserSessionIssuer(t, ctx, conn, projectID)),
 	})
 	require.NoError(t, err)
 
-	_, err = metamcp_repo.New(conn).CreateMetaMCPMember(ctx, metamcp_repo.CreateMetaMCPMemberParams{
-		ProjectID:       projectID,
-		MetaMcpServerID: metaServerID,
-		McpServerID:     mcpServer.ID,
-		SortOrder:       sortOrder,
+	return gatewayMember{mcpServerID: mcpServer.ID, memberID: attachGatewayMember(t, ctx, conn, projectID, metaServerID, mcpServer.ID, sortOrder)}
+}
+
+// createToolsetGatewayMember attaches a Gram-hosted (toolset-backed) member.
+func createToolsetGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug string, sortOrder int32) gatewayMember {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(conn), authCtx, slug+"-toolset")
+
+	mcpServer, err := mcpservers_repo.New(conn).CreateMCPServer(ctx, mcpservers_repo.CreateMCPServerParams{
+		ID:                  uuid.New(),
+		ProjectID:           projectID,
+		Name:                conv.ToPGText(slug),
+		Slug:                conv.ToPGText(slug),
+		ToolsetID:           conv.ToNullUUID(toolset.ID),
+		Visibility:          "public",
+		UserSessionIssuerID: conv.ToNullUUID(createUserSessionIssuer(t, ctx, conn, projectID)),
 	})
 	require.NoError(t, err)
+
+	return gatewayMember{mcpServerID: mcpServer.ID, memberID: attachGatewayMember(t, ctx, conn, projectID, metaServerID, mcpServer.ID, sortOrder)}
+}
+
+// createUnproxiedGatewayMember attaches an unproxied member. It carries a URL
+// like a remote member does, so it is the sharpest check that the upstream
+// query selects on the backend join and not on the presence of a URL.
+func createUnproxiedGatewayMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID, slug, serverURL string, sortOrder int32) gatewayMember {
+	t.Helper()
+
+	unproxied, err := unproxiedmcp_repo.New(conn).CreateServer(ctx, unproxiedmcp_repo.CreateServerParams{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		Name:        conv.ToPGText(slug),
+		Slug:        conv.ToPGText(slug),
+		Url:         serverURL,
+		Description: conv.ToPGText(""),
+	})
+	require.NoError(t, err)
+
+	mcpServer, err := mcpservers_repo.New(conn).CreateMCPServer(ctx, mcpservers_repo.CreateMCPServerParams{
+		ID:                   uuid.New(),
+		ProjectID:            projectID,
+		Name:                 conv.ToPGText(slug),
+		Slug:                 conv.ToPGText(slug),
+		UnproxiedMcpServerID: conv.ToNullUUID(unproxied.ID),
+		Visibility:           "public",
+		UserSessionIssuerID:  conv.ToNullUUID(createUserSessionIssuer(t, ctx, conn, projectID)),
+	})
+	require.NoError(t, err)
+
+	return gatewayMember{mcpServerID: mcpServer.ID, memberID: attachGatewayMember(t, ctx, conn, projectID, metaServerID, mcpServer.ID, sortOrder)}
+}
+
+// gatewayMemberUpstreamURLs reads back what the consent-time query considers
+// probeable. Tests assert on it so a "no resource" outcome can never pass
+// vacuously on an empty candidate set.
+func gatewayMemberUpstreamURLs(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, metaServerID uuid.UUID) []string {
+	t.Helper()
+	rows, err := metamcp_repo.New(conn).ListServableMetaMCPMemberUpstreams(ctx, metamcp_repo.ListServableMetaMCPMemberUpstreamsParams{
+		MetaMcpServerID: metaServerID,
+		ProjectID:       projectID,
+	})
+	require.NoError(t, err)
+	urls := make([]string, 0, len(rows))
+	for _, row := range rows {
+		urls = append(urls, row.UpstreamUrl)
+	}
+	return urls
 }
 
 // createGatewayMetaServer creates the meta_mcp_servers row a gateway endpoint
@@ -188,6 +322,8 @@ func TestServeConsentAction_GatewayConnectNoMatchingMemberSendsNoResource(t *tes
 
 	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-nomatch", "https://aim87-unclaimed-as.example.com", []uuid.UUID{fx.shared})
 
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 1, "the member must be a probe candidate, or this asserts nothing")
+
 	loc := postConnectAction(t, fx, client)
 	_, hasResource := loc.Query()["resource"]
 	require.False(t, hasResource, "no member claims this client's authorization server — send no resource")
@@ -209,6 +345,8 @@ func TestServeConsentAction_GatewayConnectAmbiguousMembersSendNoResource(t *test
 	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-ambiguous-b", memberB.URL+"/mcp", 1)
 
 	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-ambiguous", shared, []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2, "both members must be probe candidates, or this asserts nothing")
 
 	loc := postConnectAction(t, fx, client)
 	_, hasResource := loc.Query()["resource"]
@@ -291,4 +429,252 @@ func TestServeConsentAction_NonGatewayEndpointKeepsPerClientDerivation(t *testin
 	loc := postConnectAction(t, fx, client)
 	require.Equal(t, consentUpstreamA, loc.Query().Get("resource"), "a non-gateway endpoint must keep the stored per-client derivation")
 	require.Equal(t, consentUpstreamA, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// Three members, three authorization servers, three clients: each resolves its
+// own member. Two members can be satisfied by a coin flip; three cannot.
+func TestServeConsentAction_GatewayConnectResolvesEachOfThreeMembers(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-three")
+
+	type memberCase struct {
+		as       string
+		upstream string
+		clientID uuid.UUID
+	}
+	cases := make([]memberCase, 0, 3)
+	for i, name := range []string{"alpha", "beta", "gamma"} {
+		as := "https://aim87-three-" + name + "-as.example.com"
+		upstream := newGatewayMemberUpstream(t, as).URL + "/mcp"
+		createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-three-"+name, upstream, int32(i))
+		cases = append(cases, memberCase{
+			as:       as,
+			upstream: upstream,
+			clientID: createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-three-"+name, as, []uuid.UUID{fx.shared}),
+		})
+	}
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 3)
+
+	for _, tc := range cases {
+		loc := postConnectAction(t, fx, tc.clientID)
+		require.Equal(t, tc.upstream, loc.Query().Get("resource"), "authorization server %s must resolve its own member", tc.as)
+		require.Equal(t, tc.upstream, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+	}
+}
+
+// A gateway mixes backend kinds. Only remote members can advertise RFC 9728
+// metadata, so only they are probe candidates — and the tunneled, hosted, and
+// unproxied members must not contest the match even when their own URL would
+// answer for the same authorization server.
+func TestServeConsentAction_GatewayConnectExcludesNonRemoteMembersFromTheQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-mixed")
+
+	as := "https://aim87-mixed-as.example.com"
+	remote := newGatewayMemberUpstream(t, as)
+	// The unproxied member answers for the same authorization server: if it
+	// were a candidate the match would be ambiguous and resolve to nothing.
+	unproxied := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-mixed-remote", remote.URL+"/mcp", 0)
+	createTunneledGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-mixed-tunneled", 1)
+	createToolsetGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-mixed-hosted", 2)
+	createUnproxiedGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-mixed-unproxied", unproxied.URL+"/mcp", 3)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-mixed", as, []uuid.UUID{fx.shared})
+
+	// The exclusion is the query's job, not a filter applied to its rows.
+	require.Equal(t, []string{remote.URL + "/mcp"}, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID))
+
+	loc := postConnectAction(t, fx, client)
+	require.Equal(t, remote.URL+"/mcp", loc.Query().Get("resource"))
+	require.Equal(t, remote.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// A gateway with no members at all, and a gateway whose only members are
+// non-remote, both derive nothing rather than erroring or guessing.
+func TestServeConsentAction_GatewayConnectWithNoRemoteMembersSendsNoResource(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-empty")
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-empty", "https://aim87-empty-as.example.com", []uuid.UUID{fx.shared})
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a gateway with no members has nothing to qualify a credential to")
+
+	createTunneledGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-empty-tunneled", 0)
+	createToolsetGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-empty-hosted", 1)
+	require.Empty(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID))
+
+	loc = postConnectAction(t, fx, client)
+	_, hasResource = loc.Query()["resource"]
+	require.False(t, hasResource, "members that advertise no metadata document cannot be resolved")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// Members hidden from the serving path must not participate: each of the three
+// exclusions here answers for the live member's authorization server, so any
+// one of them leaking into the candidate set makes the match ambiguous and the
+// resource empty.
+func TestServeConsentAction_GatewayConnectIgnoresDisabledAndDetachedMembers(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-hidden")
+
+	as := "https://aim87-hidden-as.example.com"
+	live := newGatewayMemberUpstream(t, as)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hidden-live", live.URL+"/mcp", 0)
+
+	createGatewayMemberWithVisibility(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hidden-disabled", newGatewayMemberUpstream(t, as).URL+"/mcp", 1, "disabled")
+
+	tombstoned := createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hidden-tombstoned", newGatewayMemberUpstream(t, as).URL+"/mcp", 2)
+	_, err := mcpservers_repo.New(fx.ti.conn).DeleteMCPServer(ctx, mcpservers_repo.DeleteMCPServerParams{ID: tombstoned.mcpServerID, ProjectID: fx.projectID})
+	require.NoError(t, err)
+
+	detached := createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-hidden-detached", newGatewayMemberUpstream(t, as).URL+"/mcp", 3)
+	_, err = metamcp_repo.New(fx.ti.conn).DeleteMetaMCPMember(ctx, metamcp_repo.DeleteMetaMCPMemberParams{ID: detached.memberID, ProjectID: fx.projectID})
+	require.NoError(t, err)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-hidden", as, []uuid.UUID{fx.shared})
+
+	require.Equal(t, []string{live.URL + "/mcp"}, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID))
+
+	loc := postConnectAction(t, fx, client)
+	require.Equal(t, live.URL+"/mcp", loc.Query().Get("resource"), "only the live member may claim the credential")
+	require.Equal(t, live.URL+"/mcp", mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// The advertised authorization server is written by the upstream while the
+// issuer URL is Gram's stored spelling, so the two disagree on trailing slash,
+// default port, and host case for one authorization server. All three must
+// match, and the recorded resource is trimmed to exactly the form
+// resolveUpstreamResource derives for the backend so routing can compare them.
+func TestServeConsentAction_GatewayConnectMatchesEquivalentIssuerSpellings(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-spelling")
+
+	type spellingCase struct {
+		name       string
+		advertised string
+		stored     string
+		upstream   string
+	}
+	cases := []spellingCase{
+		{name: "trailing slash on the advertised entry", advertised: "https://aim87-slash-as.example.com/", stored: "https://aim87-slash-as.example.com", upstream: ""},
+		{name: "trailing slash on the stored issuer", advertised: "https://aim87-stored-as.example.com", stored: "https://aim87-stored-as.example.com/", upstream: ""},
+		{name: "explicit default port", advertised: "https://aim87-port-as.example.com:443", stored: "https://aim87-port-as.example.com", upstream: ""},
+		{name: "host case", advertised: "https://AIM87-Case-AS.example.com", stored: "https://aim87-case-as.example.com", upstream: ""},
+	}
+	clients := make([]uuid.UUID, 0, len(cases))
+	for i := range cases {
+		// The member's own URL carries a trailing slash the recorded resource
+		// must lose, matching resolveUpstreamResource.
+		cases[i].upstream = newGatewayMemberUpstream(t, cases[i].advertised).URL + "/mcp/"
+		createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-spelling-"+strconv.Itoa(i), cases[i].upstream, int32(i))
+		clients = append(clients, createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-spelling-"+strconv.Itoa(i), cases[i].stored, []uuid.UUID{fx.shared}))
+	}
+
+	for i, tc := range cases {
+		loc := postConnectAction(t, fx, clients[i])
+		want := strings.TrimRight(tc.upstream, "/")
+		require.Equal(t, want, loc.Query().Get("resource"), "%s must still name one authorization server", tc.name)
+		require.Equal(t, want, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+	}
+}
+
+// Two members behind one authorization server are unsupported, and a spelling
+// difference between their advertised entries must not smuggle one of them
+// past that guard.
+func TestServeConsentAction_GatewayConnectAmbiguitySurvivesSpellingDifferences(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-spellambig")
+
+	memberA := newGatewayMemberUpstream(t, "https://aim87-spellambig-as.example.com")
+	memberB := newGatewayMemberUpstream(t, "https://AIM87-SpellAmbig-AS.example.com:443/")
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-spellambig-a", memberA.URL+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-spellambig-b", memberB.URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-spellambig", "https://aim87-spellambig-as.example.com", []uuid.UUID{fx.shared})
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "two spellings of one authorization server are still one authorization server")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, fx, loc.Query().Get("state")).Resource)
+}
+
+// A different scheme or a different path is a different authorization server,
+// so canonical matching must not collapse them onto the connecting client.
+func TestServeConsentAction_GatewayConnectKeepsDistinctIssuersApart(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, metaServerID := seedGatewayConsentEndpoint(t, "aim87-gw-distinct")
+
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-distinct-scheme", newGatewayMemberUpstream(t, "http://aim87-distinct-as.example.com").URL+"/mcp", 0)
+	createGatewayMember(t, ctx, fx.ti.conn, fx.projectID, metaServerID, "aim87-distinct-path", newGatewayMemberUpstream(t, "https://aim87-distinct-as.example.com/TENANT").URL+"/mcp", 1)
+
+	client := createConsentRemoteClient(t, ctx, fx.ti.conn, fx.projectID, fx.orgID, "aim87-distinct", "https://aim87-distinct-as.example.com/tenant", []uuid.UUID{fx.shared})
+
+	require.Len(t, gatewayMemberUpstreamURLs(t, ctx, fx.ti.conn, fx.projectID, metaServerID), 2)
+
+	loc := postConnectAction(t, fx, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "scheme and path case distinguish authorization servers")
+}
+
+// Flagged narrowing, pinned deliberately: on a gateway there is no fallback to
+// the stored per-client derivation. The same client, in the same project, with
+// the same bindings, derives a resource through a non-gateway endpoint and
+// none through the gateway when discovery misses. Widening this is a product
+// decision, not an accident — this test is what would notice it changing.
+func TestServeConsentAction_GatewayConnectDoesNotFallBackToStoredDerivation(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	projectID, orgID := consentTestTenant(t, ctx)
+
+	shared := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	memberIssuer := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	attachConsentRemoteMcpServer(t, ctx, ti.conn, projectID, memberIssuer, "aim87-fallback-srv", consentUpstreamA)
+
+	metaServerID := createGatewayMetaServer(t, ctx, ti.conn, projectID, orgID, "aim87-fallback-gw", shared)
+	// Live, servable, and simply not advertising OAuth — the "metadata
+	// unavailable at consent" case.
+	createGatewayMember(t, ctx, ti.conn, projectID, metaServerID, "aim87-fallback-member", newUpstreamWithoutMetadata(t).URL+"/mcp", 0)
+
+	newFixture := func(slug string) consentActionFixture {
+		endpoint, stateID, subject := mintConsentEndpointState(t, ctx, ti, projectID, orgID, shared, slug)
+		return consentActionFixture{
+			ti:        ti,
+			endpoint:  endpoint,
+			stateID:   stateID,
+			projectID: projectID,
+			orgID:     orgID,
+			shared:    shared,
+			subject:   subject,
+			clientA:   uuid.Nil,
+			clientB:   uuid.Nil,
+			clientC:   uuid.Nil,
+			clientD:   uuid.Nil,
+		}
+	}
+
+	// Bound to the gateway's issuer and to the member's own issuer, which is
+	// exactly the client the stored derivation can still answer for.
+	client := createConsentRemoteClient(t, ctx, ti.conn, projectID, orgID, "aim87-fallback", "https://aim87-fallback-as.example.com", []uuid.UUID{shared, memberIssuer})
+
+	direct := newFixture("aim87-fallback-direct")
+	require.Equal(t, consentUpstreamA, postConnectAction(t, direct, client).Query().Get("resource"), "the stored derivation does answer for this client")
+
+	gateway := newFixture("aim87-fallback-gateway")
+	gateway.endpoint.MetaMcpServerID = conv.ToNullUUID(metaServerID)
+	loc := postConnectAction(t, gateway, client)
+	_, hasResource := loc.Query()["resource"]
+	require.False(t, hasResource, "a gateway consent derives from discovery only; a missed probe sends no resource")
+	require.Empty(t, mintedRemoteLoginState(t, ctx, gateway, loc.Query().Get("state")).Resource)
 }

--- a/server/internal/mcp/export_test.go
+++ b/server/internal/mcp/export_test.go
@@ -1,6 +1,20 @@
 package mcp
 
-import "context"
+import (
+	"context"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+// RouteUpstreamTokenForTest exposes the real proxied-backend credential
+// selector so external tests can drive it with grants they persisted through
+// the full consent flow, rather than restating its selection rules.
+func RouteUpstreamTokenForTest(ctx context.Context, logger *slog.Logger, tokens map[uuid.UUID]remotesessions.UpstreamToken, upstreamResource string) (string, error) {
+	return routeUpstreamToken(ctx, logger, tokens, upstreamResource)
+}
 
 // BuildResolvedMcpEndpointByRefForTest exposes the challenge-resumption
 // resolver so external tests can pin its dispatch and fail-closed arms

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -250,8 +250,11 @@ ORDER BY m.sort_order, m.created_at, m.id;
 -- ListServableMetaMCPMembers is. Tunneled, hosted, and unproxied members are
 -- excluded by the join — they advertise no RFC 9728 metadata document, so
 -- they cannot be matched to a connecting client's authorization server.
+-- Visibility comes back so the caller can apply the same per-member mcp:connect
+-- filter the serving path does.
 SELECT
     m.mcp_server_id,
+    s.visibility AS mcp_server_visibility,
     r.url AS upstream_url
 FROM meta_mcp_server_members m
 JOIN mcp_servers s

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -192,6 +192,31 @@ WHERE m.meta_mcp_server_id = @meta_mcp_server_id
   AND m.deleted IS FALSE
 ORDER BY m.sort_order, m.created_at, m.id;
 
+-- name: ListServableMetaMCPMemberUpstreams :many
+-- Consent-time credential selection: the upstream URL of every servable
+-- remote-backed member of a gateway, filtered exactly as
+-- ListServableMetaMCPMembers is. Tunneled, hosted, and unproxied members are
+-- excluded by the join — they advertise no RFC 9728 metadata document, so
+-- they cannot be matched to a connecting client's authorization server.
+SELECT
+    m.mcp_server_id,
+    r.url AS upstream_url
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+ AND s.visibility <> 'disabled'
+ AND s.slug IS NOT NULL
+JOIN remote_mcp_servers r
+  ON r.id = s.remote_mcp_server_id
+ AND r.project_id = m.project_id
+ AND r.deleted IS FALSE
+WHERE m.meta_mcp_server_id = @meta_mcp_server_id
+  AND m.project_id = @project_id
+  AND m.deleted IS FALSE
+ORDER BY m.sort_order, m.created_at, m.id;
+
 -- name: UpdateMetaMCPMemberSortOrder :one
 UPDATE meta_mcp_server_members
 SET sort_order = @sort_order,

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -590,6 +590,7 @@ func (q *Queries) ListMetaMCPServers(ctx context.Context, arg ListMetaMCPServers
 const listServableMetaMCPMemberUpstreams = `-- name: ListServableMetaMCPMemberUpstreams :many
 SELECT
     m.mcp_server_id,
+    s.visibility AS mcp_server_visibility,
     r.url AS upstream_url
 FROM meta_mcp_server_members m
 JOIN mcp_servers s
@@ -614,8 +615,9 @@ type ListServableMetaMCPMemberUpstreamsParams struct {
 }
 
 type ListServableMetaMCPMemberUpstreamsRow struct {
-	McpServerID uuid.UUID
-	UpstreamUrl string
+	McpServerID         uuid.UUID
+	McpServerVisibility string
+	UpstreamUrl         string
 }
 
 // Consent-time credential selection: the upstream URL of every servable
@@ -623,6 +625,8 @@ type ListServableMetaMCPMemberUpstreamsRow struct {
 // ListServableMetaMCPMembers is. Tunneled, hosted, and unproxied members are
 // excluded by the join — they advertise no RFC 9728 metadata document, so
 // they cannot be matched to a connecting client's authorization server.
+// Visibility comes back so the caller can apply the same per-member mcp:connect
+// filter the serving path does.
 func (q *Queries) ListServableMetaMCPMemberUpstreams(ctx context.Context, arg ListServableMetaMCPMemberUpstreamsParams) ([]ListServableMetaMCPMemberUpstreamsRow, error) {
 	rows, err := q.db.Query(ctx, listServableMetaMCPMemberUpstreams, arg.MetaMcpServerID, arg.ProjectID)
 	if err != nil {
@@ -632,7 +636,7 @@ func (q *Queries) ListServableMetaMCPMemberUpstreams(ctx context.Context, arg Li
 	var items []ListServableMetaMCPMemberUpstreamsRow
 	for rows.Next() {
 		var i ListServableMetaMCPMemberUpstreamsRow
-		if err := rows.Scan(&i.McpServerID, &i.UpstreamUrl); err != nil {
+		if err := rows.Scan(&i.McpServerID, &i.McpServerVisibility, &i.UpstreamUrl); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -485,6 +485,62 @@ func (q *Queries) ListMetaMCPServers(ctx context.Context, arg ListMetaMCPServers
 	return items, nil
 }
 
+const listServableMetaMCPMemberUpstreams = `-- name: ListServableMetaMCPMemberUpstreams :many
+SELECT
+    m.mcp_server_id,
+    r.url AS upstream_url
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+ AND s.visibility <> 'disabled'
+ AND s.slug IS NOT NULL
+JOIN remote_mcp_servers r
+  ON r.id = s.remote_mcp_server_id
+ AND r.project_id = m.project_id
+ AND r.deleted IS FALSE
+WHERE m.meta_mcp_server_id = $1
+  AND m.project_id = $2
+  AND m.deleted IS FALSE
+ORDER BY m.sort_order, m.created_at, m.id
+`
+
+type ListServableMetaMCPMemberUpstreamsParams struct {
+	MetaMcpServerID uuid.UUID
+	ProjectID       uuid.UUID
+}
+
+type ListServableMetaMCPMemberUpstreamsRow struct {
+	McpServerID uuid.UUID
+	UpstreamUrl string
+}
+
+// Consent-time credential selection: the upstream URL of every servable
+// remote-backed member of a gateway, filtered exactly as
+// ListServableMetaMCPMembers is. Tunneled, hosted, and unproxied members are
+// excluded by the join — they advertise no RFC 9728 metadata document, so
+// they cannot be matched to a connecting client's authorization server.
+func (q *Queries) ListServableMetaMCPMemberUpstreams(ctx context.Context, arg ListServableMetaMCPMemberUpstreamsParams) ([]ListServableMetaMCPMemberUpstreamsRow, error) {
+	rows, err := q.db.Query(ctx, listServableMetaMCPMemberUpstreams, arg.MetaMcpServerID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListServableMetaMCPMemberUpstreamsRow
+	for rows.Next() {
+		var i ListServableMetaMCPMemberUpstreamsRow
+		if err := rows.Scan(&i.McpServerID, &i.UpstreamUrl); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listServableMetaMCPMembers = `-- name: ListServableMetaMCPMembers :many
 SELECT
     m.id,

--- a/server/internal/remotesessions/issuermigration.go
+++ b/server/internal/remotesessions/issuermigration.go
@@ -171,7 +171,7 @@ func validateMigrationScope(source, target repo.RemoteSessionIssuer) error {
 func endpointMismatches(source, target repo.RemoteSessionIssuer) []string {
 	var mismatches []string
 
-	if !issuerURLsCanonicallyEqual(source.Issuer, target.Issuer) {
+	if !IssuerURLsCanonicallyEqual(source.Issuer, target.Issuer) {
 		mismatches = append(mismatches, "issuer")
 	}
 	if !pgTextEqual(source.TokenEndpoint, target.TokenEndpoint) {
@@ -189,31 +189,6 @@ func pgTextEqual(a, b pgtype.Text) bool {
 		return false
 	}
 	return !a.Valid || a.String == b.String
-}
-
-// issuerURLsCanonicallyEqual reports whether two issuer identifiers name the
-// same upstream authorization server, collapsing the trailing-slash and
-// default-port spellings that parseCanonicalIssuerURL treats as equivalent.
-//
-// A value that does not parse as an issuer identifier is only ever equal to an
-// identical string. Migration must not widen an identity comparison on input it
-// could not understand, and rows predating validation can hold anything.
-func issuerURLsCanonicallyEqual(a, b string) bool {
-	if a == b {
-		return true
-	}
-
-	canonicalA, err := parseCanonicalIssuerURL(a)
-	if err != nil {
-		return false
-	}
-
-	canonicalB, err := parseCanonicalIssuerURL(b)
-	if err != nil {
-		return false
-	}
-
-	return canonicalA.String() == canonicalB.String()
 }
 
 // migrationWarnings names issuer fields that diverge without blocking the

--- a/server/internal/remotesessions/issuermigration_internal_test.go
+++ b/server/internal/remotesessions/issuermigration_internal_test.go
@@ -233,6 +233,12 @@ func TestIssuerURLsCanonicallyEqual_CollapsesEquivalentSpellings(t *testing.T) {
 	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:443"))
 	require.True(t, IssuerURLsCanonicallyEqual("https://IDP.example.com", "https://idp.example.com"))
 	require.True(t, IssuerURLsCanonicallyEqual("http://idp.example.com:80/x", "http://idp.example.com/x"))
+	// RFC 3986 permits leading zeros in a port and net/url reports them
+	// verbatim, so the default-port collapse has to be numeric.
+	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com:0443", "https://idp.example.com"))
+	require.True(t, IssuerURLsCanonicallyEqual("http://idp.example.com:080", "http://idp.example.com/"))
+	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com:08443", "https://idp.example.com:8443"))
+	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com:000", "https://idp.example.com:0"))
 }
 
 // TestIssuerURLsCanonicallyEqual_KeepsDistinctUpstreamsApart pins the axes that
@@ -245,6 +251,10 @@ func TestIssuerURLsCanonicallyEqual_KeepsDistinctUpstreamsApart(t *testing.T) {
 	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://other.example.com"))
 	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com/a", "https://idp.example.com/A"))
 	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:8443"))
+	// Port zero is a port, not the absence of one, however it is spelled.
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com:0", "https://idp.example.com"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com:000", "https://idp.example.com"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com:0443", "https://idp.example.com:443443"))
 }
 
 // TestIssuerURLsCanonicallyEqual_UnparseableIsOnlyEqualToItself proves a stored

--- a/server/internal/remotesessions/issuermigration_internal_test.go
+++ b/server/internal/remotesessions/issuermigration_internal_test.go
@@ -229,10 +229,10 @@ func TestMigratePreflight_CanMigrate(t *testing.T) {
 func TestIssuerURLsCanonicallyEqual_CollapsesEquivalentSpellings(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, issuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com/"))
-	require.True(t, issuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:443"))
-	require.True(t, issuerURLsCanonicallyEqual("https://IDP.example.com", "https://idp.example.com"))
-	require.True(t, issuerURLsCanonicallyEqual("http://idp.example.com:80/x", "http://idp.example.com/x"))
+	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com/"))
+	require.True(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:443"))
+	require.True(t, IssuerURLsCanonicallyEqual("https://IDP.example.com", "https://idp.example.com"))
+	require.True(t, IssuerURLsCanonicallyEqual("http://idp.example.com:80/x", "http://idp.example.com/x"))
 }
 
 // TestIssuerURLsCanonicallyEqual_KeepsDistinctUpstreamsApart pins the axes that
@@ -241,10 +241,10 @@ func TestIssuerURLsCanonicallyEqual_CollapsesEquivalentSpellings(t *testing.T) {
 func TestIssuerURLsCanonicallyEqual_KeepsDistinctUpstreamsApart(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, issuerURLsCanonicallyEqual("https://idp.example.com", "http://idp.example.com"))
-	require.False(t, issuerURLsCanonicallyEqual("https://idp.example.com", "https://other.example.com"))
-	require.False(t, issuerURLsCanonicallyEqual("https://idp.example.com/a", "https://idp.example.com/A"))
-	require.False(t, issuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:8443"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "http://idp.example.com"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://other.example.com"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com/a", "https://idp.example.com/A"))
+	require.False(t, IssuerURLsCanonicallyEqual("https://idp.example.com", "https://idp.example.com:8443"))
 }
 
 // TestIssuerURLsCanonicallyEqual_UnparseableIsOnlyEqualToItself proves a stored
@@ -254,8 +254,8 @@ func TestIssuerURLsCanonicallyEqual_KeepsDistinctUpstreamsApart(t *testing.T) {
 func TestIssuerURLsCanonicallyEqual_UnparseableIsOnlyEqualToItself(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, issuerURLsCanonicallyEqual("not a url", "not a url"))
-	require.False(t, issuerURLsCanonicallyEqual("not a url", "not a url/"))
-	require.False(t, issuerURLsCanonicallyEqual("not a url", "https://idp.example.com"))
-	require.False(t, issuerURLsCanonicallyEqual("", "https://idp.example.com"))
+	require.True(t, IssuerURLsCanonicallyEqual("not a url", "not a url"))
+	require.False(t, IssuerURLsCanonicallyEqual("not a url", "not a url/"))
+	require.False(t, IssuerURLsCanonicallyEqual("not a url", "https://idp.example.com"))
+	require.False(t, IssuerURLsCanonicallyEqual("", "https://idp.example.com"))
 }

--- a/server/internal/remotesessions/issuerurl.go
+++ b/server/internal/remotesessions/issuerurl.go
@@ -129,8 +129,16 @@ func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
 	}
 
 	// An explicit default port is the same authority as no port at all, so drop
-	// it. Any other port is significant and stays.
+	// it. Any other port is significant and stays. RFC 3986 permits leading
+	// zeros and net/url reports the port verbatim, so the digits are reduced to
+	// their numeric form first: :0443 is the default port, :08443 is :8443, and
+	// an all-zeros port is :0 rather than no port at all.
 	port := u.Port()
+	if port != "" {
+		if port = strings.TrimLeft(port, "0"); port == "" {
+			port = "0"
+		}
+	}
 	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
 		port = ""
 	}

--- a/server/internal/remotesessions/issuerurl.go
+++ b/server/internal/remotesessions/issuerurl.go
@@ -55,6 +55,35 @@ type canonicalIssuerURL struct {
 	path string
 }
 
+// IssuerURLsCanonicallyEqual reports whether two issuer identifiers name the
+// same upstream authorization server, collapsing the trailing-slash,
+// default-port, and host-case spellings that parseCanonicalIssuerURL treats as
+// equivalent. It is the one comparison to use whenever an issuer URL Gram
+// stored is matched against an issuer URL some other party wrote — a discovery
+// document's authorization_servers entry, an admin's form input — so those
+// comparisons cannot drift apart.
+//
+// A value that does not parse as an issuer identifier is only ever equal to an
+// identical string. Widening an identity comparison on input that could not be
+// understood is never right, and rows predating validation can hold anything.
+func IssuerURLsCanonicallyEqual(a, b string) bool {
+	if a == b {
+		return true
+	}
+
+	canonicalA, err := parseCanonicalIssuerURL(a)
+	if err != nil {
+		return false
+	}
+
+	canonicalB, err := parseCanonicalIssuerURL(b)
+	if err != nil {
+		return false
+	}
+
+	return canonicalA.String() == canonicalB.String()
+}
+
 // parseCanonicalIssuerURL validates raw as an issuer identifier and reduces it
 // to its canonical parts.
 func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -727,6 +727,10 @@ WHERE remote_session_client_id = @remote_session_client_id AND deleted IS FALSE;
 -- deleted IS FALSE; on conflict we overwrite every token field. A
 -- soft-deleted row falls outside the partial index, so a re-auth after
 -- revocation inserts a fresh active row alongside the tombstone.
+-- resource is the exception: an empty incoming value means "could not derive",
+-- not "no longer qualified", so it keeps the stored binding rather than
+-- un-qualifying a correct grant on a transient discovery miss at reconnect —
+-- same COALESCE/NULLIF semantics the refresh backfill uses.
 INSERT INTO remote_sessions (
     subject_urn,
     user_session_issuer_id,
@@ -761,7 +765,7 @@ DO UPDATE SET
     authorization_expires_at = EXCLUDED.authorization_expires_at,
     refresh_expires_at = EXCLUDED.refresh_expires_at,
     scopes = EXCLUDED.scopes,
-    resource = EXCLUDED.resource,
+    resource = COALESCE(NULLIF(EXCLUDED.resource, ''), remote_sessions.resource),
     updated_at = clock_timestamp()
 RETURNING *;
 

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -5753,7 +5753,7 @@ DO UPDATE SET
     authorization_expires_at = EXCLUDED.authorization_expires_at,
     refresh_expires_at = EXCLUDED.refresh_expires_at,
     scopes = EXCLUDED.scopes,
-    resource = EXCLUDED.resource,
+    resource = COALESCE(NULLIF(EXCLUDED.resource, ''), remote_sessions.resource),
     updated_at = clock_timestamp()
 RETURNING id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, authorization_expires_at, refresh_expires_at, scopes, resource, auto_refresh, last_refresh_attempt_at, last_used_at, created_at, updated_at, deleted_at, deleted
 `
@@ -5778,6 +5778,10 @@ type UpsertRemoteSessionParams struct {
 // deleted IS FALSE; on conflict we overwrite every token field. A
 // soft-deleted row falls outside the partial index, so a re-auth after
 // revocation inserts a fresh active row alongside the tombstone.
+// resource is the exception: an empty incoming value means "could not derive",
+// not "no longer qualified", so it keeps the stored binding rather than
+// un-qualifying a correct grant on a transient discovery miss at reconnect —
+// same COALESCE/NULLIF semantics the refresh backfill uses.
 func (q *Queries) UpsertRemoteSession(ctx context.Context, arg UpsertRemoteSessionParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, upsertRemoteSession,
 		arg.SubjectUrn,

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -420,3 +420,51 @@ func TestRemoteSessionRefreshActivity_SweepBackfillsNullResource(t *testing.T) {
 	require.Equal(t, mcpURL, conv.FromPGTextOrEmpty[string](sess.Resource), "the sweep must stamp the client-derived fallback")
 	require.Equal(t, spy.form.Get("resource"), conv.FromPGTextOrEmpty[string](sess.Resource), "the stored binding must equal the form resource the grant used")
 }
+
+// The reconnect upsert follows the same rule the refresh backfill does: a
+// non-empty resource binds the credential, an empty one means "could not
+// derive" and must leave a correct binding standing. A gateway-bound client
+// has no way back — the backfill derives from the client's own issuer
+// bindings, which a gateway consent never creates — so an overwrite here is
+// permanent.
+func TestUpsertRemoteSession_EmptyResourceKeepsTheStoredBinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	q := repo.New(ti.conn)
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "usi-upsert-resource")
+	clientID, _ := seedActiveClient(t, ctx, ti.conn, *authCtx.ProjectID, userIssuerID, authCtx.ActiveOrganizationID, "rsi-upsert-resource")
+	subject := urn.NewUserSubject("upsert-resource-subject")
+
+	const member = "https://member.example.com/mcp"
+	upsert := func(resource pgtype.Text) repo.RemoteSession {
+		t.Helper()
+		row, err := q.UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+			SubjectUrn:            subject,
+			UserSessionIssuerID:   userIssuerID,
+			RemoteSessionClientID: clientID,
+			AccessTokenEncrypted:  "ciphertext",
+			AccessExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+			Scopes:                []string{},
+			Resource:              resource,
+		})
+		require.NoError(t, err)
+		return row
+	}
+
+	first := upsert(conv.ToPGTextEmpty(member))
+	require.Equal(t, member, conv.FromPGTextOrEmpty[string](first.Resource))
+
+	// conv.ToPGTextEmpty turns an underivable resource into SQL NULL, and the
+	// empty string is the other spelling of the same thing.
+	require.Equal(t, member, conv.FromPGTextOrEmpty[string](upsert(conv.ToPGTextEmpty("")).Resource), "a NULL incoming resource keeps the stored binding")
+	require.Equal(t, member, conv.FromPGTextOrEmpty[string](upsert(conv.ToPGText("")).Resource), "an empty incoming resource keeps the stored binding")
+
+	const moved = "https://other-member.example.com/mcp"
+	require.Equal(t, moved, conv.FromPGTextOrEmpty[string](upsert(conv.ToPGTextEmpty(moved)).Resource), "a non-empty incoming resource still rebinds")
+	require.Equal(t, first.ID, getRemoteSessionRow(t, ctx, ti, clientID, subject).ID, "every write rotated the same row")
+}


### PR DESCRIPTION
AIM-87

## Summary

At consent on a gateway endpoint, resolve which member a connecting client's credential is for and record that member's URL as the grant's RFC 8707 resource, so `routeUpstreamToken` routes by it unchanged.

The connect arm branches on `endpoint.MetaMcpServerID.Valid`: for a gateway it enumerates the servable remote-backed members (new `ListServableMetaMCPMemberUpstreams`), drops the ones the consent subject holds no `mcp:connect` on, probes each survivor's RFC 9728 protected-resource document, and matches `authorization_servers` against the client's issuer URL. A unique match derives that member's URL, which then rides the existing consent → challenge → callback chain onto the grant. Discovery precedes rather than replaces the stored derivation — where it resolves nothing, `FallbackResourceForClient` still answers.

Comparison goes through `remotesessions.IssuerURLsCanonicallyEqual`, not a literal compare: the entry is the upstream's spelling and the issuer URL is Gram's, so one authorization server legitimately appears two ways.

## Fails closed

No match, several matches, and any member whose metadata could not be read all derive `""`, which the connect arm already handles. Only a database fault errors out, so a failed lookup cannot mint an unqualified grant.

Unreadable ≠ absent is the load-bearing part, hence a tri-state probe outcome. A slow or unprobed member makes no claim only because nobody asked, and treating that as "claims nothing" hands a rival a unique match it did not earn — inducibly so, since probe order follows `sort_order`. `conclusiveProbeMiss` splits the discovery error codes: `not_found` / `invalid_url` / `host_blocked` / `malformed` are answers; timeouts, transport errors, unexpected statuses, and budget-skips leave the member unknown, and one unknown member abandons the resolution.

Two further guards: members the subject cannot `mcp:connect` to are dropped before probing (an invisible member must not claim a credential nor contest a visible one's claim), and a document whose `resource` names something else is the host's, not the member's — the origin-style fallback returns a neighbour's document on a shared host.

Fan-out is bounded for a synchronous consent click: 3s per probe, 6s across the whole fan-out, 4 in flight.

## Two collateral fixes

- `UpsertRemoteSession` no longer overwrites a stored resource with an empty one (`COALESCE(NULLIF(...))`, as the refresh backfill does). Otherwise a reconnect during a transient discovery miss un-qualifies a correct grant.
- `parseCanonicalIssuerURL` reduces a port to numeric form before the default-port test — `net/url` reports `:0443` verbatim, so it read as significant. Also affects `issuermigration.go`, the existing caller.

## Limits, deliberate for v1

Tunneled members advertise no metadata document, so they stay fail-closed above one credential. One authorization server fronting two members of the same gateway is ambiguous by construction — a grant records one resource per (subject, client) — and is detected rather than guessed at.

Out of scope, landing separately: upstream session orchestration, live member status, outage degradation, and the `CodeNotImplemented` arm for proxied members.

## Motivation

A caller authenticates once at a gateway, so every upstream credential they hold lives under the gateway's user-session issuer, and a tool call has to forward the right member's token to that member's host.

That was not possible. `routeUpstreamToken` matches the member's URL against each grant's recorded resource, and gateway consents record none: `FallbackResourceForClient` looks for MCP servers whose own issuer the client is bound to, but members carry their own issuers while the client is bound to the gateway's. Two or more credentials then match nothing and every proxied call fails closed; exactly one hits the lone-token pass-through and is forwarded even to a mismatched upstream.

Discovery closes that without new schema, since the client's issuer is exactly what a member's metadata advertises. A stored upstream→authorization-server column remains available later as an additive cache.

## Tests

Resolver-level: `ServeConsentAction` against `httptest` members, asserting the resource that reaches the authorization server — unique match, no match, ambiguity, 404-vs-unreachable, hang, budget exhaustion, a hostile member claiming an absent member's issuer, a document naming another resource, an unconnectable member, disabled/detached members, issuer spelling variants, and the non-gateway path.

End-to-end on real Postgres: consent → challenge → callback → code exchange against live per-member authorization servers, `remote_sessions.resource` read back, then real grants through `ResolveAccessTokens` and the real `routeUpstreamToken`. Asserts the RFC 8707 indicator on the wire, per-member credential selection, that the endpoint-level resource never reaches a grant, fail-closed above one unqualified token, and that reconnect does not un-qualify.

It stops one layer short — which credential routing selects, not which bearer arrives — because proxied dispatch is still `CodeNotImplemented`. Asserting the forwarded header at the member's upstream is in the next PR's scope.
