### PR TITLE
mig: record a platform-granted own-project exemption on gcp_iam_credentials

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -6112,6 +6112,11 @@ CREATE TABLE IF NOT EXISTS gcp_iam_credentials (
   wif_pool_id TEXT,
   wif_provider_id TEXT,
   wif_project_number TEXT,
+  -- Exempts this credential from the validation that refuses an impersonation
+  -- target in the server's own GCP project. Recorded on the row because the
+  -- same validation runs on the outbound path, where there is no request actor
+  -- to consult.
+  skip_project_verification boolean NOT NULL DEFAULT FALSE,
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   CONSTRAINT gcp_iam_credentials_pkey PRIMARY KEY (external_credential_id),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -948,6 +948,7 @@ type GcpIamCredential struct {
 	WifPoolID                   pgtype.Text
 	WifProviderID               pgtype.Text
 	WifProjectNumber            pgtype.Text
+	SkipProjectVerification     bool
 	CreatedAt                   pgtype.Timestamptz
 	UpdatedAt                   pgtype.Timestamptz
 }

--- a/server/internal/externalcredentials/repo/models.go
+++ b/server/internal/externalcredentials/repo/models.go
@@ -40,6 +40,7 @@ type GcpIamCredential struct {
 	WifPoolID                   pgtype.Text
 	WifProviderID               pgtype.Text
 	WifProjectNumber            pgtype.Text
+	SkipProjectVerification     bool
 	CreatedAt                   pgtype.Timestamptz
 	UpdatedAt                   pgtype.Timestamptz
 }

--- a/server/internal/externalcredentials/repo/queries.sql.go
+++ b/server/internal/externalcredentials/repo/queries.sql.go
@@ -107,7 +107,7 @@ INSERT INTO gcp_iam_credentials (
   $4,
   $5
 )
-RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, created_at, updated_at
+RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, skip_project_verification, created_at, updated_at
 `
 
 type CreateGcpIamCredentialParams struct {
@@ -134,6 +134,7 @@ func (q *Queries) CreateGcpIamCredential(ctx context.Context, arg CreateGcpIamCr
 		&i.WifPoolID,
 		&i.WifProviderID,
 		&i.WifProjectNumber,
+		&i.SkipProjectVerification,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -196,7 +197,7 @@ func (q *Queries) GetAwsIamCredential(ctx context.Context, arg GetAwsIamCredenti
 }
 
 const getGcpIamCredential = `-- name: GetGcpIamCredential :one
-SELECT ec.id, ec.organization_id, ec.project_id, ec.provider, ec.name, ec.created_at, ec.updated_at, ec.deleted_at, ec.deleted, gcp.external_credential_id, gcp.external_credentials_provider, gcp.impersonate_service_account, gcp.wif_pool_id, gcp.wif_provider_id, gcp.wif_project_number, gcp.created_at, gcp.updated_at
+SELECT ec.id, ec.organization_id, ec.project_id, ec.provider, ec.name, ec.created_at, ec.updated_at, ec.deleted_at, ec.deleted, gcp.external_credential_id, gcp.external_credentials_provider, gcp.impersonate_service_account, gcp.wif_pool_id, gcp.wif_provider_id, gcp.wif_project_number, gcp.skip_project_verification, gcp.created_at, gcp.updated_at
 FROM external_credentials AS ec
 JOIN gcp_iam_credentials AS gcp ON gcp.external_credential_id = ec.id
 WHERE ec.id = $1
@@ -235,6 +236,7 @@ func (q *Queries) GetGcpIamCredential(ctx context.Context, arg GetGcpIamCredenti
 		&i.GcpIamCredential.WifPoolID,
 		&i.GcpIamCredential.WifProviderID,
 		&i.GcpIamCredential.WifProjectNumber,
+		&i.GcpIamCredential.SkipProjectVerification,
 		&i.GcpIamCredential.CreatedAt,
 		&i.GcpIamCredential.UpdatedAt,
 	)
@@ -479,7 +481,7 @@ SET impersonate_service_account = $1,
     wif_project_number = $4,
     updated_at = clock_timestamp()
 WHERE external_credential_id = $5
-RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, created_at, updated_at
+RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, skip_project_verification, created_at, updated_at
 `
 
 type UpdateGcpIamCredentialParams struct {
@@ -509,6 +511,7 @@ func (q *Queries) UpdateGcpIamCredential(ctx context.Context, arg UpdateGcpIamCr
 		&i.WifPoolID,
 		&i.WifProviderID,
 		&i.WifProjectNumber,
+		&i.SkipProjectVerification,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260825221933_gcp-iam-credentials-add-skip-project-verification.sql
+++ b/server/migrations/20260825221933_gcp-iam-credentials-add-skip-project-verification.sql
@@ -1,0 +1,2 @@
+-- Modify "gcp_iam_credentials" table
+ALTER TABLE "gcp_iam_credentials" ADD COLUMN "skip_project_verification" boolean NOT NULL DEFAULT false;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:YR8Bq+y29EmpreKFIZz41wX0ToSqEVRfBKlJk4bMLOU=
+h1:4ajo+XGHCwmaLM4VAkA5janya1PWNnuTBqarIm7Xla0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -366,3 +366,4 @@ h1:YR8Bq+y29EmpreKFIZz41wX0ToSqEVRfBKlJk4bMLOU=
 20260825101109_platform-mcp-cimd-storage.sql h1:+lWTYrX8sO91BWLyAP+4Z1gDOtXvlowQuZTSfCezwDE=
 20260825202304_add-mcp-server-remote-session-issuer.sql h1:mGS8dAfAZECcILMlipui+QDySif0d0s+KAgEmp3CZQE=
 20260825204553_expand-user-session-issuers-org-tier.sql h1:kJ01dQVvnahFE3UaA2zZx+58ij7KzCuBHYkozcHCCqQ=
+20260825221933_gcp-iam-credentials-add-skip-project-verification.sql h1:DZOWCldTGLdSq4DlHGhu2wnFhLiqVffCgOKC8LoGzkE=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-129/mig-record-a-platform-granted-own-project-exemption-on-gcp-iam

Adds `skip_project_verification` to `gcp_iam_credentials` so a platform administrator can exempt a credential from the screening that refuses an impersonation target in the server's own GCP project.

The exemption has to be recorded on the row rather than decided at request time. The same screening runs again on the outbound path, where there is no request actor to consult, so a write-time-only bypass would save a credential that is then refused every time something tries to use it.

`NOT NULL DEFAULT FALSE` does not rewrite the table, since Postgres 11 and later store the default in the catalog rather than scanning existing rows. `FALSE` is the correct value for every existing row, so no backfill is needed. No `CHECK` constraint, so PG305 does not apply.

Schema and migration only, plus the sqlc models the new column regenerates. No query changes and no application code: setting and honoring the column is AIM-130.