### PR TITLE
feat: check CAA records during custom domain setup

### DIFF
--- a/.changeset/custom-domain-caa-check.md
+++ b/.changeset/custom-domain-caa-check.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Custom domain setup now checks CAA records so a domain that only authorizes another CA (for example Google Trust Services) is caught before Let's Encrypt issuance fails. Verification waits until `0 issue "letsencrypt.org"` is present, health checks surface `caa_forbidden`, and the setup wizard documents the record.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -65277,7 +65277,7 @@ components:
           format: date-time
         health_issue:
           type: string
-          description: 'The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.'
+          description: 'The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.'
         health_status:
           type: string
           description: 'The latest observed domain health status. One of: unknown, healthy, unhealthy.'

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -101,6 +101,8 @@ const healthIssueMessages: Record<string, string> = {
     "We couldn't find DNS records for this domain. Set this record with your DNS provider:",
   dns_target_mismatch:
     "This domain's DNS does not resolve to the expected target. If the domain sits behind a proxy or CDN, traffic may still work; otherwise set this DNS record:",
+  caa_forbidden:
+    "CAA records for this domain do not allow Let's Encrypt to issue a TLS certificate. Add this CAA record:",
   resource_missing:
     "The routing configuration for this domain is missing. Run the check again to confirm the problem persists.",
   certificate_missing:
@@ -114,6 +116,12 @@ const healthIssueMessages: Record<string, string> = {
   check_failed:
     "We couldn't complete the latest health check. Run it again to confirm whether the domain is healthy.",
 };
+
+const LETS_ENCRYPT_CAA_RECORD = '0 issue "letsencrypt.org"';
+
+function customDomainCAARecord(domainName: string): string {
+  return `${domainName} CAA ${LETS_ENCRYPT_CAA_RECORD}`;
+}
 
 function customDomainHealthMessage(issue?: string): string {
   return issue
@@ -139,6 +147,7 @@ function CustomDomainHealthMessage({
 }) {
   const showsExpectedRecord =
     issue === "dns_not_found" || issue === "dns_target_mismatch";
+  const showsCAARecord = issue === "caa_forbidden";
   const useARecord = recordType === "a" && (aRecords?.length ?? 0) > 0;
   return (
     <>
@@ -151,6 +160,12 @@ function CustomDomainHealthMessage({
               ? `${domainName} A ${aRecords?.join(", ")}`
               : `${domainName} CNAME ${cnameTarget || getCustomDomainCNAME()}`}
           </code>
+        </>
+      )}
+      {showsCAARecord && (
+        <>
+          {" "}
+          <code className="break-all">{customDomainCAARecord(domainName)}</code>
         </>
       )}
     </>
@@ -1339,6 +1354,46 @@ function OrgDomainsInner() {
                 >
                   <Button.Icon>
                     {isTxtCopied ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button.Icon>
+                </Button>
+              </div>
+            </div>
+            <div>
+              <Text
+                variant="body"
+                className="mb-2 block text-lg font-extrabold"
+              >
+                CAA records
+              </Text>
+              <Text variant="body" className="text-muted-foreground mb-2">
+                If this domain already has CAA records — common when migrating
+                from Google or another certificate issuer — add a CAA record
+                that allows Let's Encrypt. Skip this if you have no CAA
+                records.
+              </Text>
+              <div className="bg-muted mt-2 flex items-center space-x-2 p-3">
+                <code className="flex-1 break-all">
+                  {customDomainCAARecord(subdomain)}
+                </code>
+                <Button
+                  aria-label={
+                    copiedRecordValue === customDomainCAARecord(subdomain)
+                      ? "CAA value copied"
+                      : "Copy CAA value"
+                  }
+                  variant="tertiary"
+                  size="sm"
+                  onClick={() =>
+                    void handleCopyRecordValue(customDomainCAARecord(subdomain))
+                  }
+                  className="shrink-0"
+                >
+                  <Button.Icon>
+                    {copiedRecordValue === customDomainCAARecord(subdomain) ? (
                       <CheckCircle2 className="h-4 w-4 text-green-500" />
                     ) : (
                       <Copy className="h-4 w-4" />

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -1372,8 +1372,7 @@ function OrgDomainsInner() {
               <Text variant="body" className="text-muted-foreground mb-2">
                 If this domain already has CAA records — common when migrating
                 from Google or another certificate issuer — add a CAA record
-                that allows Let's Encrypt. Skip this if you have no CAA
-                records.
+                that allows Let's Encrypt. Skip this if you have no CAA records.
               </Text>
               <div className="bg-muted mt-2 flex items-center space-x-2 p-3">
                 <code className="flex-1 break-all">

--- a/client/dashboard/src/sdk/src/models/components/customdomain.ts
+++ b/client/dashboard/src/sdk/src/models/components/customdomain.ts
@@ -47,7 +47,7 @@ export type CustomDomain = {
    */
   healthCheckedAt?: Date | undefined;
   /**
-   * The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.
+   * The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.
    */
   healthIssue?: string | undefined;
   /**

--- a/server/design/domains/design.go
+++ b/server/design/domains/design.go
@@ -24,7 +24,7 @@ var CustomDomain = Type("CustomDomain", func() {
 	Attribute("is_updating", Boolean, "The custom domain is actively being registered")
 	Attribute("ip_allowlist", ArrayOf(String), "IP addresses or CIDR ranges allowed to access this domain. Empty list means unrestricted.")
 	Attribute("health_status", String, "The latest observed domain health status. One of: unknown, healthy, unhealthy.")
-	Attribute("health_issue", String, "The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.")
+	Attribute("health_issue", String, "The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.")
 	Attribute("health_checked_at", String, func() {
 		Description("When the domain health was last checked.")
 		Format(FormatDateTime)

--- a/server/gen/domains/service.go
+++ b/server/gen/domains/service.go
@@ -108,7 +108,7 @@ type CustomDomain struct {
 	// unhealthy.
 	HealthStatus *string
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string

--- a/server/gen/http/domains/client/types.go
+++ b/server/gen/http/domains/client/types.go
@@ -70,7 +70,7 @@ type GetDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -126,7 +126,7 @@ type CreateDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -173,7 +173,7 @@ type UpdateDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -220,7 +220,7 @@ type SetRootMcpEndpointResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -273,7 +273,7 @@ type CheckHealthResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -1969,7 +1969,7 @@ type CustomDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`

--- a/server/gen/http/domains/server/types.go
+++ b/server/gen/http/domains/server/types.go
@@ -70,7 +70,7 @@ type GetDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -126,7 +126,7 @@ type CreateDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -173,7 +173,7 @@ type UpdateDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -220,7 +220,7 @@ type SetRootMcpEndpointResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -273,7 +273,7 @@ type CheckHealthResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`
@@ -1969,7 +1969,7 @@ type CustomDomainResponseBody struct {
 	// unhealthy.
 	HealthStatus *string `form:"health_status,omitempty" json:"health_status,omitempty" xml:"health_status,omitempty"`
 	// The reason the domain was last observed as unhealthy. One of: dns_not_found,
-	// dns_target_mismatch, resource_missing, certificate_missing,
+	// dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing,
 	// certificate_not_ready, certificate_expired, certificate_invalid,
 	// check_failed.
 	HealthIssue *string `form:"health_issue,omitempty" json:"health_issue,omitempty" xml:"health_issue,omitempty"`

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -66568,7 +66568,7 @@ components:
                     format: date-time
                 health_issue:
                     type: string
-                    description: 'The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.'
+                    description: 'The reason the domain was last observed as unhealthy. One of: dns_not_found, dns_target_mismatch, caa_forbidden, resource_missing, certificate_missing, certificate_not_ready, certificate_expired, certificate_invalid, check_failed.'
                 health_status:
                     type: string
                     description: 'The latest observed domain health status. One of: unknown, healthy, unhealthy.'

--- a/server/internal/background/activities/custom_domain_dns.go
+++ b/server/internal/background/activities/custom_domain_dns.go
@@ -99,6 +99,17 @@ func checkCustomDomainRouting(ctx context.Context, resolver dns.Resolver, domain
 	return "", nil
 }
 
+func checkCustomDomainCAA(ctx context.Context, resolver dns.Resolver, domain string) (customdomains.HealthIssue, error) {
+	restriction, err := dns.FindIssueRestriction(ctx, resolver, domain)
+	if err != nil {
+		return "", fmt.Errorf("resolve custom domain CAA: %w", err)
+	}
+	if restriction.Name == "" || dns.IssueAllows(restriction.Records, dns.LetsEncryptIssueDomain) {
+		return "", nil
+	}
+	return customdomains.HealthIssueCAAForbidden, nil
+}
+
 func normalizeDNSName(name string) string {
 	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(name), "."))
 }

--- a/server/internal/background/activities/custom_domain_health.go
+++ b/server/internal/background/activities/custom_domain_health.go
@@ -191,6 +191,23 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		observation.Issue = routingIssue
 		preserveCertificateExpiry = true
 	default:
+		caaIssue, caaErr := checkCustomDomainCAA(ctx, c.resolver, domain.Domain)
+		if caaErr != nil {
+			if !isFinalHealthCheckAttempt(ctx) {
+				return noNotification, fmt.Errorf("check custom domain CAA: %w", caaErr)
+			}
+			c.logger.WarnContext(ctx, "custom domain CAA health check failed", attr.SlogURLDomain(domain.Domain), attr.SlogError(caaErr))
+			observation.Status = customdomains.HealthStatusUnhealthy
+			observation.Issue = customdomains.HealthIssueCheckFailed
+			preserveCertificateExpiry = true
+			break
+		}
+		if caaIssue != "" {
+			observation.Status = customdomains.HealthStatusUnhealthy
+			observation.Issue = caaIssue
+			preserveCertificateExpiry = true
+			break
+		}
 		infrastructureHealth, infrastructureErr := c.infrastructure.CheckCustomDomainInfrastructure(ctx, k8s.CustomDomainInfrastructureCheck{
 			Domain:                    domain.Domain,
 			ResourceName:              domain.IngressName.String,

--- a/server/internal/background/activities/custom_domain_health_test.go
+++ b/server/internal/background/activities/custom_domain_health_test.go
@@ -604,3 +604,42 @@ func TestCustomDomainHealthCheckCNAMEMatchWithForeignAddressesIsMismatch(t *test
 	require.Equal(t, "unhealthy", domain.HealthStatus.String)
 	require.Equal(t, "dns_target_mismatch", domain.HealthIssue.String)
 }
+
+func TestCustomDomainHealthCheckCAAForbidden(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "custom_domain_health_caa")
+	require.NoError(t, err)
+	repository := customdomainsrepo.New(conn)
+	domainID := createActivatedCustomDomain(t, repository, "test-organization", "caa.example.com")
+
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: nil}, "custom-domain.example.com", nil, noopEmailService(t), nil, nil)
+	checker.SetResolver(dns.NewMockResolver(dns.MockResolverConfig{
+		LookupCNAMEFunc: func(context.Context, string) (string, error) { return "custom-domain.example.com.", nil },
+		LookupNetIPFunc: func(context.Context, string, string) ([]netip.Addr, error) {
+			return nil, errors.New("no A record")
+		},
+		LookupCAAFunc: func(_ context.Context, name string) ([]dns.CAA, error) {
+			if name == "caa.example.com" {
+				return []dns.CAA{{Flag: 0, Tag: "issue", Value: "pki.goog"}}, nil
+			}
+			return nil, nil
+		},
+	}))
+
+	notification, err := checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
+		CustomDomainID: domainID,
+		OrganizationID: "test-organization",
+		CheckedAt:      time.Now().UTC(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, customdomains.HealthIssueCAAForbidden, notification.Issue)
+
+	domain, err := repository.GetCustomDomainByIDAndOrganization(t.Context(), customdomainsrepo.GetCustomDomainByIDAndOrganizationParams{
+		ID:             domainID,
+		OrganizationID: "test-organization",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "unhealthy", domain.HealthStatus.String)
+	require.Equal(t, "caa_forbidden", domain.HealthIssue.String)
+}

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -209,6 +209,19 @@ func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs
 		}
 	}
 
+	caaIssue, err := checkCustomDomainCAA(ctx, d.resolver, domain.Domain)
+	if err != nil {
+		return noResult, oops.E(oops.CodeUnexpected, err, "failed to check CAA records for %s", domain.Domain).LogError(ctx, d.logger)
+	}
+	if caaIssue == customdomains.HealthIssueCAAForbidden {
+		d.logger.InfoContext(ctx, "custom domain CAA records do not authorize Let's Encrypt",
+			attr.SlogURLDomain(domain.Domain))
+		return VerifyCustomDomainResult{
+			Status: VerifyStatusDNSPending,
+			Reason: fmt.Sprintf("CAA records do not allow Let's Encrypt; add %s", dns.ExpectedLetsEncryptCAA),
+		}, nil
+	}
+
 	txtName := "_gram." + domain.Domain
 	txts, err := d.resolver.LookupTXT(ctx, txtName)
 	if err != nil {

--- a/server/internal/background/activities/verify_custom_domain_test.go
+++ b/server/internal/background/activities/verify_custom_domain_test.go
@@ -707,6 +707,78 @@ func TestVerifyCustomDomain_NXDOMAINOnTXTIsPending(t *testing.T) {
 	require.False(t, got.Verified)
 }
 
+func TestVerifyCustomDomain_CAAForbiddenIsPending(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-caa-forbidden"
+	const domain = "caa-forbidden.example.com"
+	ctx, ti := newTestInstance(t, orgID, domain)
+
+	cfg := newPassingDNSResolverConfig(testTargetCNAME, domain, orgID)
+	cfg.LookupCAAFunc = func(_ context.Context, name string) ([]dns.CAA, error) {
+		if name == domain {
+			return []dns.CAA{{Flag: 0, Tag: "issue", Value: "pki.goog"}}, nil
+		}
+		return nil, nil
+	}
+	ti.resolver = dns.NewMockResolver(cfg)
+
+	row := createDomainRow(t, ctx, ti, orgID, domain)
+	activity := newActivity(t, ti)
+
+	result, err := activity.Do(ctx, activities.VerifyCustomDomainArgs{
+		OrgID:           orgID,
+		Domain:          domain,
+		CustomDomainID:  row.ID,
+		CreatedBy:       urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"),
+		CreatedByName:   nil,
+		ProvisionerKind: "",
+		IPAllowlist:     nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, activities.VerifyStatusDNSPending, result.Status)
+	require.Contains(t, result.Reason, "letsencrypt.org")
+
+	got, err := ti.repo.GetCustomDomainByDomain(ctx, domain)
+	require.NoError(t, err)
+	require.False(t, got.Verified)
+}
+
+func TestVerifyCustomDomain_CAAAllowsLetsEncrypt(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-caa-allows"
+	const domain = "caa-allows.example.com"
+	ctx, ti := newTestInstance(t, orgID, domain)
+
+	cfg := newPassingDNSResolverConfig(testTargetCNAME, domain, orgID)
+	cfg.LookupCAAFunc = func(_ context.Context, name string) ([]dns.CAA, error) {
+		if name == domain {
+			return []dns.CAA{
+				{Flag: 0, Tag: "issue", Value: "pki.goog"},
+				{Flag: 0, Tag: "issue", Value: "letsencrypt.org"},
+			}, nil
+		}
+		return nil, nil
+	}
+	ti.resolver = dns.NewMockResolver(cfg)
+
+	row := createDomainRow(t, ctx, ti, orgID, domain)
+	activity := newActivity(t, ti)
+
+	result, err := activity.Do(ctx, activities.VerifyCustomDomainArgs{
+		OrgID:           orgID,
+		Domain:          domain,
+		CustomDomainID:  row.ID,
+		CreatedBy:       urn.NewPrincipal(urn.PrincipalTypeUser, "test-user"),
+		CreatedByName:   nil,
+		ProvisionerKind: "",
+		IPAllowlist:     nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, activities.VerifyStatusVerified, result.Status)
+}
+
 // Verify ErrNoRows is what sqlc returns for missing rows (sanity check).
 func TestGetCustomDomainByDomain_ReturnsErrNoRows(t *testing.T) {
 	t.Parallel()

--- a/server/internal/customdomains/health.go
+++ b/server/internal/customdomains/health.go
@@ -22,6 +22,7 @@ type HealthIssue string
 const (
 	HealthIssueDNSNotFound         HealthIssue = "dns_not_found"
 	HealthIssueDNSTargetMismatch   HealthIssue = "dns_target_mismatch"
+	HealthIssueCAAForbidden        HealthIssue = "caa_forbidden"
 	HealthIssueResourceMissing     HealthIssue = HealthIssue(k8s.CustomDomainInfrastructureIssueResourceMissing)
 	HealthIssueCertificateMissing  HealthIssue = HealthIssue(k8s.CustomDomainInfrastructureIssueCertificateMissing)
 	HealthIssueCertificateNotReady HealthIssue = HealthIssue(k8s.CustomDomainInfrastructureIssueCertificateNotReady)
@@ -95,6 +96,8 @@ func HealthIssueMessage(issue HealthIssue, remediation DNSRemediation) string {
 			return fmt.Sprintf("The domain's DNS no longer resolves to the expected target. Create %s.", record)
 		}
 		return "The domain's DNS no longer resolves to the expected target."
+	case HealthIssueCAAForbidden:
+		return `CAA records for this domain do not allow Let's Encrypt to issue a TLS certificate. Add a CAA record: 0 issue "letsencrypt.org".`
 	case HealthIssueResourceMissing:
 		return "The routing configuration for the domain is missing."
 	case HealthIssueCertificateMissing,

--- a/server/internal/customdomains/health_test.go
+++ b/server/internal/customdomains/health_test.go
@@ -247,6 +247,15 @@ func TestIsRetryOfUnhealthyTransition(t *testing.T) {
 	}, checkedAt))
 }
 
+func TestHealthIssueMessageCAAForbiddenNamesLetsEncryptRecord(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		`CAA records for this domain do not allow Let's Encrypt to issue a TLS certificate. Add a CAA record: 0 issue "letsencrypt.org".`,
+		HealthIssueMessage(HealthIssueCAAForbidden, DNSRemediation{Domain: "chat.example.com", ExpectedCNAME: "cname.example.com.", ExpectedARecords: nil}),
+	)
+}
+
 func TestHealthIssueMessageCertificateProblemsAreManagedByGram(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/dns/caa.go
+++ b/server/internal/dns/caa.go
@@ -1,0 +1,120 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// LetsEncryptIssueDomain is the CAA issue value that authorizes cert-manager's
+// gram-letsencrypt ClusterIssuer.
+const LetsEncryptIssueDomain = "letsencrypt.org"
+
+// ExpectedLetsEncryptCAA is the customer-facing record that authorizes
+// Let's Encrypt when a domain already has a CAA RRset.
+const ExpectedLetsEncryptCAA = `0 issue "letsencrypt.org"`
+
+// CAA is one Certification Authority Authorization record (RFC 8659).
+type CAA struct {
+	// Flag is the record flag octet. The issuer-critical bit is 1.
+	Flag uint8
+
+	// Tag is the property name, typically issue, issuewild, or iodef.
+	Tag string
+
+	// Value is the property value. For issue tags this is a CA domain name,
+	// optionally followed by a semicolon and parameters.
+	Value string
+}
+
+// IssueRestriction is the closest CAA RRset that applies to a hostname.
+// An empty Name means no CAA records were found walking to the TLD, so any
+// CA may issue.
+type IssueRestriction struct {
+	// Name is the DNS name whose CAA RRset was used. Empty when none found.
+	Name string
+
+	// Records is the CAA RRset at Name.
+	Records []CAA
+}
+
+// FindIssueRestriction walks domain and its parents until a CAA RRset is
+// found or only the TLD remains. NXDOMAIN and empty answers continue the
+// walk; any other lookup error is returned.
+func FindIssueRestriction(ctx context.Context, resolver Resolver, domain string) (IssueRestriction, error) {
+	var none IssueRestriction
+	name := normalizeDNSName(domain)
+	for name != "" && strings.Contains(name, ".") {
+		records, err := resolver.LookupCAA(ctx, name)
+		if err != nil {
+			var dnsErr *net.DNSError
+			if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+				name = parentDNSName(name)
+				continue
+			}
+			return none, fmt.Errorf("lookup CAA %s: %w", name, err)
+		}
+		if len(records) > 0 {
+			return IssueRestriction{Name: name, Records: records}, nil
+		}
+		name = parentDNSName(name)
+	}
+	return none, nil
+}
+
+// IssueAllows reports whether the closest CAA RRset authorizes issuer to
+// issue a non-wildcard certificate. No issue tags (only iodef / issuewild /
+// issuemail) do not restrict non-wildcard issuance. A critical unknown tag
+// denies issuance.
+func IssueAllows(records []CAA, issuer string) bool {
+	issuer = strings.ToLower(strings.TrimSpace(issuer))
+	sawIssue := false
+	for _, rec := range records {
+		tag := strings.ToLower(rec.Tag)
+		if rec.Flag&1 != 0 && !knownCAATag(tag) {
+			return false
+		}
+		if tag != "issue" {
+			continue
+		}
+		sawIssue = true
+		if issueValueAllows(rec.Value, issuer) {
+			return true
+		}
+	}
+	return !sawIssue
+}
+
+func knownCAATag(tag string) bool {
+	switch tag {
+	case "issue", "issuewild", "iodef", "issuemail":
+		return true
+	default:
+		return false
+	}
+}
+
+func issueValueAllows(value, issuer string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || value == ";" {
+		return false
+	}
+	domain, _, _ := strings.Cut(value, ";")
+	domain = strings.ToLower(strings.Trim(strings.TrimSpace(domain), `"'`))
+	return domain == issuer
+}
+
+func parentDNSName(name string) string {
+	name = normalizeDNSName(name)
+	i := strings.Index(name, ".")
+	if i < 0 {
+		return ""
+	}
+	return name[i+1:]
+}
+
+func normalizeDNSName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(name), "."))
+}

--- a/server/internal/dns/caa_lookup.go
+++ b/server/internal/dns/caa_lookup.go
@@ -1,0 +1,288 @@
+package dns
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const (
+	typeCAA          dnsmessage.Type = 257
+	caaLookupTimeout                 = 5 * time.Second
+	resolvConfPath                   = "/etc/resolv.conf"
+	dnsHeaderLen                     = 12
+	dnsPort                          = "53"
+)
+
+func lookupCAA(ctx context.Context, resolver *net.Resolver, name string) ([]CAA, error) {
+	name = normalizeDNSName(name)
+	if name == "" {
+		return nil, &net.DNSError{
+			UnwrapErr:   nil,
+			Err:         "empty name",
+			Name:        name,
+			Server:      "",
+			IsTimeout:   false,
+			IsTemporary: false,
+			IsNotFound:  true,
+		}
+	}
+
+	qname, err := dnsmessage.NewName(ensureFQDN(name))
+	if err != nil {
+		return nil, fmt.Errorf("caa query name %q: %w", name, err)
+	}
+
+	query := dnsmessage.Message{
+		Header: dnsmessage.Header{
+			ID:                 uint16(rand.UintN(1 << 16)), //nolint:gosec // DNS message id
+			RecursionDesired:   true,
+			RecursionAvailable: false,
+			Response:           false,
+			OpCode:             0,
+			Authoritative:      false,
+			Truncated:          false,
+			AuthenticData:      false,
+			CheckingDisabled:   false,
+			RCode:              dnsmessage.RCodeSuccess,
+		},
+		Questions: []dnsmessage.Question{{
+			Name:  qname,
+			Type:  typeCAA,
+			Class: dnsmessage.ClassINET,
+		}},
+		Answers:     nil,
+		Authorities: nil,
+		Additionals: nil,
+	}
+	payload, err := query.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("pack caa query: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, caaLookupTimeout)
+	defer cancel()
+
+	resp, err := exchangeDNS(ctx, resolver, payload)
+	if err != nil {
+		return nil, fmt.Errorf("caa lookup %s: %w", name, err)
+	}
+
+	records, err := parseCAAAnswers(resp, name)
+	if err != nil {
+		return nil, fmt.Errorf("parse caa response for %s: %w", name, err)
+	}
+	return records, nil
+}
+
+func exchangeDNS(ctx context.Context, resolver *net.Resolver, payload []byte) ([]byte, error) {
+	if resolver != nil && resolver.Dial != nil {
+		conn, err := resolver.Dial(ctx, "udp", "0.0.0.0:53")
+		if err != nil {
+			return nil, fmt.Errorf("dial resolver: %w", err)
+		}
+		defer conn.Close() //nolint:errcheck // best-effort cleanup
+		if deadline, ok := ctx.Deadline(); ok {
+			if err := conn.SetDeadline(deadline); err != nil {
+				return nil, fmt.Errorf("set resolver deadline: %w", err)
+			}
+		}
+		if _, err := conn.Write(payload); err != nil {
+			return nil, fmt.Errorf("write caa query: %w", err)
+		}
+		buf := make([]byte, 4096)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, fmt.Errorf("read caa response: %w", err)
+		}
+		return buf[:n], nil
+	}
+
+	nameservers, err := systemNameservers()
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	dialer := net.Dialer{}
+	for _, ns := range nameservers {
+		resp, err := exchangeUDP(ctx, &dialer, ns, payload)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		return resp, nil
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no nameservers configured")
+	}
+	return nil, lastErr
+}
+
+func exchangeUDP(ctx context.Context, dialer *net.Dialer, nameserver string, payload []byte) ([]byte, error) {
+	conn, err := dialer.DialContext(ctx, "udp", net.JoinHostPort(nameserver, dnsPort))
+	if err != nil {
+		return nil, fmt.Errorf("dial nameserver %s: %w", nameserver, err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return nil, fmt.Errorf("set nameserver deadline: %w", err)
+		}
+	}
+	if _, err := conn.Write(payload); err != nil {
+		return nil, fmt.Errorf("write caa query: %w", err)
+	}
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, fmt.Errorf("read caa response: %w", err)
+	}
+	return buf[:n], nil
+}
+
+func systemNameservers() ([]string, error) {
+	data, err := os.ReadFile(resolvConfPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", resolvConfPath, err)
+	}
+	var nameservers []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+		nameservers = append(nameservers, fields[1])
+	}
+	if len(nameservers) == 0 {
+		return nil, fmt.Errorf("no nameserver entries in %s", resolvConfPath)
+	}
+	return nameservers, nil
+}
+
+func parseCAAAnswers(msg []byte, name string) ([]CAA, error) {
+	if len(msg) < dnsHeaderLen {
+		return nil, errors.New("response too short")
+	}
+	rcode := msg[3] & 0x0f
+	if rcode == uint8(dnsmessage.RCodeNameError) {
+		return nil, &net.DNSError{
+			UnwrapErr:   nil,
+			Err:         "no such host",
+			Name:        name,
+			Server:      "",
+			IsTimeout:   false,
+			IsTemporary: false,
+			IsNotFound:  true,
+		}
+	}
+	if rcode != uint8(dnsmessage.RCodeSuccess) {
+		return nil, fmt.Errorf("rcode %d", rcode)
+	}
+
+	qdcount := binary.BigEndian.Uint16(msg[4:6])
+	ancount := binary.BigEndian.Uint16(msg[6:8])
+	off := dnsHeaderLen
+	var err error
+	for range qdcount {
+		off, err = skipDNSName(msg, off)
+		if err != nil {
+			return nil, err
+		}
+		if off+4 > len(msg) {
+			return nil, errors.New("truncated question")
+		}
+		off += 4
+	}
+
+	var records []CAA
+	for range ancount {
+		off, err = skipDNSName(msg, off)
+		if err != nil {
+			return nil, err
+		}
+		if off+10 > len(msg) {
+			return nil, errors.New("truncated answer header")
+		}
+		typ := binary.BigEndian.Uint16(msg[off : off+2])
+		rdlen := int(binary.BigEndian.Uint16(msg[off+8 : off+10]))
+		off += 10
+		if off+rdlen > len(msg) {
+			return nil, errors.New("truncated answer rdata")
+		}
+		if typ == uint16(typeCAA) {
+			rec, err := parseCAAResource(msg[off : off+rdlen])
+			if err != nil {
+				return nil, err
+			}
+			records = append(records, rec)
+		}
+		off += rdlen
+	}
+	return records, nil
+}
+
+func parseCAAResource(rdata []byte) (CAA, error) {
+	var none CAA
+	if len(rdata) < 2 {
+		return none, errors.New("caa rdata too short")
+	}
+	flag := rdata[0]
+	tagLen := int(rdata[1])
+	if tagLen == 0 || 2+tagLen > len(rdata) {
+		return none, errors.New("caa tag length out of range")
+	}
+	return CAA{
+		Flag:  flag,
+		Tag:   string(rdata[2 : 2+tagLen]),
+		Value: string(rdata[2+tagLen:]),
+	}, nil
+}
+
+func skipDNSName(msg []byte, off int) (int, error) {
+	// At most one compression pointer may appear; after following it the
+	// caller's offset is the byte after the pointer (2 bytes).
+	jumped := false
+	start := off
+	for hops := 0; hops < 128; hops++ {
+		if off >= len(msg) {
+			return 0, errors.New("name out of range")
+		}
+		length := int(msg[off])
+		if length == 0 {
+			if !jumped {
+				return off + 1, nil
+			}
+			return start + 2, nil
+		}
+		if length&0xc0 == 0xc0 {
+			if off+1 >= len(msg) {
+				return 0, errors.New("truncated name pointer")
+			}
+			if !jumped {
+				start = off
+			}
+			off = int(binary.BigEndian.Uint16(msg[off:off+2]) & 0x3fff)
+			jumped = true
+			continue
+		}
+		if length&0xc0 != 0 {
+			return 0, errors.New("invalid name label")
+		}
+		off += 1 + length
+		if jumped {
+			// Still walking the pointed-to name; return after we hit the
+			// terminator so the caller offset is the original pointer + 2.
+			continue
+		}
+	}
+	return 0, errors.New("name too long")
+}

--- a/server/internal/dns/caa_lookup_test.go
+++ b/server/internal/dns/caa_lookup_test.go
@@ -1,0 +1,64 @@
+package dns
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func TestParseCAAResource(t *testing.T) {
+	t.Parallel()
+
+	rec, err := parseCAAResource([]byte{0, 5, 'i', 's', 's', 'u', 'e', 'p', 'k', 'i', '.', 'g', 'o', 'o', 'g'})
+	require.NoError(t, err)
+	require.Equal(t, CAA{Flag: 0, Tag: "issue", Value: "pki.goog"}, rec)
+}
+
+func TestParseCAAAnswersNXDOMAIN(t *testing.T) {
+	t.Parallel()
+
+	msg := make([]byte, dnsHeaderLen)
+	msg[3] = uint8(dnsmessage.RCodeNameError)
+	_, err := parseCAAAnswers(msg, "missing.example.com")
+	require.Error(t, err)
+	var dnsErr *net.DNSError
+	require.ErrorAs(t, err, &dnsErr)
+	require.True(t, dnsErr.IsNotFound)
+}
+
+func TestParseCAAAnswersExtractsIssueRecord(t *testing.T) {
+	t.Parallel()
+
+	rdata := []byte{0, 5, 'i', 's', 's', 'u', 'e', 'l', 'e', 't', 's', 'e', 'n', 'c', 'r', 'y', 'p', 't', '.', 'o', 'r', 'g'}
+
+	msg := make([]byte, 0, 128)
+	header := make([]byte, dnsHeaderLen)
+	binary.BigEndian.PutUint16(header[4:6], 1)
+	binary.BigEndian.PutUint16(header[6:8], 1)
+	msg = append(msg, header...)
+	msg = appendDNSName(msg, "example.com")
+	msg = binary.BigEndian.AppendUint16(msg, uint16(typeCAA))
+	msg = binary.BigEndian.AppendUint16(msg, uint16(dnsmessage.ClassINET))
+	msg = appendDNSName(msg, "example.com")
+	msg = binary.BigEndian.AppendUint16(msg, uint16(typeCAA))
+	msg = binary.BigEndian.AppendUint16(msg, uint16(dnsmessage.ClassINET))
+	msg = binary.BigEndian.AppendUint32(msg, 60)
+	msg = binary.BigEndian.AppendUint16(msg, uint16(len(rdata)))
+	msg = append(msg, rdata...)
+
+	records, err := parseCAAAnswers(msg, "example.com")
+	require.NoError(t, err)
+	require.Equal(t, []CAA{{Flag: 0, Tag: "issue", Value: "letsencrypt.org"}}, records)
+}
+
+func appendDNSName(dst []byte, name string) []byte {
+	for _, label := range strings.Split(name, ".") {
+		dst = append(dst, byte(len(label)))
+		dst = append(dst, label...)
+	}
+	return append(dst, 0)
+}

--- a/server/internal/dns/caa_test.go
+++ b/server/internal/dns/caa_test.go
@@ -1,0 +1,98 @@
+package dns_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/dns"
+)
+
+func TestIssueAllowsNoIssueTags(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, dns.IssueAllows(nil, dns.LetsEncryptIssueDomain))
+	require.True(t, dns.IssueAllows([]dns.CAA{{
+		Flag:  0,
+		Tag:   "iodef",
+		Value: "mailto:dns@example.com",
+	}}, dns.LetsEncryptIssueDomain))
+}
+
+func TestIssueAllowsLetsEncryptAmongOthers(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, dns.IssueAllows([]dns.CAA{
+		{Flag: 0, Tag: "issue", Value: "pki.goog"},
+		{Flag: 0, Tag: "issue", Value: `letsencrypt.org; validationmethods=dns-01`},
+	}, dns.LetsEncryptIssueDomain))
+}
+
+func TestIssueAllowsRejectsOtherIssuers(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, dns.IssueAllows([]dns.CAA{
+		{Flag: 0, Tag: "issue", Value: "pki.goog"},
+		{Flag: 0, Tag: "issue", Value: "digicert.com"},
+	}, dns.LetsEncryptIssueDomain))
+	require.False(t, dns.IssueAllows([]dns.CAA{
+		{Flag: 0, Tag: "issue", Value: ";"},
+	}, dns.LetsEncryptIssueDomain))
+}
+
+func TestIssueAllowsRejectsCriticalUnknownTag(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, dns.IssueAllows([]dns.CAA{
+		{Flag: 1, Tag: "future-property", Value: "x"},
+		{Flag: 0, Tag: "issue", Value: "letsencrypt.org"},
+	}, dns.LetsEncryptIssueDomain))
+}
+
+func TestFindIssueRestrictionUsesClosestRRset(t *testing.T) {
+	t.Parallel()
+
+	resolver := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupCAAFunc: func(_ context.Context, name string) ([]dns.CAA, error) {
+			switch name {
+			case "mcp.example.com":
+				return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+			case "example.com":
+				return []dns.CAA{{Flag: 0, Tag: "issue", Value: "pki.goog"}}, nil
+			default:
+				return nil, nil
+			}
+		},
+	})
+
+	restriction, err := dns.FindIssueRestriction(t.Context(), resolver, "mcp.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "example.com", restriction.Name)
+	require.Len(t, restriction.Records, 1)
+	require.Equal(t, "pki.goog", restriction.Records[0].Value)
+	require.False(t, dns.IssueAllows(restriction.Records, dns.LetsEncryptIssueDomain))
+}
+
+func TestFindIssueRestrictionAllowsWhenNoRecords(t *testing.T) {
+	t.Parallel()
+
+	restriction, err := dns.FindIssueRestriction(t.Context(), dns.NewMockResolver(dns.MockResolverConfig{}), "chat.example.com")
+	require.NoError(t, err)
+	require.Empty(t, restriction.Name)
+	require.True(t, dns.IssueAllows(restriction.Records, dns.LetsEncryptIssueDomain))
+}
+
+func TestFindIssueRestrictionPropagatesLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	resolver := dns.NewMockResolver(dns.MockResolverConfig{
+		LookupCAAFunc: func(context.Context, string) ([]dns.CAA, error) {
+			return nil, &net.DNSError{Err: "server failure", IsNotFound: false}
+		},
+	})
+
+	_, err := dns.FindIssueRestriction(t.Context(), resolver, "chat.example.com")
+	require.Error(t, err)
+}

--- a/server/internal/dns/doc.go
+++ b/server/internal/dns/doc.go
@@ -1,5 +1,6 @@
 // Package dns provides a [Resolver] interface for DNS lookups whose method
-// signatures match [net.Resolver]. Use [NewNetResolver] for production and
+// signatures match [net.Resolver], plus [Resolver.LookupCAA] which the
+// standard library does not expose. Use [NewNetResolver] for production and
 // [NewMockResolver] for deterministic testing. [MockResolver.Resolver] returns
 // a [net.Resolver] with a custom Dial that routes queries through the mock
 // functions, so it can be used anywhere a [net.Resolver] is expected.

--- a/server/internal/dns/mock_resolver.go
+++ b/server/internal/dns/mock_resolver.go
@@ -21,6 +21,7 @@ type MockResolverConfig struct {
 	LookupNSFunc     func(ctx context.Context, name string) ([]*net.NS, error)
 	LookupSRVFunc    func(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
 	LookupTXTFunc    func(ctx context.Context, name string) ([]string, error)
+	LookupCAAFunc    func(ctx context.Context, name string) ([]CAA, error)
 }
 
 // MockResolver implements [Resolver] with configurable function fields for
@@ -36,6 +37,7 @@ type MockResolver struct {
 	lookupNSFunc     func(ctx context.Context, name string) ([]*net.NS, error)
 	lookupSRVFunc    func(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
 	lookupTXTFunc    func(ctx context.Context, name string) ([]string, error)
+	lookupCAAFunc    func(ctx context.Context, name string) ([]CAA, error)
 }
 
 // NewMockResolver creates a [MockResolver] from the given configuration. Any
@@ -52,6 +54,7 @@ func NewMockResolver(cfg MockResolverConfig) *MockResolver {
 		lookupNSFunc:     cfg.LookupNSFunc,
 		lookupSRVFunc:    cfg.LookupSRVFunc,
 		lookupTXTFunc:    cfg.LookupTXTFunc,
+		lookupCAAFunc:    cfg.LookupCAAFunc,
 	}
 
 	if m.lookupAddrFunc == nil {
@@ -102,6 +105,13 @@ func NewMockResolver(cfg MockResolverConfig) *MockResolver {
 	if m.lookupTXTFunc == nil {
 		m.lookupTXTFunc = func(context.Context, string) ([]string, error) {
 			return nil, errors.New("MockResolver: LookupTXTFunc not implemented")
+		}
+	}
+	if m.lookupCAAFunc == nil {
+		// No CAA records: any CA may issue. Existing tests that never
+		// configured CAA keep that RFC 8659 default.
+		m.lookupCAAFunc = func(context.Context, string) ([]CAA, error) {
+			return nil, nil
 		}
 	}
 
@@ -156,4 +166,8 @@ func (m *MockResolver) LookupSRV(ctx context.Context, service, proto, name strin
 
 func (m *MockResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
 	return m.lookupTXTFunc(ctx, name)
+}
+
+func (m *MockResolver) LookupCAA(ctx context.Context, name string) ([]CAA, error) {
+	return m.lookupCAAFunc(ctx, name)
 }

--- a/server/internal/dns/net_resolver.go
+++ b/server/internal/dns/net_resolver.go
@@ -57,3 +57,7 @@ func (n *NetResolver) LookupSRV(ctx context.Context, service, proto, name string
 func (n *NetResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
 	return n.resolver.LookupTXT(ctx, name)
 }
+
+func (n *NetResolver) LookupCAA(ctx context.Context, name string) ([]CAA, error) {
+	return lookupCAA(ctx, n.resolver, name)
+}

--- a/server/internal/dns/resolver.go
+++ b/server/internal/dns/resolver.go
@@ -20,6 +20,9 @@ type Resolver interface {
 	LookupNS(ctx context.Context, name string) ([]*net.NS, error)
 	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
 	LookupTXT(ctx context.Context, name string) ([]string, error)
+	// LookupCAA is not on [net.Resolver]; custom-domain certificate issuance
+	// needs it to decide whether Let's Encrypt is authorized for a hostname.
+	LookupCAA(ctx context.Context, name string) ([]CAA, error)
 
 	// Resolver returns the underlying *[net.Resolver]. For [NetResolver] this
 	// is the real resolver; for [MockResolver] it is a resolver whose Dial


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [AIS-661](https://linear.app/speakeasy/issue/AIS-661/feat-check-caa-records-during-custom-domain-setup).

A Google MCP switchover failed because the domain's CAA RRset only authorized another CA. Custom domain setup now checks CAA so that case is caught automatically instead of requiring a manual DNS review.

## What changed

- DNS resolver gains `LookupCAA` and RFC 8659-style tree walking (`FindIssueRestriction` / `IssueAllows`).
- Custom domain verification stays `dns_pending` until Let's Encrypt (`letsencrypt.org`) is authorized. Registration is not blocked at `CreateDomain` so we avoid a live DNS lookup on the request path.
- Activated-domain health checks surface a new `caa_forbidden` issue ahead of generic `certificate_not_ready`.
- The org domains setup wizard documents the expected `0 issue "letsencrypt.org"` record and health copy names it when issuance is blocked.
- Regenerated the TypeScript SDK / Speakeasy OpenAPI so `health_issue` documents `caa_forbidden`.

## Testing

- `mise run test:server ./internal/dns/ ./internal/customdomains/ ./internal/background/activities/` — 441 tests, including CAA policy, lookup, verification pending/allow, and health `caa_forbidden`.
- `mise run lint:server` and `aube run -F dashboard lint` passed.
- Manual check of the Custom Domain wizard: entering `mcp.example.com` updates the CAA record to `mcp.example.com CAA 0 issue "letsencrypt.org"` and the copy control works.

![Custom Domain wizard showing the new CAA records step](https://cursor.com/artifacts/c/art-805662bf-994f-442b-a953-d49c03715773)

![CAA records section with Let](https://cursor.com/artifacts/c/art-1bab4050-f245-4883-9f3e-6a67a874a763)

<a href="https://cursor.com/agents/bc-856d0e7b-4133-43e5-8861-d7a031ea8c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcaa_setup_wizard.mp4"><img src="https://cursor.com/artifacts/c/art-1d67ed99-23a2-4602-bcdd-6a4ebf6ba3ef" alt="caa_setup_wizard.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-661](https://linear.app/speakeasy/issue/AIS-661/feat-check-caa-records-during-custom-domain-setup)

<div><a href="https://cursor.com/agents/bc-856d0e7b-4133-43e5-8861-d7a031ea8c1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-856d0e7b-4133-43e5-8861-d7a031ea8c1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

