### PR TITLE
feat: replace Gemini CLI with Antigravity CLI and add Antigravity IDE

### DIFF
--- a/.changeset/antigravity-mcp-install-clients.md
+++ b/.changeset/antigravity-mcp-install-clients.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Replace Gemini CLI with Antigravity CLI on the hosted MCP install page and add Antigravity IDE as an install option. Both use Antigravity's `mcp_config.json` format (`serverUrl` plus optional `headers`).

--- a/server/internal/mcpmetadata/hosted_page.html.tmpl
+++ b/server/internal/mcpmetadata/hosted_page.html.tmpl
@@ -1001,70 +1001,109 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
         </ol>
       </div>
     </template>
-    <template class="install-target-template" data-install-target="gemini-cli">
+    {{ define "antigravityMCPConfigSnippet" }}
+            <div class="card code-container">
+              <button class="copy-button waiting">
+                <svg
+                  class="icon icon-copy"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy"></use>
+                </svg>
+                <svg
+                  class="icon icon-copy-success"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                >
+                  <use href="#icon-copy-check"></use>
+                </svg>
+              </button>
+              <!-- prettier-ignore -->
+              <code class="code-snippet language-json" data-scope-url-text>{
+  "mcpServers": {
+    "{{ .MCPSlug }}": {
+      "serverUrl": "{{ .MCPURL }}"{{- if .SecurityInputs }},
+      "headers": {
+        {{- range $i, $input := .SecurityInputs }}{{- if $i }},{{ end }}
+        "{{ $input.SystemName | asHTTPHeader }}": "your-{{ $input.DisplayName | asPosixName }}-value"{{- end }}
+      }
+      {{- end }}
+    }
+  }
+}</code>
+            </div>
+    {{ end }}
+    <template class="install-target-template" data-install-target="antigravity-cli">
       <div class="modal-content">
         <h1>Instructions</h1>
         <ol>
           <li class="instruction-item">
-            Ensure the Gemini CLI executable is available in your path
+            Ensure the Antigravity CLI (<code>agy</code>) executable is available
+            in your path
           </li>
           <li class="instruction-item">
-            Execute the following snippet in your shell:
-            <div class="card code-container">
-              <button class="copy-button waiting">
-                <svg
-                  class="icon icon-copy"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  <use href="#icon-copy"></use>
-                </svg>
-                <svg
-                  class="icon icon-copy-success"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  <use href="#icon-copy-check"></use>
-                </svg>
-              </button>
-              <!-- prettier-ignore -->
-              <code class="code-snippet language-sh" data-scope-url-text>gemini mcp add --transport http "{{ .MCPSlug }}" "{{ .MCPURL }}"{{- range .SecurityInputs }} \
-  --header '{{ .SystemName | asHTTPHeader }}:{{ printf "${%s}" (.DisplayName | asPosixName) }}'{{- end }}</code>
-            </div>
+            Merge the following into your global
+            <code>~/.gemini/config/mcp_config.json</code> or workspace
+            <code>.agents/mcp_config.json</code>:
+            {{ template "antigravityMCPConfigSnippet" . }}
           </li>
-          {{- if .SecurityInputs }}
+          {{- if .IsOAuth }}
           <li class="instruction-item">
-            Set these environment variables in your shell before running the
-            command above:
-            <div class="card code-container">
-              <button class="copy-button waiting">
-                <svg
-                  class="icon icon-copy"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  <use href="#icon-copy"></use>
-                </svg>
-                <svg
-                  class="icon icon-copy-success"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                >
-                  <use href="#icon-copy-check"></use>
-                </svg>
-              </button>
-              <!-- prettier-ignore -->
-              <code class="code-snippet language-sh">{{- range .SecurityInputs -}}
-export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-value"{{- end }}</code>
-            </div>
+            This server uses OAuth. Antigravity can authenticate automatically
+            via dynamic client registration. If prompted, open Agent Settings and
+            click <strong>Authenticate</strong> next to the server.
+          </li>
+          {{- else if .SecurityInputs }}
+          <li class="instruction-item">
+            Replace each <code>your-*-value</code> placeholder above with your
+            actual credential. Antigravity also expands
+            <code>${VAR}</code> environment-variable references in this file.
           </li>
           {{- end }}
           <li class="instruction-item">
-            Restart Gemini CLI to load the new configuration
+            Restart Antigravity CLI, or type <code>/mcp</code> in an active
+            session, to load the new configuration
+          </li>
+        </ol>
+      </div>
+    </template>
+    <template class="install-target-template" data-install-target="antigravity-ide">
+      <div class="modal-content">
+        <h1>Instructions</h1>
+        <ol>
+          <li class="instruction-item">
+            In Antigravity IDE, click <strong>…</strong> at the top of the
+            editor's agent side panel and select <strong>MCP Servers</strong>
+          </li>
+          <li class="instruction-item">
+            Click <strong>Manage MCP Servers</strong>, then
+            <strong>View raw config</strong>. This opens
+            <code>~/.gemini/config/mcp_config.json</code> (or workspace
+            <code>.agents/mcp_config.json</code>)
+          </li>
+          <li class="instruction-item">
+            Merge in the following configuration:
+            {{ template "antigravityMCPConfigSnippet" . }}
+          </li>
+          {{- if .IsOAuth }}
+          <li class="instruction-item">
+            This server uses OAuth. Antigravity can authenticate automatically
+            via dynamic client registration. If prompted, open Agent Settings and
+            click <strong>Authenticate</strong> next to the server.
+          </li>
+          {{- else if .SecurityInputs }}
+          <li class="instruction-item">
+            Replace each <code>your-*-value</code> placeholder above with your
+            actual credential. Antigravity also expands
+            <code>${VAR}</code> environment-variable references in this file.
+          </li>
+          {{- end }}
+          <li class="instruction-item">
+            Save the file. Toggle the server off and on in Manage MCP Servers, or
+            restart Antigravity IDE, to load the new configuration
           </li>
         </ol>
       </div>
@@ -1477,9 +1516,16 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
                   <button
                     class="popover-button"
                     data-install-method="modal"
-                    data-install-target="gemini-cli"
+                    data-install-target="antigravity-cli"
                   >
-                    Gemini CLI
+                    Antigravity CLI
+                  </button>
+                  <button
+                    class="popover-button"
+                    data-install-method="modal"
+                    data-install-target="antigravity-ide"
+                  >
+                    Antigravity IDE
                   </button>
                   <button
                     class="popover-button"
@@ -1732,38 +1778,50 @@ export {{ .DisplayName | asPosixName }}="your-{{ .DisplayName | asPosixName }}-v
               tabindex="0"
               class="card install-target"
               data-install-method="modal"
-              data-install-target="gemini-cli"
+              data-install-target="antigravity-cli"
+            >
+              <div class="target">
+                <!-- Official Antigravity logomark. Source: Google Antigravity
+                     press assets / lobehub/lobe-icons antigravity.svg -->
+                <svg
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M21.751 22.607c1.34 1.005 3.35.335 1.508-1.508C17.73 15.74 18.904 1 12.037 1 5.17 1 6.342 15.74.815 21.1c-2.01 2.009.167 2.511 1.507 1.506 5.192-3.517 4.857-9.714 9.715-9.714 4.857 0 4.522 6.197 9.714 9.715z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>Antigravity CLI</span>
+              </div>
+            </div>
+            <div
+              tabindex="0"
+              class="card install-target"
+              data-install-method="modal"
+              data-install-target="antigravity-ide"
             >
               <div class="target">
                 <svg
                   width="32"
                   height="32"
-                  viewBox="0 0 32 32"
+                  viewBox="0 0 24 24"
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
                 >
                   <path
-                    d="M16 2L19.5 12.5L30 16L19.5 19.5L16 30L12.5 19.5L2 16L12.5 12.5L16 2Z"
-                    fill="url(#gemini-gradient)"
+                    fill-rule="evenodd"
+                    d="M21.751 22.607c1.34 1.005 3.35.335 1.508-1.508C17.73 15.74 18.904 1 12.037 1 5.17 1 6.342 15.74.815 21.1c-2.01 2.009.167 2.511 1.507 1.506 5.192-3.517 4.857-9.714 9.715-9.714 4.857 0 4.522 6.197 9.714 9.715z"
+                    fill="currentColor"
                   />
-                  <defs>
-                    <linearGradient
-                      id="gemini-gradient"
-                      x1="2"
-                      y1="2"
-                      x2="30"
-                      y2="30"
-                      gradientUnits="userSpaceOnUse"
-                    >
-                      <stop offset="0%" stop-color="#4285F4" />
-                      <stop offset="25%" stop-color="#34A853" />
-                      <stop offset="50%" stop-color="#FBBC04" />
-                      <stop offset="75%" stop-color="#EA4335" />
-                      <stop offset="100%" stop-color="#4285F4" />
-                    </linearGradient>
-                  </defs>
                 </svg>
-                <span>Gemini CLI</span>
+                <span>Antigravity IDE</span>
               </div>
             </div>
             <div

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -976,6 +976,104 @@ func TestServeInstallPage_ClaudeDesktop_WithSecurityInputs(t *testing.T) {
 	assert.NotContains(t, body, "For Teams &amp; Enterprise", "should not render the Teams & Enterprise admin connector footer")
 }
 
+// TestServeInstallPage_AntigravityClients_NoSecurityInputs verifies the hosted
+// install page offers Antigravity CLI and Antigravity IDE (replacing Gemini CLI)
+// with the documented mcp_config.json / serverUrl snippet.
+func TestServeInstallPage_AntigravityClients_NoSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "antigravity-public-" + uuid.New().String()[:8]
+	toolset, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Public Antigravity Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("public toolset with no security inputs"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	err = toolsets_repo.New(testInstance.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-install-target="antigravity-cli"`)
+	assert.Contains(t, body, `data-install-target="antigravity-ide"`)
+	assert.Contains(t, body, "Antigravity CLI")
+	assert.Contains(t, body, "Antigravity IDE")
+	assert.Contains(t, body, `"serverUrl"`, "Antigravity remote servers use serverUrl, not url")
+	assert.Contains(t, body, "~/.gemini/config/mcp_config.json")
+	assert.Contains(t, body, ".agents/mcp_config.json")
+	assert.NotContains(t, body, "Gemini CLI")
+	assert.NotContains(t, body, "gemini mcp add")
+	assert.NotContains(t, body, `data-install-target="gemini-cli"`)
+	assert.NotContains(t, body, `"headers"`, "public servers without security inputs should omit the headers object")
+}
+
+// TestServeInstallPage_AntigravityClients_WithSecurityInputs verifies Antigravity
+// install snippets include HTTP headers in mcp_config.json when the server
+// requires credentials.
+func TestServeInstallPage_AntigravityClients_WithSecurityInputs(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	mcpSlug := "antigravity-private-" + uuid.New().String()[:8]
+	_, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private Antigravity Toolset",
+		Slug:                   mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("private toolset producing security inputs via gram security mode"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	err = testInstance.service.ServeInstallPage(rr, req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.Contains(t, body, `data-install-target="antigravity-cli"`)
+	assert.Contains(t, body, `data-install-target="antigravity-ide"`)
+	assert.Contains(t, body, `"serverUrl"`)
+	assert.Contains(t, body, `"headers"`)
+	assert.Contains(t, body, "your-")
+	assert.Contains(t, body, "${VAR}", "should mention Antigravity env-var expansion")
+}
+
 // TestServeInstallPage_PrivateWithGramOAuth_NoAuthorizationHeader regression-tests
 // AGE-1962: a private MCP server with a Gram OAuth proxy attached must not render
 // the GRAM_KEY Authorization header (or gram-environment) in the install snippets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces Gemini CLI with **Antigravity CLI** on the hosted MCP install page and adds **Antigravity IDE** as a first-class install option (DNO-972).

Gemini CLI has been succeeded by Antigravity CLI (`agy`). The hosted install page previously showed `gemini mcp add --transport http …`, which is no longer the documented Antigravity path.

Both new clients use Antigravity's official MCP config:

- Global: `~/.gemini/config/mcp_config.json`
- Workspace: `.agents/mcp_config.json`
- Remote servers use `serverUrl` (not `url` / `httpUrl`) plus optional `headers`

CLI instructions cover merging that file and verifying with `/mcp`. IDE instructions follow the official Manage MCP Servers → View raw config path.

## Demo

![Install cards showing Antigravity CLI and Antigravity IDE](https://cursor.com/artifacts/c/art-6443146c-7bcb-4840-ae0b-e9aaec45c4e3)

![Antigravity CLI install instructions modal](https://cursor.com/artifacts/c/art-247b66fe-a540-41cb-8c82-120a5d2a9e2e)

![Antigravity IDE install instructions modal](https://cursor.com/artifacts/c/art-e66b2a83-824f-4a6e-a603-2ff1b7162b13)

<a href="https://cursor.com/agents/bc-06178960-8760-4d50-952d-a994c31ea433/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fantigravity-mcp-install-clients.mp4"><img src="https://cursor.com/artifacts/c/art-e379617c-090f-4663-82d8-e5b1c90d5406" alt="antigravity-mcp-install-clients.mp4" /></a>

## Test plan

- [x] `TestServeInstallPage_AntigravityClients_NoSecurityInputs` — public page lists Antigravity CLI/IDE, uses `serverUrl`, and no longer mentions Gemini CLI
- [x] `TestServeInstallPage_AntigravityClients_WithSecurityInputs` — private servers include `headers` and mention `${VAR}` expansion
- [x] `mise run test:server ./internal/mcpmetadata/ -run 'TestServeInstallPage_Antigravity|TestServeInstallPage_ClaudeDesktop'`
- [x] `mise lint:server`
- [x] Loaded a local MCP install page and confirmed both Antigravity cards open the correct instruction modals

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-972](https://linear.app/speakeasy/issue/DNO-972/feat-change-gemini-cli-antigravity-cli-on-mcp-installation-page-and)

<div><a href="https://cursor.com/agents/bc-06178960-8760-4d50-952d-a994c31ea433?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06178960-8760-4d50-952d-a994c31ea433&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

