### PR TITLE
feat(platform-mcp): add risk mutation safety controls

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -204,6 +204,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		},
 		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
+		RiskMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -299,7 +303,11 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
-	runtime := platformmcp.NewRuntimeWithLifecycle(
+	riskMutationControls, err := platformmcp.NewRiskMutationControls(config.DB, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), budgets.RiskMutations, config.JWTSigningKey)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP risk mutation controls: %w", err)
+	}
+	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
 		gate,
@@ -321,6 +329,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
+		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -522,6 +531,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		},
 		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
+		RiskMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -606,7 +619,11 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
-	runtime := platformmcp.NewRuntimeWithLifecycle(
+	riskMutationControls, err := platformmcp.NewRiskMutationControls(config.DB, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), budgets.RiskMutations, config.JWTSigningKey)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create browser Platform MCP risk mutation controls: %w", err)
+	}
+	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
 		gate,
@@ -625,6 +642,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
+		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -56,6 +57,7 @@ type platformMCPConfig struct {
 	Environment            string
 	JWTSigningKey          string
 	ProductFeatures        *productfeatures.Client
+	FeatureFlags           feature.Provider
 	Authz                  *authz.Engine
 	Encryption             *encryption.Client
 	Identity               *identity.Resolver

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1538,6 +1538,7 @@ func newStartCommand() *cli.Command {
 				Environment:            c.String("environment"),
 				JWTSigningKey:          c.String(usersessions.JWTSigningKeyFlag),
 				ProductFeatures:        productFeatures,
+				FeatureFlags:           featureFlags,
 				Authz:                  authzEngine,
 				Encryption:             encryptionClient,
 				Identity:               identityResolver,

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -36,6 +36,11 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
+	// FlagPlatformMCPRiskMutations is the exact-project kill switch for risk
+	// policy and exclusion writes exposed through Platform MCP. It is evaluated
+	// at invocation time and fails closed when absent, disabled, or indeterminate.
+	FlagPlatformMCPRiskMutations Flag = "platform-mcp-risk-mutations"
+
 	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
 	// assistant the Platform MCP read toolset — the "platform" platform
 	// toolset re-serving the Platform MCP read tools over the assistant

--- a/server/internal/platformmcp/lifecycle_metadata.go
+++ b/server/internal/platformmcp/lifecycle_metadata.go
@@ -189,6 +189,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 		InputHash:            inputHash,
 		Status:               receiptStatusPending,
 		ResultCode:           pgtype.Text{String: "", Valid: false},
+		ResultPayload:        nil,
 		ExpiresAt:            pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	if err != nil {
@@ -208,6 +209,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 		RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true},
 		Status:         receiptStatusSucceeded,
 		ResultCode:     conv.ToPGText(receiptResultMetadataUpdated),
+		ResultPayload:  nil,
 		ID:             receipt.ID,
 		OrganizationID: principal.OrganizationID,
 	})

--- a/server/internal/platformmcp/lifecycle_visibility.go
+++ b/server/internal/platformmcp/lifecycle_visibility.go
@@ -179,7 +179,7 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 	if server.Visibility != from || !hmac.Equal([]byte(lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility)), []byte(input.ExpectedVersion)) {
 		return UpdateMCPVisibilityResult{}, ErrRegistrationConflict
 	}
-	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, ConnectionID: connectionID, ConnectionGeneration: generation, UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: operation, IdempotencyKey: input.IdempotencyKey, InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ExpiresAt: pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true}})
+	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, ConnectionID: connectionID, ConnectionGeneration: generation, UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: operation, IdempotencyKey: input.IdempotencyKey, InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true}})
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("create platform mcp visibility receipt: %w", err)
 	}
@@ -187,7 +187,7 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("update platform mcp visibility: %w", err)
 	}
-	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText(to), ID: receipt.ID, OrganizationID: principal.OrganizationID})
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText(to), ResultPayload: nil, ID: receipt.ID, OrganizationID: principal.OrganizationID})
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("complete platform mcp visibility receipt: %w", err)
 	}

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -28,6 +28,8 @@ const (
 	LifecycleOrganizationLimitName     = "platform-mcp-lifecycle-organization"
 	SessionRecallConnectionLimitName   = "platform-mcp-session-recall-connection"
 	SessionRecallOrganizationLimitName = "platform-mcp-session-recall-organization"
+	RiskMutationConnectionLimitName    = "platform-mcp-risk-mutation-connection"
+	RiskMutationOrganizationLimitName  = "platform-mcp-risk-mutation-organization"
 )
 
 const (
@@ -51,6 +53,12 @@ const (
 	// fund them by spending the summary allowance.
 	SensitiveDiagnosticQueriesPerConnectionPerMinute   = 30
 	SensitiveDiagnosticQueriesPerOrganizationPerMinute = 300
+
+	// RiskMutationsPer* bound all risk policy and exclusion writes together.
+	// Keeping one shared budget prevents a caller from multiplying the permitted
+	// write rate by alternating between mutation tools.
+	RiskMutationsPerConnectionPerMinute   = 5
+	RiskMutationsPerOrganizationPerMinute = 50
 
 	// DrilldownRowsPerConnectionPerWindow and
 	// DrilldownMetricQueriesPerConnectionPerWindow are the second cap the
@@ -101,19 +109,32 @@ func (b OperationBudget) valid() bool {
 }
 
 func (b OperationBudget) Allow(ctx context.Context, principal Principal) error {
+	return b.allow(ctx, principal, false)
+}
+
+// AllowConnectionOrOrganization charges OAuth calls to both their connection
+// and organization buckets. A connection-less assistant has no connection to
+// charge, so it consumes only the organization allowance.
+func (b OperationBudget) AllowConnectionOrOrganization(ctx context.Context, principal Principal) error {
+	return b.allow(ctx, principal, true)
+}
+
+func (b OperationBudget) allow(ctx context.Context, principal Principal, organizationOnlyWithoutConnection bool) error {
 	if !b.valid() || principal.OrganizationID == "" {
 		return ErrOperationBudgetUnavailable
 	}
-	actorKey, err := operationBudgetActorKey(principal)
-	if err != nil {
-		return err
-	}
-	connection, err := b.Connection.Allow(ctx, actorKey)
-	if err != nil {
-		return fmt.Errorf("limit platform mcp actor operation: %w: %w", ErrOperationBudgetUnavailable, err)
-	}
-	if !connection.Allowed {
-		return ErrOperationRateLimited
+	if principal.HasConnection() || !organizationOnlyWithoutConnection {
+		actorKey, err := operationBudgetActorKey(principal)
+		if err != nil {
+			return err
+		}
+		connection, err := b.Connection.Allow(ctx, actorKey)
+		if err != nil {
+			return fmt.Errorf("limit platform mcp actor operation: %w: %w", ErrOperationBudgetUnavailable, err)
+		}
+		if !connection.Allowed {
+			return ErrOperationRateLimited
+		}
 	}
 	organization, err := b.Organization.Allow(ctx, principal.OrganizationID)
 	if err != nil {
@@ -187,6 +208,9 @@ type OperationBudgets struct {
 	// SensitiveSessionRecall meters continue_session — the only operation that
 	// serves whole-transcript content — on its own low allowance.
 	SensitiveSessionRecall OperationBudget
+	// RiskMutations is shared by policy and exclusion writes. Connection-less
+	// assistant calls consume only its organization bucket.
+	RiskMutations OperationBudget
 	// DrilldownVolume meters what the drill-downs return rather than how often
 	// they are called: rows and spans against one bucket, metric queries
 	// against another, both per connection over DrilldownVolumeWindow.
@@ -242,5 +266,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -83,6 +83,30 @@ func TestOperationBudgetThrottlesAConnectionlessAssistantBeforeOrganization(t *t
 	require.Empty(t, organization.keys)
 }
 
+func TestRiskMutationBudgetUsesOnlyOrganizationForConnectionlessAssistant(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).AllowConnectionOrOrganization(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant})
+
+	require.NoError(t, err)
+	require.Empty(t, connection.keys)
+	require.Equal(t, []string{"organization"}, organization.keys)
+}
+
+func TestRiskMutationBudgetStillChargesOAuthConnectionFirst(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).AllowConnectionOrOrganization(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ConnectionID: "connection", Generation: "generation"})
+
+	require.ErrorIs(t, err, ErrOperationRateLimited)
+	require.Equal(t, []string{"connection"}, connection.keys)
+	require.Empty(t, organization.keys)
+}
+
 func TestOperationBudgetRejectsAConnectionClaimedByGenerationAlone(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -692,6 +692,7 @@ INSERT INTO platform_mcp_operation_receipts (
     input_hash,
     status,
     result_code,
+    result_payload,
     expires_at
 ) VALUES (
     @organization_id,
@@ -706,6 +707,7 @@ INSERT INTO platform_mcp_operation_receipts (
     @input_hash,
     @status,
     @result_code,
+    @result_payload,
     @expires_at
 )
 RETURNING *;
@@ -724,6 +726,7 @@ UPDATE platform_mcp_operation_receipts
 SET registration_id = @registration_id,
     status = @status,
     result_code = @result_code,
+    result_payload = @result_payload,
     updated_at = clock_timestamp()
 WHERE id = @id
   AND organization_id = @organization_id

--- a/server/internal/platformmcp/registration.go
+++ b/server/internal/platformmcp/registration.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -72,6 +73,7 @@ type OperationReceipt struct {
 	RegistrationID uuid.NullUUID
 	Status         string
 	ResultCode     string
+	ResultPayload  []byte
 	InputHash      string
 	ExpiresAt      time.Time
 	Replayed       bool
@@ -927,6 +929,7 @@ func operationReceiptFromRow(row platformrepo.PlatformMcpOperationReceipt, repla
 		RegistrationID:       row.RegistrationID,
 		Status:               row.Status,
 		ResultCode:           row.ResultCode.String,
+		ResultPayload:        slices.Clone(row.ResultPayload),
 		InputHash:            row.InputHash,
 		ExpiresAt:            row.ExpiresAt.Time,
 		Replayed:             replayed,

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -2,7 +2,9 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -1040,6 +1042,59 @@ func seedRegistrationEligibleCohort(t *testing.T, ctx context.Context, conn *pgx
 // The assistant issues a handoff with no connection and the dashboard, which
 // authenticates under its own session, redeems it. This is the whole point of
 // the connection-less surfaces: neither step can key on a connection.
+func TestRiskMutationReceiptReplayConflictAndRollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_risk_mutation_receipt")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	store := NewRiskMutationReceiptStore(conn)
+	request := RiskMutationReceiptRequest{Operation: operationCreateRiskPolicy, IdempotencyKey: "risk-create-key", Input: map[string]any{"name": "normalized", "enabled": true}}
+	calls := 0
+
+	result := CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: project.ID.String(), Slug: project.Slug}, Policy: RiskPolicyReceiptSummary{ID: "11111111-1111-4111-8111-111111111111", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", MatchedExisting: false, ResultCategory: "created"}
+	first, err := store.Execute(ctx, principal, project, request, func(_ context.Context, _ pgx.Tx) (RiskMutationReceiptResult, error) {
+		calls++
+		return result, nil
+	})
+	require.NoError(t, err)
+	require.False(t, first.Replayed)
+	expectedPayload, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedPayload), string(first.ResultPayload))
+
+	replayed, err := store.Execute(ctx, principal, project, request, func(context.Context, pgx.Tx) (RiskMutationReceiptResult, error) {
+		calls++
+		return nil, errors.New("replay must not execute callback")
+	})
+	require.NoError(t, err)
+	require.True(t, replayed.Replayed)
+	require.Equal(t, first.ID, replayed.ID)
+	require.Equal(t, 1, calls)
+
+	changed := request
+	changed.Input = map[string]any{"name": "different", "enabled": true}
+	_, err = store.Execute(ctx, principal, project, changed, func(context.Context, pgx.Tx) (RiskMutationReceiptResult, error) { return nil, nil })
+	require.ErrorIs(t, err, ErrRiskMutationConflict)
+
+	failed := RiskMutationReceiptRequest{Operation: operationCreateRiskExclusion, IdempotencyKey: "rollback-key", Input: map[string]any{"match_type": "source", "match_value": "gitleaks"}}
+	_, err = store.Execute(ctx, principal, project, failed, func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error) {
+		if _, err := projectsrepo.New(tx).UploadProjectLogo(ctx, projectsrepo.UploadProjectLogoParams{LogoAssetID: uuid.NullUUID{UUID: uuid.New(), Valid: true}, ProjectID: project.ID}); err != nil {
+			return nil, fmt.Errorf("set rollback sentinel project logo: %w", err)
+		}
+		// The callback represents domain + audit work in the shared transaction;
+		// this injected audit failure must roll back the domain row and receipt.
+		return nil, errors.New("injected audit failure")
+	})
+	require.ErrorContains(t, err, "injected audit failure")
+	_, err = platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: failed.Operation, IdempotencyKey: failed.IdempotencyKey})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	rolledBack, err := projectsrepo.New(conn).GetProjectByIDAndOrganizationID(ctx, projectsrepo.GetProjectByIDAndOrganizationIDParams{ID: project.ID, OrganizationID: principal.OrganizationID})
+	require.NoError(t, err)
+	require.False(t, rolledBack.LogoAssetID.Valid)
+}
+
 func TestSetupHandoffRoundTripsWithoutAConnection(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -100,6 +100,7 @@ func NewRegistrationService(catalog Catalog, gate CatalogRegistrationGateChecker
 			Handoff:           OperationBudget{Connection: nil, Organization: nil},
 			SetupStart:        OperationBudget{Connection: nil, Organization: nil},
 			Repair:            OperationBudget{Connection: nil, Organization: nil},
+			RiskMutations:     OperationBudget{Connection: nil, Organization: nil},
 			LifecycleMetadata: OperationBudget{Connection: nil, Organization: nil},
 		},
 	}

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -170,9 +170,10 @@ UPDATE platform_mcp_operation_receipts
 SET registration_id = $1,
     status = $2,
     result_code = $3,
+    result_payload = $4,
     updated_at = clock_timestamp()
-WHERE id = $4
-  AND organization_id = $5
+WHERE id = $5
+  AND organization_id = $6
 RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
 
@@ -180,6 +181,7 @@ type CompletePlatformMCPOperationReceiptParams struct {
 	RegistrationID uuid.NullUUID
 	Status         string
 	ResultCode     pgtype.Text
+	ResultPayload  []byte
 	ID             uuid.UUID
 	OrganizationID string
 }
@@ -189,6 +191,7 @@ func (q *Queries) CompletePlatformMCPOperationReceipt(ctx context.Context, arg C
 		arg.RegistrationID,
 		arg.Status,
 		arg.ResultCode,
+		arg.ResultPayload,
 		arg.ID,
 		arg.OrganizationID,
 	)
@@ -929,6 +932,7 @@ INSERT INTO platform_mcp_operation_receipts (
     input_hash,
     status,
     result_code,
+    result_payload,
     expires_at
 ) VALUES (
     $1,
@@ -943,7 +947,8 @@ INSERT INTO platform_mcp_operation_receipts (
     $10,
     $11,
     $12,
-    $13
+    $13,
+    $14
 )
 RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
@@ -961,6 +966,7 @@ type CreatePlatformMCPOperationReceiptParams struct {
 	InputHash            string
 	Status               string
 	ResultCode           pgtype.Text
+	ResultPayload        []byte
 	ExpiresAt            pgtype.Timestamptz
 }
 
@@ -978,6 +984,7 @@ func (q *Queries) CreatePlatformMCPOperationReceipt(ctx context.Context, arg Cre
 		arg.InputHash,
 		arg.Status,
 		arg.ResultCode,
+		arg.ResultPayload,
 		arg.ExpiresAt,
 	)
 	var i PlatformMcpOperationReceipt

--- a/server/internal/platformmcp/risk_mutation_controls.go
+++ b/server/internal/platformmcp/risk_mutation_controls.go
@@ -1,0 +1,134 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const (
+	operationCreateRiskPolicy    = "create_risk_policy"
+	operationUpdateRiskPolicy    = "update_risk_policy"
+	operationCreateRiskExclusion = "create_risk_exclusion"
+	operationUpdateRiskExclusion = "update_risk_exclusion"
+)
+
+var (
+	ErrRiskMutationUnavailable = errors.New("platform mcp risk mutations unavailable")
+	ErrRiskMutationInvalid     = errors.New("invalid platform mcp risk mutation")
+	ErrRiskMutationNotFound    = errors.New("platform mcp risk mutation target not found")
+	ErrRiskMutationConflict    = errors.New("platform mcp risk mutation conflict")
+)
+
+// RiskMutationError is safe to map into a tool refusal. Message deliberately
+// contains no policy, prompt, URL, principal, CEL, or exclusion material.
+type RiskMutationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *RiskMutationError) Error() string { return e.Message }
+func (e *RiskMutationError) Unwrap() error { return e.Cause }
+
+// RiskMutationControls owns the checks shared by every risk write. Admission is
+// intentionally separate from receipt execution so callers can prove the flag
+// and budget fail before opening a write transaction.
+type RiskMutationControls struct {
+	flags         feature.Provider
+	organizations OrganizationSlugResolver
+	projects      riskProjectResolver
+	budget        OperationBudget
+	receipts      *RiskMutationReceiptStore
+	versions      *riskVersionCodec
+}
+
+func NewRiskMutationControls(db *pgxpool.Pool, flags feature.Provider, organizations OrganizationSlugResolver, budget OperationBudget, keyMaterial string) (*RiskMutationControls, error) {
+	if db == nil || organizations == nil || keyMaterial == "" {
+		return nil, ErrRiskMutationUnavailable
+	}
+	versions, err := newRiskVersionCodec(keyMaterial)
+	if err != nil {
+		return nil, err
+	}
+	return &RiskMutationControls{
+		flags:         flags,
+		organizations: organizations,
+		projects:      postgresRiskProjectResolver{queries: platformrepo.New(db)},
+		budget:        budget,
+		receipts:      NewRiskMutationReceiptStore(db),
+		versions:      versions,
+	}, nil
+}
+
+// Admit resolves an explicit project and checks its exact rollout cohort at
+// invocation time. Missing providers, errors, and indeterminate evaluations all
+// fail closed. The mutation budget is consumed only after the kill switch is on.
+func (c *RiskMutationControls) Admit(ctx context.Context, principal Principal, projectSlug string) (ResolvedProject, error) {
+	if c == nil || c.flags == nil || c.organizations == nil || c.projects == nil || !c.budget.valid() || c.receipts == nil || c.versions == nil {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	if principal.OrganizationID == "" || principal.UserID == "" || projectSlug == "" {
+		return ResolvedProject{}, &RiskMutationError{Code: "invalid_request", Message: "An exact project and attributable user are required for risk mutations.", Cause: ErrRiskMutationInvalid}
+	}
+	project, err := c.projects.Resolve(ctx, principal.OrganizationID, "", projectSlug)
+	if errors.Is(err, ErrRiskReadNotFound) {
+		return ResolvedProject{}, &RiskMutationError{Code: "not_found", Message: "The requested risk mutation project is not available.", Cause: fmt.Errorf("%w: %w", ErrRiskMutationNotFound, err)}
+	}
+	if err != nil {
+		return ResolvedProject{}, riskMutationUnavailableWithCause(err)
+	}
+	organizationSlug, err := c.organizations.OrganizationSlug(ctx, principal.OrganizationID)
+	if err != nil || organizationSlug == "" {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, c.flags, feature.FlagPlatformMCPRiskMutations, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, project.Slug))
+	if err != nil || evaluation != feature.EvaluationEnabled {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	if err := c.budget.AllowConnectionOrOrganization(ctx, principal); err != nil {
+		switch {
+		case errors.Is(err, ErrOperationRateLimited):
+			return ResolvedProject{}, &RiskMutationError{Code: "rate_limited", Message: "The risk mutation rate limit was reached.", Cause: err}
+		default:
+			return ResolvedProject{}, riskMutationUnavailable()
+		}
+	}
+	return project, nil
+}
+
+func riskMutationUnavailable() error {
+	return riskMutationUnavailableWithCause(nil)
+}
+
+func riskMutationUnavailableWithCause(cause error) error {
+	if cause != nil {
+		cause = fmt.Errorf("%w: %w", ErrRiskMutationUnavailable, cause)
+	} else {
+		cause = ErrRiskMutationUnavailable
+	}
+	return &RiskMutationError{Code: unavailableCode, Message: "Risk mutations are not enabled for this project.", Cause: cause}
+}
+
+func riskMutationConflict(message string) error {
+	return &RiskMutationError{Code: "conflict", Message: message, Cause: ErrRiskMutationConflict}
+}
+
+func (c *RiskMutationControls) Receipts() *RiskMutationReceiptStore {
+	if c == nil {
+		return nil
+	}
+	return c.receipts
+}
+
+func (c *RiskMutationControls) Versions() *riskVersionCodec {
+	if c == nil {
+		return nil
+	}
+	return c.versions
+}

--- a/server/internal/platformmcp/risk_mutation_controls.go
+++ b/server/internal/platformmcp/risk_mutation_controls.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 )
 
@@ -35,6 +36,32 @@ type RiskMutationError struct {
 
 func (e *RiskMutationError) Error() string { return e.Message }
 func (e *RiskMutationError) Unwrap() error { return e.Cause }
+
+// OrganizationSlugResolver is the narrow organization lookup needed to target
+// the exact-project risk mutation kill switch. It remains separate from the
+// product-feature-only Platform MCP organization gate.
+type OrganizationSlugResolver interface {
+	OrganizationSlug(ctx context.Context, organizationID string) (string, error)
+}
+
+type PostgresOrganizationSlugResolver struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresOrganizationSlugResolver(db *pgxpool.Pool) *PostgresOrganizationSlugResolver {
+	return &PostgresOrganizationSlugResolver{db: db}
+}
+
+func (r *PostgresOrganizationSlugResolver) OrganizationSlug(ctx context.Context, organizationID string) (string, error) {
+	if r == nil || r.db == nil || organizationID == "" {
+		return "", ErrRiskMutationUnavailable
+	}
+	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		return "", fmt.Errorf("get organization for Platform MCP risk mutation: %w", err)
+	}
+	return organization.Slug, nil
+}
 
 // RiskMutationControls owns the checks shared by every risk write. Admission is
 // intentionally separate from receipt execution so callers can prove the flag

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -143,14 +144,46 @@ func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
 	codec, err := newRiskVersionCodec("test-key")
 	require.NoError(t, err)
 	prompt := "sensitive prompt material"
-	policy := policycore.Policy{ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt, AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
-	state := RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`), AllowedURLs: []string{"https://b.example", "https://a.example"}, StandingDecisionState: []string{"decision:two", "decision:one"}}
+	includeA, includeB := "message.type == 'a'", "message.type == 'b'"
+	exemptA, exemptB := "message.source == 'a'", "message.source == 'b'"
+	policy := policycore.Policy{
+		ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt,
+		AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+		DetectionScopes: []policycore.DetectionScope{
+			{Category: "tool_output", ScopeInclude: &includeB, ScopeExempt: &exemptB},
+			{Category: "tool_output", ScopeInclude: &includeA, ScopeExempt: &exemptA},
+			{Category: "prompt", ScopeInclude: nil, ScopeExempt: nil},
+		},
+	}
+	state := RiskPolicyVersionState{
+		Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`),
+		AllowedURLGrants: []RiskPolicyVersionGrant{
+			{PrincipalURN: "user:two", Selector: json.RawMessage(`{"server_url":"https://example.test/mcp","resource_id":"policy"}`)},
+			{PrincipalURN: "user:one", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		},
+		BlockedURLGrants:      []RiskPolicyVersionGrant{},
+		StandingDecisionState: []string{"decision:two", "decision:one"},
+	}
 	token, err := codec.PolicyVersion(state)
 	require.NoError(t, err)
-	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`), AllowedURLs: []string{"https://a.example", "https://b.example"}, StandingDecisionState: []string{"decision:one", "decision:two"}})
+	canonicalPolicy := policy
+	canonicalPolicy.DetectionScopes = []policycore.DetectionScope{
+		{Category: "prompt", ScopeInclude: nil, ScopeExempt: nil},
+		{Category: "tool_output", ScopeInclude: &includeA, ScopeExempt: &exemptA},
+		{Category: "tool_output", ScopeInclude: &includeB, ScopeExempt: &exemptB},
+	}
+	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{
+		Policy: canonicalPolicy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`),
+		AllowedURLGrants: []RiskPolicyVersionGrant{
+			{PrincipalURN: "user:one", Selector: json.RawMessage(`{ "server_url": "https://example.test/mcp", "resource_id": "policy" }`)},
+			{PrincipalURN: "user:two", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		},
+		BlockedURLGrants:      []RiskPolicyVersionGrant{},
+		StandingDecisionState: []string{"decision:one", "decision:two"},
+	})
 	require.NoError(t, err)
 
-	require.Equal(t, token, canonical)
+	require.Equal(t, token, canonical, "canonical ordering must include the complete detection scope state")
 	require.NotContains(t, token, prompt)
 	require.True(t, codec.ValidPolicyVersion(state, token))
 	pending, total := int64(3), int64(10)
@@ -161,7 +194,17 @@ func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, token, progressToken, "read-time analysis progress is not policy concurrency state")
 	policy.Enabled = true
-	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLs: state.AllowedURLs, StandingDecisionState: state.StandingDecisionState}, token))
+	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLGrants: state.AllowedURLGrants, BlockedURLGrants: state.BlockedURLGrants, StandingDecisionState: state.StandingDecisionState}, token))
+	grantChanged := state
+	grantChanged.AllowedURLGrants = []RiskPolicyVersionGrant{
+		{PrincipalURN: "user:three", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		{PrincipalURN: "user:one", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+	}
+	require.False(t, codec.ValidPolicyVersion(grantChanged, token), "grant audiences are policy concurrency state")
+	grantChanged = state
+	grantChanged.AllowedURLGrants = slices.Clone(state.AllowedURLGrants)
+	grantChanged.AllowedURLGrants[0].Selector = json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp","server_identity":"other"}`)
+	require.False(t, codec.ValidPolicyVersion(grantChanged, token), "complete grant selectors are policy concurrency state")
 
 	exclusion := exclusioncore.Exclusion{ID: uuid.New(), ProjectID: policy.ProjectID, OrganizationID: "organization", MatchType: "exact", MatchValue: "sensitive exact match", Enabled: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
 	exclusionToken, err := codec.ExclusionVersion(exclusion)
@@ -225,9 +268,45 @@ func TestRiskMutationReceiptResultAllowlistCoversEveryOperation(t *testing.T) {
 			t.Parallel()
 			_, err := encodeRiskMutationResult(test.operation, test.valid)
 			require.NoError(t, err)
+			_, err = encodeRiskMutationResult(test.operation, receiptResultPointer(test.valid))
+			require.NoError(t, err, "non-nil pointers to closed receipt projections remain safe")
 			_, err = encodeRiskMutationResult(test.operation, test.invalid)
 			require.ErrorIs(t, err, ErrRiskMutationUnavailable)
 		})
+	}
+
+	for _, test := range []struct {
+		name      string
+		operation string
+		result    RiskMutationReceiptResult
+	}{
+		{name: "create policy", operation: operationCreateRiskPolicy, result: (*CreateRiskPolicyReceiptResult)(nil)},
+		{name: "update policy", operation: operationUpdateRiskPolicy, result: (*UpdateRiskPolicyReceiptResult)(nil)},
+		{name: "create exclusion", operation: operationCreateRiskExclusion, result: (*CreateRiskExclusionReceiptResult)(nil)},
+		{name: "update exclusion", operation: operationUpdateRiskExclusion, result: (*UpdateRiskExclusionReceiptResult)(nil)},
+	} {
+		t.Run("typed nil "+test.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				_, err := encodeRiskMutationResult(test.operation, test.result)
+				require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+			})
+		})
+	}
+}
+
+func receiptResultPointer(result RiskMutationReceiptResult) RiskMutationReceiptResult {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult:
+		return &typed
+	case UpdateRiskPolicyReceiptResult:
+		return &typed
+	case CreateRiskExclusionReceiptResult:
+		return &typed
+	case UpdateRiskExclusionReceiptResult:
+		return &typed
+	default:
+		return nil
 	}
 }
 
@@ -258,6 +337,28 @@ func TestRiskMutationHandlerSelectionAcceptsExportedSuccessContract(t *testing.T
 		return
 	}
 	require.Fail(t, "create risk policy descriptor was not registered")
+}
+
+func TestRiskMutationHandlerSelectionRequiresAvailableCatalogForLiveCallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	called := false
+	registerRiskMutationHandlers(registrar, policycatalog.Catalog{}, false, &RiskMutationHandlers{
+		Controls: &RiskMutationControls{},
+		CreatePolicy: func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskPolicyToolOutput, error) {
+			called = true
+			return nil, CreateRiskPolicyToolOutput{}, nil
+		},
+	})
+
+	create := descriptorByName(t, registrar, operationCreateRiskPolicy)
+	_, err := create.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), json.RawMessage(`{"project_slug":"default","policy_type":"prompt_based","name":"policy","enabled":true,"prompt":"instruction","idempotency_key":"key"}`))
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	require.Contains(t, refusal.Payload, `"code":"feature_unavailable"`)
+	require.False(t, called, "catalog failure must keep live callbacks unavailable")
 }
 
 func TestRiskMutationHandlerSelectionDefaultsEveryWriteToStableRefusal(t *testing.T) {

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -1,0 +1,305 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+)
+
+type riskMutationFlagProvider struct {
+	evaluation feature.Evaluation
+	err        error
+	flag       feature.Flag
+	groups     map[string]string
+}
+
+func (p *riskMutationFlagProvider) IsFlagEnabled(context.Context, feature.Flag, string, map[string]string) (bool, error) {
+	return false, nil
+}
+func (p *riskMutationFlagProvider) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+	return false, nil
+}
+func (p *riskMutationFlagProvider) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
+	return nil, nil
+}
+func (p *riskMutationFlagProvider) EvaluateFlag(_ context.Context, flag feature.Flag, _ string, groups map[string]string) (feature.Evaluation, error) {
+	p.flag = flag
+	p.groups = groups
+	return p.evaluation, p.err
+}
+
+type riskMutationOrganizationResolver struct {
+	slug string
+	err  error
+}
+
+func (r riskMutationOrganizationResolver) OrganizationSlug(context.Context, string) (string, error) {
+	return r.slug, r.err
+}
+
+func TestRiskMutationAdmissionRequiresExactEnabledProjectBeforeBudget(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "project"}
+	projects := &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectSlug: project.Slug}}}
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	flags := &riskMutationFlagProvider{evaluation: feature.EvaluationDisabled}
+	controls := &RiskMutationControls{
+		flags: flags, organizations: riskMutationOrganizationResolver{slug: "organization-slug"}, projects: projects,
+		budget: OperationBudget{Connection: connection, Organization: organization}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+
+	_, err := controls.Admit(t.Context(), principal, project.Slug)
+
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+	require.Equal(t, feature.FlagPlatformMCPRiskMutations, flags.flag)
+	require.Equal(t, feature.OrgProjectGroups("organization-slug", project.Slug), flags.groups)
+	require.Empty(t, connection.keys, "a disabled kill switch must refuse before consuming budget")
+	require.Empty(t, organization.keys)
+}
+
+func TestRiskMutationAdmissionDistinguishesMissingProjectFromResolverOutage(t *testing.T) {
+	t.Parallel()
+
+	backendFailure := errors.New("database unavailable")
+	for _, test := range []struct {
+		name     string
+		resolve  error
+		wantCode string
+		wantErr  error
+	}{
+		{name: "missing project", resolve: ErrRiskReadNotFound, wantCode: "not_found", wantErr: ErrRiskMutationNotFound},
+		{name: "resolver outage", resolve: backendFailure, wantCode: unavailableCode, wantErr: ErrRiskMutationUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			controls := &RiskMutationControls{
+				flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization-slug"},
+				projects: &stubRiskProjects{err: test.resolve}, budget: OperationBudget{Connection: &recordingOperationLimiter{}, Organization: &recordingOperationLimiter{}}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+			}
+			_, err := controls.Admit(t.Context(), Principal{UserID: "user", OrganizationID: "organization"}, "project")
+			var mutationErr *RiskMutationError
+			require.ErrorAs(t, err, &mutationErr)
+			require.Equal(t, test.wantCode, mutationErr.Code)
+			require.ErrorIs(t, err, test.wantErr)
+			if errors.Is(test.resolve, backendFailure) {
+				require.ErrorIs(t, err, backendFailure)
+			}
+		})
+	}
+}
+
+func TestRiskMutationAdmissionConnectionlessAssistantUsesOrganizationBudget(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "project"}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	controls := &RiskMutationControls{
+		flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization-slug"},
+		projects: &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectSlug: project.Slug}}},
+		budget:   OperationBudget{Connection: &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}, Organization: organization}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant}
+
+	resolved, err := controls.Admit(t.Context(), principal, project.Slug)
+
+	require.NoError(t, err)
+	require.Equal(t, project, resolved)
+	require.Equal(t, []string{"organization"}, organization.keys)
+}
+
+func TestRiskMutationInputHashIsCanonicalAndOperationSeparated(t *testing.T) {
+	t.Parallel()
+
+	first, err := riskMutationInputHash(operationCreateRiskPolicy, map[string]any{"enabled": true, "name": "policy"})
+	require.NoError(t, err)
+	second, err := riskMutationInputHash(operationCreateRiskPolicy, map[string]any{"name": "policy", "enabled": true})
+	require.NoError(t, err)
+	other, err := riskMutationInputHash(operationUpdateRiskPolicy, map[string]any{"enabled": true, "name": "policy"})
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+	require.NotEqual(t, first, other)
+}
+
+func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newRiskVersionCodec("test-key")
+	require.NoError(t, err)
+	prompt := "sensitive prompt material"
+	policy := policycore.Policy{ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt, AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	state := RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`), AllowedURLs: []string{"https://b.example", "https://a.example"}, StandingDecisionState: []string{"decision:two", "decision:one"}}
+	token, err := codec.PolicyVersion(state)
+	require.NoError(t, err)
+	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`), AllowedURLs: []string{"https://a.example", "https://b.example"}, StandingDecisionState: []string{"decision:one", "decision:two"}})
+	require.NoError(t, err)
+
+	require.Equal(t, token, canonical)
+	require.NotContains(t, token, prompt)
+	require.True(t, codec.ValidPolicyVersion(state, token))
+	pending, total := int64(3), int64(10)
+	progressOnly := state
+	progressOnly.Policy.PendingMessages = &pending
+	progressOnly.Policy.TotalMessages = &total
+	progressToken, err := codec.PolicyVersion(progressOnly)
+	require.NoError(t, err)
+	require.Equal(t, token, progressToken, "read-time analysis progress is not policy concurrency state")
+	policy.Enabled = true
+	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLs: state.AllowedURLs, StandingDecisionState: state.StandingDecisionState}, token))
+
+	exclusion := exclusioncore.Exclusion{ID: uuid.New(), ProjectID: policy.ProjectID, OrganizationID: "organization", MatchType: "exact", MatchValue: "sensitive exact match", Enabled: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	exclusionToken, err := codec.ExclusionVersion(exclusion)
+	require.NoError(t, err)
+	require.NotContains(t, exclusionToken, exclusion.MatchValue)
+	require.True(t, codec.ValidExclusionVersion(exclusion, exclusionToken))
+	exclusion.Enabled = false
+	require.False(t, codec.ValidExclusionVersion(exclusion, exclusionToken))
+}
+
+func TestRiskMutationReceiptResultIsClosedAndOperationBound(t *testing.T) {
+	t.Parallel()
+
+	result := CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}, Policy: RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", MatchedExisting: false, ResultCategory: "created"}
+	payload, err := encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"project":{"id":"11111111-1111-4111-8111-111111111111","slug":"default"},"policy":{"id":"22222222-2222-4222-8222-222222222222","policy_type":"standard","enabled":true,"action":"flag"},"version":"opaque","matched_existing":false,"result_category":"created"}`, string(payload))
+	require.NotContains(t, string(payload), "prompt")
+	require.NotContains(t, string(payload), "match_value")
+
+	_, err = encodeRiskMutationResult(operationUpdateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+
+	result.Policy.Action = "prompt material smuggled as action"
+	_, err = encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+
+	result.Policy.Action = "flag"
+	result.Project.Slug = "prompt material smuggled as slug"
+	_, err = encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+}
+
+func TestRiskMutationReceiptResultAllowlistCoversEveryOperation(t *testing.T) {
+	t.Parallel()
+
+	project := RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}
+	policy := RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}
+	exclusion := RiskExclusionReceiptSummary{ID: "33333333-3333-4333-8333-333333333333", MatchType: "source", Enabled: true}
+	for _, action := range []string{"flag", "warn", "block", "quarantine"} {
+		t.Run("policy action "+action, func(t *testing.T) {
+			t.Parallel()
+			candidate := policy
+			candidate.Action = action
+			_, err := encodeRiskMutationResult(operationUpdateRiskPolicy, UpdateRiskPolicyReceiptResult{Project: project, Policy: candidate, Version: "opaque", ResultCategory: "updated"})
+			require.NoError(t, err)
+		})
+	}
+	for _, test := range []struct {
+		name      string
+		operation string
+		valid     RiskMutationReceiptResult
+		invalid   RiskMutationReceiptResult
+	}{
+		{name: "create policy", operation: operationCreateRiskPolicy, valid: CreateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "created"}, invalid: CreateRiskPolicyReceiptResult{Project: project, Policy: RiskPolicyReceiptSummary{ID: policy.ID, PolicyType: "unsupported", Enabled: true, Action: "flag"}, Version: "opaque", ResultCategory: "created"}},
+		{name: "update policy", operation: operationUpdateRiskPolicy, valid: UpdateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "updated"}, invalid: UpdateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "user content"}},
+		{name: "create exclusion", operation: operationCreateRiskExclusion, valid: CreateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "created", Reconciliation: "scheduled"}, invalid: CreateRiskExclusionReceiptResult{Project: project, Exclusion: RiskExclusionReceiptSummary{ID: exclusion.ID, MatchType: "user content", Enabled: true}, Version: "opaque", ResultCategory: "created", Reconciliation: "scheduled"}},
+		{name: "update exclusion", operation: operationUpdateRiskExclusion, valid: UpdateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "updated", Reconciliation: "scheduled"}, invalid: UpdateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "updated", Reconciliation: "complete"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := encodeRiskMutationResult(test.operation, test.valid)
+			require.NoError(t, err)
+			_, err = encodeRiskMutationResult(test.operation, test.invalid)
+			require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+		})
+	}
+}
+
+func TestRiskMutationHandlerSelectionAcceptsExportedSuccessContract(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := policycatalog.Build()
+	require.NoError(t, err)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	want := CreateRiskPolicyToolOutput{
+		CreateRiskPolicyReceiptResult: CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}, Policy: RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", ResultCategory: "created"},
+		Receipt:                       RiskMutationToolReceipt{ID: "33333333-3333-4333-8333-333333333333", Replayed: false},
+	}
+	registerRiskMutationHandlers(registrar, catalog, true, &RiskMutationHandlers{
+		Controls: &RiskMutationControls{},
+		CreatePolicy: func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskPolicyToolOutput, error) {
+			return nil, want, nil
+		},
+	})
+	for _, descriptor := range registrar.Descriptors() {
+		if descriptor.Name != operationCreateRiskPolicy {
+			continue
+		}
+		got, err := descriptor.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), json.RawMessage(`{"project_slug":"default","policy_type":"standard","name":"policy","enabled":true,"sources":["gitleaks"],"idempotency_key":"key"}`))
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+		return
+	}
+	require.Fail(t, "create risk policy descriptor was not registered")
+}
+
+func TestRiskMutationHandlerSelectionDefaultsEveryWriteToStableRefusal(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := policycatalog.Build()
+	require.NoError(t, err)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	registerRiskMutationHandlers(registrar, catalog, true, &RiskMutationHandlers{})
+	arguments := map[string]json.RawMessage{
+		"create_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_type":"standard","name":"policy","enabled":true,"sources":["gitleaks"],"idempotency_key":"key"}`),
+		"update_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_id":"11111111-1111-4111-8111-111111111111","expected_version":"version","idempotency_key":"key","patch":{"enabled":true}}`),
+		"create_risk_exclusion": json.RawMessage(`{"project_slug":"default","match_type":"source","match_value":"gitleaks","enabled":true,"idempotency_key":"key"}`),
+		"update_risk_exclusion": json.RawMessage(`{"project_slug":"default","exclusion_id":"11111111-1111-4111-8111-111111111111","enabled":true,"expected_version":"version","idempotency_key":"key"}`),
+	}
+	for _, descriptor := range registrar.Descriptors() {
+		input, ok := arguments[descriptor.Name]
+		if !ok || (!strings.HasPrefix(descriptor.Name, "create_risk_") && !strings.HasPrefix(descriptor.Name, "update_risk_")) {
+			continue
+		}
+		_, err := descriptor.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), input)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `"code":"feature_unavailable"`)
+	}
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(t.Context(), serverTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "risk-stub-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(t.Context(), clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	refused, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: operationCreateRiskPolicy, Arguments: map[string]any{"project_slug": "default", "policy_type": "standard", "name": "policy", "enabled": true, "sources": []string{"gitleaks"}, "idempotency_key": "key"}})
+	require.NoError(t, err)
+	require.True(t, refused.IsError)
+	require.Nil(t, refused.StructuredContent, "disabled tools must not emit a zero-valued structured success output")
+	require.Len(t, refused.Content, 1)
+	text, ok := refused.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"code":"feature_unavailable","feature":"risk_mutations","message":"This Platform MCP capability is not enabled for the current rollout."}`, text.Text)
+}

--- a/server/internal/platformmcp/risk_mutation_receipt.go
+++ b/server/internal/platformmcp/risk_mutation_receipt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -219,10 +220,11 @@ func riskMutationOperation(operation string) bool {
 }
 
 func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult) (json.RawMessage, error) {
-	if result == nil || result.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(result) {
+	normalized, valid := normalizedRiskMutationReceiptResult(result)
+	if !valid || normalized.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(normalized) {
 		return nil, invalidRiskMutationReceiptResult()
 	}
-	payload, err := json.Marshal(result)
+	payload, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, fmt.Errorf("encode risk mutation receipt result: %w", err)
 	}
@@ -230,6 +232,30 @@ func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult
 		return nil, &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
 	}
 	return payload, nil
+}
+
+func normalizedRiskMutationReceiptResult(result RiskMutationReceiptResult) (RiskMutationReceiptResult, bool) {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult, UpdateRiskPolicyReceiptResult, CreateRiskExclusionReceiptResult, UpdateRiskExclusionReceiptResult:
+		return typed, true
+	case *CreateRiskPolicyReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *UpdateRiskPolicyReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *CreateRiskExclusionReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *UpdateRiskExclusionReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	}
+	return nil, false
 }
 
 func validRiskMutationReceiptResult(result RiskMutationReceiptResult) bool {
@@ -287,12 +313,7 @@ func validRiskReceiptVersion(version string) bool {
 }
 
 func validRiskResultCategory(category string, allowed ...string) bool {
-	for _, value := range allowed {
-		if category == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, category)
 }
 
 func invalidRiskMutationReceiptResult() error {

--- a/server/internal/platformmcp/risk_mutation_receipt.go
+++ b/server/internal/platformmcp/risk_mutation_receipt.go
@@ -1,0 +1,300 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const maxRiskMutationReceiptPayloadBytes = 16 << 10
+
+// RiskMutationReceiptRequest is the safe identity of one normalized write.
+// Input must already have schema defaults, canonical ordering, and transport
+// aliases resolved. It is hashed and is never persisted or logged directly.
+type RiskMutationReceiptRequest struct {
+	Operation      string
+	IdempotencyKey string
+	Input          any
+}
+
+// RiskMutationReceiptResult is implemented only by the four closed, redacted
+// result projections below. Callbacks cannot supply an open JSON object, so a
+// new user-authored field cannot silently enter operation receipts.
+type RiskMutationReceiptResult interface {
+	riskMutationReceiptOperation() string
+}
+
+type RiskMutationReceiptProject struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+}
+
+// RiskPolicyReceiptSummary contains only fixed-vocabulary administrative state.
+// Policy names, prompts, CEL, model configuration, principals, and URLs are
+// deliberately absent.
+type RiskPolicyReceiptSummary struct {
+	ID         string `json:"id"`
+	PolicyType string `json:"policy_type"`
+	Enabled    bool   `json:"enabled"`
+	Action     string `json:"action,omitempty"`
+}
+
+// RiskExclusionReceiptSummary omits match values and filters even for
+// allowlisted match types so exact and legacy-regex content can never leak.
+type RiskExclusionReceiptSummary struct {
+	ID        string  `json:"id"`
+	PolicyID  *string `json:"policy_id,omitempty"`
+	MatchType string  `json:"match_type"`
+	Enabled   bool    `json:"enabled"`
+}
+
+type CreateRiskPolicyReceiptResult struct {
+	Project         RiskMutationReceiptProject `json:"project"`
+	Policy          RiskPolicyReceiptSummary   `json:"policy"`
+	Version         string                     `json:"version"`
+	MatchedExisting bool                       `json:"matched_existing"`
+	ResultCategory  string                     `json:"result_category"`
+}
+
+func (CreateRiskPolicyReceiptResult) riskMutationReceiptOperation() string {
+	return operationCreateRiskPolicy
+}
+
+type UpdateRiskPolicyReceiptResult struct {
+	Project        RiskMutationReceiptProject `json:"project"`
+	Policy         RiskPolicyReceiptSummary   `json:"policy"`
+	Version        string                     `json:"version"`
+	ResultCategory string                     `json:"result_category"`
+}
+
+func (UpdateRiskPolicyReceiptResult) riskMutationReceiptOperation() string {
+	return operationUpdateRiskPolicy
+}
+
+type CreateRiskExclusionReceiptResult struct {
+	Project         RiskMutationReceiptProject  `json:"project"`
+	Exclusion       RiskExclusionReceiptSummary `json:"exclusion"`
+	Version         string                      `json:"version"`
+	MatchedExisting bool                        `json:"matched_existing"`
+	ResultCategory  string                      `json:"result_category"`
+	Reconciliation  string                      `json:"reconciliation"`
+}
+
+func (CreateRiskExclusionReceiptResult) riskMutationReceiptOperation() string {
+	return operationCreateRiskExclusion
+}
+
+type UpdateRiskExclusionReceiptResult struct {
+	Project        RiskMutationReceiptProject  `json:"project"`
+	Exclusion      RiskExclusionReceiptSummary `json:"exclusion"`
+	Version        string                      `json:"version"`
+	ResultCategory string                      `json:"result_category"`
+	Reconciliation string                      `json:"reconciliation"`
+}
+
+func (UpdateRiskExclusionReceiptResult) riskMutationReceiptOperation() string {
+	return operationUpdateRiskExclusion
+}
+
+// RiskMutationTransaction performs the domain write and audit write using the
+// same transaction that owns the receipt. Its result must be one of the closed
+// operation-specific projections above.
+type RiskMutationTransaction func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error)
+
+type RiskMutationReceiptStore struct {
+	db  *pgxpool.Pool
+	now func() time.Time
+}
+
+func NewRiskMutationReceiptStore(db *pgxpool.Pool) *RiskMutationReceiptStore {
+	return &RiskMutationReceiptStore{db: db, now: time.Now}
+}
+
+// Execute serializes one user's exact operation/project/key, replays an exact
+// completed input from its stored result, and commits receipt + domain + audit
+// atomically. Any callback, completion, or commit failure rolls all three back.
+func (s *RiskMutationReceiptStore) Execute(ctx context.Context, principal Principal, project ResolvedProject, request RiskMutationReceiptRequest, mutate RiskMutationTransaction) (OperationReceipt, error) {
+	if s == nil || s.db == nil || s.now == nil || mutate == nil || principal.OrganizationID == "" || principal.UserID == "" || project.ID == uuid.Nil || project.Slug == "" || request.IdempotencyKey == "" || len(request.IdempotencyKey) > 128 || !riskMutationOperation(request.Operation) {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation request is invalid.", Cause: ErrRiskMutationInvalid}
+	}
+	inputHash, err := riskMutationInputHash(request.Operation, request.Input)
+	if err != nil {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation request could not be normalized.", Cause: ErrRiskMutationInvalid}
+	}
+	connectionID, generation, err := principalConnection(principal)
+	if err != nil {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation caller identity is invalid.", Cause: ErrRiskMutationInvalid}
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("begin risk mutation receipt: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := platformrepo.New(tx)
+	lock := platformrepo.LockPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID.String(), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
+	if err := q.LockPlatformMCPOperationReceipt(ctx, lock); err != nil {
+		return OperationReceipt{}, fmt.Errorf("lock risk mutation receipt: %w", err)
+	}
+	lookup := platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
+	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(lookup)); err != nil {
+		return OperationReceipt{}, fmt.Errorf("reclaim expired risk mutation receipt: %w", err)
+	}
+	stored, err := q.GetPlatformMCPOperationReceipt(ctx, lookup)
+	switch {
+	case err == nil:
+		if stored.InputHash != inputHash {
+			return OperationReceipt{}, riskMutationConflict("The idempotency key was already used with different risk mutation input.")
+		}
+		if stored.Status != receiptStatusSucceeded || len(stored.ResultPayload) == 0 {
+			return OperationReceipt{}, riskMutationConflict("The matching risk mutation has no completed replay result.")
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return OperationReceipt{}, fmt.Errorf("commit risk mutation replay: %w", err)
+		}
+		return operationReceiptFromRow(stored, true), nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return OperationReceipt{}, fmt.Errorf("load risk mutation receipt: %w", err)
+	}
+
+	created, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, ConnectionID: connectionID, ConnectionGeneration: generation,
+		UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey,
+		InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: timestamp(s.now().UTC().Add(receiptLifetime)),
+	})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("create risk mutation receipt: %w", err)
+	}
+	result, err := mutate(ctx, tx)
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("apply risk mutation transaction: %w", err)
+	}
+	payload, err := encodeRiskMutationResult(request.Operation, result)
+	if err != nil {
+		return OperationReceipt{}, err
+	}
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{
+		RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText("succeeded"), ResultPayload: payload, ID: created.ID, OrganizationID: principal.OrganizationID,
+	})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("complete risk mutation receipt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return OperationReceipt{}, fmt.Errorf("commit risk mutation: %w", err)
+	}
+	return operationReceiptFromRow(completed, false), nil
+}
+
+func riskMutationInputHash(operation string, normalized any) (string, error) {
+	if !riskMutationOperation(operation) || normalized == nil {
+		return "", ErrRiskMutationInvalid
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("encode normalized risk mutation input: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("platform-mcp-risk-mutation-v1\x00"+operation+"\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func riskMutationOperation(operation string) bool {
+	switch operation {
+	case operationCreateRiskPolicy, operationUpdateRiskPolicy, operationCreateRiskExclusion, operationUpdateRiskExclusion:
+		return true
+	default:
+		return false
+	}
+}
+
+func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult) (json.RawMessage, error) {
+	if result == nil || result.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(result) {
+		return nil, invalidRiskMutationReceiptResult()
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode risk mutation receipt result: %w", err)
+	}
+	if len(payload) == 0 || len(payload) > maxRiskMutationReceiptPayloadBytes {
+		return nil, &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
+	}
+	return payload, nil
+}
+
+func validRiskMutationReceiptResult(result RiskMutationReceiptResult) bool {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskPolicyReceiptSummary(typed.Policy) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "created", "matched_existing")
+	case UpdateRiskPolicyReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskPolicyReceiptSummary(typed.Policy) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "updated")
+	case CreateRiskExclusionReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskExclusionReceiptSummary(typed.Exclusion) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "created", "matched_existing") && typed.Reconciliation == "scheduled"
+	case UpdateRiskExclusionReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskExclusionReceiptSummary(typed.Exclusion) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "updated") && typed.Reconciliation == "scheduled"
+	default:
+		return false
+	}
+}
+
+func validRiskReceiptProject(project RiskMutationReceiptProject) bool {
+	return uuid.Validate(project.ID) == nil && validRiskReceiptSlug(project.Slug)
+}
+
+func validRiskReceiptSlug(slug string) bool {
+	if slug == "" || len(slug) > 128 {
+		return false
+	}
+	for _, char := range slug {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func validRiskPolicyReceiptSummary(policy RiskPolicyReceiptSummary) bool {
+	return uuid.Validate(policy.ID) == nil && (policy.PolicyType == "standard" || policy.PolicyType == "prompt_based") && (policy.Action == "" || policy.Action == "flag" || policy.Action == "warn" || policy.Action == "block" || policy.Action == "quarantine")
+}
+
+func validRiskExclusionReceiptSummary(exclusion RiskExclusionReceiptSummary) bool {
+	if uuid.Validate(exclusion.ID) != nil || (exclusion.MatchType != "exact" && exclusion.MatchType != "rule_id" && exclusion.MatchType != "source" && exclusion.MatchType != "entity_type" && exclusion.MatchType != "regex") {
+		return false
+	}
+	return exclusion.PolicyID == nil || uuid.Validate(*exclusion.PolicyID) == nil
+}
+
+func validRiskReceiptVersion(version string) bool {
+	if version == "" || len(version) > 2048 {
+		return false
+	}
+	for _, char := range version {
+		if (char < 'A' || char > 'Z') && (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func validRiskResultCategory(category string, allowed ...string) bool {
+	for _, value := range allowed {
+		if category == value {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidRiskMutationReceiptResult() error {
+	return &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
+}

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -29,11 +29,15 @@ type stubRiskProjects struct {
 	project  ResolvedProject
 	expected []riskProjectCall
 	calls    []riskProjectCall
+	err      error
 }
 
 func (s *stubRiskProjects) Resolve(_ context.Context, organizationID, projectID, projectSlug string) (ResolvedProject, error) {
 	call := riskProjectCall{organizationID: organizationID, projectID: projectID, projectSlug: projectSlug}
 	s.calls = append(s.calls, call)
+	if s.err != nil {
+		return ResolvedProject{}, s.err
+	}
 	index := len(s.calls) - 1
 	if index >= len(s.expected) || s.expected[index] != call {
 		return ResolvedProject{}, fmt.Errorf("unexpected project resolution call: %+v", call)

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -36,15 +36,23 @@ func newRiskVersionCodec(keyMaterial string) (*riskVersionCodec, error) {
 }
 
 // RiskPolicyVersionState is the complete locked policy state needed for an
-// optimistic-concurrency token. Grant-backed URLs, standing-decision state, and
-// canonical analyzer JSON are included because they can change enforcement
-// without changing the policy's public summary. They remain inside the HMAC.
+// optimistic-concurrency token. Grant-backed URL selectors and audiences,
+// standing-decision state, and canonical analyzer JSON are included because
+// they can change enforcement without changing the policy's public summary.
+// They remain inside the HMAC.
 type RiskPolicyVersionState struct {
 	Policy                policycore.Policy
 	AnalyzerConfig        json.RawMessage
-	AllowedURLs           []string
-	BlockedURLs           []string
+	AllowedURLGrants      []RiskPolicyVersionGrant
+	BlockedURLGrants      []RiskPolicyVersionGrant
 	StandingDecisionState []string
+}
+
+// RiskPolicyVersionGrant captures the complete enforcement identity of one URL
+// grant. The principal and canonical selector remain inside the opaque HMAC.
+type RiskPolicyVersionGrant struct {
+	PrincipalURN string          `json:"principal_urn"`
+	Selector     json.RawMessage `json:"selector"`
 }
 
 // PolicyVersion authenticates the complete transport-neutral persisted policy
@@ -72,18 +80,16 @@ func (c *riskVersionCodec) PolicyVersion(input RiskPolicyVersionState) (string, 
 	state.Policy.MessageTypes = sortedStrings(state.Policy.MessageTypes)
 	state.Policy.AudiencePrincipalURNs = sortedStrings(state.Policy.AudiencePrincipalURNs)
 	state.Policy.DetectionScopes = slices.Clone(state.Policy.DetectionScopes)
-	state.AllowedURLs = sortedStrings(state.AllowedURLs)
-	state.BlockedURLs = sortedStrings(state.BlockedURLs)
+	state.AllowedURLGrants, err = canonicalRiskPolicyVersionGrants(state.AllowedURLGrants)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
+	state.BlockedURLGrants, err = canonicalRiskPolicyVersionGrants(state.BlockedURLGrants)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
 	state.StandingDecisionState = sortedStrings(state.StandingDecisionState)
-	slices.SortFunc(state.Policy.DetectionScopes, func(a, b policycore.DetectionScope) int {
-		if a.Category < b.Category {
-			return -1
-		}
-		if a.Category > b.Category {
-			return 1
-		}
-		return 0
-	})
+	slices.SortFunc(state.Policy.DetectionScopes, compareDetectionScopes)
 	return c.encode("policy", state)
 }
 
@@ -101,6 +107,60 @@ func (c *riskVersionCodec) ValidPolicyVersion(state RiskPolicyVersionState, toke
 func (c *riskVersionCodec) ValidExclusionVersion(exclusion exclusioncore.Exclusion, token string) bool {
 	expected, err := c.ExclusionVersion(exclusion)
 	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func canonicalRiskPolicyVersionGrants(grants []RiskPolicyVersionGrant) ([]RiskPolicyVersionGrant, error) {
+	result := slices.Clone(grants)
+	for index := range result {
+		selector, err := canonicalJSON(result[index].Selector)
+		if err != nil {
+			return nil, err
+		}
+		result[index].Selector = selector
+	}
+	slices.SortFunc(result, func(a, b RiskPolicyVersionGrant) int {
+		if order := compareStrings(a.PrincipalURN, b.PrincipalURN); order != 0 {
+			return order
+		}
+		return compareStrings(string(a.Selector), string(b.Selector))
+	})
+	return slices.CompactFunc(result, func(a, b RiskPolicyVersionGrant) bool {
+		return a.PrincipalURN == b.PrincipalURN && string(a.Selector) == string(b.Selector)
+	}), nil
+}
+
+func compareDetectionScopes(a, b policycore.DetectionScope) int {
+	if order := compareStrings(a.Category, b.Category); order != 0 {
+		return order
+	}
+	if order := compareOptionalStrings(a.ScopeInclude, b.ScopeInclude); order != 0 {
+		return order
+	}
+	return compareOptionalStrings(a.ScopeExempt, b.ScopeExempt)
+}
+
+func compareOptionalStrings(a, b *string) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return compareStrings(*a, *b)
+	}
+}
+
+func compareStrings(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func (c *riskVersionCodec) encode(kind string, state any) (string, error) {

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -1,0 +1,143 @@
+package platformmcp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+)
+
+const riskVersionCodecVersion = 1
+
+var errRiskVersionInvalid = errors.New("invalid platform mcp risk version")
+
+type riskVersionCodec struct {
+	key []byte
+}
+
+type riskVersionEnvelope struct {
+	Version int    `json:"v"`
+	Kind    string `json:"k"`
+	MAC     string `json:"m"`
+}
+
+func newRiskVersionCodec(keyMaterial string) (*riskVersionCodec, error) {
+	if keyMaterial == "" {
+		return nil, ErrRiskMutationUnavailable
+	}
+	key := sha256.Sum256([]byte("platform-mcp-risk-version:" + keyMaterial))
+	return &riskVersionCodec{key: key[:]}, nil
+}
+
+// RiskPolicyVersionState is the complete locked policy state needed for an
+// optimistic-concurrency token. Grant-backed URLs, standing-decision state, and
+// canonical analyzer JSON are included because they can change enforcement
+// without changing the policy's public summary. They remain inside the HMAC.
+type RiskPolicyVersionState struct {
+	Policy                policycore.Policy
+	AnalyzerConfig        json.RawMessage
+	AllowedURLs           []string
+	BlockedURLs           []string
+	StandingDecisionState []string
+}
+
+// PolicyVersion authenticates the complete transport-neutral persisted policy
+// state. Sensitive prompt, URL-derived scope, model configuration, and audience
+// values contribute only inside the HMAC and never appear in the token.
+func (c *riskVersionCodec) PolicyVersion(input RiskPolicyVersionState) (string, error) {
+	state := input
+	// Progress is computed when a policy is read and changes as background
+	// analysis advances; it is not part of the locked policy definition. Keep
+	// persisted score, version, and timestamps, which do represent admin-visible
+	// policy state and must invalidate stale writes.
+	state.Policy.PendingMessages = nil
+	state.Policy.TotalMessages = nil
+	canonicalAnalyzer, err := canonicalJSON(state.AnalyzerConfig)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
+	state.AnalyzerConfig = canonicalAnalyzer
+	state.Policy.Sources = sortedStrings(state.Policy.Sources)
+	state.Policy.PresidioEntities = sortedStrings(state.Policy.PresidioEntities)
+	state.Policy.ApprovedEmailDomains = sortedStrings(state.Policy.ApprovedEmailDomains)
+	state.Policy.PromptInjectionRules = sortedStrings(state.Policy.PromptInjectionRules)
+	state.Policy.DisabledRules = sortedStrings(state.Policy.DisabledRules)
+	state.Policy.CustomRuleIDs = sortedStrings(state.Policy.CustomRuleIDs)
+	state.Policy.MessageTypes = sortedStrings(state.Policy.MessageTypes)
+	state.Policy.AudiencePrincipalURNs = sortedStrings(state.Policy.AudiencePrincipalURNs)
+	state.Policy.DetectionScopes = slices.Clone(state.Policy.DetectionScopes)
+	state.AllowedURLs = sortedStrings(state.AllowedURLs)
+	state.BlockedURLs = sortedStrings(state.BlockedURLs)
+	state.StandingDecisionState = sortedStrings(state.StandingDecisionState)
+	slices.SortFunc(state.Policy.DetectionScopes, func(a, b policycore.DetectionScope) int {
+		if a.Category < b.Category {
+			return -1
+		}
+		if a.Category > b.Category {
+			return 1
+		}
+		return 0
+	})
+	return c.encode("policy", state)
+}
+
+// ExclusionVersion authenticates every persisted exclusion field. Exact match
+// values remain inside the HMAC and cannot be recovered from the opaque token.
+func (c *riskVersionCodec) ExclusionVersion(exclusion exclusioncore.Exclusion) (string, error) {
+	return c.encode("exclusion", exclusion)
+}
+
+func (c *riskVersionCodec) ValidPolicyVersion(state RiskPolicyVersionState, token string) bool {
+	expected, err := c.PolicyVersion(state)
+	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (c *riskVersionCodec) ValidExclusionVersion(exclusion exclusioncore.Exclusion, token string) bool {
+	expected, err := c.ExclusionVersion(exclusion)
+	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (c *riskVersionCodec) encode(kind string, state any) (string, error) {
+	if c == nil || len(c.key) == 0 || kind == "" {
+		return "", errRiskVersionInvalid
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("encode risk version state: %w", err)
+	}
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write([]byte("platform-mcp-risk-version-v1\x00" + kind + "\x00"))
+	_, _ = mac.Write(payload)
+	envelope, err := json.Marshal(riskVersionEnvelope{Version: riskVersionCodecVersion, Kind: kind, MAC: base64.RawURLEncoding.EncodeToString(mac.Sum(nil))})
+	if err != nil {
+		return "", fmt.Errorf("encode risk version envelope: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(envelope), nil
+}
+
+func sortedStrings(values []string) []string {
+	result := slices.Clone(values)
+	slices.Sort(result)
+	return slices.Compact(result)
+}
+
+func canonicalJSON(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode analyzer configuration: %w", err)
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical analyzer configuration: %w", err)
+	}
+	return canonical, nil
+}

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -127,10 +127,14 @@ func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, ga
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
 func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
+	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+}
+
+func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, candidate)
+	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -134,7 +134,7 @@ func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog,
 	updatePolicy := unavailableRiskMutationTool[UpdateRiskPolicyToolOutput]()
 	createExclusion := unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()
 	updateExclusion := unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()
-	if handlers != nil && handlers.Controls != nil {
+	if catalogAvailable && handlers != nil && handlers.Controls != nil {
 		if handlers.CreatePolicy != nil {
 			createPolicy = handlers.CreatePolicy
 		}

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -14,9 +14,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
 )
 
-func registerRiskTools(reg *Registrar, risk *RiskReadService) {
+// registerRiskToolsWithMutations is the single handler-selection seam used by
+// the external endpoint and assistant catalogue. PR 6 deliberately passes no
+// live handlers, so every mutation remains the same stable unavailable stub.
+func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutations *RiskMutationHandlers) {
 	if risk == nil || !risk.valid() {
-		registerUnavailableRiskTools(reg)
+		registerUnavailableRiskToolsWithMutations(reg, mutations)
 		return
 	}
 	addTool(reg, &mcp.Tool{
@@ -52,14 +55,22 @@ func registerRiskTools(reg *Registrar, risk *RiskReadService) {
 			return risk.ListExclusions(ctx, principal, input)
 		})
 	})
-	registerRiskMutationStubs(reg, risk.catalog, true)
+	registerRiskMutationHandlers(reg, risk.catalog, true, mutations)
 }
 
 func registerUnavailableRiskTools(reg *Registrar) {
-	registerUnavailableRiskToolsWithCatalog(reg, policycatalog.Build)
+	registerUnavailableRiskToolsWithMutations(reg, nil)
+}
+
+func registerUnavailableRiskToolsWithMutations(reg *Registrar, mutations *RiskMutationHandlers) {
+	registerUnavailableRiskToolsWithCatalogAndMutations(reg, policycatalog.Build, mutations)
 }
 
 func registerUnavailableRiskToolsWithCatalog(reg *Registrar, buildCatalog func() (policycatalog.Catalog, error)) {
+	registerUnavailableRiskToolsWithCatalogAndMutations(reg, buildCatalog, nil)
+}
+
+func registerUnavailableRiskToolsWithCatalogAndMutations(reg *Registrar, buildCatalog func() (policycatalog.Catalog, error), mutations *RiskMutationHandlers) {
 	for _, tool := range []struct {
 		name, title, description string
 		schema                   *jsonschema.Schema
@@ -71,10 +82,46 @@ func registerUnavailableRiskToolsWithCatalog(reg *Registrar, buildCatalog func()
 		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, Annotations: readOnlyAnnotations(), InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, unavailableTool("risk_reads"))
 	}
 	catalog, err := buildCatalog()
-	registerRiskMutationStubs(reg, catalog, err == nil)
+	registerRiskMutationHandlers(reg, catalog, err == nil, mutations)
 }
 
-func registerRiskMutationStubs(reg *Registrar, catalog policycatalog.Catalog, catalogAvailable bool) {
+type RiskMutationToolReceipt struct {
+	ID       string `json:"id"`
+	Replayed bool   `json:"replayed"`
+}
+
+type CreateRiskPolicyToolOutput struct {
+	CreateRiskPolicyReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type UpdateRiskPolicyToolOutput struct {
+	UpdateRiskPolicyReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type CreateRiskExclusionToolOutput struct {
+	CreateRiskExclusionReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type UpdateRiskExclusionToolOutput struct {
+	UpdateRiskExclusionReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+// RiskMutationHandlers names the four final live callbacks without enabling
+// them. Every callback has an exported success type that composition code can
+// construct, while the schemas remain owned by this package.
+type RiskMutationHandlers struct {
+	Controls        *RiskMutationControls
+	CreatePolicy    mcp.ToolHandlerFor[map[string]any, CreateRiskPolicyToolOutput]
+	UpdatePolicy    mcp.ToolHandlerFor[map[string]any, UpdateRiskPolicyToolOutput]
+	CreateExclusion mcp.ToolHandlerFor[map[string]any, CreateRiskExclusionToolOutput]
+	UpdateExclusion mcp.ToolHandlerFor[map[string]any, UpdateRiskExclusionToolOutput]
+}
+
+func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog, catalogAvailable bool, handlers *RiskMutationHandlers) {
 	createPolicySchema := fallbackCreateRiskPolicySchema()
 	updatePolicySchema := fallbackUpdateRiskPolicySchema()
 	createExclusionSchema := fallbackCreateRiskExclusionSchema()
@@ -83,16 +130,43 @@ func registerRiskMutationStubs(reg *Registrar, catalog policycatalog.Catalog, ca
 		updatePolicySchema = updateRiskPolicySchema(catalog)
 		createExclusionSchema = createRiskExclusionSchema(catalog)
 	}
-	for _, tool := range []struct {
-		name, title, description string
-		schema                   *jsonschema.Schema
-	}{
-		{"create_risk_policy", "Create Risk Policy", "Create a risk policy in an explicit project. Risk mutations are not enabled in this rollout.", createPolicySchema},
-		{"update_risk_policy", "Update Risk Policy", "Patch a risk policy in an explicit project using an opaque expected version. Risk mutations are not enabled in this rollout.", updatePolicySchema},
-		{"create_risk_exclusion", "Create Risk Exclusion", "Create a non-regex risk exclusion in an explicit project. Risk mutations are not enabled in this rollout.", createExclusionSchema},
-		{"update_risk_exclusion", "Update Risk Exclusion", "Enable or disable one risk exclusion without changing its definition. Risk mutations are not enabled in this rollout.", updateRiskExclusionSchema()},
-	} {
-		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("risk_mutations"))
+	createPolicy := unavailableRiskMutationTool[CreateRiskPolicyToolOutput]()
+	updatePolicy := unavailableRiskMutationTool[UpdateRiskPolicyToolOutput]()
+	createExclusion := unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()
+	updateExclusion := unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()
+	if handlers != nil && handlers.Controls != nil {
+		if handlers.CreatePolicy != nil {
+			createPolicy = handlers.CreatePolicy
+		}
+		if handlers.UpdatePolicy != nil {
+			updatePolicy = handlers.UpdatePolicy
+		}
+		if handlers.CreateExclusion != nil {
+			createExclusion = handlers.CreateExclusion
+		}
+		if handlers.UpdateExclusion != nil {
+			updateExclusion = handlers.UpdateExclusion
+		}
+	}
+	meta := ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}
+	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: "Create a risk policy in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createPolicySchema}, meta, createPolicy)
+	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: "Patch a risk policy in an explicit project using an opaque expected version. Risk mutations are not enabled in this rollout.", InputSchema: updatePolicySchema}, meta, updatePolicy)
+	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: "Create a non-regex risk exclusion in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createExclusionSchema}, meta, createExclusion)
+	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: "Enable or disable one risk exclusion without changing its definition. Risk mutations are not enabled in this rollout.", InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
+}
+
+func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, Out] {
+	return func(_ context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, Out, error) {
+		var zero Out
+		result := featureUnavailableResult{Code: unavailableCode, Feature: "risk_mutations", Message: "This Platform MCP capability is not enabled for the current rollout."}
+		content, err := json.Marshal(result)
+		if err != nil {
+			return nil, zero, fmt.Errorf("encode unavailable risk mutation result: %w", err)
+		}
+		// Return a tool error rather than an existing IsError result. The MCP SDK
+		// short-circuits on errors before marshaling the typed zero Out value, so
+		// disabled tools emit no empty structured success fields.
+		return nil, zero, &ToolRefusalError{Payload: string(content)}
 	}
 }
 

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -149,6 +149,10 @@ type operationBudgetResult struct {
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+}
+
+func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -176,9 +180,9 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 
 	registerReadTools(reg, reader, cursorKeyMaterial)
 	if postgresReader, ok := reader.(*PostgresReader); ok {
-		registerRiskTools(reg, postgresReader.riskReads)
+		registerRiskToolsWithMutations(reg, postgresReader.riskReads, riskMutations)
 	} else {
-		registerUnavailableRiskTools(reg)
+		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
 	}
 	registerSetupResources(reg, setupResources, time.Now)
 	if registrations == nil || !registrations.budgets.Docs.valid() {


### PR DESCRIPTION
## Why

AGE-3168 needs reusable safety controls before Platform MCP can activate risk policy or exclusion writes. This stacked PR builds those controls without releasing write capability.

## What changed

- Added an exact-project, fail-closed `platform-mcp-risk-mutations` flag gate and shared 5/50 mutation budgets for OAuth and connectionless assistant calls.
- Added bounded operation receipt payloads, canonical input hashing, exact replay/conflict handling, and a transaction callback that keeps receipt, domain, and audit writes atomic.
- Added opaque HMAC policy/exclusion versions covering enforcement state while excluding volatile read progress.
- Added runtime handler-selection plumbing; all four risk mutation tools still return the existing stable `feature_unavailable` refusal.

## Review notes

- This PR is stacked on the risk-read PR; review the receipt transaction in `server/internal/platformmcp/risk_mutation_receipt.go` and the fail-closed admission path in `server/internal/platformmcp/risk_mutation_controls.go` most closely.
- Policy and exclusion write handlers remain intentionally out of scope for this PR.
- No schema migration is included; the pre-existing `result_payload` column is now used by generated SQLc methods.

## Testing

- `mise run test:server ./internal/platformmcp -run 'TestRiskMutation|TestRiskVersion|TestOperationBudget|TestRiskToolRegistration|TestUnavailableRiskToolRegistration'` — passed, 23 tests.
- `mise lint:server` — passed.
- `mise build:server --readonly` — passed.
- Affected Platform MCP, assistant adapter, and server command test packages compile with `go test -c`.
- Independent review completed; its policy-version progress-field finding was fixed and revalidated.

## Rollout / deployment notes

- No write capability is released. Keep `platform-mcp-risk-mutations` absent or disabled until the follow-up policy mutation PR.
