### PR TITLE
feat: let platform administrators name a Gram-project service account on an organization GCP credential

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -408,6 +408,8 @@ const (
 	WorkOSSSOEnabledKey               = attribute.Key("gram.workos.sso_enabled")
 	WorkOSSCIMEnabledKey              = attribute.Key("gram.workos.scim_enabled")
 	WorkOSDirectoryUserIDKey          = attribute.Key("gram.workos.directory_user_id")
+	ExternalCredentialIDKey           = attribute.Key("gram.external_credential.id")
+	GCPImpersonateServiceAccountKey   = attribute.Key("gram.gcp.impersonate_service_account")
 	WorkOSDirectoryGroupIDKey         = attribute.Key("gram.workos.directory_group_id")
 	OutcomeKey                        = attribute.Key("gram.outcome")
 	PackageNameKey                    = attribute.Key("gram.package.name")
@@ -1612,6 +1614,18 @@ func SlogWorkOSOrganizationID(v string) slog.Attr {
 
 func WorkOSUserID(v string) attribute.KeyValue { return WorkOSUserIDKey.String(v) }
 func SlogWorkOSUserID(v string) slog.Attr      { return slog.String(string(WorkOSUserIDKey), v) }
+
+func ExternalCredentialID(v string) attribute.KeyValue { return ExternalCredentialIDKey.String(v) }
+func SlogExternalCredentialID(v string) slog.Attr {
+	return slog.String(string(ExternalCredentialIDKey), v)
+}
+
+func GCPImpersonateServiceAccount(v string) attribute.KeyValue {
+	return GCPImpersonateServiceAccountKey.String(v)
+}
+func SlogGCPImpersonateServiceAccount(v string) slog.Attr {
+	return slog.String(string(GCPImpersonateServiceAccountKey), v)
+}
 
 func WorkOSLinkedUserID(v string) attribute.KeyValue { return WorkOSLinkedUserIDKey.String(v) }
 func SlogWorkOSLinkedUserID(v string) slog.Attr {

--- a/server/internal/externalcredentials/adminhandlers.go
+++ b/server/internal/externalcredentials/adminhandlers.go
@@ -87,12 +87,17 @@ func (s *Service) CreateGcpIamPlatformCredential(ctx context.Context, payload *a
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating platform external credential").LogError(ctx, logger)
 	}
 
+	// The platform tier screens no impersonation target at all, so it has
+	// nothing to be exempted from. These rows also carry a NULL organization_id,
+	// which no external key can join to, so they are never screened at runtime
+	// either.
 	gcp, err := q.CreateGcpIamCredential(ctx, repo.CreateGcpIamCredentialParams{
 		ExternalCredentialID:      ec.ID,
 		ImpersonateServiceAccount: cols.ImpersonateServiceAccount,
 		WifPoolID:                 cols.WifPoolID,
 		WifProviderID:             cols.WifProviderID,
 		WifProjectNumber:          cols.WifProjectNumber,
+		SkipProjectVerification:   false,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating platform gcp iam credential").LogError(ctx, logger)
@@ -172,6 +177,7 @@ func (s *Service) UpdateGcpIamPlatformCredential(ctx context.Context, payload *a
 		WifPoolID:                 cols.WifPoolID,
 		WifProviderID:             cols.WifProviderID,
 		WifProjectNumber:          cols.WifProjectNumber,
+		SkipProjectVerification:   false,
 		ExternalCredentialID:      id,
 	})
 	if err != nil {

--- a/server/internal/externalcredentials/creategcpiamcredential_test.go
+++ b/server/internal/externalcredentials/creategcpiamcredential_test.go
@@ -62,6 +62,10 @@ func TestCreateGcpIamCredential_TargetInGramProjectRejected(t *testing.T) {
 		ImpersonateServiceAccount: gramProjectServiceAccount("someone-else"),
 	})
 	requireOopsCode(t, err, oops.CodeBadRequest)
+
+	// Only staff can lift this refusal, and the operator has no way to tell that
+	// from the refusal itself, so the message has to say where to go.
+	require.ErrorContains(t, err, "contact Speakeasy support")
 }
 
 func TestCreateGcpIamCredential_ForbiddenForReadOnly(t *testing.T) {

--- a/server/internal/externalcredentials/gcpprojectexemption_test.go
+++ b/server/internal/externalcredentials/gcpprojectexemption_test.go
@@ -1,0 +1,310 @@
+package externalcredentials_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/external_credentials"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// Speakeasy staff dogfood the feature against a service account in Gram's own
+// project, which is exactly what the screening refuses for everyone else.
+func TestCreateGcpIamCredential_PlatformAdminExemptsGramProjectTarget(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-staff-dogfood",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	require.Equal(t, gramProjectServiceAccount("internal"), *cred.ImpersonateServiceAccount)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, true)
+}
+
+// The exemption is not a blanket bypass of the screening: it forgives one
+// refusal. An address that cannot be placed in a project was never compared
+// against Gram's, so there is nothing to forgive.
+func TestCreateGcpIamCredential_PlatformAdminStillRefusedMalformedTarget(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	_, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-staff-malformed",
+		ImpersonateServiceAccount: "123456789012-compute@developer.gserviceaccount.com",
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// An ordinary target needs no exemption, so a platform administrator's write
+// must not stamp one on it. Recording the flag for every staff write would
+// grant a standing bypass to rows that never asked for one.
+func TestCreateGcpIamCredential_PlatformAdminRecordsNoExemptionForCustomerTarget(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-staff-ordinary-target",
+		ImpersonateServiceAccount: "signer@customer-project.iam.gserviceaccount.com",
+	})
+	require.NoError(t, err)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, false)
+}
+
+// The payload requires the impersonation target, so the dashboard resubmits it
+// even when the operator only edited the name. Without carrying the exemption
+// forward, an organization could never rename a credential staff had exempted.
+func TestUpdateGcpIamCredential_OrgAdminRenamesExemptedCredential(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	target := gramProjectServiceAccount("internal")
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-before-rename",
+		ImpersonateServiceAccount: target,
+	})
+	require.NoError(t, err)
+
+	renamed, err := ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-after-rename",
+		ImpersonateServiceAccount: target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "gcp-exempt-after-rename", renamed.Name)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, true)
+}
+
+// Capitalization is not a new identity. Re-submitting the same account cased
+// differently must not read as naming another one, which would re-impose the
+// refusal on an edit that changed nothing.
+func TestUpdateGcpIamCredential_ExemptionSurvivesCaseDifference(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-case",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+
+	updated, err := ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-case",
+		ImpersonateServiceAccount: gramProjectServiceAccount("INTERNAL"),
+	})
+	require.NoError(t, err)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, true)
+
+	// The caller may not change this target at all, so the approved spelling is
+	// what persists. Writing their capitalization back would let an edit that is
+	// required to be a no-op rewrite the identity the credential authenticates
+	// as, and GCP resolves a service account by an id that is lowercase-only.
+	require.Equal(t, gramProjectServiceAccount("internal"), *updated.ImpersonateServiceAccount)
+}
+
+// The exemption is pinned to the service account staff approved, so the edit
+// path cannot be turned into a probe for other internal service accounts.
+func TestUpdateGcpIamCredential_ExemptionDoesNotTransferToAnotherGramProjectTarget(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-pinned",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-pinned",
+		ImpersonateServiceAccount: gramProjectServiceAccount("someone-else"),
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, true)
+}
+
+// Moving the target away clears the exemption, so moving it back is refused.
+// The flag cannot be parked on a credential and recovered later.
+func TestUpdateGcpIamCredential_ExemptionLostByRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	target := gramProjectServiceAccount("internal")
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-round-trip",
+		ImpersonateServiceAccount: target,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-round-trip",
+		ImpersonateServiceAccount: "signer@customer-project.iam.gserviceaccount.com",
+	})
+	require.NoError(t, err)
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, false)
+
+	_, err = ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-round-trip",
+		ImpersonateServiceAccount: target,
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// A row that predates the screening carries no exemption, so re-saving it stays
+// refused. The carry-forward rule must not launder those rows into exempt ones.
+func TestUpdateGcpIamCredential_UnscreenedRowIsNotCarriedForward(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	created := createGCPUnscreenedCredentialDirect(t, ctx, ti, "gcp-legacy-unscreened")
+
+	_, err := ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        created.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-legacy-renamed",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// Verify reports what an exempted credential can actually do. Re-screening it
+// without the exemption would report a refusal no edit through this API could
+// clear.
+func TestVerifyGcpIamCredential_HonorsStoredExemption(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-verify",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+
+	result, err := ti.service.VerifyGcpIamCredential(orgAdmin(t, ctx), &gen.VerifyGcpIamCredentialPayload{
+		ID:           cred.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Verified)
+	require.Equal(t, gramProjectServiceAccount("internal"), *result.Principal)
+}
+
+// A platform administrator can also grant the exemption by editing an existing
+// credential, including lifting one written before the screening existed. The
+// log is the only durable record of that grant, so it has to fire here too.
+func TestUpdateGcpIamCredential_PlatformAdminGrantsExemptionOnUpdate(t *testing.T) {
+	t.Parallel()
+	ctx, ti, logs := newTestServiceWithLogs(t)
+
+	created := createGCPUnscreenedCredentialDirect(t, ctx, ti, "gcp-legacy-to-lift")
+	requireSkipProjectVerification(t, ctx, ti, created.ID, false)
+
+	_, err := ti.service.UpdateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        created.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-legacy-lifted",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+
+	requireSkipProjectVerification(t, ctx, ti, created.ID, true)
+	require.Contains(t, logs.String(), "exempted a gcp iam credential from own-project screening")
+}
+
+// Re-pointing an exempted credential at a second internal service account is a
+// new grant of a new pair, even though the stored column does not change. The
+// exemption is pinned to the pair, so a record keyed on the column alone would
+// let the second grant happen with nothing written down anywhere.
+func TestUpdateGcpIamCredential_RepointingExemptedCredentialIsANewGrant(t *testing.T) {
+	t.Parallel()
+	ctx, ti, logs := newTestServiceWithLogs(t)
+
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-repointed",
+		ImpersonateServiceAccount: gramProjectServiceAccount("internal"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(logs.String(), "exempted a gcp iam credential from own-project screening"))
+
+	updated, err := ti.service.UpdateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-repointed",
+		ImpersonateServiceAccount: gramProjectServiceAccount("second-internal"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, gramProjectServiceAccount("second-internal"), *updated.ImpersonateServiceAccount)
+
+	requireSkipProjectVerification(t, ctx, ti, cred.ID, true)
+	require.Equal(t, 2, strings.Count(logs.String(), "exempted a gcp iam credential from own-project screening"),
+		"re-pointing an exempted credential at another service account is a second grant")
+}
+
+// Carrying an existing exemption forward is not a grant, so a re-save that
+// changes nothing must stay silent. Logging every write by a platform
+// administrator would bury the grants among the re-saves.
+func TestUpdateGcpIamCredential_CarryingExemptionForwardIsNotLogged(t *testing.T) {
+	t.Parallel()
+	ctx, ti, logs := newTestServiceWithLogs(t)
+
+	target := gramProjectServiceAccount("internal")
+	cred, err := ti.service.CreateGcpIamCredential(withAdmin(t, orgAdmin(t, ctx)), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-resaved",
+		ImpersonateServiceAccount: target,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateGcpIamCredential(orgAdmin(t, ctx), &gen.UpdateGcpIamCredentialPayload{
+		ID:                        cred.ID,
+		SessionToken:              nil,
+		Name:                      "gcp-exempt-resaved-again",
+		ImpersonateServiceAccount: target,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, strings.Count(logs.String(), "exempted a gcp iam credential from own-project screening"),
+		"only the original grant is a grant")
+}
+
+// The support-contact suffix belongs to the one refusal staff can lift. A
+// malformed address is self-serve, so pointing the operator at a human queue
+// would be wrong.
+func TestCreateGcpIamCredential_MalformedTargetRefusalOffersNoSupportContact(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	_, err := ti.service.CreateGcpIamCredential(orgAdmin(t, ctx), &gen.CreateGcpIamCredentialPayload{
+		SessionToken:              nil,
+		Name:                      "gcp-malformed-no-support",
+		ImpersonateServiceAccount: "person@example.com",
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+	require.NotContains(t, err.Error(), "Speakeasy support")
+}

--- a/server/internal/externalcredentials/impl.go
+++ b/server/internal/externalcredentials/impl.go
@@ -129,23 +129,114 @@ func (s *Service) requireOrgAccess(ctx context.Context, scope authz.Scope) (*con
 	return authCtx, logger, nil
 }
 
+// priorTarget is a credential's impersonation state as already stored. Update
+// passes the row it is about to replace; create passes the zero value, having
+// nothing to carry forward.
+type priorTarget struct {
+	// ImpersonateServiceAccount is the target the stored row names.
+	ImpersonateServiceAccount string
+
+	// SkipProjectVerification is the stored exemption from the own-project
+	// refusal.
+	SkipProjectVerification bool
+}
+
+// impersonationDecision is what one write's screening settled: the target to
+// store, and whether the row carries the exemption from the own-project refusal.
+type impersonationDecision struct {
+	// Target is the trimmed service account the row should name.
+	Target string
+
+	// Exempt is what the row's skip_project_verification column should hold.
+	Exempt bool
+
+	// NewGrant reports that this write hands the credential an exemption it did
+	// not already hold for this same service account. It drives the log, which
+	// is the only durable record of the grant, so it tracks the pair the
+	// exemption is pinned to rather than the column alone: re-pointing an
+	// already-exempt credential at a second service account is a new grant even
+	// though the column does not change.
+	NewGrant bool
+}
+
 // resolveOrgImpersonationTarget validates the service account an organization
-// credential wants Gram to impersonate, returning the trimmed target.
-func (s *Service) resolveOrgImpersonationTarget(ctx context.Context, logger *slog.Logger, raw string) (string, error) {
+// credential wants Gram to impersonate, returning the trimmed target and
+// whether the row should record an exemption from the own-project refusal.
+//
+// Two callers may name a service account in Gram's own project. A platform
+// administrator may, which is how Speakeasy staff dogfood the feature against
+// an internal service account. And anyone may keep one a platform administrator
+// already approved, so long as they submit it unchanged: the update payload
+// replaces every column, so the dashboard resubmits the target even when the
+// operator only renamed the credential, and without this an exempted credential
+// could never be edited again by the organization that owns it.
+//
+// Carrying the exemption forward does not let it be laundered onto a different
+// identity, because it is pinned to the target rather than to the credential.
+// Naming any other service account in Gram's own project is screened as an
+// ordinary caller and refused, so the edit path cannot be used to probe which
+// internal service accounts Gram can impersonate. Moving the target away and
+// back refuses too: the intervening write records no exemption.
+func (s *Service) resolveOrgImpersonationTarget(ctx context.Context, logger *slog.Logger, raw string, isPlatformAdmin bool, prior priorTarget) (impersonationDecision, error) {
 	target := strings.TrimSpace(raw)
 	if target == "" {
-		return "", oops.E(oops.CodeBadRequest, nil, "impersonate_service_account is required").LogError(ctx, logger)
+		return impersonationDecision{}, oops.E(oops.CodeBadRequest, nil, "impersonate_service_account is required").LogError(ctx, logger)
 	}
 
-	reason, err := s.gcpIdentity.ImpersonationTargetProblem(ctx, logger, target)
+	kind, reason, err := s.gcpIdentity.ImpersonationTargetProblem(ctx, logger, target)
 	if err != nil {
-		return "", oops.E(oops.CodeUnexpected, err, "cannot validate impersonate_service_account right now, try again shortly").LogError(ctx, logger)
-	}
-	if reason != "" {
-		return "", oops.E(oops.CodeBadRequest, nil, "%s", reason).LogError(ctx, logger)
+		return impersonationDecision{}, oops.E(oops.CodeUnexpected, err, "cannot validate impersonate_service_account right now, try again shortly").LogError(ctx, logger)
 	}
 
-	return target, nil
+	switch kind {
+	case gcpauth.TargetOK:
+		return impersonationDecision{Target: target, Exempt: false, NewGrant: false}, nil
+
+	case gcpauth.TargetOwnProject:
+		// Compared case-insensitively so re-submitting the same account with
+		// different capitalization is not read as naming a new one, which would
+		// re-impose the refusal on an edit that changed nothing.
+		carried := prior.SkipProjectVerification && strings.EqualFold(target, strings.TrimSpace(prior.ImpersonateServiceAccount))
+		if !isPlatformAdmin && !carried {
+			return impersonationDecision{}, oops.E(oops.CodeBadRequest, nil, "%s; if you need this, contact Speakeasy support", reason).LogError(ctx, logger)
+		}
+
+		if carried {
+			// Persist the spelling that was approved rather than the one just
+			// submitted. The two differ only in case, and the caller may not
+			// change this target at all, so writing back their capitalization
+			// would let an edit that is required to be a no-op rewrite the
+			// identity the credential authenticates as.
+			return impersonationDecision{Target: strings.TrimSpace(prior.ImpersonateServiceAccount), Exempt: true, NewGrant: false}, nil
+		}
+
+		return impersonationDecision{Target: target, Exempt: true, NewGrant: true}, nil
+
+	case gcpauth.TargetMalformed:
+		return impersonationDecision{}, oops.E(oops.CodeBadRequest, nil, "%s", reason).LogError(ctx, logger)
+
+	default:
+		return impersonationDecision{}, oops.E(oops.CodeUnexpected, nil, "cannot validate impersonate_service_account right now, try again shortly").LogError(ctx, logger)
+	}
+}
+
+// logExemptionGranted records a credential gaining the exemption from the
+// own-project refusal. Only the transition is logged, not every write that
+// carries an existing exemption forward, so the grant stands out from the
+// re-saves that follow it.
+//
+// This log is the only durable record of the grant. The exemption is
+// deliberately absent from the audit snapshot and from every API surface,
+// because putting it there would show an organization a decision it cannot make
+// or undo. That leaves the actor and the organization it was exercised in
+// visible only here.
+func logExemptionGranted(ctx context.Context, logger *slog.Logger, authCtx *contextvalues.AuthContext, credentialID uuid.UUID, target string) {
+	logger.InfoContext(ctx, "platform admin exempted a gcp iam credential from own-project screening",
+		attr.SlogUserID(authCtx.UserID),
+		attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
+		attr.SlogExternalCredentialID(credentialID.String()),
+		attr.SlogGCPImpersonateServiceAccount(target),
+	)
 }
 
 // verifyDetailMaxLen bounds the provider text a failed probe echoes back. The
@@ -351,7 +442,10 @@ func (s *Service) CreateGcpIamCredential(ctx context.Context, payload *gen.Creat
 	// The organization tier is impersonation-only, so the WIF columns are never
 	// written here and resolveGcpColumns (which infers between all three modes)
 	// does not apply.
-	impersonate, err := s.resolveOrgImpersonationTarget(ctx, logger, payload.ImpersonateServiceAccount)
+	decision, err := s.resolveOrgImpersonationTarget(ctx, logger, payload.ImpersonateServiceAccount, authCtx.IsAdmin, priorTarget{
+		ImpersonateServiceAccount: "",
+		SkipProjectVerification:   false,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -375,10 +469,11 @@ func (s *Service) CreateGcpIamCredential(ctx context.Context, payload *gen.Creat
 
 	gcp, err := q.CreateGcpIamCredential(ctx, repo.CreateGcpIamCredentialParams{
 		ExternalCredentialID:      ec.ID,
-		ImpersonateServiceAccount: conv.ToPGText(impersonate),
+		ImpersonateServiceAccount: conv.ToPGText(decision.Target),
 		WifPoolID:                 pgtype.Text{String: "", Valid: false},
 		WifProviderID:             pgtype.Text{String: "", Valid: false},
 		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   decision.Exempt,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error creating gcp iam credential").LogError(ctx, logger)
@@ -400,6 +495,10 @@ func (s *Service) CreateGcpIamCredential(ctx context.Context, payload *gen.Creat
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving external credential").LogError(ctx, logger)
 	}
 
+	if decision.NewGrant {
+		logExemptionGranted(ctx, logger, authCtx, ec.ID, decision.Target)
+	}
+
 	return mv.BuildGcpIamCredentialView(ec, gcp), nil
 }
 
@@ -417,11 +516,6 @@ func (s *Service) UpdateGcpIamCredential(ctx context.Context, payload *gen.Updat
 	name := strings.TrimSpace(payload.Name)
 	if name == "" {
 		return nil, oops.E(oops.CodeBadRequest, nil, "name is required").LogError(ctx, logger)
-	}
-
-	impersonate, err := s.resolveOrgImpersonationTarget(ctx, logger, payload.ImpersonateServiceAccount)
-	if err != nil {
-		return nil, err
 	}
 
 	dbtx, err := s.db.Begin(ctx)
@@ -443,6 +537,24 @@ func (s *Service) UpdateGcpIamCredential(ctx context.Context, payload *gen.Updat
 		return nil, oops.E(oops.CodeUnexpected, err, "error loading gcp iam credential").LogError(ctx, logger)
 	}
 
+	// Screened after the row it may carry an exemption from has been read, since
+	// the decision depends on that row's target. The read takes no row lock and
+	// runs at READ COMMITTED, so a concurrent write can still land between it and
+	// the update below; that cannot produce an exemption for an unapproved
+	// service account, because carrying one forward demands an exact target
+	// match, but two racing edits can leave the later one's exemption standing.
+	//
+	// The screening resolves an ambient identity, which is memoized for the
+	// process lifetime, so this holds the transaction open across a network call
+	// at most once per process.
+	decision, err := s.resolveOrgImpersonationTarget(ctx, logger, payload.ImpersonateServiceAccount, authCtx.IsAdmin, priorTarget{
+		ImpersonateServiceAccount: current.GcpIamCredential.ImpersonateServiceAccount.String,
+		SkipProjectVerification:   current.GcpIamCredential.SkipProjectVerification,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	ec, err := q.UpdateExternalCredential(ctx, repo.UpdateExternalCredentialParams{
 		Name:           name,
 		ID:             id,
@@ -461,10 +573,11 @@ func (s *Service) UpdateGcpIamCredential(ctx context.Context, payload *gen.Updat
 	// precisely because impersonation is the only mode the form can express —
 	// there is no field the caller could omit and silently lose.
 	gcp, err := q.UpdateGcpIamCredential(ctx, repo.UpdateGcpIamCredentialParams{
-		ImpersonateServiceAccount: conv.ToPGText(impersonate),
+		ImpersonateServiceAccount: conv.ToPGText(decision.Target),
 		WifPoolID:                 pgtype.Text{String: "", Valid: false},
 		WifProviderID:             pgtype.Text{String: "", Valid: false},
 		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   decision.Exempt,
 		ExternalCredentialID:      id,
 	})
 	if err != nil {
@@ -487,6 +600,10 @@ func (s *Service) UpdateGcpIamCredential(ctx context.Context, payload *gen.Updat
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving external credential").LogError(ctx, logger)
+	}
+
+	if decision.NewGrant {
+		logExemptionGranted(ctx, logger, authCtx, id, decision.Target)
 	}
 
 	return mv.BuildGcpIamCredentialView(ec, gcp), nil
@@ -645,11 +762,16 @@ func (s *Service) VerifyGcpIamCredential(ctx context.Context, payload *gen.Verif
 	// can impersonate. A screening the server cannot evaluate is an error rather
 	// than an unverified result: reporting "not verified" would blame the
 	// customer's configuration for a fault on Gram's side.
-	reason, err := s.gcpIdentity.ImpersonationTargetProblem(ctx, logger, target)
+	//
+	// A row a platform administrator exempted is forgiven the own-project
+	// refusal, so probing it reports what it can actually do rather than a
+	// refusal no edit through this API can clear.
+	kind, reason, err := s.gcpIdentity.ImpersonationTargetProblem(ctx, logger, target)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "cannot verify this credential right now, try again shortly").LogError(ctx, logger)
 	}
-	if reason != "" {
+	exempted := kind == gcpauth.TargetOwnProject && row.GcpIamCredential.SkipProjectVerification
+	if kind != gcpauth.TargetOK && !exempted {
 		return &gen.VerifyCredentialResult{
 			Verified:  false,
 			Principal: conv.PtrEmpty(target),

--- a/server/internal/externalcredentials/queries.sql
+++ b/server/internal/externalcredentials/queries.sql
@@ -27,13 +27,15 @@ INSERT INTO gcp_iam_credentials (
   impersonate_service_account,
   wif_pool_id,
   wif_provider_id,
-  wif_project_number
+  wif_project_number,
+  skip_project_verification
 ) VALUES (
   @external_credential_id,
   sqlc.narg('impersonate_service_account'),
   sqlc.narg('wif_pool_id'),
   sqlc.narg('wif_provider_id'),
-  sqlc.narg('wif_project_number')
+  sqlc.narg('wif_project_number'),
+  @skip_project_verification
 )
 RETURNING *;
 
@@ -107,6 +109,7 @@ SET impersonate_service_account = sqlc.narg('impersonate_service_account'),
     wif_pool_id = sqlc.narg('wif_pool_id'),
     wif_provider_id = sqlc.narg('wif_provider_id'),
     wif_project_number = sqlc.narg('wif_project_number'),
+    skip_project_verification = @skip_project_verification,
     updated_at = clock_timestamp()
 WHERE external_credential_id = @external_credential_id
 RETURNING *;

--- a/server/internal/externalcredentials/repo/queries.sql.go
+++ b/server/internal/externalcredentials/repo/queries.sql.go
@@ -99,13 +99,15 @@ INSERT INTO gcp_iam_credentials (
   impersonate_service_account,
   wif_pool_id,
   wif_provider_id,
-  wif_project_number
+  wif_project_number,
+  skip_project_verification
 ) VALUES (
   $1,
   $2,
   $3,
   $4,
-  $5
+  $5,
+  $6
 )
 RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, skip_project_verification, created_at, updated_at
 `
@@ -116,6 +118,7 @@ type CreateGcpIamCredentialParams struct {
 	WifPoolID                 pgtype.Text
 	WifProviderID             pgtype.Text
 	WifProjectNumber          pgtype.Text
+	SkipProjectVerification   bool
 }
 
 func (q *Queries) CreateGcpIamCredential(ctx context.Context, arg CreateGcpIamCredentialParams) (GcpIamCredential, error) {
@@ -125,6 +128,7 @@ func (q *Queries) CreateGcpIamCredential(ctx context.Context, arg CreateGcpIamCr
 		arg.WifPoolID,
 		arg.WifProviderID,
 		arg.WifProjectNumber,
+		arg.SkipProjectVerification,
 	)
 	var i GcpIamCredential
 	err := row.Scan(
@@ -479,8 +483,9 @@ SET impersonate_service_account = $1,
     wif_pool_id = $2,
     wif_provider_id = $3,
     wif_project_number = $4,
+    skip_project_verification = $5,
     updated_at = clock_timestamp()
-WHERE external_credential_id = $5
+WHERE external_credential_id = $6
 RETURNING external_credential_id, external_credentials_provider, impersonate_service_account, wif_pool_id, wif_provider_id, wif_project_number, skip_project_verification, created_at, updated_at
 `
 
@@ -489,6 +494,7 @@ type UpdateGcpIamCredentialParams struct {
 	WifPoolID                 pgtype.Text
 	WifProviderID             pgtype.Text
 	WifProjectNumber          pgtype.Text
+	SkipProjectVerification   bool
 	ExternalCredentialID      uuid.UUID
 }
 
@@ -501,6 +507,7 @@ func (q *Queries) UpdateGcpIamCredential(ctx context.Context, arg UpdateGcpIamCr
 		arg.WifPoolID,
 		arg.WifProviderID,
 		arg.WifProjectNumber,
+		arg.SkipProjectVerification,
 		arg.ExternalCredentialID,
 	)
 	var i GcpIamCredential

--- a/server/internal/externalcredentials/setup_test.go
+++ b/server/internal/externalcredentials/setup_test.go
@@ -1,10 +1,14 @@
 package externalcredentials_test
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -64,24 +68,94 @@ type testInstance struct {
 	orgID       string
 }
 
+// orgAdmin returns ctx carrying the org:admin grant every credential mutation
+// requires. Platform administrators hold it too, so the staff tests wrap this
+// rather than replacing it.
+func orgAdmin(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+	return authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource))
+}
+
 // withAdmin returns ctx with the auth context's IsAdmin flag flipped to true.
 // Admin-only endpoints opt in explicitly so non-admin paths exercise the
 // realistic default produced by authztest.InitAuthContext.
+//
+// The flag is set on a copy. The context holds a pointer, so flipping it in
+// place would raise the caller's own context to admin as well, and a test that
+// went on to act as an ordinary administrator would silently keep the staff
+// privileges it meant to drop.
 func withAdmin(t *testing.T, ctx context.Context) context.Context {
 	t.Helper()
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
-	authCtx.IsAdmin = true
-	return contextvalues.SetAuthContext(ctx, authCtx)
+
+	elevated := *authCtx
+	elevated.IsAdmin = true
+
+	return contextvalues.SetAuthContext(ctx, &elevated)
+}
+
+// logCapture collects the service's log output so a test can assert on a record
+// that exists nowhere else. Guarded because slog handlers may be called from any
+// goroutine the service uses.
+type logCapture struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *logCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	n, err := c.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("capture log output: %w", err)
+	}
+
+	return n, nil
+}
+
+func (c *logCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
+	return newTestServiceWithLogger(t, testenv.NewLogger(t))
+}
+
+// newTestServiceWithLogs is newTestService with the service's logs captured. The
+// exemption grant is deliberately absent from the audit snapshot and from every
+// API surface, so its log line is the only evidence it happened and the only
+// thing a test can assert against.
+//
+// Only the tests that make that assertion use this: it swaps out the logger
+// testenv provides, which pretty-prints under `go test -v` and discards
+// otherwise.
+func newTestServiceWithLogs(t *testing.T) (context.Context, *testInstance, *logCapture) {
+	t.Helper()
+
+	logs := &logCapture{mu: sync.Mutex{}, buf: bytes.Buffer{}}
+	logger := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       slog.LevelInfo,
+		ReplaceAttr: nil,
+	}))
+
+	ctx, ti := newTestServiceWithLogger(t, logger)
+
+	return ctx, ti, logs
+}
+
+func newTestServiceWithLogger(t *testing.T, logger *slog.Logger) (context.Context, *testInstance) {
+	t.Helper()
+
 	ctx := t.Context()
 
-	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 
 	conn, err := infra.CloneTestDatabase(t, "testdb")
@@ -150,6 +224,23 @@ func gramProjectServiceAccount(name string) string {
 	return name + "@" + domain
 }
 
+// requireSkipProjectVerification asserts the stored exemption on a credential.
+// It reads the column straight from the database because no API surface returns
+// it: the server decides it and the organization never sees it.
+func requireSkipProjectVerification(t *testing.T, ctx context.Context, ti *testInstance, credentialID string, want bool) {
+	t.Helper()
+
+	id, err := uuid.Parse(credentialID)
+	require.NoError(t, err)
+
+	row, err := repo.New(ti.conn).GetGcpIamCredential(ctx, repo.GetGcpIamCredentialParams{
+		ID:             id,
+		OrganizationID: conv.ToPGText(ti.orgID),
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, row.GcpIamCredential.SkipProjectVerification)
+}
+
 func requireOopsCode(t *testing.T, err error, code oops.Code) {
 	t.Helper()
 
@@ -214,6 +305,22 @@ func createGCPWifCredentialDirect(t *testing.T, ctx context.Context, ti *testIns
 		WifPoolID:                 conv.ToPGText("gram-pool"),
 		WifProviderID:             conv.ToPGText("gram-provider"),
 		WifProjectNumber:          conv.ToPGText("123456789012"),
+	})
+}
+
+// createGCPUnscreenedCredentialDirect is a fixture for a row written before the
+// impersonation screening existed: it names a service account in Gram's own
+// project while carrying no exemption, which the API refuses to produce today.
+func createGCPUnscreenedCredentialDirect(t *testing.T, ctx context.Context, ti *testInstance, name string) *gen.GcpIamCredential {
+	t.Helper()
+
+	return createGCPCredentialDirect(t, ctx, ti, name, repo.CreateGcpIamCredentialParams{
+		ExternalCredentialID:      uuid.Nil,
+		ImpersonateServiceAccount: conv.ToPGText(gramProjectServiceAccount("internal")),
+		WifPoolID:                 pgtype.Text{String: "", Valid: false},
+		WifProviderID:             pgtype.Text{String: "", Valid: false},
+		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   false,
 	})
 }
 

--- a/server/internal/externalkeys/queries.sql
+++ b/server/internal/externalkeys/queries.sql
@@ -89,7 +89,8 @@ SELECT
   gic.impersonate_service_account,
   gic.wif_pool_id,
   gic.wif_provider_id,
-  gic.wif_project_number
+  gic.wif_project_number,
+  gic.skip_project_verification
 FROM external_keys AS ek
 JOIN gcp_kms_keys AS gcp ON gcp.external_key_id = ek.id
 LEFT JOIN external_credentials AS ec

--- a/server/internal/externalkeys/repo/queries.sql.go
+++ b/server/internal/externalkeys/repo/queries.sql.go
@@ -297,7 +297,8 @@ SELECT
   gic.impersonate_service_account,
   gic.wif_pool_id,
   gic.wif_provider_id,
-  gic.wif_project_number
+  gic.wif_project_number,
+  gic.skip_project_verification
 FROM external_keys AS ek
 JOIN gcp_kms_keys AS gcp ON gcp.external_key_id = ek.id
 LEFT JOIN external_credentials AS ec
@@ -327,6 +328,7 @@ type GetGcpKmsKeyForVerifyRow struct {
 	WifPoolID                 pgtype.Text
 	WifProviderID             pgtype.Text
 	WifProjectNumber          pgtype.Text
+	SkipProjectVerification   pgtype.Bool
 }
 
 // Loads everything the verify probe needs in one read: the key, its provider
@@ -374,6 +376,7 @@ func (q *Queries) GetGcpKmsKeyForVerify(ctx context.Context, arg GetGcpKmsKeyFor
 		&i.WifPoolID,
 		&i.WifProviderID,
 		&i.WifProjectNumber,
+		&i.SkipProjectVerification,
 	)
 	return i, err
 }

--- a/server/internal/externalkeys/verify.go
+++ b/server/internal/externalkeys/verify.go
@@ -167,6 +167,7 @@ func (s *Service) resolveVerifyIdentity(ctx context.Context, logger *slog.Logger
 		Present:                   row.CredentialID.Valid,
 		ImpersonateServiceAccount: row.ImpersonateServiceAccount.String,
 		HasWifConfig:              row.WifPoolID.Valid || row.WifProviderID.Valid || row.WifProjectNumber.Valid,
+		SkipProjectVerification:   row.SkipProjectVerification.Bool,
 	})
 	if err != nil {
 		return credential, "", "", oops.E(oops.CodeUnexpected, err, "cannot verify this key right now, try again shortly").LogError(ctx, logger)

--- a/server/internal/externalkeys/verifygcpkmskey_test.go
+++ b/server/internal/externalkeys/verifygcpkmskey_test.go
@@ -332,6 +332,35 @@ func TestVerifyGcpKmsKey_RescreensTargetInGramProject(t *testing.T) {
 	require.Equal(t, 0, ti.kms.Closed())
 }
 
+// A platform administrator can grant a credential an exemption from that same
+// refusal, which is how Speakeasy staff dogfood the feature. This path has no
+// request actor to consult, so the exemption has to be readable from the row:
+// without it the credential would save and then be refused on every probe.
+func TestVerifyGcpKmsKey_HonorsStoredProjectVerificationExemption(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredentialDirect(t, ctx, ti, "staff-exempted", extcredrepo.CreateGcpIamCredentialParams{
+		ExternalCredentialID:      uuid.Nil,
+		ImpersonateServiceAccount: conv.ToPGText(gramProjectServiceAccount("internal")),
+		WifPoolID:                 pgtype.Text{String: "", Valid: false},
+		WifProviderID:             pgtype.Text{String: "", Valid: false},
+		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   true,
+	})
+	key := createGcpKmsKey(t, ctx, ti, "behind-exempted-sa", credID)
+
+	result, err := ti.service.VerifyGcpKmsKey(adminCtx(t, ctx), &gen.VerifyGcpKmsKeyPayload{
+		ID:           key.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+
+	require.True(t, result.Verified)
+	require.Equal(t, "verified", result.ProbeOutcome)
+	require.Equal(t, 1, ti.kms.Closed())
+}
+
 // external_credentials.deleted is a generated column, so a soft delete never
 // fires the external_keys foreign key. The delete path now refuses to orphan a
 // key, but rows orphaned before that guard existed still resolve here, and they

--- a/server/internal/jsonwebkeysets/gcpprojectexemption_test.go
+++ b/server/internal/jsonwebkeysets/gcpprojectexemption_test.go
@@ -1,0 +1,68 @@
+package jsonwebkeysets_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/json_web_key_sets"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	extcredrepo "github.com/speakeasy-api/gram/server/internal/externalcredentials/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// Minting signs with the credential's identity, so a key backed by a service
+// account in Gram's own project would sign as an internal identity on behalf of
+// a customer. Creating a set mints its first key, so the screening refuses the
+// set outright.
+func TestCreateSet_RefusesTargetInGramProject(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredentialDirect(t, ctx, ti, "legacy-unscreened", extcredrepo.CreateGcpIamCredentialParams{
+		ExternalCredentialID:      uuid.Nil,
+		ImpersonateServiceAccount: conv.ToPGText(gramProjectServiceAccount("internal")),
+		WifPoolID:                 pgtype.Text{String: "", Valid: false},
+		WifProviderID:             pgtype.Text{String: "", Valid: false},
+		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   false,
+	})
+	ek := createGcpKmsKey(t, ctx, ti, "behind-internal-sa", credID)
+
+	_, err := ti.service.CreateSet(adminCtx(t, ctx), &gen.CreateSetPayload{
+		SessionToken:  nil,
+		Name:          "refused",
+		ExternalKeyID: ek.ID,
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// A platform administrator can grant that credential an exemption. Minting runs
+// with no request actor, so it has to read the grant from the row: otherwise the
+// credential would save and then fail on every signature it was created for.
+// Both mint sites are covered here, since creating the set mints once and
+// publishing into it mints again.
+func TestPublishKey_HonorsStoredProjectVerificationExemption(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredentialDirect(t, ctx, ti, "staff-exempted", extcredrepo.CreateGcpIamCredentialParams{
+		ExternalCredentialID:      uuid.Nil,
+		ImpersonateServiceAccount: conv.ToPGText(gramProjectServiceAccount("internal")),
+		WifPoolID:                 pgtype.Text{String: "", Valid: false},
+		WifProviderID:             pgtype.Text{String: "", Valid: false},
+		WifProjectNumber:          pgtype.Text{String: "", Valid: false},
+		SkipProjectVerification:   true,
+	})
+	ek := createGcpKmsKey(t, ctx, ti, "behind-exempted-sa", credID)
+	set := createSet(t, ctx, ti, "exempted", ek.ID)
+
+	published, err := ti.service.PublishKey(adminCtx(t, ctx), &gen.PublishKeyPayload{
+		SetID:        set.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ek.ID, published.ExternalKeyID)
+}

--- a/server/internal/jsonwebkeysets/mint.go
+++ b/server/internal/jsonwebkeysets/mint.go
@@ -122,6 +122,7 @@ func (s *Service) mintFromExternalKey(ctx context.Context, logger *slog.Logger, 
 		Present:                   row.CredentialID.Valid,
 		ImpersonateServiceAccount: row.ImpersonateServiceAccount.String,
 		HasWifConfig:              row.WifPoolID.Valid || row.WifProviderID.Valid || row.WifProjectNumber.Valid,
+		SkipProjectVerification:   row.SkipProjectVerification.Bool,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "cannot publish a key right now, try again shortly").LogError(ctx, logger)

--- a/server/internal/jsonwebkeysets/queries.sql
+++ b/server/internal/jsonwebkeysets/queries.sql
@@ -20,7 +20,8 @@ SELECT
   gic.impersonate_service_account,
   gic.wif_pool_id,
   gic.wif_provider_id,
-  gic.wif_project_number
+  gic.wif_project_number,
+  gic.skip_project_verification
 FROM external_keys AS ek
 LEFT JOIN gcp_kms_keys AS gcp ON gcp.external_key_id = ek.id
 LEFT JOIN external_credentials AS ec

--- a/server/internal/jsonwebkeysets/repo/queries.sql.go
+++ b/server/internal/jsonwebkeysets/repo/queries.sql.go
@@ -247,7 +247,8 @@ SELECT
   gic.impersonate_service_account,
   gic.wif_pool_id,
   gic.wif_provider_id,
-  gic.wif_project_number
+  gic.wif_project_number,
+  gic.skip_project_verification
 FROM external_keys AS ek
 LEFT JOIN gcp_kms_keys AS gcp ON gcp.external_key_id = ek.id
 LEFT JOIN external_credentials AS ec
@@ -277,6 +278,7 @@ type GetExternalKeyForMintRow struct {
 	WifPoolID                 pgtype.Text
 	WifProviderID             pgtype.Text
 	WifProjectNumber          pgtype.Text
+	SkipProjectVerification   pgtype.Bool
 }
 
 // Loads everything the mint path needs in one read, before the write
@@ -315,6 +317,7 @@ func (q *Queries) GetExternalKeyForMint(ctx context.Context, arg GetExternalKeyF
 		&i.WifPoolID,
 		&i.WifProviderID,
 		&i.WifProjectNumber,
+		&i.SkipProjectVerification,
 	)
 	return i, err
 }

--- a/server/internal/jsonwebkeysets/setup_test.go
+++ b/server/internal/jsonwebkeysets/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -283,6 +284,36 @@ func createGcpIamCredential(t *testing.T, ctx context.Context, ti *testInstance,
 	require.NotNil(t, cred)
 
 	return cred.ID
+}
+
+// gramProjectServiceAccount builds a service account address inside the same
+// project the stub resolver reports as Gram's own, which is what the
+// impersonation screening refuses. Derived from the stub's constant so these
+// tests cannot drift from it.
+func gramProjectServiceAccount(name string) string {
+	_, domain, _ := strings.Cut(gcpauth.StubResolverPrincipal, "@")
+	return name + "@" + domain
+}
+
+// createGcpIamCredentialDirect writes a credential straight through the repo,
+// so tests can build rows the credential API refuses to produce.
+func createGcpIamCredentialDirect(t *testing.T, ctx context.Context, ti *testInstance, name string, gcpParams extcredrepo.CreateGcpIamCredentialParams) string {
+	t.Helper()
+
+	q := extcredrepo.New(ti.conn)
+
+	ec, err := q.CreateExternalCredential(ctx, extcredrepo.CreateExternalCredentialParams{
+		OrganizationID: conv.ToPGText(ti.orgID),
+		Provider:       "gcp_iam",
+		Name:           name,
+	})
+	require.NoError(t, err)
+
+	gcpParams.ExternalCredentialID = ec.ID
+	_, err = q.CreateGcpIamCredential(ctx, gcpParams)
+	require.NoError(t, err)
+
+	return ec.ID.String()
 }
 
 // createGcpKmsKey is a fixture: a gcp_kms external key backed by the given

--- a/server/internal/thirdparty/gcp/gcpauth/identity.go
+++ b/server/internal/thirdparty/gcp/gcpauth/identity.go
@@ -125,12 +125,46 @@ func (i *Identity) GramPrincipal(ctx context.Context) (string, error) {
 	return principal.Email, nil
 }
 
-// ImpersonationTargetProblem reports why a target must not be impersonated, or
-// "" when it is acceptable. A non-nil error means the policy could not be
-// evaluated at all, which callers must never treat as acceptance: the screening
-// exists because Gram publishes its own service account by design, so without it
-// an organization member could name an internal service account and use a verify
-// probe to discover which ones Gram holds impersonation rights on.
+// TargetProblemKind classifies why an impersonation target must not be used.
+//
+// It exists so a caller can tell the two refusals apart without matching on
+// message text: one of them is exemptible by a platform administrator and the
+// other never is, and a screening decision that turned on the wording of a
+// sentence would break the moment that sentence was reworded.
+type TargetProblemKind string
+
+const (
+	// TargetUnknown is the zero value, returned only alongside an error. It is
+	// deliberately not the acceptable case: a caller who reads the kind without
+	// checking the error gets a value that no acceptance test matches, so a
+	// screening that could not be evaluated fails closed rather than reading as
+	// permission.
+	TargetUnknown TargetProblemKind = ""
+
+	// TargetOK means the target may be impersonated.
+	TargetOK TargetProblemKind = "ok"
+
+	// TargetMalformed means the target is not a user-managed service account
+	// address, so it cannot be placed in a project at all. No exemption applies
+	// to it: a target that cannot be placed cannot be screened.
+	TargetMalformed TargetProblemKind = "malformed"
+
+	// TargetOwnProject means the target names a service account in this
+	// deployment's own GCP project, which ordinary callers must never reach.
+	TargetOwnProject TargetProblemKind = "own_project"
+)
+
+// ImpersonationTargetProblem classifies why a target must not be impersonated,
+// returning TargetOK when it is acceptable. The accompanying reason explains the
+// refusal in terms the target's owner can act on and is empty when the kind is
+// TargetOK.
+//
+// A non-nil error means the policy could not be evaluated at all, which callers
+// must never treat as acceptance: the screening exists because this deployment
+// publishes its own service account by design, so without it an organization
+// member could name an internal service account and use a verify probe to
+// discover which ones it holds impersonation rights on. Only one of the three
+// return paths is ever meaningful at a time.
 //
 // Both sides of the comparison have to be a user-managed address for it to mean
 // anything. Google's default compute and App Engine service accounts identify
@@ -139,14 +173,14 @@ func (i *Identity) GramPrincipal(ctx context.Context) (string, error) {
 //
 // The logger is taken per call rather than held on the identity so the refusal
 // lands with the caller's request-scoped attributes.
-func (i *Identity) ImpersonationTargetProblem(ctx context.Context, logger *slog.Logger, target string) (string, error) {
+func (i *Identity) ImpersonationTargetProblem(ctx context.Context, logger *slog.Logger, target string) (TargetProblemKind, string, error) {
 	if serviceAccountProject(target) == "" {
-		return "impersonate_service_account must be a user-managed service account (name@PROJECT_ID.iam.gserviceaccount.com)", nil
+		return TargetMalformed, "impersonate_service_account must be a user-managed service account (name@PROJECT_ID.iam.gserviceaccount.com)", nil
 	}
 
 	gramSA, err := i.GramPrincipal(ctx)
 	if err != nil {
-		return "", fmt.Errorf("resolve gram's own gcp identity to screen impersonation target: %w", err)
+		return TargetUnknown, "", fmt.Errorf("resolve gram's own gcp identity to screen impersonation target: %w", err)
 	}
 
 	gramProject := serviceAccountProject(gramSA)
@@ -158,14 +192,14 @@ func (i *Identity) ImpersonationTargetProblem(ctx context.Context, logger *slog.
 		// Gram a dedicated service account) rather than a hole to leave open.
 		logger.ErrorContext(ctx, "gram's own gcp identity is not a user-managed service account, cannot screen impersonation targets",
 			attr.SlogError(errors.New("unrecognized service account form")))
-		return "", fmt.Errorf("gram's own gcp identity %q is not a user-managed service account", gramSA)
+		return TargetUnknown, "", fmt.Errorf("gram's own gcp identity %q is not a user-managed service account", gramSA)
 	}
 
 	if serviceAccountProject(target) == gramProject {
-		return "impersonate_service_account must be a service account in your own GCP project", nil
+		return TargetOwnProject, "impersonate_service_account must be a service account in your own GCP project", nil
 	}
 
-	return "", nil
+	return TargetOK, "", nil
 }
 
 // serviceAccountProject extracts the project id from a user-managed GCP service

--- a/server/internal/thirdparty/gcp/gcpauth/identity_test.go
+++ b/server/internal/thirdparty/gcp/gcpauth/identity_test.go
@@ -102,9 +102,10 @@ func TestIdentity_ImpersonationTargetProblemAccepts(t *testing.T) {
 
 	identity := gcpauth.NewIdentity(newCountingResolver())
 
-	reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
+	kind, reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
 	require.NoError(t, err)
-	require.Empty(t, reason, "a user-managed service account in someone else's project is acceptable")
+	require.Equal(t, gcpauth.TargetOK, kind, "a user-managed service account in someone else's project is acceptable")
+	require.Empty(t, reason)
 }
 
 // The screening exists because Gram publishes its own service account, so a
@@ -114,8 +115,9 @@ func TestIdentity_ImpersonationTargetProblemRefusesGramProject(t *testing.T) {
 
 	identity := gcpauth.NewIdentity(newCountingResolver())
 
-	reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "internal@gram-stub.iam.gserviceaccount.com")
+	kind, reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "internal@gram-stub.iam.gserviceaccount.com")
 	require.NoError(t, err)
+	require.Equal(t, gcpauth.TargetOwnProject, kind)
 	require.Contains(t, reason, "your own GCP project")
 }
 
@@ -141,14 +143,16 @@ func TestIdentity_ImpersonationTargetProblemRefusesUnplaceable(t *testing.T) {
 		"service-123456789012@compute-system.iam.gserviceaccount.com",
 		"123456789012@cloudservices.iam.gserviceaccount.com",
 	} {
-		reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), target)
+		kind, reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), target)
 		require.NoError(t, err, "%q", target)
+		require.Equal(t, gcpauth.TargetMalformed, kind, "%q must be refused", target)
 		require.Contains(t, reason, "user-managed service account", "%q must be refused", target)
 	}
 }
 
-// A screening the server cannot evaluate is an error, never an acceptance.
-// Callers must not be able to read "" (acceptable) out of a failed evaluation.
+// A screening the server cannot evaluate is an error, never an acceptance. The
+// kind returned alongside it carries no meaning, so nothing here asserts one:
+// the error is the whole of what a caller may act on.
 func TestIdentity_ImpersonationTargetProblemErrorsWhenUnevaluatable(t *testing.T) {
 	t.Parallel()
 
@@ -158,7 +162,7 @@ func TestIdentity_ImpersonationTargetProblemErrorsWhenUnevaluatable(t *testing.T
 	})
 	identity := gcpauth.NewIdentity(resolver)
 
-	reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
+	_, reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
 	require.Error(t, err)
 	require.Empty(t, reason)
 }
@@ -174,7 +178,7 @@ func TestIdentity_ImpersonationTargetProblemErrorsWhenGramIsUnplaceable(t *testi
 	})
 	identity := gcpauth.NewIdentity(resolver)
 
-	reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
+	_, reason, err := identity.ImpersonationTargetProblem(t.Context(), testenv.NewLogger(t), "signer@customer-project.iam.gserviceaccount.com")
 	require.Error(t, err)
 	require.Empty(t, reason)
 }

--- a/server/internal/thirdparty/gcp/gcpauth/stored_credential.go
+++ b/server/internal/thirdparty/gcp/gcpauth/stored_credential.go
@@ -42,6 +42,17 @@ type StoredCredential struct {
 	// HasWifConfig reports whether any Workload Identity Federation column is
 	// still set on the row.
 	HasWifConfig bool
+
+	// SkipProjectVerification exempts this credential from the refusal of
+	// targets in this deployment's own GCP project, which a platform
+	// administrator granted when the row was written. The exemption is recorded
+	// on the row because this screening also runs where no request actor exists
+	// to consult.
+	//
+	// It must always be read from the stored column. Writing a literal true at a
+	// call site grants the exemption to a credential nobody approved, which is
+	// the whole of what the screening prevents.
+	SkipProjectVerification bool
 }
 
 // ScreenStoredCredential settles which identity an outbound GCP call should
@@ -66,6 +77,12 @@ type StoredCredential struct {
 // earlier can still name a service account in Gram's own project — and an
 // endpoint would then authenticate as it against a caller-supplied resource
 // name, which is an inventory oracle for Gram's own GCP estate.
+//
+// A row carrying SkipProjectVerification is forgiven that final refusal, and
+// only that one. The screening still runs in full: forgiving a classified
+// refusal rather than skipping the comparison costs nothing here, because this
+// path resolves the ambient identity on every call regardless, and it keeps the
+// exemption from widening to a malformed address.
 func (i *Identity) ScreenStoredCredential(ctx context.Context, logger *slog.Logger, stored StoredCredential) (Credential, StoredCredentialProblem, string, error) {
 	if !stored.Present {
 		return noCredential(), StoredCredentialDeleted, "the backing credential for this key was deleted; point the key at a live credential", nil
@@ -78,11 +95,12 @@ func (i *Identity) ScreenStoredCredential(ctx context.Context, logger *slog.Logg
 		return noCredential(), StoredCredentialUnusable, "the backing credential still uses Workload Identity Federation, which cannot be used; save it again to convert it to impersonation", nil
 	}
 
-	reason, err := i.ImpersonationTargetProblem(ctx, logger, stored.ImpersonateServiceAccount)
+	kind, reason, err := i.ImpersonationTargetProblem(ctx, logger, stored.ImpersonateServiceAccount)
 	if err != nil {
 		return noCredential(), "", "", err
 	}
-	if reason != "" {
+	exempted := kind == TargetOwnProject && stored.SkipProjectVerification
+	if kind != TargetOK && !exempted {
 		return noCredential(), StoredCredentialUnusable, reason, nil
 	}
 

--- a/server/internal/thirdparty/gcp/gcpauth/stored_credential_test.go
+++ b/server/internal/thirdparty/gcp/gcpauth/stored_credential_test.go
@@ -1,0 +1,131 @@
+package gcpauth_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/gcp/gcpauth"
+)
+
+// gramProjectTarget is a user-managed service account inside the same project as
+// StubResolverPrincipal, so the screening places it in Gram's own project.
+const gramProjectTarget = "internal@gram-stub.iam.gserviceaccount.com"
+
+func TestScreenStoredCredential_AcceptsCustomerTarget(t *testing.T) {
+	t.Parallel()
+
+	identity := gcpauth.NewIdentity(gcpauth.NewStubResolver())
+
+	credential, problem, detail, err := identity.ScreenStoredCredential(t.Context(), testenv.NewLogger(t), gcpauth.StoredCredential{
+		Present:                   true,
+		ImpersonateServiceAccount: "signer@customer-project.iam.gserviceaccount.com",
+		HasWifConfig:              false,
+		SkipProjectVerification:   false,
+	})
+	require.NoError(t, err)
+	require.Empty(t, problem)
+	require.Empty(t, detail)
+	require.Equal(t, "signer@customer-project.iam.gserviceaccount.com", credential.ImpersonateServiceAccount)
+}
+
+// The outbound path has no request actor, so the exemption a platform
+// administrator granted has to be readable from the row. Without this the
+// credential would save and then be refused on every mint and every verify.
+func TestScreenStoredCredential_ExemptionAllowsGramProjectTarget(t *testing.T) {
+	t.Parallel()
+
+	identity := gcpauth.NewIdentity(gcpauth.NewStubResolver())
+
+	credential, problem, detail, err := identity.ScreenStoredCredential(t.Context(), testenv.NewLogger(t), gcpauth.StoredCredential{
+		Present:                   true,
+		ImpersonateServiceAccount: gramProjectTarget,
+		HasWifConfig:              false,
+		SkipProjectVerification:   true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, problem)
+	require.Empty(t, detail)
+	require.Equal(t, gramProjectTarget, credential.ImpersonateServiceAccount)
+}
+
+func TestScreenStoredCredential_RefusesGramProjectTargetWithoutExemption(t *testing.T) {
+	t.Parallel()
+
+	identity := gcpauth.NewIdentity(gcpauth.NewStubResolver())
+
+	_, problem, detail, err := identity.ScreenStoredCredential(t.Context(), testenv.NewLogger(t), gcpauth.StoredCredential{
+		Present:                   true,
+		ImpersonateServiceAccount: gramProjectTarget,
+		HasWifConfig:              false,
+		SkipProjectVerification:   false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gcpauth.StoredCredentialUnusable, problem)
+	require.Contains(t, detail, "your own GCP project")
+}
+
+// The exemption covers the own-project refusal and nothing else. A target that
+// cannot be placed in a project at all was never compared against Gram's, so
+// forgiving it would widen the grant to addresses no administrator approved.
+func TestScreenStoredCredential_ExemptionDoesNotForgiveMalformedTarget(t *testing.T) {
+	t.Parallel()
+
+	identity := gcpauth.NewIdentity(gcpauth.NewStubResolver())
+
+	for _, target := range []string{
+		"123456789012-compute@developer.gserviceaccount.com",
+		"person@example.com",
+		"service-123456789012@gcp-sa-cloudkms.iam.gserviceaccount.com",
+	} {
+		_, problem, detail, err := identity.ScreenStoredCredential(t.Context(), testenv.NewLogger(t), gcpauth.StoredCredential{
+			Present:                   true,
+			ImpersonateServiceAccount: target,
+			HasWifConfig:              false,
+			SkipProjectVerification:   true,
+		})
+		require.NoError(t, err, "%q", target)
+		require.Equal(t, gcpauth.StoredCredentialUnusable, problem, "%q must stay refused", target)
+		require.Contains(t, detail, "user-managed service account", "%q", target)
+	}
+}
+
+// The steps above the screening are more fundamental than it, so the exemption
+// must not carry a row past them.
+func TestScreenStoredCredential_ExemptionDoesNotForgiveUnusableRows(t *testing.T) {
+	t.Parallel()
+
+	identity := gcpauth.NewIdentity(gcpauth.NewStubResolver())
+	logger := testenv.NewLogger(t)
+
+	_, problem, detail, err := identity.ScreenStoredCredential(t.Context(), logger, gcpauth.StoredCredential{
+		Present:                   false,
+		ImpersonateServiceAccount: gramProjectTarget,
+		HasWifConfig:              false,
+		SkipProjectVerification:   true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gcpauth.StoredCredentialDeleted, problem)
+	require.Contains(t, detail, "deleted")
+
+	_, problem, detail, err = identity.ScreenStoredCredential(t.Context(), logger, gcpauth.StoredCredential{
+		Present:                   true,
+		ImpersonateServiceAccount: "",
+		HasWifConfig:              false,
+		SkipProjectVerification:   true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gcpauth.StoredCredentialUnusable, problem)
+	require.Contains(t, detail, "names no service account")
+
+	_, problem, detail, err = identity.ScreenStoredCredential(t.Context(), logger, gcpauth.StoredCredential{
+		Present:                   true,
+		ImpersonateServiceAccount: gramProjectTarget,
+		HasWifConfig:              true,
+		SkipProjectVerification:   true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gcpauth.StoredCredentialUnusable, problem)
+	require.Contains(t, detail, "Workload Identity Federation")
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-130/feat-let-platform-administrators-name-a-gram-project-service-account

## Summary

Platform administrators can now name a service account in Gram's own GCP project, which the impersonation screening otherwise refuses.

The grant is recorded on `gcp_iam_credentials.skip_project_verification` rather than decided per request, because the same screening runs on the outbound mint and verify paths, which have no request actor to consult: a write-time-only bypass would save a credential that then failed on every use.

It is pinned to a (credential, service account) pair rather than recomputed per write, so an organization can still rename a credential a platform administrator exempted while any change of target stays refused. The grant is invisible in the product by design, so an info log naming the actor, the organization and the target is its only record.

Shape of the change:

- `gcpauth`: `ImpersonationTargetProblem` returns a classified refusal (`TargetOK` / `TargetMalformed` / `TargetOwnProject`) instead of a bare string, so a caller can tell the exemptible refusal from a malformed address without matching on message text. Its zero value is `TargetUnknown`, so a screening that could not be evaluated fails closed rather than reading as permission. `StoredCredential` gains `SkipProjectVerification`, and `ScreenStoredCredential` forgives the own-project refusal, and only that one, when it is set.
- `externalcredentials`: `resolveOrgImpersonationTarget` takes the caller's platform-admin flag plus the prior stored state and returns the target, whether to record the exemption, and whether this write is a new grant. `UpdateGcpIamCredential` now screens inside the transaction, after the prior row is read, since the decision depends on it.
- The two runtime read paths (`jsonwebkeysets` mint, `externalkeys` verify) select and honor the column. Both reach it through a `LEFT JOIN`, so a missing, soft-deleted, or cross-organization credential reads as `false`.
- The platform tier is untouched and always writes `false`. Those rows carry a NULL `organization_id`, which no external key can join to, so they are never screened at runtime either.

No Goa design change. The column is never accepted from a client and never returned, and it is deliberately absent from the audit snapshot, since that renders in the organization's audit log.

## Motivation

The screening refuses any impersonation target whose GCP project id equals Gram's own. That exists because Gram publishes its own service account by design: without it, an organization member could name an internal service account and use the write or verify path to learn which ones Gram holds impersonation rights on. The refusal should stay for organization members and be liftable for platform administrators.

It could not be lifted in the handler alone. `Identity.ScreenStoredCredential` re-runs the same screening on the outbound path, from `jsonwebkeysets/mint.go` and `externalkeys/verify.go`, and neither has a request actor. A write-time-only bypass would produce a credential that saved cleanly and was then refused as `credential_unusable` on every mint and every verify. That is why the exemption is a column, added by AIM-129.

Two alternatives were considered and rejected. A `skipProjectVerification` parameter on the screening call is unnecessary, because the outbound path already resolves Gram's own identity on every call, so classifying and then forgiving costs nothing and keeps a security-critical positional boolean out of the API. A distinct audit action for the grant would be more durable than a log, but `metadata` and action names are both returned to the organization by `auditlogs.list`, and there is no durable and invisible slot in the audit system.

Pinning the exemption to a service account rather than to a credential is what makes the carry-forward safe. `impersonate_service_account` is required on the update payload, so the dashboard resubmits it even when the operator only edited the display name; without carrying the grant forward, an organization could never edit a credential a platform administrator had exempted. Naming any other account in Gram's own project is screened as an ordinary caller and refused, so the edit path cannot be used to probe, and moving the target away and back destroys the exemption rather than preserving it.

Two accepted residuals, both recorded on the issue: an organization administrator who deletes an exempted credential cannot recreate it without staff, and the platform-admin gate is per user rather than per organization, so a staff member inside a customer organization can record the exemption on a row that organization owns. The active organization id in the log is the mitigation for the second.

One unrelated fix rides along: `withAdmin` in `externalcredentials/setup_test.go` mutated the shared `*AuthContext` in place, so raising one context to platform admin raised the test's base context too, and any later step meaning to act as an ordinary organization administrator silently kept the staff privileges. It now sets the flag on a copy.
