### PR TITLE
chore: Add Skydive to CIMD known clients

### DIFF
--- a/server/internal/usersessions/cimd/admission/catalog.go
+++ b/server/internal/usersessions/cimd/admission/catalog.go
@@ -265,6 +265,17 @@ var catalog = []Preset{
 		DisplayOnly: false,
 		Enabled:     true,
 	},
+
+	// Verified 2026-08-26. The apex form (skydive.com, no www) 301s to the
+	// www document, whose client_id is the www form, so the apex URL is not
+	// itself a valid client_id and is deliberately absent.
+	{
+		VendorKey:   "skydive",
+		DisplayName: "Skydive",
+		URL:         "https://www.skydive.com/api/v1/external-oauth/client-metadata",
+		DisplayOnly: false,
+		Enabled:     true,
+	},
 }
 
 // catalogURLs and catalogPatterns index the enabled catalog entries for the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Skydive (www.skydive.com) to the CIMD admission preset catalog to prevent authorization failures once admission enforcement flips to presets mode.

## Background

Datadog monitor 315279120 ("CIMD admission denials") fired for a `denied_not_listed` decision on Skydive's client_id. Currently in reporting mode, the request continued normally, but once enforcement flips to presets mode (AIM-93), this will become a hard `/authorize` rejection with no client-side recourse.

## Changes

- Added exact (non-pattern) entry for `https://www.skydive.com/api/v1/external-oauth/client-metadata` in `server/internal/usersessions/cimd/admission/catalog.go`
- Entry follows the same pattern as other single-document vendors (Hermes Agent, Factory Droid, etc.)

## Verification

Document verified 2026-08-26:
- ✅ HTTP 200, valid JSON, `application/json` content-type  
- ✅ `client_id` matches URL exactly (byte-for-byte)
- ✅ `token_endpoint_auth_method`: `none` (public client, passes Gram's validator)
- ✅ Single hosted https redirect_uri on same host as client_id
- ✅ `grant_types`: `authorization_code`, `refresh_token`
- ✅ `response_types`: `code`
- ✅ Apex form (skydive.com) returns 301 to www form, so only the www URL is a presentable client_id

## Testing

All existing tests pass. No test changes needed—`catalog_test.go` asserts invariants over the catalog rather than naming individual vendors, so the new entry is covered automatically.

## Related

Resolves: AIM-132  
Context: AIM-93 (enforcement flip pre-flight)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIM-132](https://linear.app/speakeasy/issue/AIM-132/feat-add-skydive-to-cimd-known-clients)

<div><a href="https://cursor.com/agents/bc-02522e30-d134-4d46-8f6f-3815acc800c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02522e30-d134-4d46-8f6f-3815acc800c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

