### PR TITLE
feat: record the tool.call metric for external MCP and prompt tool executions

### DIFF
--- a/.changeset/tool-call-external-mcp-prompt.md
+++ b/.changeset/tool-call-external-mcp-prompt.md
@@ -1,0 +1,7 @@
+---
+"server": patch
+---
+
+Tool call metrics now cover external MCP and prompt tools, which previously went unmeasured, so usage and failure reporting account for every kind of tool an MCP server can serve.
+
+External MCP calls are recorded against the upstream tool that ran, and a failure the upstream reports inside its result, such as an expired credential returned as tool output rather than as an error status, now counts as a failure rather than a success.

--- a/server/internal/gateway/metrics.go
+++ b/server/internal/gateway/metrics.go
@@ -17,6 +17,63 @@ type metrics struct {
 	toolCallsCounter metric.Int64Counter
 }
 
+// toolCallOutcome classifies how a tool execution ended, on the gram.outcome
+// dimension of the tool.call counter. The status code cannot carry this on its
+// own: an external MCP server reports failure in-band, as a result flagged
+// isError on an otherwise successful HTTP 200 response.
+type toolCallOutcome string
+
+const (
+	// toolCallOutcomeSuccess is a tool that ran and reported no failure.
+	toolCallOutcomeSuccess toolCallOutcome = "success"
+
+	// toolCallOutcomeToolError is a tool that ran and reported a failure,
+	// whether through its status code or in-band in its result.
+	toolCallOutcomeToolError toolCallOutcome = "tool_error"
+
+	// toolCallOutcomeNoResponse is a tool that produced no response at all: a
+	// connection failure, a cancelled call, or an error raised before anything
+	// was written back to the caller.
+	toolCallOutcomeNoResponse toolCallOutcome = "no_response"
+)
+
+// toolCallOutcomeForStatus derives the outcome from the status written back to
+// the caller. Zero is the sentinel for a call that never produced a response,
+// and is reported separately from a tool that ran and returned a failing
+// status.
+func toolCallOutcomeForStatus(statusCode int) toolCallOutcome {
+	switch {
+	case statusCode == 0:
+		return toolCallOutcomeNoResponse
+	case statusCode >= 400:
+		return toolCallOutcomeToolError
+	default:
+		return toolCallOutcomeSuccess
+	}
+}
+
+// toolCallRecord describes one completed tool execution for the tool.call
+// counter.
+type toolCallRecord struct {
+	// OrganizationID owns the tool that ran.
+	OrganizationID string
+
+	// URN identifies the tool and supplies the tool kind dimension.
+	URN urn.Tool
+
+	// ToolName is the name recorded on the tool name dimension. It can differ
+	// from the URN name, which for some kinds names the tool's source rather
+	// than the tool that ran.
+	ToolName string
+
+	// StatusCode is the HTTP status the executor wrote back to the caller, or
+	// 0 when it wrote none.
+	StatusCode int
+
+	// Outcome classifies the execution for failure-rate reporting.
+	Outcome toolCallOutcome
+}
+
 func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 	toolCallsCounter, err := meter.Int64Counter(
 		"tool.call",
@@ -32,16 +89,17 @@ func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 	}
 }
 
-func (m *metrics) RecordToolCall(ctx context.Context, orgID string, toolURN urn.Tool, statusCode int) {
+func (m *metrics) RecordToolCall(ctx context.Context, rec toolCallRecord) {
 	if m.toolCallsCounter == nil {
 		return
 	}
 
 	kv := []attribute.KeyValue{
-		attr.ToolCallKind(string(toolURN.Kind)),
-		attr.ToolName(toolURN.Name),
-		attr.OrganizationID(orgID),
-		semconv.HTTPResponseStatusCode(statusCode),
+		attr.ToolCallKind(string(rec.URN.Kind)),
+		attr.ToolName(rec.ToolName),
+		attr.OrganizationID(rec.OrganizationID),
+		attr.Outcome(rec.Outcome),
+		semconv.HTTPResponseStatusCode(rec.StatusCode),
 	}
 
 	bag := baggage.FromContext(ctx)
@@ -61,6 +119,7 @@ func (m *metrics) RecordResourceCall(ctx context.Context, orgID string, resource
 	kv := []attribute.KeyValue{
 		attr.ResourceURN(resourceURN.String()),
 		attr.OrganizationID(orgID),
+		attr.Outcome(toolCallOutcomeForStatus(statusCode)),
 		semconv.HTTPResponseStatusCode(statusCode),
 	}
 

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -206,7 +206,7 @@ func (tp *ToolProxy) Do(
 	case ToolKindPlatform:
 		return tp.doPlatform(ctx, logger.With(attr.SlogComponent("gateway-platform-caller")), w, requestBody, env, plan, attrs)
 	case ToolKindExternalMCP:
-		return tp.doExternalMCP(ctx, logger.With(attr.SlogComponent("gateway-externalmcp-caller")), w, requestBody, env, plan.ExternalMCP)
+		return tp.doExternalMCP(ctx, logger.With(attr.SlogComponent("gateway-externalmcp-caller")), w, requestBody, env, plan.Descriptor, plan.ExternalMCP)
 	default:
 		return fmt.Errorf("tool type not supported: %s", plan.Kind)
 	}
@@ -235,7 +235,13 @@ func (tp *ToolProxy) doPlatform(
 			attr.SlogHTTPResponseStatusCode(responseStatusCode),
 			attr.SlogHTTPRequestMethod(http.MethodPost),
 		)
-		tp.metrics.RecordToolCall(ctx, plan.Descriptor.OrganizationID, plan.Descriptor.URN, responseStatusCode)
+		tp.metrics.RecordToolCall(ctx, toolCallRecord{
+			OrganizationID: plan.Descriptor.OrganizationID,
+			URN:            plan.Descriptor.URN,
+			ToolName:       plan.Descriptor.URN.Name,
+			StatusCode:     responseStatusCode,
+			Outcome:        toolCallOutcomeForStatus(responseStatusCode),
+		})
 		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
 	}()
 
@@ -458,7 +464,13 @@ func (tp *ToolProxy) doFunction(
 			attr.SlogHTTPResponseHeaderContentType(ct),
 		)
 		// Record metrics for the tool call, some cardinality is introduced with org and tool name we will keep an eye on it
-		tp.metrics.RecordToolCall(ctx, descriptor.OrganizationID, descriptor.URN, responseStatusCode)
+		tp.metrics.RecordToolCall(ctx, toolCallRecord{
+			OrganizationID: descriptor.OrganizationID,
+			URN:            descriptor.URN,
+			ToolName:       descriptor.URN.Name,
+			StatusCode:     responseStatusCode,
+			Outcome:        toolCallOutcomeForStatus(responseStatusCode),
+		})
 
 		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
 	}()
@@ -546,7 +558,13 @@ func (tp *ToolProxy) doHTTP(
 			attr.SlogHTTPResponseHeaderContentType(plan.RequestContentType.Value),
 		)
 		// Record metrics for the tool call, some cardinality is introduced with org and tool name we will keep an eye on it
-		tp.metrics.RecordToolCall(ctx, descriptor.OrganizationID, descriptor.URN, responseStatusCode)
+		tp.metrics.RecordToolCall(ctx, toolCallRecord{
+			OrganizationID: descriptor.OrganizationID,
+			URN:            descriptor.URN,
+			ToolName:       descriptor.URN.Name,
+			StatusCode:     responseStatusCode,
+			Outcome:        toolCallOutcomeForStatus(responseStatusCode),
+		})
 
 		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
 	}()
@@ -791,18 +809,36 @@ type promptGetParams struct {
 }
 
 func (tp *ToolProxy) doPrompt(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, requestBody io.Reader, env toolconfig.ToolCallEnv, descriptor *ToolDescriptor, plan *PromptToolCallPlan) error {
+	span := trace.SpanFromContext(ctx)
+
+	var responseStatusCode int
+	defer func() {
+		tp.metrics.RecordToolCall(ctx, toolCallRecord{
+			OrganizationID: descriptor.OrganizationID,
+			URN:            descriptor.URN,
+			ToolName:       descriptor.URN.Name,
+			StatusCode:     responseStatusCode,
+			Outcome:        toolCallOutcomeForStatus(responseStatusCode),
+		})
+
+		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
+	}()
+
 	var params promptGetParams
 	if err := json.NewDecoder(requestBody).Decode(&params); err != nil {
+		responseStatusCode = http.StatusBadRequest
 		return oops.E(oops.CodeBadRequest, err, "failed to parse get prompt request").LogError(ctx, logger)
 	}
 
 	promptData, err := templates.RenderTemplate(ctx, logger, plan.Prompt, plan.Kind, plan.Engine, params.Arguments)
 	if err != nil {
+		responseStatusCode = http.StatusBadRequest
 		return oops.E(oops.CodeBadRequest, err, "failed to render template").LogError(ctx, logger)
 	}
 
+	responseStatusCode = http.StatusOK
 	w.Header().Set("Content-Type", "text/plain")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(responseStatusCode)
 	if _, err := w.Write([]byte(promptData)); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to write prompt data").LogError(ctx, logger)
 	}
@@ -857,15 +893,48 @@ func (tp *ToolProxy) doExternalMCP(
 	w http.ResponseWriter,
 	requestBody io.Reader,
 	env toolconfig.ToolCallEnv,
+	descriptor *ToolDescriptor,
 	plan *ExternalMCPToolCallPlan,
 ) error {
+	span := trace.SpanFromContext(ctx)
+
+	// Use the tool name from the plan (resolved by the proxy tool executor for
+	// proxy tools, or set directly for materialized tools)
+	toolName := plan.ToolName
+
+	// A proxy tool's name is whatever the caller sent after the server slug:
+	// nothing validates it against the upstream's tool list. Only a name the
+	// upstream answered successfully reaches the metric dimension, so a bogus
+	// name cannot mint a timeseries per call, including against an upstream
+	// that rejects an unknown tool in-band as an errored result rather than as
+	// a protocol error. Every other call is attributed to the URN name.
+	recordedToolName := descriptor.URN.Name
+
+	var responseStatusCode int
+	// An in-band failure is still answered with a 200, so the status code alone
+	// would record the call as a success.
+	var upstreamReportedError bool
+	defer func() {
+		outcome := toolCallOutcomeForStatus(responseStatusCode)
+		if upstreamReportedError {
+			outcome = toolCallOutcomeToolError
+		}
+
+		tp.metrics.RecordToolCall(ctx, toolCallRecord{
+			OrganizationID: descriptor.OrganizationID,
+			URN:            descriptor.URN,
+			ToolName:       recordedToolName,
+			StatusCode:     responseStatusCode,
+			Outcome:        outcome,
+		})
+
+		span.SetAttributes(attr.HTTPResponseStatusCode(responseStatusCode))
+	}()
+
 	arguments, err := io.ReadAll(requestBody)
 	if err != nil {
 		return oops.E(oops.CodeBadRequest, err, "failed to read tool arguments").LogError(ctx, logger)
 	}
-
-	// Use the tool name from the plan (set by Match for proxy tools, or directly for materialized tools)
-	toolName := plan.ToolName
 
 	// Only pass OAuth token if this plan requires it
 	var oauthToken string
@@ -897,21 +966,25 @@ func (tp *ToolProxy) doExternalMCP(
 
 	// An upstream that reports failure in-band — a result carrying isError
 	// rather than a transport or protocol error — reaches none of the error
-	// paths above, so the whole class is otherwise invisible: the result is
-	// forwarded to the caller and nothing is recorded. Providers that surface a
-	// rejected or expired bearer as a tool result rather than a 401 are the
-	// motivating case, since the failure is then visible to the end user and to
-	// no one operating the service.
+	// paths above, and the result is forwarded to the caller as a successful
+	// response, so this is the only place the failure can be detected.
+	// Providers that surface a rejected or expired bearer as a tool result
+	// rather than a 401 are the motivating case, since the failure is
+	// otherwise visible to the end user and to no one operating the service.
 	if callResult.IsError {
+		upstreamReportedError = true
 		logger.ErrorContext(ctx, "external MCP tool returned an error result",
 			attr.SlogToolName(toolName),
 			attr.SlogURL(plan.RemoteURL),
 			attr.SlogErrorMessage(externalMCPErrorSummary(callResult.Content)),
 		)
+	} else {
+		recordedToolName = toolName
 	}
 
+	responseStatusCode = http.StatusOK
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(responseStatusCode)
 
 	response := struct {
 		Content []json.RawMessage `json:"content"`

--- a/server/internal/gateway/toolcall_metrics_test.go
+++ b/server/internal/gateway/toolcall_metrics_test.go
@@ -1,0 +1,409 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testmcp"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// toolCallSeries collects the tool.call data points recorded so far, keyed by
+// their attribute set. Every executor records exactly one point per call, so a
+// test asserting on a single call reads the only entry.
+func toolCallSeries(t *testing.T, reader sdkmetric.Reader) map[attribute.Set]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	points := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "tool.call" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "tool.call must be an int64 counter")
+			for _, dp := range sum.DataPoints {
+				points[dp.Attributes] = dp.Value
+			}
+		}
+	}
+
+	return points
+}
+
+// onlyToolCallAttributes returns the attribute set of the single tool.call
+// series recorded, failing when the call recorded no point or more than one.
+func onlyToolCallAttributes(t *testing.T, reader sdkmetric.Reader) attribute.Set {
+	t.Helper()
+
+	points := toolCallSeries(t, reader)
+	require.Len(t, points, 1, "a tool call must record exactly one tool.call series")
+
+	for set, value := range points {
+		require.Equal(t, int64(1), value)
+		return set
+	}
+
+	return *attribute.EmptySet()
+}
+
+func attributeValue(t *testing.T, set attribute.Set, key attribute.Key) string {
+	t.Helper()
+
+	value, ok := set.Value(key)
+	require.True(t, ok, "attribute %s must be present", key)
+
+	return value.Emit()
+}
+
+func newMetricToolProxy(t *testing.T, reader sdkmetric.Reader) *ToolProxy {
+	t.Helper()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	return NewToolProxy(
+		testenv.NewLogger(t),
+		tracerProvider,
+		sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
+		ToolCallSourceMCP,
+		testenv.NewEncryptionClient(t),
+		nil,
+		policy,
+		funcs,
+		nil,
+	)
+}
+
+func newExternalMCPToolDescriptor() *ToolDescriptor {
+	return &ToolDescriptor{
+		ID:               uuid.New().String(),
+		Name:             "notion",
+		Description:      nil,
+		DeploymentID:     uuid.New().String(),
+		ProjectID:        uuid.New().String(),
+		ProjectSlug:      "test-project",
+		OrganizationID:   uuid.New().String(),
+		OrganizationSlug: "test-org",
+		// Proxy tools name the MCP server, not the tool that runs.
+		URN: urn.NewTool(urn.ToolKindExternalMCP, "notion", "proxy"),
+	}
+}
+
+func newExternalMCPTestServer(t *testing.T, isError bool) *httptest.Server {
+	t.Helper()
+
+	server := testmcp.NewStreamableHTTPServer(t, &testmcp.Server{
+		Tools: []testmcp.Tool{{
+			Annotations:  nil,
+			Description:  "Search a workspace",
+			Icons:        nil,
+			InputSchema:  map[string]any{"type": "object"},
+			Meta:         nil,
+			Name:         "search",
+			OutputSchema: nil,
+			Response: testmcp.ToolResponse{
+				Content: []map[string]any{{"type": "text", "text": "result"}},
+				IsError: isError,
+			},
+			Title: "",
+		}},
+	})
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+func externalMCPPlan(remoteURL string) *ExternalMCPToolCallPlan {
+	return &ExternalMCPToolCallPlan{
+		RemoteURL:         remoteURL,
+		ToolName:          "search",
+		Slug:              "notion",
+		RequiresOAuth:     false,
+		TransportType:     externalmcptypes.TransportTypeStreamableHTTP,
+		HeaderDefinitions: nil,
+	}
+}
+
+func callToolProxy(t *testing.T, ctx context.Context, proxy *ToolProxy, plan *ToolCallPlan, body string) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	err := proxy.Do(ctx, recorder, bytes.NewReader([]byte(body)), toolconfig.ToolCallEnv{
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+		GramChatID: "",
+		MCPClient:  toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""},
+	}, plan, tm.HTTPLogAttributes{})
+
+	return recorder, err
+}
+
+// A status of zero means no response was produced at all, which is a different
+// operational signal from a tool that ran and returned a failing status.
+func TestToolCallOutcomeForStatus(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, toolCallOutcomeNoResponse, toolCallOutcomeForStatus(0))
+	require.Equal(t, toolCallOutcomeSuccess, toolCallOutcomeForStatus(http.StatusOK))
+	require.Equal(t, toolCallOutcomeSuccess, toolCallOutcomeForStatus(http.StatusFound))
+	require.Equal(t, toolCallOutcomeToolError, toolCallOutcomeForStatus(http.StatusBadRequest))
+	require.Equal(t, toolCallOutcomeToolError, toolCallOutcomeForStatus(http.StatusInternalServerError))
+}
+
+// External MCP executions were absent from tool.call entirely, so the counter
+// undercounted every billable tool call served through an external MCP server.
+func TestToolProxy_Do_ExternalMCP_RecordsToolCall(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+	server := newExternalMCPTestServer(t, false)
+	descriptor := newExternalMCPToolDescriptor()
+
+	recorder, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(descriptor, externalMCPPlan(server.URL)), `{}`)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(urn.ToolKindExternalMCP), attributeValue(t, set, attr.ToolCallKindKey))
+	require.Equal(t, string(toolCallOutcomeSuccess), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "200", attributeValue(t, set, attribute.Key("http.response.status_code")))
+	require.Equal(t, descriptor.OrganizationID, attributeValue(t, set, attr.OrganizationIDKey))
+}
+
+// The upstream tool name is resolved only when the call is dispatched, so
+// reading it off the proxy tool's URN would label every external MCP series
+// "proxy" and leave dashboards unable to name the tool that ran.
+func TestToolProxy_Do_ExternalMCP_RecordsUpstreamToolName(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+	server := newExternalMCPTestServer(t, false)
+	descriptor := newExternalMCPToolDescriptor()
+	require.Equal(t, "proxy", descriptor.URN.Name, "the descriptor must carry the placeholder name this test is about")
+
+	_, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(descriptor, externalMCPPlan(server.URL)), `{}`)
+	require.NoError(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, "search", attributeValue(t, set, attr.ToolNameKey))
+}
+
+// Some upstreams answer an unknown tool name with an errored result rather
+// than a protocol error, which would put the caller's unvalidated string on the
+// metric dimension. Only a name the upstream answered successfully is recorded,
+// so an errored result is attributed to the URN name whatever it was called.
+func TestToolProxy_Do_ExternalMCP_DoesNotRecordToolNameOnErroredResult(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+	server := newExternalMCPTestServer(t, true)
+	descriptor := newExternalMCPToolDescriptor()
+
+	_, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(descriptor, externalMCPPlan(server.URL)), `{}`)
+	require.NoError(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, descriptor.URN.Name, attributeValue(t, set, attr.ToolNameKey))
+	require.Equal(t, string(toolCallOutcomeToolError), attributeValue(t, set, attr.OutcomeKey))
+}
+
+// A proxy tool's name is taken from the caller's request without being checked
+// against the upstream's tool list, so a call that never reached a tool must
+// not put that string on a metric dimension.
+func TestToolProxy_Do_ExternalMCP_DoesNotRecordUnreachedToolName(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+	server := newExternalMCPTestServer(t, false)
+	descriptor := newExternalMCPToolDescriptor()
+
+	plan := externalMCPPlan(server.URL)
+	plan.ToolName = "no-such-tool-" + uuid.NewString()
+
+	_, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(descriptor, plan), `{}`)
+	require.Error(t, err, "the upstream must reject a tool it does not expose")
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, descriptor.URN.Name, attributeValue(t, set, attr.ToolNameKey))
+}
+
+// An upstream reporting failure in-band still answers with HTTP 200, so the
+// status code records it as a success. The outcome dimension is the only place
+// this failure class is visible.
+func TestToolProxy_Do_ExternalMCP_RecordsUpstreamErrorResultAsToolError(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+	server := newExternalMCPTestServer(t, true)
+
+	recorder, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(newExternalMCPToolDescriptor(), externalMCPPlan(server.URL)), `{}`)
+	require.NoError(t, err, "an errored tool result is forwarded to the caller, not raised as a gateway error")
+	require.Equal(t, http.StatusOK, recorder.Code, "the response written to the caller must be unchanged")
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(toolCallOutcomeToolError), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "200", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}
+
+// A call that never reaches a working upstream writes no response at all, and
+// is counted apart from a tool that ran and failed. The upstream here answers
+// the MCP handshake with a 404, the shape a misconfigured remote URL takes.
+func TestToolProxy_Do_ExternalMCP_RecordsNoResponseWhenUpstreamRejectsHandshake(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	_, err := callToolProxy(t, t.Context(), proxy, NewExternalMCPToolCallPlan(newExternalMCPToolDescriptor(), externalMCPPlan(upstream.URL)), `{}`)
+	require.Error(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(toolCallOutcomeNoResponse), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "0", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}
+
+// The three executors that already recorded tool.call were rewritten onto the
+// record struct, so their emitted labels are pinned here: the tool name comes
+// from the URN, not from the descriptor's own name.
+func TestToolProxy_Do_HTTP_RecordsUnchangedToolCallLabels(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	descriptor := newTestToolDescriptor()
+	plan := NewHTTPToolCallPlan(descriptor, &HTTPToolCallPlan{
+		ServerEnvVar:       "TEST_SERVER_URL",
+		DefaultServerUrl:   NullString{Value: upstream.URL, Valid: true},
+		Security:           []*HTTPToolSecurity{},
+		SecurityScopes:     map[string][]string{},
+		Method:             http.MethodGet,
+		Path:               "/things",
+		Schema:             []byte{},
+		HeaderParams:       map[string]*HTTPParameter{},
+		QueryParams:        map[string]*HTTPParameter{},
+		PathParams:         map[string]*HTTPParameter{},
+		RequestContentType: NullString{Value: "application/json", Valid: true},
+		ResponseFilter:     nil,
+	})
+
+	_, err := callToolProxy(t, t.Context(), proxy, plan, `{}`)
+	require.NoError(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(urn.ToolKindHTTP), attributeValue(t, set, attr.ToolCallKindKey))
+	require.Equal(t, descriptor.URN.Name, attributeValue(t, set, attr.ToolNameKey))
+	require.Equal(t, string(toolCallOutcomeSuccess), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "200", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}
+
+func newPromptToolCallPlanForTest(engine string) *ToolCallPlan {
+	descriptor := &ToolDescriptor{
+		ID:               uuid.New().String(),
+		Name:             "summarize",
+		Description:      nil,
+		DeploymentID:     "",
+		ProjectID:        uuid.New().String(),
+		ProjectSlug:      "test-project",
+		OrganizationID:   uuid.New().String(),
+		OrganizationSlug: "test-org",
+		URN:              urn.NewTool(urn.ToolKindPrompt, "doc", "summarize"),
+	}
+
+	return NewPromptToolCallPlan(descriptor, &PromptToolCallPlan{
+		TemplateID: uuid.New().String(),
+		Prompt:     "Summarize {{topic}}",
+		Engine:     engine,
+		Kind:       "prompt",
+	})
+}
+
+// Prompt executions were the second tool kind missing from tool.call, which is
+// why their volume could not be measured at all.
+func TestToolProxy_Do_Prompt_RecordsToolCall(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+
+	recorder, err := callToolProxy(t, t.Context(), proxy, newPromptToolCallPlanForTest("mustache"), `{"arguments":{"topic":"gram"}}`)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, "Summarize gram", recorder.Body.String())
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(urn.ToolKindPrompt), attributeValue(t, set, attr.ToolCallKindKey))
+	require.Equal(t, "summarize", attributeValue(t, set, attr.ToolNameKey))
+	require.Equal(t, string(toolCallOutcomeSuccess), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "200", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}
+
+// The prompt executor rejects an unparseable request before rendering, which is
+// the other path the caller sees as a bad request.
+func TestToolProxy_Do_Prompt_RecordsUnparseableRequestAsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+
+	_, err := callToolProxy(t, t.Context(), proxy, newPromptToolCallPlanForTest("mustache"), `not json`)
+	require.Error(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(toolCallOutcomeToolError), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "400", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}
+
+// A prompt that fails to render answers the caller with a bad request, so the
+// metric records that status rather than the no-response sentinel.
+func TestToolProxy_Do_Prompt_RecordsRenderFailureAsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	proxy := newMetricToolProxy(t, reader)
+
+	_, err := callToolProxy(t, t.Context(), proxy, newPromptToolCallPlanForTest("unsupported-engine"), `{"arguments":{}}`)
+	require.Error(t, err)
+
+	set := onlyToolCallAttributes(t, reader)
+	require.Equal(t, string(toolCallOutcomeToolError), attributeValue(t, set, attr.OutcomeKey))
+	require.Equal(t, "400", attributeValue(t, set, attribute.Key("http.response.status_code")))
+}


### PR DESCRIPTION
Resolves https://linear.app/speakeasy/issue/AIM-131/record-the-toolcall-metric-for-external-mcp-and-prompt-tool-executions

## Summary

`ToolProxy.Do` dispatches to five executors, and two of them, `doExternalMCP` and `doPrompt`, ran without ever recording `tool.call`. Both now record it from a deferred closure like the other three, carrying the status the executor wrote back to the caller: 200 on success, 0 when nothing was written, and 400 on the prompt executor's two bad-request paths. No status is synthesized and the responses themselves are unchanged.

The counter gains a `gram.outcome` dimension (`success`, `tool_error`, `no_response`) across all five executors and `RecordResourceCall`, which adds to the same counter and would otherwise leave its points in an empty bucket. An external MCP server reports failure in-band, as a result flagged `isError` on an otherwise successful 200, so the status code alone cannot separate those calls from successful ones. `RecordToolCall` now takes a `toolCallRecord` struct instead of positional arguments, so `exhaustruct` forces every call site to state the new fields.

External MCP calls are labeled with the upstream tool name, which proxy tools resolve only at dispatch, in place of the placeholder name (`proxy`) their URN carries. That name is the segment of the caller's request after the server slug and is never checked against the upstream's tool list, so only a name the upstream answered successfully reaches the dimension. A rejected call, whether the upstream reports it in-band or as a protocol error, is attributed to the URN name instead, and the error log still carries the name that was called.

## Motivation

`tool.call` carried no `externalmcp` or `prompt` values at all, leaving it roughly 9% short of the tool executions actually served over a 24 hour production window. External MCP tool calls are billed (`billing.ToolCallTypeExternalMCP`), so the counter understated billable executions by about that much, and the roughly 3.3% of external MCP calls that fail reached no failure signal anywhere. About 95% of those failures are `isError` results, which are invisible to any predicate keyed on a 4xx or 5xx status.

Synthesizing a failing status for the `isError` case was considered and rejected. It would contradict the convention documented on `remotemcp/proxy/metrics.go`, where the status label reflects the upstream's HTTP status and user-facing outcomes get their own dimension, and it would leave a synthesized 502 indistinguishable from an upstream that really returned one. The `gram.outcome` shape follows the same precedent as the remote session refresh and revoke counters.

## Follow-ups

- Failure-rate reporting on the MCP traffic dashboard is keyed on a 4xx or 5xx status and should move to `gram.outcome`, otherwise the added external MCP volume grows the denominator without the numerator.
- Client cancellations currently land in `no_response` alongside connect failures. The remote session refresh counter splits `canceled` out for exactly this reason; worth doing here if we alert on the external MCP failure rate.
- MCP `prompts/get` is served by `handlePromptsGet` and never reaches the gateway, so the new `prompt` series covers prompt-as-tool calls only, not total prompt volume.
