### PR TITLE
feat: dual-write organization_id across user session issuers and their children

### DIFF
--- a/.changeset/user-session-organization-dual-write.md
+++ b/.changeset/user-session-organization-dual-write.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Every new user session issuer, OAuth client, CIMD client grant, session, and consent row now records the organization that owns it alongside its project, so organization tenancy is present from the moment a row is written. Nothing reads the column yet and no existing behavior changes; rows created before this point keep a NULL organization until a separate backfill runs.

--- a/server/internal/mcp/authnchallenge_cimd_admission_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_admission_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -85,12 +86,16 @@ func seedFreshIssuerToolset(t *testing.T, ctx context.Context, ti *testInstance)
 func allowCustomCimdURL(t *testing.T, ctx context.Context, ti *testInstance, toolset toolsets_repo.Toolset, clientID string) {
 	t.Helper()
 
-	_, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuerCimdClient(ctx, usersessions_repo.CreateUserSessionIssuerCimdClientParams{
+	row, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuerCimdClient(ctx, usersessions_repo.CreateUserSessionIssuerCimdClientParams{
 		ProjectID:           toolset.ProjectID,
 		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
 		ClientIDMetadataUri: clientID,
 	})
 	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, authCtx.ActiveOrganizationID, row.OrganizationID.String, "the grant must inherit its issuer's organization")
 }
 
 // revokeCustomCimdURL soft-deletes an issuer's custom CIMD URL, the

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -96,6 +96,7 @@ func seedPrivateToolsetWithIssuer(
 
 	issuer, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
 		ProjectID:          *authCtx.ProjectID,
+		OrganizationID:     conv.ToPGText(authCtx.ActiveOrganizationID),
 		Slug:               slug + "-issuer",
 		AuthnChallengeMode: "chain",
 		SessionDuration:    pgtype.Interval{Microseconds: 3600 * 1e6, Valid: true},

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -628,7 +628,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// mcp_servers_issuer_required_check.
 	issuerID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if (ids.RemoteMcpServerID.Valid || ids.TunneledMcpServerID.Valid) && !existing.UserSessionIssuerID.Valid {
-		issuerID, err = mintServerUserSessionIssuer(ctx, dbtx, *authCtx.ProjectID, slug)
+		issuerID, err = mintServerUserSessionIssuer(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, slug)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "mint mcp server issuer").LogError(ctx, logger)
 		}

--- a/server/internal/mcpservers/transaction.go
+++ b/server/internal/mcpservers/transaction.go
@@ -51,7 +51,7 @@ func CreateMCPServerInTransaction(ctx context.Context, tx pgx.Tx, auditLogger *a
 
 	issuerID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if input.RemoteMCPServerID.Valid || input.TunneledMCPServerID.Valid {
-		issuerID, err = mintServerUserSessionIssuer(ctx, tx, input.ProjectID, slug)
+		issuerID, err = mintServerUserSessionIssuer(ctx, tx, input.OrganizationID, input.ProjectID, slug)
 		if err != nil {
 			return repo.McpServer{}, fmt.Errorf("mint MCP server issuer: %w", err)
 		}

--- a/server/internal/mcpservers/usersessionissuer.go
+++ b/server/internal/mcpservers/usersessionissuer.go
@@ -53,6 +53,7 @@ func buildUserSessionResourceSlug(baseSlug string) (string, error) {
 func mintServerUserSessionIssuer(
 	ctx context.Context,
 	dbtx pgx.Tx,
+	organizationID string,
 	projectID uuid.UUID,
 	serverSlug string,
 ) (uuid.NullUUID, error) {
@@ -63,6 +64,7 @@ func mintServerUserSessionIssuer(
 
 	issuer, err := usersessionsrepo.New(dbtx).CreateUserSessionIssuer(ctx, usersessionsrepo.CreateUserSessionIssuerParams{
 		ProjectID:          projectID,
+		OrganizationID:     conv.ToPGText(organizationID),
 		Slug:               issuerSlug,
 		AuthnChallengeMode: "interactive",
 		SessionDuration: pgtype.Interval{

--- a/server/internal/oauthtest/issuergated.go
+++ b/server/internal/oauthtest/issuergated.go
@@ -94,6 +94,7 @@ func CreateIssuerGatedToolset(
 
 	usi, err := usersRepo.CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
 		ProjectID:          *authCtx.ProjectID,
+		OrganizationID:     conv.ToPGText(authCtx.ActiveOrganizationID),
 		Slug:               "usi-" + suffix,
 		AuthnChallengeMode: mode,
 		SessionDuration: pgtype.Interval{

--- a/server/internal/platformmcp/registration.go
+++ b/server/internal/platformmcp/registration.go
@@ -758,6 +758,7 @@ func (s *RegistrationStore) createPrivateRegistrationComponents(ctx context.Cont
 	}
 	issuer, err := usersessionsrepo.New(tx).CreateUserSessionIssuer(ctx, usersessionsrepo.CreateUserSessionIssuerParams{
 		ProjectID:          project.ID,
+		OrganizationID:     conv.ToPGText(registration.OrganizationID),
 		Slug:               "platform-mcp-issuer-" + suffix,
 		AuthnChallengeMode: "interactive",
 		SessionDuration: pgtype.Interval{

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -261,6 +261,15 @@ UPDATE user_session_issuers
 SET client_id_metadata_admission_mode = @client_id_metadata_admission_mode
 WHERE id = @id AND project_id = @project_id::uuid AND deleted IS FALSE;
 
+-- name: SetUserSessionIssuerOrganizationID :exec
+-- Test-only fixture: repoints an issuer's organization so tests can observe
+-- what a child row does when its parent's tenancy no longer matches its own.
+-- No production path moves an issuer between organizations yet, so there is
+-- no other way to reach that state.
+UPDATE user_session_issuers
+SET organization_id = @organization_id
+WHERE id = @id AND project_id = @project_id::uuid AND deleted IS FALSE;
+
 -- name: InsertPluginAssignmentFixture :exec
 -- Test-only fixture: writes a plugin_assignments row with an EXPLICIT
 -- organization_id so tests can seed a cross-tenant/stale assignment that the

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1612,6 +1612,27 @@ func (q *Queries) SetUserSessionIssuerCIMDAdmissionMode(ctx context.Context, arg
 	return err
 }
 
+const setUserSessionIssuerOrganizationID = `-- name: SetUserSessionIssuerOrganizationID :exec
+UPDATE user_session_issuers
+SET organization_id = $1
+WHERE id = $2 AND project_id = $3::uuid AND deleted IS FALSE
+`
+
+type SetUserSessionIssuerOrganizationIDParams struct {
+	OrganizationID pgtype.Text
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+}
+
+// Test-only fixture: repoints an issuer's organization so tests can observe
+// what a child row does when its parent's tenancy no longer matches its own.
+// No production path moves an issuer between organizations yet, so there is
+// no other way to reach that state.
+func (q *Queries) SetUserSessionIssuerOrganizationID(ctx context.Context, arg SetUserSessionIssuerOrganizationIDParams) error {
+	_, err := q.db.Exec(ctx, setUserSessionIssuerOrganizationID, arg.OrganizationID, arg.ID, arg.ProjectID)
+	return err
+}
+
 const setWorkosLastEventIDFixture = `-- name: SetWorkosLastEventIDFixture :exec
 UPDATE organization_metadata
 SET workos_last_event_id = $1

--- a/server/internal/usersessions/clientauthmethodpersistence_test.go
+++ b/server/internal/usersessions/clientauthmethodpersistence_test.go
@@ -59,10 +59,67 @@ func TestUpsertUserSessionClientFromCIMD_RefreshesAuthMethod(t *testing.T) {
 	requireOrganizationID(t, ctx, refreshed.OrganizationID)
 }
 
-// An authorize-time refresh fills in a client's organization when it has none
-// but never moves one it already carries. The DO UPDATE branch leaves
-// project_id untouched, so adopting the issuer's current organization instead
-// would leave a row whose two tenancy columns name different owners.
+// An authorize-time refresh fills in the organization of a client that has
+// none. That is how a client created before the column existed picks up its
+// tenancy on its own, rather than staying untenanted until the backfill runs.
+func TestUpsertUserSessionClientFromCIMD_FillsMissingOrganizationOnRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	issuerID := seedIssuer(t, ctx, ti, "cimd-org-fill")
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// Strip the issuer's organization so the client below derives a NULL one,
+	// standing in for a row written before the column existed.
+	testQueries := testrepo.New(ti.conn)
+	require.NoError(t, testQueries.SetUserSessionIssuerOrganizationID(ctx, testrepo.SetUserSessionIssuerOrganizationIDParams{
+		OrganizationID: pgtype.Text{String: "", Valid: false},
+		ID:             issuerID,
+		ProjectID:      *authCtx.ProjectID,
+	}))
+
+	documentURL := "https://org-fill.example.com/oauth/client.json"
+	queries := repo.New(ti.conn)
+
+	seeded, err := queries.UpsertUserSessionClientFromCIMD(ctx, repo.UpsertUserSessionClientFromCIMDParams{
+		UserSessionIssuerID:     issuerID,
+		ClientID:                documentURL,
+		ClientName:              "Original Name",
+		RedirectUris:            []string{"https://org-fill.example.com/cb"},
+		CacheTtlSeconds:         3600,
+		ClientIDMetadataEtag:    pgtype.Text{String: `"v1"`, Valid: true},
+		TokenEndpointAuthMethod: "none",
+	})
+	require.NoError(t, err)
+	require.False(t, seeded.OrganizationID.Valid, "the client must inherit the issuer's missing organization")
+
+	require.NoError(t, testQueries.SetUserSessionIssuerOrganizationID(ctx, testrepo.SetUserSessionIssuerOrganizationIDParams{
+		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		ID:             issuerID,
+		ProjectID:      *authCtx.ProjectID,
+	}))
+
+	refreshed, err := queries.UpsertUserSessionClientFromCIMD(ctx, repo.UpsertUserSessionClientFromCIMDParams{
+		UserSessionIssuerID:     issuerID,
+		ClientID:                documentURL,
+		ClientName:              "Renamed",
+		RedirectUris:            []string{"https://org-fill.example.com/cb"},
+		CacheTtlSeconds:         3600,
+		ClientIDMetadataEtag:    pgtype.Text{String: `"v2"`, Valid: true},
+		TokenEndpointAuthMethod: "none",
+	})
+	require.NoError(t, err)
+	require.Equal(t, seeded.ID, refreshed.ID, "the refresh must update the same row, not insert a second one")
+	requireOrganizationID(t, ctx, refreshed.OrganizationID)
+}
+
+// An authorize-time refresh never moves a client that already carries an
+// organization, even once its issuer belongs to a different one. The DO UPDATE
+// branch leaves project_id untouched, so adopting the issuer's current
+// organization would leave a row whose two tenancy columns name different
+// owners.
 func TestUpsertUserSessionClientFromCIMD_KeepsOrganizationOnRefresh(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/clientauthmethodpersistence_test.go
+++ b/server/internal/usersessions/clientauthmethodpersistence_test.go
@@ -2,11 +2,15 @@ package usersessions_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -34,6 +38,7 @@ func TestUpsertUserSessionClientFromCIMD_RefreshesAuthMethod(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "none", seeded.TokenEndpointAuthMethod.String)
+	requireOrganizationID(t, ctx, seeded.OrganizationID)
 
 	// The same client_id again, as an authorize-time refresh would, this time
 	// declaring an asymmetric method.
@@ -51,6 +56,74 @@ func TestUpsertUserSessionClientFromCIMD_RefreshesAuthMethod(t *testing.T) {
 	require.Equal(t, "Renamed", refreshed.ClientName)
 	require.True(t, refreshed.TokenEndpointAuthMethod.Valid)
 	require.Equal(t, "private_key_jwt", refreshed.TokenEndpointAuthMethod.String)
+	requireOrganizationID(t, ctx, refreshed.OrganizationID)
+}
+
+// An authorize-time refresh fills in a client's organization when it has none
+// but never moves one it already carries. The DO UPDATE branch leaves
+// project_id untouched, so adopting the issuer's current organization instead
+// would leave a row whose two tenancy columns name different owners.
+func TestUpsertUserSessionClientFromCIMD_KeepsOrganizationOnRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	issuerID := seedIssuer(t, ctx, ti, "cimd-org-refresh")
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	documentURL := "https://org-refresh.example.com/oauth/client.json"
+	queries := repo.New(ti.conn)
+
+	seeded, err := queries.UpsertUserSessionClientFromCIMD(ctx, repo.UpsertUserSessionClientFromCIMDParams{
+		UserSessionIssuerID:     issuerID,
+		ClientID:                documentURL,
+		ClientName:              "Original Name",
+		RedirectUris:            []string{"https://org-refresh.example.com/cb"},
+		CacheTtlSeconds:         3600,
+		ClientIDMetadataEtag:    pgtype.Text{String: `"v1"`, Valid: true},
+		TokenEndpointAuthMethod: "none",
+	})
+	require.NoError(t, err)
+	requireOrganizationID(t, ctx, seeded.OrganizationID)
+
+	// Repoint the issuer at a second organization, the only way to make the
+	// parent's tenancy disagree with the child's.
+	otherOrgID := "org-" + uuid.NewString()
+	trialStart := time.Now().UTC()
+	testQueries := testrepo.New(ti.conn)
+	require.NoError(t, testQueries.CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID:                 otherOrgID,
+		Name:               "Other Org",
+		Slug:               "other-org-" + uuid.NewString()[:8],
+		GramAccountType:    "free",
+		WorkosID:           pgtype.Text{String: "", Valid: false},
+		Whitelisted:        false,
+		FreeTrialStartedAt: pgtype.Timestamptz{Time: trialStart, InfinityModifier: 0, Valid: true},
+		FreeTrialEndsAt:    pgtype.Timestamptz{Time: trialStart.Add(14 * 24 * time.Hour), InfinityModifier: 0, Valid: true},
+		DisabledAt:         pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: 0, Valid: false},
+		CreatedAt:          pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: 0, Valid: false},
+	}))
+	require.NoError(t, testQueries.SetUserSessionIssuerOrganizationID(ctx, testrepo.SetUserSessionIssuerOrganizationIDParams{
+		OrganizationID: conv.ToPGText(otherOrgID),
+		ID:             issuerID,
+		ProjectID:      *authCtx.ProjectID,
+	}))
+
+	refreshed, err := queries.UpsertUserSessionClientFromCIMD(ctx, repo.UpsertUserSessionClientFromCIMDParams{
+		UserSessionIssuerID:     issuerID,
+		ClientID:                documentURL,
+		ClientName:              "Renamed",
+		RedirectUris:            []string{"https://org-refresh.example.com/cb"},
+		CacheTtlSeconds:         3600,
+		ClientIDMetadataEtag:    pgtype.Text{String: `"v2"`, Valid: true},
+		TokenEndpointAuthMethod: "none",
+	})
+	require.NoError(t, err)
+	require.Equal(t, seeded.ID, refreshed.ID, "the refresh must update the same row, not insert a second one")
+	require.Equal(t, "Renamed", refreshed.ClientName, "the refresh must still replace mutable metadata")
+	require.Equal(t, seeded.OrganizationID.String, refreshed.OrganizationID.String, "a refresh must not move the client to the issuer's new organization")
+	require.Equal(t, seeded.ProjectID, refreshed.ProjectID)
 }
 
 // A refresh replaces both key-source columns wholesale, writing the unused

--- a/server/internal/usersessions/createusersessionissuer_test.go
+++ b/server/internal/usersessions/createusersessionissuer_test.go
@@ -3,6 +3,7 @@ package usersessions_test
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/user_session_issuers"
@@ -11,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 func TestCreateUserSessionIssuer(t *testing.T) {
@@ -34,6 +36,15 @@ func TestCreateUserSessionIssuer(t *testing.T) {
 	require.Equal(t, "issuer-one", created.Slug)
 	require.Equal(t, "chain", created.AuthnChallengeMode)
 	require.Equal(t, 24, created.SessionDurationHours)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	row, err := repo.New(ti.conn).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{
+		ID:        uuid.MustParse(created.ID),
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	requireOrganizationID(t, ctx, row.OrganizationID)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionUserSessionIssuerCreate)
 	require.NoError(t, err)

--- a/server/internal/usersessions/issuerhandlers.go
+++ b/server/internal/usersessions/issuerhandlers.go
@@ -56,6 +56,7 @@ func (s *Service) CreateUserSessionIssuer(ctx context.Context, payload *gen.Crea
 
 	row, err := repo.New(dbtx).CreateUserSessionIssuer(ctx, repo.CreateUserSessionIssuerParams{
 		ProjectID:          *authCtx.ProjectID,
+		OrganizationID:     conv.ToPGText(authCtx.ActiveOrganizationID),
 		Slug:               payload.Slug,
 		AuthnChallengeMode: payload.AuthnChallengeMode,
 		SessionDuration:    pgtype.Interval{Microseconds: dur.Microseconds(), Days: 0, Months: 0, Valid: true},

--- a/server/internal/usersessions/listusersessionconsents_test.go
+++ b/server/internal/usersessions/listusersessionconsents_test.go
@@ -29,10 +29,12 @@ func TestListUserSessionConsents(t *testing.T) {
 
 	client, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "list-consents-client")
 	require.NoError(t, err)
+	requireOrganizationID(t, ctx, client.OrganizationID)
 
 	for _, principal := range []urn.SessionSubject{urn.NewUserSubject("p1"), urn.NewUserSubject("p2")} {
-		_, err := seedUserSessionConsent(t, ctx, ti.conn, client.ID, principal)
+		consent, err := seedUserSessionConsent(t, ctx, ti.conn, client.ID, principal)
 		require.NoError(t, err)
+		requireOrganizationID(t, ctx, consent.OrganizationID)
 	}
 
 	got, err := ti.service.ListUserSessionConsents(ctx, &gen.ListUserSessionConsentsPayload{

--- a/server/internal/usersessions/listusersessions_test.go
+++ b/server/internal/usersessions/listusersessions_test.go
@@ -30,8 +30,9 @@ func TestListUserSessions(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, principal := range []urn.SessionSubject{urn.NewUserSubject("p1"), urn.NewUserSubject("p2"), urn.NewUserSubject("p3")} {
-		_, err := seedUserSession(t, ctx, ti.conn, uuid.MustParse(issuer.ID), principal)
+		session, err := seedUserSession(t, ctx, ti.conn, uuid.MustParse(issuer.ID), principal)
 		require.NoError(t, err)
+		requireOrganizationID(t, ctx, session.OrganizationID)
 	}
 
 	got, err := ti.service.ListUserSessions(ctx, &gen.ListUserSessionsPayload{

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -1,12 +1,14 @@
 -- name: CreateUserSessionIssuer :one
 INSERT INTO user_session_issuers (
     project_id,
+    organization_id,
     slug,
     authn_challenge_mode,
     session_duration
 )
 VALUES (
     @project_id::uuid,
+    @organization_id,
     @slug,
     @authn_challenge_mode,
     @session_duration
@@ -246,19 +248,23 @@ SELECT EXISTS (
 -- than silently reviving an old one.
 --
 -- `inserted` distinguishes the two so the caller only records an add event
--- for a real new grant. The DO UPDATE is a deliberate no-op write of the
--- existing updated_at: a genuine touch would misreport a re-add as a
+-- for a real new grant. The DO UPDATE deliberately rewrites updated_at with
+-- its own existing value: a genuine touch would misreport a re-add as a
 -- modification, but ON CONFLICT still needs an action for RETURNING to
 -- yield the row. `xmax = 0` is the standard test for "this row came from
--- the INSERT rather than the UPDATE".
-INSERT INTO user_session_issuer_cimd_clients (project_id, user_session_issuer_id, client_id_metadata_uri)
-SELECT @project_id::uuid, iss.id, @client_id_metadata_uri
+-- the INSERT rather than the UPDATE". organization_id is the one column the
+-- branch really writes, and only when the row has none, so re-adding a grant
+-- can fill in tenancy without ever moving it.
+INSERT INTO user_session_issuer_cimd_clients (project_id, organization_id, user_session_issuer_id, client_id_metadata_uri)
+SELECT @project_id::uuid, iss.organization_id, iss.id, @client_id_metadata_uri
 FROM user_session_issuers AS iss
 WHERE iss.id = @user_session_issuer_id
   AND iss.project_id = @project_id::uuid
   AND iss.deleted IS FALSE
 ON CONFLICT (user_session_issuer_id, client_id_metadata_uri) WHERE deleted IS FALSE
-DO UPDATE SET updated_at = user_session_issuer_cimd_clients.updated_at
+DO UPDATE SET
+    organization_id = COALESCE(user_session_issuer_cimd_clients.organization_id, EXCLUDED.organization_id),
+    updated_at = user_session_issuer_cimd_clients.updated_at
 RETURNING *, (xmax = 0) AS inserted;
 
 -- name: GetUserSessionIssuerCimdClientByID :one
@@ -478,6 +484,7 @@ WHERE user_session_issuer_id = @user_session_issuer_id
 -- Registers a client from an RFC 7591 request.
 INSERT INTO user_session_clients (
     project_id,
+    organization_id,
     user_session_issuer_id,
     client_id,
     client_secret_hash,
@@ -490,6 +497,7 @@ INSERT INTO user_session_clients (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
+    (SELECT organization_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
     @user_session_issuer_id,
     @client_id,
     @client_secret_hash,
@@ -528,6 +536,7 @@ RETURNING *;
 --     already map to invalid_client.
 INSERT INTO user_session_clients (
     project_id,
+    organization_id,
     user_session_issuer_id,
     client_id,
     client_secret_hash,
@@ -544,6 +553,7 @@ INSERT INTO user_session_clients (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
+    (SELECT organization_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
     @user_session_issuer_id,
     @client_id,
     NULL,
@@ -560,6 +570,14 @@ VALUES (
 )
 ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
 DO UPDATE SET
+    -- Fill-only: a refresh may populate an organization the row was created
+    -- without, but never replaces one it already carries, so the stored value
+    -- comes first. Deliberately asymmetric with project_id, which this branch
+    -- leaves alone entirely, because a row created before organization
+    -- tenancy existed has no other occasion to acquire one. Tracking the
+    -- parent instead would move a row's organization while its project_id
+    -- stayed put, leaving the two contradicting each other.
+    organization_id = COALESCE(user_session_clients.organization_id, EXCLUDED.organization_id),
     client_name = EXCLUDED.client_name,
     redirect_uris = EXCLUDED.redirect_uris,
     client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
@@ -691,6 +709,7 @@ RETURNING *;
 -- HandleToken's refresh_token grant.
 INSERT INTO user_sessions (
     project_id,
+    organization_id,
     user_session_issuer_id,
     user_session_client_id,
     subject_urn,
@@ -702,6 +721,7 @@ INSERT INTO user_sessions (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
+    (SELECT organization_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
     @user_session_issuer_id,
     @user_session_client_id,
     @subject_urn,
@@ -716,12 +736,14 @@ RETURNING *;
 -- name: CreateUserSessionConsent :one
 INSERT INTO user_session_consents (
     project_id,
+    organization_id,
     subject_urn,
     user_session_client_id,
     remote_set_hash
 )
 VALUES (
     (SELECT project_id FROM user_session_clients WHERE id = @user_session_client_id),
+    (SELECT organization_id FROM user_session_clients WHERE id = @user_session_client_id),
     @subject_urn,
     @user_session_client_id,
     @remote_set_hash

--- a/server/internal/usersessions/refreshusersessionclientcimd_test.go
+++ b/server/internal/usersessions/refreshusersessionclientcimd_test.go
@@ -225,6 +225,7 @@ func TestRefreshUserSessionClientCIMD(t *testing.T) {
 
 	ctx, ti, ds, seeded := newRefreshTestSetup(t, "refresh-client-issuer")
 	backdateFetchedAt(t, ctx, ti, seeded.ID)
+	requireOrganizationID(t, ctx, seeded.OrganizationID)
 
 	ds.set(t, func(ds *cimdDocServer) {
 		ds.etag = `"v1"`

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -104,6 +104,7 @@ func (q *Queries) CountActiveUserSessionsByClientIDs(ctx context.Context, userSe
 const createUserSession = `-- name: CreateUserSession :one
 INSERT INTO user_sessions (
     project_id,
+    organization_id,
     user_session_issuer_id,
     user_session_client_id,
     subject_urn,
@@ -115,6 +116,7 @@ INSERT INTO user_sessions (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
+    (SELECT organization_id FROM user_session_issuers WHERE id = $1),
     $1,
     $2,
     $3,
@@ -178,6 +180,7 @@ const createUserSessionClient = `-- name: CreateUserSessionClient :one
 
 INSERT INTO user_session_clients (
     project_id,
+    organization_id,
     user_session_issuer_id,
     client_id,
     client_secret_hash,
@@ -190,6 +193,7 @@ INSERT INTO user_session_clients (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
+    (SELECT organization_id FROM user_session_issuers WHERE id = $1),
     $1,
     $2,
     $3,
@@ -261,12 +265,14 @@ func (q *Queries) CreateUserSessionClient(ctx context.Context, arg CreateUserSes
 const createUserSessionConsent = `-- name: CreateUserSessionConsent :one
 INSERT INTO user_session_consents (
     project_id,
+    organization_id,
     subject_urn,
     user_session_client_id,
     remote_set_hash
 )
 VALUES (
     (SELECT project_id FROM user_session_clients WHERE id = $1),
+    (SELECT organization_id FROM user_session_clients WHERE id = $1),
     $2,
     $1,
     $3
@@ -302,6 +308,7 @@ func (q *Queries) CreateUserSessionConsent(ctx context.Context, arg CreateUserSe
 const createUserSessionIssuer = `-- name: CreateUserSessionIssuer :one
 INSERT INTO user_session_issuers (
     project_id,
+    organization_id,
     slug,
     authn_challenge_mode,
     session_duration
@@ -310,13 +317,15 @@ VALUES (
     $1::uuid,
     $2,
     $3,
-    $4
+    $4,
+    $5
 )
 RETURNING id, project_id, organization_id, slug, authn_challenge_mode, session_duration, classification, client_id_metadata_admission_mode, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateUserSessionIssuerParams struct {
 	ProjectID          uuid.UUID
+	OrganizationID     pgtype.Text
 	Slug               string
 	AuthnChallengeMode string
 	SessionDuration    pgtype.Interval
@@ -325,6 +334,7 @@ type CreateUserSessionIssuerParams struct {
 func (q *Queries) CreateUserSessionIssuer(ctx context.Context, arg CreateUserSessionIssuerParams) (UserSessionIssuer, error) {
 	row := q.db.QueryRow(ctx, createUserSessionIssuer,
 		arg.ProjectID,
+		arg.OrganizationID,
 		arg.Slug,
 		arg.AuthnChallengeMode,
 		arg.SessionDuration,
@@ -348,14 +358,16 @@ func (q *Queries) CreateUserSessionIssuer(ctx context.Context, arg CreateUserSes
 }
 
 const createUserSessionIssuerCimdClient = `-- name: CreateUserSessionIssuerCimdClient :one
-INSERT INTO user_session_issuer_cimd_clients (project_id, user_session_issuer_id, client_id_metadata_uri)
-SELECT $1::uuid, iss.id, $2
+INSERT INTO user_session_issuer_cimd_clients (project_id, organization_id, user_session_issuer_id, client_id_metadata_uri)
+SELECT $1::uuid, iss.organization_id, iss.id, $2
 FROM user_session_issuers AS iss
 WHERE iss.id = $3
   AND iss.project_id = $1::uuid
   AND iss.deleted IS FALSE
 ON CONFLICT (user_session_issuer_id, client_id_metadata_uri) WHERE deleted IS FALSE
-DO UPDATE SET updated_at = user_session_issuer_cimd_clients.updated_at
+DO UPDATE SET
+    organization_id = COALESCE(user_session_issuer_cimd_clients.organization_id, EXCLUDED.organization_id),
+    updated_at = user_session_issuer_cimd_clients.updated_at
 RETURNING id, project_id, organization_id, user_session_issuer_id, client_id_metadata_uri, created_at, updated_at, deleted_at, deleted, (xmax = 0) AS inserted
 `
 
@@ -387,11 +399,13 @@ type CreateUserSessionIssuerCimdClientRow struct {
 // than silently reviving an old one.
 //
 // `inserted` distinguishes the two so the caller only records an add event
-// for a real new grant. The DO UPDATE is a deliberate no-op write of the
-// existing updated_at: a genuine touch would misreport a re-add as a
+// for a real new grant. The DO UPDATE deliberately rewrites updated_at with
+// its own existing value: a genuine touch would misreport a re-add as a
 // modification, but ON CONFLICT still needs an action for RETURNING to
 // yield the row. `xmax = 0` is the standard test for "this row came from
-// the INSERT rather than the UPDATE".
+// the INSERT rather than the UPDATE". organization_id is the one column the
+// branch really writes, and only when the row has none, so re-adding a grant
+// can fill in tenancy without ever moving it.
 func (q *Queries) CreateUserSessionIssuerCimdClient(ctx context.Context, arg CreateUserSessionIssuerCimdClientParams) (CreateUserSessionIssuerCimdClientRow, error) {
 	row := q.db.QueryRow(ctx, createUserSessionIssuerCimdClient, arg.ProjectID, arg.ClientIDMetadataUri, arg.UserSessionIssuerID)
 	var i CreateUserSessionIssuerCimdClientRow
@@ -2291,6 +2305,7 @@ func (q *Queries) UpdateUserSessionIssuer(ctx context.Context, arg UpdateUserSes
 const upsertUserSessionClientFromCIMD = `-- name: UpsertUserSessionClientFromCIMD :one
 INSERT INTO user_session_clients (
     project_id,
+    organization_id,
     user_session_issuer_id,
     client_id,
     client_secret_hash,
@@ -2307,6 +2322,7 @@ INSERT INTO user_session_clients (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
+    (SELECT organization_id FROM user_session_issuers WHERE id = $1),
     $1,
     $2,
     NULL,
@@ -2323,6 +2339,14 @@ VALUES (
 )
 ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
 DO UPDATE SET
+    -- Fill-only: a refresh may populate an organization the row was created
+    -- without, but never replaces one it already carries, so the stored value
+    -- comes first. Deliberately asymmetric with project_id, which this branch
+    -- leaves alone entirely, because a row created before organization
+    -- tenancy existed has no other occasion to acquire one. Tracking the
+    -- parent instead would move a row's organization while its project_id
+    -- stayed put, leaving the two contradicting each other.
+    organization_id = COALESCE(user_session_clients.organization_id, EXCLUDED.organization_id),
     client_name = EXCLUDED.client_name,
     redirect_uris = EXCLUDED.redirect_uris,
     client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,

--- a/server/internal/usersessions/setup_test.go
+++ b/server/internal/usersessions/setup_test.go
@@ -349,6 +349,21 @@ func seedUserSessionConsent(t *testing.T, ctx context.Context, conn *pgxpool.Poo
 	return row, nil
 }
 
+// requireOrganizationID asserts that a row carries the organization tenancy of
+// the test's auth context. Every user-session row is written with its
+// organization alongside its project, either supplied by the writer or derived
+// from the row's parent, so a NULL here means a write path skipped it.
+func requireOrganizationID(t *testing.T, ctx context.Context, got pgtype.Text) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+
+	require.True(t, got.Valid, "organization_id must not be NULL")
+	require.Equal(t, authCtx.ActiveOrganizationID, got.String)
+}
+
 // seedIssuer creates an issuer with the given slug and returns its id.
 func seedIssuer(t *testing.T, ctx context.Context, ti *testInstance, slug string) uuid.UUID {
 	t.Helper()


### PR DESCRIPTION
[AIM-102](https://linear.app/speakeasy/issue/AIM-102/feat-dual-write-organization-id-across-user-session-issuers-and-their)

## Summary

Populates `organization_id` on every new row in the five tables the expand migration added: `user_session_issuers`, `user_session_clients`, `user_session_issuer_cimd_clients`, `user_sessions`, and `user_session_consents`.

`user_session_issuers` is the only one where Go supplies tenancy, so its writers now take it explicitly. `mintServerUserSessionIssuer` gains an `organizationID` parameter threaded from both of its callers rather than resolving it from the project inside the transaction. An audit turned up two writers beyond the three the issue named: platform MCP catalog registration and the local demo seed's tunnel fixture.

The four child tables never receive tenancy from Go, so they derive it in SQL from the same parent row their `project_id` already comes from. `user_session_consents` derives from `user_session_clients`; the rest derive from `user_session_issuers`. `CreateUserSessionIssuerCimdClient` writes the column from the issuer row it already reads, and its `project_id` predicate is deliberately untouched.

Both CIMD upserts fill `organization_id` on their `ON CONFLICT` branch only when the row has none, so an authorize-time refresh can complete a row that predates the column without moving one that is already tenanted.

Assertions live in existing tests, one per table, plus one new test covering the fill-only branch. That branch is only observable when a parent's organization differs from its child's, which needs a test-only fixture to reach, so it gets a dedicated test rather than an inline assertion.

## Motivation

The expand migration added the column but writes nothing to it, so every row created after it lands with a NULL. The backfill can only fix rows that exist when it runs, which makes the ordering strict: this deploys first, the backfill runs behind it, and the read rescope follows independently.

Two shape decisions are worth calling out for review.

The children use a second correlated subquery beside the existing `project_id` one rather than restructuring to `INSERT ... SELECT`. The restructure reads the parent once instead of twice, but it turns a missing parent into `pgx.ErrNoRows`, and `client_resolver.go` already maps that to an OAuth `invalid_client` response to signal a deliberate `DO UPDATE` guard refusal. A tenancy bug would then be indistinguishable from that refusal, with no 500 and no log. The concurrency argument for restructuring does not apply: a single statement takes one snapshot, so two subqueries cannot observe different versions of the parent.

The `ON CONFLICT` fill is ordered `COALESCE(stored, excluded)`, not the reverse. Those branches leave `project_id` alone, so adopting the issuer's current organization would leave a row whose two tenancy columns name different owners. This is latent today and becomes reachable once issuers can be rescoped.

Nothing here lets a caller create an organization-tier issuer, so in practice every row this writes will have both columns set. Out of scope: backfilling existing rows, rescoping reads, any organization-tier creation surface, and making the column `NOT NULL`.

One caveat for the backfill issue, captured on AIM-101: because the children derive tenancy from their parent, a new child of a pre-existing parent still lands NULL, and consents are two hops out, so they land NULL if either the issuer or the client predates this deploy. The backfill statements hop directly from `projects` rather than through the parent chain, so they handle those rows and need no ordering among themselves. What does not hold is the assumption that the deploy stops NULL rows from arriving: expect consent population to sit near zero until the backfill runs, and the read rescope must not treat "created after this deploy" as meaning populated.

