### PR TITLE
chore: upgrade modelcontextprotocol/go-sdk to v1.7.0 (MCP 2026-07-28)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/moby/moby/client v0.4.0
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oschwald/maxminddb-golang v1.13.1
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgx-contrib/pgxotel v0.0.0-20250908221444-24ae56d05ec0

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -332,6 +332,12 @@ type authRoundTripper struct {
 }
 
 func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Configured headers are operator-supplied and are not yet reserved against
+	// the protocol's own header names, so a definition naming Mcp-Method would
+	// overwrite the SDK's value below. Classify the request from what the SDK
+	// sent, before that can happen.
+	discoverProbe := req.Header.Get(headerMCPMethod) == methodServerDiscover
+
 	if rt.authorization != "" || len(rt.headers) > 0 {
 		req = req.Clone(req.Context())
 		if rt.authorization != "" {
@@ -342,7 +348,7 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
-	if req.Header.Get(headerMCPMethod) == methodServerDiscover {
+	if discoverProbe {
 		req = req.WithContext(context.WithValue(req.Context(), discoverProbeContextKey{}, true))
 	}
 

--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -126,7 +126,7 @@ func NewClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardia
 	if opts.DisableRetries {
 		httpClient = guardianPolicy.PooledClient()
 	} else {
-		httpClient = guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
+		httpClient = guardianPolicy.PooledClient(guardian.WithRetryConfig(discoverAwareRetryConfig(logger, remoteURL)))
 	}
 	trasnport := httpClient.Transport
 	authRT := &authRoundTripper{
@@ -342,6 +342,10 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 	}
 
+	if req.Header.Get(headerMCPMethod) == methodServerDiscover {
+		req = req.WithContext(context.WithValue(req.Context(), discoverProbeContextKey{}, true))
+	}
+
 	resp, err := rt.base.RoundTrip(req)
 	if err != nil {
 		return nil, fmt.Errorf("external mcp round trip: %w", err)
@@ -357,4 +361,60 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	return resp, nil
+}
+
+const (
+	// headerMCPMethod mirrors the JSON-RPC method of an MCP request into an
+	// HTTP header. The SDK sets it only from protocol revision 2026-07-28
+	// onwards, so the legacy initialize handshake never carries it.
+	headerMCPMethod = "Mcp-Method"
+
+	// methodServerDiscover is the capability probe the SDK sends before every
+	// connect. An upstream that predates protocol revision 2026-07-28 rejects
+	// it, and the SDK then falls back to the legacy initialize handshake on
+	// the same connection.
+	methodServerDiscover = "server/discover"
+)
+
+// discoverProbeContextKey marks a request context as belonging to the
+// server/discover capability probe. The marker is set on the outbound request
+// and read back by the retry policy, which only receives a context and a
+// response and so cannot recognize the probe on a transport failure otherwise.
+type discoverProbeContextKey struct{}
+
+// discoverAwareRetryConfig returns the default retry configuration with one
+// exception: the server/discover capability probe is never retried.
+//
+// A rejected probe is the expected answer from any upstream that predates MCP
+// 2026-07-28, and the SDK answers it by falling back to the legacy initialize
+// handshake. Retrying a rejection that will not change spends the whole backoff
+// budget first: five attempts and roughly 15 seconds, on a client that connects
+// once per tool call. Every other request, the fallback handshake and the tool
+// call included, keeps the full retry budget.
+func discoverAwareRetryConfig(logger *slog.Logger, remoteURL string) *guardian.RetryConfig {
+	config := guardian.DefaultRetryConfig()
+	checkRetry := config.CheckRetry
+
+	config.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		retry, checkErr := checkRetry(ctx, resp, err)
+		if !retry {
+			return retry, checkErr
+		}
+		if probe, _ := ctx.Value(discoverProbeContextKey{}).(bool); !probe {
+			return retry, checkErr
+		}
+
+		args := []any{attr.SlogURL(remoteURL)}
+		if resp != nil {
+			args = append(args, attr.SlogHTTPResponseStatusCode(resp.StatusCode))
+		}
+		if err != nil {
+			args = append(args, attr.SlogError(err))
+		}
+		logger.InfoContext(ctx, "external mcp server rejected the capability probe, falling back to the legacy handshake", args...)
+
+		return false, checkErr
+	}
+
+	return config
 }

--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -146,11 +146,12 @@ func NewClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardia
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{
-		Name:       "gram-server",
-		Version:    "1.0.0",
-		Title:      "",
-		WebsiteURL: "https://getgram.ai",
-		Icons:      nil,
+		Name:        "gram-server",
+		Version:     "1.0.0",
+		Title:       "",
+		Description: "",
+		WebsiteURL:  "https://getgram.ai",
+		Icons:       nil,
 	}, nil)
 
 	// mcp.StreamableClientTransport treats MaxRetries == 0 as "use the SDK's
@@ -290,9 +291,11 @@ func (c *Client) CallTool(ctx context.Context, toolName string, arguments json.R
 
 	c.beginRequest()
 	callResult, err := c.session.CallTool(ctx, &mcp.CallToolParams{
-		Meta:      mcp.Meta{},
-		Name:      toolName,
-		Arguments: args,
+		Meta:           mcp.Meta{},
+		Name:           toolName,
+		Arguments:      args,
+		InputResponses: nil,
+		RequestState:   "",
 	})
 	if err != nil {
 		return nil, classifyRequestError("call tool on external mcp server", c.remoteURL, c.authRT, c.bodyLimitRT, err)

--- a/server/internal/externalmcp/mcpclient_discoverprobe_test.go
+++ b/server/internal/externalmcp/mcpclient_discoverprobe_test.go
@@ -78,7 +78,7 @@ func (h *handshakeRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func newDiscoverProbeClient(t *testing.T, handler http.Handler) (*Client, error) {
+func newDiscoverProbeClient(t *testing.T, handler http.Handler, headers map[string]string) (*Client, error) {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
@@ -95,7 +95,7 @@ func newDiscoverProbeClient(t *testing.T, handler http.Handler) (*Client, error)
 		policy,
 		server.URL,
 		types.TransportTypeStreamableHTTP,
-		&ClientOptions{DisableRetries: false},
+		&ClientOptions{DisableRetries: false, Headers: headers},
 	)
 }
 
@@ -114,7 +114,7 @@ func TestNewClientDoesNotRetryRejectedDiscoverProbe(t *testing.T) {
 		return 0
 	})
 
-	client, err := newDiscoverProbeClient(t, recorder)
+	client, err := newDiscoverProbeClient(t, recorder, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
@@ -138,10 +138,55 @@ func TestNewClientRetriesNonDiscoverFailures(t *testing.T) {
 		}
 	})
 
-	client, err := newDiscoverProbeClient(t, recorder)
+	client, err := newDiscoverProbeClient(t, recorder, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
 	require.Equal(t, 1, recorder.attemptsFor(methodServerDiscover), "the capability probe must not be retried")
 	require.Equal(t, 2, recorder.attemptsFor("initialize"), "a failed legacy handshake must be retried")
+}
+
+// Configured headers are operator-supplied and are not reserved against the
+// protocol's own header names, so a header definition may name Mcp-Method. The
+// probe must still be recognized from what the SDK sent rather than from the
+// overwritten value, or the exemption silently stops applying.
+func TestNewClientClassifiesDiscoverProbeBeforeConfiguredHeaders(t *testing.T) {
+	t.Parallel()
+
+	recorder := newHandshakeRecorder(func(method string, _ int) int {
+		if method == methodServerDiscover {
+			return http.StatusInternalServerError
+		}
+		return 0
+	})
+
+	client, err := newDiscoverProbeClient(t, recorder, map[string]string{headerMCPMethod: "tools/call"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Equal(t, 1, recorder.attemptsFor(methodServerDiscover), "a configured Mcp-Method must not defeat the exemption")
+}
+
+// The mirror of the case above: a configured Mcp-Method naming the probe must
+// not classify unrelated requests as the probe, which would strip the retry
+// budget from the request that most depends on it.
+func TestNewClientConfiguredDiscoverHeaderDoesNotStripRetries(t *testing.T) {
+	t.Parallel()
+
+	recorder := newHandshakeRecorder(func(method string, attempt int) int {
+		switch {
+		case method == methodServerDiscover:
+			return http.StatusInternalServerError
+		case method == "initialize" && attempt == 1:
+			return http.StatusInternalServerError
+		default:
+			return 0
+		}
+	})
+
+	client, err := newDiscoverProbeClient(t, recorder, map[string]string{headerMCPMethod: methodServerDiscover})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Equal(t, 2, recorder.attemptsFor("initialize"), "a configured Mcp-Method must not classify other requests as the probe")
 }

--- a/server/internal/externalmcp/mcpclient_discoverprobe_test.go
+++ b/server/internal/externalmcp/mcpclient_discoverprobe_test.go
@@ -1,0 +1,147 @@
+package externalmcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// handshakeRecorder is a minimal Streamable HTTP MCP server that counts the
+// HTTP attempts made per JSON-RPC method. It answers the legacy initialize
+// handshake and delegates every other method to the supplied responder, which
+// decides the status code for that attempt.
+type handshakeRecorder struct {
+	mu       sync.Mutex
+	attempts map[string]int
+
+	// respond reports the status code to answer with for the given method and
+	// 1-based attempt number. A zero return means the recorder answers the
+	// method itself.
+	respond func(method string, attempt int) int
+}
+
+func newHandshakeRecorder(respond func(method string, attempt int) int) *handshakeRecorder {
+	return &handshakeRecorder{attempts: map[string]int{}, respond: respond}
+}
+
+func (h *handshakeRecorder) attemptsFor(method string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.attempts[method]
+}
+
+func (h *handshakeRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var envelope struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	h.mu.Lock()
+	h.attempts[envelope.Method]++
+	attempt := h.attempts[envelope.Method]
+	h.mu.Unlock()
+
+	if status := h.respond(envelope.Method, attempt); status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+
+	// Notifications carry no id and must be acknowledged with 202 and no body.
+	if len(envelope.ID) == 0 {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Mcp-Session-Id", "test-session")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      envelope.ID,
+		"result": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"serverInfo":      map[string]any{"name": "recorder", "version": "1.0.0"},
+		},
+	})
+}
+
+func newDiscoverProbeClient(t *testing.T, handler http.Handler) (*Client, error) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	// An unsafe policy is required so the client may dial httptest's loopback
+	// listener; the default policy blocks 127.0.0.0/8.
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	return NewClient(
+		t.Context(),
+		testenv.NewLogger(t),
+		policy,
+		server.URL,
+		types.TransportTypeStreamableHTTP,
+		&ClientOptions{DisableRetries: false},
+	)
+}
+
+// A server that predates MCP 2026-07-28 may answer the server/discover
+// capability probe with a 5xx. That answer will not change on a retry, and the
+// SDK responds to it by falling back to the legacy initialize handshake, so
+// the probe must be attempted exactly once rather than spending the full
+// retry budget first.
+func TestNewClientDoesNotRetryRejectedDiscoverProbe(t *testing.T) {
+	t.Parallel()
+
+	recorder := newHandshakeRecorder(func(method string, _ int) int {
+		if method == methodServerDiscover {
+			return http.StatusInternalServerError
+		}
+		return 0
+	})
+
+	client, err := newDiscoverProbeClient(t, recorder)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Equal(t, 1, recorder.attemptsFor(methodServerDiscover), "the capability probe must not be retried")
+	require.Equal(t, 1, recorder.attemptsFor("initialize"), "the legacy handshake must run once the probe is refused")
+}
+
+// The retry budget is withheld from the capability probe only. A failure on
+// any other request, the fallback handshake included, must still be retried.
+func TestNewClientRetriesNonDiscoverFailures(t *testing.T) {
+	t.Parallel()
+
+	recorder := newHandshakeRecorder(func(method string, attempt int) int {
+		switch {
+		case method == methodServerDiscover:
+			return http.StatusInternalServerError
+		case method == "initialize" && attempt == 1:
+			return http.StatusInternalServerError
+		default:
+			return 0
+		}
+	})
+
+	client, err := newDiscoverProbeClient(t, recorder)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.Equal(t, 1, recorder.attemptsFor(methodServerDiscover), "the capability probe must not be retried")
+	require.Equal(t, 2, recorder.attemptsFor("initialize"), "a failed legacy handshake must be retried")
+}

--- a/server/internal/externalmcp/mcpclient_discoverprobe_test.go
+++ b/server/internal/externalmcp/mcpclient_discoverprobe_test.go
@@ -21,6 +21,7 @@ import (
 type handshakeRecorder struct {
 	mu       sync.Mutex
 	attempts map[string]int
+	headers  map[string]http.Header
 
 	// respond reports the status code to answer with for the given method and
 	// 1-based attempt number. A zero return means the recorder answers the
@@ -29,7 +30,18 @@ type handshakeRecorder struct {
 }
 
 func newHandshakeRecorder(respond func(method string, attempt int) int) *handshakeRecorder {
-	return &handshakeRecorder{attempts: map[string]int{}, respond: respond}
+	return &handshakeRecorder{attempts: map[string]int{}, headers: map[string]http.Header{}, respond: respond}
+}
+
+// headerFor returns the value the first attempt of method carried for the named
+// header. Tests that depend on a header reaching the wire assert on this before
+// asserting on the behavior that header is supposed to drive, so a break in
+// header injection surfaces as a failure rather than as a silently uncovered
+// case.
+func (h *handshakeRecorder) headerFor(method, name string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.headers[method].Get(name)
 }
 
 func (h *handshakeRecorder) attemptsFor(method string) int {
@@ -51,6 +63,9 @@ func (h *handshakeRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	h.attempts[envelope.Method]++
 	attempt := h.attempts[envelope.Method]
+	if _, seen := h.headers[envelope.Method]; !seen {
+		h.headers[envelope.Method] = r.Header.Clone()
+	}
 	h.mu.Unlock()
 
 	if status := h.respond(envelope.Method, attempt); status != 0 {
@@ -164,6 +179,7 @@ func TestNewClientClassifiesDiscoverProbeBeforeConfiguredHeaders(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
+	require.Equal(t, "tools/call", recorder.headerFor(methodServerDiscover, headerMCPMethod), "the configured header must reach the wire, or the overwrite is never exercised")
 	require.Equal(t, 1, recorder.attemptsFor(methodServerDiscover), "a configured Mcp-Method must not defeat the exemption")
 }
 
@@ -188,5 +204,6 @@ func TestNewClientConfiguredDiscoverHeaderDoesNotStripRetries(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close() })
 
+	require.Equal(t, methodServerDiscover, recorder.headerFor("initialize", headerMCPMethod), "the configured header must reach the wire, or the misclassification is never exercised")
 	require.Equal(t, 2, recorder.attemptsFor("initialize"), "a configured Mcp-Method must not classify other requests as the probe")
 }

--- a/server/internal/platformmcp/remotesessionprovider/adapter.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter.go
@@ -232,11 +232,12 @@ func (a *Adapter) probe(ctx context.Context, descriptor Descriptor, token string
 	httpClient.Transport = authRT
 
 	client := mcp.NewClient(&mcp.Implementation{
-		Name:       "platform-mcp-readiness",
-		Title:      "",
-		Version:    "1.0.0",
-		WebsiteURL: "",
-		Icons:      nil,
+		Name:        "platform-mcp-readiness",
+		Title:       "",
+		Description: "",
+		Version:     "1.0.0",
+		WebsiteURL:  "",
+		Icons:       nil,
 	}, nil)
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
 		Endpoint:             descriptor.StreamableHTTPURL,

--- a/server/internal/remotemcp/proxy/resources_list_response.go
+++ b/server/internal/remotemcp/proxy/resources_list_response.go
@@ -70,6 +70,7 @@ func resourcesListResponseFromRemoteMessage(request *ResourcesListRequest, msg *
 
 	result := &mcp.ListResourcesResult{
 		Meta:       nil,
+		Cacheable:  mcp.Cacheable{TTLMs: 0, CacheScope: ""},
 		NextCursor: "",
 		Resources:  nil,
 	}

--- a/server/internal/remotemcp/proxy/resources_read_request.go
+++ b/server/internal/remotemcp/proxy/resources_read_request.go
@@ -51,8 +51,10 @@ func resourcesReadRequestFromUserRequest(req *UserRequest) (*ResourcesReadReques
 	}
 
 	params := &mcp.ReadResourceParams{
-		Meta: nil,
-		URI:  "",
+		Meta:           nil,
+		URI:            "",
+		InputResponses: nil,
+		RequestState:   "",
 	}
 	if err := json.Unmarshal(rpcReq.Params, params); err != nil {
 		return nil, false

--- a/server/internal/remotemcp/proxy/resources_read_response.go
+++ b/server/internal/remotemcp/proxy/resources_read_response.go
@@ -69,8 +69,11 @@ func resourcesReadResponseFromRemoteMessage(request *ResourcesReadRequest, msg *
 	}
 
 	result := &mcp.ReadResourceResult{
-		Meta:     nil,
-		Contents: nil,
+		Meta:          nil,
+		Cacheable:     mcp.Cacheable{TTLMs: 0, CacheScope: ""},
+		Contents:      nil,
+		InputRequests: nil,
+		RequestState:  "",
 	}
 	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
 		return nil, false

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -64,9 +64,11 @@ func toolsCallRequestFromUserRequest(req *UserRequest) (*ToolsCallRequest, bool)
 	}
 
 	params := &mcp.CallToolParamsRaw{
-		Arguments: nil,
-		Meta:      nil,
-		Name:      "",
+		Arguments:      nil,
+		Meta:           nil,
+		Name:           "",
+		InputResponses: nil,
+		RequestState:   "",
 	}
 	if err := json.Unmarshal(rpcReq.Params, params); err != nil {
 		return nil, false

--- a/server/internal/remotemcp/proxy/tools_call_response.go
+++ b/server/internal/remotemcp/proxy/tools_call_response.go
@@ -75,6 +75,8 @@ func toolsCallResponseFromRemoteMessage(request *ToolsCallRequest, msg *RemoteMe
 		IsError:           false,
 		Meta:              nil,
 		StructuredContent: nil,
+		InputRequests:     nil,
+		RequestState:      "",
 	}
 	if err := json.Unmarshal(rpcResp.Result, result); err != nil {
 		return nil, false

--- a/server/internal/remotemcp/proxy/tools_list_response.go
+++ b/server/internal/remotemcp/proxy/tools_list_response.go
@@ -70,6 +70,7 @@ func toolsListResponseFromRemoteMessage(request *ToolsListRequest, msg *RemoteMe
 
 	result := &mcp.ListToolsResult{
 		Meta:       nil,
+		Cacheable:  mcp.Cacheable{TTLMs: 0, CacheScope: ""},
 		NextCursor: "",
 		Tools:      nil,
 	}

--- a/server/internal/testmcp/server.go
+++ b/server/internal/testmcp/server.go
@@ -49,11 +49,12 @@ type Server struct {
 // a Tool to its MCP representation is returned to the caller.
 func (s *Server) mcpServer() (*mcp.Server, error) {
 	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Icons:      nil,
-		Name:       "testmcp-server",
-		Title:      "",
-		Version:    "1.0.0",
-		WebsiteURL: "",
+		Icons:       nil,
+		Name:        "testmcp-server",
+		Title:       "",
+		Description: "",
+		Version:     "1.0.0",
+		WebsiteURL:  "",
 	}, nil)
 
 	for _, tool := range s.Tools {

--- a/server/internal/testmcp/tool.go
+++ b/server/internal/testmcp/tool.go
@@ -88,6 +88,8 @@ func (t Tool) mcpToolHandler() mcp.ToolHandler {
 			IsError:           response.IsError,
 			Meta:              nil,
 			StructuredContent: nil,
+			InputRequests:     nil,
+			RequestState:      "",
 		}, nil
 	}
 }


### PR DESCRIPTION
[AIM-39](https://linear.app/speakeasy/issue/AIM-39/chore-upgrade-modelcontextprotocolgo-sdk-to-v170-mcp-2026-07-28)

## Summary

Two commits, reviewable independently.

**`chore:` the bump.** `github.com/modelcontextprotocol/go-sdk` `v1.6.1` to `v1.7.0`, which implements MCP protocol revision `2026-07-28`. Only `go.mod` and `go.sum` move, with no transitive bumps. Everything else is `exhaustruct` field additions for members the SDK added, all set to zero values, so today's wire output is unchanged: `Implementation.Description`; `InputRequests`, `InputResponses`, and `RequestState` on the call and read params and results (these back multi round-trip requests); and the embedded `Cacheable` on the list and read results.

Two behavior changes ride along with the bump itself:

- **Every SDK client connect now probes `server/discover` first**, falling back to a legacy `initialize` at `2025-11-25` on any error. There is no exported opt-out. This affects `externalmcp`, `platformmcp` catalog readiness, and the remote session provider adapter.
- **`/platform/mcp` starts accepting `2026-07-28`** automatically, because `Stateless: true` is exactly the mode where the SDK enables the new protocol. Accepted ungated: the client population there is first-party only (assistant token), and the SDK offers no per-handler knob short of the `MCPGODEBUG` hatches that v1.9.0 removes.

The hosted MCP gateway and the remote MCP proxy are hand-rolled and take no SDK behavior, so neither changes here. Consuming the new capabilities (gateway `server/discover`, advertising `2026-07-28`, caching hints) stays in the sibling issues.

**`fix:` the retry exemption.** `externalmcp` no longer retries the `server/discover` capability probe. The probe is recognized by the `Mcp-Method: server/discover` header, which the SDK sets only from revision `2026-07-28` onwards, so the fallback `initialize` never carries it and keeps the full retry budget, as does the tool call itself. The marker is stamped onto the request context inside `authRoundTripper`, which sits outside the retry loop and is the only place that sees per-request headers, so the exemption also covers transport failures where `CheckRetry` receives a nil response.

## Motivation

`externalmcp.NewClient` builds a fresh SDK client and connects on **every** external MCP tool call; sessions are not pooled. When retries are enabled it uses the default guardian retry config, which is `retryablehttp` with five attempts and exponential backoff on 5xx and 429, and nothing in the guardian chain sets an `http.Client.Timeout`.

So an upstream that predates `2026-07-28` and answers the unknown `server/discover` method with a 5xx, rather than the conformant 200 plus a JSON-RPC method-not-found, spends the entire backoff budget before the SDK gives up and falls back. Measured against a 500-on-discover server with the fix reverted: **five attempts and 15.01s for a single connect**. That answer is not going to change on a retry, and the whole wait is dead time in front of a fallback that was always going to run.

This is a **latency** change, not a correctness fix. The SDK wraps a failed discover in `jsonrpc2.ErrRejected` specifically so the connection survives and the legacy fallback always gets its turn, so nothing fails today, it is only slow. It is a separate commit for that reason: it can be dropped without affecting the bump.

Trade-offs worth a reviewer's attention:

- A single **transient** 5xx or 429 on the probe now downgrades that session to `2025-11-25` instead of being retried. Because sessions are per tool call, the negotiated revision becomes non-deterministic against a flaky upstream. The exemption logs at info when it fires, which is the only visibility into how often that happens.
- A rate-limited upstream receives two POSTs (probe plus fallback) instead of one honored `Retry-After`.

Exposure is limited to the two call sites that enable retries, the gateway proxy and the proxy tool executor. The `mcpapproval` and `unproxiedmcp` probes already disable retries, and both `platformmcp` SDK-client probes use a client with no retry config and a bounded probe timeout.

Two gaps are deliberately left open and tracked separately. The extra round trip is **unconditional**, so even a fully conformant upstream costs one extra POST per tool call; only session pooling fixes that. And the missing `http.Client.Timeout` means a black-holing upstream can still hang a tool call indefinitely, which is pre-existing and orthogonal to this bump.
