### PR TITLE
feat: manage Platform MCP risk policies

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -41,6 +41,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
@@ -70,6 +72,9 @@ type platformMCPConfig struct {
 	PluginPublisher        *plugins.Service
 	TemporalEnv            *tenv.Environment
 	Skills                 platformmcp.SkillsManagement
+	RiskPolicyApprovals    policycore.ApprovalCoordinator
+	RiskPolicySignaler     policycore.PolicySignaler
+	RiskPolicyCache        policycore.PolicyCacheInvalidator
 	// Telemetry is the Gram-owned ClickHouse read model the diagnostics tools
 	// answer from. Nil disables them rather than serving an empty answer, which
 	// a caller would read as "nothing is wrong".
@@ -309,6 +314,14 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create local Platform MCP risk mutation controls: %w", err)
 	}
+	riskMutations, err := platformmcp.NewRiskPolicyMutationHandlers(
+		config.DB,
+		riskMutationControls,
+		risk.NewPolicyMutationCore(config.DB, config.AuditLogger, config.RiskPolicyApprovals, config.RiskPolicySignaler, config.RiskPolicyCache),
+	)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP risk policy mutations: %w", err)
+	}
 	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
@@ -331,7 +344,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
-		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
+		riskMutations,
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -625,6 +638,14 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	if err != nil {
 		return AssistantSurface{}, fmt.Errorf("create browser Platform MCP risk mutation controls: %w", err)
 	}
+	riskMutations, err := platformmcp.NewRiskPolicyMutationHandlers(
+		config.DB,
+		riskMutationControls,
+		risk.NewPolicyMutationCore(config.DB, config.AuditLogger, config.RiskPolicyApprovals, config.RiskPolicySignaler, config.RiskPolicyCache),
+	)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create browser Platform MCP risk policy mutations: %w", err)
+	}
 	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
@@ -644,7 +665,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
-		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
+		riskMutations,
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -204,6 +204,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		},
 		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
+		RiskMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -299,7 +303,11 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
-	runtime := platformmcp.NewRuntimeWithLifecycle(
+	riskMutationControls, err := platformmcp.NewRiskMutationControls(config.DB, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), budgets.RiskMutations, config.JWTSigningKey)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create local Platform MCP risk mutation controls: %w", err)
+	}
+	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
 		gate,
@@ -321,6 +329,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
+		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
 		fixtureConfig.CatalogDescriptor(),
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)
@@ -522,6 +531,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		},
 		Skills:            newBudget(platformmcp.SkillsConnectionLimitName, platformmcp.SkillsOrganizationLimitName),
 		LifecycleMetadata: newBudget(platformmcp.LifecycleConnectionLimitName, platformmcp.LifecycleOrganizationLimitName),
+		RiskMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -606,7 +619,11 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
-	runtime := platformmcp.NewRuntimeWithLifecycle(
+	riskMutationControls, err := platformmcp.NewRiskMutationControls(config.DB, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), budgets.RiskMutations, config.JWTSigningKey)
+	if err != nil {
+		return AssistantSurface{}, fmt.Errorf("create browser Platform MCP risk mutation controls: %w", err)
+	}
+	runtime := platformmcp.NewRuntimeWithRiskMutations(
 		config.Logger,
 		authenticator,
 		gate,
@@ -625,6 +642,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		diagnostics,
 		pluginInventory,
 		sessionRecall,
+		&platformmcp.RiskMutationHandlers{Controls: riskMutationControls},
 		platformmcp.CatalogDescriptor{},
 	).WithOAuthTelemetry(oauthTelemetry)
 	oauth.Attach(config.Mux)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -56,6 +57,7 @@ type platformMCPConfig struct {
 	Environment            string
 	JWTSigningKey          string
 	ProductFeatures        *productfeatures.Client
+	FeatureFlags           feature.Provider
 	Authz                  *authz.Engine
 	Encryption             *encryption.Client
 	Identity               *identity.Resolver

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1538,6 +1538,7 @@ func newStartCommand() *cli.Command {
 				Environment:            c.String("environment"),
 				JWTSigningKey:          c.String(usersessions.JWTSigningKeyFlag),
 				ProductFeatures:        productFeatures,
+				FeatureFlags:           featureFlags,
 				Authz:                  authzEngine,
 				Encryption:             encryptionClient,
 				Identity:               identityResolver,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1526,6 +1526,11 @@ func newStartCommand() *cli.Command {
 			mcpCatalog := externalmcp.NewCatalogService(db, mcpRegistryClient, nil)
 			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, mcpCatalog, authzEngine, serverURL))
 			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, serverURL))
+			riskSignaler := background.NewThrottledSignaler(
+				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
+				30*time.Second,
+				logger,
+			)
 			platformMCPAssistant, err := configurePlatformMCP(ctx, platformMCPConfig{
 				Logger:                 logger,
 				MeterProvider:          meterProvider,
@@ -1551,6 +1556,9 @@ func newStartCommand() *cli.Command {
 				PluginPublisher:        pluginPublisher,
 				TemporalEnv:            temporalEnv,
 				Skills:                 skillsService,
+				RiskPolicyApprovals:    mcpApprovalService,
+				RiskPolicySignaler:     riskSignaler,
+				RiskPolicyCache:        shadowMCPClient,
 				Telemetry:              telemetryrepo.New(chDB),
 				TelemetryDrilldown:     telemetryrepo.New(chDB),
 				SessionCapture:         platformmcp.FeatureChecker(sessionCaptureEnabled),
@@ -1569,11 +1577,6 @@ func newStartCommand() *cli.Command {
 			functions.Attach(mux, functions.NewService(logger, tracerProvider, db, encryptionClient, tigrisStore))
 			otelsvc.Attach(mux, otelsvc.NewService(logger, tracerProvider, db, chDB, sessionManager, authzEngine, otelsvc.FeatureChecker(logsEnabled), publishers.OTELSpans, publishers.OTELLogs, publishers.OTELMetrics))
 
-			riskSignaler := background.NewThrottledSignaler(
-				&background.TemporalRiskAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
-				30*time.Second,
-				logger,
-			)
 			// riskSignaler.Shutdown is intentionally NOT registered as a shutdownFunc.
 			// runShutdown runs every func concurrently, which races temporalClient.Close()
 			// against the signaler's trailing-edge flush over the same gRPC connection

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -36,6 +36,11 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
+	// FlagPlatformMCPRiskMutations is the exact-project kill switch for risk
+	// policy and exclusion writes exposed through Platform MCP. It is evaluated
+	// at invocation time and fails closed when absent, disabled, or indeterminate.
+	FlagPlatformMCPRiskMutations Flag = "platform-mcp-risk-mutations"
+
 	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
 	// assistant the Platform MCP read toolset — the "platform" platform
 	// toolset re-serving the Platform MCP read tools over the assistant

--- a/server/internal/platformmcp/lifecycle_metadata.go
+++ b/server/internal/platformmcp/lifecycle_metadata.go
@@ -189,6 +189,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 		InputHash:            inputHash,
 		Status:               receiptStatusPending,
 		ResultCode:           pgtype.Text{String: "", Valid: false},
+		ResultPayload:        nil,
 		ExpiresAt:            pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true},
 	})
 	if err != nil {
@@ -208,6 +209,7 @@ func (s *LifecycleMetadataService) Update(ctx context.Context, principal Princip
 		RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true},
 		Status:         receiptStatusSucceeded,
 		ResultCode:     conv.ToPGText(receiptResultMetadataUpdated),
+		ResultPayload:  nil,
 		ID:             receipt.ID,
 		OrganizationID: principal.OrganizationID,
 	})

--- a/server/internal/platformmcp/lifecycle_visibility.go
+++ b/server/internal/platformmcp/lifecycle_visibility.go
@@ -179,7 +179,7 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 	if server.Visibility != from || !hmac.Equal([]byte(lifecycleMetadataVersion(s.key, server.ID.String(), server.ProjectID.String(), lifecycleMCPDisplayName(server), server.Slug.String, server.Visibility)), []byte(input.ExpectedVersion)) {
 		return UpdateMCPVisibilityResult{}, ErrRegistrationConflict
 	}
-	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, ConnectionID: connectionID, ConnectionGeneration: generation, UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: operation, IdempotencyKey: input.IdempotencyKey, InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ExpiresAt: pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true}})
+	receipt, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, ConnectionID: connectionID, ConnectionGeneration: generation, UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: operation, IdempotencyKey: input.IdempotencyKey, InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: pgtype.Timestamptz{Time: s.now().Add(receiptLifetime), InfinityModifier: pgtype.Finite, Valid: true}})
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("create platform mcp visibility receipt: %w", err)
 	}
@@ -187,7 +187,7 @@ func (s *LifecycleVisibilityService) update(ctx context.Context, principal Princ
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("update platform mcp visibility: %w", err)
 	}
-	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText(to), ID: receipt.ID, OrganizationID: principal.OrganizationID})
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: registrationID, Valid: true}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText(to), ResultPayload: nil, ID: receipt.ID, OrganizationID: principal.OrganizationID})
 	if err != nil {
 		return UpdateMCPVisibilityResult{}, fmt.Errorf("complete platform mcp visibility receipt: %w", err)
 	}

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -28,6 +28,8 @@ const (
 	LifecycleOrganizationLimitName     = "platform-mcp-lifecycle-organization"
 	SessionRecallConnectionLimitName   = "platform-mcp-session-recall-connection"
 	SessionRecallOrganizationLimitName = "platform-mcp-session-recall-organization"
+	RiskMutationConnectionLimitName    = "platform-mcp-risk-mutation-connection"
+	RiskMutationOrganizationLimitName  = "platform-mcp-risk-mutation-organization"
 )
 
 const (
@@ -51,6 +53,12 @@ const (
 	// fund them by spending the summary allowance.
 	SensitiveDiagnosticQueriesPerConnectionPerMinute   = 30
 	SensitiveDiagnosticQueriesPerOrganizationPerMinute = 300
+
+	// RiskMutationsPer* bound all risk policy and exclusion writes together.
+	// Keeping one shared budget prevents a caller from multiplying the permitted
+	// write rate by alternating between mutation tools.
+	RiskMutationsPerConnectionPerMinute   = 5
+	RiskMutationsPerOrganizationPerMinute = 50
 
 	// DrilldownRowsPerConnectionPerWindow and
 	// DrilldownMetricQueriesPerConnectionPerWindow are the second cap the
@@ -101,19 +109,32 @@ func (b OperationBudget) valid() bool {
 }
 
 func (b OperationBudget) Allow(ctx context.Context, principal Principal) error {
+	return b.allow(ctx, principal, false)
+}
+
+// AllowConnectionOrOrganization charges OAuth calls to both their connection
+// and organization buckets. A connection-less assistant has no connection to
+// charge, so it consumes only the organization allowance.
+func (b OperationBudget) AllowConnectionOrOrganization(ctx context.Context, principal Principal) error {
+	return b.allow(ctx, principal, true)
+}
+
+func (b OperationBudget) allow(ctx context.Context, principal Principal, organizationOnlyWithoutConnection bool) error {
 	if !b.valid() || principal.OrganizationID == "" {
 		return ErrOperationBudgetUnavailable
 	}
-	actorKey, err := operationBudgetActorKey(principal)
-	if err != nil {
-		return err
-	}
-	connection, err := b.Connection.Allow(ctx, actorKey)
-	if err != nil {
-		return fmt.Errorf("limit platform mcp actor operation: %w: %w", ErrOperationBudgetUnavailable, err)
-	}
-	if !connection.Allowed {
-		return ErrOperationRateLimited
+	if principal.HasConnection() || !organizationOnlyWithoutConnection {
+		actorKey, err := operationBudgetActorKey(principal)
+		if err != nil {
+			return err
+		}
+		connection, err := b.Connection.Allow(ctx, actorKey)
+		if err != nil {
+			return fmt.Errorf("limit platform mcp actor operation: %w: %w", ErrOperationBudgetUnavailable, err)
+		}
+		if !connection.Allowed {
+			return ErrOperationRateLimited
+		}
 	}
 	organization, err := b.Organization.Allow(ctx, principal.OrganizationID)
 	if err != nil {
@@ -187,6 +208,9 @@ type OperationBudgets struct {
 	// SensitiveSessionRecall meters continue_session — the only operation that
 	// serves whole-transcript content — on its own low allowance.
 	SensitiveSessionRecall OperationBudget
+	// RiskMutations is shared by policy and exclusion writes. Connection-less
+	// assistant calls consume only its organization bucket.
+	RiskMutations OperationBudget
 	// DrilldownVolume meters what the drill-downs return rather than how often
 	// they are called: rows and spans against one bucket, metric queries
 	// against another, both per connection over DrilldownVolumeWindow.
@@ -242,5 +266,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -83,6 +83,30 @@ func TestOperationBudgetThrottlesAConnectionlessAssistantBeforeOrganization(t *t
 	require.Empty(t, organization.keys)
 }
 
+func TestRiskMutationBudgetUsesOnlyOrganizationForConnectionlessAssistant(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).AllowConnectionOrOrganization(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant})
+
+	require.NoError(t, err)
+	require.Empty(t, connection.keys)
+	require.Equal(t, []string{"organization"}, organization.keys)
+}
+
+func TestRiskMutationBudgetStillChargesOAuthConnectionFirst(t *testing.T) {
+	t.Parallel()
+
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	err := (OperationBudget{Connection: connection, Organization: organization}).AllowConnectionOrOrganization(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ConnectionID: "connection", Generation: "generation"})
+
+	require.ErrorIs(t, err, ErrOperationRateLimited)
+	require.Equal(t, []string{"connection"}, connection.keys)
+	require.Empty(t, organization.keys)
+}
+
 func TestOperationBudgetRejectsAConnectionClaimedByGenerationAlone(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -692,6 +692,7 @@ INSERT INTO platform_mcp_operation_receipts (
     input_hash,
     status,
     result_code,
+    result_payload,
     expires_at
 ) VALUES (
     @organization_id,
@@ -706,6 +707,7 @@ INSERT INTO platform_mcp_operation_receipts (
     @input_hash,
     @status,
     @result_code,
+    @result_payload,
     @expires_at
 )
 RETURNING *;
@@ -724,6 +726,7 @@ UPDATE platform_mcp_operation_receipts
 SET registration_id = @registration_id,
     status = @status,
     result_code = @result_code,
+    result_payload = @result_payload,
     updated_at = clock_timestamp()
 WHERE id = @id
   AND organization_id = @organization_id

--- a/server/internal/platformmcp/registration.go
+++ b/server/internal/platformmcp/registration.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -72,6 +73,7 @@ type OperationReceipt struct {
 	RegistrationID uuid.NullUUID
 	Status         string
 	ResultCode     string
+	ResultPayload  []byte
 	InputHash      string
 	ExpiresAt      time.Time
 	Replayed       bool
@@ -927,6 +929,7 @@ func operationReceiptFromRow(row platformrepo.PlatformMcpOperationReceipt, repla
 		RegistrationID:       row.RegistrationID,
 		Status:               row.Status,
 		ResultCode:           row.ResultCode.String,
+		ResultPayload:        slices.Clone(row.ResultPayload),
 		InputHash:            row.InputHash,
 		ExpiresAt:            row.ExpiresAt.Time,
 		Replayed:             replayed,

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -2,7 +2,9 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -1040,6 +1042,59 @@ func seedRegistrationEligibleCohort(t *testing.T, ctx context.Context, conn *pgx
 // The assistant issues a handoff with no connection and the dashboard, which
 // authenticates under its own session, redeems it. This is the whole point of
 // the connection-less surfaces: neither step can key on a connection.
+func TestRiskMutationReceiptReplayConflictAndRollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_risk_mutation_receipt")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	store := NewRiskMutationReceiptStore(conn)
+	request := RiskMutationReceiptRequest{Operation: operationCreateRiskPolicy, IdempotencyKey: "risk-create-key", Input: map[string]any{"name": "normalized", "enabled": true}}
+	calls := 0
+
+	result := CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: project.ID.String(), Slug: project.Slug}, Policy: RiskPolicyReceiptSummary{ID: "11111111-1111-4111-8111-111111111111", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", MatchedExisting: false, ResultCategory: "created"}
+	first, err := store.Execute(ctx, principal, project, request, func(_ context.Context, _ pgx.Tx) (RiskMutationReceiptResult, error) {
+		calls++
+		return result, nil
+	})
+	require.NoError(t, err)
+	require.False(t, first.Replayed)
+	expectedPayload, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedPayload), string(first.ResultPayload))
+
+	replayed, err := store.Execute(ctx, principal, project, request, func(context.Context, pgx.Tx) (RiskMutationReceiptResult, error) {
+		calls++
+		return nil, errors.New("replay must not execute callback")
+	})
+	require.NoError(t, err)
+	require.True(t, replayed.Replayed)
+	require.Equal(t, first.ID, replayed.ID)
+	require.Equal(t, 1, calls)
+
+	changed := request
+	changed.Input = map[string]any{"name": "different", "enabled": true}
+	_, err = store.Execute(ctx, principal, project, changed, func(context.Context, pgx.Tx) (RiskMutationReceiptResult, error) { return nil, nil })
+	require.ErrorIs(t, err, ErrRiskMutationConflict)
+
+	failed := RiskMutationReceiptRequest{Operation: operationCreateRiskExclusion, IdempotencyKey: "rollback-key", Input: map[string]any{"match_type": "source", "match_value": "gitleaks"}}
+	_, err = store.Execute(ctx, principal, project, failed, func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error) {
+		if _, err := projectsrepo.New(tx).UploadProjectLogo(ctx, projectsrepo.UploadProjectLogoParams{LogoAssetID: uuid.NullUUID{UUID: uuid.New(), Valid: true}, ProjectID: project.ID}); err != nil {
+			return nil, fmt.Errorf("set rollback sentinel project logo: %w", err)
+		}
+		// The callback represents domain + audit work in the shared transaction;
+		// this injected audit failure must roll back the domain row and receipt.
+		return nil, errors.New("injected audit failure")
+	})
+	require.ErrorContains(t, err, "injected audit failure")
+	_, err = platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: failed.Operation, IdempotencyKey: failed.IdempotencyKey})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	rolledBack, err := projectsrepo.New(conn).GetProjectByIDAndOrganizationID(ctx, projectsrepo.GetProjectByIDAndOrganizationIDParams{ID: project.ID, OrganizationID: principal.OrganizationID})
+	require.NoError(t, err)
+	require.False(t, rolledBack.LogoAssetID.Valid)
+}
+
 func TestSetupHandoffRoundTripsWithoutAConnection(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/registration_service.go
+++ b/server/internal/platformmcp/registration_service.go
@@ -100,6 +100,7 @@ func NewRegistrationService(catalog Catalog, gate CatalogRegistrationGateChecker
 			Handoff:           OperationBudget{Connection: nil, Organization: nil},
 			SetupStart:        OperationBudget{Connection: nil, Organization: nil},
 			Repair:            OperationBudget{Connection: nil, Organization: nil},
+			RiskMutations:     OperationBudget{Connection: nil, Organization: nil},
 			LifecycleMetadata: OperationBudget{Connection: nil, Organization: nil},
 		},
 	}

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -170,9 +170,10 @@ UPDATE platform_mcp_operation_receipts
 SET registration_id = $1,
     status = $2,
     result_code = $3,
+    result_payload = $4,
     updated_at = clock_timestamp()
-WHERE id = $4
-  AND organization_id = $5
+WHERE id = $5
+  AND organization_id = $6
 RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
 
@@ -180,6 +181,7 @@ type CompletePlatformMCPOperationReceiptParams struct {
 	RegistrationID uuid.NullUUID
 	Status         string
 	ResultCode     pgtype.Text
+	ResultPayload  []byte
 	ID             uuid.UUID
 	OrganizationID string
 }
@@ -189,6 +191,7 @@ func (q *Queries) CompletePlatformMCPOperationReceipt(ctx context.Context, arg C
 		arg.RegistrationID,
 		arg.Status,
 		arg.ResultCode,
+		arg.ResultPayload,
 		arg.ID,
 		arg.OrganizationID,
 	)
@@ -929,6 +932,7 @@ INSERT INTO platform_mcp_operation_receipts (
     input_hash,
     status,
     result_code,
+    result_payload,
     expires_at
 ) VALUES (
     $1,
@@ -943,7 +947,8 @@ INSERT INTO platform_mcp_operation_receipts (
     $10,
     $11,
     $12,
-    $13
+    $13,
+    $14
 )
 RETURNING id, organization_id, project_id, registration_id, connection_id, connection_generation, user_id, acting_surface, operation, idempotency_key, input_hash, status, result_code, result_payload, expires_at, created_at, updated_at
 `
@@ -961,6 +966,7 @@ type CreatePlatformMCPOperationReceiptParams struct {
 	InputHash            string
 	Status               string
 	ResultCode           pgtype.Text
+	ResultPayload        []byte
 	ExpiresAt            pgtype.Timestamptz
 }
 
@@ -978,6 +984,7 @@ func (q *Queries) CreatePlatformMCPOperationReceipt(ctx context.Context, arg Cre
 		arg.InputHash,
 		arg.Status,
 		arg.ResultCode,
+		arg.ResultPayload,
 		arg.ExpiresAt,
 	)
 	var i PlatformMcpOperationReceipt

--- a/server/internal/platformmcp/risk_mutation_controls.go
+++ b/server/internal/platformmcp/risk_mutation_controls.go
@@ -1,0 +1,134 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const (
+	operationCreateRiskPolicy    = "create_risk_policy"
+	operationUpdateRiskPolicy    = "update_risk_policy"
+	operationCreateRiskExclusion = "create_risk_exclusion"
+	operationUpdateRiskExclusion = "update_risk_exclusion"
+)
+
+var (
+	ErrRiskMutationUnavailable = errors.New("platform mcp risk mutations unavailable")
+	ErrRiskMutationInvalid     = errors.New("invalid platform mcp risk mutation")
+	ErrRiskMutationNotFound    = errors.New("platform mcp risk mutation target not found")
+	ErrRiskMutationConflict    = errors.New("platform mcp risk mutation conflict")
+)
+
+// RiskMutationError is safe to map into a tool refusal. Message deliberately
+// contains no policy, prompt, URL, principal, CEL, or exclusion material.
+type RiskMutationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *RiskMutationError) Error() string { return e.Message }
+func (e *RiskMutationError) Unwrap() error { return e.Cause }
+
+// RiskMutationControls owns the checks shared by every risk write. Admission is
+// intentionally separate from receipt execution so callers can prove the flag
+// and budget fail before opening a write transaction.
+type RiskMutationControls struct {
+	flags         feature.Provider
+	organizations OrganizationSlugResolver
+	projects      riskProjectResolver
+	budget        OperationBudget
+	receipts      *RiskMutationReceiptStore
+	versions      *riskVersionCodec
+}
+
+func NewRiskMutationControls(db *pgxpool.Pool, flags feature.Provider, organizations OrganizationSlugResolver, budget OperationBudget, keyMaterial string) (*RiskMutationControls, error) {
+	if db == nil || organizations == nil || keyMaterial == "" {
+		return nil, ErrRiskMutationUnavailable
+	}
+	versions, err := newRiskVersionCodec(keyMaterial)
+	if err != nil {
+		return nil, err
+	}
+	return &RiskMutationControls{
+		flags:         flags,
+		organizations: organizations,
+		projects:      postgresRiskProjectResolver{queries: platformrepo.New(db)},
+		budget:        budget,
+		receipts:      NewRiskMutationReceiptStore(db),
+		versions:      versions,
+	}, nil
+}
+
+// Admit resolves an explicit project and checks its exact rollout cohort at
+// invocation time. Missing providers, errors, and indeterminate evaluations all
+// fail closed. The mutation budget is consumed only after the kill switch is on.
+func (c *RiskMutationControls) Admit(ctx context.Context, principal Principal, projectSlug string) (ResolvedProject, error) {
+	if c == nil || c.flags == nil || c.organizations == nil || c.projects == nil || !c.budget.valid() || c.receipts == nil || c.versions == nil {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	if principal.OrganizationID == "" || principal.UserID == "" || projectSlug == "" {
+		return ResolvedProject{}, &RiskMutationError{Code: "invalid_request", Message: "An exact project and attributable user are required for risk mutations.", Cause: ErrRiskMutationInvalid}
+	}
+	project, err := c.projects.Resolve(ctx, principal.OrganizationID, "", projectSlug)
+	if errors.Is(err, ErrRiskReadNotFound) {
+		return ResolvedProject{}, &RiskMutationError{Code: "not_found", Message: "The requested risk mutation project is not available.", Cause: fmt.Errorf("%w: %w", ErrRiskMutationNotFound, err)}
+	}
+	if err != nil {
+		return ResolvedProject{}, riskMutationUnavailableWithCause(err)
+	}
+	organizationSlug, err := c.organizations.OrganizationSlug(ctx, principal.OrganizationID)
+	if err != nil || organizationSlug == "" {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, c.flags, feature.FlagPlatformMCPRiskMutations, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, project.Slug))
+	if err != nil || evaluation != feature.EvaluationEnabled {
+		return ResolvedProject{}, riskMutationUnavailable()
+	}
+	if err := c.budget.AllowConnectionOrOrganization(ctx, principal); err != nil {
+		switch {
+		case errors.Is(err, ErrOperationRateLimited):
+			return ResolvedProject{}, &RiskMutationError{Code: "rate_limited", Message: "The risk mutation rate limit was reached.", Cause: err}
+		default:
+			return ResolvedProject{}, riskMutationUnavailable()
+		}
+	}
+	return project, nil
+}
+
+func riskMutationUnavailable() error {
+	return riskMutationUnavailableWithCause(nil)
+}
+
+func riskMutationUnavailableWithCause(cause error) error {
+	if cause != nil {
+		cause = fmt.Errorf("%w: %w", ErrRiskMutationUnavailable, cause)
+	} else {
+		cause = ErrRiskMutationUnavailable
+	}
+	return &RiskMutationError{Code: unavailableCode, Message: "Risk mutations are not enabled for this project.", Cause: cause}
+}
+
+func riskMutationConflict(message string) error {
+	return &RiskMutationError{Code: "conflict", Message: message, Cause: ErrRiskMutationConflict}
+}
+
+func (c *RiskMutationControls) Receipts() *RiskMutationReceiptStore {
+	if c == nil {
+		return nil
+	}
+	return c.receipts
+}
+
+func (c *RiskMutationControls) Versions() *riskVersionCodec {
+	if c == nil {
+		return nil
+	}
+	return c.versions
+}

--- a/server/internal/platformmcp/risk_mutation_controls.go
+++ b/server/internal/platformmcp/risk_mutation_controls.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 )
 
@@ -35,6 +36,32 @@ type RiskMutationError struct {
 
 func (e *RiskMutationError) Error() string { return e.Message }
 func (e *RiskMutationError) Unwrap() error { return e.Cause }
+
+// OrganizationSlugResolver is the narrow organization lookup needed to target
+// the exact-project risk mutation kill switch. It remains separate from the
+// product-feature-only Platform MCP organization gate.
+type OrganizationSlugResolver interface {
+	OrganizationSlug(ctx context.Context, organizationID string) (string, error)
+}
+
+type PostgresOrganizationSlugResolver struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresOrganizationSlugResolver(db *pgxpool.Pool) *PostgresOrganizationSlugResolver {
+	return &PostgresOrganizationSlugResolver{db: db}
+}
+
+func (r *PostgresOrganizationSlugResolver) OrganizationSlug(ctx context.Context, organizationID string) (string, error) {
+	if r == nil || r.db == nil || organizationID == "" {
+		return "", ErrRiskMutationUnavailable
+	}
+	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		return "", fmt.Errorf("get organization for Platform MCP risk mutation: %w", err)
+	}
+	return organization.Slug, nil
+}
 
 // RiskMutationControls owns the checks shared by every risk write. Admission is
 // intentionally separate from receipt execution so callers can prove the flag

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -327,6 +327,8 @@ func TestRiskMutationHandlerSelectionAcceptsExportedSuccessContract(t *testing.T
 			return nil, want, nil
 		},
 	})
+	require.NotContains(t, descriptorByName(t, registrar, operationCreateRiskPolicy).Description, "not enabled")
+	require.Contains(t, descriptorByName(t, registrar, operationUpdateRiskPolicy).Description, "not enabled")
 	for _, descriptor := range registrar.Descriptors() {
 		if descriptor.Name != operationCreateRiskPolicy {
 			continue
@@ -358,6 +360,7 @@ func TestRiskMutationHandlerSelectionRequiresAvailableCatalogForLiveCallbacks(t 
 	var refusal *ToolRefusalError
 	require.ErrorAs(t, err, &refusal)
 	require.Contains(t, refusal.Payload, `"code":"feature_unavailable"`)
+	require.Contains(t, create.Description, "not enabled")
 	require.False(t, called, "catalog failure must keep live callbacks unavailable")
 }
 
@@ -370,6 +373,9 @@ func TestRiskMutationHandlerSelectionDefaultsEveryWriteToStableRefusal(t *testin
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
 	registrar := newRegistrar(server)
 	registerRiskMutationHandlers(registrar, catalog, true, &RiskMutationHandlers{})
+	for _, name := range []string{operationCreateRiskPolicy, operationUpdateRiskPolicy, operationCreateRiskExclusion, operationUpdateRiskExclusion} {
+		require.Contains(t, descriptorByName(t, registrar, name).Description, "not enabled")
+	}
 	arguments := map[string]json.RawMessage{
 		"create_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_type":"standard","name":"policy","enabled":true,"sources":["gitleaks"],"idempotency_key":"key"}`),
 		"update_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_id":"11111111-1111-4111-8111-111111111111","expected_version":"version","idempotency_key":"key","patch":{"enabled":true}}`),

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -143,14 +144,46 @@ func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
 	codec, err := newRiskVersionCodec("test-key")
 	require.NoError(t, err)
 	prompt := "sensitive prompt material"
-	policy := policycore.Policy{ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt, AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
-	state := RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`), AllowedURLs: []string{"https://b.example", "https://a.example"}, StandingDecisionState: []string{"decision:two", "decision:one"}}
+	includeA, includeB := "message.type == 'a'", "message.type == 'b'"
+	exemptA, exemptB := "message.source == 'a'", "message.source == 'b'"
+	policy := policycore.Policy{
+		ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt,
+		AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+		DetectionScopes: []policycore.DetectionScope{
+			{Category: "tool_output", ScopeInclude: &includeB, ScopeExempt: &exemptB},
+			{Category: "tool_output", ScopeInclude: &includeA, ScopeExempt: &exemptA},
+			{Category: "prompt", ScopeInclude: nil, ScopeExempt: nil},
+		},
+	}
+	state := RiskPolicyVersionState{
+		Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`),
+		AllowedURLGrants: []RiskPolicyVersionGrant{
+			{PrincipalURN: "user:two", Selector: json.RawMessage(`{"server_url":"https://example.test/mcp","resource_id":"policy"}`)},
+			{PrincipalURN: "user:one", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		},
+		BlockedURLGrants:      []RiskPolicyVersionGrant{},
+		StandingDecisionState: []string{"decision:two", "decision:one"},
+	}
 	token, err := codec.PolicyVersion(state)
 	require.NoError(t, err)
-	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`), AllowedURLs: []string{"https://a.example", "https://b.example"}, StandingDecisionState: []string{"decision:one", "decision:two"}})
+	canonicalPolicy := policy
+	canonicalPolicy.DetectionScopes = []policycore.DetectionScope{
+		{Category: "prompt", ScopeInclude: nil, ScopeExempt: nil},
+		{Category: "tool_output", ScopeInclude: &includeA, ScopeExempt: &exemptA},
+		{Category: "tool_output", ScopeInclude: &includeB, ScopeExempt: &exemptB},
+	}
+	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{
+		Policy: canonicalPolicy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`),
+		AllowedURLGrants: []RiskPolicyVersionGrant{
+			{PrincipalURN: "user:one", Selector: json.RawMessage(`{ "server_url": "https://example.test/mcp", "resource_id": "policy" }`)},
+			{PrincipalURN: "user:two", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		},
+		BlockedURLGrants:      []RiskPolicyVersionGrant{},
+		StandingDecisionState: []string{"decision:one", "decision:two"},
+	})
 	require.NoError(t, err)
 
-	require.Equal(t, token, canonical)
+	require.Equal(t, token, canonical, "canonical ordering must include the complete detection scope state")
 	require.NotContains(t, token, prompt)
 	require.True(t, codec.ValidPolicyVersion(state, token))
 	pending, total := int64(3), int64(10)
@@ -161,7 +194,17 @@ func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, token, progressToken, "read-time analysis progress is not policy concurrency state")
 	policy.Enabled = true
-	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLs: state.AllowedURLs, StandingDecisionState: state.StandingDecisionState}, token))
+	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLGrants: state.AllowedURLGrants, BlockedURLGrants: state.BlockedURLGrants, StandingDecisionState: state.StandingDecisionState}, token))
+	grantChanged := state
+	grantChanged.AllowedURLGrants = []RiskPolicyVersionGrant{
+		{PrincipalURN: "user:three", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+		{PrincipalURN: "user:one", Selector: json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp"}`)},
+	}
+	require.False(t, codec.ValidPolicyVersion(grantChanged, token), "grant audiences are policy concurrency state")
+	grantChanged = state
+	grantChanged.AllowedURLGrants = slices.Clone(state.AllowedURLGrants)
+	grantChanged.AllowedURLGrants[0].Selector = json.RawMessage(`{"resource_id":"policy","server_url":"https://example.test/mcp","server_identity":"other"}`)
+	require.False(t, codec.ValidPolicyVersion(grantChanged, token), "complete grant selectors are policy concurrency state")
 
 	exclusion := exclusioncore.Exclusion{ID: uuid.New(), ProjectID: policy.ProjectID, OrganizationID: "organization", MatchType: "exact", MatchValue: "sensitive exact match", Enabled: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
 	exclusionToken, err := codec.ExclusionVersion(exclusion)
@@ -225,9 +268,45 @@ func TestRiskMutationReceiptResultAllowlistCoversEveryOperation(t *testing.T) {
 			t.Parallel()
 			_, err := encodeRiskMutationResult(test.operation, test.valid)
 			require.NoError(t, err)
+			_, err = encodeRiskMutationResult(test.operation, receiptResultPointer(test.valid))
+			require.NoError(t, err, "non-nil pointers to closed receipt projections remain safe")
 			_, err = encodeRiskMutationResult(test.operation, test.invalid)
 			require.ErrorIs(t, err, ErrRiskMutationUnavailable)
 		})
+	}
+
+	for _, test := range []struct {
+		name      string
+		operation string
+		result    RiskMutationReceiptResult
+	}{
+		{name: "create policy", operation: operationCreateRiskPolicy, result: (*CreateRiskPolicyReceiptResult)(nil)},
+		{name: "update policy", operation: operationUpdateRiskPolicy, result: (*UpdateRiskPolicyReceiptResult)(nil)},
+		{name: "create exclusion", operation: operationCreateRiskExclusion, result: (*CreateRiskExclusionReceiptResult)(nil)},
+		{name: "update exclusion", operation: operationUpdateRiskExclusion, result: (*UpdateRiskExclusionReceiptResult)(nil)},
+	} {
+		t.Run("typed nil "+test.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, func() {
+				_, err := encodeRiskMutationResult(test.operation, test.result)
+				require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+			})
+		})
+	}
+}
+
+func receiptResultPointer(result RiskMutationReceiptResult) RiskMutationReceiptResult {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult:
+		return &typed
+	case UpdateRiskPolicyReceiptResult:
+		return &typed
+	case CreateRiskExclusionReceiptResult:
+		return &typed
+	case UpdateRiskExclusionReceiptResult:
+		return &typed
+	default:
+		return nil
 	}
 }
 
@@ -258,6 +337,28 @@ func TestRiskMutationHandlerSelectionAcceptsExportedSuccessContract(t *testing.T
 		return
 	}
 	require.Fail(t, "create risk policy descriptor was not registered")
+}
+
+func TestRiskMutationHandlerSelectionRequiresAvailableCatalogForLiveCallbacks(t *testing.T) {
+	t.Parallel()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	called := false
+	registerRiskMutationHandlers(registrar, policycatalog.Catalog{}, false, &RiskMutationHandlers{
+		Controls: &RiskMutationControls{},
+		CreatePolicy: func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskPolicyToolOutput, error) {
+			called = true
+			return nil, CreateRiskPolicyToolOutput{}, nil
+		},
+	})
+
+	create := descriptorByName(t, registrar, operationCreateRiskPolicy)
+	_, err := create.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), json.RawMessage(`{"project_slug":"default","policy_type":"prompt_based","name":"policy","enabled":true,"prompt":"instruction","idempotency_key":"key"}`))
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	require.Contains(t, refusal.Payload, `"code":"feature_unavailable"`)
+	require.False(t, called, "catalog failure must keep live callbacks unavailable")
 }
 
 func TestRiskMutationHandlerSelectionDefaultsEveryWriteToStableRefusal(t *testing.T) {

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -1,0 +1,305 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+)
+
+type riskMutationFlagProvider struct {
+	evaluation feature.Evaluation
+	err        error
+	flag       feature.Flag
+	groups     map[string]string
+}
+
+func (p *riskMutationFlagProvider) IsFlagEnabled(context.Context, feature.Flag, string, map[string]string) (bool, error) {
+	return false, nil
+}
+func (p *riskMutationFlagProvider) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+	return false, nil
+}
+func (p *riskMutationFlagProvider) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
+	return nil, nil
+}
+func (p *riskMutationFlagProvider) EvaluateFlag(_ context.Context, flag feature.Flag, _ string, groups map[string]string) (feature.Evaluation, error) {
+	p.flag = flag
+	p.groups = groups
+	return p.evaluation, p.err
+}
+
+type riskMutationOrganizationResolver struct {
+	slug string
+	err  error
+}
+
+func (r riskMutationOrganizationResolver) OrganizationSlug(context.Context, string) (string, error) {
+	return r.slug, r.err
+}
+
+func TestRiskMutationAdmissionRequiresExactEnabledProjectBeforeBudget(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "project"}
+	projects := &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectSlug: project.Slug}}}
+	connection := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	flags := &riskMutationFlagProvider{evaluation: feature.EvaluationDisabled}
+	controls := &RiskMutationControls{
+		flags: flags, organizations: riskMutationOrganizationResolver{slug: "organization-slug"}, projects: projects,
+		budget: OperationBudget{Connection: connection, Organization: organization}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+
+	_, err := controls.Admit(t.Context(), principal, project.Slug)
+
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+	require.Equal(t, feature.FlagPlatformMCPRiskMutations, flags.flag)
+	require.Equal(t, feature.OrgProjectGroups("organization-slug", project.Slug), flags.groups)
+	require.Empty(t, connection.keys, "a disabled kill switch must refuse before consuming budget")
+	require.Empty(t, organization.keys)
+}
+
+func TestRiskMutationAdmissionDistinguishesMissingProjectFromResolverOutage(t *testing.T) {
+	t.Parallel()
+
+	backendFailure := errors.New("database unavailable")
+	for _, test := range []struct {
+		name     string
+		resolve  error
+		wantCode string
+		wantErr  error
+	}{
+		{name: "missing project", resolve: ErrRiskReadNotFound, wantCode: "not_found", wantErr: ErrRiskMutationNotFound},
+		{name: "resolver outage", resolve: backendFailure, wantCode: unavailableCode, wantErr: ErrRiskMutationUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			controls := &RiskMutationControls{
+				flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization-slug"},
+				projects: &stubRiskProjects{err: test.resolve}, budget: OperationBudget{Connection: &recordingOperationLimiter{}, Organization: &recordingOperationLimiter{}}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+			}
+			_, err := controls.Admit(t.Context(), Principal{UserID: "user", OrganizationID: "organization"}, "project")
+			var mutationErr *RiskMutationError
+			require.ErrorAs(t, err, &mutationErr)
+			require.Equal(t, test.wantCode, mutationErr.Code)
+			require.ErrorIs(t, err, test.wantErr)
+			if errors.Is(test.resolve, backendFailure) {
+				require.ErrorIs(t, err, backendFailure)
+			}
+		})
+	}
+}
+
+func TestRiskMutationAdmissionConnectionlessAssistantUsesOrganizationBudget(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "project"}
+	organization := &recordingOperationLimiter{result: ratelimit.Result{Allowed: true}}
+	controls := &RiskMutationControls{
+		flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization-slug"},
+		projects: &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectSlug: project.Slug}}},
+		budget:   OperationBudget{Connection: &recordingOperationLimiter{result: ratelimit.Result{Allowed: false}}, Organization: organization}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ClientID: AssistantClientID, Surface: SurfaceProjectAssistant}
+
+	resolved, err := controls.Admit(t.Context(), principal, project.Slug)
+
+	require.NoError(t, err)
+	require.Equal(t, project, resolved)
+	require.Equal(t, []string{"organization"}, organization.keys)
+}
+
+func TestRiskMutationInputHashIsCanonicalAndOperationSeparated(t *testing.T) {
+	t.Parallel()
+
+	first, err := riskMutationInputHash(operationCreateRiskPolicy, map[string]any{"enabled": true, "name": "policy"})
+	require.NoError(t, err)
+	second, err := riskMutationInputHash(operationCreateRiskPolicy, map[string]any{"name": "policy", "enabled": true})
+	require.NoError(t, err)
+	other, err := riskMutationInputHash(operationUpdateRiskPolicy, map[string]any{"enabled": true, "name": "policy"})
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+	require.NotEqual(t, first, other)
+}
+
+func TestRiskVersionTokensAreOpaqueAndStateSensitive(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newRiskVersionCodec("test-key")
+	require.NoError(t, err)
+	prompt := "sensitive prompt material"
+	policy := policycore.Policy{ID: uuid.New(), ProjectID: uuid.New(), OrganizationID: "organization", Name: "policy", PolicyType: "prompt_based", Prompt: &prompt, AudiencePrincipalURNs: []string{"user:two", "user:one"}, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	state := RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{"threshold":0.5,"nested":{"enabled":true}}`), AllowedURLs: []string{"https://b.example", "https://a.example"}, StandingDecisionState: []string{"decision:two", "decision:one"}}
+	token, err := codec.PolicyVersion(state)
+	require.NoError(t, err)
+	canonical, err := codec.PolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: json.RawMessage(`{ "nested": { "enabled": true }, "threshold": 0.5 }`), AllowedURLs: []string{"https://a.example", "https://b.example"}, StandingDecisionState: []string{"decision:one", "decision:two"}})
+	require.NoError(t, err)
+
+	require.Equal(t, token, canonical)
+	require.NotContains(t, token, prompt)
+	require.True(t, codec.ValidPolicyVersion(state, token))
+	pending, total := int64(3), int64(10)
+	progressOnly := state
+	progressOnly.Policy.PendingMessages = &pending
+	progressOnly.Policy.TotalMessages = &total
+	progressToken, err := codec.PolicyVersion(progressOnly)
+	require.NoError(t, err)
+	require.Equal(t, token, progressToken, "read-time analysis progress is not policy concurrency state")
+	policy.Enabled = true
+	require.False(t, codec.ValidPolicyVersion(RiskPolicyVersionState{Policy: policy, AnalyzerConfig: state.AnalyzerConfig, AllowedURLs: state.AllowedURLs, StandingDecisionState: state.StandingDecisionState}, token))
+
+	exclusion := exclusioncore.Exclusion{ID: uuid.New(), ProjectID: policy.ProjectID, OrganizationID: "organization", MatchType: "exact", MatchValue: "sensitive exact match", Enabled: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	exclusionToken, err := codec.ExclusionVersion(exclusion)
+	require.NoError(t, err)
+	require.NotContains(t, exclusionToken, exclusion.MatchValue)
+	require.True(t, codec.ValidExclusionVersion(exclusion, exclusionToken))
+	exclusion.Enabled = false
+	require.False(t, codec.ValidExclusionVersion(exclusion, exclusionToken))
+}
+
+func TestRiskMutationReceiptResultIsClosedAndOperationBound(t *testing.T) {
+	t.Parallel()
+
+	result := CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}, Policy: RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", MatchedExisting: false, ResultCategory: "created"}
+	payload, err := encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"project":{"id":"11111111-1111-4111-8111-111111111111","slug":"default"},"policy":{"id":"22222222-2222-4222-8222-222222222222","policy_type":"standard","enabled":true,"action":"flag"},"version":"opaque","matched_existing":false,"result_category":"created"}`, string(payload))
+	require.NotContains(t, string(payload), "prompt")
+	require.NotContains(t, string(payload), "match_value")
+
+	_, err = encodeRiskMutationResult(operationUpdateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+
+	result.Policy.Action = "prompt material smuggled as action"
+	_, err = encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+
+	result.Policy.Action = "flag"
+	result.Project.Slug = "prompt material smuggled as slug"
+	_, err = encodeRiskMutationResult(operationCreateRiskPolicy, result)
+	require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+}
+
+func TestRiskMutationReceiptResultAllowlistCoversEveryOperation(t *testing.T) {
+	t.Parallel()
+
+	project := RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}
+	policy := RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}
+	exclusion := RiskExclusionReceiptSummary{ID: "33333333-3333-4333-8333-333333333333", MatchType: "source", Enabled: true}
+	for _, action := range []string{"flag", "warn", "block", "quarantine"} {
+		t.Run("policy action "+action, func(t *testing.T) {
+			t.Parallel()
+			candidate := policy
+			candidate.Action = action
+			_, err := encodeRiskMutationResult(operationUpdateRiskPolicy, UpdateRiskPolicyReceiptResult{Project: project, Policy: candidate, Version: "opaque", ResultCategory: "updated"})
+			require.NoError(t, err)
+		})
+	}
+	for _, test := range []struct {
+		name      string
+		operation string
+		valid     RiskMutationReceiptResult
+		invalid   RiskMutationReceiptResult
+	}{
+		{name: "create policy", operation: operationCreateRiskPolicy, valid: CreateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "created"}, invalid: CreateRiskPolicyReceiptResult{Project: project, Policy: RiskPolicyReceiptSummary{ID: policy.ID, PolicyType: "unsupported", Enabled: true, Action: "flag"}, Version: "opaque", ResultCategory: "created"}},
+		{name: "update policy", operation: operationUpdateRiskPolicy, valid: UpdateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "updated"}, invalid: UpdateRiskPolicyReceiptResult{Project: project, Policy: policy, Version: "opaque", ResultCategory: "user content"}},
+		{name: "create exclusion", operation: operationCreateRiskExclusion, valid: CreateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "created", Reconciliation: "scheduled"}, invalid: CreateRiskExclusionReceiptResult{Project: project, Exclusion: RiskExclusionReceiptSummary{ID: exclusion.ID, MatchType: "user content", Enabled: true}, Version: "opaque", ResultCategory: "created", Reconciliation: "scheduled"}},
+		{name: "update exclusion", operation: operationUpdateRiskExclusion, valid: UpdateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "updated", Reconciliation: "scheduled"}, invalid: UpdateRiskExclusionReceiptResult{Project: project, Exclusion: exclusion, Version: "opaque", ResultCategory: "updated", Reconciliation: "complete"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := encodeRiskMutationResult(test.operation, test.valid)
+			require.NoError(t, err)
+			_, err = encodeRiskMutationResult(test.operation, test.invalid)
+			require.ErrorIs(t, err, ErrRiskMutationUnavailable)
+		})
+	}
+}
+
+func TestRiskMutationHandlerSelectionAcceptsExportedSuccessContract(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := policycatalog.Build()
+	require.NoError(t, err)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	want := CreateRiskPolicyToolOutput{
+		CreateRiskPolicyReceiptResult: CreateRiskPolicyReceiptResult{Project: RiskMutationReceiptProject{ID: "11111111-1111-4111-8111-111111111111", Slug: "default"}, Policy: RiskPolicyReceiptSummary{ID: "22222222-2222-4222-8222-222222222222", PolicyType: "standard", Enabled: true, Action: "flag"}, Version: "opaque", ResultCategory: "created"},
+		Receipt:                       RiskMutationToolReceipt{ID: "33333333-3333-4333-8333-333333333333", Replayed: false},
+	}
+	registerRiskMutationHandlers(registrar, catalog, true, &RiskMutationHandlers{
+		Controls: &RiskMutationControls{},
+		CreatePolicy: func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskPolicyToolOutput, error) {
+			return nil, want, nil
+		},
+	})
+	for _, descriptor := range registrar.Descriptors() {
+		if descriptor.Name != operationCreateRiskPolicy {
+			continue
+		}
+		got, err := descriptor.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), json.RawMessage(`{"project_slug":"default","policy_type":"standard","name":"policy","enabled":true,"sources":["gitleaks"],"idempotency_key":"key"}`))
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+		return
+	}
+	require.Fail(t, "create risk policy descriptor was not registered")
+}
+
+func TestRiskMutationHandlerSelectionDefaultsEveryWriteToStableRefusal(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := policycatalog.Build()
+	require.NoError(t, err)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	registrar := newRegistrar(server)
+	registerRiskMutationHandlers(registrar, catalog, true, &RiskMutationHandlers{})
+	arguments := map[string]json.RawMessage{
+		"create_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_type":"standard","name":"policy","enabled":true,"sources":["gitleaks"],"idempotency_key":"key"}`),
+		"update_risk_policy":    json.RawMessage(`{"project_slug":"default","policy_id":"11111111-1111-4111-8111-111111111111","expected_version":"version","idempotency_key":"key","patch":{"enabled":true}}`),
+		"create_risk_exclusion": json.RawMessage(`{"project_slug":"default","match_type":"source","match_value":"gitleaks","enabled":true,"idempotency_key":"key"}`),
+		"update_risk_exclusion": json.RawMessage(`{"project_slug":"default","exclusion_id":"11111111-1111-4111-8111-111111111111","enabled":true,"expected_version":"version","idempotency_key":"key"}`),
+	}
+	for _, descriptor := range registrar.Descriptors() {
+		input, ok := arguments[descriptor.Name]
+		if !ok || (!strings.HasPrefix(descriptor.Name, "create_risk_") && !strings.HasPrefix(descriptor.Name, "update_risk_")) {
+			continue
+		}
+		_, err := descriptor.Invoke(ContextWithPrincipal(t.Context(), testRiskPrincipal("user")), input)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `"code":"feature_unavailable"`)
+	}
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(t.Context(), serverTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "risk-stub-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(t.Context(), clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	refused, err := session.CallTool(t.Context(), &mcp.CallToolParams{Name: operationCreateRiskPolicy, Arguments: map[string]any{"project_slug": "default", "policy_type": "standard", "name": "policy", "enabled": true, "sources": []string{"gitleaks"}, "idempotency_key": "key"}})
+	require.NoError(t, err)
+	require.True(t, refused.IsError)
+	require.Nil(t, refused.StructuredContent, "disabled tools must not emit a zero-valued structured success output")
+	require.Len(t, refused.Content, 1)
+	text, ok := refused.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"code":"feature_unavailable","feature":"risk_mutations","message":"This Platform MCP capability is not enabled for the current rollout."}`, text.Text)
+}

--- a/server/internal/platformmcp/risk_mutation_receipt.go
+++ b/server/internal/platformmcp/risk_mutation_receipt.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -219,10 +220,11 @@ func riskMutationOperation(operation string) bool {
 }
 
 func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult) (json.RawMessage, error) {
-	if result == nil || result.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(result) {
+	normalized, valid := normalizedRiskMutationReceiptResult(result)
+	if !valid || normalized.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(normalized) {
 		return nil, invalidRiskMutationReceiptResult()
 	}
-	payload, err := json.Marshal(result)
+	payload, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, fmt.Errorf("encode risk mutation receipt result: %w", err)
 	}
@@ -230,6 +232,30 @@ func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult
 		return nil, &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
 	}
 	return payload, nil
+}
+
+func normalizedRiskMutationReceiptResult(result RiskMutationReceiptResult) (RiskMutationReceiptResult, bool) {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult, UpdateRiskPolicyReceiptResult, CreateRiskExclusionReceiptResult, UpdateRiskExclusionReceiptResult:
+		return typed, true
+	case *CreateRiskPolicyReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *UpdateRiskPolicyReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *CreateRiskExclusionReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	case *UpdateRiskExclusionReceiptResult:
+		if typed != nil {
+			return *typed, true
+		}
+	}
+	return nil, false
 }
 
 func validRiskMutationReceiptResult(result RiskMutationReceiptResult) bool {
@@ -287,12 +313,7 @@ func validRiskReceiptVersion(version string) bool {
 }
 
 func validRiskResultCategory(category string, allowed ...string) bool {
-	for _, value := range allowed {
-		if category == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, category)
 }
 
 func invalidRiskMutationReceiptResult() error {

--- a/server/internal/platformmcp/risk_mutation_receipt.go
+++ b/server/internal/platformmcp/risk_mutation_receipt.go
@@ -1,0 +1,300 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const maxRiskMutationReceiptPayloadBytes = 16 << 10
+
+// RiskMutationReceiptRequest is the safe identity of one normalized write.
+// Input must already have schema defaults, canonical ordering, and transport
+// aliases resolved. It is hashed and is never persisted or logged directly.
+type RiskMutationReceiptRequest struct {
+	Operation      string
+	IdempotencyKey string
+	Input          any
+}
+
+// RiskMutationReceiptResult is implemented only by the four closed, redacted
+// result projections below. Callbacks cannot supply an open JSON object, so a
+// new user-authored field cannot silently enter operation receipts.
+type RiskMutationReceiptResult interface {
+	riskMutationReceiptOperation() string
+}
+
+type RiskMutationReceiptProject struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+}
+
+// RiskPolicyReceiptSummary contains only fixed-vocabulary administrative state.
+// Policy names, prompts, CEL, model configuration, principals, and URLs are
+// deliberately absent.
+type RiskPolicyReceiptSummary struct {
+	ID         string `json:"id"`
+	PolicyType string `json:"policy_type"`
+	Enabled    bool   `json:"enabled"`
+	Action     string `json:"action,omitempty"`
+}
+
+// RiskExclusionReceiptSummary omits match values and filters even for
+// allowlisted match types so exact and legacy-regex content can never leak.
+type RiskExclusionReceiptSummary struct {
+	ID        string  `json:"id"`
+	PolicyID  *string `json:"policy_id,omitempty"`
+	MatchType string  `json:"match_type"`
+	Enabled   bool    `json:"enabled"`
+}
+
+type CreateRiskPolicyReceiptResult struct {
+	Project         RiskMutationReceiptProject `json:"project"`
+	Policy          RiskPolicyReceiptSummary   `json:"policy"`
+	Version         string                     `json:"version"`
+	MatchedExisting bool                       `json:"matched_existing"`
+	ResultCategory  string                     `json:"result_category"`
+}
+
+func (CreateRiskPolicyReceiptResult) riskMutationReceiptOperation() string {
+	return operationCreateRiskPolicy
+}
+
+type UpdateRiskPolicyReceiptResult struct {
+	Project        RiskMutationReceiptProject `json:"project"`
+	Policy         RiskPolicyReceiptSummary   `json:"policy"`
+	Version        string                     `json:"version"`
+	ResultCategory string                     `json:"result_category"`
+}
+
+func (UpdateRiskPolicyReceiptResult) riskMutationReceiptOperation() string {
+	return operationUpdateRiskPolicy
+}
+
+type CreateRiskExclusionReceiptResult struct {
+	Project         RiskMutationReceiptProject  `json:"project"`
+	Exclusion       RiskExclusionReceiptSummary `json:"exclusion"`
+	Version         string                      `json:"version"`
+	MatchedExisting bool                        `json:"matched_existing"`
+	ResultCategory  string                      `json:"result_category"`
+	Reconciliation  string                      `json:"reconciliation"`
+}
+
+func (CreateRiskExclusionReceiptResult) riskMutationReceiptOperation() string {
+	return operationCreateRiskExclusion
+}
+
+type UpdateRiskExclusionReceiptResult struct {
+	Project        RiskMutationReceiptProject  `json:"project"`
+	Exclusion      RiskExclusionReceiptSummary `json:"exclusion"`
+	Version        string                      `json:"version"`
+	ResultCategory string                      `json:"result_category"`
+	Reconciliation string                      `json:"reconciliation"`
+}
+
+func (UpdateRiskExclusionReceiptResult) riskMutationReceiptOperation() string {
+	return operationUpdateRiskExclusion
+}
+
+// RiskMutationTransaction performs the domain write and audit write using the
+// same transaction that owns the receipt. Its result must be one of the closed
+// operation-specific projections above.
+type RiskMutationTransaction func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error)
+
+type RiskMutationReceiptStore struct {
+	db  *pgxpool.Pool
+	now func() time.Time
+}
+
+func NewRiskMutationReceiptStore(db *pgxpool.Pool) *RiskMutationReceiptStore {
+	return &RiskMutationReceiptStore{db: db, now: time.Now}
+}
+
+// Execute serializes one user's exact operation/project/key, replays an exact
+// completed input from its stored result, and commits receipt + domain + audit
+// atomically. Any callback, completion, or commit failure rolls all three back.
+func (s *RiskMutationReceiptStore) Execute(ctx context.Context, principal Principal, project ResolvedProject, request RiskMutationReceiptRequest, mutate RiskMutationTransaction) (OperationReceipt, error) {
+	if s == nil || s.db == nil || s.now == nil || mutate == nil || principal.OrganizationID == "" || principal.UserID == "" || project.ID == uuid.Nil || project.Slug == "" || request.IdempotencyKey == "" || len(request.IdempotencyKey) > 128 || !riskMutationOperation(request.Operation) {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation request is invalid.", Cause: ErrRiskMutationInvalid}
+	}
+	inputHash, err := riskMutationInputHash(request.Operation, request.Input)
+	if err != nil {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation request could not be normalized.", Cause: ErrRiskMutationInvalid}
+	}
+	connectionID, generation, err := principalConnection(principal)
+	if err != nil {
+		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation caller identity is invalid.", Cause: ErrRiskMutationInvalid}
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("begin risk mutation receipt: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := platformrepo.New(tx)
+	lock := platformrepo.LockPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID.String(), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
+	if err := q.LockPlatformMCPOperationReceipt(ctx, lock); err != nil {
+		return OperationReceipt{}, fmt.Errorf("lock risk mutation receipt: %w", err)
+	}
+	lookup := platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
+	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(lookup)); err != nil {
+		return OperationReceipt{}, fmt.Errorf("reclaim expired risk mutation receipt: %w", err)
+	}
+	stored, err := q.GetPlatformMCPOperationReceipt(ctx, lookup)
+	switch {
+	case err == nil:
+		if stored.InputHash != inputHash {
+			return OperationReceipt{}, riskMutationConflict("The idempotency key was already used with different risk mutation input.")
+		}
+		if stored.Status != receiptStatusSucceeded || len(stored.ResultPayload) == 0 {
+			return OperationReceipt{}, riskMutationConflict("The matching risk mutation has no completed replay result.")
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return OperationReceipt{}, fmt.Errorf("commit risk mutation replay: %w", err)
+		}
+		return operationReceiptFromRow(stored, true), nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return OperationReceipt{}, fmt.Errorf("load risk mutation receipt: %w", err)
+	}
+
+	created, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, ConnectionID: connectionID, ConnectionGeneration: generation,
+		UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey,
+		InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: timestamp(s.now().UTC().Add(receiptLifetime)),
+	})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("create risk mutation receipt: %w", err)
+	}
+	result, err := mutate(ctx, tx)
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("apply risk mutation transaction: %w", err)
+	}
+	payload, err := encodeRiskMutationResult(request.Operation, result)
+	if err != nil {
+		return OperationReceipt{}, err
+	}
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{
+		RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText("succeeded"), ResultPayload: payload, ID: created.ID, OrganizationID: principal.OrganizationID,
+	})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("complete risk mutation receipt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return OperationReceipt{}, fmt.Errorf("commit risk mutation: %w", err)
+	}
+	return operationReceiptFromRow(completed, false), nil
+}
+
+func riskMutationInputHash(operation string, normalized any) (string, error) {
+	if !riskMutationOperation(operation) || normalized == nil {
+		return "", ErrRiskMutationInvalid
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("encode normalized risk mutation input: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("platform-mcp-risk-mutation-v1\x00"+operation+"\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func riskMutationOperation(operation string) bool {
+	switch operation {
+	case operationCreateRiskPolicy, operationUpdateRiskPolicy, operationCreateRiskExclusion, operationUpdateRiskExclusion:
+		return true
+	default:
+		return false
+	}
+}
+
+func encodeRiskMutationResult(operation string, result RiskMutationReceiptResult) (json.RawMessage, error) {
+	if result == nil || result.riskMutationReceiptOperation() != operation || !validRiskMutationReceiptResult(result) {
+		return nil, invalidRiskMutationReceiptResult()
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode risk mutation receipt result: %w", err)
+	}
+	if len(payload) == 0 || len(payload) > maxRiskMutationReceiptPayloadBytes {
+		return nil, &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
+	}
+	return payload, nil
+}
+
+func validRiskMutationReceiptResult(result RiskMutationReceiptResult) bool {
+	switch typed := result.(type) {
+	case CreateRiskPolicyReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskPolicyReceiptSummary(typed.Policy) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "created", "matched_existing")
+	case UpdateRiskPolicyReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskPolicyReceiptSummary(typed.Policy) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "updated")
+	case CreateRiskExclusionReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskExclusionReceiptSummary(typed.Exclusion) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "created", "matched_existing") && typed.Reconciliation == "scheduled"
+	case UpdateRiskExclusionReceiptResult:
+		return validRiskReceiptProject(typed.Project) && validRiskExclusionReceiptSummary(typed.Exclusion) && validRiskReceiptVersion(typed.Version) && validRiskResultCategory(typed.ResultCategory, "updated") && typed.Reconciliation == "scheduled"
+	default:
+		return false
+	}
+}
+
+func validRiskReceiptProject(project RiskMutationReceiptProject) bool {
+	return uuid.Validate(project.ID) == nil && validRiskReceiptSlug(project.Slug)
+}
+
+func validRiskReceiptSlug(slug string) bool {
+	if slug == "" || len(slug) > 128 {
+		return false
+	}
+	for _, char := range slug {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func validRiskPolicyReceiptSummary(policy RiskPolicyReceiptSummary) bool {
+	return uuid.Validate(policy.ID) == nil && (policy.PolicyType == "standard" || policy.PolicyType == "prompt_based") && (policy.Action == "" || policy.Action == "flag" || policy.Action == "warn" || policy.Action == "block" || policy.Action == "quarantine")
+}
+
+func validRiskExclusionReceiptSummary(exclusion RiskExclusionReceiptSummary) bool {
+	if uuid.Validate(exclusion.ID) != nil || (exclusion.MatchType != "exact" && exclusion.MatchType != "rule_id" && exclusion.MatchType != "source" && exclusion.MatchType != "entity_type" && exclusion.MatchType != "regex") {
+		return false
+	}
+	return exclusion.PolicyID == nil || uuid.Validate(*exclusion.PolicyID) == nil
+}
+
+func validRiskReceiptVersion(version string) bool {
+	if version == "" || len(version) > 2048 {
+		return false
+	}
+	for _, char := range version {
+		if (char < 'A' || char > 'Z') && (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func validRiskResultCategory(category string, allowed ...string) bool {
+	for _, value := range allowed {
+		if category == value {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidRiskMutationReceiptResult() error {
+	return &RiskMutationError{Code: unavailableCode, Message: "The risk mutation result could not be stored safely.", Cause: ErrRiskMutationUnavailable}
+}

--- a/server/internal/platformmcp/risk_policy_mutations.go
+++ b/server/internal/platformmcp/risk_policy_mutations.go
@@ -1,0 +1,900 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	ra "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	defaultRiskPolicyAction            = "flag"
+	defaultRiskPolicyScore             = 5.0
+	defaultRiskPolicyPresidioThreshold = 0.5
+	riskPolicyAudienceEveryone         = "everyone"
+	maxRiskPolicyPromptRunes           = 4000
+	maxRiskPolicyUserMessageRunes      = 500
+	maxRiskPolicyApprovedEmailDomains  = 50
+)
+
+type riskPolicyMutationService struct {
+	db       *pgxpool.Pool
+	controls *RiskMutationControls
+	policies *policycore.Core
+	catalog  policycatalog.Catalog
+}
+
+type createRiskPolicyInput struct {
+	ProjectSlug            string               `json:"project_slug"`
+	PolicyType             string               `json:"policy_type"`
+	Name                   string               `json:"name"`
+	Enabled                bool                 `json:"enabled"`
+	Action                 string               `json:"action,omitempty"`
+	Score                  *float64             `json:"score,omitempty"`
+	MessageTypes           []string             `json:"message_types,omitempty"`
+	UserMessage            *string              `json:"user_message,omitempty"`
+	Sources                []string             `json:"sources,omitempty"`
+	PresidioEntities       []string             `json:"presidio_entities,omitempty"`
+	PresidioScoreThreshold *float64             `json:"presidio_score_threshold,omitempty"`
+	PromptInjectionRules   []string             `json:"prompt_injection_rules,omitempty"`
+	DisabledRules          []string             `json:"disabled_rules,omitempty"`
+	ApprovedEmailDomains   []string             `json:"approved_email_domains,omitempty"`
+	DetectionScopes        []riskDetectionScope `json:"detection_scopes,omitempty"`
+	Prompt                 string               `json:"prompt,omitempty"`
+	IdempotencyKey         string               `json:"idempotency_key"`
+}
+
+type updateRiskPolicyInput struct {
+	ProjectSlug     string                     `json:"project_slug"`
+	PolicyID        string                     `json:"policy_id"`
+	ExpectedVersion string                     `json:"expected_version"`
+	IdempotencyKey  string                     `json:"idempotency_key"`
+	Patch           map[string]json.RawMessage `json:"patch"`
+}
+
+type riskDetectionScope struct {
+	Category     string   `json:"category"`
+	MessageTypes []string `json:"message_types"`
+}
+
+type normalizedCreateRiskPolicy struct {
+	ProjectSlug            string               `json:"project_slug"`
+	PolicyType             string               `json:"policy_type"`
+	Name                   string               `json:"name"`
+	Enabled                bool                 `json:"enabled"`
+	Action                 string               `json:"action"`
+	Score                  float64              `json:"score"`
+	MessageTypes           []string             `json:"message_types"`
+	UserMessage            *string              `json:"user_message,omitempty"`
+	Sources                []string             `json:"sources"`
+	PresidioEntities       []string             `json:"presidio_entities"`
+	PresidioScoreThreshold *float64             `json:"presidio_score_threshold,omitempty"`
+	PromptInjectionRules   []string             `json:"prompt_injection_rules"`
+	DisabledRules          []string             `json:"disabled_rules"`
+	ApprovedEmailDomains   []string             `json:"approved_email_domains"`
+	DetectionScopes        []riskDetectionScope `json:"detection_scopes"`
+	PromptDigest           string               `json:"prompt_digest,omitempty"`
+}
+
+type preparedRiskPolicyCreate struct {
+	normalized normalizedCreateRiskPolicy
+	params     riskrepo.CreateRiskPolicyParams
+}
+
+// NewRiskPolicyMutationHandlers activates only policy create/update. Exclusion
+// callbacks remain nil and therefore retain the stable feature_unavailable stubs.
+func NewRiskPolicyMutationHandlers(db *pgxpool.Pool, controls *RiskMutationControls, policies *policycore.Core) (*RiskMutationHandlers, error) {
+	if db == nil || controls == nil || policies == nil {
+		return nil, ErrRiskMutationUnavailable
+	}
+	catalog, err := policycatalog.Build()
+	if err != nil {
+		return nil, fmt.Errorf("build risk policy mutation catalog: %w", err)
+	}
+	service := &riskPolicyMutationService{db: db, controls: controls, policies: policies, catalog: catalog}
+	return &RiskMutationHandlers{
+		Controls:        controls,
+		CreatePolicy:    service.createPolicyTool,
+		UpdatePolicy:    service.updatePolicyTool,
+		CreateExclusion: nil,
+		UpdateExclusion: nil,
+	}, nil
+}
+
+func (s *riskPolicyMutationService) createPolicyTool(ctx context.Context, _ *mcp.CallToolRequest, raw map[string]any) (*mcp.CallToolResult, CreateRiskPolicyToolOutput, error) {
+	var zero CreateRiskPolicyToolOutput
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	var input createRiskPolicyInput
+	if err := decodeRiskMutationInput(raw, &input); err != nil {
+		return riskMutationToolRefusal[CreateRiskPolicyToolOutput](err)
+	}
+	project, err := s.controls.Admit(ctx, principal, strings.TrimSpace(input.ProjectSlug))
+	if err != nil {
+		return riskMutationToolRefusal[CreateRiskPolicyToolOutput](err)
+	}
+	prepared, err := s.prepareCreate(ctx, principal, project, input)
+	if err != nil {
+		return riskMutationToolRefusal[CreateRiskPolicyToolOutput](err)
+	}
+
+	var committed *policycore.MutationResult
+	receipt, err := s.controls.Receipts().Execute(ctx, principal, project, RiskMutationReceiptRequest{
+		Operation: operationCreateRiskPolicy, IdempotencyKey: input.IdempotencyKey, Input: prepared.normalized,
+	}, func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error) {
+		if err := riskrepo.New(tx).LockRiskPolicyMutations(ctx, project.ID.String()); err != nil {
+			return nil, fmt.Errorf("lock risk policy create convergence: %w", err)
+		}
+		matched, err := s.matchExistingCreate(ctx, tx, principal.OrganizationID, project.ID, prepared)
+		if err != nil {
+			return nil, err
+		}
+		if matched != nil {
+			result, err := s.createReceiptResult(ctx, tx, project, matched.Row, matched.AudiencePrincipalURNs, true)
+			return result, err
+		}
+		result, err := s.policies.CreatePolicyInTransaction(ctx, tx, policycore.CreateMutation{
+			Params:             prepared.params,
+			AudiencePrincipals: []urn.Principal{authz.AllUsersPrincipal()},
+			AllowedURLs:        nil,
+			AllowedURLsSet:     false,
+			BlockedURLs:        nil,
+			BlockedURLsSet:     false,
+			Actor: policycore.Actor{
+				Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+				DisplayName: nil,
+				Slug:        nil,
+			},
+		})
+		if err != nil {
+			return nil, mapRiskPolicyMutationError(err)
+		}
+		committed = &result
+		return s.createReceiptResult(ctx, tx, project, result.Row, result.AudiencePrincipalURNs, false)
+	})
+	if err != nil {
+		return riskMutationToolRefusal[CreateRiskPolicyToolOutput](err)
+	}
+	if committed != nil {
+		s.policies.AfterCreatePolicy(ctx, *committed)
+	}
+	var result CreateRiskPolicyReceiptResult
+	if err := json.Unmarshal(receipt.ResultPayload, &result); err != nil {
+		return nil, zero, fmt.Errorf("decode create risk policy receipt result: %w", err)
+	}
+	return nil, CreateRiskPolicyToolOutput{CreateRiskPolicyReceiptResult: result, Receipt: riskMutationToolReceipt(receipt)}, nil
+}
+
+func (s *riskPolicyMutationService) updatePolicyTool(ctx context.Context, _ *mcp.CallToolRequest, raw map[string]any) (*mcp.CallToolResult, UpdateRiskPolicyToolOutput, error) {
+	var zero UpdateRiskPolicyToolOutput
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	var input updateRiskPolicyInput
+	if err := decodeRiskMutationInput(raw, &input); err != nil {
+		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
+	}
+	project, err := s.controls.Admit(ctx, principal, strings.TrimSpace(input.ProjectSlug))
+	if err != nil {
+		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
+	}
+	policyID, err := uuid.Parse(input.PolicyID)
+	if err != nil || input.ExpectedVersion == "" || len(input.Patch) == 0 {
+		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](invalidRiskPolicyRequest())
+	}
+	normalizedPatch, err := normalizeRiskPolicyPatchForReceipt(input.Patch)
+	if err != nil {
+		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
+	}
+
+	var committed *policycore.MutationResult
+	receipt, err := s.controls.Receipts().Execute(ctx, principal, project, RiskMutationReceiptRequest{
+		Operation: operationUpdateRiskPolicy, IdempotencyKey: input.IdempotencyKey,
+		Input: map[string]any{"project_slug": project.Slug, "policy_id": policyID.String(), "expected_version": input.ExpectedVersion, "patch": normalizedPatch},
+	}, func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error) {
+		current, err := riskrepo.New(tx).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: policyID, ProjectID: project.ID})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, riskPolicyNotFound()
+		}
+		if err != nil {
+			return nil, fmt.Errorf("load risk policy update target: %w", err)
+		}
+		mutation, _, err := s.prepareUpdate(ctx, tx, principal, project, current, input)
+		if err != nil {
+			return nil, err
+		}
+		mutation.ValidateLocked = func(ctx context.Context, tx pgx.Tx, locked policycore.Policy) error {
+			state, err := riskPolicyVersionState(ctx, tx, locked, true)
+			if err != nil {
+				return riskMutationUnavailableWithCause(err)
+			}
+			if !s.controls.Versions().ValidPolicyVersion(state, input.ExpectedVersion) {
+				return riskMutationConflict("The risk policy changed after it was read. Read it again and retry with the new version.")
+			}
+			return nil
+		}
+		result, err := s.policies.UpdatePolicyInTransaction(ctx, tx, mutation)
+		if err != nil {
+			return nil, mapRiskPolicyMutationError(err)
+		}
+		committed = &result
+		return s.updateReceiptResult(ctx, tx, project, result.Row, result.AudiencePrincipalURNs)
+	})
+	if err != nil {
+		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
+	}
+	if committed != nil {
+		s.policies.AfterUpdatePolicy(ctx, *committed)
+	}
+	var result UpdateRiskPolicyReceiptResult
+	if err := json.Unmarshal(receipt.ResultPayload, &result); err != nil {
+		return nil, zero, fmt.Errorf("decode update risk policy receipt result: %w", err)
+	}
+	if receipt.Replayed && result.Policy.PolicyType == "prompt_based" {
+		if err := s.requirePromptPolicies(ctx, principal, project); err != nil {
+			return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
+		}
+	}
+	return nil, UpdateRiskPolicyToolOutput{UpdateRiskPolicyReceiptResult: result, Receipt: riskMutationToolReceipt(receipt)}, nil
+}
+
+func normalizeRiskPolicyPatchForReceipt(patch map[string]json.RawMessage) (map[string]any, error) {
+	if len(patch) == 0 {
+		return nil, invalidRiskPolicyRequest()
+	}
+	normalized := make(map[string]any, len(patch))
+	for field, raw := range patch {
+		switch field {
+		case "name", "action":
+			var value string
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = strings.TrimSpace(value)
+		case "user_message":
+			var value string
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = value
+		case "prompt":
+			var value string
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			digest := sha256.Sum256([]byte(strings.TrimSpace(value)))
+			normalized[field] = hex.EncodeToString(digest[:])
+		case "enabled":
+			var value bool
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = value
+		case "score", "presidio_score_threshold":
+			var value float64
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = value
+		case "message_types", "sources", "presidio_entities", "prompt_injection_rules", "disabled_rules", "approved_email_domains":
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			if field == "approved_email_domains" {
+				var err error
+				value, err = policycore.NormalizeApprovedEmailDomains(value)
+				if err != nil {
+					return nil, invalidRiskPolicyRequest()
+				}
+			}
+			normalized[field] = canonicalStrings(value)
+		case "detection_scopes":
+			var value []riskDetectionScope
+			if json.Unmarshal(raw, &value) != nil {
+				return nil, invalidRiskPolicyRequest()
+			}
+			for index := range value {
+				value[index].MessageTypes = canonicalStrings(value[index].MessageTypes)
+			}
+			slices.SortFunc(value, func(a, b riskDetectionScope) int { return strings.Compare(a.Category, b.Category) })
+			normalized[field] = value
+		default:
+			return nil, invalidRiskPolicyRequest()
+		}
+	}
+	return normalized, nil
+}
+
+func decodeRiskMutationInput(raw map[string]any, target any) error {
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return invalidRiskPolicyRequest()
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(encoded)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return invalidRiskPolicyRequest()
+	}
+	return nil
+}
+
+func (s *riskPolicyMutationService) prepareCreate(ctx context.Context, principal Principal, project ResolvedProject, input createRiskPolicyInput) (preparedRiskPolicyCreate, error) {
+	input.ProjectSlug = strings.TrimSpace(input.ProjectSlug)
+	input.Name = strings.TrimSpace(input.Name)
+	input.PolicyType = strings.TrimSpace(input.PolicyType)
+	if input.ProjectSlug != project.Slug || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 || policycore.ValidateName(input.Name) != nil || !slices.Contains(s.catalog.PolicyTypes, input.PolicyType) {
+		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+	}
+	action := input.Action
+	if action == "" {
+		action = defaultRiskPolicyAction
+	}
+	score := defaultRiskPolicyScore
+	if input.Score != nil {
+		score = *input.Score
+	}
+	if !slices.Contains(s.catalog.Actions, action) || score < 0.1 || score > 10 || !utf8.ValidString(input.Name) {
+		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+	}
+	messageTypes := canonicalStrings(input.MessageTypes)
+	if input.MessageTypes == nil {
+		messageTypes = slices.Clone(s.catalog.PolicyMessageTypes)
+	}
+	if !allIn(messageTypes, s.catalog.PolicyMessageTypes) || len(messageTypes) == 0 || invalidUserMessage(input.UserMessage) {
+		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+	}
+
+	normalized := normalizedCreateRiskPolicy{
+		ProjectSlug: project.Slug, PolicyType: input.PolicyType, Name: input.Name, Enabled: input.Enabled,
+		Action: action, Score: score, MessageTypes: messageTypes, UserMessage: input.UserMessage,
+		Sources: []string{}, PresidioEntities: []string{}, PresidioScoreThreshold: nil, PromptInjectionRules: []string{}, DisabledRules: []string{}, ApprovedEmailDomains: []string{}, DetectionScopes: []riskDetectionScope{}, PromptDigest: "",
+	}
+	params := riskrepo.CreateRiskPolicyParams{
+		ID: uuid.Nil, ProjectID: project.ID, OrganizationID: principal.OrganizationID, Name: input.Name,
+		PolicyType: input.PolicyType, Sources: []string{}, PresidioEntities: []string{}, AnalyzerConfig: nil,
+		PromptInjectionRules: []string{}, DisabledRules: []string{}, CustomRuleIds: []string{}, MessageTypes: messageTypes,
+		ScopeInclude: pgtype.Text{String: "", Valid: false}, ScopeExempt: pgtype.Text{String: "", Valid: false}, Enabled: input.Enabled, Action: action,
+		AudienceType: riskPolicyAudienceEveryone, ShadowMcpDisposition: pgtype.Text{String: "", Valid: false}, AutoName: false,
+		UserMessage: conv.PtrToPGTextEmpty(input.UserMessage), Prompt: pgtype.Text{String: "", Valid: false}, ModelConfig: nil,
+		Score: pgtype.Float8{Float64: score, Valid: true},
+	}
+
+	switch input.PolicyType {
+	case "prompt_based":
+		prompt := strings.TrimSpace(input.Prompt)
+		if prompt == "" || utf8.RuneCountInString(prompt) > maxRiskPolicyPromptRunes || len(input.Sources)+len(input.PresidioEntities)+len(input.PromptInjectionRules)+len(input.DisabledRules)+len(input.ApprovedEmailDomains)+len(input.DetectionScopes) > 0 || input.PresidioScoreThreshold != nil {
+			return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+		}
+		if err := s.requirePromptPolicies(ctx, principal, project); err != nil {
+			return preparedRiskPolicyCreate{}, err
+		}
+		digest := sha256.Sum256([]byte(prompt))
+		normalized.PromptDigest = hex.EncodeToString(digest[:])
+		params.Prompt = conv.ToPGText(prompt)
+	case "standard":
+		sources := canonicalStrings(input.Sources)
+		entities := canonicalStrings(input.PresidioEntities)
+		disabledRules := canonicalStrings(input.DisabledRules)
+		promptRules := canonicalStrings(input.PromptInjectionRules)
+		if len(sources) == 0 || !allIn(sources, s.catalog.Sources) || !allIn(entities, s.catalog.PresidioEntities) || !allIn(disabledRules, s.catalog.DisabledRules) || !allIn(promptRules, s.catalog.PromptInjectionRules) || policycore.ValidateSourceAction(sources, action) != nil {
+			return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+		}
+		hasPresidio := slices.Contains(sources, policycatalog.PresidioSource)
+		if hasPresidio != (len(entities) > 0) {
+			return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+		}
+		domains, err := policycore.NormalizeApprovedEmailDomains(input.ApprovedEmailDomains)
+		if err != nil || len(domains) > maxRiskPolicyApprovedEmailDomains {
+			return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+		}
+		slices.Sort(domains)
+		threshold := defaultRiskPolicyPresidioThreshold
+		if input.PresidioScoreThreshold != nil {
+			threshold = *input.PresidioScoreThreshold
+		}
+		if threshold < 0 || threshold > 1 || (!hasPresidio && input.PresidioScoreThreshold != nil) {
+			return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+		}
+		scopes, analyzer, err := s.buildDetectionScopes(input.DetectionScopes, sources, entities, nil)
+		if err != nil {
+			return preparedRiskPolicyCreate{}, err
+		}
+		analyzer, err = ra.WithPresidioScoreThreshold(analyzer, &threshold)
+		if err == nil {
+			analyzer, err = ra.WithApprovedEmailDomains(analyzer, domains)
+		}
+		if err != nil {
+			return preparedRiskPolicyCreate{}, riskMutationUnavailableWithCause(err)
+		}
+		normalized.Sources, normalized.PresidioEntities = sources, entities
+		normalized.PresidioScoreThreshold = &threshold
+		normalized.PromptInjectionRules, normalized.DisabledRules = promptRules, disabledRules
+		normalized.ApprovedEmailDomains, normalized.DetectionScopes = domains, scopes
+		params.Sources, params.PresidioEntities, params.AnalyzerConfig = sources, entities, analyzer
+		params.PromptInjectionRules, params.DisabledRules = promptRules, disabledRules
+	default:
+		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return preparedRiskPolicyCreate{}, riskMutationUnavailableWithCause(err)
+	}
+	params.ID = id
+	return preparedRiskPolicyCreate{normalized: normalized, params: params}, nil
+}
+
+func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, db riskrepo.DBTX, principal Principal, project ResolvedProject, current riskrepo.RiskPolicy, input updateRiskPolicyInput) (policycore.UpdateMutation, map[string]any, error) {
+	if input.ProjectSlug != project.Slug || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 {
+		return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+	}
+	params := riskrepo.UpdateRiskPolicyParams{
+		ID: current.ID, ProjectID: project.ID, Name: current.Name, Sources: slices.Clone(current.Sources), PresidioEntities: slices.Clone(current.PresidioEntities), AnalyzerConfig: slices.Clone(current.AnalyzerConfig),
+		PromptInjectionRules: slices.Clone(current.PromptInjectionRules), DisabledRules: slices.Clone(current.DisabledRules), CustomRuleIds: slices.Clone(current.CustomRuleIds), MessageTypes: slices.Clone(current.MessageTypes),
+		ScopeInclude: current.ScopeInclude, ScopeExempt: current.ScopeExempt, Enabled: current.Enabled, Action: current.Action, AudienceType: current.AudienceType, AutoName: current.AutoName,
+		UserMessage: current.UserMessage, Prompt: current.Prompt, ModelConfig: slices.Clone(current.ModelConfig), Score: pgtype.Float8{Float64: current.Score, Valid: true},
+	}
+	normalized := make(map[string]any, len(input.Patch))
+	changedSources, changedAction := false, false
+	// Apply dependencies before fields that validate against them. Iterating the
+	// caller's map directly would make a combined sources + detection_scopes patch
+	// depend on randomized Go map order.
+	for _, field := range []string{
+		"sources", "presidio_entities", "action", "name", "enabled", "score", "prompt", "user_message",
+		"message_types", "presidio_score_threshold", "approved_email_domains", "prompt_injection_rules", "disabled_rules", "detection_scopes",
+	} {
+		raw, ok := input.Patch[field]
+		if !ok {
+			continue
+		}
+		switch field {
+		case "name":
+			var value string
+			if json.Unmarshal(raw, &value) != nil || policycore.ValidateName(strings.TrimSpace(value)) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.Name = strings.TrimSpace(value)
+			normalized[field] = params.Name
+		case "enabled":
+			if json.Unmarshal(raw, &params.Enabled) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = params.Enabled
+		case "action":
+			if json.Unmarshal(raw, &params.Action) != nil || !slices.Contains(s.catalog.Actions, params.Action) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			normalized[field] = params.Action
+			changedAction = true
+		case "score":
+			var value float64
+			if json.Unmarshal(raw, &value) != nil || value < 0.1 || value > 10 {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.Score = pgtype.Float8{Float64: value, Valid: true}
+			normalized[field] = value
+		case "prompt":
+			if current.PolicyType != "prompt_based" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = strings.TrimSpace(value)
+			if value == "" || utf8.RuneCountInString(value) > maxRiskPolicyPromptRunes {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.Prompt = conv.ToPGText(value)
+			digest := sha256.Sum256([]byte(value))
+			normalized[field] = hex.EncodeToString(digest[:])
+		case "user_message":
+			var value string
+			if json.Unmarshal(raw, &value) != nil || utf8.RuneCountInString(value) > maxRiskPolicyUserMessageRunes {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.UserMessage = conv.ToPGTextEmpty(value)
+			normalized[field] = value
+		case "message_types":
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = canonicalStrings(value)
+			if len(value) == 0 || !allIn(value, s.catalog.PolicyMessageTypes) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.MessageTypes = value
+			normalized[field] = value
+		case "sources":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = canonicalStrings(value)
+			if len(value) == 0 || !allIn(value, s.catalog.Sources) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.Sources = value
+			normalized[field] = value
+			changedSources = true
+		case "presidio_entities":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = canonicalStrings(value)
+			if !allIn(value, s.catalog.PresidioEntities) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.PresidioEntities = value
+			normalized[field] = value
+		case "presidio_score_threshold":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value float64
+			if json.Unmarshal(raw, &value) != nil || value < 0 || value > 1 {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			updated, err := ra.WithPresidioScoreThreshold(params.AnalyzerConfig, &value)
+			if err != nil {
+				return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
+			}
+			params.AnalyzerConfig = updated
+			normalized[field] = value
+		case "approved_email_domains":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value, err := policycore.NormalizeApprovedEmailDomains(value)
+			if err != nil || len(value) > maxRiskPolicyApprovedEmailDomains {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			slices.Sort(value)
+			updated, err := ra.WithApprovedEmailDomains(params.AnalyzerConfig, value)
+			if err != nil {
+				return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
+			}
+			params.AnalyzerConfig = updated
+			normalized[field] = value
+		case "detection_scopes":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []riskDetectionScope
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			scopes, updated, err := s.buildDetectionScopes(value, params.Sources, params.PresidioEntities, params.AnalyzerConfig)
+			if err != nil {
+				return policycore.UpdateMutation{}, nil, err
+			}
+			params.AnalyzerConfig = updated
+			normalized[field] = scopes
+		case "prompt_injection_rules":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = canonicalStrings(value)
+			if !allIn(value, s.catalog.PromptInjectionRules) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.PromptInjectionRules = value
+			normalized[field] = value
+		case "disabled_rules":
+			if current.PolicyType != "standard" {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			var value []string
+			if json.Unmarshal(raw, &value) != nil {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			value = canonicalStrings(value)
+			if !allIn(value, s.catalog.DisabledRules) {
+				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+			}
+			params.DisabledRules = value
+			normalized[field] = value
+		}
+	}
+	if len(normalized) != len(input.Patch) {
+		return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+	}
+	if current.PolicyType == "prompt_based" {
+		if err := s.requirePromptPolicies(ctx, principal, project); err != nil {
+			return policycore.UpdateMutation{}, nil, err
+		}
+	}
+	if changedSources || changedAction {
+		if !slices.Contains(s.catalog.Actions, params.Action) || policycore.ValidateSourceAction(params.Sources, params.Action) != nil {
+			return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+		}
+	}
+	effectiveDisposition := valueOrEmpty(policycore.Project(current, nil, nil).ShadowMCPDisposition)
+	if effectiveDisposition != "" && shadowmcp.EffectiveDisposition(current.ShadowMcpDisposition, params.Sources, params.Action) == "" {
+		// A Platform patch cannot author or remove Shadow MCP URL decisions. Do
+		// not silently drop an effective blocking posture and orphan its URL grants,
+		// including legacy block_all policies with no stored disposition value.
+		return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+	}
+	if current.PolicyType == "standard" {
+		hasPresidio := slices.Contains(params.Sources, policycatalog.PresidioSource)
+		if (changedSources || input.Patch["presidio_entities"] != nil) && hasPresidio != (len(params.PresidioEntities) > 0) {
+			return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+		}
+		if input.Patch["presidio_score_threshold"] != nil && !hasPresidio {
+			return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
+		}
+		if (changedSources || input.Patch["presidio_entities"] != nil) && input.Patch["detection_scopes"] == nil {
+			if err := s.validatePreservedDetectionScopes(current, params.Sources, params.PresidioEntities); err != nil {
+				return policycore.UpdateMutation{}, nil, err
+			}
+		}
+	}
+	audience, err := policycore.New(db).AudiencePrincipalURNs(ctx, principal.OrganizationID, current.ID.String())
+	if err != nil {
+		return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
+	}
+	principals := make([]urn.Principal, 0, len(audience))
+	for _, value := range audience {
+		parsed, err := urn.ParsePrincipal(value)
+		if err != nil {
+			return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
+		}
+		principals = append(principals, parsed)
+	}
+	return policycore.UpdateMutation{
+		Current: current, Params: params, AudiencePrincipals: principals, AudienceChanged: false,
+		AllowedURLs: nil, AllowedURLsSet: false, BlockedURLs: nil, BlockedURLsSet: false,
+		EffectiveDisposition: effectiveDisposition,
+		SupersedeDecisions:   false,
+		ValidateLocked:       nil,
+		Actor: policycore.Actor{
+			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+			DisplayName: nil,
+			Slug:        nil,
+		},
+	}, normalized, nil
+}
+
+func (s *riskPolicyMutationService) buildDetectionScopes(input []riskDetectionScope, sources, entities []string, base []byte) ([]riskDetectionScope, []byte, error) {
+	normalized := make([]riskDetectionScope, 0, len(input))
+	seen := make(map[string]struct{}, len(input))
+	configs := make([]ra.DetectionScopeConfig, 0, len(input))
+	for _, scope := range input {
+		messages := canonicalStrings(scope.MessageTypes)
+		if !slices.Contains(s.catalog.DetectionScopeCategories, scope.Category) || len(messages) == 0 || !allIn(messages, s.catalog.PolicyMessageTypes) {
+			return nil, nil, invalidRiskPolicyRequest()
+		}
+		if _, ok := seen[scope.Category]; ok || !riskCategoryReachable(scope.Category, sources, entities) {
+			return nil, nil, invalidRiskPolicyRequest()
+		}
+		seen[scope.Category] = struct{}{}
+		encoded, err := policycatalog.EncodeDetectionScope(messages, s.catalog)
+		if err != nil {
+			return nil, nil, invalidRiskPolicyRequest()
+		}
+		normalized = append(normalized, riskDetectionScope{Category: scope.Category, MessageTypes: messages})
+		configs = append(configs, ra.DetectionScopeConfig{Category: scope.Category, ScopeInclude: encoded, ScopeExempt: ""})
+	}
+	slices.SortFunc(normalized, func(a, b riskDetectionScope) int { return strings.Compare(a.Category, b.Category) })
+	slices.SortFunc(configs, func(a, b ra.DetectionScopeConfig) int { return strings.Compare(a.Category, b.Category) })
+	updated, err := ra.WithDetectionScopes(base, configs)
+	if err != nil {
+		return nil, nil, riskMutationUnavailableWithCause(err)
+	}
+	return normalized, updated, nil
+}
+
+func (s *riskPolicyMutationService) validatePreservedDetectionScopes(current riskrepo.RiskPolicy, sources, entities []string) error {
+	policy := policycore.Project(current, nil, nil)
+	for _, scope := range policy.DetectionScopes {
+		include := valueOrEmpty(scope.ScopeInclude)
+		exempt := valueOrEmpty(scope.ScopeExempt)
+		if _, supported := policycatalog.DecodeDetectionScope(include, exempt, s.catalog); !supported {
+			// Preserve legacy/raw CEL without reinterpreting it as D3-owned state.
+			return nil
+		}
+		if !slices.Contains(s.catalog.DetectionScopeCategories, scope.Category) || !riskCategoryReachable(scope.Category, sources, entities) {
+			return invalidRiskPolicyRequest()
+		}
+	}
+	return nil
+}
+
+func riskCategoryReachable(category string, sources, entities []string) bool {
+	for _, source := range sources {
+		if string(categories.Classify(source, "")) == category {
+			return true
+		}
+	}
+	for _, entity := range entities {
+		if string(categories.Classify(policycatalog.PresidioSource, policycatalog.CanonicalPresidioRuleID(entity))) == category {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *riskPolicyMutationService) requirePromptPolicies(ctx context.Context, principal Principal, project ResolvedProject) error {
+	organizationSlug, err := s.controls.organizations.OrganizationSlug(ctx, principal.OrganizationID)
+	if err != nil || organizationSlug == "" {
+		return riskMutationUnavailable()
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, s.controls.flags, feature.FlagPromptPolicies, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, project.Slug))
+	if err != nil || evaluation != feature.EvaluationEnabled {
+		return riskMutationUnavailable()
+	}
+	return nil
+}
+
+func (s *riskPolicyMutationService) matchExistingCreate(ctx context.Context, tx pgx.Tx, organizationID string, projectID uuid.UUID, prepared preparedRiskPolicyCreate) (*policycore.MutationResult, error) {
+	rows, err := riskrepo.New(tx).ListRiskPolicies(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list risk policies for create convergence: %w", err)
+	}
+	matches := make([]policycore.MutationResult, 0, 1)
+	for _, row := range rows {
+		audience, err := policycore.New(tx).AudiencePrincipalURNs(ctx, organizationID, row.ID.String())
+		if err != nil {
+			return nil, fmt.Errorf("load risk policy audience for create convergence: %w", err)
+		}
+		if riskPolicyCreateMatches(row, audience, prepared.params) {
+			matches = append(matches, policycore.MutationResult{Row: row, AudiencePrincipalURNs: audience})
+		}
+	}
+	if len(matches) > 1 {
+		return nil, riskMutationConflict("More than one existing policy matches this definition.")
+	}
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	return nil, nil
+}
+
+func riskPolicyCreateMatches(row riskrepo.RiskPolicy, audience []string, desired riskrepo.CreateRiskPolicyParams) bool {
+	return row.OrganizationID == desired.OrganizationID && row.Name == desired.Name && row.PolicyType == desired.PolicyType && row.Enabled == desired.Enabled && row.Action == desired.Action && row.AudienceType == desired.AudienceType && row.AutoName == desired.AutoName && row.Score == desired.Score.Float64 &&
+		reflect.DeepEqual(canonicalStrings(row.Sources), canonicalStrings(desired.Sources)) && reflect.DeepEqual(canonicalStrings(row.PresidioEntities), canonicalStrings(desired.PresidioEntities)) && reflect.DeepEqual(canonicalStrings(row.PromptInjectionRules), canonicalStrings(desired.PromptInjectionRules)) && reflect.DeepEqual(canonicalStrings(row.DisabledRules), canonicalStrings(desired.DisabledRules)) && len(row.CustomRuleIds) == 0 && reflect.DeepEqual(canonicalStrings(row.MessageTypes), canonicalStrings(desired.MessageTypes)) &&
+		canonicalJSONEqual(row.AnalyzerConfig, desired.AnalyzerConfig) && row.ScopeInclude == desired.ScopeInclude && row.ScopeExempt == desired.ScopeExempt && row.ShadowMcpDisposition == desired.ShadowMcpDisposition && row.UserMessage == desired.UserMessage && row.Prompt == desired.Prompt && len(row.ModelConfig) == 0 && reflect.DeepEqual(canonicalStrings(audience), []string{authz.AllUsersPrincipal().String()})
+}
+
+func canonicalJSONEqual(a, b []byte) bool {
+	ca, errA := canonicalJSON(a)
+	cb, errB := canonicalJSON(b)
+	return errA == nil && errB == nil && reflect.DeepEqual(ca, cb)
+}
+
+func (s *riskPolicyMutationService) createReceiptResult(ctx context.Context, db riskrepo.DBTX, project ResolvedProject, row riskrepo.RiskPolicy, audience []string, matched bool) (CreateRiskPolicyReceiptResult, error) {
+	state, err := riskPolicyVersionState(ctx, db, policycore.Project(row, audience, nil), true)
+	if err != nil {
+		return CreateRiskPolicyReceiptResult{}, err
+	}
+	version, err := s.controls.Versions().PolicyVersion(state)
+	if err != nil {
+		return CreateRiskPolicyReceiptResult{}, err
+	}
+	category := "created"
+	if matched {
+		category = "matched_existing"
+	}
+	return CreateRiskPolicyReceiptResult{Project: riskReceiptProject(project), Policy: riskPolicyReceiptSummary(row), Version: version, MatchedExisting: matched, ResultCategory: category}, nil
+}
+
+func (s *riskPolicyMutationService) updateReceiptResult(ctx context.Context, db riskrepo.DBTX, project ResolvedProject, row riskrepo.RiskPolicy, audience []string) (UpdateRiskPolicyReceiptResult, error) {
+	state, err := riskPolicyVersionState(ctx, db, policycore.Project(row, audience, nil), true)
+	if err != nil {
+		return UpdateRiskPolicyReceiptResult{}, err
+	}
+	version, err := s.controls.Versions().PolicyVersion(state)
+	if err != nil {
+		return UpdateRiskPolicyReceiptResult{}, err
+	}
+	return UpdateRiskPolicyReceiptResult{Project: riskReceiptProject(project), Policy: riskPolicyReceiptSummary(row), Version: version, ResultCategory: "updated"}, nil
+}
+
+func riskReceiptProject(project ResolvedProject) RiskMutationReceiptProject {
+	return RiskMutationReceiptProject{ID: project.ID.String(), Slug: project.Slug}
+}
+func riskPolicyReceiptSummary(row riskrepo.RiskPolicy) RiskPolicyReceiptSummary {
+	return RiskPolicyReceiptSummary{ID: row.ID.String(), PolicyType: row.PolicyType, Enabled: row.Enabled, Action: row.Action}
+}
+func riskMutationToolReceipt(receipt OperationReceipt) RiskMutationToolReceipt {
+	return RiskMutationToolReceipt{ID: receipt.ID.String(), Replayed: receipt.Replayed}
+}
+
+func riskMutationToolRefusal[Out any](err error) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	var mutation *RiskMutationError
+	if !errors.As(err, &mutation) {
+		err = riskMutationUnavailableWithCause(err)
+		if !errors.As(err, &mutation) {
+			return nil, zero, err
+		}
+	}
+	payload, marshalErr := json.Marshal(featureUnavailableResult{Code: mutation.Code, Feature: "risk_mutations", Message: mutation.Message})
+	if marshalErr != nil {
+		return nil, zero, fmt.Errorf("encode risk mutation refusal: %w", marshalErr)
+	}
+	return nil, zero, &ToolRefusalError{Payload: string(payload)}
+}
+
+func mapRiskPolicyMutationError(err error) error {
+	var mutation *RiskMutationError
+	var stale *policycore.StalePolicyError
+	var blockingConflict *policycore.BlockingPolicyConflictError
+	var decisionConflict *policycore.DecisionConflictError
+	switch {
+	case errors.As(err, &mutation):
+		return mutation
+	case errors.As(err, &stale), errors.As(err, &blockingConflict), errors.As(err, &decisionConflict):
+		return riskMutationConflict("The risk policy could not be changed because its current state conflicts with the request.")
+	case errors.Is(err, policycore.ErrLoadPolicy):
+		return riskPolicyNotFound()
+	default:
+		return riskMutationUnavailableWithCause(err)
+	}
+}
+
+func invalidRiskPolicyRequest() error {
+	return &RiskMutationError{Code: "invalid_request", Message: "The risk policy mutation request is invalid.", Cause: ErrRiskMutationInvalid}
+}
+func riskPolicyNotFound() error {
+	return &RiskMutationError{Code: "not_found", Message: "The requested risk policy is not available in this project.", Cause: ErrRiskMutationNotFound}
+}
+func invalidUserMessage(value *string) bool {
+	return value != nil && utf8.RuneCountInString(*value) > maxRiskPolicyUserMessageRunes
+}
+func canonicalStrings(values []string) []string {
+	result := slices.Clone(values)
+	slices.Sort(result)
+	return slices.Compact(result)
+}
+func allIn(values, allowed []string) bool {
+	for _, value := range values {
+		if !slices.Contains(allowed, value) {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/platformmcp/risk_policy_mutations.go
+++ b/server/internal/platformmcp/risk_policy_mutations.go
@@ -200,7 +200,8 @@ func (s *riskPolicyMutationService) updatePolicyTool(ctx context.Context, _ *mcp
 	if err := decodeRiskMutationInput(raw, &input); err != nil {
 		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
 	}
-	project, err := s.controls.Admit(ctx, principal, strings.TrimSpace(input.ProjectSlug))
+	input.ProjectSlug = strings.TrimSpace(input.ProjectSlug)
+	project, err := s.controls.Admit(ctx, principal, input.ProjectSlug)
 	if err != nil {
 		return riskMutationToolRefusal[UpdateRiskPolicyToolOutput](err)
 	}
@@ -225,19 +226,19 @@ func (s *riskPolicyMutationService) updatePolicyTool(ctx context.Context, _ *mcp
 		if err != nil {
 			return nil, fmt.Errorf("load risk policy update target: %w", err)
 		}
-		mutation, _, err := s.prepareUpdate(ctx, tx, principal, project, current, input)
+		mutation, _, err := s.prepareUpdate(ctx, principal, project, current, input)
 		if err != nil {
 			return nil, err
 		}
-		mutation.ValidateLocked = func(ctx context.Context, tx pgx.Tx, locked policycore.Policy) error {
+		mutation.ValidateLocked = func(ctx context.Context, tx pgx.Tx, locked policycore.Policy) (policycore.Policy, error) {
 			state, err := riskPolicyVersionState(ctx, tx, locked, true)
 			if err != nil {
-				return riskMutationUnavailableWithCause(err)
+				return policycore.Policy{}, riskMutationUnavailableWithCause(err)
 			}
 			if !s.controls.Versions().ValidPolicyVersion(state, input.ExpectedVersion) {
-				return riskMutationConflict("The risk policy changed after it was read. Read it again and retry with the new version.")
+				return policycore.Policy{}, riskMutationConflict("The risk policy changed after it was read. Read it again and retry with the new version.")
 			}
-			return nil
+			return state.Policy, nil
 		}
 		result, err := s.policies.UpdatePolicyInTransaction(ctx, tx, mutation)
 		if err != nil {
@@ -450,8 +451,8 @@ func (s *riskPolicyMutationService) prepareCreate(ctx context.Context, principal
 	return preparedRiskPolicyCreate{normalized: normalized, params: params}, nil
 }
 
-func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, db riskrepo.DBTX, principal Principal, project ResolvedProject, current riskrepo.RiskPolicy, input updateRiskPolicyInput) (policycore.UpdateMutation, map[string]any, error) {
-	if input.ProjectSlug != project.Slug || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 {
+func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, principal Principal, project ResolvedProject, current riskrepo.RiskPolicy, input updateRiskPolicyInput) (policycore.UpdateMutation, map[string]any, error) {
+	if strings.TrimSpace(input.ProjectSlug) != project.Slug || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 {
 		return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
 	}
 	params := riskrepo.UpdateRiskPolicyParams{
@@ -672,20 +673,8 @@ func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, db riskre
 			}
 		}
 	}
-	audience, err := policycore.New(db).AudiencePrincipalURNs(ctx, principal.OrganizationID, current.ID.String())
-	if err != nil {
-		return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
-	}
-	principals := make([]urn.Principal, 0, len(audience))
-	for _, value := range audience {
-		parsed, err := urn.ParsePrincipal(value)
-		if err != nil {
-			return policycore.UpdateMutation{}, nil, riskMutationUnavailableWithCause(err)
-		}
-		principals = append(principals, parsed)
-	}
 	return policycore.UpdateMutation{
-		Current: current, Params: params, AudiencePrincipals: principals, AudienceChanged: false,
+		Current: current, Params: params, AudiencePrincipals: nil, AudienceChanged: false,
 		AllowedURLs: nil, AllowedURLsSet: false, BlockedURLs: nil, BlockedURLsSet: false,
 		EffectiveDisposition: effectiveDisposition,
 		SupersedeDecisions:   false,
@@ -770,7 +759,11 @@ func (s *riskPolicyMutationService) requirePromptPolicies(ctx context.Context, p
 }
 
 func (s *riskPolicyMutationService) matchExistingCreate(ctx context.Context, tx pgx.Tx, organizationID string, projectID uuid.UUID, prepared preparedRiskPolicyCreate) (*policycore.MutationResult, error) {
-	rows, err := riskrepo.New(tx).ListRiskPolicies(ctx, projectID)
+	rows, err := riskrepo.New(tx).ListRiskPolicyCreateCandidates(ctx, riskrepo.ListRiskPolicyCreateCandidatesParams{
+		ProjectID:  projectID,
+		Name:       prepared.params.Name,
+		PolicyType: prepared.normalized.PolicyType,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list risk policies for create convergence: %w", err)
 	}

--- a/server/internal/platformmcp/risk_policy_mutations_integration_test.go
+++ b/server/internal/platformmcp/risk_policy_mutations_integration_test.go
@@ -96,7 +96,7 @@ func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
 	requireRiskMutationRefusal(t, err, "conflict")
 
 	updateInput := map[string]any{
-		"project_slug":     project.Slug,
+		"project_slug":     "  " + project.Slug + "  ",
 		"policy_id":        policyID.String(),
 		"expected_version": read.Policy.Version,
 		"idempotency_key":  "update-policy-key",
@@ -114,16 +114,33 @@ func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
 	require.ElementsMatch(t, []string{"gitleaks"}, stored.Sources, "omitted sparse fields are preserved")
 	require.True(t, stored.Enabled)
 
+	targetedAudience := urn.NewPrincipal(urn.PrincipalTypeUser, "targeted-user")
+	require.NoError(t, authz.ReplaceGrantAudience(ctx, conn, authz.ResourceGrant{
+		Resource:   authz.Resource{OrganizationID: principal.OrganizationID, Scope: authz.ScopeRiskPolicyEvaluate, ResourceID: policyID.String()},
+		Principals: []urn.Principal{targetedAudience},
+		Selector:   authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID.String()),
+	}))
+	targetedRead, err := reads.GetPolicy(ctx, principal, GetRiskPolicyInput{ProjectSlug: project.Slug, PolicyID: policyID.String()})
+	require.NoError(t, err)
+	require.NotEqual(t, updated.Version, targetedRead.Policy.Version, "an audience-only enforcement change invalidates the policy version")
+
 	secondUpdate := map[string]any{
 		"project_slug":     project.Slug,
 		"policy_id":        policyID.String(),
-		"expected_version": updated.Version,
+		"expected_version": targetedRead.Policy.Version,
 		"idempotency_key":  "update-policy-key-2",
 		"patch":            map[string]any{"enabled": false},
 	}
 	_, second, err := handlers.UpdatePolicy(ctx, nil, secondUpdate)
 	require.NoError(t, err)
-	require.NotEqual(t, updated.Version, second.Version)
+	require.NotEqual(t, targetedRead.Policy.Version, second.Version)
+	evaluationGrants, err := authz.ListGrantsForResource(ctx, conn, authz.Resource{OrganizationID: principal.OrganizationID, Scope: authz.ScopeRiskPolicyEvaluate, ResourceID: policyID.String()})
+	require.NoError(t, err)
+	require.Len(t, evaluationGrants, 1)
+	require.Equal(t, targetedAudience.String(), evaluationGrants[0].PrincipalUrn, "a sparse update preserves the locked audience")
+	postUpdateRead, err := reads.GetPolicy(ctx, principal, GetRiskPolicyInput{ProjectSlug: project.Slug, PolicyID: policyID.String()})
+	require.NoError(t, err)
+	require.Equal(t, second.Version, postUpdateRead.Policy.Version, "the mutation result uses the locked authoritative audience")
 
 	_, replayedUpdate, err := handlers.UpdatePolicy(ctx, nil, updateInput)
 	require.NoError(t, err)
@@ -171,6 +188,10 @@ func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
 	}
 	_, promptCreated, err := handlers.CreatePolicy(ctx, nil, promptInput)
 	require.NoError(t, err)
+	candidates, err := riskrepo.New(conn).ListRiskPolicyCreateCandidates(ctx, riskrepo.ListRiskPolicyCreateCandidatesParams{ProjectID: project.ID, Name: "Policy", PolicyType: "standard"})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, policyID, candidates[0].ID, "create convergence narrows by project, name, and policy type")
 	flags.SetFlag(feature.FlagPromptPolicies, principal.OrganizationID, false)
 	promptReplay := cloneRiskMutationInput(promptInput)
 	_, _, err = handlers.CreatePolicy(ctx, nil, promptReplay)

--- a/server/internal/platformmcp/risk_policy_mutations_integration_test.go
+++ b/server/internal/platformmcp/risk_policy_mutations_integration_test.go
@@ -188,7 +188,7 @@ func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
 	}
 	_, promptCreated, err := handlers.CreatePolicy(ctx, nil, promptInput)
 	require.NoError(t, err)
-	candidates, err := riskrepo.New(conn).ListRiskPolicyCreateCandidates(ctx, riskrepo.ListRiskPolicyCreateCandidatesParams{ProjectID: project.ID, Name: "Policy", PolicyType: "standard"})
+	candidates, err := riskrepo.New(conn).ListRiskPolicyCreateCandidates(ctx, riskrepo.ListRiskPolicyCreateCandidatesParams{ProjectID: project.ID, Name: "Renamed", PolicyType: "standard"})
 	require.NoError(t, err)
 	require.Len(t, candidates, 1)
 	require.Equal(t, policyID, candidates[0].ID, "create convergence narrows by project, name, and policy type")

--- a/server/internal/platformmcp/risk_policy_mutations_integration_test.go
+++ b/server/internal/platformmcp/risk_policy_mutations_integration_test.go
@@ -1,0 +1,249 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type noopRiskPolicySignaler struct{}
+
+func (noopRiskPolicySignaler) Signal(context.Context, uuid.UUID) error { return nil }
+
+func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_risk_policy_mutations")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	principal.ClientID = "test-client"
+	principal.Surface = SurfacePlatformMCP
+	ctx = ContextWithPrincipal(ctx, principal)
+
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagPlatformMCPRiskMutations, principal.OrganizationID, true)
+	flags.SetFlag(feature.FlagPromptPolicies, principal.OrganizationID, true)
+	controls, err := NewRiskMutationControls(conn, flags, NewPostgresOrganizationSlugResolver(conn), testOperationBudget(), "risk-policy-test-key")
+	require.NoError(t, err)
+	policies := risk.NewPolicyMutationCore(conn, audit.NewLogger(), nil, noopRiskPolicySignaler{}, nil)
+	handlers, err := NewRiskPolicyMutationHandlers(conn, controls, policies)
+	require.NoError(t, err)
+	require.Nil(t, handlers.CreateExclusion)
+	require.Nil(t, handlers.UpdateExclusion)
+
+	createInput := map[string]any{
+		"project_slug":    project.Slug,
+		"policy_type":     "standard",
+		"name":            "Policy",
+		"enabled":         true,
+		"sources":         []string{"gitleaks"},
+		"idempotency_key": "create-policy-key",
+	}
+	_, created, err := handlers.CreatePolicy(ctx, nil, createInput)
+	require.NoError(t, err)
+	require.False(t, created.Receipt.Replayed)
+	require.Equal(t, "created", created.ResultCategory)
+	require.Equal(t, project.ID.String(), created.Project.ID)
+	require.NotEmpty(t, created.Version)
+
+	policyID, err := uuid.Parse(created.Policy.ID)
+	require.NoError(t, err)
+	stored, err := riskrepo.New(conn).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: policyID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Equal(t, "flag", stored.Action)
+	require.InDelta(t, 5.0, stored.Score, 0)
+	require.ElementsMatch(t, []string{"gitleaks"}, stored.Sources)
+	require.ElementsMatch(t, []string{"assistant_message", "tool_request", "tool_response", "user_message"}, stored.MessageTypes)
+
+	createAudit, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionRiskPolicyCreate)
+	require.NoError(t, err)
+	require.Equal(t, policyID.String(), createAudit.SubjectID)
+	require.Equal(t, principal.UserID, createAudit.ActorID)
+
+	reads, err := newRiskReadService(conn, "risk-policy-test-key")
+	require.NoError(t, err)
+	read, err := reads.GetPolicy(ctx, principal, GetRiskPolicyInput{ProjectSlug: project.Slug, PolicyID: policyID.String()})
+	require.NoError(t, err)
+	require.Equal(t, created.Version, read.Policy.Version)
+	require.Equal(t, created.Policy.ID, read.Policy.ID)
+
+	_, replayedCreate, err := handlers.CreatePolicy(ctx, nil, createInput)
+	require.NoError(t, err)
+	require.True(t, replayedCreate.Receipt.Replayed)
+	require.Equal(t, created.Receipt.ID, replayedCreate.Receipt.ID)
+	require.Equal(t, created.Version, replayedCreate.Version)
+
+	changedCreate := cloneRiskMutationInput(createInput)
+	changedCreate["name"] = "Different"
+	_, _, err = handlers.CreatePolicy(ctx, nil, changedCreate)
+	requireRiskMutationRefusal(t, err, "conflict")
+
+	updateInput := map[string]any{
+		"project_slug":     project.Slug,
+		"policy_id":        policyID.String(),
+		"expected_version": read.Policy.Version,
+		"idempotency_key":  "update-policy-key",
+		"patch":            map[string]any{"name": "Renamed"},
+	}
+	_, updated, err := handlers.UpdatePolicy(ctx, nil, updateInput)
+	require.NoError(t, err)
+	require.False(t, updated.Receipt.Replayed)
+	require.Equal(t, "updated", updated.ResultCategory)
+	require.NotEqual(t, created.Version, updated.Version)
+
+	stored, err = riskrepo.New(conn).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: policyID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Equal(t, "Renamed", stored.Name)
+	require.ElementsMatch(t, []string{"gitleaks"}, stored.Sources, "omitted sparse fields are preserved")
+	require.True(t, stored.Enabled)
+
+	secondUpdate := map[string]any{
+		"project_slug":     project.Slug,
+		"policy_id":        policyID.String(),
+		"expected_version": updated.Version,
+		"idempotency_key":  "update-policy-key-2",
+		"patch":            map[string]any{"enabled": false},
+	}
+	_, second, err := handlers.UpdatePolicy(ctx, nil, secondUpdate)
+	require.NoError(t, err)
+	require.NotEqual(t, updated.Version, second.Version)
+
+	_, replayedUpdate, err := handlers.UpdatePolicy(ctx, nil, updateInput)
+	require.NoError(t, err)
+	require.True(t, replayedUpdate.Receipt.Replayed)
+	require.Equal(t, updated.Version, replayedUpdate.Version, "replay returns the original stored result rather than mutable current state")
+
+	changedUpdate := cloneRiskMutationInput(updateInput)
+	changedUpdate["patch"] = map[string]any{"name": "Other"}
+	_, _, err = handlers.UpdatePolicy(ctx, nil, changedUpdate)
+	requireRiskMutationRefusal(t, err, "conflict")
+
+	staleUpdate := cloneRiskMutationInput(updateInput)
+	staleUpdate["idempotency_key"] = "stale-update-key"
+	_, _, err = handlers.UpdatePolicy(ctx, nil, staleUpdate)
+	requireRiskMutationRefusal(t, err, "conflict")
+
+	stored, err = riskrepo.New(conn).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: policyID, ProjectID: project.ID})
+	require.NoError(t, err)
+	serverURL := "https://version-audience.example.test/mcp"
+	require.NoError(t, policybypass.ReplacePolicyURLAudience(ctx, conn, principal.OrganizationID, authz.ScopeRiskPolicyBypass, policyID.String(), serverURL, []urn.Principal{
+		urn.NewPrincipal(urn.PrincipalTypeUser, "first-user"),
+	}))
+	policy := policycore.Project(stored, []string{authz.AllUsersPrincipal().String()}, nil)
+	firstGrantState, err := riskPolicyVersionState(ctx, conn, policy, false)
+	require.NoError(t, err)
+	firstGrantVersion, err := controls.Versions().PolicyVersion(firstGrantState)
+	require.NoError(t, err)
+	require.NoError(t, policybypass.ReplacePolicyURLAudience(ctx, conn, principal.OrganizationID, authz.ScopeRiskPolicyBypass, policyID.String(), serverURL, []urn.Principal{
+		urn.NewPrincipal(urn.PrincipalTypeUser, "second-user"),
+	}))
+	secondGrantState, err := riskPolicyVersionState(ctx, conn, policy, false)
+	require.NoError(t, err)
+	secondGrantVersion, err := controls.Versions().PolicyVersion(secondGrantState)
+	require.NoError(t, err)
+	require.NotEqual(t, firstGrantVersion, secondGrantVersion, "changing only a URL grant audience must invalidate the policy version")
+
+	prompt := "sensitive prompt that must not enter the receipt"
+	promptInput := map[string]any{
+		"project_slug":    project.Slug,
+		"policy_type":     "prompt_based",
+		"name":            "Prompt policy",
+		"enabled":         true,
+		"prompt":          prompt,
+		"idempotency_key": "prompt-policy-key",
+	}
+	_, promptCreated, err := handlers.CreatePolicy(ctx, nil, promptInput)
+	require.NoError(t, err)
+	flags.SetFlag(feature.FlagPromptPolicies, principal.OrganizationID, false)
+	promptReplay := cloneRiskMutationInput(promptInput)
+	_, _, err = handlers.CreatePolicy(ctx, nil, promptReplay)
+	requireRiskMutationRefusal(t, err, unavailableCode)
+	flags.SetFlag(feature.FlagPromptPolicies, principal.OrganizationID, true)
+
+	promptReceiptID, err := uuid.Parse(promptCreated.Receipt.ID)
+	require.NoError(t, err)
+	receipt, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID,
+		UserID:         conv.ToPGText(principal.UserID),
+		SubjectUrn:     userSubjectURN(principal.UserID),
+		ProjectID:      project.ID,
+		Operation:      operationCreateRiskPolicy,
+		IdempotencyKey: "prompt-policy-key",
+	})
+	require.NoError(t, err)
+	require.Equal(t, promptReceiptID, receipt.ID)
+	require.NotContains(t, string(receipt.ResultPayload), prompt)
+	require.NotContains(t, string(receipt.ResultPayload), "Prompt policy")
+	var safeResult CreateRiskPolicyReceiptResult
+	require.NoError(t, json.Unmarshal(receipt.ResultPayload, &safeResult))
+	require.Equal(t, promptCreated.Policy.ID, safeResult.Policy.ID)
+
+	legacyBlockingInput := map[string]any{
+		"project_slug":    project.Slug,
+		"policy_type":     "standard",
+		"name":            "Legacy blocking policy",
+		"enabled":         true,
+		"action":          "block",
+		"sources":         []string{"shadow_mcp"},
+		"idempotency_key": "legacy-blocking-policy-key",
+	}
+	_, legacyBlocking, err := handlers.CreatePolicy(ctx, nil, legacyBlockingInput)
+	require.NoError(t, err)
+	legacyBlockingID, err := uuid.Parse(legacyBlocking.Policy.ID)
+	require.NoError(t, err)
+	legacyStored, err := riskrepo.New(conn).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: legacyBlockingID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.False(t, legacyStored.ShadowMcpDisposition.Valid, "legacy block_all posture has no stored disposition")
+
+	_, _, err = handlers.UpdatePolicy(ctx, nil, map[string]any{
+		"project_slug":     project.Slug,
+		"policy_id":        legacyBlocking.Policy.ID,
+		"expected_version": legacyBlocking.Version,
+		"idempotency_key":  "drop-legacy-blocking-posture-key",
+		"patch":            map[string]any{"sources": []string{"gitleaks"}},
+	})
+	requireRiskMutationRefusal(t, err, "invalid_request")
+	legacyStored, err = riskrepo.New(conn).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: legacyBlockingID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"shadow_mcp"}, legacyStored.Sources)
+	require.Equal(t, "block", legacyStored.Action)
+
+	_, _, err = unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()(ctx, nil, map[string]any{})
+	requireRiskMutationRefusal(t, err, unavailableCode)
+	_, _, err = unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()(ctx, nil, map[string]any{})
+	requireRiskMutationRefusal(t, err, unavailableCode)
+}
+
+func cloneRiskMutationInput(input map[string]any) map[string]any {
+	cloned := make(map[string]any, len(input))
+	maps.Copy(cloned, input)
+	return cloned
+}
+
+func requireRiskMutationRefusal(t *testing.T, err error, code string) {
+	t.Helper()
+	var refusal *ToolRefusalError
+	require.ErrorAs(t, err, &refusal)
+	var payload struct {
+		Code string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(refusal.Payload), &payload))
+	require.Equal(t, code, payload.Code)
+}

--- a/server/internal/platformmcp/risk_reads.go
+++ b/server/internal/platformmcp/risk_reads.go
@@ -31,7 +31,6 @@ var (
 
 type riskPolicyReader interface {
 	ListPage(ctx context.Context, organizationID string, projectID uuid.UUID, cursor *policycore.PageCursor, limit int32) ([]policycore.Policy, error)
-	Get(ctx context.Context, projectID, policyID uuid.UUID) (policycore.Policy, error)
 }
 
 type riskExclusionReader interface {
@@ -85,6 +84,7 @@ type RiskReadService struct {
 	catalog            policycatalog.Catalog
 	catalogFingerprint string
 	redactionKey       []byte
+	loadPolicyDetail   func(context.Context, uuid.UUID, uuid.UUID) (policycore.Policy, string, error)
 }
 
 func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService, error) {
@@ -103,6 +103,10 @@ func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService,
 	if err != nil {
 		return nil, fmt.Errorf("fingerprint risk policy catalog: %w", err)
 	}
+	versions, err := newRiskVersionCodec(keyMaterial)
+	if err != nil {
+		return nil, err
+	}
 	redactionKey := sha256.Sum256([]byte("platform-mcp-risk-value:" + keyMaterial))
 	return &RiskReadService{
 		projects:           postgresRiskProjectResolver{queries: platformrepo.New(db)},
@@ -112,6 +116,35 @@ func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService,
 		catalog:            catalog,
 		catalogFingerprint: fingerprint,
 		redactionKey:       redactionKey[:],
+		loadPolicyDetail: func(ctx context.Context, projectID, policyID uuid.UUID) (policycore.Policy, string, error) {
+			tx, err := db.BeginTx(ctx, pgx.TxOptions{
+				IsoLevel:       pgx.RepeatableRead,
+				AccessMode:     pgx.ReadOnly,
+				DeferrableMode: "",
+				BeginQuery:     "",
+				CommitQuery:    "",
+			})
+			if err != nil {
+				return policycore.Policy{}, "", fmt.Errorf("begin risk policy detail snapshot: %w", err)
+			}
+			defer func() { _ = tx.Rollback(ctx) }()
+			policy, err := policycore.New(tx).Get(ctx, projectID, policyID)
+			if err != nil {
+				return policycore.Policy{}, "", fmt.Errorf("load risk policy detail snapshot: %w", err)
+			}
+			state, err := riskPolicyVersionState(ctx, tx, policy, false)
+			if err != nil {
+				return policycore.Policy{}, "", err
+			}
+			version, err := versions.PolicyVersion(state)
+			if err != nil {
+				return policycore.Policy{}, "", err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return policycore.Policy{}, "", fmt.Errorf("commit risk policy detail snapshot: %w", err)
+			}
+			return policy, version, nil
+		},
 	}, nil
 }
 
@@ -146,6 +179,7 @@ type RiskDetectionScope struct {
 
 type RiskPolicyDetail struct {
 	RiskPolicySummary
+	Version                string               `json:"version"`
 	PresidioEntities       []string             `json:"presidio_entities"`
 	PresidioScoreThreshold *float64             `json:"presidio_score_threshold,omitempty"`
 	ApprovedEmailDomains   []string             `json:"approved_email_domains"`
@@ -267,14 +301,16 @@ func (s *RiskReadService) GetPolicy(ctx context.Context, principal Principal, in
 	if err != nil {
 		return GetRiskPolicyOutput{}, ErrRiskReadInvalid
 	}
-	policy, err := s.policies.Get(ctx, project.ID, policyID)
+	policy, version, err := s.loadPolicyDetail(ctx, project.ID, policyID)
 	if errors.Is(err, policycore.ErrLoadPolicy) {
 		return GetRiskPolicyOutput{}, ErrRiskReadNotFound
 	}
 	if err != nil {
-		return GetRiskPolicyOutput{}, fmt.Errorf("get risk policy: %w", err)
+		return GetRiskPolicyOutput{}, fmt.Errorf("get risk policy detail: %w", err)
 	}
-	return GetRiskPolicyOutput{Project: riskProject(project), CatalogVersion: s.catalog.Schema, CatalogFingerprint: s.catalogFingerprint, Policy: s.policyDetail(policy)}, nil
+	detail := s.policyDetail(policy)
+	detail.Version = version
+	return GetRiskPolicyOutput{Project: riskProject(project), CatalogVersion: s.catalog.Schema, CatalogFingerprint: s.catalogFingerprint, Policy: detail}, nil
 }
 
 func (s *RiskReadService) ListExclusions(ctx context.Context, principal Principal, input ListRiskExclusionsInput) (ListRiskExclusionsOutput, error) {
@@ -324,7 +360,7 @@ func (s *RiskReadService) ListExclusions(ctx context.Context, principal Principa
 }
 
 func (s *RiskReadService) valid() bool {
-	return s != nil && s.projects != nil && s.policies != nil && s.exclusions != nil && s.cursor != nil && len(s.redactionKey) > 0 && s.catalog.Schema != "" && s.catalogFingerprint != ""
+	return s != nil && s.projects != nil && s.policies != nil && s.exclusions != nil && s.cursor != nil && len(s.redactionKey) > 0 && s.catalog.Schema != "" && s.catalogFingerprint != "" && s.loadPolicyDetail != nil
 }
 
 func riskPageLimit(value int) (int, error) {
@@ -359,6 +395,7 @@ func (s *RiskReadService) policyDetail(policy policycore.Policy) RiskPolicyDetai
 	detectionScopes, _ := s.projectDetectionScopes(policy)
 	detail := RiskPolicyDetail{
 		RiskPolicySummary:      s.policySummary(policy),
+		Version:                "",
 		PresidioEntities:       allowlisted(policy.PresidioEntities, s.catalog.PresidioEntities),
 		PresidioScoreThreshold: policy.PresidioScoreThreshold,
 		ApprovedEmailDomains:   append([]string{}, policy.ApprovedEmailDomains...),

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -57,8 +57,11 @@ func (s *stubRiskPolicies) ListPage(_ context.Context, _ string, _ uuid.UUID, cu
 	return s.policies, nil
 }
 
-func (s *stubRiskPolicies) Get(_ context.Context, _, _ uuid.UUID) (policycore.Policy, error) {
-	return s.policy, s.getErr
+func (s *stubRiskPolicies) loadDetail(_ context.Context, _, _ uuid.UUID) (policycore.Policy, string, error) {
+	if s.getErr != nil {
+		return policycore.Policy{}, "", fmt.Errorf("load test risk policy detail: %w", s.getErr)
+	}
+	return s.policy, "opaque-version", nil
 }
 
 type stubRiskExclusions struct {
@@ -71,7 +74,7 @@ func (s *stubRiskExclusions) ListPage(_ context.Context, _ uuid.UUID, _ uuid.Nul
 	return s.exclusions, nil
 }
 
-func testRiskReadService(t *testing.T, projects riskProjectResolver, policies riskPolicyReader, exclusions riskExclusionReader) *RiskReadService {
+func testRiskReadService(t *testing.T, projects riskProjectResolver, policies *stubRiskPolicies, exclusions riskExclusionReader) *RiskReadService {
 	t.Helper()
 	catalog, err := policycatalog.Build()
 	require.NoError(t, err)
@@ -82,7 +85,8 @@ func testRiskReadService(t *testing.T, projects riskProjectResolver, policies ri
 	return &RiskReadService{
 		projects: projects, policies: policies, exclusions: exclusions,
 		cursor: cursor, catalog: catalog, catalogFingerprint: fingerprint,
-		redactionKey: []byte("0123456789abcdef0123456789abcdef"),
+		redactionKey:     []byte("0123456789abcdef0123456789abcdef"),
+		loadPolicyDetail: policies.loadDetail,
 	}
 }
 
@@ -152,6 +156,7 @@ func TestRiskReadProjectionsOmitSensitivePolicyFields(t *testing.T) {
 	require.Equal(t, &prompt, output.Policy.Prompt)
 	require.Empty(t, output.Policy.ApprovedEmailDomains)
 	require.NotNil(t, output.Policy.ApprovedEmailDomains)
+	require.Equal(t, "opaque-version", output.Policy.Version)
 	require.Empty(t, output.Policy.Action)
 	require.ElementsMatch(t, []string{"custom_rules", "model_config", "raw_scope", "targeted_audience", "unknown_detector_value", "unsupported_action"}, output.Policy.Compatibility.UnsupportedFields)
 

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -29,11 +29,15 @@ type stubRiskProjects struct {
 	project  ResolvedProject
 	expected []riskProjectCall
 	calls    []riskProjectCall
+	err      error
 }
 
 func (s *stubRiskProjects) Resolve(_ context.Context, organizationID, projectID, projectSlug string) (ResolvedProject, error) {
 	call := riskProjectCall{organizationID: organizationID, projectID: projectID, projectSlug: projectSlug}
 	s.calls = append(s.calls, call)
+	if s.err != nil {
+		return ResolvedProject{}, s.err
+	}
 	index := len(s.calls) - 1
 	if index >= len(s.expected) || s.expected[index] != call {
 		return ResolvedProject{}, fmt.Errorf("unexpected project resolution call: %+v", call)

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -184,18 +184,23 @@ func riskPolicyVersionState(ctx context.Context, db riskrepo.DBTX, policy policy
 	if err != nil {
 		return RiskPolicyVersionState{}, fmt.Errorf("load risk policy version row: %w", err)
 	}
+	audience, err := policycore.New(db).AudiencePrincipalURNs(ctx, row.OrganizationID, row.ID.String())
+	if err != nil {
+		return RiskPolicyVersionState{}, fmt.Errorf("load risk policy version audience: %w", err)
+	}
+	state.Policy = policycore.Project(row, audience, nil)
 	state.AnalyzerConfig = row.AnalyzerConfig
-	allowedGrants, err := riskPolicyVersionURLGrants(ctx, db, policy, authz.ScopeRiskPolicyBypass)
+	allowedGrants, err := riskPolicyVersionURLGrants(ctx, db, state.Policy, authz.ScopeRiskPolicyBypass)
 	if err != nil {
 		return RiskPolicyVersionState{}, err
 	}
-	blockedGrants, err := riskPolicyVersionURLGrants(ctx, db, policy, authz.ScopeRiskPolicyBlock)
+	blockedGrants, err := riskPolicyVersionURLGrants(ctx, db, state.Policy, authz.ScopeRiskPolicyBlock)
 	if err != nil {
 		return RiskPolicyVersionState{}, err
 	}
 	state.AllowedURLGrants = allowedGrants
 	state.BlockedURLGrants = blockedGrants
-	standing, err := approvalQueries.ListStandingServerDecisionsForProject(ctx, policy.ProjectID)
+	standing, err := approvalQueries.ListStandingServerDecisionsForProject(ctx, state.Policy.ProjectID)
 	if err != nil {
 		return RiskPolicyVersionState{}, fmt.Errorf("load risk policy standing decisions: %w", err)
 	}

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -36,15 +36,23 @@ func newRiskVersionCodec(keyMaterial string) (*riskVersionCodec, error) {
 }
 
 // RiskPolicyVersionState is the complete locked policy state needed for an
-// optimistic-concurrency token. Grant-backed URLs, standing-decision state, and
-// canonical analyzer JSON are included because they can change enforcement
-// without changing the policy's public summary. They remain inside the HMAC.
+// optimistic-concurrency token. Grant-backed URL selectors and audiences,
+// standing-decision state, and canonical analyzer JSON are included because
+// they can change enforcement without changing the policy's public summary.
+// They remain inside the HMAC.
 type RiskPolicyVersionState struct {
 	Policy                policycore.Policy
 	AnalyzerConfig        json.RawMessage
-	AllowedURLs           []string
-	BlockedURLs           []string
+	AllowedURLGrants      []RiskPolicyVersionGrant
+	BlockedURLGrants      []RiskPolicyVersionGrant
 	StandingDecisionState []string
+}
+
+// RiskPolicyVersionGrant captures the complete enforcement identity of one URL
+// grant. The principal and canonical selector remain inside the opaque HMAC.
+type RiskPolicyVersionGrant struct {
+	PrincipalURN string          `json:"principal_urn"`
+	Selector     json.RawMessage `json:"selector"`
 }
 
 // PolicyVersion authenticates the complete transport-neutral persisted policy
@@ -72,18 +80,16 @@ func (c *riskVersionCodec) PolicyVersion(input RiskPolicyVersionState) (string, 
 	state.Policy.MessageTypes = sortedStrings(state.Policy.MessageTypes)
 	state.Policy.AudiencePrincipalURNs = sortedStrings(state.Policy.AudiencePrincipalURNs)
 	state.Policy.DetectionScopes = slices.Clone(state.Policy.DetectionScopes)
-	state.AllowedURLs = sortedStrings(state.AllowedURLs)
-	state.BlockedURLs = sortedStrings(state.BlockedURLs)
+	state.AllowedURLGrants, err = canonicalRiskPolicyVersionGrants(state.AllowedURLGrants)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
+	state.BlockedURLGrants, err = canonicalRiskPolicyVersionGrants(state.BlockedURLGrants)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
 	state.StandingDecisionState = sortedStrings(state.StandingDecisionState)
-	slices.SortFunc(state.Policy.DetectionScopes, func(a, b policycore.DetectionScope) int {
-		if a.Category < b.Category {
-			return -1
-		}
-		if a.Category > b.Category {
-			return 1
-		}
-		return 0
-	})
+	slices.SortFunc(state.Policy.DetectionScopes, compareDetectionScopes)
 	return c.encode("policy", state)
 }
 
@@ -101,6 +107,60 @@ func (c *riskVersionCodec) ValidPolicyVersion(state RiskPolicyVersionState, toke
 func (c *riskVersionCodec) ValidExclusionVersion(exclusion exclusioncore.Exclusion, token string) bool {
 	expected, err := c.ExclusionVersion(exclusion)
 	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func canonicalRiskPolicyVersionGrants(grants []RiskPolicyVersionGrant) ([]RiskPolicyVersionGrant, error) {
+	result := slices.Clone(grants)
+	for index := range result {
+		selector, err := canonicalJSON(result[index].Selector)
+		if err != nil {
+			return nil, err
+		}
+		result[index].Selector = selector
+	}
+	slices.SortFunc(result, func(a, b RiskPolicyVersionGrant) int {
+		if order := compareStrings(a.PrincipalURN, b.PrincipalURN); order != 0 {
+			return order
+		}
+		return compareStrings(string(a.Selector), string(b.Selector))
+	})
+	return slices.CompactFunc(result, func(a, b RiskPolicyVersionGrant) bool {
+		return a.PrincipalURN == b.PrincipalURN && string(a.Selector) == string(b.Selector)
+	}), nil
+}
+
+func compareDetectionScopes(a, b policycore.DetectionScope) int {
+	if order := compareStrings(a.Category, b.Category); order != 0 {
+		return order
+	}
+	if order := compareOptionalStrings(a.ScopeInclude, b.ScopeInclude); order != 0 {
+		return order
+	}
+	return compareOptionalStrings(a.ScopeExempt, b.ScopeExempt)
+}
+
+func compareOptionalStrings(a, b *string) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return compareStrings(*a, *b)
+	}
+}
+
+func compareStrings(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func (c *riskVersionCodec) encode(kind string, state any) (string, error) {

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -1,6 +1,7 @@
 package platformmcp
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -9,8 +10,11 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	approvalrepo "github.com/speakeasy-api/gram/server/internal/mcpapproval/repo"
 	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
 const riskVersionCodecVersion = 1
@@ -161,6 +165,72 @@ func compareStrings(a, b string) int {
 	default:
 		return 0
 	}
+}
+
+// riskPolicyVersionState loads every grant-backed part of a policy definition
+// from the same database snapshot as the policy row. Sensitive URLs, principals,
+// selectors, and standing decisions contribute only to the HMAC and are never
+// returned. Mutation validation requests the enforcement lock before any of
+// those reads; repeatable-read projections already have one stable snapshot.
+func riskPolicyVersionState(ctx context.Context, db riskrepo.DBTX, policy policycore.Policy, lockEnforcement bool) (RiskPolicyVersionState, error) {
+	state := RiskPolicyVersionState{Policy: policy, AnalyzerConfig: nil, AllowedURLGrants: []RiskPolicyVersionGrant{}, BlockedURLGrants: []RiskPolicyVersionGrant{}, StandingDecisionState: []string{}}
+	approvalQueries := approvalrepo.New(db)
+	if lockEnforcement {
+		if err := approvalQueries.LockProjectEnforcementState(ctx, policy.ProjectID.String()); err != nil {
+			return RiskPolicyVersionState{}, fmt.Errorf("lock risk policy enforcement state: %w", err)
+		}
+	}
+	row, err := riskrepo.New(db).GetRiskPolicy(ctx, riskrepo.GetRiskPolicyParams{ID: policy.ID, ProjectID: policy.ProjectID})
+	if err != nil {
+		return RiskPolicyVersionState{}, fmt.Errorf("load risk policy version row: %w", err)
+	}
+	state.AnalyzerConfig = row.AnalyzerConfig
+	allowedGrants, err := riskPolicyVersionURLGrants(ctx, db, policy, authz.ScopeRiskPolicyBypass)
+	if err != nil {
+		return RiskPolicyVersionState{}, err
+	}
+	blockedGrants, err := riskPolicyVersionURLGrants(ctx, db, policy, authz.ScopeRiskPolicyBlock)
+	if err != nil {
+		return RiskPolicyVersionState{}, err
+	}
+	state.AllowedURLGrants = allowedGrants
+	state.BlockedURLGrants = blockedGrants
+	standing, err := approvalQueries.ListStandingServerDecisionsForProject(ctx, policy.ProjectID)
+	if err != nil {
+		return RiskPolicyVersionState{}, fmt.Errorf("load risk policy standing decisions: %w", err)
+	}
+	for _, decision := range standing {
+		encoded, err := json.Marshal(struct {
+			ID         string   `json:"id"`
+			TargetKey  string   `json:"target_key"`
+			Decision   string   `json:"decision"`
+			Principals []string `json:"principals"`
+		}{ID: decision.ID.String(), TargetKey: decision.TargetKey, Decision: decision.Decision, Principals: sortedStrings(decision.GrantedPrincipalUrns)})
+		if err != nil {
+			return RiskPolicyVersionState{}, fmt.Errorf("encode risk policy standing decision: %w", err)
+		}
+		state.StandingDecisionState = append(state.StandingDecisionState, string(encoded))
+	}
+	return state, nil
+}
+
+func riskPolicyVersionURLGrants(ctx context.Context, db riskrepo.DBTX, policy policycore.Policy, scope authz.Scope) ([]RiskPolicyVersionGrant, error) {
+	grants, err := authz.ListGrantsForResource(ctx, db, authz.Resource{OrganizationID: policy.OrganizationID, Scope: scope, ResourceID: policy.ID.String()})
+	if err != nil {
+		return nil, fmt.Errorf("load risk policy version grants: %w", err)
+	}
+	state := make([]RiskPolicyVersionGrant, 0, len(grants))
+	for _, grant := range grants {
+		if grant.Selector[authz.SelectorKeyServerURL] == "" {
+			continue
+		}
+		selector, err := grant.Selector.MarshalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("encode risk policy version grant selector: %w", err)
+		}
+		state = append(state, RiskPolicyVersionGrant{PrincipalURN: grant.PrincipalUrn, Selector: selector})
+	}
+	return state, nil
 }
 
 func (c *riskVersionCodec) encode(kind string, state any) (string, error) {

--- a/server/internal/platformmcp/risk_version.go
+++ b/server/internal/platformmcp/risk_version.go
@@ -1,0 +1,143 @@
+package platformmcp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+)
+
+const riskVersionCodecVersion = 1
+
+var errRiskVersionInvalid = errors.New("invalid platform mcp risk version")
+
+type riskVersionCodec struct {
+	key []byte
+}
+
+type riskVersionEnvelope struct {
+	Version int    `json:"v"`
+	Kind    string `json:"k"`
+	MAC     string `json:"m"`
+}
+
+func newRiskVersionCodec(keyMaterial string) (*riskVersionCodec, error) {
+	if keyMaterial == "" {
+		return nil, ErrRiskMutationUnavailable
+	}
+	key := sha256.Sum256([]byte("platform-mcp-risk-version:" + keyMaterial))
+	return &riskVersionCodec{key: key[:]}, nil
+}
+
+// RiskPolicyVersionState is the complete locked policy state needed for an
+// optimistic-concurrency token. Grant-backed URLs, standing-decision state, and
+// canonical analyzer JSON are included because they can change enforcement
+// without changing the policy's public summary. They remain inside the HMAC.
+type RiskPolicyVersionState struct {
+	Policy                policycore.Policy
+	AnalyzerConfig        json.RawMessage
+	AllowedURLs           []string
+	BlockedURLs           []string
+	StandingDecisionState []string
+}
+
+// PolicyVersion authenticates the complete transport-neutral persisted policy
+// state. Sensitive prompt, URL-derived scope, model configuration, and audience
+// values contribute only inside the HMAC and never appear in the token.
+func (c *riskVersionCodec) PolicyVersion(input RiskPolicyVersionState) (string, error) {
+	state := input
+	// Progress is computed when a policy is read and changes as background
+	// analysis advances; it is not part of the locked policy definition. Keep
+	// persisted score, version, and timestamps, which do represent admin-visible
+	// policy state and must invalidate stale writes.
+	state.Policy.PendingMessages = nil
+	state.Policy.TotalMessages = nil
+	canonicalAnalyzer, err := canonicalJSON(state.AnalyzerConfig)
+	if err != nil {
+		return "", errRiskVersionInvalid
+	}
+	state.AnalyzerConfig = canonicalAnalyzer
+	state.Policy.Sources = sortedStrings(state.Policy.Sources)
+	state.Policy.PresidioEntities = sortedStrings(state.Policy.PresidioEntities)
+	state.Policy.ApprovedEmailDomains = sortedStrings(state.Policy.ApprovedEmailDomains)
+	state.Policy.PromptInjectionRules = sortedStrings(state.Policy.PromptInjectionRules)
+	state.Policy.DisabledRules = sortedStrings(state.Policy.DisabledRules)
+	state.Policy.CustomRuleIDs = sortedStrings(state.Policy.CustomRuleIDs)
+	state.Policy.MessageTypes = sortedStrings(state.Policy.MessageTypes)
+	state.Policy.AudiencePrincipalURNs = sortedStrings(state.Policy.AudiencePrincipalURNs)
+	state.Policy.DetectionScopes = slices.Clone(state.Policy.DetectionScopes)
+	state.AllowedURLs = sortedStrings(state.AllowedURLs)
+	state.BlockedURLs = sortedStrings(state.BlockedURLs)
+	state.StandingDecisionState = sortedStrings(state.StandingDecisionState)
+	slices.SortFunc(state.Policy.DetectionScopes, func(a, b policycore.DetectionScope) int {
+		if a.Category < b.Category {
+			return -1
+		}
+		if a.Category > b.Category {
+			return 1
+		}
+		return 0
+	})
+	return c.encode("policy", state)
+}
+
+// ExclusionVersion authenticates every persisted exclusion field. Exact match
+// values remain inside the HMAC and cannot be recovered from the opaque token.
+func (c *riskVersionCodec) ExclusionVersion(exclusion exclusioncore.Exclusion) (string, error) {
+	return c.encode("exclusion", exclusion)
+}
+
+func (c *riskVersionCodec) ValidPolicyVersion(state RiskPolicyVersionState, token string) bool {
+	expected, err := c.PolicyVersion(state)
+	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (c *riskVersionCodec) ValidExclusionVersion(exclusion exclusioncore.Exclusion, token string) bool {
+	expected, err := c.ExclusionVersion(exclusion)
+	return err == nil && hmac.Equal([]byte(expected), []byte(token))
+}
+
+func (c *riskVersionCodec) encode(kind string, state any) (string, error) {
+	if c == nil || len(c.key) == 0 || kind == "" {
+		return "", errRiskVersionInvalid
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", fmt.Errorf("encode risk version state: %w", err)
+	}
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write([]byte("platform-mcp-risk-version-v1\x00" + kind + "\x00"))
+	_, _ = mac.Write(payload)
+	envelope, err := json.Marshal(riskVersionEnvelope{Version: riskVersionCodecVersion, Kind: kind, MAC: base64.RawURLEncoding.EncodeToString(mac.Sum(nil))})
+	if err != nil {
+		return "", fmt.Errorf("encode risk version envelope: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(envelope), nil
+}
+
+func sortedStrings(values []string) []string {
+	result := slices.Clone(values)
+	slices.Sort(result)
+	return slices.Compact(result)
+}
+
+func canonicalJSON(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("decode analyzer configuration: %w", err)
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical analyzer configuration: %w", err)
+	}
+	return canonical, nil
+}

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -127,10 +127,14 @@ func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, ga
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
 func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
+	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+}
+
+func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServer(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, candidate)
+	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -134,7 +134,7 @@ func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog,
 	updatePolicy := unavailableRiskMutationTool[UpdateRiskPolicyToolOutput]()
 	createExclusion := unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()
 	updateExclusion := unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()
-	if handlers != nil && handlers.Controls != nil {
+	if catalogAvailable && handlers != nil && handlers.Controls != nil {
 		if handlers.CreatePolicy != nil {
 			createPolicy = handlers.CreatePolicy
 		}

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -134,25 +134,33 @@ func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog,
 	updatePolicy := unavailableRiskMutationTool[UpdateRiskPolicyToolOutput]()
 	createExclusion := unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()
 	updateExclusion := unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()
+	createPolicyDescription := "Create a risk policy in an explicit project. Risk policy mutations are not enabled in this rollout."
+	updatePolicyDescription := "Patch a risk policy in an explicit project. Risk policy mutations are not enabled in this rollout."
+	createExclusionDescription := "Create a non-regex risk exclusion in an explicit project. Exclusion mutations are not enabled in this rollout."
+	updateExclusionDescription := "Enable or disable one risk exclusion without changing its definition. Exclusion mutations are not enabled in this rollout."
 	if catalogAvailable && handlers != nil && handlers.Controls != nil {
 		if handlers.CreatePolicy != nil {
 			createPolicy = handlers.CreatePolicy
+			createPolicyDescription = "Create an allowlisted standard or prompt-based risk policy in an explicit project with idempotent replay safety."
 		}
 		if handlers.UpdatePolicy != nil {
 			updatePolicy = handlers.UpdatePolicy
+			updatePolicyDescription = "Patch allowlisted fields on a risk policy in an explicit project using an opaque expected version; omitted fields are preserved."
 		}
 		if handlers.CreateExclusion != nil {
 			createExclusion = handlers.CreateExclusion
+			createExclusionDescription = "Create a non-regex risk exclusion in an explicit project with idempotent replay safety."
 		}
 		if handlers.UpdateExclusion != nil {
 			updateExclusion = handlers.UpdateExclusion
+			updateExclusionDescription = "Enable or disable one risk exclusion without changing its definition using an opaque expected version."
 		}
 	}
 	meta := ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}
-	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: "Create an allowlisted standard or prompt-based risk policy in an explicit project with idempotent replay safety.", InputSchema: createPolicySchema}, meta, createPolicy)
-	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: "Patch allowlisted fields on a risk policy in an explicit project using an opaque expected version; omitted fields are preserved.", InputSchema: updatePolicySchema}, meta, updatePolicy)
-	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: "Create a non-regex risk exclusion in an explicit project. Exclusion mutations are not enabled in this rollout.", InputSchema: createExclusionSchema}, meta, createExclusion)
-	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: "Enable or disable one risk exclusion without changing its definition. Exclusion mutations are not enabled in this rollout.", InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
+	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: createPolicyDescription, InputSchema: createPolicySchema}, meta, createPolicy)
+	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: updatePolicyDescription, InputSchema: updatePolicySchema}, meta, updatePolicy)
+	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: createExclusionDescription, InputSchema: createExclusionSchema}, meta, createExclusion)
+	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: updateExclusionDescription, InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
 }
 
 func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, Out] {

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -14,9 +14,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
 )
 
-func registerRiskTools(reg *Registrar, risk *RiskReadService) {
+// registerRiskToolsWithMutations is the single handler-selection seam used by
+// the external endpoint and assistant catalogue. PR 6 deliberately passes no
+// live handlers, so every mutation remains the same stable unavailable stub.
+func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutations *RiskMutationHandlers) {
 	if risk == nil || !risk.valid() {
-		registerUnavailableRiskTools(reg)
+		registerUnavailableRiskToolsWithMutations(reg, mutations)
 		return
 	}
 	addTool(reg, &mcp.Tool{
@@ -52,14 +55,22 @@ func registerRiskTools(reg *Registrar, risk *RiskReadService) {
 			return risk.ListExclusions(ctx, principal, input)
 		})
 	})
-	registerRiskMutationStubs(reg, risk.catalog, true)
+	registerRiskMutationHandlers(reg, risk.catalog, true, mutations)
 }
 
 func registerUnavailableRiskTools(reg *Registrar) {
-	registerUnavailableRiskToolsWithCatalog(reg, policycatalog.Build)
+	registerUnavailableRiskToolsWithMutations(reg, nil)
+}
+
+func registerUnavailableRiskToolsWithMutations(reg *Registrar, mutations *RiskMutationHandlers) {
+	registerUnavailableRiskToolsWithCatalogAndMutations(reg, policycatalog.Build, mutations)
 }
 
 func registerUnavailableRiskToolsWithCatalog(reg *Registrar, buildCatalog func() (policycatalog.Catalog, error)) {
+	registerUnavailableRiskToolsWithCatalogAndMutations(reg, buildCatalog, nil)
+}
+
+func registerUnavailableRiskToolsWithCatalogAndMutations(reg *Registrar, buildCatalog func() (policycatalog.Catalog, error), mutations *RiskMutationHandlers) {
 	for _, tool := range []struct {
 		name, title, description string
 		schema                   *jsonschema.Schema
@@ -71,10 +82,46 @@ func registerUnavailableRiskToolsWithCatalog(reg *Registrar, buildCatalog func()
 		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, Annotations: readOnlyAnnotations(), InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, unavailableTool("risk_reads"))
 	}
 	catalog, err := buildCatalog()
-	registerRiskMutationStubs(reg, catalog, err == nil)
+	registerRiskMutationHandlers(reg, catalog, err == nil, mutations)
 }
 
-func registerRiskMutationStubs(reg *Registrar, catalog policycatalog.Catalog, catalogAvailable bool) {
+type RiskMutationToolReceipt struct {
+	ID       string `json:"id"`
+	Replayed bool   `json:"replayed"`
+}
+
+type CreateRiskPolicyToolOutput struct {
+	CreateRiskPolicyReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type UpdateRiskPolicyToolOutput struct {
+	UpdateRiskPolicyReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type CreateRiskExclusionToolOutput struct {
+	CreateRiskExclusionReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type UpdateRiskExclusionToolOutput struct {
+	UpdateRiskExclusionReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+// RiskMutationHandlers names the four final live callbacks without enabling
+// them. Every callback has an exported success type that composition code can
+// construct, while the schemas remain owned by this package.
+type RiskMutationHandlers struct {
+	Controls        *RiskMutationControls
+	CreatePolicy    mcp.ToolHandlerFor[map[string]any, CreateRiskPolicyToolOutput]
+	UpdatePolicy    mcp.ToolHandlerFor[map[string]any, UpdateRiskPolicyToolOutput]
+	CreateExclusion mcp.ToolHandlerFor[map[string]any, CreateRiskExclusionToolOutput]
+	UpdateExclusion mcp.ToolHandlerFor[map[string]any, UpdateRiskExclusionToolOutput]
+}
+
+func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog, catalogAvailable bool, handlers *RiskMutationHandlers) {
 	createPolicySchema := fallbackCreateRiskPolicySchema()
 	updatePolicySchema := fallbackUpdateRiskPolicySchema()
 	createExclusionSchema := fallbackCreateRiskExclusionSchema()
@@ -83,16 +130,43 @@ func registerRiskMutationStubs(reg *Registrar, catalog policycatalog.Catalog, ca
 		updatePolicySchema = updateRiskPolicySchema(catalog)
 		createExclusionSchema = createRiskExclusionSchema(catalog)
 	}
-	for _, tool := range []struct {
-		name, title, description string
-		schema                   *jsonschema.Schema
-	}{
-		{"create_risk_policy", "Create Risk Policy", "Create a risk policy in an explicit project. Risk mutations are not enabled in this rollout.", createPolicySchema},
-		{"update_risk_policy", "Update Risk Policy", "Patch a risk policy in an explicit project using an opaque expected version. Risk mutations are not enabled in this rollout.", updatePolicySchema},
-		{"create_risk_exclusion", "Create Risk Exclusion", "Create a non-regex risk exclusion in an explicit project. Risk mutations are not enabled in this rollout.", createExclusionSchema},
-		{"update_risk_exclusion", "Update Risk Exclusion", "Enable or disable one risk exclusion without changing its definition. Risk mutations are not enabled in this rollout.", updateRiskExclusionSchema()},
-	} {
-		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("risk_mutations"))
+	createPolicy := unavailableRiskMutationTool[CreateRiskPolicyToolOutput]()
+	updatePolicy := unavailableRiskMutationTool[UpdateRiskPolicyToolOutput]()
+	createExclusion := unavailableRiskMutationTool[CreateRiskExclusionToolOutput]()
+	updateExclusion := unavailableRiskMutationTool[UpdateRiskExclusionToolOutput]()
+	if handlers != nil && handlers.Controls != nil {
+		if handlers.CreatePolicy != nil {
+			createPolicy = handlers.CreatePolicy
+		}
+		if handlers.UpdatePolicy != nil {
+			updatePolicy = handlers.UpdatePolicy
+		}
+		if handlers.CreateExclusion != nil {
+			createExclusion = handlers.CreateExclusion
+		}
+		if handlers.UpdateExclusion != nil {
+			updateExclusion = handlers.UpdateExclusion
+		}
+	}
+	meta := ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}
+	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: "Create a risk policy in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createPolicySchema}, meta, createPolicy)
+	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: "Patch a risk policy in an explicit project using an opaque expected version. Risk mutations are not enabled in this rollout.", InputSchema: updatePolicySchema}, meta, updatePolicy)
+	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: "Create a non-regex risk exclusion in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createExclusionSchema}, meta, createExclusion)
+	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: "Enable or disable one risk exclusion without changing its definition. Risk mutations are not enabled in this rollout.", InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
+}
+
+func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, Out] {
+	return func(_ context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, Out, error) {
+		var zero Out
+		result := featureUnavailableResult{Code: unavailableCode, Feature: "risk_mutations", Message: "This Platform MCP capability is not enabled for the current rollout."}
+		content, err := json.Marshal(result)
+		if err != nil {
+			return nil, zero, fmt.Errorf("encode unavailable risk mutation result: %w", err)
+		}
+		// Return a tool error rather than an existing IsError result. The MCP SDK
+		// short-circuits on errors before marshaling the typed zero Out value, so
+		// disabled tools emit no empty structured success fields.
+		return nil, zero, &ToolRefusalError{Payload: string(content)}
 	}
 }
 

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -15,8 +15,8 @@ import (
 )
 
 // registerRiskToolsWithMutations is the single handler-selection seam used by
-// the external endpoint and assistant catalogue. PR 6 deliberately passes no
-// live handlers, so every mutation remains the same stable unavailable stub.
+// the external endpoint and assistant catalogue. Policy callbacks may be live
+// while exclusion callbacks remain stable unavailable stubs during rollout.
 func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutations *RiskMutationHandlers) {
 	if risk == nil || !risk.valid() {
 		registerUnavailableRiskToolsWithMutations(reg, mutations)
@@ -110,8 +110,8 @@ type UpdateRiskExclusionToolOutput struct {
 	Receipt RiskMutationToolReceipt `json:"receipt"`
 }
 
-// RiskMutationHandlers names the four final live callbacks without enabling
-// them. Every callback has an exported success type that composition code can
+// RiskMutationHandlers names the four independently selectable callbacks.
+// Every callback has an exported success type that composition code can
 // construct, while the schemas remain owned by this package.
 type RiskMutationHandlers struct {
 	Controls        *RiskMutationControls
@@ -149,10 +149,10 @@ func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog,
 		}
 	}
 	meta := ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}
-	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: "Create a risk policy in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createPolicySchema}, meta, createPolicy)
-	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: "Patch a risk policy in an explicit project using an opaque expected version. Risk mutations are not enabled in this rollout.", InputSchema: updatePolicySchema}, meta, updatePolicy)
-	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: "Create a non-regex risk exclusion in an explicit project. Risk mutations are not enabled in this rollout.", InputSchema: createExclusionSchema}, meta, createExclusion)
-	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: "Enable or disable one risk exclusion without changing its definition. Risk mutations are not enabled in this rollout.", InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
+	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: "Create an allowlisted standard or prompt-based risk policy in an explicit project with idempotent replay safety.", InputSchema: createPolicySchema}, meta, createPolicy)
+	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: "Patch allowlisted fields on a risk policy in an explicit project using an opaque expected version; omitted fields are preserved.", InputSchema: updatePolicySchema}, meta, updatePolicy)
+	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: "Create a non-regex risk exclusion in an explicit project. Exclusion mutations are not enabled in this rollout.", InputSchema: createExclusionSchema}, meta, createExclusion)
+	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: "Enable or disable one risk exclusion without changing its definition. Exclusion mutations are not enabled in this rollout.", InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
 }
 
 func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, Out] {

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -149,6 +149,10 @@ type operationBudgetResult struct {
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+}
+
+func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -176,9 +180,9 @@ func newServer(reader Reader, catalog Catalog, registrations *RegistrationServic
 
 	registerReadTools(reg, reader, cursorKeyMaterial)
 	if postgresReader, ok := reader.(*PostgresReader); ok {
-		registerRiskTools(reg, postgresReader.riskReads)
+		registerRiskToolsWithMutations(reg, postgresReader.riskReads, riskMutations)
 	} else {
-		registerUnavailableRiskTools(reg)
+		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
 	}
 	registerSetupResources(reg, setupResources, time.Now)
 	if registrations == nil || !registrations.budgets.Docs.valid() {

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1022,6 +1022,7 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 		BlockedURLsSet:       payload.ShadowMcpBlockedUrls != nil,
 		EffectiveDisposition: effectiveDisposition,
 		SupersedeDecisions:   payload.SupersedeDecisions != nil && *payload.SupersedeDecisions,
+		ValidateLocked:       nil,
 		Actor: policycore.Actor{
 			Principal:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 			DisplayName: authCtx.Email,

--- a/server/internal/risk/policy_mutation.go
+++ b/server/internal/risk/policy_mutation.go
@@ -6,14 +6,31 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 )
 
 type policyMutationAuditor struct {
 	logger *audit.Logger
+}
+
+// NewPolicyMutationCore composes the shared risk policy command for non-Goa
+// adapters. It preserves the same audit, approval, URL-grant, signal, and cache
+// dependencies used by the dashboard service.
+func NewPolicyMutationCore(db *pgxpool.Pool, auditLogger *audit.Logger, approvals policycore.ApprovalCoordinator, signaler policycore.PolicySignaler, cacheInvalidator policycore.PolicyCacheInvalidator) *policycore.Core {
+	return policycore.New(db, policycore.MutationDependencies{
+		Transactor:       db,
+		Auditor:          policyMutationAuditor{logger: auditLogger},
+		Approvals:        approvals,
+		ReconcileURLs:    policycore.ReconcilePolicyURLs(policybypass.ReconcilePolicyURLs),
+		Signaler:         signaler,
+		CacheInvalidator: cacheInvalidator,
+	})
 }
 
 func (a policyMutationAuditor) LogPolicyCreate(ctx context.Context, db repo.DBTX, event policycore.CreateAuditEvent) error {

--- a/server/internal/risk/policycore/mutation.go
+++ b/server/internal/risk/policycore/mutation.go
@@ -107,7 +107,11 @@ type UpdateMutation struct {
 	BlockedURLsSet       bool
 	EffectiveDisposition string
 	SupersedeDecisions   bool
-	Actor                Actor
+	// ValidateLocked runs after the current row and audience are locked but
+	// before any domain write. Platform adapters use it for opaque optimistic
+	// concurrency tokens without moving policy mutation logic out of this core.
+	ValidateLocked func(context.Context, pgx.Tx, Policy) error
+	Actor          Actor
 }
 
 // MutationResult is the committed policy row and canonical audience.
@@ -165,6 +169,32 @@ func (c *Core) CreatePolicy(ctx context.Context, input CreateMutation) (Mutation
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	result, err := c.createPolicyInTransaction(ctx, tx, input, deps)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return MutationResult{}, mutationError("commit risk policy create", err)
+	}
+	c.AfterCreatePolicy(ctx, result)
+	return result, nil
+}
+
+// CreatePolicyInTransaction applies the complete policy create and audit to a
+// caller-owned transaction. The caller owns commit and must invoke
+// AfterCreatePolicy only after that commit succeeds.
+func (c *Core) CreatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input CreateMutation) (MutationResult, error) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if tx == nil {
+		return MutationResult{}, mutationError("policy mutation transaction is not configured", nil)
+	}
+	return c.createPolicyInTransaction(ctx, tx, input, deps)
+}
+
+func (c *Core) createPolicyInTransaction(ctx context.Context, tx pgx.Tx, input CreateMutation, deps *MutationDependencies) (MutationResult, error) {
 	queries := repo.New(tx)
 	if err := queries.LockRiskPolicyMutations(ctx, input.Params.ProjectID.String()); err != nil {
 		return MutationResult{}, mutationError("lock risk policy mutations", err)
@@ -222,17 +252,22 @@ func (c *Core) CreatePolicy(ctx context.Context, input CreateMutation) (Mutation
 	}); err != nil {
 		return MutationResult{}, mutationError("log risk policy create", err)
 	}
-	if err := tx.Commit(ctx); err != nil {
-		return MutationResult{}, mutationError("commit risk policy create", err)
-	}
-
-	if deps.CacheInvalidator != nil {
-		deps.CacheInvalidator.Invalidate(ctx, row.ProjectID)
-	}
-	if row.Enabled {
-		_ = deps.Signaler.Signal(ctx, row.ProjectID)
-	}
 	return MutationResult{Row: row, AudiencePrincipalURNs: audience}, nil
+}
+
+// AfterCreatePolicy runs best-effort convergence only after the transaction
+// containing the policy, audit, and any outer receipt has committed.
+func (c *Core) AfterCreatePolicy(ctx context.Context, result MutationResult) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return
+	}
+	if deps.CacheInvalidator != nil {
+		deps.CacheInvalidator.Invalidate(ctx, result.Row.ProjectID)
+	}
+	if result.Row.Enabled {
+		_ = deps.Signaler.Signal(ctx, result.Row.ProjectID)
+	}
 }
 
 // UpdatePolicy locks the current row, rejects a stale prepared command, and
@@ -249,6 +284,32 @@ func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (Mutation
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	result, err := c.updatePolicyInTransaction(ctx, tx, input, deps)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return MutationResult{}, mutationError("commit risk policy update", err)
+	}
+	c.AfterUpdatePolicy(ctx, result)
+	return result, nil
+}
+
+// UpdatePolicyInTransaction applies the complete locked sparse update and audit
+// to a caller-owned transaction. The caller owns commit and must invoke
+// AfterUpdatePolicy only after that commit succeeds.
+func (c *Core) UpdatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input UpdateMutation) (MutationResult, error) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if tx == nil {
+		return MutationResult{}, mutationError("policy mutation transaction is not configured", nil)
+	}
+	return c.updatePolicyInTransaction(ctx, tx, input, deps)
+}
+
+func (c *Core) updatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input UpdateMutation, deps *MutationDependencies) (MutationResult, error) {
 	queries := repo.New(tx)
 	if err := queries.LockRiskPolicyMutations(ctx, input.Params.ProjectID.String()); err != nil {
 		return MutationResult{}, mutationError("lock risk policy mutations", err)
@@ -275,12 +336,19 @@ func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (Mutation
 	if err != nil {
 		return MutationResult{}, mutationError("load risk policy audience snapshot", err)
 	}
+	if input.ValidateLocked != nil {
+		if err := input.ValidateLocked(ctx, tx, Project(locked, currentAudience, nil)); err != nil {
+			return MutationResult{}, err
+		}
+	}
 	row, err := queries.UpdateRiskPolicy(ctx, input.Params)
 	if err != nil {
 		return MutationResult{}, mutationError("update risk policy", err)
 	}
-	if err := replaceAudience(ctx, tx, row.OrganizationID, row.ID.String(), input.AudiencePrincipals); err != nil {
-		return MutationResult{}, mutationError("sync risk policy audience", err)
+	if input.AudienceChanged {
+		if err := replaceAudience(ctx, tx, row.OrganizationID, row.ID.String(), input.AudiencePrincipals); err != nil {
+			return MutationResult{}, mutationError("sync risk policy audience", err)
+		}
 	}
 
 	wasBlocking := isBlockingShadowPolicy(locked)
@@ -354,15 +422,20 @@ func (c *Core) UpdatePolicy(ctx context.Context, input UpdateMutation) (Mutation
 	}); err != nil {
 		return MutationResult{}, mutationError("log risk policy update", err)
 	}
-	if err := tx.Commit(ctx); err != nil {
-		return MutationResult{}, mutationError("commit risk policy update", err)
-	}
-
-	if deps.CacheInvalidator != nil {
-		deps.CacheInvalidator.Invalidate(ctx, row.ProjectID)
-	}
-	_ = deps.Signaler.Signal(ctx, row.ProjectID)
 	return MutationResult{Row: row, AudiencePrincipalURNs: audience}, nil
+}
+
+// AfterUpdatePolicy runs best-effort convergence only after the transaction
+// containing the policy, audit, and any outer receipt has committed.
+func (c *Core) AfterUpdatePolicy(ctx context.Context, result MutationResult) {
+	deps, err := c.requireMutationDependencies()
+	if err != nil {
+		return
+	}
+	if deps.CacheInvalidator != nil {
+		deps.CacheInvalidator.Invalidate(ctx, result.Row.ProjectID)
+	}
+	_ = deps.Signaler.Signal(ctx, result.Row.ProjectID)
 }
 
 func (c *Core) requireMutationDependencies() (*MutationDependencies, error) {

--- a/server/internal/risk/policycore/mutation.go
+++ b/server/internal/risk/policycore/mutation.go
@@ -107,10 +107,10 @@ type UpdateMutation struct {
 	BlockedURLsSet       bool
 	EffectiveDisposition string
 	SupersedeDecisions   bool
-	// ValidateLocked runs after the current row and audience are locked but
-	// before any domain write. Platform adapters use it for opaque optimistic
-	// concurrency tokens without moving policy mutation logic out of this core.
-	ValidateLocked func(context.Context, pgx.Tx, Policy) error
+	// ValidateLocked runs after the current row is locked but before any domain
+	// write. It returns the authoritative policy snapshot used by the adapter for
+	// validation so the core can carry its audience through audit and results.
+	ValidateLocked func(context.Context, pgx.Tx, Policy) (Policy, error)
 	Actor          Actor
 }
 
@@ -337,8 +337,17 @@ func (c *Core) updatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input U
 		return MutationResult{}, mutationError("load risk policy audience snapshot", err)
 	}
 	if input.ValidateLocked != nil {
-		if err := input.ValidateLocked(ctx, tx, Project(locked, currentAudience, nil)); err != nil {
+		validated, err := input.ValidateLocked(ctx, tx, Project(locked, currentAudience, nil))
+		if err != nil {
 			return MutationResult{}, err
+		}
+		currentAudience = validated.AudiencePrincipalURNs
+	}
+	effectiveAudience := input.AudiencePrincipals
+	if !input.AudienceChanged {
+		effectiveAudience, err = parsePrincipalURNs(currentAudience)
+		if err != nil {
+			return MutationResult{}, mutationError("parse risk policy audience snapshot", err)
 		}
 	}
 	row, err := queries.UpdateRiskPolicy(ctx, input.Params)
@@ -388,7 +397,7 @@ func (c *Core) updatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input U
 			PolicyID:       row.ID.String(),
 			Scope:          authz.ScopeRiskPolicyBypass,
 			DesiredURLs:    optionalURLs(input.AllowedURLs, input.AllowedURLsSet),
-			Principals:     input.AudiencePrincipals,
+			Principals:     effectiveAudience,
 			PreserveURLs:   preserveDecisionURLs,
 		}); err != nil {
 			return MutationResult{}, mutationError("reconcile shadow mcp policy allowed urls", err)
@@ -412,7 +421,7 @@ func (c *Core) updatePolicyInTransaction(ctx context.Context, tx pgx.Tx, input U
 		}
 	}
 
-	audience := principalStrings(input.AudiencePrincipals)
+	audience := principalStrings(effectiveAudience)
 	if err := deps.Auditor.LogPolicyUpdate(ctx, tx, UpdateAuditEvent{
 		OrganizationID: row.OrganizationID,
 		ProjectID:      row.ProjectID,
@@ -466,6 +475,18 @@ func principalStrings(principals []urn.Principal) []string {
 		values = append(values, principal.String())
 	}
 	return values
+}
+
+func parsePrincipalURNs(values []string) ([]urn.Principal, error) {
+	principals := make([]urn.Principal, 0, len(values))
+	for _, value := range values {
+		principal, err := urn.ParsePrincipal(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse principal %q: %w", value, err)
+		}
+		principals = append(principals, principal)
+	}
+	return principals, nil
 }
 
 func isBlockingShadowPolicy(row repo.RiskPolicy) bool {

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -87,6 +87,17 @@ WHERE project_id = @project_id
   AND deleted IS FALSE
 ORDER BY created_at DESC;
 
+-- name: ListRiskPolicyCreateCandidates :many
+-- Platform MCP create convergence narrows by the stable public identity before
+-- loading sensitive policy definitions for exact canonical comparison.
+SELECT *
+FROM risk_policies
+WHERE project_id = @project_id
+  AND name = @name
+  AND policy_type = @policy_type
+  AND deleted IS FALSE
+ORDER BY id;
+
 -- name: ListRiskPoliciesPage :many
 -- Platform MCP keyset page. The existing unbounded query remains the Goa
 -- compatibility path.

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -3718,6 +3718,73 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 	return items, nil
 }
 
+const listRiskPolicyCreateCandidates = `-- name: ListRiskPolicyCreateCandidates :many
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+FROM risk_policies
+WHERE project_id = $1
+  AND name = $2
+  AND policy_type = $3
+  AND deleted IS FALSE
+ORDER BY id
+`
+
+type ListRiskPolicyCreateCandidatesParams struct {
+	ProjectID  uuid.UUID
+	Name       string
+	PolicyType string
+}
+
+// Platform MCP create convergence narrows by the stable public identity before
+// loading sensitive policy definitions for exact canonical comparison.
+func (q *Queries) ListRiskPolicyCreateCandidates(ctx context.Context, arg ListRiskPolicyCreateCandidatesParams) ([]RiskPolicy, error) {
+	rows, err := q.db.Query(ctx, listRiskPolicyCreateCandidates, arg.ProjectID, arg.Name, arg.PolicyType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []RiskPolicy
+	for rows.Next() {
+		var i RiskPolicy
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.OrganizationID,
+			&i.Enabled,
+			&i.Name,
+			&i.PolicyType,
+			&i.Sources,
+			&i.PresidioEntities,
+			&i.AnalyzerConfig,
+			&i.PromptInjectionRules,
+			&i.DisabledRules,
+			&i.CustomRuleIds,
+			&i.MessageTypes,
+			&i.ScopeInclude,
+			&i.ScopeExempt,
+			&i.Action,
+			&i.AudienceType,
+			&i.ShadowMcpDisposition,
+			&i.AutoName,
+			&i.UserMessage,
+			&i.Prompt,
+			&i.ModelConfig,
+			&i.Score,
+			&i.Version,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRiskPolicyEvalReviews = `-- name: ListRiskPolicyEvalReviews :many
 SELECT id, project_id, organization_id, risk_policy_id, risk_policy_version, chat_id, verdict, reviewed_by, created_at, updated_at, deleted_at, deleted
 FROM risk_policy_eval_reviews


### PR DESCRIPTION
AGE-3168

## Summary

- Activate `create_risk_policy` and `update_risk_policy` for Platform MCP behind the existing exact-project mutation controls and prompt-policy gate.
- Reuse the shared risk policy transaction for atomic domain, audit, and operation-receipt commits, with safe replay payloads and post-commit convergence.
- Add sparse legacy-safe updates, opaque full-state versions, exact-create convergence, and redacted mutation results.
- Keep both risk exclusion mutation tools unavailable for the next stacked PR.

## Motivation

The preceding stack established stable risk descriptors and fail-closed mutation infrastructure while all writes remained disabled. This slice enables only policy administration for the approved rollout cohort without creating a parallel domain path or broadening the allowlisted policy contract.
