### PR TITLE
fix: stop set_mcp_client_admission crash-looping the server at boot

### DIFF
--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -310,3 +310,17 @@ func TestAdvertisedOutputSchemaMatchesTheSubjectCountWireForm(t *testing.T) {
 		require.NoError(t, resolved.Validate(decoded), "output %s", encoded)
 	}
 }
+
+// Schema inference panics at process boot, so a tool input the nil-dependency
+// server never registers can crash-loop production while CI stays green. The
+// jsonschema tag is a description; a "word=" prefix is rejected outright.
+func TestClientAdmissionToolInputsInferSchemas(t *testing.T) {
+	t.Parallel()
+
+	_, err := jsonschema.For[GetMCPClientAdmissionToolInput](nil)
+	require.NoError(t, err)
+
+	schema, err := jsonschema.For[SetMCPClientAdmissionToolInput](nil)
+	require.NoError(t, err)
+	require.Contains(t, schema.Properties["mode"].Description, "presets, open, or disabled")
+}

--- a/server/internal/platformmcp/jsonschema_tags_test.go
+++ b/server/internal/platformmcp/jsonschema_tags_test.go
@@ -1,0 +1,56 @@
+package platformmcp
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// jsonschema-go reads the whole jsonschema tag as the field description and
+// rejects one that begins with "word=", so a tag written as if it took
+// key=value directives panics the process during schema inference. Inference
+// runs when a tool registers, and most tools register only once their
+// dependencies are configured, so a bad tag boots fine in tests with nil
+// dependencies and crash-loops the deployment. Scan the source instead, which
+// sees every tag regardless of which branch registered its tool.
+func TestJSONSchemaTagsAreDescriptions(t *testing.T) {
+	t.Parallel()
+
+	directive := regexp.MustCompile(`^\w+=`)
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs)
+
+	tags := 0
+	for _, pkg := range pkgs {
+		ast.Inspect(pkg, func(node ast.Node) bool {
+			field, ok := node.(*ast.Field)
+			if !ok || field.Tag == nil {
+				return true
+			}
+			raw, err := strconv.Unquote(field.Tag.Value)
+			if err != nil {
+				return true
+			}
+			tag, ok := reflect.StructTag(raw).Lookup("jsonschema")
+			if !ok {
+				return true
+			}
+			tags++
+			position := fset.Position(field.Tag.Pos())
+			require.NotEmpty(t, tag, "%s: empty jsonschema tag", position)
+			require.False(t, directive.MatchString(tag),
+				"%s: jsonschema tag is a plain description, not key=value directives: %q", position, tag)
+			return true
+		})
+	}
+	require.NotZero(t, tags, "the scan found no jsonschema tags, so it is not guarding anything")
+}

--- a/server/internal/platformmcp/tool_client_admission.go
+++ b/server/internal/platformmcp/tool_client_admission.go
@@ -18,7 +18,7 @@ type GetMCPClientAdmissionToolInput struct {
 type SetMCPClientAdmissionToolInput struct {
 	ProjectSlug    string `json:"project_slug" jsonschema:"explicit AICP project slug that owns the reviewed MCP registration"`
 	RegistrationID string `json:"registration_id" jsonschema:"Platform MCP registration ID returned by register_catalog_mcp or register_remote_mcp"`
-	Mode           string `json:"mode" jsonschema:"enum=presets,enum=open,enum=disabled,admission policy for MCP clients that identify themselves with a client ID metadata document"`
+	Mode           string `json:"mode" jsonschema:"admission policy for MCP clients that identify themselves with a client ID metadata document; one of presets, open, or disabled"`
 	Confirmed      bool   `json:"confirmed" jsonschema:"set true only after the user explicitly confirms this exact admission mode for this exact MCP; the change takes effect for every MCP client of the server"`
 }
 


### PR DESCRIPTION
## Summary

`SetMCPClientAdmissionToolInput.Mode` carried a `jsonschema` struct tag written as key=value directives (`enum=presets,enum=open,enum=disabled,<description>`). jsonschema-go v0.4.3 treats the entire tag as the field description and rejects one beginning with `word=`, so schema inference for that tool returned an error and `prepareInputSchema` panicked.

- Rewrite the tag as a plain description that names the accepted values. Runtime validation is unchanged: `set_mcp_client_admission` already rejects an unknown mode via `admission.IsValidMode`.
- Add `TestClientAdmissionToolInputsInferSchemas`, which infers both client-admission tool input schemas directly rather than through a registration branch.
- Add `TestJSONSchemaTagsAreDescriptions`, which parses the package source and fails on any `jsonschema` tag that is empty or begins with `word=`.

## Motivation

Schema inference runs when a tool registers, and the panic aborts `gram start` inside `configurePlatformMCP`, before the server binds. The container exits at boot on every attempt, so the deployment sits in CrashLoopBackOff and the rollout never reaches a healthy state.

Existing tests did not catch it. `newServer` registers the real client-admission tools only when the registration service has client admission and its lifecycle-metadata budget configured; with the nil dependencies the unit tests pass, the unavailable stubs register instead, and those inputs carry no `jsonschema` tags. The same gate pattern covers every tool in the package, so roughly 120 tags across it were only ever exercised in a configured deployment.

The AST scan closes that gap for the whole package without a booted server or live dependencies: it reads the tags from source, so it sees them regardless of which branch would register the tool.
