### PR TITLE
feat: Update signup and login panel copy and button labels

### DIFF
--- a/client/dashboard/src/pages/login/components/login-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.test.tsx
@@ -21,9 +21,9 @@ describe("LoginPanel", () => {
     renderPanel();
 
     const link = screen.getByRole("link", {
-      name: /sign-up for a 14-day trial/i,
+      name: /sign up/i,
     });
     expect(link.getAttribute("href")).toBe("/sign-up");
-    expect(screen.getByText(/no account/i)).toBeTruthy();
+    expect(screen.getByText(/don't have an account/i)).toBeTruthy();
   });
 });

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -49,12 +49,12 @@ export function LoginPanel({
       </p>
 
       <p className="mt-2 text-[14px] text-(--muted-strong)">
-        No account?{" "}
+        Don't have an account?{" "}
         <Link
           to={authPageHref("/sign-up", redirectTo)}
           className="text-(--link) underline hover:text-(--focus)"
         >
-          Sign-up for a 14-day trial.
+          Sign up
         </Link>
       </p>
     </>

--- a/client/dashboard/src/pages/login/components/signup-panel.test.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.test.tsx
@@ -36,7 +36,7 @@ describe("SignUpPanel", () => {
 
   it("leaves the CTA enabled on a pristine empty form", () => {
     renderPanel();
-    const cta = screen.getByRole("button", { name: /start trial/i });
+    const cta = screen.getByRole("button", { name: /create account/i });
     expect(cta.hasAttribute("disabled")).toBe(false);
   });
 
@@ -45,7 +45,7 @@ describe("SignUpPanel", () => {
     renderPanel();
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(await screen.findByText("Company name is required")).toBeTruthy();
   });
@@ -55,7 +55,7 @@ describe("SignUpPanel", () => {
     renderPanel();
 
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(await screen.findByText("Email is required")).toBeTruthy();
   });
@@ -69,7 +69,7 @@ describe("SignUpPanel", () => {
     expect(await screen.findByText(/valid email/i)).toBeTruthy();
     expect(
       screen
-        .getByRole("button", { name: /start trial/i })
+        .getByRole("button", { name: /create account/i })
         .hasAttribute("disabled"),
     ).toBe(true);
   });
@@ -89,7 +89,7 @@ describe("SignUpPanel", () => {
       ).toBeTruthy();
       expect(
         screen
-          .getByRole("button", { name: /start trial/i })
+          .getByRole("button", { name: /create account/i })
           .hasAttribute("disabled"),
       ).toBe(true);
     },
@@ -115,7 +115,7 @@ describe("SignUpPanel", () => {
     expect(field.getAttribute("aria-invalid")).toBeNull();
     expect(
       screen
-        .getByRole("button", { name: /start trial/i })
+        .getByRole("button", { name: /create account/i })
         .hasAttribute("disabled"),
     ).toBe(false);
   });
@@ -130,7 +130,7 @@ describe("SignUpPanel", () => {
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "アクメ株式会社");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(assign).toHaveBeenCalledTimes(1);
     const target = assign.mock.calls[0]?.[0] as string;
@@ -151,7 +151,7 @@ describe("SignUpPanel", () => {
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(assign).toHaveBeenCalledTimes(1);
     const target = assign.mock.calls[0]?.[0] as string;
@@ -172,7 +172,7 @@ describe("SignUpPanel", () => {
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     const target = assign.mock.calls[0]?.[0] as string;
     expect(new URL(target).searchParams.get("redirect")).toBe(
@@ -196,7 +196,7 @@ describe("SignUpPanel", () => {
     // navigation the panel cannot catch.
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(assign).toHaveBeenCalledTimes(1);
     const target = assign.mock.calls[0]?.[0] as string;
@@ -221,7 +221,7 @@ describe("SignUpPanel", () => {
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(telemetryCapture).toHaveBeenCalledWith("onboarding_event", {
       action: "signup_started",
@@ -241,7 +241,7 @@ describe("SignUpPanel", () => {
 
     await user.type(screen.getByLabelText("Work email"), "someone@example.com");
     await user.type(screen.getByLabelText("Company name"), "Acme Inc");
-    const cta = screen.getByRole("button", { name: /start trial/i });
+    const cta = screen.getByRole("button", { name: /create account/i });
 
     await user.click(cta);
     expect(cta.hasAttribute("disabled")).toBe(true);
@@ -260,7 +260,7 @@ describe("SignUpPanel", () => {
     const user = userEvent.setup();
     renderPanel();
 
-    await user.click(screen.getByRole("button", { name: /start trial/i }));
+    await user.click(screen.getByRole("button", { name: /create account/i }));
 
     expect(await screen.findByText("Company name is required")).toBeTruthy();
     expect(telemetryCapture).not.toHaveBeenCalled();

--- a/client/dashboard/src/pages/login/components/signup-panel.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.tsx
@@ -232,7 +232,7 @@ export function SignUpPanel({
                   "mx-auto px-[22px] disabled:cursor-not-allowed disabled:opacity-50",
                 )}
               >
-                Start Trial
+                Create Account
               </button>
             </>
           )}


### PR DESCRIPTION
Updates user-facing text in the authentication panels to improve clarity and consistency.

**Changes:**
- Changed "Start Trial" button label to "Create Account" in the signup panel
- Updated signup panel test assertions to match the new button label
- Changed login panel copy from "No account?" to "Don't have an account?"
- Updated login panel signup link text from "Sign-up for a 14-day trial" to "Sign up"
- Updated login panel test assertions to match the new copy

These changes simplify the signup messaging and remove trial-specific language from the initial account creation flow.

https://claude.ai/code/session_014uKmWk64qey24uKHg8K4ND