### PR TITLE
mig: add org default_host and custom_domains.scope

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -64,6 +64,14 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 
   scim_enabled boolean DEFAULT FALSE,
   sso_enabled boolean DEFAULT FALSE,
+
+  -- The host customer-facing URLs are rendered with for this organization.
+  -- NULL means the deployment's canonical host. A non-NULL value must be a
+  -- configured platform host or the org's own active app-scoped custom domain;
+  -- that rule lives in application code and is re-checked on read, so deleting
+  -- the domain falls back to the canonical host without a data migration.
+  default_host TEXT,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   disabled_at timestamptz,
@@ -1543,6 +1551,10 @@ CREATE TABLE IF NOT EXISTS custom_domains (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,
   domain TEXT NOT NULL,
+  -- What the domain serves: 'mcp' (MCP server endpoints only) or 'app' (the
+  -- full control plane). Allowed values live in application code. Existing rows
+  -- predate the distinction and are all 'mcp', which the default backfills.
+  scope TEXT NOT NULL DEFAULT 'mcp',
   verified BOOLEAN NOT NULL DEFAULT FALSE,
   activated BOOLEAN NOT NULL DEFAULT FALSE,
   -- Generic resource identifier: Ingress name (provisioner_kind='ingress') or HTTPRoute name (provisioner_kind='gateway').
@@ -1580,8 +1592,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS custom_domains_domain_key
 ON custom_domains (domain)
 WHERE deleted IS FALSE;
 
-CREATE UNIQUE INDEX IF NOT EXISTS custom_domains_organization_id_key
-ON custom_domains (organization_id)
+CREATE UNIQUE INDEX IF NOT EXISTS custom_domains_organization_id_scope_key
+ON custom_domains (organization_id, scope)
 WHERE deleted IS FALSE;
 
 -- External OAuth Server Metadata (RFC 8414 compliant)

--- a/server/internal/customdomains/repo/models.go
+++ b/server/internal/customdomains/repo/models.go
@@ -13,6 +13,7 @@ type CustomDomain struct {
 	ID                       uuid.UUID
 	OrganizationID           string
 	Domain                   string
+	Scope                    string
 	Verified                 bool
 	Activated                bool
 	IngressName              pgtype.Text

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -95,7 +95,7 @@ INSERT INTO custom_domains (
     $5,
     $6
 )
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDomainParams struct {
@@ -121,6 +121,7 @@ func (q *Queries) CreateCustomDomain(ctx context.Context, arg CreateCustomDomain
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -217,7 +218,7 @@ func (q *Queries) EnsureCustomDomainResourceNames(ctx context.Context, arg Ensur
 }
 
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE domain = $1
   AND deleted IS FALSE
@@ -230,6 +231,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -252,7 +254,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 }
 
 const getCustomDomainByID = `-- name: GetCustomDomainByID :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND deleted IS FALSE
@@ -265,6 +267,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -287,7 +290,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 }
 
 const getCustomDomainByIDAndOrganization = `-- name: GetCustomDomainByIDAndOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -310,6 +313,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -332,7 +336,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 }
 
 const getCustomDomainByOrganization = `-- name: GetCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -346,6 +350,7 @@ func (q *Queries) GetCustomDomainByOrganization(ctx context.Context, organizatio
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -574,7 +579,7 @@ func (q *Queries) GetOrganizationSlugForHealthNotification(ctx context.Context, 
 }
 
 const getPendingDeletedCustomDomainByOrganization = `-- name: GetPendingDeletedCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS TRUE
@@ -591,6 +596,7 @@ func (q *Queries) GetPendingDeletedCustomDomainByOrganization(ctx context.Contex
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -813,7 +819,7 @@ func (q *Queries) LockCustomDomainByID(ctx context.Context, id uuid.UUID) (uuid.
 }
 
 const lockCustomDomainByIDAndOrganization = `-- name: LockCustomDomainByIDAndOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -836,6 +842,7 @@ func (q *Queries) LockCustomDomainByIDAndOrganization(ctx context.Context, arg L
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -858,7 +865,7 @@ func (q *Queries) LockCustomDomainByIDAndOrganization(ctx context.Context, arg L
 }
 
 const lockCustomDomainByOrganization = `-- name: LockCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -873,6 +880,7 @@ func (q *Queries) LockCustomDomainByOrganization(ctx context.Context, organizati
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -941,7 +949,7 @@ SET
     updated_at = clock_timestamp()
 WHERE id = $1
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 // Ownership verification is the sole writer of verified=true (the _gram TXT
@@ -953,6 +961,7 @@ func (q *Queries) SetCustomDomainVerified(ctx context.Context, id uuid.UUID) (Cu
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -1005,7 +1014,7 @@ SET
     updated_at = clock_timestamp()
 WHERE id = $6
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainParams struct {
@@ -1031,6 +1040,7 @@ func (q *Queries) UpdateCustomDomain(ctx context.Context, arg UpdateCustomDomain
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -1065,7 +1075,7 @@ SET
 WHERE id = $7
   AND organization_id = $8
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainHealthParams struct {
@@ -1095,6 +1105,7 @@ func (q *Queries) UpdateCustomDomainHealth(ctx context.Context, arg UpdateCustom
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -1123,7 +1134,7 @@ SET
     updated_at = clock_timestamp()
 WHERE organization_id = $2
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainIPAllowlistParams struct {
@@ -1138,6 +1149,7 @@ func (q *Queries) UpdateCustomDomainIPAllowlist(ctx context.Context, arg UpdateC
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -1167,7 +1179,7 @@ SET
     provisioner_kind = $3,
     updated_at = clock_timestamp()
 WHERE id = $4
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainResourceNamesParams struct {
@@ -1191,6 +1203,7 @@ func (q *Queries) UpdateCustomDomainResourceNames(ctx context.Context, arg Updat
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,
@@ -1226,7 +1239,7 @@ SET
     updated_at = clock_timestamp()
 WHERE organization_id = $5
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainSettingsParams struct {
@@ -1250,6 +1263,7 @@ func (q *Queries) UpdateCustomDomainSettings(ctx context.Context, arg UpdateCust
 		&i.ID,
 		&i.OrganizationID,
 		&i.Domain,
+		&i.Scope,
 		&i.Verified,
 		&i.Activated,
 		&i.IngressName,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -510,6 +510,7 @@ type CustomDomain struct {
 	ID                       uuid.UUID
 	OrganizationID           string
 	Domain                   string
+	Scope                    string
 	Verified                 bool
 	Activated                bool
 	IngressName              pgtype.Text
@@ -1485,6 +1486,7 @@ type OrganizationMetadatum struct {
 	FreeTrialEndsAt    pgtype.Timestamptz
 	ScimEnabled        pgtype.Bool
 	SsoEnabled         pgtype.Bool
+	DefaultHost        pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DisabledAt         pgtype.Timestamptz

--- a/server/internal/organizations/repo/models.go
+++ b/server/internal/organizations/repo/models.go
@@ -39,6 +39,7 @@ type OrganizationMetadatum struct {
 	FreeTrialEndsAt    pgtype.Timestamptz
 	ScimEnabled        pgtype.Bool
 	SsoEnabled         pgtype.Bool
+	DefaultHost        pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DisabledAt         pgtype.Timestamptz

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -197,7 +197,7 @@ INSERT INTO organization_metadata (
     $5,
     $6
 )
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type CreateOrganizationMetadataFromWorkOSParams struct {
@@ -237,6 +237,7 @@ func (q *Queries) CreateOrganizationMetadataFromWorkOS(ctx context.Context, arg 
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -408,7 +409,7 @@ func (q *Queries) GetInvitationByTokenHash(ctx context.Context, tokenHash string
 }
 
 const getOrganizationByWorkosID = `-- name: GetOrganizationByWorkosID :one
-SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 FROM organization_metadata
 WHERE workos_id = $1
 `
@@ -431,6 +432,7 @@ func (q *Queries) GetOrganizationByWorkosID(ctx context.Context, workosID pgtype
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -439,7 +441,7 @@ func (q *Queries) GetOrganizationByWorkosID(ctx context.Context, workosID pgtype
 }
 
 const getOrganizationMetadata = `-- name: GetOrganizationMetadata :one
-SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 FROM organization_metadata
 WHERE id = $1
 `
@@ -462,6 +464,7 @@ func (q *Queries) GetOrganizationMetadata(ctx context.Context, id string) (Organ
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -470,7 +473,7 @@ func (q *Queries) GetOrganizationMetadata(ctx context.Context, id string) (Organ
 }
 
 const getOrganizationMetadataBySlug = `-- name: GetOrganizationMetadataBySlug :one
-SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 FROM organization_metadata
 WHERE slug = $1
 `
@@ -493,6 +496,7 @@ func (q *Queries) GetOrganizationMetadataBySlug(ctx context.Context, slug string
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -1233,7 +1237,7 @@ SET gram_account_type = $1,
 WHERE id = $2
   AND gram_account_type = $3
   AND gram_account_type NOT IN ('payg', 'enterprise')
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type SetAccountTypeIfUnchangedParams struct {
@@ -1260,6 +1264,7 @@ func (q *Queries) SetAccountTypeIfUnchanged(ctx context.Context, arg SetAccountT
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -1273,7 +1278,7 @@ SET workos_id = $1,
     updated_at = clock_timestamp()
 WHERE id = $2 AND
     workos_id IS NULL
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type SetOrgWorkosIDParams struct {
@@ -1299,6 +1304,7 @@ func (q *Queries) SetOrgWorkosID(ctx context.Context, arg SetOrgWorkosIDParams) 
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -1600,7 +1606,7 @@ SET name = $1,
     workos_last_event_id = $4,
     updated_at = clock_timestamp()
 WHERE id = $5
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type UpdateOrganizationMetadataFromWorkOSParams struct {
@@ -1639,6 +1645,7 @@ func (q *Queries) UpdateOrganizationMetadataFromWorkOS(ctx context.Context, arg 
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -1670,7 +1677,7 @@ ON CONFLICT (id) DO UPDATE SET
         ELSE organization_metadata.whitelisted
     END,
     updated_at = clock_timestamp()
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type UpsertOrganizationMetadataParams struct {
@@ -1705,6 +1712,7 @@ func (q *Queries) UpsertOrganizationMetadata(ctx context.Context, arg UpsertOrga
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,
@@ -1734,7 +1742,7 @@ ON CONFLICT (id) DO UPDATE SET
     workos_updated_at = EXCLUDED.workos_updated_at,
     workos_last_event_id = EXCLUDED.workos_last_event_id,
     updated_at = clock_timestamp()
-RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+RETURNING id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, default_host, created_at, updated_at, disabled_at
 `
 
 type UpsertOrganizationMetadataFromWorkOSParams struct {
@@ -1775,6 +1783,7 @@ func (q *Queries) UpsertOrganizationMetadataFromWorkOS(ctx context.Context, arg 
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,

--- a/server/internal/projects/repo/queries.sql.go
+++ b/server/internal/projects/repo/queries.sql.go
@@ -188,7 +188,7 @@ SELECT
     p.slug as project_slug,
     
     -- Organization metadata fields
-    om.id, om.name, om.slug, om.gram_account_type, om.workos_id, om.workos_updated_at, om.workos_last_event_id, om.svix_app_id, om.webhooks_enabled, om.whitelisted, om.free_trial_started_at, om.free_trial_ends_at, om.scim_enabled, om.sso_enabled, om.created_at, om.updated_at, om.disabled_at
+    om.id, om.name, om.slug, om.gram_account_type, om.workos_id, om.workos_updated_at, om.workos_last_event_id, om.svix_app_id, om.webhooks_enabled, om.whitelisted, om.free_trial_started_at, om.free_trial_ends_at, om.scim_enabled, om.sso_enabled, om.default_host, om.created_at, om.updated_at, om.disabled_at
     
 FROM projects p
 INNER JOIN organization_metadata om ON p.organization_id = om.id
@@ -214,6 +214,7 @@ type GetProjectWithOrganizationMetadataRow struct {
 	FreeTrialEndsAt    pgtype.Timestamptz
 	ScimEnabled        pgtype.Bool
 	SsoEnabled         pgtype.Bool
+	DefaultHost        pgtype.Text
 	CreatedAt          pgtype.Timestamptz
 	UpdatedAt          pgtype.Timestamptz
 	DisabledAt         pgtype.Timestamptz
@@ -240,6 +241,7 @@ func (q *Queries) GetProjectWithOrganizationMetadata(ctx context.Context, id uui
 		&i.FreeTrialEndsAt,
 		&i.ScimEnabled,
 		&i.SsoEnabled,
+		&i.DefaultHost,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DisabledAt,

--- a/server/migrations/20260826105733_org-default-host-and-domain-scope.sql
+++ b/server/migrations/20260826105733_org-default-host-and-domain-scope.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Modify "custom_domains" table
+ALTER TABLE "custom_domains" ADD COLUMN "scope" text NOT NULL DEFAULT 'mcp';
+-- Create index "custom_domains_organization_id_scope_key" to table: "custom_domains"
+CREATE UNIQUE INDEX CONCURRENTLY "custom_domains_organization_id_scope_key" ON "custom_domains" ("organization_id", "scope") WHERE (deleted IS FALSE);
+-- Modify "organization_metadata" table
+ALTER TABLE "organization_metadata" ADD COLUMN "default_host" text NULL;

--- a/server/migrations/20260826105809_drop-custom-domains-org-unique-index.sql
+++ b/server/migrations/20260826105809_drop-custom-domains-org-unique-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Drop index "custom_domains_organization_id_key" from table: "custom_domains"
+DROP INDEX CONCURRENTLY "custom_domains_organization_id_key";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4ajo+XGHCwmaLM4VAkA5janya1PWNnuTBqarIm7Xla0=
+h1:xSmCQV3DaGY5zXL/aBtlUL7O0EyVJ5+PgqEdwyVaHoY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -367,3 +367,5 @@ h1:4ajo+XGHCwmaLM4VAkA5janya1PWNnuTBqarIm7Xla0=
 20260825202304_add-mcp-server-remote-session-issuer.sql h1:mGS8dAfAZECcILMlipui+QDySif0d0s+KAgEmp3CZQE=
 20260825204553_expand-user-session-issuers-org-tier.sql h1:kJ01dQVvnahFE3UaA2zZx+58ij7KzCuBHYkozcHCCqQ=
 20260825221933_gcp-iam-credentials-add-skip-project-verification.sql h1:DZOWCldTGLdSq4DlHGhu2wnFhLiqVffCgOKC8LoGzkE=
+20260826105733_org-default-host-and-domain-scope.sql h1:infVre5E2SS9t6mFmM1ye3V4evbxo9zSYn/UJMLVjWw=
+20260826105809_drop-custom-domains-org-unique-index.sql h1:3o3ndOeT+96nHnjSzu66IyBAqJkbDwCf5KhfPSC7mlQ=


### PR DESCRIPTION
GRW-23

## Summary

Schema-only change adding the two columns the host model needs.

- `organization_metadata.default_host` (nullable). NULL means the deployment's canonical host. Nothing reads it yet.
- `custom_domains.scope` (`NOT NULL DEFAULT 'mcp'`). Discriminates what a domain serves: `mcp` for the MCP endpoints a custom domain serves today, `app` for the full control plane. The default backfills every existing row to `mcp`, which is what they all are, so no DML is needed.
- The `custom_domains_organization_id_key` unique index is replaced by `custom_domains_organization_id_scope_key` on `(organization_id, scope)`, both partial on `deleted IS FALSE`. An organization can now hold one MCP domain and one app domain at once; with every existing row at `mcp`, the constraint is otherwise unchanged.

Atlas emits both index operations `CONCURRENTLY` under `-- atlas:txmode none`, so the drop and the create do not share a transaction and there is a brief window with no uniqueness index on the table. That is inherent to a concurrent rebuild, and the new index admits a strict superset of what the old one did.

Allowed values for `scope` live in application code rather than a `CHECK`, per the schema conventions, so adding a scope later needs no migration.

The regenerated sqlc models are included: the new columns appear in `SELECT *` result structs, which is mechanical and required to keep the build green.

## Motivation

First step of the host-agnostic refactor. Gram is moving off a single hardcoded platform host towards a deployment that answers on several first-party hosts and, per organization, on a customer-owned app-scoped domain. Both facts have to be storable before any code can read them, and the migration ships on its own so it can roll out — and be reverted — independently of the behaviour that follows.
