### PR TITLE
feat: host model — hosts package, first-party host set, pinned outbound callback

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -52,6 +52,10 @@ type platformMCPConfig struct {
 	DB                     *pgxpool.Pool
 	Redis                  *redis.Client
 	ServerURL              *url.URL
+	// OutboundCallbackURL is the deployment's pinned outbound OAuth callback
+	// host. Everything advertised to an upstream provider renders on it rather
+	// than on ServerURL, which may move.
+	OutboundCallbackURL    *url.URL
 	DashboardURL           *url.URL
 	Environment            string
 	JWTSigningKey          string
@@ -267,7 +271,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).
-		WithIdentityProviderAttachment(platformmcp.NewCatalogIdentityProviderAttachmentService(config.DB, config.Encryption, config.GuardianPolicy, config.AuditLogger, config.ServerURL)).
+		WithIdentityProviderAttachment(platformmcp.NewCatalogIdentityProviderAttachmentService(config.DB, config.Encryption, config.GuardianPolicy, config.AuditLogger, config.OutboundCallbackURL)).
 		WithClientAdmission(platformmcp.NewClientAdmissionService(config.DB, config.AuditLogger)).
 		WithTelemetry(telemetry)
 	dashboardSetupStarter := platformmcp.NewDashboardSetupService(store, registrationGate, authorizer, adapters, budgets.SetupStart)
@@ -329,8 +333,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 // covered it, and the model would be left to invent the steps.
 func platformMCPSetupResources(config platformMCPConfig) ([]platformmcp.SetupResource, error) {
 	// The one redirect_uri for every provider and slug, derived the same way
-	// externalmcp, remotesessions, and the dashboard derive it.
-	callbackURL := config.ServerURL.JoinPath("mcp", "remote_login_callback").String()
+	// externalmcp, remotesessions, and the dashboard derive it: from the pinned
+	// outbound callback host, because a provider's registration outlives any
+	// change to the canonical host.
+	callbackURL := config.OutboundCallbackURL.JoinPath("mcp", "remote_login_callback").String()
 	resources, err := setupcorpus.Build(setupcorpus.Options{OAuthCallbackURL: callbackURL})
 	if err != nil {
 		return nil, fmt.Errorf("build platform mcp setup corpus: %w", err)
@@ -581,7 +587,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		WithOperationBudgets(budgets).
 		WithReadiness(readiness).
 		WithDashboardURL(config.DashboardURL).
-		WithIdentityProviderAttachment(platformmcp.NewCatalogIdentityProviderAttachmentService(config.DB, config.Encryption, config.GuardianPolicy, config.AuditLogger, config.ServerURL)).
+		WithIdentityProviderAttachment(platformmcp.NewCatalogIdentityProviderAttachmentService(config.DB, config.Encryption, config.GuardianPolicy, config.AuditLogger, config.OutboundCallbackURL)).
 		WithClientAdmission(platformmcp.NewClientAdmissionService(config.DB, config.AuditLogger)).
 		WithTelemetry(telemetry)
 	dashboardSetupStarter := platformmcp.NewDashboardSetupService(store, registrationGate, authorizer, adapters, budgets.SetupStart)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -45,13 +45,13 @@ import (
 )
 
 type platformMCPConfig struct {
-	Logger                 *slog.Logger
-	MeterProvider          metric.MeterProvider
-	TracerProvider         trace.TracerProvider
-	Mux                    goahttp.Muxer
-	DB                     *pgxpool.Pool
-	Redis                  *redis.Client
-	ServerURL              *url.URL
+	Logger         *slog.Logger
+	MeterProvider  metric.MeterProvider
+	TracerProvider trace.TracerProvider
+	Mux            goahttp.Muxer
+	DB             *pgxpool.Pool
+	Redis          *redis.Client
+	ServerURL      *url.URL
 	// OutboundCallbackURL is the deployment's pinned outbound OAuth callback
 	// host. Everything advertised to an upstream provider renders on it rather
 	// than on ServerURL, which may move.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -69,6 +69,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/hosts"
 	"github.com/speakeasy-api/gram/server/internal/instances"
 	"github.com/speakeasy-api/gram/server/internal/integrations"
 	"github.com/speakeasy-api/gram/server/internal/jsonwebkeysets"
@@ -252,6 +253,16 @@ func newStartCommand() *cli.Command {
 			Usage:    "The public URL of the server",
 			EnvVars:  []string{"GRAM_SERVER_URL"},
 			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "platform-hosts",
+			Usage:   "Comma-separated list of first-party hosts this deployment answers on, as full URLs. The server-url host is always included. Requests on any of them skip the custom-domain lookup",
+			EnvVars: []string{"GRAM_PLATFORM_HOSTS"},
+		},
+		&cli.StringFlag{
+			Name:    "outbound-callback-url",
+			Usage:   "The base URL advertised to upstream OAuth providers as Gram's redirect target and CIMD client_id. Pinned independently of server-url because upstream registrations and vendor allowlists hold this value. Defaults to server-url, which is what a single-host deployment wants",
+			EnvVars: []string{"GRAM_OUTBOUND_CALLBACK_URL"},
 		},
 		&cli.StringFlag{
 			Name:     "environment",
@@ -799,6 +810,26 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to parse server url: %w", err)
 			}
 
+			// An unset outbound callback follows server-url, which keeps a
+			// single-host deployment behaving exactly as it does today.
+			outboundCallbackURL := serverURL
+			if raw := c.String("outbound-callback-url"); raw != "" {
+				outboundCallbackURL, err = url.Parse(raw)
+				if err != nil {
+					return fmt.Errorf("failed to parse outbound callback url: %w", err)
+				}
+			}
+
+			platformHostURLs, err := hosts.ParseList(c.String("platform-hosts"))
+			if err != nil {
+				return fmt.Errorf("failed to parse platform hosts: %w", err)
+			}
+
+			platformHosts, err := hosts.New(logger, db, serverURL, platformHostURLs, outboundCallbackURL)
+			if err != nil {
+				return fmt.Errorf("failed to build host model: %w", err)
+			}
+
 			siteURL, err := url.Parse(c.String("site-url"))
 			if err != nil {
 				return fmt.Errorf("failed to parse site url: %w", err)
@@ -1013,7 +1044,7 @@ func newStartCommand() *cli.Command {
 				guardianPolicy,
 				cache.NewRedisCacheAdapter(redisClient),
 				serverURL,
-			)
+			).WithOutboundCallbackURL(platformHosts.OutboundCallback())
 
 			toolDispositionCache := mcpservers.NewToolDispositionCache(logger, db, cache.NewRedisCacheAdapter(redisClient))
 			var platformSelectedUseRecorder toolcallobserver.SuccessRecorder = platformmcp.NewSelectedUseRecorder(db)
@@ -1238,7 +1269,7 @@ func newStartCommand() *cli.Command {
 			mux.Use(middleware.NewHTTPLoggingMiddleware(logger))
 			mux.Use(middleware.NewRecovery(logger))
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url"), chatSessionsManager))
-			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL))
+			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), platformHosts))
 			mux.Use(middleware.SessionMiddleware)
 			mux.Use(middleware.RBACOverrideMiddleware())
 			// LiteLLM dispatch must run before OTLP forwarding: LiteLLM ingest
@@ -1478,7 +1509,7 @@ func newStartCommand() *cli.Command {
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			metamcp.Attach(mux, metamcp.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv))
 			remoteSessionsCache := cache.NewRedisCacheAdapter(redisClient)
-			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache))
+			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache)).WithOutboundCallbackURL(platformHosts.OutboundCallback())
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient)))
 			tokenexchange.Attach(mux, tokenexchange.NewService(logger, tracerProvider, db, sessionManager, authzEngine, c.String("environment")))
 			remotesessions.Attach(mux, remoteSessionsService)
@@ -1529,6 +1560,7 @@ func newStartCommand() *cli.Command {
 				DB:                     db,
 				Redis:                  redisClient,
 				ServerURL:              serverURL,
+				OutboundCallbackURL:    platformHosts.OutboundCallback(),
 				DashboardURL:           siteURL,
 				Environment:            c.String("environment"),
 				JWTSigningKey:          c.String(usersessions.JWTSigningKeyFlag),

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -810,22 +810,7 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to parse server url: %w", err)
 			}
 
-			// An unset outbound callback follows server-url, which keeps a
-			// single-host deployment behaving exactly as it does today.
-			outboundCallbackURL := serverURL
-			if raw := c.String("outbound-callback-url"); raw != "" {
-				outboundCallbackURL, err = url.Parse(raw)
-				if err != nil {
-					return fmt.Errorf("failed to parse outbound callback url: %w", err)
-				}
-			}
-
-			platformHostURLs, err := hosts.ParseList(c.String("platform-hosts"))
-			if err != nil {
-				return fmt.Errorf("failed to parse platform hosts: %w", err)
-			}
-
-			platformHosts, err := hosts.New(logger, db, serverURL, platformHostURLs, outboundCallbackURL)
+			platformHosts, err := hosts.NewFromConfig(logger, db, serverURL, c.String("platform-hosts"), c.String("outbound-callback-url"))
 			if err != nil {
 				return fmt.Errorf("failed to build host model: %w", err)
 			}

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -729,22 +729,7 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to parse server url: %w", err)
 			}
 
-			// An unset outbound callback follows server-url, which keeps a
-			// single-host deployment behaving exactly as it does today.
-			outboundCallbackURL := serverURL
-			if raw := c.String("outbound-callback-url"); raw != "" {
-				outboundCallbackURL, err = url.Parse(raw)
-				if err != nil {
-					return fmt.Errorf("failed to parse outbound callback url: %w", err)
-				}
-			}
-
-			platformHostURLs, err := hosts.ParseList(c.String("platform-hosts"))
-			if err != nil {
-				return fmt.Errorf("failed to parse platform hosts: %w", err)
-			}
-
-			platformHosts, err := hosts.New(logger, db, serverURL, platformHostURLs, outboundCallbackURL)
+			platformHosts, err := hosts.NewFromConfig(logger, db, serverURL, c.String("platform-hosts"), c.String("outbound-callback-url"))
 			if err != nil {
 				return fmt.Errorf("failed to build host model: %w", err)
 			}

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/hosts"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcpclient"
@@ -89,6 +90,16 @@ func newWorkerCommand() *cli.Command {
 			Usage:    "The public URL of the server",
 			EnvVars:  []string{"GRAM_SERVER_URL"},
 			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "platform-hosts",
+			Usage:   "Comma-separated list of first-party hosts this deployment answers on, as full URLs. The server-url host is always included. Requests on any of them skip the custom-domain lookup",
+			EnvVars: []string{"GRAM_PLATFORM_HOSTS"},
+		},
+		&cli.StringFlag{
+			Name:    "outbound-callback-url",
+			Usage:   "The base URL advertised to upstream OAuth providers as Gram's redirect target and CIMD client_id. Pinned independently of server-url because upstream registrations and vendor allowlists hold this value. Defaults to server-url, which is what a single-host deployment wants",
+			EnvVars: []string{"GRAM_OUTBOUND_CALLBACK_URL"},
 		},
 		&cli.StringFlag{
 			Name:     "environment",
@@ -718,6 +729,26 @@ func newWorkerCommand() *cli.Command {
 				return fmt.Errorf("failed to parse server url: %w", err)
 			}
 
+			// An unset outbound callback follows server-url, which keeps a
+			// single-host deployment behaving exactly as it does today.
+			outboundCallbackURL := serverURL
+			if raw := c.String("outbound-callback-url"); raw != "" {
+				outboundCallbackURL, err = url.Parse(raw)
+				if err != nil {
+					return fmt.Errorf("failed to parse outbound callback url: %w", err)
+				}
+			}
+
+			platformHostURLs, err := hosts.ParseList(c.String("platform-hosts"))
+			if err != nil {
+				return fmt.Errorf("failed to parse platform hosts: %w", err)
+			}
+
+			platformHosts, err := hosts.New(logger, db, serverURL, platformHostURLs, outboundCallbackURL)
+			if err != nil {
+				return fmt.Errorf("failed to build host model: %w", err)
+			}
+
 			pylonClient, err := pylon.NewPylon(logger, c.String("pylon-verification-secret"))
 			if err != nil {
 				return fmt.Errorf("failed to create pylon client: %w", err)
@@ -785,7 +816,7 @@ func newWorkerCommand() *cli.Command {
 				guardianPolicy,
 				cache.NewRedisCacheAdapter(redisClient),
 				serverURL,
-			)
+			).WithOutboundCallbackURL(platformHosts.OutboundCallback())
 
 			mcpService := mcp.NewService(
 				logger,

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -5,16 +5,16 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"net/url"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	"github.com/speakeasy-api/gram/server/internal/hosts"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
+func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, platformHosts *hosts.Hosts) func(next http.Handler) http.Handler {
 	domainsRepo := domainsRepo.New(db)
 	logger = logger.With(attr.SlogComponent("custom_domains_middleware"))
 
@@ -38,7 +38,10 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 				return
 			}
 
-			if host == serverURL.Host {
+			// Every platform host is first-party and skips the lookup, not
+			// just the canonical one: a deployment answering on more than one
+			// of its own hosts must not 403 the others.
+			if platformHosts.IsPlatform(host) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/server/internal/customdomains/middleware_test.go
+++ b/server/internal/customdomains/middleware_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	"github.com/speakeasy-api/gram/server/internal/hosts"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -62,13 +63,27 @@ func newTestInstance(t *testing.T) (context.Context, *testInstance) {
 	}
 }
 
+// newPlatformHosts builds a host model whose canonical host is the first URL
+// given and whose remaining URLs are additional first-party platform hosts.
+func newPlatformHosts(t *testing.T, conn *pgxpool.Pool, urls ...string) *hosts.Hosts {
+	t.Helper()
+
+	parsed := make([]*url.URL, 0, len(urls))
+	for _, raw := range urls {
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+		parsed = append(parsed, u)
+	}
+
+	h, err := hosts.New(testenv.NewLogger(t), conn, parsed[0], parsed[1:], parsed[0])
+	require.NoError(t, err)
+	return h
+}
+
 func TestCustomDomainsMiddleware(t *testing.T) {
 	t.Parallel()
 	ctx, instance := newTestInstance(t)
 	logger := testenv.NewLogger(t)
-
-	serverURL, err := url.Parse("https://api.speakeasyapi.dev")
-	require.NoError(t, err)
 
 	tests := []struct {
 		name           string
@@ -218,7 +233,7 @@ func TestCustomDomainsMiddleware(t *testing.T) {
 			}
 
 			// Create the middleware
-			middlewareFunc := customdomains.Middleware(logger, instance.conn, tt.env, serverURL)
+			middlewareFunc := customdomains.Middleware(logger, instance.conn, tt.env, newPlatformHosts(t, instance.conn, "https://api.speakeasyapi.dev"))
 
 			// Create a test handler that captures context and responds
 			var capturedCtx context.Context
@@ -262,15 +277,38 @@ func TestCustomDomainsMiddleware(t *testing.T) {
 	}
 }
 
+// A deployment answering on more than one first-party host must treat every one
+// of them as platform, not just the canonical one.
+func TestCustomDomainsMiddleware_SecondPlatformHostIsFirstParty(t *testing.T) {
+	t.Parallel()
+	_, instance := newTestInstance(t)
+	logger := testenv.NewLogger(t)
+
+	platformHosts := newPlatformHosts(t, instance.conn, "https://api.speakeasyapi.dev", "https://ai.speakeasy.com")
+	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", platformHosts)
+
+	var capturedCtx context.Context
+	handler := middlewareFunc(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "https://ai.speakeasy.com/test", nil)
+	req.Host = "ai.speakeasy.com"
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, "a second platform host must not 403")
+	require.Nil(t, customdomains.FromContext(capturedCtx), "a platform host carries no custom-domain context")
+}
+
 func TestCustomDomainsMiddleware_DeletedDomain(t *testing.T) {
 	t.Parallel()
 	ctx, instance := newTestInstance(t)
 	logger := testenv.NewLogger(t)
 
-	serverURL, err := url.Parse("https://api.speakeasyapi.dev")
-	require.NoError(t, err)
-
-	_, err = instance.domainsRepo.CreateCustomDomain(ctx, repo.CreateCustomDomainParams{
+	_, err := instance.domainsRepo.CreateCustomDomain(ctx, repo.CreateCustomDomainParams{
 		OrganizationID: "org-deleted",
 		Domain:         "deleted.example.com",
 		IngressName:    pgtype.Text{String: "", Valid: false},
@@ -283,7 +321,7 @@ func TestCustomDomainsMiddleware_DeletedDomain(t *testing.T) {
 	err = instance.domainsRepo.DeleteCustomDomain(ctx, "org-deleted")
 	require.NoError(t, err)
 
-	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", newPlatformHosts(t, instance.conn, "https://api.speakeasyapi.dev"))
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called for deleted domain")
@@ -307,15 +345,12 @@ func TestCustomDomainsMiddleware_DatabaseErrors(t *testing.T) {
 	ctx, _ := newTestInstance(t)
 	logger := testenv.NewLogger(t)
 
-	serverURL, err := url.Parse("https://api.speakeasyapi.dev")
-	require.NoError(t, err)
-
 	// Create middleware with a closed connection to simulate database error
 	closedConn, err := infra.CloneTestDatabase(t, "closed_testdb")
 	require.NoError(t, err)
 	closedConn.Close()
 
-	middlewareFunc := customdomains.Middleware(logger, closedConn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, closedConn, "prod", newPlatformHosts(t, closedConn, "https://api.speakeasyapi.dev"))
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called when database error occurs")
@@ -341,10 +376,7 @@ func TestCustomDomainsMiddleware_MissingHost(t *testing.T) {
 	ctx, instance := newTestInstance(t)
 	logger := testenv.NewLogger(t)
 
-	serverURL, err := url.Parse("https://api.speakeasyapi.dev")
-	require.NoError(t, err)
-
-	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", serverURL)
+	middlewareFunc := customdomains.Middleware(logger, instance.conn, "prod", newPlatformHosts(t, instance.conn, "https://api.speakeasyapi.dev"))
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Handler should not be called with empty host")

--- a/server/internal/customdomains/queries.sql
+++ b/server/internal/customdomains/queries.sql
@@ -41,6 +41,19 @@ WHERE organization_id = @organization_id
 LIMIT 1
 FOR UPDATE;
 
+-- name: GetActiveAppScopedCustomDomainForOrganization :one
+-- The one domain an organization may serve the full control plane on. Read on
+-- every host resolution, so a domain that is deleted or deactivated makes the
+-- organization fall back to the canonical host without a data migration.
+SELECT *
+FROM custom_domains
+WHERE organization_id = @organization_id
+  AND scope = 'app'
+  AND verified IS TRUE
+  AND activated IS TRUE
+  AND deleted IS FALSE
+LIMIT 1;
+
 -- name: GetCustomDomainByDomain :one
 SELECT *
 FROM custom_domains

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -217,6 +217,49 @@ func (q *Queries) EnsureCustomDomainResourceNames(ctx context.Context, arg Ensur
 	return result.RowsAffected(), nil
 }
 
+const getActiveAppScopedCustomDomainForOrganization = `-- name: GetActiveAppScopedCustomDomainForOrganization :one
+SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+FROM custom_domains
+WHERE organization_id = $1
+  AND scope = 'app'
+  AND verified IS TRUE
+  AND activated IS TRUE
+  AND deleted IS FALSE
+LIMIT 1
+`
+
+// The one domain an organization may serve the full control plane on. Read on
+// every host resolution, so a domain that is deleted or deactivated makes the
+// organization fall back to the canonical host without a data migration.
+func (q *Queries) GetActiveAppScopedCustomDomainForOrganization(ctx context.Context, organizationID string) (CustomDomain, error) {
+	row := q.db.QueryRow(ctx, getActiveAppScopedCustomDomainForOrganization, organizationID)
+	var i CustomDomain
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.Domain,
+		&i.Scope,
+		&i.Verified,
+		&i.Activated,
+		&i.IngressName,
+		&i.CertSecretName,
+		&i.ProvisionerKind,
+		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
 SELECT id, organization_id, domain, scope, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains

--- a/server/internal/hosts/hosts.go
+++ b/server/internal/hosts/hosts.go
@@ -39,11 +39,18 @@ import (
 // Hosts answers host questions for one deployment. Construct it once at
 // startup with New and share it; it holds no per-request state.
 type Hosts struct {
-	logger           *slog.Logger
-	db               *pgxpool.Pool
+	logger *slog.Logger
+	db     *pgxpool.Pool
+
+	// canonical and outboundCallback keep whatever base path they were
+	// configured with. Callers join onto them, so dropping a configured prefix
+	// would silently move every URL rendered from them.
 	canonical        *url.URL
-	platform         []*url.URL
 	outboundCallback *url.URL
+
+	// platform holds scheme+host only: it exists to answer host membership,
+	// where a path would never match a Host header.
+	platform []*url.URL
 }
 
 // New builds the host model for a deployment.
@@ -85,9 +92,9 @@ func New(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platform []*
 	return &Hosts{
 		logger:           logger.With(attr.SlogComponent("hosts")),
 		db:               db,
-		canonical:        origin(canonical),
+		canonical:        clone(canonical),
+		outboundCallback: clone(outboundCallback),
 		platform:         all,
-		outboundCallback: origin(outboundCallback),
 	}, nil
 }
 
@@ -114,13 +121,14 @@ func NewFromConfig(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, pl
 
 // validate rejects a URL that cannot be rendered as an absolute public one. A
 // scheme-relative URL such as //app.getgram.ai parses without error and has a
-// host, so the host check alone would let it through.
+// host, so the host check alone would let it through, and a non-HTTP scheme
+// would render a URL no browser or Authorization Server can follow.
 func validate(what string, u *url.URL) error {
 	switch {
 	case u == nil || u.Host == "":
 		return fmt.Errorf("hosts: %s is required", what)
-	case u.Scheme == "":
-		return fmt.Errorf("hosts: %s %q has no scheme", what, u.String())
+	case u.Scheme != "http" && u.Scheme != "https":
+		return fmt.Errorf("hosts: %s %q must be an http or https url", what, u.String())
 	default:
 		return nil
 	}
@@ -149,7 +157,8 @@ func ParseList(raw string) ([]*url.URL, error) {
 }
 
 // Canonical is the deployment's primary host: the fallback for every URL that
-// has no better host to render with.
+// has no better host to render with. Returned with its configured base path
+// intact, so callers can join onto it.
 func (h *Hosts) Canonical() *url.URL { return clone(h.canonical) }
 
 // PlatformHosts is every first-party host the deployment answers on, canonical
@@ -239,11 +248,13 @@ func (h *Hosts) Resolve(ctx context.Context, req *http.Request, organizationID s
 	return h.Canonical()
 }
 
-// at renders a host as a URL on the canonical scheme. Platform hosts and custom
-// domains share the deployment's scheme (https everywhere but local dev), so
-// there is nothing per-host to carry.
+// at renders a host as a URL on the canonical scheme and base path. Platform
+// hosts and custom domains share the deployment's scheme (https everywhere but
+// local dev) and its path prefix, so there is nothing per-host to carry.
 func (h *Hosts) at(host string) *url.URL {
-	return &url.URL{Scheme: h.canonical.Scheme, Host: strings.ToLower(host)}
+	rendered := *h.canonical
+	rendered.Host = strings.ToLower(host)
+	return &rendered
 }
 
 // defaultHost is the organization's configured default host, empty when unset

--- a/server/internal/hosts/hosts.go
+++ b/server/internal/hosts/hosts.go
@@ -92,8 +92,8 @@ func New(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platform []*
 	return &Hosts{
 		logger:           logger.With(attr.SlogComponent("hosts")),
 		db:               db,
-		canonical:        clone(canonical),
-		outboundCallback: clone(outboundCallback),
+		canonical:        base(canonical),
+		outboundCallback: base(outboundCallback),
 		platform:         all,
 	}, nil
 }
@@ -129,6 +129,10 @@ func validate(what string, u *url.URL) error {
 		return fmt.Errorf("hosts: %s is required", what)
 	case u.Scheme != "http" && u.Scheme != "https":
 		return fmt.Errorf("hosts: %s %q must be an http or https url", what, u.String())
+	case u.User != nil:
+		// Credentials in a configured URL would be copied into every URL
+		// rendered from it, including ones sent to upstream providers.
+		return fmt.Errorf("hosts: %s must not carry userinfo", what)
 	default:
 		return nil
 	}
@@ -292,10 +296,17 @@ func (h *Hosts) appScopedDomain(ctx context.Context, organizationID string) stri
 	return domain.Domain
 }
 
-// origin strips everything but scheme and host, so a configured URL with a
-// trailing path or query cannot leak into a rendered one.
+// origin strips everything but scheme and host, for the platform-host set,
+// where membership is answered against a Host header.
 func origin(u *url.URL) *url.URL {
 	return &url.URL{Scheme: u.Scheme, Host: strings.ToLower(u.Host)}
+}
+
+// base keeps scheme, host, and path. A query or fragment on a configured URL
+// would end up before the path every caller joins onto, so the callback path
+// would land after it and the redirect would break.
+func base(u *url.URL) *url.URL {
+	return &url.URL{Scheme: u.Scheme, Host: strings.ToLower(u.Host), Path: u.Path}
 }
 
 func clone(u *url.URL) *url.URL {

--- a/server/internal/hosts/hosts.go
+++ b/server/internal/hosts/hosts.go
@@ -1,0 +1,244 @@
+// Package hosts is the single source of truth for the hosts a Gram deployment
+// answers on and the host every rendered URL should carry.
+//
+// A deployment serves three kinds of host:
+//
+//   - Platform hosts. First-party hosts Gram itself owns (app.getgram.ai,
+//     ai.speakeasy.com). Every one of them is equally first-party: no
+//     custom-domain lookup, no per-org scoping. One of them is the canonical
+//     host, the fallback whenever nothing better is known.
+//   - Custom domains. Customer-owned hosts, verified and activated per
+//     organization. An 'app'-scoped one may serve the full control plane; an
+//     'mcp'-scoped one serves MCP endpoints only.
+//   - The outbound callback host. Pinned separately from all of the above,
+//     because it appears in upstream OAuth registrations we do not control.
+//
+// Resolve is how a caller turns "which org is this for, and where did the
+// request come from" into the host to render URLs with. Everything else here
+// is deployment configuration.
+package hosts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+// Hosts answers host questions for one deployment. Construct it once at
+// startup with New and share it; it holds no per-request state.
+type Hosts struct {
+	logger           *slog.Logger
+	db               *pgxpool.Pool
+	canonical        *url.URL
+	platform         []*url.URL
+	outboundCallback *url.URL
+}
+
+// New builds the host model for a deployment.
+//
+// canonical is the deployment's primary host (GRAM_SERVER_URL). platform is
+// every first-party host the deployment answers on; the canonical host is
+// always one of them, whether or not it appears in the list. outboundCallback
+// is the host upstream OAuth providers redirect back to.
+func New(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platform []*url.URL, outboundCallback *url.URL) (*Hosts, error) {
+	switch {
+	case db == nil:
+		return nil, errors.New("hosts: database pool is required")
+	case canonical == nil || canonical.Host == "":
+		return nil, errors.New("hosts: canonical url is required")
+	case outboundCallback == nil || outboundCallback.Host == "":
+		return nil, errors.New("hosts: outbound callback url is required")
+	}
+
+	all := []*url.URL{origin(canonical)}
+	for _, u := range platform {
+		if u == nil || u.Host == "" {
+			return nil, errors.New("hosts: platform host list contains an empty url")
+		}
+		if o := origin(u); !slices.ContainsFunc(all, func(known *url.URL) bool { return known.Host == o.Host }) {
+			all = append(all, o)
+		}
+	}
+
+	return &Hosts{
+		logger:           logger.With(attr.SlogComponent("hosts")),
+		db:               db,
+		canonical:        origin(canonical),
+		platform:         all,
+		outboundCallback: origin(outboundCallback),
+	}, nil
+}
+
+// ParseList parses a comma-separated list of platform host URLs, as the
+// platform-hosts flag carries them. An empty string yields no hosts, which New
+// reads as "the canonical host alone".
+func ParseList(raw string) ([]*url.URL, error) {
+	var out []*url.URL
+	for part := range strings.SplitSeq(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		u, err := url.Parse(part)
+		if err != nil {
+			return nil, fmt.Errorf("parse platform host %q: %w", part, err)
+		}
+		if u.Host == "" {
+			return nil, fmt.Errorf("platform host %q has no host component", part)
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}
+
+// Canonical is the deployment's primary host: the fallback for every URL that
+// has no better host to render with.
+func (h *Hosts) Canonical() *url.URL { return clone(h.canonical) }
+
+// PlatformHosts is every first-party host the deployment answers on, canonical
+// first. Requests arriving on any of them skip the custom-domain lookup.
+func (h *Hosts) PlatformHosts() []*url.URL {
+	out := make([]*url.URL, 0, len(h.platform))
+	for _, u := range h.platform {
+		out = append(out, clone(u))
+	}
+	return out
+}
+
+// Auth is the host that serves login, session, and IdP callback routes. Pinned
+// to the canonical host: the auth surface is single-homed so session cookies
+// and the IdP's registered redirect URIs stay on one origin. Those redirect
+// URIs are ours to change, so this follows the canonical host rather than
+// being configured separately — unlike OutboundCallback.
+func (h *Hosts) Auth() *url.URL { return clone(h.canonical) }
+
+// OutboundCallback is the host Gram sends upstream OAuth providers as its own
+// redirect target and publishes as its CIMD client_id.
+//
+// It is configured independently of the canonical host and does not follow it.
+// The value is registered on customer-owned OAuth apps and vendor allowlists
+// (Figma, Canva, ...) that we cannot migrate, so moving the canonical host must
+// not move this one. Handlers still serve on every platform host; only the
+// advertised URL is pinned.
+func (h *Hosts) OutboundCallback() *url.URL { return clone(h.outboundCallback) }
+
+// IsPlatform reports whether a request host (the Host header, so possibly with
+// a port) is one of the deployment's first-party hosts.
+func (h *Hosts) IsPlatform(host string) bool {
+	if host == "" {
+		return false
+	}
+	return slices.ContainsFunc(h.platform, func(u *url.URL) bool { return u.Host == host })
+}
+
+// Resolve is the host to render customer-facing URLs with for an organization,
+// in preference order:
+//
+//  1. The host the request arrived on, when the organization may be served
+//     there — any platform host, or the org's own active app-scoped domain.
+//  2. The organization's configured default host, subject to the same rule.
+//  3. The canonical host.
+//
+// The validity rule is re-checked on every call rather than trusted from the
+// stored column, so an organization whose app-scoped domain was deleted or
+// deactivated falls back to the canonical host on the next request.
+//
+// req may be nil for callers with no request in hand (background work), which
+// simply skips step 1.
+func (h *Hosts) Resolve(ctx context.Context, req *http.Request, organizationID string) *url.URL {
+	appDomainLoaded := false
+	var appDomain string
+	servable := func(host string) bool {
+		if host == "" {
+			return false
+		}
+		if h.IsPlatform(host) {
+			return true
+		}
+		if organizationID == "" {
+			return false
+		}
+		if !appDomainLoaded {
+			appDomain = h.appScopedDomain(ctx, organizationID)
+			appDomainLoaded = true
+		}
+		return appDomain != "" && appDomain == host
+	}
+
+	if req != nil && servable(req.Host) {
+		return h.at(req.Host)
+	}
+
+	if organizationID != "" {
+		if def := h.defaultHost(ctx, organizationID); servable(def) {
+			return h.at(def)
+		}
+	}
+
+	return h.Canonical()
+}
+
+// at renders a host as a URL on the canonical scheme. Platform hosts and custom
+// domains share the deployment's scheme (https everywhere but local dev), so
+// there is nothing per-host to carry.
+func (h *Hosts) at(host string) *url.URL {
+	return &url.URL{Scheme: h.canonical.Scheme, Host: host}
+}
+
+// defaultHost is the organization's configured default host, empty when unset
+// or unreadable. A failed read is logged and degrades to the canonical host
+// rather than failing the request: rendering a URL on the wrong first-party
+// host is recoverable, refusing to render one is not.
+func (h *Hosts) defaultHost(ctx context.Context, organizationID string) string {
+	org, err := orgRepo.New(h.db).GetOrganizationMetadata(ctx, organizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return ""
+	case err != nil:
+		h.logger.ErrorContext(ctx, "failed to read organization default host",
+			attr.SlogOrganizationID(organizationID), attr.SlogError(err))
+		return ""
+	}
+	if !org.DefaultHost.Valid {
+		return ""
+	}
+	return org.DefaultHost.String
+}
+
+// appScopedDomain is the organization's active app-scoped custom domain, empty
+// when it has none.
+func (h *Hosts) appScopedDomain(ctx context.Context, organizationID string) string {
+	domain, err := domainsRepo.New(h.db).GetActiveAppScopedCustomDomainForOrganization(ctx, organizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return ""
+	case err != nil:
+		h.logger.ErrorContext(ctx, "failed to read organization app-scoped custom domain",
+			attr.SlogOrganizationID(organizationID), attr.SlogError(err))
+		return ""
+	}
+	return domain.Domain
+}
+
+// origin strips everything but scheme and host, so a configured URL with a
+// trailing path or query cannot leak into a rendered one.
+func origin(u *url.URL) *url.URL {
+	return &url.URL{Scheme: u.Scheme, Host: u.Host}
+}
+
+func clone(u *url.URL) *url.URL {
+	c := *u
+	return &c
+}

--- a/server/internal/hosts/hosts.go
+++ b/server/internal/hosts/hosts.go
@@ -304,9 +304,10 @@ func origin(u *url.URL) *url.URL {
 
 // base keeps scheme, host, and path. A query or fragment on a configured URL
 // would end up before the path every caller joins onto, so the callback path
-// would land after it and the redirect would break.
+// would land after it and the redirect would break. RawPath rides along so a
+// path holding an escaped character still renders the way it was configured.
 func base(u *url.URL) *url.URL {
-	return &url.URL{Scheme: u.Scheme, Host: strings.ToLower(u.Host), Path: u.Path}
+	return &url.URL{Scheme: u.Scheme, Host: strings.ToLower(u.Host), Path: u.Path, RawPath: u.RawPath}
 }
 
 func clone(u *url.URL) *url.URL {

--- a/server/internal/hosts/hosts.go
+++ b/server/internal/hosts/hosts.go
@@ -49,27 +49,37 @@ type Hosts struct {
 // New builds the host model for a deployment.
 //
 // canonical is the deployment's primary host (GRAM_SERVER_URL). platform is
-// every first-party host the deployment answers on; the canonical host is
-// always one of them, whether or not it appears in the list. outboundCallback
+// every additional first-party host the deployment answers on. outboundCallback
 // is the host upstream OAuth providers redirect back to.
+//
+// The canonical host and the outbound callback host are always platform hosts,
+// whether or not they appear in the list. The callback host has to be: Gram
+// serves the callback route there, and a host that is not first-party is
+// rejected by the custom-domain middleware, which would 403 every upstream
+// redirect back into a remote login.
 func New(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platform []*url.URL, outboundCallback *url.URL) (*Hosts, error) {
-	switch {
-	case db == nil:
+	if db == nil {
 		return nil, errors.New("hosts: database pool is required")
-	case canonical == nil || canonical.Host == "":
-		return nil, errors.New("hosts: canonical url is required")
-	case outboundCallback == nil || outboundCallback.Host == "":
-		return nil, errors.New("hosts: outbound callback url is required")
+	}
+	if err := validate("canonical url", canonical); err != nil {
+		return nil, err
+	}
+	if err := validate("outbound callback url", outboundCallback); err != nil {
+		return nil, err
 	}
 
 	all := []*url.URL{origin(canonical)}
-	for _, u := range platform {
-		if u == nil || u.Host == "" {
-			return nil, errors.New("hosts: platform host list contains an empty url")
-		}
+	add := func(u *url.URL) {
 		if o := origin(u); !slices.ContainsFunc(all, func(known *url.URL) bool { return known.Host == o.Host }) {
 			all = append(all, o)
 		}
+	}
+	add(outboundCallback)
+	for _, u := range platform {
+		if err := validate("platform host", u); err != nil {
+			return nil, err
+		}
+		add(u)
 	}
 
 	return &Hosts{
@@ -79,6 +89,41 @@ func New(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platform []*
 		platform:         all,
 		outboundCallback: origin(outboundCallback),
 	}, nil
+}
+
+// NewFromConfig builds the host model from the raw flag values the server and
+// worker commands carry, so the two stay in step as the model grows. An empty
+// outboundCallbackRaw follows the canonical host, which is what a single-host
+// deployment wants.
+func NewFromConfig(logger *slog.Logger, db *pgxpool.Pool, canonical *url.URL, platformHostsRaw, outboundCallbackRaw string) (*Hosts, error) {
+	platform, err := ParseList(platformHostsRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	outboundCallback := canonical
+	if outboundCallbackRaw != "" {
+		outboundCallback, err = url.Parse(outboundCallbackRaw)
+		if err != nil {
+			return nil, fmt.Errorf("parse outbound callback url %q: %w", outboundCallbackRaw, err)
+		}
+	}
+
+	return New(logger, db, canonical, platform, outboundCallback)
+}
+
+// validate rejects a URL that cannot be rendered as an absolute public one. A
+// scheme-relative URL such as //app.getgram.ai parses without error and has a
+// host, so the host check alone would let it through.
+func validate(what string, u *url.URL) error {
+	switch {
+	case u == nil || u.Host == "":
+		return fmt.Errorf("hosts: %s is required", what)
+	case u.Scheme == "":
+		return fmt.Errorf("hosts: %s %q has no scheme", what, u.String())
+	default:
+		return nil
+	}
 }
 
 // ParseList parses a comma-separated list of platform host URLs, as the
@@ -95,8 +140,8 @@ func ParseList(raw string) ([]*url.URL, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse platform host %q: %w", part, err)
 		}
-		if u.Host == "" {
-			return nil, fmt.Errorf("platform host %q has no host component", part)
+		if err := validate("platform host", u); err != nil {
+			return nil, err
 		}
 		out = append(out, u)
 	}
@@ -135,11 +180,15 @@ func (h *Hosts) Auth() *url.URL { return clone(h.canonical) }
 func (h *Hosts) OutboundCallback() *url.URL { return clone(h.outboundCallback) }
 
 // IsPlatform reports whether a request host (the Host header, so possibly with
-// a port) is one of the deployment's first-party hosts.
+// a port) is one of the deployment's first-party hosts. Hosts are compared
+// case-insensitively: a Host header is not required to be lowercase, and
+// rejecting a mixed-case one would drop a first-party request into the
+// custom-domain lookup and 403 it.
 func (h *Hosts) IsPlatform(host string) bool {
 	if host == "" {
 		return false
 	}
+	host = strings.ToLower(host)
 	return slices.ContainsFunc(h.platform, func(u *url.URL) bool { return u.Host == host })
 }
 
@@ -174,7 +223,7 @@ func (h *Hosts) Resolve(ctx context.Context, req *http.Request, organizationID s
 			appDomain = h.appScopedDomain(ctx, organizationID)
 			appDomainLoaded = true
 		}
-		return appDomain != "" && appDomain == host
+		return appDomain != "" && strings.EqualFold(appDomain, host)
 	}
 
 	if req != nil && servable(req.Host) {
@@ -194,7 +243,7 @@ func (h *Hosts) Resolve(ctx context.Context, req *http.Request, organizationID s
 // domains share the deployment's scheme (https everywhere but local dev), so
 // there is nothing per-host to carry.
 func (h *Hosts) at(host string) *url.URL {
-	return &url.URL{Scheme: h.canonical.Scheme, Host: host}
+	return &url.URL{Scheme: h.canonical.Scheme, Host: strings.ToLower(host)}
 }
 
 // defaultHost is the organization's configured default host, empty when unset
@@ -235,7 +284,7 @@ func (h *Hosts) appScopedDomain(ctx context.Context, organizationID string) stri
 // origin strips everything but scheme and host, so a configured URL with a
 // trailing path or query cannot leak into a rendered one.
 func origin(u *url.URL) *url.URL {
-	return &url.URL{Scheme: u.Scheme, Host: u.Host}
+	return &url.URL{Scheme: u.Scheme, Host: strings.ToLower(u.Host)}
 }
 
 func clone(u *url.URL) *url.URL {

--- a/server/internal/hosts/hosts_test.go
+++ b/server/internal/hosts/hosts_test.go
@@ -180,6 +180,35 @@ func TestNew_RejectsMissingConfiguration(t *testing.T) {
 
 	_, err = hosts.ParseList("//app.getgram.ai")
 	require.Error(t, err)
+
+	// A non-HTTP scheme renders a URL nothing can follow.
+	_, err = hosts.New(logger, conn, mustParse(t, "ftp://app.getgram.ai"), nil, canonical)
+	require.Error(t, err)
+}
+
+// A configured base path belongs to every URL rendered from the deployment, so
+// stripping it would silently move them.
+func TestBasePathIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	conn := newConn(t)
+	canonical := mustParse(t, "https://app.getgram.ai/gram")
+
+	h, err := hosts.New(testenv.NewLogger(t), conn, canonical, nil, mustParse(t, "https://callback.example.com/oauth"))
+	require.NoError(t, err)
+
+	require.Equal(t, "https://app.getgram.ai/gram", h.Canonical().String())
+	require.Equal(t, "https://callback.example.com/oauth", h.OutboundCallback().String())
+
+	// Membership still answers on the host alone, which is all a Host header
+	// carries.
+	require.True(t, h.IsPlatform("app.getgram.ai"))
+	require.True(t, h.IsPlatform("callback.example.com"))
+
+	// A resolved host is rendered on the canonical scheme and base path.
+	req := httptest.NewRequest(http.MethodGet, "https://callback.example.com/test", nil)
+	req.Host = "callback.example.com"
+	require.Equal(t, "https://callback.example.com/gram", h.Resolve(t.Context(), req, "").String())
 }
 
 func TestNewFromConfig(t *testing.T) {

--- a/server/internal/hosts/hosts_test.go
+++ b/server/internal/hosts/hosts_test.go
@@ -1,0 +1,313 @@
+package hosts_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/hosts"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+const (
+	canonicalURL = "https://app.getgram.ai"
+	secondaryURL = "https://ai.speakeasy.com"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("Failed to launch test infrastructure: %v", err)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("Failed to cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func newConn(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	conn, err := infra.CloneTestDatabase(t, "hosts_testdb")
+	require.NoError(t, err)
+	return conn
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+// newHosts builds a host model over conn with canonicalURL as the canonical
+// host and the given extra platform hosts.
+func newHosts(t *testing.T, conn *pgxpool.Pool, platform ...string) *hosts.Hosts {
+	t.Helper()
+
+	extra := make([]*url.URL, 0, len(platform))
+	for _, raw := range platform {
+		extra = append(extra, mustParse(t, raw))
+	}
+
+	h, err := hosts.New(testenv.NewLogger(t), conn, mustParse(t, canonicalURL), extra, mustParse(t, canonicalURL))
+	require.NoError(t, err)
+	return h
+}
+
+// seedOrg inserts an organization with the given default host. An empty
+// defaultHost leaves the column NULL.
+func seedOrg(t *testing.T, conn *pgxpool.Pool, orgID, defaultHost string) {
+	t.Helper()
+
+	require.NoError(t, orgRepo.New(conn).CreateOrganizationMetadata(t.Context(), orgRepo.CreateOrganizationMetadataParams{
+		ID:   orgID,
+		Name: orgID,
+		Slug: orgID,
+	}))
+
+	require.NoError(t, testrepo.New(conn).SetOrganizationDefaultHostFixture(t.Context(), testrepo.SetOrganizationDefaultHostFixtureParams{
+		ID:          orgID,
+		DefaultHost: conv.PtrToPGTextEmpty(conv.PtrEmpty(defaultHost)),
+	}))
+}
+
+// seedDomain inserts a verified custom domain at the given scope.
+func seedDomain(t *testing.T, conn *pgxpool.Pool, orgID, domain, scope string, activated bool) {
+	t.Helper()
+
+	require.NoError(t, testrepo.New(conn).CreateScopedCustomDomainFixture(t.Context(), testrepo.CreateScopedCustomDomainFixtureParams{
+		OrganizationID: orgID,
+		Domain:         domain,
+		Scope:          scope,
+		Verified:       true,
+		Activated:      activated,
+	}))
+}
+
+func TestNew_CanonicalIsAlwaysAPlatformHost(t *testing.T) {
+	t.Parallel()
+
+	h := newHosts(t, newConn(t))
+
+	require.True(t, h.IsPlatform("app.getgram.ai"))
+	require.False(t, h.IsPlatform("ai.speakeasy.com"))
+	require.Equal(t, []*url.URL{mustParse(t, canonicalURL)}, h.PlatformHosts())
+}
+
+func TestNew_DeduplicatesCanonicalFromPlatformList(t *testing.T) {
+	t.Parallel()
+
+	h := newHosts(t, newConn(t), canonicalURL, secondaryURL)
+
+	require.Equal(t, []*url.URL{mustParse(t, canonicalURL), mustParse(t, secondaryURL)}, h.PlatformHosts())
+}
+
+func TestNew_RejectsMissingConfiguration(t *testing.T) {
+	t.Parallel()
+
+	conn := newConn(t)
+	logger := testenv.NewLogger(t)
+	canonical := mustParse(t, canonicalURL)
+
+	_, err := hosts.New(logger, nil, canonical, nil, canonical)
+	require.Error(t, err)
+
+	_, err = hosts.New(logger, conn, nil, nil, canonical)
+	require.Error(t, err)
+
+	_, err = hosts.New(logger, conn, canonical, nil, nil)
+	require.Error(t, err)
+
+	_, err = hosts.New(logger, conn, canonical, []*url.URL{{}}, canonical)
+	require.Error(t, err)
+}
+
+// The outbound callback is what upstream OAuth providers hold; moving the
+// canonical host must not move it.
+func TestOutboundCallback_DoesNotFollowCanonicalHost(t *testing.T) {
+	t.Parallel()
+
+	h, err := hosts.New(testenv.NewLogger(t), newConn(t),
+		mustParse(t, secondaryURL), nil, mustParse(t, canonicalURL))
+	require.NoError(t, err)
+
+	require.Equal(t, secondaryURL, h.Canonical().String())
+	require.Equal(t, secondaryURL, h.Auth().String())
+	require.Equal(t, canonicalURL, h.OutboundCallback().String())
+}
+
+func TestParseList(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := hosts.ParseList("  https://app.getgram.ai ,, https://ai.speakeasy.com  ")
+	require.NoError(t, err)
+	require.Equal(t, []*url.URL{mustParse(t, canonicalURL), mustParse(t, secondaryURL)}, parsed)
+
+	empty, err := hosts.ParseList("")
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	_, err = hosts.ParseList("not-a-url")
+	require.Error(t, err)
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	conn := newConn(t)
+
+	const (
+		orgPlain      = "org-no-preference"
+		orgSecondary  = "org-default-secondary"
+		orgAppDomain  = "org-app-domain"
+		orgStaleHost  = "org-stale-default"
+		orgMCPOnly    = "org-mcp-only"
+		orgDeactivate = "org-deactivated-app-domain"
+		orgBoth       = "org-both-scopes"
+	)
+
+	seedOrg(t, conn, orgPlain, "")
+	seedOrg(t, conn, orgSecondary, "ai.speakeasy.com")
+	seedOrg(t, conn, orgAppDomain, "gram.customer.example")
+	seedDomain(t, conn, orgAppDomain, "gram.customer.example", "app", true)
+	seedOrg(t, conn, orgStaleHost, "gone.customer.example")
+	seedOrg(t, conn, orgMCPOnly, "mcp.customer.example")
+	seedDomain(t, conn, orgMCPOnly, "mcp.customer.example", "mcp", true)
+	seedOrg(t, conn, orgDeactivate, "pending.customer.example")
+	seedDomain(t, conn, orgDeactivate, "pending.customer.example", "app", false)
+
+	// One organization holding both scopes at once, which the per-scope unique
+	// index allows and the previous one-domain-per-org index did not.
+	seedOrg(t, conn, orgBoth, "app.both.example")
+	seedDomain(t, conn, orgBoth, "mcp.both.example", "mcp", true)
+	seedDomain(t, conn, orgBoth, "app.both.example", "app", true)
+
+	h := newHosts(t, conn, secondaryURL)
+
+	tests := []struct {
+		name        string
+		requestHost string
+		orgID       string
+		want        string
+		description string
+	}{
+		{
+			name:        "request host wins when it is a platform host",
+			requestHost: "ai.speakeasy.com",
+			orgID:       orgPlain,
+			want:        secondaryURL,
+			description: "a first-party host the request already arrived on is kept",
+		},
+		{
+			name:        "request host wins when it is the org's app-scoped domain",
+			requestHost: "gram.customer.example",
+			orgID:       orgAppDomain,
+			want:        "https://gram.customer.example",
+			description: "an org served on its own app domain keeps rendering URLs there",
+		},
+		{
+			name:        "another org's app domain does not count as a request host",
+			requestHost: "gram.customer.example",
+			orgID:       orgPlain,
+			want:        canonicalURL,
+			description: "app domains are per-org, so this falls through to the canonical host",
+		},
+		{
+			name:        "org default host is used when the request host is unusable",
+			requestHost: "unknown.example.com",
+			orgID:       orgSecondary,
+			want:        secondaryURL,
+			description: "second fallback: the org's configured default host",
+		},
+		{
+			name:        "org default host is used when there is no request",
+			requestHost: "",
+			orgID:       orgSecondary,
+			want:        secondaryURL,
+			description: "background callers have no request and start at the default host",
+		},
+		{
+			name:        "org default host pointing at a domain the org no longer has falls back",
+			requestHost: "",
+			orgID:       orgStaleHost,
+			want:        canonicalURL,
+			description: "validity is re-checked on read, so a deleted domain degrades to canonical",
+		},
+		{
+			name:        "an mcp-scoped domain is not a valid default host",
+			requestHost: "mcp.customer.example",
+			orgID:       orgMCPOnly,
+			want:        canonicalURL,
+			description: "only app-scoped domains may render control-plane URLs",
+		},
+		{
+			name:        "a not-yet-activated app domain is not a valid default host",
+			requestHost: "",
+			orgID:       orgDeactivate,
+			want:        canonicalURL,
+			description: "the domain must be verified and activated to be served",
+		},
+		{
+			name:        "an org may hold an mcp and an app domain at once",
+			requestHost: "",
+			orgID:       orgBoth,
+			want:        "https://app.both.example",
+			description: "only the app-scoped one is eligible to render control-plane URLs",
+		},
+		{
+			name:        "canonical host when the org has no preference",
+			requestHost: "",
+			orgID:       orgPlain,
+			want:        canonicalURL,
+			description: "third fallback: the canonical host",
+		},
+		{
+			name:        "canonical host when there is no organization at all",
+			requestHost: "unknown.example.com",
+			orgID:       "",
+			want:        canonicalURL,
+			description: "no org means no org-scoped host to prefer",
+		},
+		{
+			name:        "canonical host for an organization that does not exist",
+			requestHost: "",
+			orgID:       "org-missing",
+			want:        canonicalURL,
+			description: "a missing org row is not an error, just no preference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var req *http.Request
+			if tt.requestHost != "" {
+				req = httptest.NewRequest(http.MethodGet, "https://"+tt.requestHost+"/test", nil)
+				req.Host = tt.requestHost
+			}
+
+			require.Equal(t, tt.want, h.Resolve(t.Context(), req, tt.orgID).String(), tt.description)
+		})
+	}
+}

--- a/server/internal/hosts/hosts_test.go
+++ b/server/internal/hosts/hosts_test.go
@@ -122,6 +122,29 @@ func TestNew_DeduplicatesCanonicalFromPlatformList(t *testing.T) {
 	require.Equal(t, []*url.URL{mustParse(t, canonicalURL), mustParse(t, secondaryURL)}, h.PlatformHosts())
 }
 
+// Gram serves the callback route on the outbound callback host, so that host
+// has to be first-party — otherwise the custom-domain middleware 403s every
+// upstream redirect back into a remote login.
+func TestNew_OutboundCallbackHostIsAlwaysAPlatformHost(t *testing.T) {
+	t.Parallel()
+
+	h, err := hosts.New(testenv.NewLogger(t), newConn(t),
+		mustParse(t, secondaryURL), nil, mustParse(t, canonicalURL))
+	require.NoError(t, err)
+
+	require.True(t, h.IsPlatform("app.getgram.ai"))
+	require.Equal(t, []*url.URL{mustParse(t, secondaryURL), mustParse(t, canonicalURL)}, h.PlatformHosts())
+}
+
+// A Host header is not required to be lowercase.
+func TestIsPlatform_IsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	h := newHosts(t, newConn(t))
+
+	require.True(t, h.IsPlatform("App.GetGram.AI"))
+}
+
 func TestNew_RejectsMissingConfiguration(t *testing.T) {
 	t.Parallel()
 
@@ -139,6 +162,49 @@ func TestNew_RejectsMissingConfiguration(t *testing.T) {
 	require.Error(t, err)
 
 	_, err = hosts.New(logger, conn, canonical, []*url.URL{{}}, canonical)
+	require.Error(t, err)
+
+	// A scheme-relative URL parses cleanly and has a host, but cannot be
+	// rendered as an absolute public URL.
+	schemeless := mustParse(t, "//app.getgram.ai")
+	require.Equal(t, "app.getgram.ai", schemeless.Host)
+
+	_, err = hosts.New(logger, conn, schemeless, nil, canonical)
+	require.Error(t, err)
+
+	_, err = hosts.New(logger, conn, canonical, nil, schemeless)
+	require.Error(t, err)
+
+	_, err = hosts.New(logger, conn, canonical, []*url.URL{schemeless}, canonical)
+	require.Error(t, err)
+
+	_, err = hosts.ParseList("//app.getgram.ai")
+	require.Error(t, err)
+}
+
+func TestNewFromConfig(t *testing.T) {
+	t.Parallel()
+
+	conn := newConn(t)
+	logger := testenv.NewLogger(t)
+	canonical := mustParse(t, canonicalURL)
+
+	// An unset outbound callback follows the canonical host.
+	h, err := hosts.NewFromConfig(logger, conn, canonical, "", "")
+	require.NoError(t, err)
+	require.Equal(t, canonicalURL, h.OutboundCallback().String())
+	require.Equal(t, []*url.URL{canonical}, h.PlatformHosts())
+
+	h, err = hosts.NewFromConfig(logger, conn, canonical, secondaryURL, "https://callback.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "https://callback.example.com", h.OutboundCallback().String())
+	require.True(t, h.IsPlatform("callback.example.com"))
+	require.True(t, h.IsPlatform("ai.speakeasy.com"))
+
+	_, err = hosts.NewFromConfig(logger, conn, canonical, "", "not-a-url")
+	require.Error(t, err)
+
+	_, err = hosts.NewFromConfig(logger, conn, canonical, "not-a-url", "")
 	require.Error(t, err)
 }
 

--- a/server/internal/hosts/hosts_test.go
+++ b/server/internal/hosts/hosts_test.go
@@ -208,6 +208,11 @@ func TestBasePathIsPreserved(t *testing.T) {
 	require.Equal(t, "https://app.getgram.ai/gram", withNoise.Canonical().String())
 	require.Equal(t, "https://callback.example.com/oauth", withNoise.OutboundCallback().String())
 
+	// An escaped character in the base path survives.
+	escaped, err := hosts.New(testenv.NewLogger(t), conn, mustParse(t, "https://app.getgram.ai/a%2Fb"), nil, canonical)
+	require.NoError(t, err)
+	require.Equal(t, "https://app.getgram.ai/a%2Fb", escaped.Canonical().String())
+
 	// Credentials would be copied into URLs sent upstream.
 	_, err = hosts.New(testenv.NewLogger(t), conn, mustParse(t, "https://user:pass@app.getgram.ai"), nil, canonical)
 	require.Error(t, err)

--- a/server/internal/hosts/hosts_test.go
+++ b/server/internal/hosts/hosts_test.go
@@ -200,6 +200,18 @@ func TestBasePathIsPreserved(t *testing.T) {
 	require.Equal(t, "https://app.getgram.ai/gram", h.Canonical().String())
 	require.Equal(t, "https://callback.example.com/oauth", h.OutboundCallback().String())
 
+	// A query or fragment sits before the path callers join onto, so it is
+	// dropped rather than carried into every rendered URL.
+	withNoise, err := hosts.New(testenv.NewLogger(t), conn,
+		mustParse(t, "https://app.getgram.ai/gram?trace=1#top"), nil, mustParse(t, "https://callback.example.com/oauth?x=1"))
+	require.NoError(t, err)
+	require.Equal(t, "https://app.getgram.ai/gram", withNoise.Canonical().String())
+	require.Equal(t, "https://callback.example.com/oauth", withNoise.OutboundCallback().String())
+
+	// Credentials would be copied into URLs sent upstream.
+	_, err = hosts.New(testenv.NewLogger(t), conn, mustParse(t, "https://user:pass@app.getgram.ai"), nil, canonical)
+	require.Error(t, err)
+
 	// Membership still answers on the host alone, which is all a Host header
 	// carries.
 	require.True(t, h.IsPlatform("app.getgram.ai"))

--- a/server/internal/platformmcp/catalog_identity_provider_attachment.go
+++ b/server/internal/platformmcp/catalog_identity_provider_attachment.go
@@ -59,15 +59,18 @@ type CatalogIdentityProviderAttachmentService struct {
 	enc       *encryption.Client
 	policy    *guardian.Policy
 	audit     *audit.Logger
-	serverURL *url.URL
+	// outboundCallbackURL is the deployment's pinned outbound callback host,
+	// which is what dynamic client registration publishes upstream as its
+	// redirect target. Not the canonical host: registrations outlive it.
+	outboundCallbackURL *url.URL
 }
 
-func NewCatalogIdentityProviderAttachmentService(db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, auditLogger *audit.Logger, serverURL *url.URL) *CatalogIdentityProviderAttachmentService {
-	if serverURL == nil {
+func NewCatalogIdentityProviderAttachmentService(db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, auditLogger *audit.Logger, outboundCallbackURL *url.URL) *CatalogIdentityProviderAttachmentService {
+	if outboundCallbackURL == nil {
 		return &CatalogIdentityProviderAttachmentService{}
 	}
-	serverURLCopy := *serverURL
-	return &CatalogIdentityProviderAttachmentService{db: db, enc: enc, policy: policy, audit: auditLogger, serverURL: &serverURLCopy}
+	callbackCopy := *outboundCallbackURL
+	return &CatalogIdentityProviderAttachmentService{db: db, enc: enc, policy: policy, audit: auditLogger, outboundCallbackURL: &callbackCopy}
 }
 
 // Attach discovers the exact provider advertised by the lifecycle-owned Remote
@@ -75,7 +78,7 @@ func NewCatalogIdentityProviderAttachmentService(db *pgxpool.Pool, enc *encrypti
 // and binds it to the registration's existing user-session issuer. It is safe
 // to retry after a successful call: the existing matching binding is reused.
 func (s *CatalogIdentityProviderAttachmentService) Attach(ctx context.Context, principal Principal, project ResolvedProject, registrationID uuid.UUID) (CatalogIdentityProviderAttachmentResult, error) {
-	if s == nil || s.db == nil || s.enc == nil || s.policy == nil || s.audit == nil || s.serverURL == nil || principal.UserID == "" || principal.OrganizationID == "" || project.ID == uuid.Nil || registrationID == uuid.Nil {
+	if s == nil || s.db == nil || s.enc == nil || s.policy == nil || s.audit == nil || s.outboundCallbackURL == nil || principal.UserID == "" || principal.OrganizationID == "" || project.ID == uuid.Nil || registrationID == uuid.Nil {
 		return CatalogIdentityProviderAttachmentResult{}, ErrIdentityProviderAttachmentUnavailable
 	}
 
@@ -156,7 +159,7 @@ func (s *CatalogIdentityProviderAttachmentService) attachLocked(ctx context.Cont
 	// This is server-to-server; any client secret stays in the stack frame only
 	// until createAndAttachClient encrypts it for persistence.
 	scope := strings.Join(resourceMetadata.ScopesSupported, " ")
-	registered, err := remotesessions.RegisterDynamicClient(ctx, s.policy, s.serverURL, remotesessions.ProxyRegisterRequest{
+	registered, err := remotesessions.RegisterDynamicClient(ctx, s.policy, s.outboundCallbackURL, remotesessions.ProxyRegisterRequest{
 		RegistrationEndpoint:    metadata.RegistrationEndpoint,
 		Scope:                   optionalString(scope),
 		TokenEndpointAuthMethod: optionalString(browserCatalogDCRAuthMethod),

--- a/server/internal/platformmcp/catalog_identity_provider_attachment.go
+++ b/server/internal/platformmcp/catalog_identity_provider_attachment.go
@@ -55,10 +55,10 @@ type CatalogIdentityProviderAttachment interface {
 }
 
 type CatalogIdentityProviderAttachmentService struct {
-	db        *pgxpool.Pool
-	enc       *encryption.Client
-	policy    *guardian.Policy
-	audit     *audit.Logger
+	db     *pgxpool.Pool
+	enc    *encryption.Client
+	policy *guardian.Policy
+	audit  *audit.Logger
 	// outboundCallbackURL is the deployment's pinned outbound callback host,
 	// which is what dynamic client registration publishes upstream as its
 	// redirect target. Not the canonical host: registrations outlive it.

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -188,7 +188,7 @@ func NewChallengeManager(
 
 		outboundCallbackURL: serverURL,
 
-		revoker:   NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
+		revoker: NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
 		authorizeInterceptors: []interceptors.AuthorizeInterceptor{
 			interceptors.NewGoogle(logger),
 		},

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -141,6 +141,11 @@ type ChallengeManager struct {
 	refresher *RefreshService
 	serverURL *url.URL
 
+	// outboundCallbackURL is the host every outbound redirect_uri and CIMD
+	// client_id is rendered on. See Service.outboundCallbackURL: pinned apart
+	// from serverURL because upstream providers hold these values.
+	outboundCallbackURL *url.URL
+
 	// revoker pushes RFC 7009 revocations upstream when the consent screen
 	// disconnects a remote session, so the provider drops the tokens rather
 	// than only Gram forgetting them.
@@ -180,12 +185,25 @@ func NewChallengeManager(
 		locks:     cacheImpl,
 		refresher: NewRefreshService(logger, meterProvider, db, enc, policy, cacheImpl),
 		serverURL: serverURL,
+
+		outboundCallbackURL: serverURL,
+
 		revoker:   NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
 		authorizeInterceptors: []interceptors.AuthorizeInterceptor{
 			interceptors.NewGoogle(logger),
 		},
 		metrics: remotesessionmetrics.NewAuthorize(logger, meterProvider),
 	}
+}
+
+// WithOutboundCallbackURL pins the host every outbound redirect_uri and CIMD
+// client_id is rendered on. Returns the manager so it can be chained onto the
+// constructor.
+func (m *ChallengeManager) WithOutboundCallbackURL(u *url.URL) *ChallengeManager {
+	if u != nil {
+		m.outboundCallbackURL = u
+	}
+	return m
 }
 
 // Client is the joined view of a remote_session_client + its
@@ -808,7 +826,7 @@ func (m *ChallengeManager) callbackURL(routeBase string) string {
 	if routeBase == "" {
 		routeBase = canonicalCallbackRouteBase
 	}
-	return strings.TrimRight(m.serverURL.String(), "/") + "/" + routeBase + "/remote_login_callback"
+	return strings.TrimRight(m.outboundCallbackURL.String(), "/") + "/" + routeBase + "/remote_login_callback"
 }
 
 // legacyCallbackURL is the oauth_proxy_servers-era redirect_uri. Used only for
@@ -816,7 +834,7 @@ func (m *ChallengeManager) callbackURL(routeBase string) string {
 // this path; HandleLegacyProxyCallback forwards them into
 // /mcp/remote_login_callback.
 func (m *ChallengeManager) legacyCallbackURL() string {
-	return strings.TrimRight(m.serverURL.String(), "/") + "/oauth/callback"
+	return strings.TrimRight(m.outboundCallbackURL.String(), "/") + "/oauth/callback"
 }
 
 // HandleLegacyProxyCallback is the shim behind `GET /oauth/callback`, the
@@ -826,7 +844,7 @@ func (m *ChallengeManager) legacyCallbackURL() string {
 // code, error) unchanged to the canonical /mcp/remote_login_callback, where the
 // remote-session flow finishes the exchange.
 func (m *ChallengeManager) HandleLegacyProxyCallback(w http.ResponseWriter, r *http.Request) error {
-	target := strings.TrimRight(m.serverURL.String(), "/") + "/" + canonicalCallbackRouteBase + "/remote_login_callback"
+	target := strings.TrimRight(m.outboundCallbackURL.String(), "/") + "/" + canonicalCallbackRouteBase + "/remote_login_callback"
 	if raw := r.URL.RawQuery; raw != "" {
 		target += "?" + raw
 	}

--- a/server/internal/remotesessions/cimd.go
+++ b/server/internal/remotesessions/cimd.go
@@ -47,13 +47,15 @@ const cimdClientName = "Speakeasy"
 // for parity with the sibling OAuth metadata documents.
 const clientMetadataDocumentPath = "/.well-known/oauth-client/"
 
-// ClientMetadataDocumentURL builds the platform-canonical CIMD document URL for
-// a client id. serverURL is the Gram deployment's public base URL; the path
-// component is the client's globally unique primary key. This is the value
-// stored as both client_id and client_id_metadata_uri on a CIMD-mode row and
-// the URL Gram sends upstream as client_id.
-func ClientMetadataDocumentURL(serverURL *url.URL, clientID uuid.UUID) string {
-	return strings.TrimRight(serverURL.String(), "/") + clientMetadataDocumentPath + clientID.String()
+// ClientMetadataDocumentURL builds the CIMD document URL for a client id.
+// outboundCallbackURL is the deployment's pinned outbound callback host — not
+// its canonical host, which may move — and the path component is the client's
+// globally unique primary key. This is the value stored as both client_id and
+// client_id_metadata_uri on a CIMD-mode row and the URL Gram sends upstream as
+// client_id; an upstream Authorization Server dereferences it long after the
+// row was written, so it has to stay put.
+func ClientMetadataDocumentURL(outboundCallbackURL *url.URL, clientID uuid.UUID) string {
+	return strings.TrimRight(outboundCallbackURL.String(), "/") + clientMetadataDocumentPath + clientID.String()
 }
 
 // clientMetadataDocument is the JSON body served at the CIMD endpoint. Fields

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -236,7 +236,7 @@ func (s *Service) CreateCimd(ctx context.Context, payload *gen.CreateCimdPayload
 		ProjectID:             conv.ToNullUUID(*authCtx.ProjectID),
 		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID: issuerID,
-		ClientIDMetadataUri:   ClientMetadataDocumentURL(s.serverURL, clientID),
+		ClientIDMetadataUri:   ClientMetadataDocumentURL(s.outboundCallbackURL, clientID),
 		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now().UTC()),
 		Scope:                 payload.Scope,
 		Audience:              conv.PtrToPGText(payload.Audience),

--- a/server/internal/remotesessions/impl.go
+++ b/server/internal/remotesessions/impl.go
@@ -59,6 +59,14 @@ type Service struct {
 	serverURL    *url.URL
 	refresher    *RefreshService
 	revoker      *UpstreamRevoker
+
+	// outboundCallbackURL is the host advertised to upstream OAuth providers:
+	// the redirect_uri sent on every outbound authorize and the client_id URL
+	// published in CIMD documents. Pinned independently of serverURL because
+	// those values live on customer OAuth apps and vendor allowlists we cannot
+	// migrate. Defaults to serverURL, which is what a single-host deployment
+	// wants; WithOutboundCallbackURL pins it elsewhere.
+	outboundCallbackURL *url.URL
 }
 
 var (
@@ -95,7 +103,18 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 		serverURL:    serverURL,
 		refresher:    refresher,
 		revoker:      NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
+
+		outboundCallbackURL: serverURL,
 	}
+}
+
+// WithOutboundCallbackURL pins the host advertised to upstream OAuth providers.
+// Returns the service so it can be chained onto the constructor.
+func (s *Service) WithOutboundCallbackURL(u *url.URL) *Service {
+	if u != nil {
+		s.outboundCallbackURL = u
+	}
+	return s
 }
 
 func Attach(mux goahttp.Muxer, service *Service) {

--- a/server/internal/remotesessions/legacycallback_test.go
+++ b/server/internal/remotesessions/legacycallback_test.go
@@ -12,13 +12,13 @@ import (
 // A legacy_callback_url client's upstream redirects to /oauth/callback; the
 // shim must forward the query string verbatim to /mcp/remote_login_callback so
 // the remote-session flow can finish the exchange. The forwarder only reads
-// serverURL, so a bare ChallengeManager is enough.
+// outboundCallbackURL, so a bare ChallengeManager is enough.
 func TestHandleLegacyProxyCallbackForwardsToRemoteLogin(t *testing.T) {
 	t.Parallel()
 
-	serverURL, err := url.Parse("https://api.example.com")
+	callbackURL, err := url.Parse("https://api.example.com")
 	require.NoError(t, err)
-	m := &ChallengeManager{serverURL: serverURL}
+	m := &ChallengeManager{outboundCallbackURL: callbackURL}
 
 	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state=abc123&code=xyz789", nil)
 	rec := httptest.NewRecorder()
@@ -36,9 +36,9 @@ func TestHandleLegacyProxyCallbackForwardsToRemoteLogin(t *testing.T) {
 func TestHandleLegacyProxyCallbackForwardsError(t *testing.T) {
 	t.Parallel()
 
-	serverURL, err := url.Parse("https://api.example.com")
+	callbackURL, err := url.Parse("https://api.example.com")
 	require.NoError(t, err)
-	m := &ChallengeManager{serverURL: serverURL}
+	m := &ChallengeManager{outboundCallbackURL: callbackURL}
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/oauth/callback?state=s1&error=access_denied&error_description=nope", nil)

--- a/server/internal/remotesessions/organizationclienthandlers.go
+++ b/server/internal/remotesessions/organizationclienthandlers.go
@@ -465,7 +465,7 @@ func (s *Service) CreateCimdClient(ctx context.Context, payload *orgclientsgen.C
 		ProjectID:             clientProjectID,
 		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
 		RemoteSessionIssuerID: issuerID,
-		ClientIDMetadataUri:   ClientMetadataDocumentURL(s.serverURL, clientID),
+		ClientIDMetadataUri:   ClientMetadataDocumentURL(s.outboundCallbackURL, clientID),
 		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now().UTC()),
 		Scope:                 payload.Scope,
 		Audience:              conv.PtrToPGText(payload.Audience),

--- a/server/internal/remotesessions/outboundcallback_internal_test.go
+++ b/server/internal/remotesessions/outboundcallback_internal_test.go
@@ -1,0 +1,81 @@
+package remotesessions
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// Upstream OAuth registrations and vendor allowlists hold Gram's redirect URI
+// and CIMD client_id, and we cannot migrate them. Moving the canonical host
+// must therefore leave both untouched.
+func TestOutboundCallbackURLIsPinnedAgainstCanonicalHost(t *testing.T) {
+	t.Parallel()
+
+	pinned, err := url.Parse("https://app.getgram.ai")
+	require.NoError(t, err)
+
+	// The deployment's canonical host has moved elsewhere.
+	canonical, err := url.Parse("https://ai.speakeasy.com")
+	require.NoError(t, err)
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	mgr := NewChallengeManager(
+		testenv.NewLogger(t),
+		tracerProvider,
+		testenv.NewMeterProvider(t),
+		nil,
+		nil,
+		policy,
+		cache.NoopCache,
+		canonical,
+	).WithOutboundCallbackURL(pinned)
+
+	require.Equal(t, "https://app.getgram.ai/mcp/remote_login_callback", mgr.callbackURL(""))
+	require.Equal(t, "https://app.getgram.ai/mcp/remote_login_callback", mgr.callbackURL("mcp"))
+	require.Equal(t, "https://app.getgram.ai/x/mcp/remote_login_callback", mgr.callbackURL("x/mcp"))
+	require.Equal(t, "https://app.getgram.ai/oauth/callback", mgr.legacyCallbackURL())
+
+	clientID := uuid.MustParse("00000000-0000-0000-0000-0000000000ff")
+	require.Equal(t,
+		"https://app.getgram.ai/.well-known/oauth-client/"+clientID.String(),
+		ClientMetadataDocumentURL(pinned, clientID))
+}
+
+// A deployment that configures nothing extra keeps today's behaviour: the
+// outbound callback is the server URL.
+func TestOutboundCallbackURLDefaultsToServerURL(t *testing.T) {
+	t.Parallel()
+
+	serverURL, err := url.Parse("https://app.getgram.ai")
+	require.NoError(t, err)
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	mgr := NewChallengeManager(
+		testenv.NewLogger(t),
+		tracerProvider,
+		testenv.NewMeterProvider(t),
+		nil,
+		nil,
+		policy,
+		cache.NoopCache,
+		serverURL,
+	)
+
+	require.Equal(t, "https://app.getgram.ai/mcp/remote_login_callback", mgr.callbackURL(""))
+
+	// A nil override is ignored rather than clearing the default.
+	require.Equal(t, "https://app.getgram.ai/mcp/remote_login_callback", mgr.WithOutboundCallbackURL(nil).callbackURL(""))
+}

--- a/server/internal/remotesessions/proxyregister.go
+++ b/server/internal/remotesessions/proxyregister.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -83,8 +84,12 @@ type DCRResponse struct {
 // registration endpoint were discovered from a persisted resource, never from
 // an MCP or browser input. The returned secret is transient and callers must
 // encrypt it before persistence without returning or logging it.
-func RegisterDynamicClient(ctx context.Context, policy *guardian.Policy, serverURL *url.URL, request ProxyRegisterRequest) (ProxyRegisterResponse, error) {
-	if policy == nil || serverURL == nil {
+//
+// outboundCallbackURL is the deployment's pinned outbound callback host, not
+// its canonical host: the redirect URIs registered here live on the upstream
+// provider indefinitely, so they must not move when the canonical host does.
+func RegisterDynamicClient(ctx context.Context, policy *guardian.Policy, outboundCallbackURL *url.URL, request ProxyRegisterRequest) (ProxyRegisterResponse, error) {
+	if policy == nil || outboundCallbackURL == nil {
 		return ProxyRegisterResponse{}, fmt.Errorf("dynamic client registration is not configured")
 	}
 
@@ -93,7 +98,7 @@ func RegisterDynamicClient(ctx context.Context, policy *guardian.Policy, serverU
 		return ProxyRegisterResponse{}, ErrInvalidDynamicClientRegistrationEndpoint
 	}
 
-	origin := serverURL.String()
+	origin := strings.TrimRight(outboundCallbackURL.String(), "/")
 	redirectURIs := []string{
 		fmt.Sprintf("%s/oauth/callback", origin),
 		fmt.Sprintf("%s/mcp/remote_login_callback", origin),
@@ -200,7 +205,7 @@ func (s *Service) handleProxyRegister(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeBadRequest, err, "invalid JSON in request body").LogError(ctx, s.logger)
 	}
 
-	registered, err := RegisterDynamicClient(ctx, s.policy, s.serverURL, req)
+	registered, err := RegisterDynamicClient(ctx, s.policy, s.outboundCallbackURL, req)
 	if err != nil {
 		if errors.Is(err, ErrInvalidDynamicClientRegistrationEndpoint) {
 			return oops.E(oops.CodeBadRequest, err, "invalid identity provider registration endpoint").LogWarn(ctx, s.logger)

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -198,6 +198,33 @@ INSERT INTO organization_metadata (
     COALESCE(sqlc.narg('created_at')::timestamptz, clock_timestamp())
 );
 
+-- name: SetOrganizationDefaultHostFixture :exec
+-- Test-only fixture for seeding an organization's default host. Deliberately
+-- kept out of CreateOrganizationMetadataFixture for the same reason as
+-- SetWorkosLastEventIDFixture: a column added mid-list renumbers every
+-- positional placeholder after it.
+UPDATE organization_metadata
+SET default_host = sqlc.narg('default_host')::text
+WHERE id = @id;
+
+-- name: CreateScopedCustomDomainFixture :exec
+-- Test-only fixture for seeding a custom domain at a chosen scope and
+-- verification state. CreateCustomDomain writes neither, so host-resolution
+-- tests cannot build their fixtures with it.
+INSERT INTO custom_domains (
+    organization_id,
+    domain,
+    scope,
+    verified,
+    activated
+) VALUES (
+    @organization_id,
+    @domain,
+    @scope,
+    @verified,
+    @activated
+);
+
 -- name: SetWorkosLastEventIDFixture :exec
 -- Test-only fixture for seeding the WorkOS webhook cursor on an organization
 -- that already exists. Deliberately kept out of

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -250,6 +250,44 @@ func (q *Queries) CreateRemoteMCPServerMaterializationFailureTriggerFixture(ctx 
 	return err
 }
 
+const createScopedCustomDomainFixture = `-- name: CreateScopedCustomDomainFixture :exec
+INSERT INTO custom_domains (
+    organization_id,
+    domain,
+    scope,
+    verified,
+    activated
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5
+)
+`
+
+type CreateScopedCustomDomainFixtureParams struct {
+	OrganizationID string
+	Domain         string
+	Scope          string
+	Verified       bool
+	Activated      bool
+}
+
+// Test-only fixture for seeding a custom domain at a chosen scope and
+// verification state. CreateCustomDomain writes neither, so host-resolution
+// tests cannot build their fixtures with it.
+func (q *Queries) CreateScopedCustomDomainFixture(ctx context.Context, arg CreateScopedCustomDomainFixtureParams) error {
+	_, err := q.db.Exec(ctx, createScopedCustomDomainFixture,
+		arg.OrganizationID,
+		arg.Domain,
+		arg.Scope,
+		arg.Verified,
+		arg.Activated,
+	)
+	return err
+}
+
 const deferDeviceIntegrationSyncsFixture = `-- name: DeferDeviceIntegrationSyncsFixture :exec
 UPDATE device_integration_syncs s
 SET next_poll_after = clock_timestamp() + interval '1 hour'
@@ -1552,6 +1590,26 @@ type SetOrgWebhookConfigParams struct {
 // Sets the Svix app ID and webhooks_enabled flag on an organization.
 func (q *Queries) SetOrgWebhookConfig(ctx context.Context, arg SetOrgWebhookConfigParams) error {
 	_, err := q.db.Exec(ctx, setOrgWebhookConfig, arg.SvixAppID, arg.WebhooksEnabled, arg.OrganizationID)
+	return err
+}
+
+const setOrganizationDefaultHostFixture = `-- name: SetOrganizationDefaultHostFixture :exec
+UPDATE organization_metadata
+SET default_host = $1::text
+WHERE id = $2
+`
+
+type SetOrganizationDefaultHostFixtureParams struct {
+	DefaultHost pgtype.Text
+	ID          string
+}
+
+// Test-only fixture for seeding an organization's default host. Deliberately
+// kept out of CreateOrganizationMetadataFixture for the same reason as
+// SetWorkosLastEventIDFixture: a column added mid-list renumbers every
+// positional placeholder after it.
+func (q *Queries) SetOrganizationDefaultHostFixture(ctx context.Context, arg SetOrganizationDefaultHostFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOrganizationDefaultHostFixture, arg.DefaultHost, arg.ID)
 	return err
 }
 


### PR DESCRIPTION
GRW-21

Stacked on #5752 (`mig: add org default_host and custom_domains.scope`) — review that one first; this PR targets it as its base.

## Summary

Introduces `server/internal/hosts`, the single source of truth for the hosts a deployment answers on and the host a rendered URL should carry. Inert on the existing host: nothing about `app.getgram.ai` changes.

**The package.** `Canonical()`, `PlatformHosts()`, `Auth()`, and `OutboundCallback()` describe the deployment. `Resolve(ctx, req, orgID)` picks the host to render customer-facing URLs with, in order: the host the request arrived on, the organization's configured default host, then the canonical host. A host only qualifies if it is a platform host or that organization's own active app-scoped custom domain — re-checked on every call rather than trusted from the stored column, so an organization whose domain is deleted or deactivated falls back to canonical on the next request without a data migration. A failed read logs and degrades to canonical rather than failing the request.

**Configuration.** Two settings alongside `GRAM_SERVER_URL`, on both `start` and `worker`:

- `GRAM_PLATFORM_HOSTS` — comma-separated first-party hosts. The server-url host is always included, so an unset list means "the canonical host alone".
- `GRAM_OUTBOUND_CALLBACK_URL` — what is advertised to upstream OAuth providers.

Both default to `server-url`, which keeps a single-host deployment byte-identical to today. Note this deviates from the ticket, which specified a hardcoded `https://app.getgram.ai` default: that would silently point local and dev deployments at production. Pinning it is a deployment-config change on the production environment, which lives outside this repo.

**Platform hosts are first-party.** The custom-domain middleware compared the request host against `server-url` and 403'd anything else that was not a registered custom domain, so a second first-party host would have been rejected. It now tests membership of the platform-host set; other hosts still fall through to the custom-domain lookup unchanged.

**The outbound callback is pinned.** The remote-login `redirect_uri`, the legacy `/oauth/callback` shim, dynamic client registration's `redirect_uris`, the CIMD `client_id` URL, and the Platform MCP setup corpus's published callback all render on the outbound callback host instead of the canonical one. `ChallengeManager` and the remote-sessions service gained an `outboundCallbackURL` that defaults to `serverURL`, set through a chainable `WithOutboundCallbackURL`; the Platform MCP identity-provider attachment service takes the pinned URL in place of the server URL. Handlers still serve on every platform host — only the advertised URL is pinned.

Also adds `GetActiveAppScopedCustomDomainForOrganization` to the custom-domains queries, and two test-only fixtures in `testenv` for seeding an organization's default host and a scoped custom domain.

## Motivation

Gram is moving off a single hardcoded platform host. Two things have to be true before any of that behaviour can land: the deployment has to know which hosts are its own, and the values upstream OAuth providers hold have to stop tracking whichever host we happen to call canonical.

The second is the load-bearing half. Upstream redirect URIs and the CIMD client ID sit on customer-owned OAuth apps and vendor allowlists we do not control — Figma, Canva, and others — and cannot be migrated on our schedule. Pinning them behind their own setting is what makes it safe to move the canonical host later; the tests assert that flipping the canonical host leaves both untouched rather than assuming it.

Call sites still read `GRAM_SERVER_URL` after this PR. GRW-32 moves them onto `Resolve`.
