### PR TITLE
fix: attribute upstream MCP failures distinctly in logs and errors

### DIFF
--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -410,7 +410,13 @@ func handleToolsCall(
 			recordToolCallErrorStatus(ctx, rw, rejected)
 			return nil, rejected
 		}
-		failure := oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
+		// Preserve the original classification (e.g. CodeGatewayError for
+		// upstream transport failures) instead of collapsing to CodeUnexpected.
+		code := oops.CodeUnexpected
+		if shareable, ok := errors.AsType[*oops.ShareableError](err); ok {
+			code = shareable.Code
+		}
+		failure := oops.E(code, err, "failed to execute tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
 		recordToolCallErrorStatus(ctx, rw, failure)
 		return nil, failure
 	}

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -103,6 +104,9 @@ func isSkippedResponseHeader(name string) bool {
 // [http.ResponseWriter.WriteHeader]; once the status line is written, header
 // mutations are silently dropped.
 func applyResponseHeaders(w http.ResponseWriter, remoteResp *http.Response, wwwAuthenticate string) {
+	// Marks the access log's gram.http.response.external attribute so relayed
+	// upstream statuses (including 5xx) are distinguishable from Gram faults.
+	w.Header().Set(constants.HeaderProxiedResponse, "1")
 	replaceChallenge := wwwAuthenticate != "" &&
 		(remoteResp.StatusCode == http.StatusUnauthorized || remoteResp.StatusCode == http.StatusForbidden)
 	for name, values := range remoteResp.Header {


### PR DESCRIPTION
## Summary

- `remotemcp/proxy.applyResponseHeaders` now stamps `X-Gram-Proxy-Response: 1` on every relayed upstream response (both the buffered and SSE relay paths), so the HTTP logging middleware attaches `gram.http.response.external:true` to the `"response"` access-log line for proxied MCP traffic.
- Tool call failures in `mcp/rpc_tools_call.go` preserve the original `oops` code (e.g. `CodeGatewayError` for upstream transport failures) instead of collapsing everything to `CodeUnexpected`.

## Motivation

When a tenant's upstream MCP server is flaky, Gram relays the upstream 5xx verbatim on `/mcp/<slug>` with nothing in the logs distinguishing it from a Gram fault. This has been paging oncall repeatedly through the platform and per-endpoint 5xx monitors. With the attribute in place, monitors can exclude upstream-attributed errors while still paging on genuine Gram-origin 5xx. The `gram.http.response.external` attribute already existed for this purpose but never reached `/mcp` responses because the tool proxy writes into a buffered response writer whose headers are discarded; setting it at the relay chokepoint fixes that for proxy-backed MCP servers.
