### PR TITLE
fix: hide OAuth install steps for public tunneled MCP servers

### DIFF
--- a/.changeset/tunnel-install-page-no-oauth-steps.md
+++ b/.changeset/tunnel-install-page-no-oauth-steps.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The hosted MCP install page no longer shows OAuth-only setup steps (such as `codex mcp login`) for publicly served tunneled MCP servers. Public tunnels are served anonymously, so the page now matches the runtime behavior and only renders OAuth instructions when a connecting client will actually be sent through an OAuth flow.

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1339,6 +1339,10 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 		return oops.E(oops.CodeUnexpected, err, "resolve mcp endpoint url").LogError(ctx, s.logger, attr.SlogMcpServerID(mcpServer.ID.String()))
 	}
 
+	// Anonymous public tunnels are served without OAuth even though the schema
+	// forces an issuer on every tunneled backend (mirrors serveendpoint.go issuerGated).
+	tunneledPublic := mcpServer.TunneledMcpServerID.Valid && mcpServer.Visibility == mcpservers.VisibilityPublic
+
 	return s.writeInstallPage(ctx, w, hostedPageRenderInputs{
 		// Remote-MCP-backed installs don't expose Gram-side env vars or a tools
 		// list yet: the page renders the URL + branding only.
@@ -1353,10 +1357,8 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 		DocsText:       docsText,
 		Instructions:   instructions,
 		IsPublic:       ic.isPublic(),
-		// Remote-MCP-backed installs have no toolset, so OAuth is driven solely
-		// by the server's user-session issuer (mirrors resolveSecurityMode).
-		IsOAuth: mcpServer.UserSessionIssuerID.Valid,
-		OrgName: ic.organization.Name,
+		IsOAuth:        mcpServer.UserSessionIssuerID.Valid && !tunneledPublic,
+		OrgName:        ic.organization.Name,
 		// Remote-MCP-backed installs have no tool list, so no filter scopes.
 		FilteringEnabled: false,
 		Scopes:           nil,

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -32,6 +32,7 @@ import (
 	remotemcp_repo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	tools_repo "github.com/speakeasy-api/gram/server/internal/tools/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -1448,6 +1449,86 @@ func TestServeInstallPage_McpServer_RemoteBacked_PublicRenders(t *testing.T) {
 	assert.Contains(t, body, endpointSlug, "rendered page should reference the mcp_endpoint slug")
 	assert.Contains(t, body, "Connect to Remote MCP", "instructions from mcp_server-keyed metadata should render")
 	assert.Contains(t, body, docURL, "docs URL from mcp_server-keyed metadata should render")
+}
+
+func TestServeInstallPage_McpServer_TunneledPublic_NoOAuthSteps(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPMetadataService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	tunneledServer, err := tunneledmcprepo.New(ti.conn).CreateServer(ctx, tunneledmcprepo.CreateServerParams{
+		ID:        uuid.New(),
+		ProjectID: *authCtx.ProjectID,
+		Name:      "Public Tunneled MCP Server",
+		KeyHash:   "test-key-hash",
+		KeyPrefix: "test-key-prefix",
+	})
+	require.NoError(t, err)
+
+	issuer := createUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+	endpointSlug := "tunneled-mcp-public-" + uuid.NewString()[:8]
+	createMcpServerWithEndpoint(t, ctx, ti, mcpServerFixtureOptions{
+		name:                "Tunneled MCP Public",
+		visibility:          mcpservers.VisibilityPublic,
+		endpointSlug:        endpointSlug,
+		tunneledMcpServerID: uuid.NullUUID{UUID: tunneledServer.ID, Valid: true},
+		userSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+	})
+
+	req := httptest.NewRequest("GET", "/mcp/"+endpointSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", endpointSlug)
+	req = req.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	assert.NotContains(t, body, "codex mcp login")
+	assert.NotContains(t, body, "so authenticate with it before use")
+}
+
+func TestServeInstallPage_McpServer_TunneledPrivate_ShowsOAuthSteps(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPMetadataService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	tunneledServer, err := tunneledmcprepo.New(ti.conn).CreateServer(ctx, tunneledmcprepo.CreateServerParams{
+		ID:        uuid.New(),
+		ProjectID: *authCtx.ProjectID,
+		Name:      "Private Tunneled MCP Server",
+		KeyHash:   "test-key-hash",
+		KeyPrefix: "test-key-prefix",
+	})
+	require.NoError(t, err)
+
+	issuer := createUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+	endpointSlug := "tunneled-mcp-private-" + uuid.NewString()[:8]
+	createMcpServerWithEndpoint(t, ctx, ti, mcpServerFixtureOptions{
+		name:                "Tunneled MCP Private",
+		visibility:          mcpservers.VisibilityPrivate,
+		endpointSlug:        endpointSlug,
+		tunneledMcpServerID: uuid.NullUUID{UUID: tunneledServer.ID, Valid: true},
+		userSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+	})
+
+	req := httptest.NewRequest("GET", "/mcp/"+endpointSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", endpointSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	assert.Contains(t, rr.Body.String(), "codex mcp login")
 }
 
 // TestServeInstallPage_McpServer_RemoteBacked_PrivateRedirectsToLogin

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -109,14 +109,15 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 
 // mcpServerFixtureOptions tunes the fixture pair created by
 // createMcpServerWithEndpoint. ToolsetID is non-Nil for toolset-backed
-// mcp_servers (the dual-source bridge path); RemoteMcpServerID is non-Nil for
-// Remote-MCP-backed installs.
+// mcp_servers (the dual-source bridge path); RemoteMcpServerID and
+// TunneledMcpServerID select their respective remote backends.
 type mcpServerFixtureOptions struct {
 	name                string
 	visibility          string
 	endpointSlug        string
 	toolsetID           uuid.NullUUID
 	remoteMcpServerID   uuid.NullUUID
+	tunneledMcpServerID uuid.NullUUID
 	customDomainID      uuid.NullUUID
 	userSessionIssuerID uuid.NullUUID
 }
@@ -143,10 +144,7 @@ func createMcpServerWithEndpoint(
 		opts.endpointSlug = "test-endpoint-" + uuid.NewString()[:8]
 	}
 
-	// mcp_servers carries an XOR check on (toolset_id, remote_mcp_server_id);
-	// when neither is supplied by the caller, default to a fresh toolset so
-	// fixtures focused on the metadata flow don't need to spell out a backend.
-	if !opts.toolsetID.Valid && !opts.remoteMcpServerID.Valid {
+	if !opts.toolsetID.Valid && !opts.remoteMcpServerID.Valid && !opts.tunneledMcpServerID.Valid {
 		toolset, err := toolsets_repo.New(ti.conn).CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
 			OrganizationID:         authCtx.ActiveOrganizationID,
 			ProjectID:              *authCtx.ProjectID,
@@ -172,6 +170,7 @@ func createMcpServerWithEndpoint(
 		EnvironmentID:       uuid.NullUUID{},
 		UserSessionIssuerID: opts.userSessionIssuerID,
 		RemoteMcpServerID:   opts.remoteMcpServerID,
+		TunneledMcpServerID: opts.tunneledMcpServerID,
 		ToolsetID:           opts.toolsetID,
 		Visibility:          opts.visibility,
 	})


### PR DESCRIPTION
## What

The hosted MCP install page rendered the OAuth-only install steps — including the Codex CLI `codex mcp login "<slug>"` step and the "This server uses OAuth, so authenticate with it before use" prose — for tunneled MCP servers with public visibility, even though those servers are served anonymously with no OAuth flow.

## Why

`renderRemoteMcpInstallPage` derived the page's `IsOAuth` flag from `mcpServer.UserSessionIssuerID.Valid` alone. The `mcp_servers_issuer_required_check` schema constraint forces an issuer onto every tunneled- or remote-backed `mcp_servers` row, so the flag was unconditionally true for tunneled servers. The runtime serve path already excludes anonymous public tunnels from issuer gating (`issuerGated := mcpServer.UserSessionIssuerID.Valid && !isTunneledPublic(mcpServer)` in `serveendpoint.go`); the install page was missing that exclusion.

## How

- Mirror the runtime rule in the install page renderer: `IsOAuth` is now false when the server is tunneled-backed with public visibility.
- Test fixture support for tunneled-backed `mcp_servers` (`tunneledMcpServerID` option).
- Tests: public tunneled install page must not contain the OAuth steps; private tunneled install page (issuer-gated at runtime) still must.

Validated end to end on a local stack: seeded a public tunneled server and an issuer-gated remote server; the tunneled install page renders `codex mcp add` without the login step, the remote one still renders `codex mcp login`.
