### PR TITLE
fix: lower log relay failures to warnings

### DIFF
--- a/server/internal/otel/handler_log_relay.go
+++ b/server/internal/otel/handler_log_relay.go
@@ -194,7 +194,7 @@ func (h *LogRelayHandler) handleBatch(ctx context.Context, messages []logRelayMe
 					h.recordDroppedLogs(ctx, len(item.batch.items), reason)
 				}
 
-				logger.ErrorContext(
+				logger.WarnContext(
 					ctx,
 					"relay otel logs",
 					attr.SlogError(err),


### PR DESCRIPTION
## Summary

Lower log relay delivery failure messages from error to warning while retaining the error, organization, destination, and delivery outcome metrics.

## Motivation

Customer-controlled destinations can reject relay requests without indicating a `gram-streams` service failure. Keeping these messages at error level feeds the component error-log anomaly monitor and pages on-call for downstream delivery problems already represented by dedicated dropped and failed record metrics. Warning level preserves diagnostic visibility without classifying the condition as a service error.
