### PR TITLE
fix: gate customer log relay by organization

### DIFF
--- a/.changeset/otel-log-customer-relay.md
+++ b/.changeset/otel-log-customer-relay.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Gate customer OTEL log forwarding per organization with a PostHog organization-group flag so mixed batches relay only enabled organizations while disabled, missing, or unavailable evaluations acknowledge records without delivery.

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -532,6 +532,8 @@ func newStreamsCommand() *cli.Command {
 				replicaDB,
 				encryptionClient,
 				guardianPolicy,
+				featureFlags,
+				cache.NewRedisCacheAdapter(redisClient),
 			)
 
 			spanRelayHandler := otelsvc.NewSpanRelayHandler(

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -533,7 +533,6 @@ func newStreamsCommand() *cli.Command {
 				encryptionClient,
 				guardianPolicy,
 				featureFlags,
-				cache.NewRedisCacheAdapter(redisClient),
 			)
 
 			spanRelayHandler := otelsvc.NewSpanRelayHandler(

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -122,6 +122,13 @@ const (
 	// plugins.canaryHooksOrgSlugs), independent of this flag, so a PostHog outage
 	// can't strand it on stale hooks.
 	FlagHooksRollout Flag = "hooks-rollout"
+
+	// FlagOTELLogCustomerRelay controls which organizations have normalized
+	// OTEL logs relayed to customer-defined destinations. It is targeted by
+	// PostHog organization group (org slug) and fails closed per organization,
+	// so one unavailable evaluation never changes another organization's
+	// delivery.
+	FlagOTELLogCustomerRelay Flag = "otel-log-customer-relay"
 )
 
 // Variants of FlagAssistantPlatformMCP. Anything else — no variant, an

--- a/server/internal/otel/handler_log_relay.go
+++ b/server/internal/otel/handler_log_relay.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -37,12 +36,11 @@ const (
 )
 
 type LogRelayHandler struct {
-	logger         *slog.Logger
-	recordsDropped metric.Int64Counter
-	recordsFailed  metric.Int64Counter
-	relay          *signalRelay
-	features       feature.Provider
-	organizations  logRelayOrganizationSlugResolver
+	logger           *slog.Logger
+	recordsDropped   metric.Int64Counter
+	recordsFailed    metric.Int64Counter
+	relay            *signalRelay
+	organizationGate logRelayOrganizationGate
 }
 
 type logProvenanceKey struct {
@@ -68,7 +66,6 @@ func NewLogRelayHandler(
 	encryptionClient *encryption.Client,
 	policy *guardian.Policy,
 	features feature.Provider,
-	cacheImpl cache.Cache,
 ) *LogRelayHandler {
 	logger = logger.With(attr.SlogComponent("log-relay-handler"))
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/otel")
@@ -98,11 +95,10 @@ func NewLogRelayHandler(
 			"/v1/logs",
 			"log",
 		),
-		features: features,
-		organizations: newPostgresLogRelayOrganizationSlugResolver(
-			logger.With(attr.SlogCacheNamespace("otel_log_relay_organization")),
+		organizationGate: newLogRelayOrganizationGate(
+			logger,
 			readReplica,
-			cacheImpl,
+			features,
 		),
 	}
 }
@@ -130,7 +126,6 @@ func (h *LogRelayHandler) handleBatch(ctx context.Context, messages []logRelayMe
 		h.recordDroppedLogs(ctx, invalid, relayReasonInvalid)
 	}
 
-	relayEnabledByOrganization := make(map[string]bool)
 	type destinationResult struct {
 		destination *relayDestination
 		err         error
@@ -144,36 +139,7 @@ func (h *LogRelayHandler) handleBatch(ctx context.Context, messages []logRelayMe
 
 	for _, provenanceGroup := range groups {
 		organizationID := provenanceGroup.key.organizationID
-		enabled, evaluated := relayEnabledByOrganization[organizationID]
-		if !evaluated {
-			organizationSlug, err := h.organizations.OrganizationSlug(ctx, organizationID)
-			if err != nil {
-				logger.WarnContext(
-					ctx,
-					"resolve organization for customer log relay feature flag",
-					attr.SlogError(err),
-					attr.SlogOrganizationID(organizationID),
-				)
-			} else if organizationSlug != "" {
-				enabled, err = h.features.IsFlagEnabled(
-					ctx,
-					feature.FlagOTELLogCustomerRelay,
-					organizationID,
-					feature.OrgProjectGroups(organizationSlug, ""),
-				)
-				if err != nil {
-					enabled = false
-					logger.WarnContext(
-						ctx,
-						"evaluate customer log relay feature flag",
-						attr.SlogError(err),
-						attr.SlogOrganizationID(organizationID),
-					)
-				}
-			}
-			relayEnabledByOrganization[organizationID] = enabled
-		}
-		if !enabled {
+		if !h.organizationGate.Enabled(ctx, organizationID) {
 			continue
 		}
 

--- a/server/internal/otel/handler_log_relay.go
+++ b/server/internal/otel/handler_log_relay.go
@@ -19,7 +19,9 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/streams"
@@ -39,6 +41,8 @@ type LogRelayHandler struct {
 	recordsDropped metric.Int64Counter
 	recordsFailed  metric.Int64Counter
 	relay          *signalRelay
+	features       feature.Provider
+	organizations  logRelayOrganizationSlugResolver
 }
 
 type logProvenanceKey struct {
@@ -63,6 +67,8 @@ func NewLogRelayHandler(
 	readReplica *pgxpool.Pool,
 	encryptionClient *encryption.Client,
 	policy *guardian.Policy,
+	features feature.Provider,
+	cacheImpl cache.Cache,
 ) *LogRelayHandler {
 	logger = logger.With(attr.SlogComponent("log-relay-handler"))
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/otel")
@@ -92,6 +98,12 @@ func NewLogRelayHandler(
 			"/v1/logs",
 			"log",
 		),
+		features: features,
+		organizations: newPostgresLogRelayOrganizationSlugResolver(
+			logger.With(attr.SlogCacheNamespace("otel_log_relay_organization")),
+			readReplica,
+			cacheImpl,
+		),
 	}
 }
 
@@ -118,6 +130,7 @@ func (h *LogRelayHandler) handleBatch(ctx context.Context, messages []logRelayMe
 		h.recordDroppedLogs(ctx, invalid, relayReasonInvalid)
 	}
 
+	relayEnabledByOrganization := make(map[string]bool)
 	type destinationResult struct {
 		destination *relayDestination
 		err         error
@@ -130,6 +143,40 @@ func (h *LogRelayHandler) handleBatch(ctx context.Context, messages []logRelayMe
 	deliveries := make([]destinationDelivery, 0, len(groups))
 
 	for _, provenanceGroup := range groups {
+		organizationID := provenanceGroup.key.organizationID
+		enabled, evaluated := relayEnabledByOrganization[organizationID]
+		if !evaluated {
+			organizationSlug, err := h.organizations.OrganizationSlug(ctx, organizationID)
+			if err != nil {
+				logger.WarnContext(
+					ctx,
+					"resolve organization for customer log relay feature flag",
+					attr.SlogError(err),
+					attr.SlogOrganizationID(organizationID),
+				)
+			} else if organizationSlug != "" {
+				enabled, err = h.features.IsFlagEnabled(
+					ctx,
+					feature.FlagOTELLogCustomerRelay,
+					organizationID,
+					feature.OrgProjectGroups(organizationSlug, ""),
+				)
+				if err != nil {
+					enabled = false
+					logger.WarnContext(
+						ctx,
+						"evaluate customer log relay feature flag",
+						attr.SlogError(err),
+						attr.SlogOrganizationID(organizationID),
+					)
+				}
+			}
+			relayEnabledByOrganization[organizationID] = enabled
+		}
+		if !enabled {
+			continue
+		}
+
 		result, ok := destinations[provenanceGroup.key.organizationID]
 		if !ok {
 			result.destination, result.err = h.relay.destinationForOrganization(ctx, provenanceGroup.key.organizationID)

--- a/server/internal/otel/handler_log_relay_test.go
+++ b/server/internal/otel/handler_log_relay_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,6 +85,21 @@ func (p *logRelayTestFeatureProvider) snapshotCalls() []logRelayFeatureFlagCall 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return slices.Clone(p.calls)
+}
+
+func (p *logRelayTestFeatureProvider) setResult(distinctID string, result logRelayFeatureFlagResult) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.results == nil {
+		p.results = make(map[string]logRelayFeatureFlagResult)
+	}
+	p.results[distinctID] = result
+}
+
+type logRelayOrganizationSlugResolverFunc func(context.Context, string) (string, error)
+
+func (f logRelayOrganizationSlugResolverFunc) OrganizationSlug(ctx context.Context, organizationID string) (string, error) {
+	return f(ctx, organizationID)
 }
 
 type logRelayOrganizationSlugResult struct {
@@ -272,10 +288,21 @@ func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
 			distinctID: testLogOtherOrganizationID,
 			groups:     feature.OrgProjectGroups("error-org", ""),
 		},
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogOtherOrganizationID,
+			groups:     feature.OrgProjectGroups("error-org", ""),
+		},
 	}, flags.snapshotCalls())
 	require.Equal(
 		t,
-		[]string{testLogOrganizationID, testLogOtherOrganizationID, testLogThirdOrganizationID},
+		[]string{
+			testLogOrganizationID,
+			testLogOtherOrganizationID,
+			testLogThirdOrganizationID,
+			testLogOtherOrganizationID,
+			testLogThirdOrganizationID,
+		},
 		organizations.snapshotCalls(),
 	)
 }
@@ -308,6 +335,7 @@ func TestLogRelayOrganizationGateCoalescesConcurrentLookups(t *testing.T) {
 		organizations,
 		logRelayOrganizationGateMaxSize,
 		logRelayOrganizationGateCacheTTL,
+		logRelayOrganizationGateLookupTimeout,
 	)
 
 	const callers = 32
@@ -332,6 +360,133 @@ func TestLogRelayOrganizationGateCoalescesConcurrentLookups(t *testing.T) {
 	}
 	require.Equal(t, []string{testLogOrganizationID}, organizations.snapshotCalls())
 	require.Len(t, flags.snapshotCalls(), 1)
+}
+
+func TestLogRelayOrganizationGateCallerCancellationDoesNotCancelSharedLookup(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var organizationCalls atomic.Int64
+	organizations := logRelayOrganizationSlugResolverFunc(func(ctx context.Context, _ string) (string, error) {
+		if organizationCalls.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+			return "enabled-org", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	})
+	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID: {enabled: true, err: nil},
+		},
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	gate := newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		flags,
+		organizations,
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+		time.Second,
+	)
+
+	callerCtx, cancelCaller := context.WithCancel(t.Context())
+	firstResult := make(chan bool, 1)
+	go func() {
+		firstResult <- gate.Enabled(callerCtx, testLogOrganizationID)
+	}()
+	<-started
+	cancelCaller()
+	require.False(t, <-firstResult)
+
+	secondResult := make(chan bool, 1)
+	go func() {
+		secondResult <- gate.Enabled(t.Context(), testLogOrganizationID)
+	}()
+	close(release)
+	require.True(t, <-secondResult)
+	require.True(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	require.Equal(t, int64(1), organizationCalls.Load())
+	require.Len(t, flags.snapshotCalls(), 1)
+}
+
+func TestLogRelayOrganizationGateBoundsLookupAndDoesNotCacheTimeout(t *testing.T) {
+	t.Parallel()
+
+	finished := make(chan struct{})
+	var organizationCalls atomic.Int64
+	organizations := logRelayOrganizationSlugResolverFunc(func(ctx context.Context, _ string) (string, error) {
+		if organizationCalls.Add(1) == 1 {
+			<-ctx.Done()
+			close(finished)
+			return "", ctx.Err()
+		}
+		return "enabled-org", nil
+	})
+	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID: {enabled: true, err: nil},
+		},
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	gate := newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		flags,
+		organizations,
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+		50*time.Millisecond,
+	)
+
+	require.False(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	<-finished
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.True(collect, gate.Enabled(t.Context(), testLogOrganizationID))
+	}, time.Second, 5*time.Millisecond)
+	require.True(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	require.Equal(t, int64(2), organizationCalls.Load())
+	require.Len(t, flags.snapshotCalls(), 1)
+}
+
+func TestLogRelayOrganizationGateDoesNotCacheFeatureProviderError(t *testing.T) {
+	t.Parallel()
+
+	var organizationCalls atomic.Int64
+	organizations := logRelayOrganizationSlugResolverFunc(func(context.Context, string) (string, error) {
+		organizationCalls.Add(1)
+		return "enabled-org", nil
+	})
+	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID: {enabled: false, err: errors.New("evaluate flag")},
+		},
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	gate := newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		flags,
+		organizations,
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+		time.Second,
+	)
+
+	require.False(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	flags.setResult(testLogOrganizationID, logRelayFeatureFlagResult{enabled: true, err: nil})
+	require.True(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	require.True(t, gate.Enabled(t.Context(), testLogOrganizationID))
+	require.Equal(t, int64(2), organizationCalls.Load())
+	require.Len(t, flags.snapshotCalls(), 2)
 }
 
 func TestLogRelayOrganizationGateBoundsCachedOrganizations(t *testing.T) {
@@ -360,6 +515,7 @@ func TestLogRelayOrganizationGateBoundsCachedOrganizations(t *testing.T) {
 		organizations,
 		2,
 		time.Hour,
+		logRelayOrganizationGateLookupTimeout,
 	)
 
 	require.True(t, gate.Enabled(t.Context(), "organization-1"))
@@ -666,6 +822,7 @@ func newLogRelayTestHandlerWithFeatures(
 		organizations,
 		logRelayOrganizationGateMaxSize,
 		logRelayOrganizationGateCacheTTL,
+		logRelayOrganizationGateLookupTimeout,
 	)
 	return handler
 }

--- a/server/internal/otel/handler_log_relay_test.go
+++ b/server/internal/otel/handler_log_relay_test.go
@@ -1,6 +1,8 @@
 package otel
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +19,8 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
@@ -34,6 +38,60 @@ type capturedLogRelayRequest struct {
 type logRelayRequestCapture struct {
 	mu       sync.Mutex
 	requests []capturedLogRelayRequest
+}
+
+type logRelayFeatureFlagCall struct {
+	flag       feature.Flag
+	distinctID string
+	groups     map[string]string
+}
+
+type logRelayFeatureFlagResult struct {
+	enabled bool
+	err     error
+}
+
+type logRelayTestFeatureProvider struct {
+	results       map[string]logRelayFeatureFlagResult
+	defaultResult logRelayFeatureFlagResult
+	calls         []logRelayFeatureFlagCall
+}
+
+func (p *logRelayTestFeatureProvider) IsFlagEnabled(_ context.Context, flag feature.Flag, distinctID string, groups map[string]string) (bool, error) {
+	p.calls = append(p.calls, logRelayFeatureFlagCall{
+		flag:       flag,
+		distinctID: distinctID,
+		groups:     groups,
+	})
+	result, ok := p.results[distinctID]
+	if !ok {
+		result = p.defaultResult
+	}
+	return result.enabled, result.err
+}
+
+func (p *logRelayTestFeatureProvider) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+	return false, nil
+}
+
+func (p *logRelayTestFeatureProvider) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
+	return nil, nil
+}
+
+type logRelayOrganizationSlugResult struct {
+	slug string
+	err  error
+}
+
+type logRelayTestOrganizationSlugResolver struct {
+	results map[string]logRelayOrganizationSlugResult
+	calls   []string
+}
+
+func (r *logRelayTestOrganizationSlugResolver) OrganizationSlug(_ context.Context, organizationID string) (string, error) {
+	r.calls = append(r.calls, organizationID)
+	result := r.results[organizationID]
+	return result.slug, result.err
 }
 
 func (c *logRelayRequestCapture) handler(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +118,120 @@ func (c *logRelayRequestCapture) snapshot() []capturedLogRelayRequest {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return slices.Clone(c.requests)
+}
+
+func TestLogRelayHandlerGatesMixedBatchByOrganization(t *testing.T) {
+	t.Parallel()
+
+	capture := &logRelayRequestCapture{mu: sync.Mutex{}, requests: nil}
+	server := httptest.NewServer(http.HandlerFunc(capture.handler))
+	t.Cleanup(server.Close)
+	flags := &logRelayTestFeatureProvider{
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID:      {enabled: true, err: nil},
+			testLogOtherOrganizationID: {enabled: false, err: nil},
+		},
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	organizations := &logRelayTestOrganizationSlugResolver{
+		results: map[string]logRelayOrganizationSlugResult{
+			testLogOrganizationID:      {slug: "enabled-org", err: nil},
+			testLogOtherOrganizationID: {slug: "disabled-org", err: nil},
+		},
+		calls: nil,
+	}
+	handler := newLogRelayTestHandlerWithFeatures(t, testenv.NewMeterProvider(t), flags, organizations)
+	cacheLogRelayTestDestination(t, handler, testLogOrganizationID, server.URL, map[string]string{"X-Customer": "enabled"})
+	cacheLogRelayTestDestination(t, handler, testLogOtherOrganizationID, server.URL, map[string]string{"X-Customer": "disabled"})
+
+	messages, failures := logRelayTestMessages(
+		relayTestLogRecord("enabled-1", testLogOrganizationID, testLogProjectID, 0),
+		relayTestLogRecord("disabled", testLogOtherOrganizationID, testLogOtherProjectID, 0),
+		relayTestLogRecord("enabled-2", testLogOrganizationID, testLogOtherProjectID, 0),
+	)
+	require.NoError(t, handler.handleBatch(t.Context(), messages))
+	for _, failure := range failures {
+		require.NoError(t, failure)
+	}
+
+	requests := capture.snapshot()
+	require.Len(t, requests, 2)
+	for _, request := range requests {
+		require.Equal(t, "enabled", request.customer)
+	}
+	require.Equal(t, []logRelayFeatureFlagCall{
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogOrganizationID,
+			groups:     feature.OrgProjectGroups("enabled-org", ""),
+		},
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogOtherOrganizationID,
+			groups:     feature.OrgProjectGroups("disabled-org", ""),
+		},
+	}, flags.calls)
+	require.Equal(t, []string{testLogOrganizationID, testLogOtherOrganizationID}, organizations.calls)
+}
+
+func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
+	t.Parallel()
+
+	capture := &logRelayRequestCapture{mu: sync.Mutex{}, requests: nil}
+	server := httptest.NewServer(http.HandlerFunc(capture.handler))
+	t.Cleanup(server.Close)
+	flags := &logRelayTestFeatureProvider{
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID:      {enabled: true, err: nil},
+			testLogOtherOrganizationID: {enabled: false, err: errors.New("evaluate flag")},
+		},
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	organizations := &logRelayTestOrganizationSlugResolver{
+		results: map[string]logRelayOrganizationSlugResult{
+			testLogOrganizationID:      {slug: "enabled-org", err: nil},
+			testLogOtherOrganizationID: {slug: "error-org", err: nil},
+			testLogThirdOrganizationID: {slug: "missing-org", err: nil},
+		},
+		calls: nil,
+	}
+	handler := newLogRelayTestHandlerWithFeatures(t, testenv.NewMeterProvider(t), flags, organizations)
+	cacheLogRelayTestDestination(t, handler, testLogOrganizationID, server.URL, map[string]string{"X-Customer": "enabled"})
+	cacheLogRelayTestDestination(t, handler, testLogOtherOrganizationID, server.URL, map[string]string{"X-Customer": "error"})
+	cacheLogRelayTestDestination(t, handler, testLogThirdOrganizationID, server.URL, map[string]string{"X-Customer": "missing"})
+
+	messages, failures := logRelayTestMessages(
+		relayTestLogRecord("enabled", testLogOrganizationID, testLogProjectID, 0),
+		relayTestLogRecord("evaluation-error", testLogOtherOrganizationID, testLogOtherProjectID, 0),
+		relayTestLogRecord("missing-flag", testLogThirdOrganizationID, testLogThirdProjectID, 0),
+	)
+	require.NoError(t, handler.handleBatch(t.Context(), messages))
+	for _, failure := range failures {
+		require.NoError(t, failure)
+	}
+
+	requests := capture.snapshot()
+	require.Len(t, requests, 1)
+	require.Equal(t, "enabled", requests[0].customer)
+	require.Equal(t, []logRelayFeatureFlagCall{
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogOrganizationID,
+			groups:     feature.OrgProjectGroups("enabled-org", ""),
+		},
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogOtherOrganizationID,
+			groups:     feature.OrgProjectGroups("error-org", ""),
+		},
+		{
+			flag:       feature.FlagOTELLogCustomerRelay,
+			distinctID: testLogThirdOrganizationID,
+			groups:     feature.OrgProjectGroups("missing-org", ""),
+		},
+	}, flags.calls)
 }
 
 func TestLogRelayHandlerGroupsByProvenanceAndCachesDestinations(t *testing.T) {
@@ -309,15 +481,42 @@ func logRelayTestMessages(records ...*otelv1.LogRecord) ([]logRelayMessage, []er
 
 func newLogRelayTestHandler(t *testing.T, meterProvider metric.MeterProvider) *LogRelayHandler {
 	t.Helper()
+	features := &logRelayTestFeatureProvider{
+		results:       nil,
+		defaultResult: logRelayFeatureFlagResult{enabled: true, err: nil},
+		calls:         nil,
+	}
+	organizations := &logRelayTestOrganizationSlugResolver{
+		results: map[string]logRelayOrganizationSlugResult{
+			testLogOrganizationID:      {slug: "org-a", err: nil},
+			testLogOtherOrganizationID: {slug: "org-b", err: nil},
+			testLogThirdOrganizationID: {slug: "org-c", err: nil},
+		},
+		calls: nil,
+	}
+	return newLogRelayTestHandlerWithFeatures(t, meterProvider, features, organizations)
+}
+
+func newLogRelayTestHandlerWithFeatures(
+	t *testing.T,
+	meterProvider metric.MeterProvider,
+	features feature.Provider,
+	organizations logRelayOrganizationSlugResolver,
+) *LogRelayHandler {
+	t.Helper()
 	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
 	require.NoError(t, err)
-	return NewLogRelayHandler(
+	handler := NewLogRelayHandler(
 		testenv.NewLogger(t),
 		meterProvider,
 		nil,
 		testenv.NewEncryptionClient(t),
 		policy,
+		features,
+		cache.NoopCache,
 	)
+	handler.organizations = organizations
+	return handler
 }
 
 func cacheLogRelayTestDestination(

--- a/server/internal/otel/handler_log_relay_test.go
+++ b/server/internal/otel/handler_log_relay_test.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -52,12 +51,15 @@ type logRelayFeatureFlagResult struct {
 }
 
 type logRelayTestFeatureProvider struct {
+	mu            sync.Mutex
 	results       map[string]logRelayFeatureFlagResult
 	defaultResult logRelayFeatureFlagResult
 	calls         []logRelayFeatureFlagCall
 }
 
 func (p *logRelayTestFeatureProvider) IsFlagEnabled(_ context.Context, flag feature.Flag, distinctID string, groups map[string]string) (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.calls = append(p.calls, logRelayFeatureFlagCall{
 		flag:       flag,
 		distinctID: distinctID,
@@ -78,20 +80,43 @@ func (p *logRelayTestFeatureProvider) FlagPayload(context.Context, feature.Flag,
 	return nil, nil
 }
 
+func (p *logRelayTestFeatureProvider) snapshotCalls() []logRelayFeatureFlagCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.calls)
+}
+
 type logRelayOrganizationSlugResult struct {
 	slug string
 	err  error
 }
 
 type logRelayTestOrganizationSlugResolver struct {
+	mu      sync.Mutex
 	results map[string]logRelayOrganizationSlugResult
 	calls   []string
+	started chan<- struct{}
+	release <-chan struct{}
 }
 
 func (r *logRelayTestOrganizationSlugResolver) OrganizationSlug(_ context.Context, organizationID string) (string, error) {
+	r.mu.Lock()
 	r.calls = append(r.calls, organizationID)
 	result := r.results[organizationID]
+	r.mu.Unlock()
+	if r.started != nil {
+		r.started <- struct{}{}
+	}
+	if r.release != nil {
+		<-r.release
+	}
 	return result.slug, result.err
+}
+
+func (r *logRelayTestOrganizationSlugResolver) snapshotCalls() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.calls)
 }
 
 func (c *logRelayRequestCapture) handler(w http.ResponseWriter, r *http.Request) {
@@ -127,6 +152,7 @@ func TestLogRelayHandlerGatesMixedBatchByOrganization(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(capture.handler))
 	t.Cleanup(server.Close)
 	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
 		results: map[string]logRelayFeatureFlagResult{
 			testLogOrganizationID:      {enabled: true, err: nil},
 			testLogOtherOrganizationID: {enabled: false, err: nil},
@@ -135,11 +161,14 @@ func TestLogRelayHandlerGatesMixedBatchByOrganization(t *testing.T) {
 		calls:         nil,
 	}
 	organizations := &logRelayTestOrganizationSlugResolver{
+		mu: sync.Mutex{},
 		results: map[string]logRelayOrganizationSlugResult{
 			testLogOrganizationID:      {slug: "enabled-org", err: nil},
 			testLogOtherOrganizationID: {slug: "disabled-org", err: nil},
 		},
-		calls: nil,
+		calls:   nil,
+		started: nil,
+		release: nil,
 	}
 	handler := newLogRelayTestHandlerWithFeatures(t, testenv.NewMeterProvider(t), flags, organizations)
 	cacheLogRelayTestDestination(t, handler, testLogOrganizationID, server.URL, map[string]string{"X-Customer": "enabled"})
@@ -154,9 +183,14 @@ func TestLogRelayHandlerGatesMixedBatchByOrganization(t *testing.T) {
 	for _, failure := range failures {
 		require.NoError(t, failure)
 	}
+	messages, failures = logRelayTestMessages(
+		relayTestLogRecord("enabled-next-batch", testLogOrganizationID, testLogProjectID, 0),
+	)
+	require.NoError(t, handler.handleBatch(t.Context(), messages))
+	require.NoError(t, failures[0])
 
 	requests := capture.snapshot()
-	require.Len(t, requests, 2)
+	require.Len(t, requests, 3)
 	for _, request := range requests {
 		require.Equal(t, "enabled", request.customer)
 	}
@@ -171,8 +205,8 @@ func TestLogRelayHandlerGatesMixedBatchByOrganization(t *testing.T) {
 			distinctID: testLogOtherOrganizationID,
 			groups:     feature.OrgProjectGroups("disabled-org", ""),
 		},
-	}, flags.calls)
-	require.Equal(t, []string{testLogOrganizationID, testLogOtherOrganizationID}, organizations.calls)
+	}, flags.snapshotCalls())
+	require.Equal(t, []string{testLogOrganizationID, testLogOtherOrganizationID}, organizations.snapshotCalls())
 }
 
 func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
@@ -182,6 +216,7 @@ func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(capture.handler))
 	t.Cleanup(server.Close)
 	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
 		results: map[string]logRelayFeatureFlagResult{
 			testLogOrganizationID:      {enabled: true, err: nil},
 			testLogOtherOrganizationID: {enabled: false, err: errors.New("evaluate flag")},
@@ -190,12 +225,15 @@ func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
 		calls:         nil,
 	}
 	organizations := &logRelayTestOrganizationSlugResolver{
+		mu: sync.Mutex{},
 		results: map[string]logRelayOrganizationSlugResult{
 			testLogOrganizationID:      {slug: "enabled-org", err: nil},
 			testLogOtherOrganizationID: {slug: "error-org", err: nil},
-			testLogThirdOrganizationID: {slug: "missing-org", err: nil},
+			testLogThirdOrganizationID: {slug: "", err: errors.New("resolve organization")},
 		},
-		calls: nil,
+		calls:   nil,
+		started: nil,
+		release: nil,
 	}
 	handler := newLogRelayTestHandlerWithFeatures(t, testenv.NewMeterProvider(t), flags, organizations)
 	cacheLogRelayTestDestination(t, handler, testLogOrganizationID, server.URL, map[string]string{"X-Customer": "enabled"})
@@ -206,6 +244,14 @@ func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
 		relayTestLogRecord("enabled", testLogOrganizationID, testLogProjectID, 0),
 		relayTestLogRecord("evaluation-error", testLogOtherOrganizationID, testLogOtherProjectID, 0),
 		relayTestLogRecord("missing-flag", testLogThirdOrganizationID, testLogThirdProjectID, 0),
+	)
+	require.NoError(t, handler.handleBatch(t.Context(), messages))
+	for _, failure := range failures {
+		require.NoError(t, failure)
+	}
+	messages, failures = logRelayTestMessages(
+		relayTestLogRecord("evaluation-error-next-batch", testLogOtherOrganizationID, testLogOtherProjectID, 0),
+		relayTestLogRecord("organization-error-next-batch", testLogThirdOrganizationID, testLogThirdProjectID, 0),
 	)
 	require.NoError(t, handler.handleBatch(t.Context(), messages))
 	for _, failure := range failures {
@@ -226,12 +272,108 @@ func TestLogRelayHandlerIsolatesFlagEvaluationFailureWithinBatch(t *testing.T) {
 			distinctID: testLogOtherOrganizationID,
 			groups:     feature.OrgProjectGroups("error-org", ""),
 		},
-		{
-			flag:       feature.FlagOTELLogCustomerRelay,
-			distinctID: testLogThirdOrganizationID,
-			groups:     feature.OrgProjectGroups("missing-org", ""),
+	}, flags.snapshotCalls())
+	require.Equal(
+		t,
+		[]string{testLogOrganizationID, testLogOtherOrganizationID, testLogThirdOrganizationID},
+		organizations.snapshotCalls(),
+	)
+}
+
+func TestLogRelayOrganizationGateCoalescesConcurrentLookups(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	flags := &logRelayTestFeatureProvider{
+		mu: sync.Mutex{},
+		results: map[string]logRelayFeatureFlagResult{
+			testLogOrganizationID: {enabled: true, err: nil},
 		},
-	}, flags.calls)
+		defaultResult: logRelayFeatureFlagResult{enabled: false, err: nil},
+		calls:         nil,
+	}
+	organizations := &logRelayTestOrganizationSlugResolver{
+		mu: sync.Mutex{},
+		results: map[string]logRelayOrganizationSlugResult{
+			testLogOrganizationID: {slug: "enabled-org", err: nil},
+		},
+		calls:   nil,
+		started: started,
+		release: release,
+	}
+	gate := newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		flags,
+		organizations,
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+	)
+
+	const callers = 32
+	begin := make(chan struct{})
+	results := make(chan bool, callers)
+	var ready sync.WaitGroup
+	ready.Add(callers)
+	for range callers {
+		go func() {
+			ready.Done()
+			<-begin
+			results <- gate.Enabled(t.Context(), testLogOrganizationID)
+		}()
+	}
+	ready.Wait()
+	close(begin)
+	<-started
+	close(release)
+
+	for range callers {
+		require.True(t, <-results)
+	}
+	require.Equal(t, []string{testLogOrganizationID}, organizations.snapshotCalls())
+	require.Len(t, flags.snapshotCalls(), 1)
+}
+
+func TestLogRelayOrganizationGateBoundsCachedOrganizations(t *testing.T) {
+	t.Parallel()
+
+	flags := &logRelayTestFeatureProvider{
+		mu:            sync.Mutex{},
+		results:       nil,
+		defaultResult: logRelayFeatureFlagResult{enabled: true, err: nil},
+		calls:         nil,
+	}
+	organizations := &logRelayTestOrganizationSlugResolver{
+		mu: sync.Mutex{},
+		results: map[string]logRelayOrganizationSlugResult{
+			"organization-1": {slug: "org-1", err: nil},
+			"organization-2": {slug: "org-2", err: nil},
+			"organization-3": {slug: "org-3", err: nil},
+		},
+		calls:   nil,
+		started: nil,
+		release: nil,
+	}
+	gate := newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		flags,
+		organizations,
+		2,
+		time.Hour,
+	)
+
+	require.True(t, gate.Enabled(t.Context(), "organization-1"))
+	require.True(t, gate.Enabled(t.Context(), "organization-2"))
+	require.True(t, gate.Enabled(t.Context(), "organization-3"))
+	require.True(t, gate.Enabled(t.Context(), "organization-1"))
+
+	require.Equal(
+		t,
+		[]string{"organization-1", "organization-2", "organization-3", "organization-1"},
+		organizations.snapshotCalls(),
+	)
+	require.Len(t, flags.snapshotCalls(), 4)
+	require.Equal(t, 2, gate.enabled.Len())
 }
 
 func TestLogRelayHandlerGroupsByProvenanceAndCachesDestinations(t *testing.T) {
@@ -482,17 +624,21 @@ func logRelayTestMessages(records ...*otelv1.LogRecord) ([]logRelayMessage, []er
 func newLogRelayTestHandler(t *testing.T, meterProvider metric.MeterProvider) *LogRelayHandler {
 	t.Helper()
 	features := &logRelayTestFeatureProvider{
+		mu:            sync.Mutex{},
 		results:       nil,
 		defaultResult: logRelayFeatureFlagResult{enabled: true, err: nil},
 		calls:         nil,
 	}
 	organizations := &logRelayTestOrganizationSlugResolver{
+		mu: sync.Mutex{},
 		results: map[string]logRelayOrganizationSlugResult{
 			testLogOrganizationID:      {slug: "org-a", err: nil},
 			testLogOtherOrganizationID: {slug: "org-b", err: nil},
 			testLogThirdOrganizationID: {slug: "org-c", err: nil},
 		},
-		calls: nil,
+		calls:   nil,
+		started: nil,
+		release: nil,
 	}
 	return newLogRelayTestHandlerWithFeatures(t, meterProvider, features, organizations)
 }
@@ -513,9 +659,14 @@ func newLogRelayTestHandlerWithFeatures(
 		testenv.NewEncryptionClient(t),
 		policy,
 		features,
-		cache.NoopCache,
 	)
-	handler.organizations = organizations
+	handler.organizationGate = newCachedLogRelayOrganizationGate(
+		testenv.NewLogger(t),
+		features,
+		organizations,
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+	)
 	return handler
 }
 

--- a/server/internal/otel/log_relay_organization.go
+++ b/server/internal/otel/log_relay_organization.go
@@ -7,43 +7,140 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/singleflight"
 
-	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/database"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 )
 
 const (
-	logRelayOrganizationSlugCacheTTL = 5 * time.Minute
-	logRelayOrganizationSlugTimeout  = time.Second
+	// A short TTL limits rollout and recovery staleness while still removing
+	// database and PostHog lookups from the per-batch hot path.
+	logRelayOrganizationGateCacheTTL = 30 * time.Second
+
+	// The subscriber sees logs from every organization, so cap the long tail of
+	// inactive organizations without evicting the normal working set.
+	logRelayOrganizationGateMaxSize = 4096
 )
 
 type logRelayOrganizationSlugResolver interface {
 	OrganizationSlug(ctx context.Context, organizationID string) (string, error)
 }
 
-type postgresLogRelayOrganizationSlugResolver struct {
-	db    database.DBTX
-	cache cache.TypedCacheObject[cachedLogRelayOrganizationSlug]
-	loads singleflight.Group
+type logRelayOrganizationGate interface {
+	Enabled(ctx context.Context, organizationID string) bool
 }
 
-func newPostgresLogRelayOrganizationSlugResolver(
+type cachedLogRelayOrganizationGate struct {
+	logger        *slog.Logger
+	features      feature.Provider
+	organizations logRelayOrganizationSlugResolver
+	enabled       *expirable.LRU[string, bool]
+	loads         singleflight.Group
+}
+
+func newLogRelayOrganizationGate(
 	logger *slog.Logger,
 	db database.DBTX,
-	cacheImpl cache.Cache,
-) *postgresLogRelayOrganizationSlugResolver {
-	return &postgresLogRelayOrganizationSlugResolver{
-		db: db,
-		cache: cache.NewTypedObjectCache[cachedLogRelayOrganizationSlug](
-			logger,
-			cacheImpl,
-			cache.SuffixNone,
-		),
-		loads: singleflight.Group{},
+	features feature.Provider,
+) *cachedLogRelayOrganizationGate {
+	return newCachedLogRelayOrganizationGate(
+		logger,
+		features,
+		&postgresLogRelayOrganizationSlugResolver{db: db},
+		logRelayOrganizationGateMaxSize,
+		logRelayOrganizationGateCacheTTL,
+	)
+}
+
+func newCachedLogRelayOrganizationGate(
+	logger *slog.Logger,
+	features feature.Provider,
+	organizations logRelayOrganizationSlugResolver,
+	maxSize int,
+	ttl time.Duration,
+) *cachedLogRelayOrganizationGate {
+	return &cachedLogRelayOrganizationGate{
+		logger:        logger,
+		features:      features,
+		organizations: organizations,
+		enabled:       expirable.NewLRU[string, bool](maxSize, nil, ttl),
+		loads:         singleflight.Group{},
 	}
+}
+
+func (g *cachedLogRelayOrganizationGate) Enabled(ctx context.Context, organizationID string) bool {
+	if organizationID == "" {
+		return false
+	}
+	if enabled, ok := g.enabled.Get(organizationID); ok {
+		return enabled
+	}
+
+	value, _, _ := g.loads.Do(organizationID, func() (any, error) {
+		if enabled, ok := g.enabled.Get(organizationID); ok {
+			return enabled, nil
+		}
+
+		// Cache unavailable evaluations as disabled. This both fails closed and
+		// prevents an upstream outage from causing a lookup for every batch;
+		// the short TTL bounds recovery delay.
+		enabled := g.evaluate(ctx, organizationID)
+		g.enabled.Add(organizationID, enabled)
+		return enabled, nil
+	})
+	enabled, ok := value.(bool)
+	if !ok {
+		g.logger.WarnContext(
+			ctx,
+			"read cached customer log relay feature flag",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogError(fmt.Errorf("unexpected result type %T", value)),
+		)
+		return false
+	}
+	return enabled
+}
+
+func (g *cachedLogRelayOrganizationGate) evaluate(ctx context.Context, organizationID string) bool {
+	organizationSlug, err := g.organizations.OrganizationSlug(ctx, organizationID)
+	if err != nil {
+		g.logger.WarnContext(
+			ctx,
+			"resolve organization for customer log relay feature flag",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+		return false
+	}
+	if organizationSlug == "" {
+		return false
+	}
+
+	enabled, err := g.features.IsFlagEnabled(
+		ctx,
+		feature.FlagOTELLogCustomerRelay,
+		organizationID,
+		feature.OrgProjectGroups(organizationSlug, ""),
+	)
+	if err != nil {
+		g.logger.WarnContext(
+			ctx,
+			"evaluate customer log relay feature flag",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+		return false
+	}
+	return enabled
+}
+
+type postgresLogRelayOrganizationSlugResolver struct {
+	db database.DBTX
 }
 
 func (r *postgresLogRelayOrganizationSlugResolver) OrganizationSlug(
@@ -54,71 +151,12 @@ func (r *postgresLogRelayOrganizationSlugResolver) OrganizationSlug(
 		return "", nil
 	}
 
-	lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), logRelayOrganizationSlugTimeout)
-	defer cancel()
-
-	cacheKey := logRelayOrganizationSlugCacheKey(organizationID)
-	if cached, err := r.cache.Get(lookupCtx, cacheKey); err == nil {
-		return cached.Slug, nil
+	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
 	}
-
-	results := r.loads.DoChan(cacheKey, func() (any, error) {
-		if cached, err := r.cache.Get(lookupCtx, cacheKey); err == nil {
-			return cached.Slug, nil
-		}
-
-		slug := ""
-		organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(lookupCtx, organizationID)
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-		case err != nil:
-			return "", fmt.Errorf("get organization metadata: %w", err)
-		default:
-			slug = organization.Slug
-		}
-
-		if err := r.cache.Store(lookupCtx, cachedLogRelayOrganizationSlug{
-			OrganizationID: organizationID,
-			Slug:           slug,
-		}); err != nil {
-			return "", fmt.Errorf("cache organization slug: %w", err)
-		}
-		return slug, nil
-	})
-
-	var result singleflight.Result
-	select {
-	case result = <-results:
-	case <-lookupCtx.Done():
-		select {
-		case result = <-results:
-		default:
-			return "", fmt.Errorf("resolve organization slug: %w", lookupCtx.Err())
-		}
+	if err != nil {
+		return "", fmt.Errorf("get organization metadata: %w", err)
 	}
-
-	slug, ok := result.Val.(string)
-	if !ok {
-		return "", fmt.Errorf("resolve organization slug: unexpected result type %T", result.Val)
-	}
-	return slug, result.Err
-}
-
-type cachedLogRelayOrganizationSlug struct {
-	OrganizationID string `json:"organization_id"`
-	Slug           string `json:"slug"`
-}
-
-var _ cache.CacheableObject[cachedLogRelayOrganizationSlug] = (*cachedLogRelayOrganizationSlug)(nil)
-
-func (c cachedLogRelayOrganizationSlug) CacheKey() string {
-	return logRelayOrganizationSlugCacheKey(c.OrganizationID)
-}
-
-func (cachedLogRelayOrganizationSlug) TTL() time.Duration {
-	return logRelayOrganizationSlugCacheTTL
-}
-
-func logRelayOrganizationSlugCacheKey(organizationID string) string {
-	return "otelLogRelayOrganizationSlug:v1:" + organizationID
+	return organization.Slug, nil
 }

--- a/server/internal/otel/log_relay_organization.go
+++ b/server/internal/otel/log_relay_organization.go
@@ -25,6 +25,9 @@ const (
 	// The subscriber sees logs from every organization, so cap the long tail of
 	// inactive organizations without evicting the normal working set.
 	logRelayOrganizationGateMaxSize = 4096
+
+	// Keep both shared cache fills and individual callers bounded independently.
+	logRelayOrganizationGateLookupTimeout = time.Second
 )
 
 type logRelayOrganizationSlugResolver interface {
@@ -41,6 +44,7 @@ type cachedLogRelayOrganizationGate struct {
 	organizations logRelayOrganizationSlugResolver
 	enabled       *expirable.LRU[string, bool]
 	loads         singleflight.Group
+	lookupTimeout time.Duration
 }
 
 func newLogRelayOrganizationGate(
@@ -54,6 +58,7 @@ func newLogRelayOrganizationGate(
 		&postgresLogRelayOrganizationSlugResolver{db: db},
 		logRelayOrganizationGateMaxSize,
 		logRelayOrganizationGateCacheTTL,
+		logRelayOrganizationGateLookupTimeout,
 	)
 }
 
@@ -63,6 +68,7 @@ func newCachedLogRelayOrganizationGate(
 	organizations logRelayOrganizationSlugResolver,
 	maxSize int,
 	ttl time.Duration,
+	lookupTimeout time.Duration,
 ) *cachedLogRelayOrganizationGate {
 	return &cachedLogRelayOrganizationGate{
 		logger:        logger,
@@ -70,6 +76,7 @@ func newCachedLogRelayOrganizationGate(
 		organizations: organizations,
 		enabled:       expirable.NewLRU[string, bool](maxSize, nil, ttl),
 		loads:         singleflight.Group{},
+		lookupTimeout: lookupTimeout,
 	}
 }
 
@@ -81,32 +88,49 @@ func (g *cachedLogRelayOrganizationGate) Enabled(ctx context.Context, organizati
 		return enabled
 	}
 
-	value, _, _ := g.loads.Do(organizationID, func() (any, error) {
+	results := g.loads.DoChan(organizationID, func() (any, error) {
 		if enabled, ok := g.enabled.Get(organizationID); ok {
 			return enabled, nil
 		}
 
-		// Cache unavailable evaluations as disabled. This both fails closed and
-		// prevents an upstream outage from causing a lookup for every batch;
-		// the short TTL bounds recovery delay.
-		enabled := g.evaluate(ctx, organizationID)
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), g.lookupTimeout)
+		defer cancel()
+
+		enabled, err := g.evaluate(lookupCtx, organizationID)
+		if err != nil {
+			return false, err
+		}
 		g.enabled.Add(organizationID, enabled)
 		return enabled, nil
 	})
-	enabled, ok := value.(bool)
+
+	waitCtx, cancel := context.WithTimeout(ctx, g.lookupTimeout)
+	defer cancel()
+
+	var result singleflight.Result
+	select {
+	case result = <-results:
+	case <-waitCtx.Done():
+		return false
+	}
+	if result.Err != nil {
+		return false
+	}
+
+	enabled, ok := result.Val.(bool)
 	if !ok {
 		g.logger.WarnContext(
 			ctx,
-			"read cached customer log relay feature flag",
+			"resolve customer log relay feature flag",
 			attr.SlogOrganizationID(organizationID),
-			attr.SlogError(fmt.Errorf("unexpected result type %T", value)),
+			attr.SlogError(fmt.Errorf("unexpected result type %T", result.Val)),
 		)
 		return false
 	}
 	return enabled
 }
 
-func (g *cachedLogRelayOrganizationGate) evaluate(ctx context.Context, organizationID string) bool {
+func (g *cachedLogRelayOrganizationGate) evaluate(ctx context.Context, organizationID string) (bool, error) {
 	organizationSlug, err := g.organizations.OrganizationSlug(ctx, organizationID)
 	if err != nil {
 		g.logger.WarnContext(
@@ -115,10 +139,10 @@ func (g *cachedLogRelayOrganizationGate) evaluate(ctx context.Context, organizat
 			attr.SlogError(err),
 			attr.SlogOrganizationID(organizationID),
 		)
-		return false
+		return false, fmt.Errorf("resolve organization slug: %w", err)
 	}
 	if organizationSlug == "" {
-		return false
+		return false, nil
 	}
 
 	enabled, err := g.features.IsFlagEnabled(
@@ -134,9 +158,9 @@ func (g *cachedLogRelayOrganizationGate) evaluate(ctx context.Context, organizat
 			attr.SlogError(err),
 			attr.SlogOrganizationID(organizationID),
 		)
-		return false
+		return false, fmt.Errorf("evaluate feature flag: %w", err)
 	}
-	return enabled
+	return enabled, nil
 }
 
 type postgresLogRelayOrganizationSlugResolver struct {

--- a/server/internal/otel/log_relay_organization.go
+++ b/server/internal/otel/log_relay_organization.go
@@ -1,0 +1,124 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/database"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+const (
+	logRelayOrganizationSlugCacheTTL = 5 * time.Minute
+	logRelayOrganizationSlugTimeout  = time.Second
+)
+
+type logRelayOrganizationSlugResolver interface {
+	OrganizationSlug(ctx context.Context, organizationID string) (string, error)
+}
+
+type postgresLogRelayOrganizationSlugResolver struct {
+	db    database.DBTX
+	cache cache.TypedCacheObject[cachedLogRelayOrganizationSlug]
+	loads singleflight.Group
+}
+
+func newPostgresLogRelayOrganizationSlugResolver(
+	logger *slog.Logger,
+	db database.DBTX,
+	cacheImpl cache.Cache,
+) *postgresLogRelayOrganizationSlugResolver {
+	return &postgresLogRelayOrganizationSlugResolver{
+		db: db,
+		cache: cache.NewTypedObjectCache[cachedLogRelayOrganizationSlug](
+			logger,
+			cacheImpl,
+			cache.SuffixNone,
+		),
+		loads: singleflight.Group{},
+	}
+}
+
+func (r *postgresLogRelayOrganizationSlugResolver) OrganizationSlug(
+	ctx context.Context,
+	organizationID string,
+) (string, error) {
+	if organizationID == "" {
+		return "", nil
+	}
+
+	lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), logRelayOrganizationSlugTimeout)
+	defer cancel()
+
+	cacheKey := logRelayOrganizationSlugCacheKey(organizationID)
+	if cached, err := r.cache.Get(lookupCtx, cacheKey); err == nil {
+		return cached.Slug, nil
+	}
+
+	results := r.loads.DoChan(cacheKey, func() (any, error) {
+		if cached, err := r.cache.Get(lookupCtx, cacheKey); err == nil {
+			return cached.Slug, nil
+		}
+
+		slug := ""
+		organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(lookupCtx, organizationID)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return "", fmt.Errorf("get organization metadata: %w", err)
+		default:
+			slug = organization.Slug
+		}
+
+		if err := r.cache.Store(lookupCtx, cachedLogRelayOrganizationSlug{
+			OrganizationID: organizationID,
+			Slug:           slug,
+		}); err != nil {
+			return "", fmt.Errorf("cache organization slug: %w", err)
+		}
+		return slug, nil
+	})
+
+	var result singleflight.Result
+	select {
+	case result = <-results:
+	case <-lookupCtx.Done():
+		select {
+		case result = <-results:
+		default:
+			return "", fmt.Errorf("resolve organization slug: %w", lookupCtx.Err())
+		}
+	}
+
+	slug, ok := result.Val.(string)
+	if !ok {
+		return "", fmt.Errorf("resolve organization slug: unexpected result type %T", result.Val)
+	}
+	return slug, result.Err
+}
+
+type cachedLogRelayOrganizationSlug struct {
+	OrganizationID string `json:"organization_id"`
+	Slug           string `json:"slug"`
+}
+
+var _ cache.CacheableObject[cachedLogRelayOrganizationSlug] = (*cachedLogRelayOrganizationSlug)(nil)
+
+func (c cachedLogRelayOrganizationSlug) CacheKey() string {
+	return logRelayOrganizationSlugCacheKey(c.OrganizationID)
+}
+
+func (cachedLogRelayOrganizationSlug) TTL() time.Duration {
+	return logRelayOrganizationSlugCacheTTL
+}
+
+func logRelayOrganizationSlugCacheKey(organizationID string) string {
+	return "otelLogRelayOrganizationSlug:v1:" + organizationID
+}


### PR DESCRIPTION
## Summary
- gate normalized OTEL log delivery with an organization-targeted PostHog flag
- cache organization slug resolution and isolate enabled organizations within mixed relay batches
- acknowledge disabled or unavailable evaluations without customer delivery or retry

## Motivation
Hooks OTEL logs now also traverse the normalized relay pipeline while the legacy middleware remains active. An organization-scoped gate prevents duplicate customer delivery and supports a controlled cutover to the new relay.

Made with [Cursor](https://cursor.com)