### PR TITLE
mig: drop the MCP server authorization exclusivity check

### DIFF
--- a/.changeset/drop-mcp-server-authorization-exclusivity.md
+++ b/.changeset/drop-mcp-server-authorization-exclusivity.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Allow an MCP server to record both its Gram-issued user session issuer and the authorization server its upstream authenticates against.

--- a/.changeset/drop-mcp-server-authorization-exclusivity.md
+++ b/.changeset/drop-mcp-server-authorization-exclusivity.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Allow an MCP server to record both its Gram-issued user session issuer and the authorization server its upstream authenticates against.
+Allow an MCP server to record both its Gram-issued user session issuer and the authorization server its upstream authenticates against, and index MCP servers by user session issuer so recomputing that record does not scan the table.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4457,8 +4457,9 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
 
   environment_id uuid,
   user_session_issuer_id uuid,
-  -- Direct upstream authorization: the client authorizes at the upstream and
-  -- its bearer is forwarded verbatim, so Gram is not the authorization server.
+  -- The authorization server the upstream authenticates against. Coexists with
+  -- user_session_issuer_id: Gram fronting an upstream does not change which AS
+  -- issued the upstream's credential.
   -- The FK cannot qualify tenancy; writers must use the tenant-scoped lookup.
   remote_session_issuer_id uuid,
   remote_mcp_server_id uuid,
@@ -4487,9 +4488,7 @@ CREATE TABLE IF NOT EXISTS mcp_servers (
   CONSTRAINT mcp_servers_tool_variations_group_id_fkey FOREIGN KEY (tool_variations_group_id) REFERENCES tool_variations_groups (id) ON DELETE SET NULL,
   CONSTRAINT mcp_servers_remote_session_issuer_id_fkey FOREIGN KEY (remote_session_issuer_id) REFERENCES remote_session_issuers (id) ON DELETE SET NULL,
   -- Exactly one backend must be set.
-  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, unproxied_mcp_server_id) = 1),
-  -- Gram-as-AS and direct upstream authorization are alternatives, never both.
-  CONSTRAINT mcp_servers_authorization_exclusivity_check CHECK (num_nonnulls(user_session_issuer_id, remote_session_issuer_id) <= 1)
+  CONSTRAINT mcp_servers_backend_exclusivity_check CHECK (num_nonnulls(remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, unproxied_mcp_server_id) = 1)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_servers_project_id_idx

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4503,6 +4503,14 @@ CREATE UNIQUE INDEX IF NOT EXISTS mcp_servers_project_id_id_key
 ON mcp_servers (project_id, id);
 
 
+-- Drives the resync that recomputes remote_session_issuer_id from a set of user
+-- session issuers. That statement runs inside every client create, attach,
+-- detach and delete, so without this it sequential-scans mcp_servers while
+-- holding write locks.
+CREATE INDEX IF NOT EXISTS mcp_servers_user_session_issuer_id_idx
+ON mcp_servers (user_session_issuer_id)
+WHERE user_session_issuer_id IS NOT NULL;
+
 CREATE INDEX IF NOT EXISTS mcp_servers_remote_mcp_server_id_idx
 ON mcp_servers (remote_mcp_server_id)
 WHERE remote_mcp_server_id IS NOT NULL;

--- a/server/migrations/20260826163849_drop-mcp-server-authorization-exclusivity.sql
+++ b/server/migrations/20260826163849_drop-mcp-server-authorization-exclusivity.sql
@@ -1,0 +1,2 @@
+-- Modify "mcp_servers" table
+ALTER TABLE "mcp_servers" DROP CONSTRAINT "mcp_servers_authorization_exclusivity_check";

--- a/server/migrations/20260826174212_add-mcp-servers-user-session-issuer-index.sql
+++ b/server/migrations/20260826174212_add-mcp-servers-user-session-issuer-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "mcp_servers_user_session_issuer_id_idx" to table: "mcp_servers"
+CREATE INDEX CONCURRENTLY "mcp_servers_user_session_issuer_id_idx" ON "mcp_servers" ("user_session_issuer_id") WHERE (user_session_issuer_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4ajo+XGHCwmaLM4VAkA5janya1PWNnuTBqarIm7Xla0=
+h1:Rh/Dt+t8gN5QAS6K9gr2E5peuTgz/T7qicGajdNA1Sg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -367,3 +367,4 @@ h1:4ajo+XGHCwmaLM4VAkA5janya1PWNnuTBqarIm7Xla0=
 20260825202304_add-mcp-server-remote-session-issuer.sql h1:mGS8dAfAZECcILMlipui+QDySif0d0s+KAgEmp3CZQE=
 20260825204553_expand-user-session-issuers-org-tier.sql h1:kJ01dQVvnahFE3UaA2zZx+58ij7KzCuBHYkozcHCCqQ=
 20260825221933_gcp-iam-credentials-add-skip-project-verification.sql h1:DZOWCldTGLdSq4DlHGhu2wnFhLiqVffCgOKC8LoGzkE=
+20260826163849_drop-mcp-server-authorization-exclusivity.sql h1:kTyvUQ+UXxaRY6PirpiwKX23Uq1VvLn5j5LxOHUXu3g=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Rh/Dt+t8gN5QAS6K9gr2E5peuTgz/T7qicGajdNA1Sg=
+h1:aI7RQxqZLKGE6m9dNCGeMozWy5tE4uNZyMHZgM/Fj7Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -368,3 +368,4 @@ h1:Rh/Dt+t8gN5QAS6K9gr2E5peuTgz/T7qicGajdNA1Sg=
 20260825204553_expand-user-session-issuers-org-tier.sql h1:kJ01dQVvnahFE3UaA2zZx+58ij7KzCuBHYkozcHCCqQ=
 20260825221933_gcp-iam-credentials-add-skip-project-verification.sql h1:DZOWCldTGLdSq4DlHGhu2wnFhLiqVffCgOKC8LoGzkE=
 20260826163849_drop-mcp-server-authorization-exclusivity.sql h1:kTyvUQ+UXxaRY6PirpiwKX23Uq1VvLn5j5LxOHUXu3g=
+20260826174212_add-mcp-servers-user-session-issuer-index.sql h1:bV8x2GJNJerKXp7s1VyyO0GBQygI7ZPXwSdDbhrIftE=


### PR DESCRIPTION
AIM-87

## Summary

Drops `mcp_servers_authorization_exclusivity_check`. Migration only.

## Motivation

The check was added in #5710 and reads `num_nonnulls(user_session_issuer_id, remote_session_issuer_id) <= 1`, on the premise that a server serves either Gram-as-authorization-server or direct upstream authorization, never both.

That premise does not survive contact with server creation. `CreateMCPServerInTransaction` mints a user session issuer unconditionally for every remote- and tunneled-backed server (`mcpservers/transaction.go:52-58`), so those rows always hold a `user_session_issuer_id` — and the check therefore makes `remote_session_issuer_id` unsettable on exactly the servers that would use it. The column has been unpopulated since it landed, and nothing in the MCP runtime path reads it.

The two ids are not alternatives. `user_session_issuer_id` is the issuer Gram mints for its own endpoint; `remote_session_issuer_id` names the authorization server the upstream authenticates against. Gram fronting an upstream does not change who issued the upstream's credential, so a proxied server legitimately has both. The column comment is updated to say so.

Changing the creation path so it stops minting an issuer was the alternative, and it is the larger and riskier change — it touches every proxied server's authorization configuration. Dropping the check is the smaller move and leaves that question open.

## What this unblocks

Gateway endpoints need to know which member a connecting client's credential belongs to, so a tool call forwards the right token to the right upstream. With this column populated, that is a join:

```sql
... WHERE m.meta_mcp_server_id = @meta_mcp_server_id
      AND s.remote_session_issuer_id = @client_remote_session_issuer_id
```

The alternative, probing each member's RFC 9728 protected-resource metadata at consent time, was implemented in #5724 and is being withdrawn: that metadata is optional so coverage is never guaranteed, the advertised authorization server can change without our knowledge, and a mismatch surfaces as a token-routing error rather than a configuration one.

Follow-ups, each its own PR: write and keep `mcp_servers.remote_session_issuer_id` in sync, backfill existing rows, then the gateway routing lookup.

## Risk

Dropping a `CHECK` is a catalog update — no table scan, no rewrite. It only widens what is representable, and no code writes the column today, so no currently reachable state changes.

Separately, the check has one live effect worth noting as it disappears: `mcp_servers_user_session_issuer_id_fkey` is `ON DELETE SET NULL`, and until now the check aborted that SET NULL for a row that also named a remote session issuer. Since no row does, nothing changes in practice. The guard that matters — the missing in-use check on `DeleteRemoteSessionIssuer` — is tracked with the other follow-ups and is unreachable while every issuer delete is a soft delete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `mcp_servers_authorization_exclusivity_check` constraint (AIM-87) so MCP servers can record both a Gram-issued `user_session_issuer_id` and an upstream `remote_session_issuer_id`. Adds a partial index on `user_session_issuer_id` so the resync that recomputes `remote_session_issuer_id` doesn't sequential-scan `mcp_servers` while holding write locks; that resync runs on every client create, attach, detach and delete.

- The check incorrectly treated these IDs as alternatives, but Gram always creates a `user_session_issuer_id` for proxied servers, making `remote_session_issuer_id` impossible to set on exactly the servers that need it.
- Both migrations are catalog-only and dependency-free: `remote_session_issuer_id` is unpopulated and unwritten today, and the index is created concurrently.

<sup>Written for commit b22bfbdf8184317b04bd91013dcbe21d12f516e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

