### PR TITLE
chore: add aube lockfile normalization task

### DIFF
--- a/.mise-tasks/deps/normalize-lockfile.sh
+++ b/.mise-tasks/deps/normalize-lockfile.sh
@@ -28,6 +28,14 @@ fi
 echo "Restoring pnpm-lock.yaml from merge base $base..."
 git restore --source="$base" --worktree -- pnpm-lock.yaml
 
+keep_normalized=0
+restore_lockfile() {
+  if [ "$keep_normalized" -eq 0 ]; then
+    git restore --worktree -- pnpm-lock.yaml
+  fi
+}
+trap restore_lockfile EXIT
+
 echo "Re-resolving manifest changes with aube..."
 aube install --lockfile-only --fix-lockfile
 
@@ -45,6 +53,7 @@ if [ -n "$unexpected" ]; then
 fi
 
 git diff --check -- pnpm-lock.yaml
+keep_normalized=1
 
 if git diff --quiet -- pnpm-lock.yaml; then
   echo "Lockfile is already normalized; no changes to review."

--- a/.mise-tasks/deps/normalize-lockfile.sh
+++ b/.mise-tasks/deps/normalize-lockfile.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#MISE description="Clean unrelated pnpm lockfile churn after a dependency update using aube"
+#MISE dir="{{ config_root }}"
+
+# pnpm can re-resolve unrelated peer snapshots during dependency updates. Start
+# from the branch's base lockfile so aube resolves only the manifest changes.
+
+set -euo pipefail
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working tree must be clean before normalizing the lockfile." >&2
+  exit 1
+fi
+
+base_ref=origin/main
+if ! git rev-parse --verify --quiet "$base_ref^{commit}" >/dev/null; then
+  echo "Error: $base_ref is unavailable. Fetch it before running this task." >&2
+  exit 1
+fi
+
+base=$(git merge-base HEAD "$base_ref")
+if ! git cat-file -e "$base:pnpm-lock.yaml" 2>/dev/null; then
+  echo "Error: pnpm-lock.yaml does not exist at merge base $base." >&2
+  exit 1
+fi
+
+echo "Restoring pnpm-lock.yaml from merge base $base..."
+git restore --source="$base" --worktree -- pnpm-lock.yaml
+
+echo "Re-resolving manifest changes with aube..."
+aube install --lockfile-only --fix-lockfile
+
+unexpected=$(
+  {
+    git diff --name-only -- . ':!pnpm-lock.yaml'
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)
+if [ -n "$unexpected" ]; then
+  echo "Error: files other than pnpm-lock.yaml changed:" >&2
+  echo "$unexpected" >&2
+  exit 1
+fi
+
+git diff --check -- pnpm-lock.yaml
+
+if git diff --quiet -- pnpm-lock.yaml; then
+  echo "Lockfile is already normalized; no changes to review."
+  exit 0
+fi
+
+echo
+echo "Normalized lockfile diff:"
+git diff --stat -- pnpm-lock.yaml
+echo
+echo "Review with: git diff -- pnpm-lock.yaml"
+echo "The task did not stage, commit, or push the change."

--- a/.mise-tasks/deps/normalize-lockfile.sh
+++ b/.mise-tasks/deps/normalize-lockfile.sh
@@ -29,12 +29,13 @@ echo "Restoring pnpm-lock.yaml from merge base $base..."
 git restore --source="$base" --worktree -- pnpm-lock.yaml
 
 keep_normalized=0
-restore_lockfile() {
+restore_tree() {
   if [ "$keep_normalized" -eq 0 ]; then
-    git restore --worktree -- pnpm-lock.yaml
+    git restore --worktree -- .
+    git clean -fd --quiet
   fi
 }
-trap restore_lockfile EXIT
+trap restore_tree EXIT
 
 echo "Re-resolving manifest changes with aube..."
 aube install --lockfile-only --fix-lockfile


### PR DESCRIPTION
## Summary

- Add `mise run deps:normalize-lockfile` to restore `pnpm-lock.yaml` from the branch merge base and re-resolve manifest changes with aube.
- Require a clean working tree, reject unexpected file changes, and leave the normalized lockfile unstaged for manual review.

## Motivation

Dependency updates generated with pnpm can include unrelated peer snapshot churn. Most churn can be tolerated, while this task provides an explicit cleanup path for unusually noisy updates without a privileged write-back workflow.
