### PR TITLE
feat: spend-gate the openclaw adapter

### DIFF
--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -553,7 +553,8 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 	}
 
 	// Spend gate runs before any risk-policy evaluation, for every adapter
-	// with a per-provider enforcement surface (claude, codex, cursor) — the
+	// with a per-provider enforcement surface (claude, codex, cursor, openclaw)
+	// — the
 	// risk scans below already run adapter-agnostically, and an over-budget
 	// actor is over budget regardless of which agent carries the event.
 	// Adapters are self-reported slugs, so this remains a cooperative-client

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -553,10 +553,10 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 	}
 
 	// Spend gate runs before any risk-policy evaluation, for every adapter
-	// with a per-provider enforcement surface (claude, codex, cursor, openclaw)
-	// — the
-	// risk scans below already run adapter-agnostically, and an over-budget
-	// actor is over budget regardless of which agent carries the event.
+	// with a per-provider enforcement surface (claude, codex, cursor,
+	// openclaw) — the risk scans below already run adapter-agnostically, and
+	// an over-budget actor is over budget regardless of which agent carries
+	// the event.
 	// Adapters are self-reported slugs, so this remains a cooperative-client
 	// boundary like the rest of the ingest surface; matching is on the
 	// lowercased value so a case variant cannot dodge the gate. opencode

--- a/server/internal/hooks/spend_gate.go
+++ b/server/internal/hooks/spend_gate.go
@@ -45,7 +45,7 @@ func (s *Service) checkSpendGate(ctx context.Context, ev hookevents.Event) *spen
 // variant cannot dodge the gate.
 func spendGatedAdapter(adapter string) bool {
 	switch strings.ToLower(strings.TrimSpace(adapter)) {
-	case "claude", "codex", "cursor":
+	case "claude", "codex", "cursor", "openclaw":
 		return true
 	default:
 		return false

--- a/server/internal/hooks/spend_gate_test.go
+++ b/server/internal/hooks/spend_gate_test.go
@@ -769,3 +769,55 @@ func TestCursor_SpendGateRedeliveryDoesNotRemintBlockPage(t *testing.T) {
 	assert.NotContains(t, *second.UserMessage, "/blocks/",
 		"idempotent redelivery must not mint another block page")
 }
+
+func TestIngest_SpendGateDeniesOpenClawToolCallWithBlockURL(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("openclaw", "tool.requested", "spend-gate-ingest-openclaw")
+	toolName := "exec"
+	toolCallID := "call-spend-openclaw-1"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"command": "ls"},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	assert.Contains(t, *result.Message, "Intern hard limit")
+	assert.Contains(t, *result.Message, "/blocks/")
+}
+
+func TestIngest_SpendGateDeniesOpenClawPrompt(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("OpenClaw", "prompt.submitted", "spend-gate-openclaw-prompt")
+	text := "hello"
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &text},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "deny", result.Decision, "case variant must not dodge the gate")
+	require.NotNil(t, result.Message)
+	assert.Contains(t, *result.Message, "Intern hard limit")
+}


### PR DESCRIPTION
Stacked on #5770. First slice of the M3 spend-gate/block-records issue.

Adds `openclaw` to `spendGatedAdapter` — enforcement on the unified ingest path is proven live (see the audit in #5770), which was the stated precondition. Two new tests mirror the existing per-adapter patterns: a `tool.requested` deny carrying the spend-rule reason and block view URL, and a case-variant `prompt.submitted` deny (`"OpenClaw"`) proving normalization holds. The existing other-adapters negative keeps `opencode` as its subject, so ungated adapters stay pinned.

Block-record rendering (the `provider` column exists on `tool_call_blocks` but is not plumbed through `GetRiskBlock` for any provider) comes next as its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFPMpADydN1tKUVJ5sivfR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `openclaw` to the spend gate on the unified ingest path, so over-limit tool calls and prompts are now denied with a block URL instead of passing through. This covers the spend-gate part of DNO-958; block-record dashboard verification remains a follow-up.

- `openclaw` now joins `claude`, `codex`, and `cursor` as a spend-gated adapter.
- Tests cover a `tool.requested` deny carrying the spend-rule reason and block URL, and a case-variant `prompt.submitted` deny proving normalization holds.
- The existing `opencode` negative stays as-is to pin ungated adapters.

<sup>Written for commit 182c7772b676f264279edc7e9905be8521b94f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

