### PR TITLE
feat: surface the blocking provider on the block page

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -76291,6 +76291,9 @@ components:
           type: string
           description: The project the block belongs to.
           format: uuid
+        provider:
+          type: string
+          description: Agent surface that reported the blocked call (adapter slug, e.g. "openclaw"), when known.
         reason:
           type: string
           description: Human-readable reason the tool call was blocked.

--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -28,6 +28,7 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   chatgpt: "ChatGPT",
   "chatgpt-work": "ChatGPT Work",
   opencode: "opencode",
+  openclaw: "OpenClaw",
   litellm: "LiteLLM",
   copilot: "Copilot",
   "github-copilot": "Copilot",

--- a/client/dashboard/src/pages/blocks/BlockDetail.test.tsx
+++ b/client/dashboard/src/pages/blocks/BlockDetail.test.tsx
@@ -128,6 +128,7 @@ const sampleBlock = {
   reason: `Speakeasy blocked this tool call: matched policy "Block Secrets" (Attempted to read .env secrets)`,
   policyName: "Block Secrets",
   toolName: "Bash",
+  provider: "openclaw",
   createdAt: "2026-06-24T21:00:00Z",
   feedback: undefined as string | undefined,
 };
@@ -166,6 +167,7 @@ describe("BlockPage", () => {
 
     expect(screen.getByText(/Blocked by policy/)).toBeTruthy();
     expect(screen.getByText(/tool Bash/)).toBeTruthy();
+    expect(screen.getByText(/via OpenClaw/)).toBeTruthy();
     // The reason box renders block.reason exactly as the backend stored it —
     // no client-side parsing of the message wording.
     expect(screen.getByText(sampleBlock.reason)).toBeTruthy();

--- a/client/dashboard/src/pages/blocks/BlockDetail.tsx
+++ b/client/dashboard/src/pages/blocks/BlockDetail.tsx
@@ -3,6 +3,7 @@ import { Text } from "@/components/ui/Text";
 import { useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { buildLoginRedirectURL } from "@/lib/utils";
+import { formatPlatform } from "@/lib/formatPlatform";
 import { useRoutes } from "@/routes";
 import { useRiskGetBlock } from "@gram/client/react-query/riskGetBlock.js";
 import { useRiskSubmitBlockFeedbackMutation } from "@gram/client/react-query/riskSubmitBlockFeedback.js";
@@ -142,6 +143,7 @@ function BlockBody({ id }: { id: string | undefined }) {
               ? `Blocked by policy “${block.policyName}”`
               : "Blocked by a Speakeasy spend rule"}
             {block.toolName ? ` · tool ${block.toolName}` : ""}
+            {block.provider ? ` · via ${formatPlatform(block.provider)}` : ""}
           </Text>
         </Stack>
       </Stack>

--- a/client/dashboard/src/sdk/src/models/components/riskblock.ts
+++ b/client/dashboard/src/sdk/src/models/components/riskblock.ts
@@ -43,6 +43,10 @@ export type RiskBlock = {
    */
   projectId: string;
   /**
+   * Agent surface that reported the blocked call (adapter slug, e.g. "openclaw"), when known.
+   */
+  provider?: string | undefined;
+  /**
    * Human-readable reason the tool call was blocked.
    */
   reason: string;
@@ -69,6 +73,7 @@ export const RiskBlock$inboundSchema: z.ZodMiniType<RiskBlock, unknown> = z
       id: z.string(),
       policy_name: z.string(),
       project_id: z.string(),
+      provider: z.optional(z.string()),
       reason: z.string(),
       tool_name: z.optional(z.string()),
     }),

--- a/server/design/risk/design.go
+++ b/server/design/risk/design.go
@@ -2010,6 +2010,7 @@ var RiskBlock = Type("RiskBlock", func() {
 	Attribute("reason", String, "Human-readable reason the tool call was blocked.")
 	Attribute("policy_name", String, "Name of the risk policy that blocked the call.")
 	Attribute("tool_name", String, "Name of the tool that was blocked, when known.")
+	Attribute("provider", String, "Agent surface that reported the blocked call (adapter slug, e.g. \"openclaw\"), when known.")
 	Attribute("created_at", String, "When the block occurred.", func() {
 		Format(FormatDateTime)
 	})

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -77668,6 +77668,9 @@ components:
                     type: string
                     description: The project the block belongs to.
                     format: uuid
+                provider:
+                    type: string
+                    description: Agent surface that reported the blocked call (adapter slug, e.g. "openclaw"), when known.
                 reason:
                     type: string
                     description: Human-readable reason the tool call was blocked.

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -1014,6 +1014,9 @@ type GetRiskBlockResponseBody struct {
 	PolicyName *string `form:"policy_name,omitempty" json:"policy_name,omitempty" xml:"policy_name,omitempty"`
 	// Name of the tool that was blocked, when known.
 	ToolName *string `form:"tool_name,omitempty" json:"tool_name,omitempty" xml:"tool_name,omitempty"`
+	// Agent surface that reported the blocked call (adapter slug, e.g.
+	// "openclaw"), when known.
+	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// When the block occurred.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// Existing feedback sentiment recorded for this block, when any.
@@ -1033,6 +1036,9 @@ type SubmitRiskBlockFeedbackResponseBody struct {
 	PolicyName *string `form:"policy_name,omitempty" json:"policy_name,omitempty" xml:"policy_name,omitempty"`
 	// Name of the tool that was blocked, when known.
 	ToolName *string `form:"tool_name,omitempty" json:"tool_name,omitempty" xml:"tool_name,omitempty"`
+	// Agent surface that reported the blocked call (adapter slug, e.g.
+	// "openclaw"), when known.
+	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// When the block occurred.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// Existing feedback sentiment recorded for this block, when any.
@@ -16299,6 +16305,7 @@ func NewGetRiskBlockRiskBlockOK(body *GetRiskBlockResponseBody) *risk.RiskBlock 
 		Reason:     *body.Reason,
 		PolicyName: *body.PolicyName,
 		ToolName:   body.ToolName,
+		Provider:   body.Provider,
 		CreatedAt:  *body.CreatedAt,
 		Feedback:   body.Feedback,
 	}
@@ -16465,6 +16472,7 @@ func NewSubmitRiskBlockFeedbackRiskBlockOK(body *SubmitRiskBlockFeedbackResponse
 		Reason:     *body.Reason,
 		PolicyName: *body.PolicyName,
 		ToolName:   body.ToolName,
+		Provider:   body.Provider,
 		CreatedAt:  *body.CreatedAt,
 		Feedback:   body.Feedback,
 	}

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -1016,6 +1016,9 @@ type GetRiskBlockResponseBody struct {
 	PolicyName string `form:"policy_name" json:"policy_name" xml:"policy_name"`
 	// Name of the tool that was blocked, when known.
 	ToolName *string `form:"tool_name,omitempty" json:"tool_name,omitempty" xml:"tool_name,omitempty"`
+	// Agent surface that reported the blocked call (adapter slug, e.g.
+	// "openclaw"), when known.
+	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// When the block occurred.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// Existing feedback sentiment recorded for this block, when any.
@@ -1035,6 +1038,9 @@ type SubmitRiskBlockFeedbackResponseBody struct {
 	PolicyName string `form:"policy_name" json:"policy_name" xml:"policy_name"`
 	// Name of the tool that was blocked, when known.
 	ToolName *string `form:"tool_name,omitempty" json:"tool_name,omitempty" xml:"tool_name,omitempty"`
+	// Agent surface that reported the blocked call (adapter slug, e.g.
+	// "openclaw"), when known.
+	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// When the block occurred.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// Existing feedback sentiment recorded for this block, when any.
@@ -11920,6 +11926,7 @@ func NewGetRiskBlockResponseBody(res *risk.RiskBlock) *GetRiskBlockResponseBody 
 		Reason:     res.Reason,
 		PolicyName: res.PolicyName,
 		ToolName:   res.ToolName,
+		Provider:   res.Provider,
 		CreatedAt:  res.CreatedAt,
 		Feedback:   res.Feedback,
 	}
@@ -11935,6 +11942,7 @@ func NewSubmitRiskBlockFeedbackResponseBody(res *risk.RiskBlock) *SubmitRiskBloc
 		Reason:     res.Reason,
 		PolicyName: res.PolicyName,
 		ToolName:   res.ToolName,
+		Provider:   res.Provider,
 		CreatedAt:  res.CreatedAt,
 		Feedback:   res.Feedback,
 	}

--- a/server/gen/risk/service.go
+++ b/server/gen/risk/service.go
@@ -980,6 +980,9 @@ type RiskBlock struct {
 	PolicyName string
 	// Name of the tool that was blocked, when known.
 	ToolName *string
+	// Agent surface that reported the blocked call (adapter slug, e.g.
+	// "openclaw"), when known.
+	Provider *string
 	// When the block occurred.
 	CreatedAt string
 	// Existing feedback sentiment recorded for this block, when any.

--- a/server/internal/risk/block.go
+++ b/server/internal/risk/block.go
@@ -61,6 +61,7 @@ func (s *Service) GetRiskBlock(ctx context.Context, payload *gen.GetRiskBlockPay
 		Reason:     blockReason(row.Reason),
 		PolicyName: row.PolicyName.String,
 		ToolName:   conv.FromPGText[string](row.ToolName),
+		Provider:   conv.PtrEmpty(row.Provider),
 		CreatedAt:  row.CreatedAt.Time.Format(time.RFC3339),
 		Feedback:   blockFeedbackSentiment(row.Feedback),
 	}, nil
@@ -121,6 +122,7 @@ func (s *Service) SubmitRiskBlockFeedback(ctx context.Context, payload *gen.Subm
 		Reason:     blockReason(row.Reason),
 		PolicyName: row.PolicyName,
 		ToolName:   conv.FromPGText[string](row.ToolName),
+		Provider:   conv.PtrEmpty(row.Provider),
 		CreatedAt:  row.CreatedAt.Time.Format(time.RFC3339),
 		Feedback:   blockFeedbackSentiment(row.Feedback),
 	}, nil

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1789,6 +1789,7 @@ SELECT
     b.project_id,
     b.reason,
     b.tool_name,
+    b.provider,
     b.feedback,
     b.created_at,
     b.user_id,
@@ -1828,7 +1829,7 @@ WHERE tool_call_blocks.id = sqlc.arg(id)
       AND our.deleted_at IS NULL
   )
 RETURNING tool_call_blocks.id, tool_call_blocks.project_id, tool_call_blocks.reason, tool_call_blocks.tool_name,
-  tool_call_blocks.feedback, tool_call_blocks.created_at,
+  tool_call_blocks.provider, tool_call_blocks.feedback, tool_call_blocks.created_at,
   COALESCE((SELECT rp.name FROM risk_policies rp WHERE rp.id = tool_call_blocks.risk_policy_id AND rp.deleted IS FALSE), '')::text AS policy_name;
 
 

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -2377,6 +2377,7 @@ SELECT
     b.project_id,
     b.reason,
     b.tool_name,
+    b.provider,
     b.feedback,
     b.created_at,
     b.user_id,
@@ -2406,6 +2407,7 @@ type GetToolCallBlockRow struct {
 	ProjectID  uuid.UUID
 	Reason     string
 	ToolName   pgtype.Text
+	Provider   string
 	Feedback   pgtype.Text
 	CreatedAt  pgtype.Timestamptz
 	UserID     string
@@ -2430,6 +2432,7 @@ func (q *Queries) GetToolCallBlock(ctx context.Context, arg GetToolCallBlockPara
 		&i.ProjectID,
 		&i.Reason,
 		&i.ToolName,
+		&i.Provider,
 		&i.Feedback,
 		&i.CreatedAt,
 		&i.UserID,
@@ -5528,7 +5531,7 @@ WHERE tool_call_blocks.id = $3
       AND our.deleted_at IS NULL
   )
 RETURNING tool_call_blocks.id, tool_call_blocks.project_id, tool_call_blocks.reason, tool_call_blocks.tool_name,
-  tool_call_blocks.feedback, tool_call_blocks.created_at,
+  tool_call_blocks.provider, tool_call_blocks.feedback, tool_call_blocks.created_at,
   COALESCE((SELECT rp.name FROM risk_policies rp WHERE rp.id = tool_call_blocks.risk_policy_id AND rp.deleted IS FALSE), '')::text AS policy_name
 `
 
@@ -5544,6 +5547,7 @@ type UpdateToolCallBlockFeedbackRow struct {
 	ProjectID  uuid.UUID
 	Reason     string
 	ToolName   pgtype.Text
+	Provider   string
 	Feedback   pgtype.Text
 	CreatedAt  pgtype.Timestamptz
 	PolicyName string
@@ -5565,6 +5569,7 @@ func (q *Queries) UpdateToolCallBlockFeedback(ctx context.Context, arg UpdateToo
 		&i.ProjectID,
 		&i.Reason,
 		&i.ToolName,
+		&i.Provider,
 		&i.Feedback,
 		&i.CreatedAt,
 		&i.PolicyName,


### PR DESCRIPTION
Stacked on #5771. Completes the block-record verification slice: the audit found `tool_call_blocks.provider` is written on every deny but never selected by `GetToolCallBlock`, so the block page couldn't attribute the block to an agent surface — for any provider, not just OpenClaw.

- `GetToolCallBlock` and `UpdateToolCallBlockFeedback` now return `provider`; `RiskBlock` carries it as an optional field (goa + sqlc + SDK regenerated).
- The block page subtitle appends `· via <label>` through the existing `formatPlatform` product-surface labels; `openclaw: "OpenClaw"` added to the map (the title-case fallback would have rendered "Openclaw").
- Dashboard test fixture pins the rendered label.

With this, an OpenClaw deny shows: policy, tool, surface, reason with block URL — the full M3 verification surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFPMpADydN1tKUVJ5sivfR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The block page now shows which agent surface reported a blocked tool call, for any provider. `tool_call_blocks.provider` was recorded on every deny, but `GetToolCallBlock` never selected it, so the page couldn't attribute the block.

- Both block queries now return `provider`; the page subtitle appends `· via <label>` from the existing product-surface label map.
- `RiskBlock` carries `provider` as an optional field across goa, sqlc, and the regenerated SDK, keeping responses backward compatible.
- Adds `openclaw: "OpenClaw"` to the label map so the title-case fallback doesn't render "Openclaw"; the dashboard test pins the rendered label.

This completes the DNO-958 block-record verification slice.

<sup>Written for commit 90f5d43760a19958c277ad345d29c5a2c75cc0b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

