### PR TITLE
feat: add GLM-5.3 Flash model

### DIFF
--- a/client/dashboard/src/elements/lib/models.ts
+++ b/client/dashboard/src/elements/lib/models.ts
@@ -33,6 +33,7 @@ export const MODELS = [
   "x-ai/grok-4.20",
   "qwen/qwen3.7-max",
   "qwen/qwen3-coder",
+  "z-ai/glm-5.3-flash",
   "moonshotai/kimi-k2.6",
   "moonshotai/kimi-k2.5",
   "mistralai/mistral-medium-3-5",

--- a/client/dashboard/src/lib/models.ts
+++ b/client/dashboard/src/lib/models.ts
@@ -64,6 +64,7 @@ export const AVAILABLE_MODELS: AvailableModel[] = [
   { value: "x-ai/grok-4.20", label: "Grok 4.20" },
   { value: "qwen/qwen3.7-max", label: "Qwen3.7 Max" },
   { value: "qwen/qwen3-coder", label: "Qwen3 Coder" },
+  { value: "z-ai/glm-5.3-flash", label: "GLM-5.3 Flash" },
   { value: "moonshotai/kimi-k2.6", label: "Kimi K2.6" },
   { value: "moonshotai/kimi-k2.5", label: "Kimi K2.5" },
   { value: "mistralai/mistral-medium-3-5", label: "Mistral Medium 3.5" },

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -174,6 +174,7 @@ var allowList = map[string]bool{
 	"x-ai/grok-4.20":                true,
 	"qwen/qwen3.7-max":              true,
 	"qwen/qwen3-coder":              true,
+	"z-ai/glm-5.3-flash":            true,
 	"moonshotai/kimi-k2.6":          true,
 	"moonshotai/kimi-k2.5":          true,
 	"mistralai/mistral-medium-3-5":  true,
@@ -200,6 +201,7 @@ var providerFallbacks = map[string]string{
 	"meta-llama": "meta-llama/llama-4-maverick",
 	"x-ai":       "x-ai/grok-4.3",
 	"qwen":       "qwen/qwen3.7-max",
+	"z-ai":       "z-ai/glm-5.3-flash",
 	"moonshotai": "moonshotai/kimi-k2.6",
 	"mistralai":  "mistralai/mistral-medium-3-5",
 }


### PR DESCRIPTION
## Summary
- allow GLM-5.3 Flash through the OpenRouter proxy
- add the model to dashboard and Elements model selectors
- pin GLM-5.3 Flash as the fallback for the z-ai provider

## Testing
- `aube run -F dashboard test -- src/lib/models.test.ts`
- `git diff --check`

## Notes
- Server package tests could not start because rootless Docker is unavailable in the local environment.