### PR TITLE
fix: derive access token expiry from JWT exp when expires_in is absent

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -461,6 +461,9 @@ const (
 	RemoteSessionIssuerIDKey            = attribute.Key("gram.remote_session_issuer.id")
 	RemoteSessionClientMigratedCountKey = attribute.Key("gram.remote_session_client.migrated_count")
 	RemoteSessionRevokeDroppedCountKey  = attribute.Key("gram.remote_session.revoke_dropped_count")
+	// RemoteSessionAccessExpiresAtKey is the upstream-reported deadline of a
+	// remote session's access token.
+	RemoteSessionAccessExpiresAtKey = attribute.Key("gram.remote_session.access_expires_at")
 
 	RiskPolicyCountKey             = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                = attribute.Key("gram.risk.policy_id")
@@ -1833,6 +1836,13 @@ func RemoteSessionRevokeDroppedCount(v int) attribute.KeyValue {
 
 func SlogRemoteSessionRevokeDroppedCount(v int) slog.Attr {
 	return slog.Int(string(RemoteSessionRevokeDroppedCountKey), v)
+}
+
+func RemoteSessionAccessExpiresAt(v time.Time) attribute.KeyValue {
+	return RemoteSessionAccessExpiresAtKey.String(v.UTC().Format(time.RFC3339))
+}
+func SlogRemoteSessionAccessExpiresAt(v time.Time) slog.Attr {
+	return slog.Time(string(RemoteSessionAccessExpiresAtKey), v)
 }
 
 func UserSessionClientMigratedCount(v int64) attribute.KeyValue {

--- a/server/internal/oauth/jwtclaims/claims.go
+++ b/server/internal/oauth/jwtclaims/claims.go
@@ -1,6 +1,8 @@
 package jwtclaims
 
 import (
+	"time"
+
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -22,4 +24,29 @@ func UnsafeExtractSubject(token string) string {
 
 	sub, _ := claims.GetSubject()
 	return sub
+}
+
+// UnsafeExtractExpiry parses the token as an unverified JWT and returns the
+// "exp" claim. The boolean is false when the token is not a valid JWT, has no
+// exp claim, or carries one that is not a numeric date.
+//
+// UNSAFE: The token signature is not verified. The returned time comes from
+// untrusted data and MUST NOT be used for authentication or authorization
+// decisions. It is suitable only for scheduling, such as deciding when to
+// attempt a refresh, where a forged value can at worst move that attempt
+// earlier or later.
+func UnsafeExtractExpiry(token string) (time.Time, bool) {
+	parser := jwt.NewParser()
+
+	claims := jwt.MapClaims{}
+	_, _, err := parser.ParseUnverified(token, claims)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return time.Time{}, false
+	}
+	return exp.Time, true
 }

--- a/server/internal/oauth/jwtclaims/claims_test.go
+++ b/server/internal/oauth/jwtclaims/claims_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,39 @@ func TestUnsafeExtractSubjectOpaqueToken(t *testing.T) {
 	t.Parallel()
 	got := UnsafeExtractSubject("eyJhbGciOiJSUzI1NiJ9.notvalidbase64.sig")
 	require.Empty(t, got)
+}
+
+func TestUnsafeExtractExpiryValidJWT(t *testing.T) {
+	t.Parallel()
+	exp := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	token := buildUnsignedJWT(map[string]any{"sub": "user-123", "exp": exp.Unix()})
+	got, ok := UnsafeExtractExpiry(token)
+	require.True(t, ok)
+	require.Equal(t, exp, got.UTC())
+}
+
+func TestUnsafeExtractExpiryMissingExp(t *testing.T) {
+	t.Parallel()
+	token := buildUnsignedJWT(map[string]any{"sub": "user-123"})
+	_, ok := UnsafeExtractExpiry(token)
+	require.False(t, ok)
+}
+
+func TestUnsafeExtractExpiryNonNumericExp(t *testing.T) {
+	t.Parallel()
+	token := buildUnsignedJWT(map[string]any{"exp": "tomorrow"})
+	_, ok := UnsafeExtractExpiry(token)
+	require.False(t, ok)
+}
+
+func TestUnsafeExtractExpiryEmptyString(t *testing.T) {
+	t.Parallel()
+	_, ok := UnsafeExtractExpiry("")
+	require.False(t, ok)
+}
+
+func TestUnsafeExtractExpiryNotAJWT(t *testing.T) {
+	t.Parallel()
+	_, ok := UnsafeExtractExpiry("xoxp-opaque-token")
+	require.False(t, ok)
 }

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -704,6 +704,23 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// expires.
 	now := time.Now()
 	accessExpires := tok.AccessExpiresAt(now)
+
+	// A deadline the provider asserts is persisted even when it has already
+	// passed: with a refresh grant the first resolution refreshes, and the
+	// session recovers on its own. With no refresh grant there is nothing to
+	// recover with — the row would report the session as connected while
+	// every resolution answered with a reconnect prompt, and a provider that
+	// pins exp to its own session rather than to this grant would mint the
+	// same dead row again on reconnect. exp is upstream wall-clock time, so a
+	// host clock running ahead of the provider reaches this too. The margin
+	// is the one the request path refreshes at, and the armed revocation
+	// above returns the pair to the provider.
+	if tok.RefreshToken == "" && accessExpires != nil && !accessExpires.After(now.Add(AccessTokenExpirySkew)) {
+		return oops.E(oops.CodeUnauthorized, nil, "the identity provider issued an access token that is expired or about to expire, and no refresh token to renew it").LogWarn(ctx, logger,
+			attr.SlogRemoteSessionAccessExpiresAt(*accessExpires),
+		)
+	}
+
 	refreshTimeout, refreshTimeoutReported := tok.RefreshTokenTimeoutSeconds()
 	refreshExpires := expirationDeadline(now, refreshTimeout, refreshTimeoutReported)
 	authorizationLifetime, authorizationLifetimeReported := tok.AuthorizationLifetimeSeconds()

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -697,16 +697,13 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		refreshEnc = &v
 	}
 
-	// expires_in is OPTIONAL per RFC 6749 §5.1. When the upstream omits it we
-	// store NULL — "no known expiry" — rather than fabricating a deadline the
-	// provider never asserted. validateAndRefresh serves that token as-is; a
-	// refresh token does not imply that the access token expires.
+	// A token with no reported expiry — neither expires_in nor a JWT exp —
+	// is stored with NULL access_expires_at, "no known expiry", rather than a
+	// deadline the provider never asserted. validateAndRefresh serves that
+	// token as-is; a refresh token does not imply that the access token
+	// expires.
 	now := time.Now()
-	var accessExpires *time.Time
-	if tok.ExpiresIn > 0 {
-		v := now.Add(time.Duration(tok.ExpiresIn) * time.Second)
-		accessExpires = &v
-	}
+	accessExpires := tok.AccessExpiresAt(now)
 	refreshTimeout, refreshTimeoutReported := tok.RefreshTokenTimeoutSeconds()
 	refreshExpires := expirationDeadline(now, refreshTimeout, refreshTimeoutReported)
 	authorizationLifetime, authorizationLifetimeReported := tok.AuthorizationLifetimeSeconds()

--- a/server/internal/remotesessions/challenge_jwt_expiry_test.go
+++ b/server/internal/remotesessions/challenge_jwt_expiry_test.go
@@ -1,0 +1,102 @@
+// challenge_jwt_expiry_test.go covers providers that omit expires_in but issue
+// JWT access tokens: the token's exp claim must become access_expires_at on
+// both the code exchange and the refresh grant, so the lazy request path
+// refreshes instead of forwarding a token the provider already rejects. The
+// mock upstream answers both grants with a JWT access token, a refresh token,
+// a non-standard issued_at, and no expires_in.
+
+package remotesessions_test
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+func TestRemoteLoginCallback_NoExpiresIn_JWTAccessToken_StoresExp(t *testing.T) {
+	t.Parallel()
+
+	exp := time.Now().Add(24 * time.Hour)
+	access := mintJWTAccessToken(t, exp)
+	ctx, env := newSyntheticExpiryEnv(t, "jwt-exp", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jwtProviderTokenBody(access, "refresh-initial")))
+	})
+
+	require.True(t, env.session.AccessExpiresAt.Valid, "JWT exp must populate access_expires_at when expires_in is absent")
+	require.WithinDuration(t, exp, env.session.AccessExpiresAt.Time, time.Second)
+	require.True(t, env.session.RefreshTokenEncrypted.Valid, "refresh token must be persisted")
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, access, resolved, "a token before its exp is served as-is")
+}
+
+func TestRemoteLoginCallback_JWTAccessToken_RefreshesOnceExpPasses(t *testing.T) {
+	t.Parallel()
+
+	initial := mintJWTAccessToken(t, time.Now().Add(24*time.Hour))
+	rotatedExp := time.Now().Add(48 * time.Hour)
+	rotated := mintJWTAccessToken(t, rotatedExp)
+	var refreshCount atomic.Int64
+	ctx, env := newSyntheticExpiryEnv(t, "jwt-refresh", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") == "refresh_token" {
+			refreshCount.Add(1)
+			_, _ = w.Write([]byte(jwtProviderTokenBody(rotated, "refresh-rotated")))
+			return
+		}
+		_, _ = w.Write([]byte(jwtProviderTokenBody(initial, "refresh-initial")))
+	})
+
+	// Stand in for the stored JWT reaching its exp.
+	require.NoError(t, env.q.SetRemoteSessionAccessExpiresAt(ctx, repo.SetRemoteSessionAccessExpiresAtParams{
+		ID:              env.session.ID,
+		ProjectID:       conv.ToNullUUID(env.projectID),
+		AccessExpiresAt: conv.ToPGTimestamptz(time.Now().Add(-time.Minute)),
+	}))
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, rotated, resolved)
+	require.Equal(t, int64(1), refreshCount.Load())
+
+	// The refresh grant response omits expires_in too, so the rotated token's
+	// exp must be the new deadline rather than NULL.
+	session, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+	require.True(t, session.AccessExpiresAt.Valid)
+	require.WithinDuration(t, rotatedExp, session.AccessExpiresAt.Time, time.Second)
+}
+
+// jwtProviderTokenBody is a token response with no expires_in: the only expiry
+// signal is the JWT's own exp claim.
+func jwtProviderTokenBody(accessToken, refreshToken string) string {
+	return `{"access_token":"` + accessToken + `","refresh_token":"` + refreshToken + `",` +
+		`"scope":"read write","token_type":"Bearer","issued_at":"1787000000000"}`
+}
+
+// mintJWTAccessToken signs a minimal access-token claim set with a throwaway
+// HMAC key. The server decodes exp without verifying the signature, so the
+// token only has to be well-formed.
+func mintJWTAccessToken(t *testing.T, exp time.Time) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp":   exp.Unix(),
+		"sub":   "user-123",
+		"scope": "read write",
+	}).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	return token
+}

--- a/server/internal/remotesessions/challenge_jwt_expiry_test.go
+++ b/server/internal/remotesessions/challenge_jwt_expiry_test.go
@@ -83,35 +83,6 @@ func TestRemoteLoginCallback_JWTAccessToken_RefreshesOnceExpPasses(t *testing.T)
 	require.WithinDuration(t, rotatedExp, session.AccessExpiresAt.Time, time.Second)
 }
 
-func TestRemoteLoginCallback_JWTAccessToken_RefreshesInsideExpirySkew(t *testing.T) {
-	t.Parallel()
-
-	// exp is still ahead of the clock but inside the skew window, so the first
-	// resolution must refresh rather than forward a token that would expire
-	// mid-request.
-	initial := mintJWTAccessToken(t, time.Now().Add(remotesessions.AccessTokenExpirySkew/2))
-	rotated := mintJWTAccessToken(t, time.Now().Add(24*time.Hour))
-	var refreshCount atomic.Int64
-	ctx, env := newSyntheticExpiryEnv(t, "jwt-skew", func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		w.Header().Set("Content-Type", "application/json")
-		if r.Form.Get("grant_type") == "refresh_token" {
-			refreshCount.Add(1)
-			_, _ = w.Write([]byte(jwtProviderTokenBody(rotated, "refresh-rotated")))
-			return
-		}
-		_, _ = w.Write([]byte(jwtProviderTokenBody(initial, "refresh-initial")))
-	})
-
-	require.True(t, env.session.AccessExpiresAt.Valid)
-	require.True(t, env.session.AccessExpiresAt.Time.After(time.Now()), "fixture must still be ahead of the clock")
-
-	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
-	require.NoError(t, err)
-	require.Equal(t, rotated, resolved)
-	require.Equal(t, int64(1), refreshCount.Load())
-}
-
 func TestRemoteLoginCallback_JWTAccessToken_PastExpWithRefreshToken_RefreshesOnFirstUse(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/challenge_jwt_expiry_test.go
+++ b/server/internal/remotesessions/challenge_jwt_expiry_test.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
@@ -108,6 +110,78 @@ func TestRemoteLoginCallback_JWTAccessToken_RefreshesInsideExpirySkew(t *testing
 	require.NoError(t, err)
 	require.Equal(t, rotated, resolved)
 	require.Equal(t, int64(1), refreshCount.Load())
+}
+
+func TestRemoteLoginCallback_JWTAccessToken_PastExpWithRefreshToken_RefreshesOnFirstUse(t *testing.T) {
+	t.Parallel()
+
+	// A provider that pins exp to its own session can hand out a token that
+	// is already past it. With a refresh grant the exchange is recorded and
+	// the first resolution recovers by refreshing.
+	expired := mintJWTAccessToken(t, time.Now().Add(-time.Minute))
+	rotated := mintJWTAccessToken(t, time.Now().Add(24*time.Hour))
+	var refreshCount atomic.Int64
+	ctx, env := newSyntheticExpiryEnv(t, "jwt-past-exp-refresh", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") == "refresh_token" {
+			refreshCount.Add(1)
+			_, _ = w.Write([]byte(jwtProviderTokenBody(rotated, "refresh-rotated")))
+			return
+		}
+		_, _ = w.Write([]byte(jwtProviderTokenBody(expired, "refresh-initial")))
+	})
+	require.True(t, env.session.AccessExpiresAt.Valid)
+	require.False(t, env.session.AccessExpiresAt.Time.After(time.Now()), "the persisted deadline is the past exp")
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, rotated, resolved)
+	require.Equal(t, int64(1), refreshCount.Load())
+}
+
+func TestRemoteLoginCallback_JWTAccessToken_PastExpWithoutRefreshToken_IsRejected(t *testing.T) {
+	t.Parallel()
+
+	// With no refresh grant nothing can recover an already-expired token.
+	// Recording the row would show the session as connected while every
+	// resolution answered with a reconnect prompt, so the exchange is
+	// declined instead.
+	expired := mintJWTAccessToken(t, time.Now().Add(-time.Minute))
+	ctx, env, _, err := driveSyntheticLogin(t, "jwt-past-exp-no-refresh", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + expired + `","scope":"read write","token_type":"Bearer"}`))
+	})
+	var rejected *oops.ShareableError
+	require.ErrorAs(t, err, &rejected)
+	require.Equal(t, oops.CodeUnauthorized, rejected.Code)
+
+	_, err = env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "a session that cannot be used is never recorded as connected")
+}
+
+func TestRemoteLoginCallback_JWTAccessToken_ExpInsideSkewWithoutRefreshToken_IsRejected(t *testing.T) {
+	t.Parallel()
+
+	// The bar is the same margin the request path refreshes at: a token with
+	// less than the skew left and nothing to renew it is not a usable session.
+	expiring := mintJWTAccessToken(t, time.Now().Add(remotesessions.AccessTokenExpirySkew/2))
+	ctx, env, _, err := driveSyntheticLogin(t, "jwt-skew-exp-no-refresh", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + expiring + `","scope":"read write","token_type":"Bearer"}`))
+	})
+	var rejected *oops.ShareableError
+	require.ErrorAs(t, err, &rejected)
+	require.Equal(t, oops.CodeUnauthorized, rejected.Code)
+
+	_, err = env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 // jwtProviderTokenBody is a token response with no expires_in: the only expiry

--- a/server/internal/remotesessions/challenge_jwt_expiry_test.go
+++ b/server/internal/remotesessions/challenge_jwt_expiry_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
@@ -78,6 +79,35 @@ func TestRemoteLoginCallback_JWTAccessToken_RefreshesOnceExpPasses(t *testing.T)
 	require.NoError(t, err)
 	require.True(t, session.AccessExpiresAt.Valid)
 	require.WithinDuration(t, rotatedExp, session.AccessExpiresAt.Time, time.Second)
+}
+
+func TestRemoteLoginCallback_JWTAccessToken_RefreshesInsideExpirySkew(t *testing.T) {
+	t.Parallel()
+
+	// exp is still ahead of the clock but inside the skew window, so the first
+	// resolution must refresh rather than forward a token that would expire
+	// mid-request.
+	initial := mintJWTAccessToken(t, time.Now().Add(remotesessions.AccessTokenExpirySkew/2))
+	rotated := mintJWTAccessToken(t, time.Now().Add(24*time.Hour))
+	var refreshCount atomic.Int64
+	ctx, env := newSyntheticExpiryEnv(t, "jwt-skew", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") == "refresh_token" {
+			refreshCount.Add(1)
+			_, _ = w.Write([]byte(jwtProviderTokenBody(rotated, "refresh-rotated")))
+			return
+		}
+		_, _ = w.Write([]byte(jwtProviderTokenBody(initial, "refresh-initial")))
+	})
+
+	require.True(t, env.session.AccessExpiresAt.Valid)
+	require.True(t, env.session.AccessExpiresAt.Time.After(time.Now()), "fixture must still be ahead of the clock")
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, rotated, resolved)
+	require.Equal(t, int64(1), refreshCount.Load())
 }
 
 // jwtProviderTokenBody is a token response with no expires_in: the only expiry

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -15,6 +15,7 @@ package remotesessions_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -177,6 +178,27 @@ type syntheticExpiryEnv struct {
 func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc) (context.Context, syntheticExpiryEnv) {
 	t.Helper()
 
+	ctx, env, callback, err := driveSyntheticLogin(t, slugSuffix, tokenHandler)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSeeOther, callback.Code)
+
+	session, err := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+	env.session = session
+
+	return ctx, env
+}
+
+// driveSyntheticLogin is newSyntheticExpiryEnv up to and including the
+// callback. The callback's recorder and error come back unasserted, so a test
+// can exercise a code exchange the callback is expected to reject; the
+// returned env carries no session row.
+func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc) (context.Context, syntheticExpiryEnv, *httptest.ResponseRecorder, error) {
+	t.Helper()
+
 	ctx, ti := newTestService(t)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -277,14 +299,10 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 	cbReq := httptest.NewRequest(http.MethodGet,
 		"/mcp/remote_login_callback?code=upstream-code&state="+url.QueryEscape(state), nil)
 	cbW := httptest.NewRecorder()
-	require.NoError(t, mgr.HandleRemoteLoginCallback(cbW, cbReq))
-	require.Equal(t, http.StatusSeeOther, cbW.Code)
-
-	session, err := q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
-		SubjectUrn:            subject,
-		RemoteSessionClientID: client.ID,
-	})
-	require.NoError(t, err)
+	callbackErr := mgr.HandleRemoteLoginCallback(cbW, cbReq)
+	if callbackErr != nil {
+		callbackErr = fmt.Errorf("handle remote login callback: %w", callbackErr)
+	}
 
 	return ctx, syntheticExpiryEnv{
 		mgr:       mgr,
@@ -297,6 +315,5 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 		organizationID: authCtx.ActiveOrganizationID,
 		clientID:       client.ID,
 		subject:        subject,
-		session:        session,
-	}
+	}, cbW, callbackErr
 }

--- a/server/internal/remotesessions/export_test.go
+++ b/server/internal/remotesessions/export_test.go
@@ -1,5 +1,0 @@
-package remotesessions
-
-// AccessTokenExpirySkew exposes accessTokenExpirySkew to external tests so a
-// deadline can be placed inside the window without hardcoding its width.
-const AccessTokenExpirySkew = accessTokenExpirySkew

--- a/server/internal/remotesessions/export_test.go
+++ b/server/internal/remotesessions/export_test.go
@@ -1,0 +1,5 @@
+package remotesessions
+
+// AccessTokenExpirySkew exposes accessTokenExpirySkew to external tests so a
+// deadline can be placed inside the window without hardcoding its width.
+const AccessTokenExpirySkew = accessTokenExpirySkew

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -299,7 +299,7 @@ func (s *RefreshService) refresh(
 	sess = current
 
 	if current.UpdatedAt.Time.After(snapshotAt) {
-		if accessTokenUsable(current, time.Now()) {
+		if accessTokenLive(current, time.Now()) {
 			plain, err := s.enc.Decrypt(current.AccessTokenEncrypted)
 			if err != nil {
 				return zero, "", fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
@@ -307,7 +307,7 @@ func (s *RefreshService) refresh(
 			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil
 		}
 	}
-	if !current.RefreshTokenEncrypted.Valid || current.RefreshTokenEncrypted.String == "" {
+	if !hasRefreshToken(current) {
 		return zero, "", ErrNoValidToken
 	}
 	if !refreshTokenUsable(current, time.Now()) {
@@ -385,7 +385,7 @@ func (s *RefreshService) refresh(
 		return zero, client.IssuerUrl, refreshErr
 	}
 
-	if !accessTokenUsable(latest, time.Now()) {
+	if !accessTokenLive(latest, time.Now()) {
 		return zero, client.IssuerUrl, refreshErr
 	}
 	plain, err := s.enc.Decrypt(latest.AccessTokenEncrypted)
@@ -397,19 +397,44 @@ func (s *RefreshService) refresh(
 }
 
 // accessTokenExpirySkew is the window before access_expires_at within which a
-// stored access token is already treated as expired. It absorbs clock drift
-// against the upstream and the time the proxied call itself takes: a token
-// that expires mid-request is rejected upstream exactly as an expired one is,
-// so refreshing a moment early costs one refresh grant where forwarding the
-// token costs the caller a failed tool call.
+// stored access token is refreshed rather than forwarded. It absorbs clock
+// drift against the upstream and the time the proxied call itself takes: a
+// token that expires mid-request is rejected upstream exactly as an expired
+// one is, so refreshing a moment early costs one refresh grant where
+// forwarding the token costs the caller a failed tool call.
 const accessTokenExpirySkew = 30 * time.Second
 
-// accessTokenUsable reports whether sess's stored access token can be
-// forwarded at now: the authorization is live and either no access expiry is
-// known or the deadline is more than accessTokenExpirySkew away.
-func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
+// accessTokenLive reports whether sess's stored access token is inside its
+// stated lifetime at now: the authorization is live and either no access
+// expiry is known or the deadline has not passed. This is the bar for adopting
+// a row a concurrent refresh wrote moments ago: that token is the newest a
+// refresh can produce, so refreshing again would only spend another grant on a
+// token with the same lifetime — and against a provider whose tokens live
+// shorter than accessTokenExpirySkew, every waiter would reject every winner.
+func accessTokenLive(sess remotesessions_repo.RemoteSession, now time.Time) bool {
 	return authorizationUsable(sess, now) &&
-		(!sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now.Add(accessTokenExpirySkew)))
+		(!sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now))
+}
+
+// accessTokenUsable reports whether sess's stored access token should be
+// forwarded at now rather than refreshed. A live token is forwarded unless a
+// usable refresh grant exists and the deadline is within
+// accessTokenExpirySkew. With no refresh path the token is forwarded until its
+// stated deadline: the only alternative is a reconnect prompt
+// accessTokenExpirySkew early, and ListRemoteSessionStatusesForSubject reports
+// that same window as active.
+func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
+	if !accessTokenLive(sess, now) {
+		return false
+	}
+	if !sess.AccessExpiresAt.Valid || !hasRefreshToken(sess) || !refreshTokenUsable(sess, now) {
+		return true
+	}
+	return sess.AccessExpiresAt.Time.After(now.Add(accessTokenExpirySkew))
+}
+
+func hasRefreshToken(sess remotesessions_repo.RemoteSession) bool {
+	return sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
 }
 
 func refreshTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
@@ -456,7 +481,7 @@ func (s *RefreshService) awaitRefreshedSession(
 		if !latest.UpdatedAt.Time.After(sess.UpdatedAt.Time) {
 			continue
 		}
-		if !accessTokenUsable(latest, time.Now()) {
+		if !accessTokenLive(latest, time.Now()) {
 			return zero, false
 		}
 

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -396,9 +396,20 @@ func (s *RefreshService) refresh(
 	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil
 }
 
+// accessTokenExpirySkew is the window before access_expires_at within which a
+// stored access token is already treated as expired. It absorbs clock drift
+// against the upstream and the time the proxied call itself takes: a token
+// that expires mid-request is rejected upstream exactly as an expired one is,
+// so refreshing a moment early costs one refresh grant where forwarding the
+// token costs the caller a failed tool call.
+const accessTokenExpirySkew = 30 * time.Second
+
+// accessTokenUsable reports whether sess's stored access token can be
+// forwarded at now: the authorization is live and either no access expiry is
+// known or the deadline is more than accessTokenExpirySkew away.
 func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
 	return authorizationUsable(sess, now) &&
-		(!sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now))
+		(!sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now.Add(accessTokenExpirySkew)))
 }
 
 func refreshTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -396,13 +396,13 @@ func (s *RefreshService) refresh(
 	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil
 }
 
-// accessTokenExpirySkew is the window before access_expires_at within which a
+// AccessTokenExpirySkew is the window before access_expires_at within which a
 // stored access token is refreshed rather than forwarded. It absorbs clock
 // drift against the upstream and the time the proxied call itself takes: a
 // token that expires mid-request is rejected upstream exactly as an expired
 // one is, so refreshing a moment early costs one refresh grant where
 // forwarding the token costs the caller a failed tool call.
-const accessTokenExpirySkew = 30 * time.Second
+const AccessTokenExpirySkew = 30 * time.Second
 
 // accessTokenLive reports whether sess's stored access token is inside its
 // stated lifetime at now: the authorization is live and either no access
@@ -410,7 +410,7 @@ const accessTokenExpirySkew = 30 * time.Second
 // a row a concurrent refresh wrote moments ago: that token is the newest a
 // refresh can produce, so refreshing again would only spend another grant on a
 // token with the same lifetime — and against a provider whose tokens live
-// shorter than accessTokenExpirySkew, every waiter would reject every winner.
+// shorter than AccessTokenExpirySkew, every waiter would reject every winner.
 func accessTokenLive(sess remotesessions_repo.RemoteSession, now time.Time) bool {
 	return authorizationUsable(sess, now) &&
 		(!sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now))
@@ -419,9 +419,9 @@ func accessTokenLive(sess remotesessions_repo.RemoteSession, now time.Time) bool
 // accessTokenUsable reports whether sess's stored access token should be
 // forwarded at now rather than refreshed. A live token is forwarded unless a
 // usable refresh grant exists and the deadline is within
-// accessTokenExpirySkew. With no refresh path the token is forwarded until its
+// AccessTokenExpirySkew. With no refresh path the token is forwarded until its
 // stated deadline: the only alternative is a reconnect prompt
-// accessTokenExpirySkew early, and ListRemoteSessionStatusesForSubject reports
+// AccessTokenExpirySkew early, and ListRemoteSessionStatusesForSubject reports
 // that same window as active.
 func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bool {
 	if !accessTokenLive(sess, now) {
@@ -430,7 +430,7 @@ func accessTokenUsable(sess remotesessions_repo.RemoteSession, now time.Time) bo
 	if !sess.AccessExpiresAt.Valid || !hasRefreshToken(sess) || !refreshTokenUsable(sess, now) {
 		return true
 	}
-	return sess.AccessExpiresAt.Time.After(now.Add(accessTokenExpirySkew))
+	return sess.AccessExpiresAt.Time.After(now.Add(AccessTokenExpirySkew))
 }
 
 func hasRefreshToken(sess remotesessions_repo.RemoteSession) bool {

--- a/server/internal/remotesessions/refreshservice_skew_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_skew_internal_test.go
@@ -10,14 +10,50 @@ import (
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
-func TestAccessTokenUsable_DeadlineInsideSkewIsExpired(t *testing.T) {
+func TestAccessTokenUsable_DeadlineInsideSkewWithRefreshIsExpired(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 	}
 	require.False(t, accessTokenUsable(sess, now), "a token expiring inside the skew window must be refreshed, not forwarded")
+}
+
+func TestAccessTokenUsable_DeadlineInsideSkewWithoutRefreshIsUsable(t *testing.T) {
+	t.Parallel()
+
+	// With nothing to refresh with, the only alternative to forwarding is a
+	// reconnect prompt accessTokenExpirySkew early — while the consent UI still
+	// reports the session as connected.
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+	}
+	require.True(t, accessTokenUsable(sess, now), "without a refresh grant the token is forwarded until its stated deadline")
+}
+
+func TestAccessTokenUsable_DeadlineInsideSkewWithExpiredRefreshIsUsable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
+		RefreshExpiresAt:      conv.ToPGTimestamptz(now.Add(-time.Second)),
+	}
+	require.True(t, accessTokenUsable(sess, now), "a refresh grant past its idle timeout is no refresh path; the token is forwarded until its deadline")
+}
+
+func TestAccessTokenUsable_PastDeadlineWithoutRefreshIsUnusable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(-time.Second)),
+	}
+	require.False(t, accessTokenUsable(sess, now))
 }
 
 func TestAccessTokenUsable_DeadlineBeyondSkewIsUsable(t *testing.T) {
@@ -25,7 +61,8 @@ func TestAccessTokenUsable_DeadlineBeyondSkewIsUsable(t *testing.T) {
 
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew + time.Second)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew + time.Second)),
+		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 	}
 	require.True(t, accessTokenUsable(sess, now))
 }
@@ -46,4 +83,39 @@ func TestAccessTokenUsable_ExpiredAuthorizationIsUnusable(t *testing.T) {
 		AuthorizationExpiresAt: conv.ToPGTimestamptz(now.Add(-time.Second)),
 	}
 	require.False(t, accessTokenUsable(sess, now))
+}
+
+func TestAccessTokenLive_DeadlineInsideSkewIsLive(t *testing.T) {
+	t.Parallel()
+
+	// The adoption bar for a row a concurrent refresh just wrote ignores the
+	// skew: that token is the newest a refresh can produce.
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
+	}
+	require.True(t, accessTokenLive(sess, now))
+	require.False(t, accessTokenUsable(sess, now), "the same row still triggers a refresh when read from a stale snapshot")
+}
+
+func TestAccessTokenLive_PastDeadlineIsNotLive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(-time.Second)),
+	}
+	require.False(t, accessTokenLive(sess, now))
+}
+
+func TestAccessTokenLive_ExpiredAuthorizationIsNotLive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt:        conv.ToPGTimestamptz(now.Add(24 * time.Hour)),
+		AuthorizationExpiresAt: conv.ToPGTimestamptz(now.Add(-time.Second)),
+	}
+	require.False(t, accessTokenLive(sess, now))
 }

--- a/server/internal/remotesessions/refreshservice_skew_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_skew_internal_test.go
@@ -1,0 +1,49 @@
+package remotesessions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+func TestAccessTokenUsable_DeadlineInsideSkewIsExpired(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+	}
+	require.False(t, accessTokenUsable(sess, now), "a token expiring inside the skew window must be refreshed, not forwarded")
+}
+
+func TestAccessTokenUsable_DeadlineBeyondSkewIsUsable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew + time.Second)),
+	}
+	require.True(t, accessTokenUsable(sess, now))
+}
+
+func TestAccessTokenUsable_NoKnownExpiryIsUsable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	require.True(t, accessTokenUsable(remotesessions_repo.RemoteSession{}, now))
+}
+
+func TestAccessTokenUsable_ExpiredAuthorizationIsUnusable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	sess := remotesessions_repo.RemoteSession{
+		AccessExpiresAt:        conv.ToPGTimestamptz(now.Add(24 * time.Hour)),
+		AuthorizationExpiresAt: conv.ToPGTimestamptz(now.Add(-time.Second)),
+	}
+	require.False(t, accessTokenUsable(sess, now))
+}

--- a/server/internal/remotesessions/refreshservice_skew_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_skew_internal_test.go
@@ -15,7 +15,7 @@ func TestAccessTokenUsable_DeadlineInsideSkewWithRefreshIsExpired(t *testing.T) 
 
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(AccessTokenExpirySkew / 2)),
 		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 	}
 	require.False(t, accessTokenUsable(sess, now), "a token expiring inside the skew window must be refreshed, not forwarded")
@@ -25,11 +25,11 @@ func TestAccessTokenUsable_DeadlineInsideSkewWithoutRefreshIsUsable(t *testing.T
 	t.Parallel()
 
 	// With nothing to refresh with, the only alternative to forwarding is a
-	// reconnect prompt accessTokenExpirySkew early — while the consent UI still
+	// reconnect prompt AccessTokenExpirySkew early — while the consent UI still
 	// reports the session as connected.
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		AccessExpiresAt: conv.ToPGTimestamptz(now.Add(AccessTokenExpirySkew / 2)),
 	}
 	require.True(t, accessTokenUsable(sess, now), "without a refresh grant the token is forwarded until its stated deadline")
 }
@@ -39,7 +39,7 @@ func TestAccessTokenUsable_DeadlineInsideSkewWithExpiredRefreshIsUsable(t *testi
 
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(AccessTokenExpirySkew / 2)),
 		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 		RefreshExpiresAt:      conv.ToPGTimestamptz(now.Add(-time.Second)),
 	}
@@ -61,7 +61,7 @@ func TestAccessTokenUsable_DeadlineBeyondSkewIsUsable(t *testing.T) {
 
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew + time.Second)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(AccessTokenExpirySkew + time.Second)),
 		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 	}
 	require.True(t, accessTokenUsable(sess, now))
@@ -92,7 +92,7 @@ func TestAccessTokenLive_DeadlineInsideSkewIsLive(t *testing.T) {
 	// skew: that token is the newest a refresh can produce.
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	sess := remotesessions_repo.RemoteSession{
-		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(accessTokenExpirySkew / 2)),
+		AccessExpiresAt:       conv.ToPGTimestamptz(now.Add(AccessTokenExpirySkew / 2)),
 		RefreshTokenEncrypted: conv.ToPGText("enc-refresh"),
 	}
 	require.True(t, accessTokenLive(sess, now))

--- a/server/internal/remotesessions/token_response.go
+++ b/server/internal/remotesessions/token_response.go
@@ -3,6 +3,8 @@ package remotesessions
 import (
 	"strings"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // tokenResponse is the slice of the upstream /token reply we care about.
@@ -41,6 +43,34 @@ func (t tokenResponse) RefreshTokenTimeoutSeconds() (int64, bool) {
 		return t.RefreshTokenExpiresIn, true
 	}
 	return 0, false
+}
+
+// AccessExpiresAt is the access token's deadline, or nil when the provider
+// reported none. expires_in (RFC 6749 §5.1) governs when present. When it is
+// omitted and the access token is itself a JWT, the token's exp claim is the
+// provider's own statement of the deadline: RFC 9068 §2.2 makes exp mandatory
+// on JWT access tokens, and some providers rely on it instead of ever sending
+// expires_in.
+//
+// The JWT is decoded without signature verification. exp only schedules a
+// refresh and never authorizes anything, so a forged value can at worst move
+// one refresh attempt earlier or later.
+func (t tokenResponse) AccessExpiresAt(now time.Time) *time.Time {
+	if t.ExpiresIn > 0 {
+		deadline := now.Add(time.Duration(t.ExpiresIn) * time.Second)
+		return &deadline
+	}
+
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(t.AccessToken, claims); err != nil {
+		return nil
+	}
+	exp, err := claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return nil
+	}
+	deadline := exp.Time
+	return &deadline
 }
 
 // AuthorizationLifetimeSeconds is the remaining absolute lifetime of the

--- a/server/internal/remotesessions/token_response.go
+++ b/server/internal/remotesessions/token_response.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/speakeasy-api/gram/server/internal/oauth/jwtclaims"
 )
 
 // tokenResponse is the slice of the upstream /token reply we care about.
@@ -66,16 +66,11 @@ func (t tokenResponse) AccessExpiresAt(now time.Time) *time.Time {
 		return &deadline
 	}
 
-	claims := jwt.MapClaims{}
-	if _, _, err := jwt.NewParser().ParseUnverified(t.AccessToken, claims); err != nil {
+	exp, ok := jwtclaims.UnsafeExtractExpiry(t.AccessToken)
+	if !ok {
 		return nil
 	}
-	exp, err := claims.GetExpirationTime()
-	if err != nil || exp == nil {
-		return nil
-	}
-	deadline := exp.Time
-	return &deadline
+	return &exp
 }
 
 // AuthorizationLifetimeSeconds is the remaining absolute lifetime of the

--- a/server/internal/remotesessions/token_response.go
+++ b/server/internal/remotesessions/token_response.go
@@ -52,6 +52,11 @@ func (t tokenResponse) RefreshTokenTimeoutSeconds() (int64, bool) {
 // on JWT access tokens, and some providers rely on it instead of ever sending
 // expires_in.
 //
+// A zero expires_in is treated as unreported. Read literally it would describe
+// a token that expired as it was issued, turning every request into a refresh
+// grant — or a reconnect prompt when no refresh token exists — for providers
+// that send 0 to mean the token never expires.
+//
 // The JWT is decoded without signature verification. exp only schedules a
 // refresh and never authorizes anything, so a forged value can at worst move
 // one refresh attempt earlier or later.

--- a/server/internal/remotesessions/token_response_test.go
+++ b/server/internal/remotesessions/token_response_test.go
@@ -2,7 +2,9 @@ package remotesessions
 
 import (
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,4 +54,75 @@ func TestTokenResponseStandardExpirationFields(t *testing.T) {
 	}).AuthorizationLifetimeSeconds()
 	require.True(t, reported)
 	require.EqualValues(t, 7200, seconds)
+}
+
+// mintJWT signs claims with a throwaway HMAC key. AccessExpiresAt decodes
+// without verification, so the signature only has to be well-formed.
+func mintJWT(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("test-key"))
+	require.NoError(t, err)
+	return token
+}
+
+func TestTokenResponseAccessExpiresAt_ExpiresInGoverns(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	tok := tokenResponse{
+		AccessToken: mintJWT(t, jwt.MapClaims{"exp": now.Add(24 * time.Hour).Unix()}),
+		ExpiresIn:   3600,
+	}
+
+	deadline := tok.AccessExpiresAt(now)
+	require.NotNil(t, deadline)
+	require.Equal(t, now.Add(time.Hour), *deadline, "expires_in is authoritative even when the JWT carries a different exp")
+}
+
+func TestTokenResponseAccessExpiresAt_JWTExpFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(24 * time.Hour)
+	tok := tokenResponse{AccessToken: mintJWT(t, jwt.MapClaims{
+		"exp":   exp.Unix(),
+		"sub":   "user-123",
+		"scope": "read write",
+	})}
+
+	deadline := tok.AccessExpiresAt(now)
+	require.NotNil(t, deadline)
+	require.WithinDuration(t, exp, *deadline, time.Second)
+}
+
+func TestTokenResponseAccessExpiresAt_OpaqueToken(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	require.Nil(t, (tokenResponse{AccessToken: "xoxp-opaque"}).AccessExpiresAt(now))
+	require.Nil(t, (tokenResponse{AccessToken: "not.a.jwt"}).AccessExpiresAt(now))
+	require.Nil(t, (tokenResponse{}).AccessExpiresAt(now))
+}
+
+func TestTokenResponseAccessExpiresAt_JWTWithoutExp(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	tok := tokenResponse{AccessToken: mintJWT(t, jwt.MapClaims{"sub": "user-123"})}
+	require.Nil(t, tok.AccessExpiresAt(now))
+}
+
+func TestTokenResponseAccessExpiresAt_PastExpIsReported(t *testing.T) {
+	t.Parallel()
+
+	// A deadline the provider asserts is stored even when it has already
+	// passed: the request path then refreshes instead of forwarding a token
+	// the provider is already rejecting.
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(-time.Minute)
+	tok := tokenResponse{AccessToken: mintJWT(t, jwt.MapClaims{"exp": exp.Unix()})}
+
+	deadline := tok.AccessExpiresAt(now)
+	require.NotNil(t, deadline)
+	require.WithinDuration(t, exp, *deadline, time.Second)
 }

--- a/server/internal/remotesessions/token_response_test.go
+++ b/server/internal/remotesessions/token_response_test.go
@@ -115,9 +115,10 @@ func TestTokenResponseAccessExpiresAt_JWTWithoutExp(t *testing.T) {
 func TestTokenResponseAccessExpiresAt_PastExpIsReported(t *testing.T) {
 	t.Parallel()
 
-	// A deadline the provider asserts is stored even when it has already
-	// passed: the request path then refreshes instead of forwarding a token
-	// the provider is already rejecting.
+	// A deadline the provider asserts is reported even when it has already
+	// passed. With a refresh grant the request path then refreshes instead of
+	// forwarding a token the provider is already rejecting; without one the
+	// code exchange declines to record the session at all.
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
 	exp := now.Add(-time.Minute)
 	tok := tokenResponse{AccessToken: mintJWT(t, jwt.MapClaims{"exp": exp.Unix()})}

--- a/server/internal/remotesessions/token_response_test.go
+++ b/server/internal/remotesessions/token_response_test.go
@@ -126,3 +126,21 @@ func TestTokenResponseAccessExpiresAt_PastExpIsReported(t *testing.T) {
 	require.NotNil(t, deadline)
 	require.WithinDuration(t, exp, *deadline, time.Second)
 }
+
+func TestTokenResponseAccessExpiresAt_ZeroExpiresInIsUnreported(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	exp := now.Add(24 * time.Hour)
+	tok := tokenResponse{
+		AccessToken: mintJWT(t, jwt.MapClaims{"exp": exp.Unix()}),
+		ExpiresIn:   0,
+	}
+
+	deadline := tok.AccessExpiresAt(now)
+	require.NotNil(t, deadline, "expires_in: 0 must fall through to the JWT exp rather than expire the token on arrival")
+	require.WithinDuration(t, exp, *deadline, time.Second)
+
+	require.Nil(t, (tokenResponse{AccessToken: "xoxp-opaque", ExpiresIn: 0}).AccessExpiresAt(now),
+		"expires_in: 0 on an opaque token is no known expiry")
+}

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -583,14 +583,10 @@ func refreshSessionTokens(
 		newRefreshEnc = conv.PtrToPGText(&v)
 	}
 
-	// expires_in absent ⇒ NULL (no known expiry), matching exchangeCode. Never
-	// fabricate a deadline the upstream did not assert.
+	// No reported expiry ⇒ NULL (no known expiry), matching the code
+	// exchange. Never fabricate a deadline the upstream did not assert.
 	now := time.Now()
-	var accessExpires *time.Time
-	if tok.ExpiresIn > 0 {
-		v := now.Add(time.Duration(tok.ExpiresIn) * time.Second)
-		accessExpires = &v
-	}
+	accessExpires := tok.AccessExpiresAt(now)
 	refreshTimeout, refreshTimeoutReported := tok.RefreshTokenTimeoutSeconds()
 	refreshExpires := conv.PtrToPGTimestamptz(expirationDeadline(now, refreshTimeout, refreshTimeoutReported))
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -18,9 +18,10 @@
 //     has linked under the user_session_issuer, returning them as a
 //     remote_session_issuer_id -> token map.
 //
-// Refresh is invoked only when the stored access_expires_at has passed
-// or is within accessTokenExpirySkew of passing. A still-valid access
-// token short-circuits: no upstream token endpoint is contacted.
+// Refresh is invoked only when the stored access_expires_at has passed,
+// or is within accessTokenExpirySkew of passing and a refresh grant is
+// available. A still-valid access token short-circuits: no upstream
+// token endpoint is contacted.
 
 package remotesessions
 
@@ -443,9 +444,10 @@ func (m *ChallengeManager) resolveBoundAccessTokens(
 // just-backfilled RFC 8707 resource, from the same row as the token.
 //
 // The usable window depends on what the upstream told us:
-//   - access_expires_at set: the upstream-stated expiry governs, less
-//     accessTokenExpirySkew so a token about to expire is refreshed before it
-//     is forwarded rather than rejected upstream mid-request.
+//   - access_expires_at set: the upstream-stated expiry governs. With a usable
+//     refresh grant, a token within accessTokenExpirySkew of it is refreshed
+//     before it is forwarded rather than rejected upstream mid-request; with
+//     none, the token is forwarded until the deadline itself.
 //   - access_expires_at NULL: no expiry was reported, so the stored access
 //     token is served as-is. A refresh token does not imply that access expires.
 //
@@ -461,7 +463,7 @@ func (m *ChallengeManager) validateAndRefresh(
 		return "", sess, ErrNoValidToken
 	}
 
-	hasRefresh := sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
+	hasRefresh := hasRefreshToken(sess)
 
 	if accessTokenUsable(sess, now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -18,9 +18,9 @@
 //     has linked under the user_session_issuer, returning them as a
 //     remote_session_issuer_id -> token map.
 //
-// Refresh is invoked only when the stored access_expires_at is in the
-// past. A still-valid access token short-circuits: no upstream token
-// endpoint is contacted.
+// Refresh is invoked only when the stored access_expires_at has passed
+// or is within accessTokenExpirySkew of passing. A still-valid access
+// token short-circuits: no upstream token endpoint is contacted.
 
 package remotesessions
 
@@ -119,8 +119,8 @@ const remoteSessionLastUsedCutoff = 5 * time.Minute
 
 // ResolveAccessToken returns the upstream access token stored for the
 // (client, subject) pair, refreshing via the upstream /token endpoint
-// when the stored access_expires_at is in the past and a
-// refresh_token is present.
+// when the stored access_expires_at has passed (or is within
+// accessTokenExpirySkew of passing) and a refresh_token is present.
 //
 // Returns ("", nil) when there is no usable token for this binding —
 // no row, expired with no refresh path, refresh failed, decryption
@@ -443,7 +443,9 @@ func (m *ChallengeManager) resolveBoundAccessTokens(
 // just-backfilled RFC 8707 resource, from the same row as the token.
 //
 // The usable window depends on what the upstream told us:
-//   - access_expires_at set: the upstream-stated expiry governs.
+//   - access_expires_at set: the upstream-stated expiry governs, less
+//     accessTokenExpirySkew so a token about to expire is refreshed before it
+//     is forwarded rather than rejected upstream mid-request.
 //   - access_expires_at NULL: no expiry was reported, so the stored access
 //     token is served as-is. A refresh token does not imply that access expires.
 //
@@ -455,13 +457,13 @@ func (m *ChallengeManager) validateAndRefresh(
 	resource string,
 ) (string, remotesessions_repo.RemoteSession, error) {
 	now := time.Now()
-	if sess.AuthorizationExpiresAt.Valid && !sess.AuthorizationExpiresAt.Time.After(now) {
+	if !authorizationUsable(sess, now) {
 		return "", sess, ErrNoValidToken
 	}
 
 	hasRefresh := sess.RefreshTokenEncrypted.Valid && sess.RefreshTokenEncrypted.String != ""
 
-	if !sess.AccessExpiresAt.Valid || sess.AccessExpiresAt.Time.After(now) {
+	if accessTokenUsable(sess, now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if err != nil {
 			return "", sess, fmt.Errorf("decrypt access token: %w", err)

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -449,6 +449,9 @@ func (m *ChallengeManager) validateAndRefresh(
 
 	hasRefresh := hasRefreshToken(sess)
 
+	// The skew and its refresh-grant condition are pinned by
+	// accessTokenUsable's unit tests; they cover this path only while the
+	// deadline check stays on the shared predicate rather than inlined.
 	if accessTokenUsable(sess, now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if err != nil {

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -21,7 +21,9 @@
 // Refresh is invoked only when the stored access_expires_at has passed,
 // or is within AccessTokenExpirySkew of passing and a refresh grant is
 // available. A still-valid access token short-circuits: no upstream
-// token endpoint is contacted.
+// token endpoint is contacted. A refresh that fails inside the skew
+// window falls back to the stored token, which is still within its
+// stated lifetime; only a failure past the deadline leaves no token.
 
 package remotesessions
 
@@ -124,9 +126,9 @@ const remoteSessionLastUsedCutoff = 5 * time.Minute
 // AccessTokenExpirySkew of passing) and a refresh_token is present.
 //
 // Returns ("", nil) when there is no usable token for this binding —
-// no row, expired with no refresh path, refresh failed, decryption
-// failed. The empty string is the "no token" signal; the caller
-// decides whether absence is a challenge or a no-op.
+// no row, expired with no refresh path, refresh failed past the
+// deadline, decryption failed. The empty string is the "no token"
+// signal; the caller decides whether absence is a challenge or a no-op.
 //
 // Returns a non-nil error only for unexpected failures (database
 // errors). "No token available" is not an error.
@@ -181,34 +183,14 @@ func (m *ChallengeManager) resolveUpstreamToken(
 			return zero, nil
 		}
 		// validateAndRefresh errors only when a refresh was required (the
-		// stored access token is past its usable window) and could not be
+		// stored access token is past its deadline) and could not be
 		// completed — the upstream rejected the refresh token, or the stored
 		// token could not be decrypted. That is a broken link needing a
 		// re-connect, distinct from "never linked" (the pgx.ErrNoRows case
 		// above). Both collapse to the same empty-token signal downstream and
-		// then to a byte-identical 401, so log the reason here — using the
-		// public-safe TokenRefreshError.Reason when present — instead of
-		// discarding it silently. The issuer URL and outcome are the ones the
-		// upstream-refresh metric recorded, so this line joins to its series;
-		// the user id is what lets "how many users are affected" be answered,
-		// since a client id is one row per provider connection, not per user.
-		reason := "upstream token refresh failed"
-		if refreshErr, ok := errors.AsType[*TokenRefreshError](err); ok {
-			reason = refreshErr.Reason
-		}
-		args := []any{
-			attr.SlogRemoteSessionClientID(clientID.String()),
-			attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
-			attr.SlogOAuthFailureReason(reason),
-			attr.SlogError(err),
-		}
-		if failure, ok := errors.AsType[*RefreshError](err); ok {
-			args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
-		}
-		if subject.Kind == urn.SessionSubjectKindUser {
-			args = append(args, attr.SlogUserID(subject.ID))
-		}
-		m.logger.WarnContext(ctx, "remote session unusable: upstream token refresh failed", args...)
+		// then to a byte-identical 401, so log the reason here instead of
+		// discarding it silently.
+		m.logger.WarnContext(ctx, "remote session unusable: upstream token refresh failed", refreshFailureAttrs(sess, err)...)
 		return zero, nil
 	}
 
@@ -447,7 +429,9 @@ func (m *ChallengeManager) resolveBoundAccessTokens(
 //   - access_expires_at set: the upstream-stated expiry governs. With a usable
 //     refresh grant, a token within AccessTokenExpirySkew of it is refreshed
 //     before it is forwarded rather than rejected upstream mid-request; with
-//     none, the token is forwarded until the deadline itself.
+//     none, the token is forwarded until the deadline itself. A refresh that
+//     fails inside the skew window falls back to the stored token until the
+//     deadline; only a failure past the deadline is an error.
 //   - access_expires_at NULL: no expiry was reported, so the stored access
 //     token is served as-is. A refresh token does not imply that access expires.
 //
@@ -479,11 +463,51 @@ func (m *ChallengeManager) validateAndRefresh(
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource, remotesessionmetrics.RefreshTriggerRequest)
 	if err != nil {
-		return "", sess, err
+		// Inside the skew window the stored token is still within its stated
+		// lifetime, so a refresh that fails there — an upstream 5xx or 429, a
+		// lock cache blip — leaves it exactly as usable as it was before the
+		// attempt. Forwarding it keeps the early refresh a pure optimization:
+		// nobody is sent to reconnect while holding a token that still works.
+		// Past the deadline there is nothing to fall back to.
+		if !accessTokenLive(sess, time.Now()) {
+			return "", sess, err
+		}
+		plain, derr := m.enc.Decrypt(sess.AccessTokenEncrypted)
+		if derr != nil {
+			return "", sess, fmt.Errorf("decrypt access token after failed refresh: %w", derr)
+		}
+		m.logger.WarnContext(ctx, "remote session refresh failed inside the expiry skew; forwarding the stored access token until its deadline", refreshFailureAttrs(sess, err)...)
+		return plain, sess, nil
 	}
 	// remotesessionmetrics.RefreshOutcomeSessionInactive lands here as an empty token, which the
 	// caller treats the same as "never linked".
 	return res.AccessToken, res.Session, nil
+}
+
+// refreshFailureAttrs is the attribute set a failed request-path refresh is
+// logged with. The reason is the public-safe TokenRefreshError.Reason when
+// there is one. The issuer URL and outcome are the ones the upstream-refresh
+// metric recorded for the attempt, so the log line joins to its series; the
+// user id is what lets "how many users are affected" be answered, since a
+// client id is one row per provider connection, not per user.
+func refreshFailureAttrs(sess remotesessions_repo.RemoteSession, err error) []any {
+	reason := "upstream token refresh failed"
+	if refreshErr, ok := errors.AsType[*TokenRefreshError](err); ok {
+		reason = refreshErr.Reason
+	}
+	args := []any{
+		attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
+		attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
+		attr.SlogOAuthFailureReason(reason),
+		attr.SlogError(err),
+	}
+	if failure, ok := errors.AsType[*RefreshError](err); ok {
+		args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
+	}
+	if sess.SubjectUrn.Kind == urn.SessionSubjectKindUser {
+		args = append(args, attr.SlogUserID(sess.SubjectUrn.ID))
+	}
+	return args
 }
 
 // refreshSessionTokens POSTs grant_type=refresh_token to the upstream token

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -19,7 +19,7 @@
 //     remote_session_issuer_id -> token map.
 //
 // Refresh is invoked only when the stored access_expires_at has passed,
-// or is within accessTokenExpirySkew of passing and a refresh grant is
+// or is within AccessTokenExpirySkew of passing and a refresh grant is
 // available. A still-valid access token short-circuits: no upstream
 // token endpoint is contacted.
 
@@ -121,7 +121,7 @@ const remoteSessionLastUsedCutoff = 5 * time.Minute
 // ResolveAccessToken returns the upstream access token stored for the
 // (client, subject) pair, refreshing via the upstream /token endpoint
 // when the stored access_expires_at has passed (or is within
-// accessTokenExpirySkew of passing) and a refresh_token is present.
+// AccessTokenExpirySkew of passing) and a refresh_token is present.
 //
 // Returns ("", nil) when there is no usable token for this binding —
 // no row, expired with no refresh path, refresh failed, decryption
@@ -445,7 +445,7 @@ func (m *ChallengeManager) resolveBoundAccessTokens(
 //
 // The usable window depends on what the upstream told us:
 //   - access_expires_at set: the upstream-stated expiry governs. With a usable
-//     refresh grant, a token within accessTokenExpirySkew of it is refreshed
+//     refresh grant, a token within AccessTokenExpirySkew of it is refreshed
 //     before it is forwarded rather than rejected upstream mid-request; with
 //     none, the token is forwarded until the deadline itself.
 //   - access_expires_at NULL: no expiry was reported, so the stored access

--- a/server/internal/remotesessions/tokenservice_concurrent_refresh_test.go
+++ b/server/internal/remotesessions/tokenservice_concurrent_refresh_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
@@ -42,6 +43,9 @@ type rotatingUpstream struct {
 	replays   int
 	arrived   int
 	gate      chan struct{}
+	// expiresIn, when positive, is the expires_in the refresh grant reports.
+	// Zero omits the field, as the initial exchange always does.
+	expiresIn int
 }
 
 func newRotatingUpstream() *rotatingUpstream {
@@ -53,6 +57,7 @@ func newRotatingUpstream() *rotatingUpstream {
 		replays:   0,
 		arrived:   0,
 		gate:      make(chan struct{}),
+		expiresIn: 0,
 	}
 }
 
@@ -118,9 +123,14 @@ func (u *rotatingUpstream) handler(w http.ResponseWriter, r *http.Request) {
 	rotated := fmt.Sprintf("refresh-rotated-%d", u.rotations)
 	u.live[rotated] = true
 
-	_, _ = w.Write(fmt.Appendf(nil,
-		`{"access_token":"access-rotated-%d","refresh_token":%q,"token_type":"Bearer"}`,
-		u.rotations, rotated))
+	response := fmt.Appendf(nil,
+		`{"access_token":"access-rotated-%d","refresh_token":%q,"token_type":"Bearer"`,
+		u.rotations, rotated)
+	if u.expiresIn > 0 {
+		response = fmt.Appendf(response, `,"expires_in":%d`, u.expiresIn)
+	}
+	response = append(response, '}')
+	_, _ = w.Write(response)
 }
 
 // resolveConcurrently drives concurrentRefreshCallers simultaneous resolves
@@ -204,4 +214,27 @@ func TestResolveAccessToken_ConcurrentRefresh_CollapsesToSingleUpstreamCall(t *t
 
 	require.Equal(t, 1, upstream.refreshAttempts(),
 		"concurrent resolves for one subject must collapse into a single upstream refresh")
+}
+
+// The adoption guard: a provider whose access tokens live for less than
+// accessTokenExpirySkew writes a row that is inside the skew window the moment
+// it lands. That token is still the newest a refresh can produce, so waiters
+// must adopt it. Rejecting it sends each of them upstream with the winner's
+// rotated refresh token — one more grant per waiter, and replays once two of
+// them race.
+func TestResolveAccessToken_ConcurrentRefresh_ShortLivedTokenIsAdopted(t *testing.T) {
+	t.Parallel()
+
+	upstream := newRotatingUpstream()
+	upstream.expiresIn = int(remotesessions.AccessTokenExpirySkew / time.Second / 2)
+	_, _, tokens := resolveConcurrently(t, "concurrent-refresh-short-lived", upstream)
+
+	for i, tok := range tokens {
+		require.Equal(t, "access-rotated-1", tok, "caller %d must adopt the single rotation", i)
+	}
+	require.Equal(t, 1, upstream.refreshAttempts(),
+		"waiters must adopt a token inside the skew window rather than refresh again")
+	require.Zero(t, upstream.consumedReplays(),
+		"a consumed refresh token was presented upstream %d time(s)",
+		upstream.consumedReplays())
 }

--- a/server/internal/remotesessions/tokenservice_concurrent_refresh_test.go
+++ b/server/internal/remotesessions/tokenservice_concurrent_refresh_test.go
@@ -217,7 +217,7 @@ func TestResolveAccessToken_ConcurrentRefresh_CollapsesToSingleUpstreamCall(t *t
 }
 
 // The adoption guard: a provider whose access tokens live for less than
-// accessTokenExpirySkew writes a row that is inside the skew window the moment
+// AccessTokenExpirySkew writes a row that is inside the skew window the moment
 // it lands. That token is still the newest a refresh can produce, so waiters
 // must adopt it. Rejecting it sends each of them upstream with the winner's
 // rotated refresh token — one more grant per waiter, and replays once two of

--- a/server/internal/remotesessions/tokenservice_expiry_skew_test.go
+++ b/server/internal/remotesessions/tokenservice_expiry_skew_test.go
@@ -7,7 +7,6 @@ package remotesessions_test
 
 import (
 	"net/http"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,17 +21,19 @@ import (
 func TestResolveAccessToken_NoRefreshToken_InsideSkew_ServedUntilDeadline(t *testing.T) {
 	t.Parallel()
 
-	const upstreamAccessToken = "access-short-lived-no-refresh"
-	expiresIn := strconv.Itoa(int((remotesessions.AccessTokenExpirySkew - 5*time.Second) / time.Second))
+	const upstreamAccessToken = "access-no-refresh"
 	ctx, env := newSyntheticExpiryEnv(t, "no-refresh-skew", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"` + upstreamAccessToken + `","token_type":"Bearer","expires_in":` + expiresIn + `}`))
+		_, _ = w.Write([]byte(`{"access_token":"` + upstreamAccessToken + `","token_type":"Bearer","expires_in":3600}`))
 	})
-
-	require.True(t, env.session.AccessExpiresAt.Valid)
 	require.False(t, env.session.RefreshTokenEncrypted.Valid, "no refresh token should be stored")
-	require.True(t, env.session.AccessExpiresAt.Time.Before(time.Now().Add(remotesessions.AccessTokenExpirySkew)),
-		"fixture must land inside the skew window")
+
+	// Stand in for the stored token reaching the skew window.
+	require.NoError(t, env.q.SetRemoteSessionAccessExpiresAt(ctx, repo.SetRemoteSessionAccessExpiresAtParams{
+		ID:              env.session.ID,
+		ProjectID:       conv.ToNullUUID(env.projectID),
+		AccessExpiresAt: conv.ToPGTimestamptz(time.Now().Add(remotesessions.AccessTokenExpirySkew / 2)),
+	}))
 
 	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)

--- a/server/internal/remotesessions/tokenservice_expiry_skew_test.go
+++ b/server/internal/remotesessions/tokenservice_expiry_skew_test.go
@@ -1,4 +1,4 @@
-// tokenservice_expiry_skew_test.go pins where accessTokenExpirySkew applies on
+// tokenservice_expiry_skew_test.go pins where AccessTokenExpirySkew applies on
 // the lazy request path. The skew trades one refresh grant for a token that
 // would otherwise be rejected upstream mid-request, so it only applies when
 // there is a refresh grant to spend.

--- a/server/internal/remotesessions/tokenservice_expiry_skew_test.go
+++ b/server/internal/remotesessions/tokenservice_expiry_skew_test.go
@@ -1,0 +1,44 @@
+// tokenservice_expiry_skew_test.go pins where accessTokenExpirySkew applies on
+// the lazy request path. The skew trades one refresh grant for a token that
+// would otherwise be rejected upstream mid-request, so it only applies when
+// there is a refresh grant to spend.
+
+package remotesessions_test
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+func TestResolveAccessToken_NoRefreshToken_InsideSkew_ServedUntilDeadline(t *testing.T) {
+	t.Parallel()
+
+	const upstreamAccessToken = "access-short-lived-no-refresh"
+	expiresIn := strconv.Itoa(int((remotesessions.AccessTokenExpirySkew - 5*time.Second) / time.Second))
+	ctx, env := newSyntheticExpiryEnv(t, "no-refresh-skew", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + upstreamAccessToken + `","token_type":"Bearer","expires_in":` + expiresIn + `}`))
+	})
+
+	require.True(t, env.session.AccessExpiresAt.Valid)
+	require.False(t, env.session.RefreshTokenEncrypted.Valid, "no refresh token should be stored")
+	require.True(t, env.session.AccessExpiresAt.Time.Before(time.Now().Add(remotesessions.AccessTokenExpirySkew)),
+		"fixture must land inside the skew window")
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, upstreamAccessToken, resolved,
+		"with no refresh grant the token is forwarded until its stated deadline, not turned into a reconnect prompt early")
+
+	// The consent UI reports the same window: connected, nothing to refresh.
+	states, err := env.mgr.RemoteSessionStatuses(ctx, env.subject, env.projectID, env.organizationID, env.session.UserSessionIssuerID)
+	require.NoError(t, err)
+	require.Equal(t, remotesessions.RemoteSessionActive, states[env.clientID].Status)
+	require.False(t, states[env.clientID].CanRefresh)
+}

--- a/server/internal/remotesessions/tokenservice_expiry_skew_test.go
+++ b/server/internal/remotesessions/tokenservice_expiry_skew_test.go
@@ -8,12 +8,15 @@ package remotesessions_test
 import (
 	"net/http"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
 func TestResolveAccessToken_NoRefreshToken_InsideSkew_ServedUntilDeadline(t *testing.T) {
@@ -41,4 +44,62 @@ func TestResolveAccessToken_NoRefreshToken_InsideSkew_ServedUntilDeadline(t *tes
 	require.NoError(t, err)
 	require.Equal(t, remotesessions.RemoteSessionActive, states[env.clientID].Status)
 	require.False(t, states[env.clientID].CanRefresh)
+}
+
+func TestResolveAccessToken_RefreshFailsInsideSkew_ServesStoredTokenUntilDeadline(t *testing.T) {
+	t.Parallel()
+
+	const upstreamAccessToken = "access-refresh-refused"
+	var refreshAttempts atomic.Int32
+	ctx, env := newSyntheticExpiryEnv(t, "refresh-fails-inside-skew", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") == "refresh_token" {
+			refreshAttempts.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + upstreamAccessToken + `","refresh_token":"refresh-initial","token_type":"Bearer","expires_in":3600}`))
+	})
+
+	// Inside the window the request path spends the refresh grant first. The
+	// upstream refusing it must not cost the caller a token that still works.
+	require.NoError(t, env.q.SetRemoteSessionAccessExpiresAt(ctx, repo.SetRemoteSessionAccessExpiresAtParams{
+		ID:              env.session.ID,
+		ProjectID:       conv.ToNullUUID(env.projectID),
+		AccessExpiresAt: conv.ToPGTimestamptz(time.Now().Add(remotesessions.AccessTokenExpirySkew / 2)),
+	}))
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, upstreamAccessToken, resolved,
+		"a failed early refresh must fall back to the stored token while it is inside its stated lifetime")
+	require.EqualValues(t, 1, refreshAttempts.Load(), "the refresh must still be attempted first")
+}
+
+func TestResolveAccessToken_RefreshFailsPastDeadline_IsUnusable(t *testing.T) {
+	t.Parallel()
+
+	var refreshAttempts atomic.Int32
+	ctx, env := newSyntheticExpiryEnv(t, "refresh-fails-past-deadline", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") == "refresh_token" {
+			refreshAttempts.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access-expired","refresh_token":"refresh-initial","token_type":"Bearer","expires_in":3600}`))
+	})
+
+	require.NoError(t, env.q.SetRemoteSessionAccessExpiresAt(ctx, repo.SetRemoteSessionAccessExpiresAtParams{
+		ID:              env.session.ID,
+		ProjectID:       conv.ToNullUUID(env.projectID),
+		AccessExpiresAt: conv.ToPGTimestamptz(time.Now().Add(-time.Minute)),
+	}))
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Empty(t, resolved, "past the deadline there is no token to fall back to")
+	require.EqualValues(t, 1, refreshAttempts.Load())
 }


### PR DESCRIPTION
AIM-136

## Summary

- `tokenResponse.AccessExpiresAt` (`server/internal/remotesessions/token_response.go`) is the single place that turns a token endpoint response into an `access_expires_at` deadline. `expires_in` governs when present; when it is omitted and the access token is itself a JWT, the token's `exp` claim (RFC 9068 §2.2) is used, read through `jwtclaims.UnsafeExtractExpiry`, a sibling of the existing `UnsafeExtractSubject`. Opaque tokens and JWTs without `exp` keep storing NULL, so providers that never report an expiry behave exactly as before. A zero `expires_in` is treated as unreported.
- The authorization-code exchange (`HandleRemoteLoginCallback`) and the refresh grant (`refreshSessionTokens`) both use it, replacing two copies of the `expires_in` arithmetic.
- The JWT is decoded without signature verification: `exp` only schedules a refresh and is never used for an authorization decision, so a forged value can at most move one refresh attempt earlier or later.
- `AccessTokenExpirySkew` (30s, `refreshservice.go`) applies on the lazy request path only, and only when a usable refresh grant exists: a token whose deadline falls inside the window is refreshed instead of forwarded, so the first call after expiry no longer fails once before the next call refreshes. With no refresh grant the token is forwarded until its stated deadline, which is the same window `ListRemoteSessionStatusesForSubject` reports as active. Concurrent-winner adoption in `RefreshNow` and `awaitRefreshedSession` ignores the skew (`accessTokenLive`): a row a concurrent refresh just wrote is the newest token a refresh can produce, so waiters adopt it even from a provider whose tokens live shorter than the skew, and single-flight holds.
- A refresh that fails inside the window (upstream 5xx or 429, a lock cache blip) falls back to the stored token until its real deadline, so the early refresh is a pure optimization and nobody is sent to reconnect while holding a token that still works. Only a failure past the deadline is a 401.
- The code exchange declines to record a session whose access token has less than the skew left and no refresh token to renew it: `exp` is absolute upstream time, and persisting such a row would show the session as connected while every resolution answered with a reconnect prompt. With a refresh token a past `exp` is persisted and the first resolution refreshes.
- Tests: unit coverage for precedence (`expires_in` wins over a differing `exp`), the JWT fallback, opaque tokens, JWTs without `exp`, an already-past `exp`, a zero `expires_in`, and both predicates — the skew boundary and its refresh-grant condition live in `accessTokenUsable`'s unit tests, and `validateAndRefresh` carries a call-site note that the request path is covered only while it stays on that shared predicate. End-to-end coverage against a mock upstream that omits `expires_in` on both grants: the deadline is persisted on exchange, the lazy request path refreshes once it passes and re-derives the deadline from the rotated token, a failed early refresh forwards the stored token while a failure past the deadline does not, a no-refresh token is forwarded until its stated deadline, short-lived tokens are adopted by concurrent waiters without extra refresh grants, and an exchange that cannot yield a usable session is rejected without persisting a row.

## Motivation

Some upstream providers never return `expires_in` and instead rely on the JWT-based access token's `exp` to communicate its lifetime, typically pinned to a fixed session timeout. Because a missing `expires_in` was persisted as NULL — "no known expiry" — `validateAndRefresh` served the stored token indefinitely and never exercised the refresh grant. Once the upstream token expired, every tool call failed with an upstream auth error while the remote session still showed as connected, and the only recovery was a manual reconnect once per session-timeout window.

Reading `exp` is a standards-grounded fallback rather than a provider-specific special case, which is why it was preferred over an issuer-level default lifetime: RFC 9068 requires `exp` on JWT access tokens, and providers that do send `expires_in` are unaffected because it keeps precedence.

Rows persisted before this change keep NULL `access_expires_at` until their next refresh (manual "Refresh Now", scheduled keepalive, or reconnect), all of which go through `refreshSessionTokens` and pick up the deadline from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
