### PR TITLE
feat: validate RFC 8707 resource indicators on the user-session OAuth surface

### DIFF
--- a/.changeset/user-session-resource-indicators.md
+++ b/.changeset/user-session-resource-indicators.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+---
+
+The user-session OAuth authorization server now validates the RFC 8707 `resource` parameter on both the authorize and token legs of `/mcp/{slug}` and `/x/mcp/{slug}`. A value that does not name the endpoint the request was addressed to is rejected with `invalid_target` — by redirect on `/authorize`, as RFC 6749 §5.2 JSON on `/token` — instead of being accepted and discarded. Clients that omit the parameter are unaffected, which keeps callers predating MCP `2026-07-28` working.
+
+The comparison target is the identifier the endpoint already publishes as its authorization-server `issuer` and its protected-resource `resource`, built from the address each request arrived on rather than from a stored URL, so a server reachable under both a custom domain and the platform origin validates correctly under either. Comparison is byte equality, matching the discipline applied to the RFC 9207 `iss` parameter on the same surface.
+
+Token minting is unchanged: the `aud` claim and bearer validation continue to use the internal resource URN, so tokens already in flight keep working and `/x/mcp` tokens stay portable between toolset-backed and remote-backed servers under one issuer.

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -125,6 +125,16 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	// below and every response built later in the flow agree on it.
 	baseURL := s.BaseURLForRequest(r)
 
+	// The endpoint's canonical URI at the address this request arrived on. One
+	// value serves three contracts: the RFC 9207 `iss` on every authorization
+	// response, the AS metadata issuer, and the RFC 9728 protected-resource
+	// `resource`. That identity is what lets the RFC 8707 check below compare
+	// against a value the client was already handed.
+	issuer, err := endpoint.RootURL(baseURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build authorization response issuer").LogError(ctx, logger)
+	}
+
 	// At this point the redirect_uri is trusted (matched against the
 	// registered set on the client row), so RFC 6749 §4.1.2.1 requires that
 	// any remaining validation errors are forwarded to the client by 302
@@ -132,10 +142,13 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	// observe the failure. The two-phase Validate split exists to make this
 	// switch unambiguous.
 	if err := req.ValidatePostRedirect(); err != nil {
-		issuer, issErr := endpoint.RootURL(baseURL)
-		if issErr != nil {
-			return oops.E(oops.CodeUnexpected, issErr, "build authorization response issuer").LogError(ctx, logger)
-		}
+		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, err)
+	}
+	// RFC 8707 §2: a resource naming some other server means the client
+	// believes it is getting a token for an endpoint this one will never mint
+	// for. Rejecting makes that misconfiguration visible at the point it
+	// happens instead of at first use.
+	if err := oauthwire.ValidateResourceIndicator(req.Resource, issuer); err != nil {
 		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, err)
 	}
 

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -142,14 +142,14 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	// observe the failure. The two-phase Validate split exists to make this
 	// switch unambiguous.
 	if err := req.ValidatePostRedirect(); err != nil {
-		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, err)
+		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, "", err)
 	}
 	// RFC 8707 §2: a resource naming some other server means the client
 	// believes it is getting a token for an endpoint this one will never mint
 	// for. Rejecting makes that misconfiguration visible at the point it
 	// happens instead of at first use.
 	if err := oauthwire.ValidateResourceIndicator(req.Resource, issuer); err != nil {
-		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, err)
+		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, "resource_mismatch", err)
 	}
 
 	challengeID := uuid.NewString()
@@ -255,7 +255,11 @@ func writeAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, logger
 // invoke this AFTER the supplied redirect_uri has been validated against the
 // registered set on the OAuth client row — passing through an untrusted URI
 // here would turn the AS into an open redirector.
-func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, issuer, redirectURI, originalState string, err error) error {
+// failureReason labels the rejection with the same vocabulary the token
+// endpoint logs (for example "resource_mismatch"), so one query finds a given
+// class of rejection on both legs. Empty when the error code alone identifies
+// the cause.
+func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, issuer, redirectURI, originalState, failureReason string, err error) error {
 	code := "invalid_request"
 	description := err.Error()
 	var oauthErr *oauthwire.Error
@@ -263,10 +267,14 @@ func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *
 		code = oauthErr.Code
 		description = oauthErr.Description
 	}
-	logger.InfoContext(ctx, "authorize request rejected (post-redirect)",
+	args := []any{
 		attr.SlogOAuthError(code),
 		attr.SlogOAuthErrorDescription(description),
-	)
+	}
+	if failureReason != "" {
+		args = append(args, attr.SlogOAuthFailureReason(failureReason))
+	}
+	logger.InfoContext(ctx, "authorize request rejected (post-redirect)", args...)
 	redirect, err := buildClientRedirect(clientRedirectParams{
 		RedirectURI:      redirectURI,
 		Issuer:           issuer,

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -148,7 +148,7 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	// believes it is getting a token for an endpoint this one will never mint
 	// for. Rejecting makes that misconfiguration visible at the point it
 	// happens instead of at first use.
-	if err := oauthwire.ValidateResourceIndicator(req.Resource, issuer); err != nil {
+	if err := oauthwire.ValidateResourceIndicators(req.Resources, issuer); err != nil {
 		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, "resource_mismatch", err)
 	}
 

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -362,3 +362,78 @@ func createPrivateIssuerGatedToolset(
 
 	return toolset, issuer
 }
+
+// RFC 8707 §2 rejection is a post-redirect outcome: the redirect_uri has
+// already been matched against the registered set, so the client learns about
+// it by 302 carrying invalid_target, never inline.
+func TestAuthorize_MismatchedResourceRejectedByRedirect(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedIssuer, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", client.ClientID)
+	q.Set("redirect_uri", client.RedirectUris[0])
+	q.Set("state", "client-state")
+	q.Set("code_challenge", "challenge")
+	q.Set("code_challenge_method", "S256")
+	q.Set("resource", "https://someone-else.example.com/mcp/"+mcpSlug)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/authorize?"+q.Encode(), nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(w, req))
+	require.Equal(t, http.StatusFound, w.Code, "a trusted redirect_uri means errors go back by redirect")
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "invalid_target", loc.Query().Get("error"))
+	require.Equal(t, "client-state", loc.Query().Get("state"))
+	require.Equal(t, advertisedIssuer, loc.Query().Get("iss"))
+}
+
+// The value a conformant client sends is the one it read from the
+// protected-resource metadata, so echoing that back must start the flow.
+func TestAuthorize_MatchingResourceStartsFlow(t *testing.T) {
+	t.Parallel()
+
+	idpURL, err := url.Parse("https://idp.example.test/authorize")
+	require.NoError(t, err)
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{buildAuthURLResult: idpURL})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedIssuer, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", client.ClientID)
+	q.Set("redirect_uri", client.RedirectUris[0])
+	q.Set("state", "client-state")
+	q.Set("code_challenge", "challenge")
+	q.Set("code_challenge_method", "S256")
+	q.Set("resource", advertisedIssuer)
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/authorize?"+q.Encode(), nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(w, req))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Empty(t, loc.Query().Get("error"), "matching resource must not be rejected")
+	require.Equal(t, idpURL.Host, loc.Host, "a matching resource must carry the flow on to the IDP")
+}

--- a/server/internal/mcp/authnchallenge_clientauth_test.go
+++ b/server/internal/mcp/authnchallenge_clientauth_test.go
@@ -296,7 +296,7 @@ func TestHandleToken_PrivateKeyJWT_RefreshGrant(t *testing.T) {
 
 	refreshToken := seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, nil)
 
-	w := postRefreshGrant(t, ti, toolset.McpSlug.String, client.ClientID, refreshToken)
+	w := postRefreshGrant(t, ti, toolset.McpSlug.String, client.ClientID, refreshToken, "")
 	requireInvalidClient(t, w)
 
 	form := url.Values{}

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -1749,13 +1749,18 @@ func seedUserSessionWithSelection(t *testing.T, ctx context.Context, ti *testIns
 	return refreshToken
 }
 
-func postRefreshGrant(t *testing.T, ti *testInstance, mcpSlug, clientID, refreshToken string) *httptest.ResponseRecorder {
+// resource is the RFC 8707 indicator to submit; empty omits the parameter,
+// which the token endpoint accepts.
+func postRefreshGrant(t *testing.T, ti *testInstance, mcpSlug, clientID, refreshToken, resource string) *httptest.ResponseRecorder {
 	t.Helper()
 
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("client_id", clientID)
+	if resource != "" {
+		form.Set("resource", resource)
+	}
 	req := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rctx := chi.NewRouteContext()
@@ -1842,14 +1847,14 @@ func TestHandleTokenRefresh_ToolSelectionResourceBinding(t *testing.T) {
 	var err error
 	_ = err
 	w := postRefreshGrant(t, ti, toolset.McpSlug.String, client.ClientID,
-		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, mismatched))
+		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, mismatched), "")
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "invalid_grant")
 	require.Contains(t, w.Body.String(), "different MCP endpoint")
 
 	matching := fmt.Appendf(nil, `{"resource":"toolset:%s","grant_id":"%s","allow":[{"type":"tool","name":"a"}]}`, toolset.ID.String(), uuid.NewString())
 	w = postRefreshGrant(t, ti, toolset.McpSlug.String, client.ClientID,
-		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, matching))
+		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, matching), "")
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "access_token")
 }

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -274,7 +274,7 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build token resource identifier").LogError(ctx, logger)
 	}
-	if err := oauthwire.ValidateResourceIndicator(req.Resource, canonicalResource); err != nil {
+	if err := oauthwire.ValidateResourceIndicators(req.Resources, canonicalResource); err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "resource_mismatch")
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
@@ -409,7 +409,7 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build token resource identifier").LogError(ctx, logger)
 	}
-	if err := oauthwire.ValidateResourceIndicator(req.Resource, canonicalResource); err != nil {
+	if err := oauthwire.ValidateResourceIndicators(req.Resources, canonicalResource); err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "resource_mismatch")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -267,6 +267,19 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
+	// RFC 8707 §2, token leg. Built from the address this request arrived on,
+	// so it matches the identifier the protected-resource metadata advertised
+	// to the client that is now redeeming its code.
+	canonicalResource, err := endpoint.RootURL(baseURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build token resource identifier").LogError(ctx, logger)
+	}
+	if err := oauthwire.ValidateResourceIndicator(req.Resource, canonicalResource); err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "resource_mismatch")
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
+	}
+
 	// Atomic GETDEL: single-use authorization code. If two clients race to
 	// redeem the same code, exactly one wins the GETDEL; the other gets
 	// ErrCacheMiss and is rejected as invalid_grant (RFC 6749 §4.1.2 / §10.5).
@@ -384,6 +397,20 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	req.SetDefaults()
 	if err := req.Validate(); err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "invalid_request")
+		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
+	}
+
+	// RFC 8707 §2 applies to the refresh leg too: MCP 2026-07-28 has clients
+	// send `resource` on every token request, so a rotation naming another
+	// server is the same misconfiguration as it is on the authorization_code
+	// grant. No flow-failure metric here — a refresh is not part of an initial
+	// flow, and the completion ratio counts only those.
+	canonicalResource, err := endpoint.RootURL(baseURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build token resource identifier").LogError(ctx, logger)
+	}
+	if err := oauthwire.ValidateResourceIndicator(req.Resource, canonicalResource); err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "resource_mismatch")
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 

--- a/server/internal/mcp/authnchallenge_token_test.go
+++ b/server/internal/mcp/authnchallenge_token_test.go
@@ -1,0 +1,127 @@
+package mcp_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// TestHandleTokenCode_ResourceIndicator covers the RFC 8707 check on the
+// authorization_code grant: a resource naming another server is invalid_target,
+// the advertised identifier is accepted, and an absent parameter stays legal
+// for clients predating MCP 2026-07-28.
+func TestHandleTokenCode_ResourceIndicator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedResource, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	verifier := "verifier-" + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	grantCache := cache.NewTypedObjectCache[mcp.UserSessionGrant](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	redirectURI := "http://127.0.0.1:51423/callback"
+
+	// Codes are single-use, so each redemption gets a freshly stored grant.
+	redeem := func(resource string) *httptest.ResponseRecorder {
+		code := "code-" + uuid.NewString()
+		require.NoError(t, grantCache.Store(ctx, mcp.UserSessionGrant{
+			Code:                        code,
+			FlowID:                      "",
+			UserSessionIssuerID:         toolset.UserSessionIssuerID.UUID,
+			UserSessionClientID:         client.ID,
+			ClientID:                    client.ClientID,
+			RedirectURI:                 redirectURI,
+			CodeChallenge:               base64.RawURLEncoding.EncodeToString(sum[:]),
+			CodeChallengeMethod:         "S256",
+			Subject:                     urn.NewUserSubject("code-user-" + uuid.NewString()),
+			DesiredSessionDurationHours: 0,
+			ToolSelection:               nil,
+			CreatedAt:                   time.Now(),
+		}))
+
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", redirectURI)
+		form.Set("client_id", client.ClientID)
+		form.Set("code_verifier", verifier)
+		if resource != "" {
+			form.Set("resource", resource)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("mcpSlug", mcpSlug)
+		req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+		w := httptest.NewRecorder()
+		require.NoError(t, ti.service.HandleToken(w, req))
+		return w
+	}
+
+	w := redeem("https://someone-else.example.com/mcp/" + mcpSlug)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid_target")
+
+	// Same server, wrong route base: /mcp and /x/mcp mint different audiences,
+	// so they are never interchangeable resource identifiers.
+	w = redeem(strings.Replace(advertisedResource, "/mcp/", "/x/mcp/", 1))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid_target")
+
+	w = redeem(advertisedResource + "/")
+	require.Equal(t, http.StatusBadRequest, w.Code, "a trailing slash is not the advertised identifier")
+
+	w = redeem(advertisedResource)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "access_token")
+
+	w = redeem("")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "access_token")
+}
+
+// TestHandleTokenRefresh_ResourceIndicator asserts the same check on the
+// refresh grant, which MCP 2026-07-28 clients also send `resource` on.
+func TestHandleTokenRefresh_ResourceIndicator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, issuer, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedResource, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	w := postRefreshGrant(t, ti, mcpSlug, client.ClientID,
+		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, nil),
+		"https://someone-else.example.com/mcp/"+mcpSlug)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "invalid_target")
+
+	w = postRefreshGrant(t, ti, mcpSlug, client.ClientID,
+		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, nil),
+		advertisedResource)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "access_token")
+
+	w = postRefreshGrant(t, ti, mcpSlug, client.ClientID,
+		seedUserSessionWithSelection(t, ctx, ti, issuer.ID, client.ID, nil), "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "access_token")
+}

--- a/server/internal/usersessions/authorizationrequest.go
+++ b/server/internal/usersessions/authorizationrequest.go
@@ -31,12 +31,13 @@ type AuthorizationRequest struct {
 	// toolsets, which always route through the IDP.
 	RequireUserIdentity bool
 
-	// Resource is the RFC 8707 resource indicator naming the MCP server the
-	// client intends to use the token with. Nil when the parameter was absent,
-	// which stays acceptable; a present value is validated against the
-	// addressed endpoint's canonical URI by
-	// oauthwire.ValidateResourceIndicator once the redirect_uri is trusted.
-	Resource *string
+	// Resources holds every RFC 8707 `resource` indicator submitted, naming the
+	// MCP server the client intends to use the token with. Empty when the
+	// parameter was absent, which stays acceptable; RFC 8707 §2 permits
+	// repeating it, and every value is validated against the addressed
+	// endpoint's canonical URI by oauthwire.ValidateResourceIndicators once the
+	// redirect_uri is trusted.
+	Resources []string
 }
 
 // AuthorizationRequestFromQuery decodes an AuthorizationRequest from
@@ -51,7 +52,7 @@ func AuthorizationRequestFromQuery(q url.Values) *AuthorizationRequest {
 		CodeChallenge:       q.Get("code_challenge"),
 		CodeChallengeMethod: q.Get("code_challenge_method"),
 		RequireUserIdentity: requireUserIdentity,
-		Resource:            oauthwire.ResourceIndicatorFrom(q),
+		Resources:           oauthwire.ResourceIndicatorsFrom(q),
 	}
 }
 

--- a/server/internal/usersessions/authorizationrequest.go
+++ b/server/internal/usersessions/authorizationrequest.go
@@ -30,6 +30,12 @@ type AuthorizationRequest struct {
 	// so Subject is stamped from authoritative claims. No-op on private
 	// toolsets, which always route through the IDP.
 	RequireUserIdentity bool
+
+	// Resource is the RFC 8707 resource indicator naming the MCP server the
+	// client intends to use the token with. Optional on the wire; validated
+	// against the addressed endpoint's canonical URI by
+	// oauthwire.ValidateResourceIndicator once the redirect_uri is trusted.
+	Resource string
 }
 
 // AuthorizationRequestFromQuery decodes an AuthorizationRequest from
@@ -44,6 +50,7 @@ func AuthorizationRequestFromQuery(q url.Values) *AuthorizationRequest {
 		CodeChallenge:       q.Get("code_challenge"),
 		CodeChallengeMethod: q.Get("code_challenge_method"),
 		RequireUserIdentity: requireUserIdentity,
+		Resource:            q.Get("resource"),
 	}
 }
 

--- a/server/internal/usersessions/authorizationrequest.go
+++ b/server/internal/usersessions/authorizationrequest.go
@@ -32,10 +32,11 @@ type AuthorizationRequest struct {
 	RequireUserIdentity bool
 
 	// Resource is the RFC 8707 resource indicator naming the MCP server the
-	// client intends to use the token with. Optional on the wire; validated
-	// against the addressed endpoint's canonical URI by
+	// client intends to use the token with. Nil when the parameter was absent,
+	// which stays acceptable; a present value is validated against the
+	// addressed endpoint's canonical URI by
 	// oauthwire.ValidateResourceIndicator once the redirect_uri is trusted.
-	Resource string
+	Resource *string
 }
 
 // AuthorizationRequestFromQuery decodes an AuthorizationRequest from
@@ -50,7 +51,7 @@ func AuthorizationRequestFromQuery(q url.Values) *AuthorizationRequest {
 		CodeChallenge:       q.Get("code_challenge"),
 		CodeChallengeMethod: q.Get("code_challenge_method"),
 		RequireUserIdentity: requireUserIdentity,
-		Resource:            q.Get("resource"),
+		Resource:            oauthwire.ResourceIndicatorFrom(q),
 	}
 }
 

--- a/server/internal/usersessions/authorizationrequest_test.go
+++ b/server/internal/usersessions/authorizationrequest_test.go
@@ -25,8 +25,7 @@ func TestAuthorizationRequestFromQuery(t *testing.T) {
 	require.Equal(t, "xyz", req.State)
 	require.Equal(t, "abc123", req.CodeChallenge)
 	require.Equal(t, "S256", req.CodeChallengeMethod)
-	require.NotNil(t, req.Resource)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
+	require.Equal(t, []string{"https://acme.example.com/mcp/support-bot"}, req.Resources)
 }
 
 func TestAuthorizationRequest_ValidateRedirectableFields(t *testing.T) {

--- a/server/internal/usersessions/authorizationrequest_test.go
+++ b/server/internal/usersessions/authorizationrequest_test.go
@@ -16,6 +16,7 @@ func TestAuthorizationRequestFromQuery(t *testing.T) {
 	q.Set("state", "xyz")
 	q.Set("code_challenge", "abc123")
 	q.Set("code_challenge_method", "S256")
+	q.Set("resource", "https://acme.example.com/mcp/support-bot")
 
 	req := AuthorizationRequestFromQuery(q)
 	require.Equal(t, "client_abc", req.ClientID)
@@ -24,6 +25,7 @@ func TestAuthorizationRequestFromQuery(t *testing.T) {
 	require.Equal(t, "xyz", req.State)
 	require.Equal(t, "abc123", req.CodeChallenge)
 	require.Equal(t, "S256", req.CodeChallengeMethod)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
 }
 
 func TestAuthorizationRequest_ValidateRedirectableFields(t *testing.T) {

--- a/server/internal/usersessions/authorizationrequest_test.go
+++ b/server/internal/usersessions/authorizationrequest_test.go
@@ -25,7 +25,8 @@ func TestAuthorizationRequestFromQuery(t *testing.T) {
 	require.Equal(t, "xyz", req.State)
 	require.Equal(t, "abc123", req.CodeChallenge)
 	require.Equal(t, "S256", req.CodeChallengeMethod)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
+	require.NotNil(t, req.Resource)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
 }
 
 func TestAuthorizationRequest_ValidateRedirectableFields(t *testing.T) {

--- a/server/internal/usersessions/oauthwire/oauthwire.go
+++ b/server/internal/usersessions/oauthwire/oauthwire.go
@@ -105,11 +105,26 @@ func ValidateRedirectURI(raw string) error {
 	}
 }
 
+// ResourceIndicatorFrom extracts the RFC 8707 `resource` parameter from a query
+// string or form body, returning nil when the parameter is absent and a pointer
+// to the raw value when it is present. The distinction is load-bearing: RFC 8707
+// §2 lets a client omit the parameter, but requires any value it does send to be
+// an absolute URI, so `resource=` is a malformed value rather than an omission
+// and must not be waved through as one.
+func ResourceIndicatorFrom(values url.Values) *string {
+	if !values.Has("resource") {
+		return nil
+	}
+	raw := values.Get("resource")
+	return &raw
+}
+
 // ValidateResourceIndicator checks an RFC 8707 `resource` parameter against
-// canonical, the resource identifier for the address the request arrived on.
-// An empty resource is accepted: RFC 8707 §2 leaves demanding the parameter to
-// the authorization server's discretion, and clients predating MCP 2026-07-28
-// do not send one.
+// canonical, the resource identifier for the address the request arrived on. A
+// nil resource is accepted: RFC 8707 §2 leaves demanding the parameter to the
+// authorization server's discretion, and clients predating MCP 2026-07-28 do not
+// send one. A present-but-empty value is rejected like any other non-matching
+// one, since the empty string is not the absolute URI the RFC requires.
 //
 // Comparison is byte equality. MCP 2026-07-28 asks implementations to accept
 // uppercase scheme and host components for robustness; this surface
@@ -122,11 +137,11 @@ func ValidateRedirectURI(raw string) error {
 // identifiers (custom domain or platform origin, each under two route bases).
 // Callers must derive it from the request being validated, never from a stored
 // or global URL.
-func ValidateResourceIndicator(resource, canonical string) error {
-	if resource == "" {
+func ValidateResourceIndicator(resource *string, canonical string) error {
+	if resource == nil {
 		return nil
 	}
-	if resource != canonical {
+	if *resource != canonical {
 		// The submitted value is deliberately not echoed: on the authorize leg
 		// this description is carried in a redirect the client renders. The
 		// expected value is already public in the protected-resource metadata.

--- a/server/internal/usersessions/oauthwire/oauthwire.go
+++ b/server/internal/usersessions/oauthwire/oauthwire.go
@@ -104,3 +104,33 @@ func ValidateRedirectURI(raw string) error {
 		return nil
 	}
 }
+
+// ValidateResourceIndicator checks an RFC 8707 `resource` parameter against
+// canonical, the resource identifier for the address the request arrived on.
+// An empty resource is accepted: RFC 8707 §2 leaves demanding the parameter to
+// the authorization server's discretion, and clients predating MCP 2026-07-28
+// do not send one.
+//
+// Comparison is byte equality. MCP 2026-07-28 asks implementations to accept
+// uppercase scheme and host components for robustness; this surface
+// deliberately declines, holding `resource` to the simple string comparison
+// (RFC 3986 §6.2.1) that RFC 9207 §2.4 mandates for `iss`. The two identifiers
+// are minted from one base URL and published in the same metadata documents,
+// so a client echoing the value it read back matches on the first attempt.
+//
+// canonical is address-specific — one MCP server is reachable under several
+// identifiers (custom domain or platform origin, each under two route bases).
+// Callers must derive it from the request being validated, never from a stored
+// or global URL.
+func ValidateResourceIndicator(resource, canonical string) error {
+	if resource == "" {
+		return nil
+	}
+	if resource != canonical {
+		// The submitted value is deliberately not echoed: on the authorize leg
+		// this description is carried in a redirect the client renders. The
+		// expected value is already public in the protected-resource metadata.
+		return &Error{Code: "invalid_target", Description: fmt.Sprintf("resource does not identify this MCP server (expected %q)", canonical)}
+	}
+	return nil
+}

--- a/server/internal/usersessions/oauthwire/oauthwire.go
+++ b/server/internal/usersessions/oauthwire/oauthwire.go
@@ -105,26 +105,31 @@ func ValidateRedirectURI(raw string) error {
 	}
 }
 
-// ResourceIndicatorFrom extracts the RFC 8707 `resource` parameter from a query
-// string or form body, returning nil when the parameter is absent and a pointer
-// to the raw value when it is present. The distinction is load-bearing: RFC 8707
-// §2 lets a client omit the parameter, but requires any value it does send to be
-// an absolute URI, so `resource=` is a malformed value rather than an omission
-// and must not be waved through as one.
-func ResourceIndicatorFrom(values url.Values) *string {
-	if !values.Has("resource") {
-		return nil
-	}
-	raw := values.Get("resource")
-	return &raw
+// ResourceIndicatorsFrom extracts every RFC 8707 `resource` parameter from a
+// query string or form body, in submission order. RFC 8707 §2 permits repeating
+// the parameter to request a token usable at several resources, so reading only
+// the first value would leave the rest unvalidated.
+//
+// The returned slice distinguishes the three cases that matter: empty when the
+// parameter was absent, which is permitted; a single element for the ordinary
+// request; and one element per submission when repeated. An explicitly empty
+// `resource=` arrives as a one-element slice holding the empty string, which is
+// a malformed value rather than an omission — the RFC requires an absolute URI —
+// and is rejected as such by ValidateResourceIndicators.
+func ResourceIndicatorsFrom(values url.Values) []string {
+	return values["resource"]
 }
 
-// ValidateResourceIndicator checks an RFC 8707 `resource` parameter against
-// canonical, the resource identifier for the address the request arrived on. A
-// nil resource is accepted: RFC 8707 §2 leaves demanding the parameter to the
-// authorization server's discretion, and clients predating MCP 2026-07-28 do not
-// send one. A present-but-empty value is rejected like any other non-matching
-// one, since the empty string is not the absolute URI the RFC requires.
+// ValidateResourceIndicators checks every submitted RFC 8707 `resource` against
+// canonical, the resource identifier for the address the request arrived on. No
+// resources at all is accepted: RFC 8707 §2 leaves demanding the parameter to
+// the authorization server's discretion, and clients predating MCP 2026-07-28 do
+// not send one.
+//
+// Every value must match. This surface mints a token audienced to exactly one
+// endpoint, so it cannot honour a request naming any other resource, and
+// accepting a matching value alongside a mismatched one would confirm a binding
+// that was never made.
 //
 // Comparison is byte equality. MCP 2026-07-28 asks implementations to accept
 // uppercase scheme and host components for robustness; this surface
@@ -137,15 +142,15 @@ func ResourceIndicatorFrom(values url.Values) *string {
 // identifiers (custom domain or platform origin, each under two route bases).
 // Callers must derive it from the request being validated, never from a stored
 // or global URL.
-func ValidateResourceIndicator(resource *string, canonical string) error {
-	if resource == nil {
-		return nil
-	}
-	if *resource != canonical {
-		// The submitted value is deliberately not echoed: on the authorize leg
-		// this description is carried in a redirect the client renders. The
-		// expected value is already public in the protected-resource metadata.
-		return &Error{Code: "invalid_target", Description: fmt.Sprintf("resource does not identify this MCP server (expected %q)", canonical)}
+func ValidateResourceIndicators(resources []string, canonical string) error {
+	for _, resource := range resources {
+		if resource != canonical {
+			// The submitted value is deliberately not echoed: on the authorize
+			// leg this description is carried in a redirect the client renders.
+			// The expected value is already public in the protected-resource
+			// metadata.
+			return &Error{Code: "invalid_target", Description: fmt.Sprintf("resource does not identify this MCP server (expected %q)", canonical)}
+		}
 	}
 	return nil
 }

--- a/server/internal/usersessions/oauthwire/oauthwire_test.go
+++ b/server/internal/usersessions/oauthwire/oauthwire_test.go
@@ -21,65 +21,65 @@ func requireInvalidTarget(t *testing.T, err error) {
 	require.Equal(t, "invalid_target", oauthErr.Code)
 }
 
-func TestValidateResourceIndicator_AcceptsAbsentResource(t *testing.T) {
+func TestValidateResourceIndicators_AcceptsAbsentResource(t *testing.T) {
 	t.Parallel()
 	// RFC 8707 §2 leaves demanding the parameter to the AS, and clients
 	// predating MCP 2026-07-28 never send one.
-	require.NoError(t, oauthwire.ValidateResourceIndicator(nil, canonicalResource))
+	require.NoError(t, oauthwire.ValidateResourceIndicators(nil, canonicalResource))
 }
 
-func TestValidateResourceIndicator_AcceptsExactMatch(t *testing.T) {
+func TestValidateResourceIndicators_AcceptsExactMatch(t *testing.T) {
 	t.Parallel()
-	require.NoError(t, oauthwire.ValidateResourceIndicator(new(canonicalResource), canonicalResource))
+	require.NoError(t, oauthwire.ValidateResourceIndicators([]string{canonicalResource}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsDifferentHost(t *testing.T) {
+func TestValidateResourceIndicators_RejectsDifferentHost(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://evil.example.com/mcp/support-bot"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{"https://evil.example.com/mcp/support-bot"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsDifferentSlug(t *testing.T) {
+func TestValidateResourceIndicators_RejectsDifferentSlug(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com/mcp/billing-bot"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{"https://acme.example.com/mcp/billing-bot"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsTrailingSlash(t *testing.T) {
+func TestValidateResourceIndicators_RejectsTrailingSlash(t *testing.T) {
 	t.Parallel()
 	// MCP 2026-07-28 tells clients to emit the no-trailing-slash form and asks
 	// nothing of servers on the accepting side, so this stays a mismatch.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new(canonicalResource+"/"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{canonicalResource + "/"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsUppercaseSchemeAndHost(t *testing.T) {
+func TestValidateResourceIndicators_RejectsUppercaseSchemeAndHost(t *testing.T) {
 	t.Parallel()
 	// Pins a deliberate deviation: MCP 2026-07-28 §Canonical Server URI says
 	// implementations SHOULD accept uppercase scheme and host components. This
 	// surface declines, holding `resource` to the same simple string
 	// comparison RFC 9207 §2.4 mandates for `iss`. Changing this is a policy
 	// decision, not a bug fix.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("HTTPS://ACME.EXAMPLE.COM/mcp/support-bot"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{"HTTPS://ACME.EXAMPLE.COM/mcp/support-bot"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsDifferentRouteBase(t *testing.T) {
+func TestValidateResourceIndicators_RejectsDifferentRouteBase(t *testing.T) {
 	t.Parallel()
 	// /mcp and /x/mcp can front the same server but mint different audiences
 	// (urn:toolset vs urn:user-session-issuer), so they are never equivalent
 	// resource identifiers.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com/x/mcp/support-bot"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{"https://acme.example.com/x/mcp/support-bot"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_RejectsDefaultPortElision(t *testing.T) {
+func TestValidateResourceIndicators_RejectsDefaultPortElision(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com:443/mcp/support-bot"), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{"https://acme.example.com:443/mcp/support-bot"}, canonicalResource))
 }
 
-func TestValidateResourceIndicator_DescriptionNamesExpectedNotSubmitted(t *testing.T) {
+func TestValidateResourceIndicators_DescriptionNamesExpectedNotSubmitted(t *testing.T) {
 	t.Parallel()
 	// The description travels in a redirect the client renders, so the
 	// submitted value must not be reflected back into it. The expected value is
 	// already public in the protected-resource metadata.
 	submitted := "https://evil.example.com/mcp/<script>"
-	err := oauthwire.ValidateResourceIndicator(&submitted, canonicalResource)
+	err := oauthwire.ValidateResourceIndicators([]string{submitted}, canonicalResource)
 
 	var oauthErr *oauthwire.Error
 	require.ErrorAs(t, err, &oauthErr)
@@ -87,24 +87,41 @@ func TestValidateResourceIndicator_DescriptionNamesExpectedNotSubmitted(t *testi
 	require.NotContains(t, oauthErr.Description, submitted)
 }
 
-func TestValidateResourceIndicator_RejectsPresentButEmpty(t *testing.T) {
+func TestValidateResourceIndicators_AcceptsRepeatedMatchingValues(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, oauthwire.ValidateResourceIndicators([]string{canonicalResource, canonicalResource}, canonicalResource))
+}
+
+func TestValidateResourceIndicators_RejectsMismatchAfterAMatch(t *testing.T) {
+	t.Parallel()
+	// RFC 8707 §2 lets a client repeat `resource`. Checking only the first
+	// would let a matching value smuggle a mismatched one past validation.
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators(
+		[]string{canonicalResource, "https://evil.example.com/mcp/support-bot"}, canonicalResource))
+}
+
+func TestValidateResourceIndicators_RejectsPresentButEmpty(t *testing.T) {
 	t.Parallel()
 	// `resource=` is a malformed value, not an omission: RFC 8707 §2 requires
 	// any value sent to be an absolute URI. Accepting it would reintroduce the
 	// silent-acceptance this validation exists to remove.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new(""), canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{""}, canonicalResource))
 }
 
-func TestResourceIndicatorFrom_DistinguishesAbsentFromEmpty(t *testing.T) {
+func TestResourceIndicatorsFrom_DistinguishesAbsentFromEmpty(t *testing.T) {
 	t.Parallel()
 
-	require.Nil(t, oauthwire.ResourceIndicatorFrom(url.Values{}), "absent must be nil")
+	require.Empty(t, oauthwire.ResourceIndicatorsFrom(url.Values{}), "absent must yield no values")
 
-	empty := oauthwire.ResourceIndicatorFrom(url.Values{"resource": []string{""}})
-	require.NotNil(t, empty, "present-but-empty must not read as absent")
-	require.Empty(t, *empty)
+	// Present-but-empty must survive as a value rather than collapse into
+	// absence: `resource=` is malformed, and validation has to see it to
+	// reject it.
+	require.Equal(t, []string{""}, oauthwire.ResourceIndicatorsFrom(url.Values{"resource": []string{""}}))
 
-	set := oauthwire.ResourceIndicatorFrom(url.Values{"resource": []string{canonicalResource}})
-	require.NotNil(t, set)
-	require.Equal(t, canonicalResource, *set)
+	require.Equal(t, []string{canonicalResource}, oauthwire.ResourceIndicatorsFrom(url.Values{"resource": []string{canonicalResource}}))
+
+	// RFC 8707 §2 permits repeating the parameter; every value must survive
+	// extraction or the later ones would go unvalidated.
+	repeated := url.Values{"resource": []string{canonicalResource, "https://evil.example.com/mcp/support-bot"}}
+	require.Len(t, oauthwire.ResourceIndicatorsFrom(repeated), 2)
 }

--- a/server/internal/usersessions/oauthwire/oauthwire_test.go
+++ b/server/internal/usersessions/oauthwire/oauthwire_test.go
@@ -1,6 +1,7 @@
 package oauthwire_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,29 +25,29 @@ func TestValidateResourceIndicator_AcceptsAbsentResource(t *testing.T) {
 	t.Parallel()
 	// RFC 8707 §2 leaves demanding the parameter to the AS, and clients
 	// predating MCP 2026-07-28 never send one.
-	require.NoError(t, oauthwire.ValidateResourceIndicator("", canonicalResource))
+	require.NoError(t, oauthwire.ValidateResourceIndicator(nil, canonicalResource))
 }
 
 func TestValidateResourceIndicator_AcceptsExactMatch(t *testing.T) {
 	t.Parallel()
-	require.NoError(t, oauthwire.ValidateResourceIndicator(canonicalResource, canonicalResource))
+	require.NoError(t, oauthwire.ValidateResourceIndicator(new(canonicalResource), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsDifferentHost(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://evil.example.com/mcp/support-bot", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://evil.example.com/mcp/support-bot"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsDifferentSlug(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com/mcp/billing-bot", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com/mcp/billing-bot"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsTrailingSlash(t *testing.T) {
 	t.Parallel()
 	// MCP 2026-07-28 tells clients to emit the no-trailing-slash form and asks
 	// nothing of servers on the accepting side, so this stays a mismatch.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(canonicalResource+"/", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new(canonicalResource+"/"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsUppercaseSchemeAndHost(t *testing.T) {
@@ -56,7 +57,7 @@ func TestValidateResourceIndicator_RejectsUppercaseSchemeAndHost(t *testing.T) {
 	// surface declines, holding `resource` to the same simple string
 	// comparison RFC 9207 §2.4 mandates for `iss`. Changing this is a policy
 	// decision, not a bug fix.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("HTTPS://ACME.EXAMPLE.COM/mcp/support-bot", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("HTTPS://ACME.EXAMPLE.COM/mcp/support-bot"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsDifferentRouteBase(t *testing.T) {
@@ -64,12 +65,12 @@ func TestValidateResourceIndicator_RejectsDifferentRouteBase(t *testing.T) {
 	// /mcp and /x/mcp can front the same server but mint different audiences
 	// (urn:toolset vs urn:user-session-issuer), so they are never equivalent
 	// resource identifiers.
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com/x/mcp/support-bot", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com/x/mcp/support-bot"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_RejectsDefaultPortElision(t *testing.T) {
 	t.Parallel()
-	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com:443/mcp/support-bot", canonicalResource))
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new("https://acme.example.com:443/mcp/support-bot"), canonicalResource))
 }
 
 func TestValidateResourceIndicator_DescriptionNamesExpectedNotSubmitted(t *testing.T) {
@@ -78,10 +79,32 @@ func TestValidateResourceIndicator_DescriptionNamesExpectedNotSubmitted(t *testi
 	// submitted value must not be reflected back into it. The expected value is
 	// already public in the protected-resource metadata.
 	submitted := "https://evil.example.com/mcp/<script>"
-	err := oauthwire.ValidateResourceIndicator(submitted, canonicalResource)
+	err := oauthwire.ValidateResourceIndicator(&submitted, canonicalResource)
 
 	var oauthErr *oauthwire.Error
 	require.ErrorAs(t, err, &oauthErr)
 	require.Contains(t, oauthErr.Description, canonicalResource)
 	require.NotContains(t, oauthErr.Description, submitted)
+}
+
+func TestValidateResourceIndicator_RejectsPresentButEmpty(t *testing.T) {
+	t.Parallel()
+	// `resource=` is a malformed value, not an omission: RFC 8707 §2 requires
+	// any value sent to be an absolute URI. Accepting it would reintroduce the
+	// silent-acceptance this validation exists to remove.
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(new(""), canonicalResource))
+}
+
+func TestResourceIndicatorFrom_DistinguishesAbsentFromEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, oauthwire.ResourceIndicatorFrom(url.Values{}), "absent must be nil")
+
+	empty := oauthwire.ResourceIndicatorFrom(url.Values{"resource": []string{""}})
+	require.NotNil(t, empty, "present-but-empty must not read as absent")
+	require.Empty(t, *empty)
+
+	set := oauthwire.ResourceIndicatorFrom(url.Values{"resource": []string{canonicalResource}})
+	require.NotNil(t, set)
+	require.Equal(t, canonicalResource, *set)
 }

--- a/server/internal/usersessions/oauthwire/oauthwire_test.go
+++ b/server/internal/usersessions/oauthwire/oauthwire_test.go
@@ -103,8 +103,8 @@ func TestValidateResourceIndicators_RejectsMismatchAfterAMatch(t *testing.T) {
 func TestValidateResourceIndicators_RejectsPresentButEmpty(t *testing.T) {
 	t.Parallel()
 	// `resource=` is a malformed value, not an omission: RFC 8707 §2 requires
-	// any value sent to be an absolute URI. Accepting it would reintroduce the
-	// silent-acceptance this validation exists to remove.
+	// any value sent to be an absolute URI. Accepting it would be exactly the
+	// silent acceptance this validation exists to remove.
 	requireInvalidTarget(t, oauthwire.ValidateResourceIndicators([]string{""}, canonicalResource))
 }
 

--- a/server/internal/usersessions/oauthwire/oauthwire_test.go
+++ b/server/internal/usersessions/oauthwire/oauthwire_test.go
@@ -1,0 +1,87 @@
+package oauthwire_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/usersessions/oauthwire"
+)
+
+// canonicalResource is the shape ResolvedMcpEndpoint.RootURL produces and the
+// protected-resource metadata advertises: <baseURL>/<RouteBase>/<Slug>.
+const canonicalResource = "https://acme.example.com/mcp/support-bot"
+
+func requireInvalidTarget(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var oauthErr *oauthwire.Error
+	require.ErrorAs(t, err, &oauthErr, "expected *oauthwire.Error, got %T (%v)", err, err)
+	require.Equal(t, "invalid_target", oauthErr.Code)
+}
+
+func TestValidateResourceIndicator_AcceptsAbsentResource(t *testing.T) {
+	t.Parallel()
+	// RFC 8707 §2 leaves demanding the parameter to the AS, and clients
+	// predating MCP 2026-07-28 never send one.
+	require.NoError(t, oauthwire.ValidateResourceIndicator("", canonicalResource))
+}
+
+func TestValidateResourceIndicator_AcceptsExactMatch(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, oauthwire.ValidateResourceIndicator(canonicalResource, canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsDifferentHost(t *testing.T) {
+	t.Parallel()
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://evil.example.com/mcp/support-bot", canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsDifferentSlug(t *testing.T) {
+	t.Parallel()
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com/mcp/billing-bot", canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsTrailingSlash(t *testing.T) {
+	t.Parallel()
+	// MCP 2026-07-28 tells clients to emit the no-trailing-slash form and asks
+	// nothing of servers on the accepting side, so this stays a mismatch.
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator(canonicalResource+"/", canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsUppercaseSchemeAndHost(t *testing.T) {
+	t.Parallel()
+	// Pins a deliberate deviation: MCP 2026-07-28 §Canonical Server URI says
+	// implementations SHOULD accept uppercase scheme and host components. This
+	// surface declines, holding `resource` to the same simple string
+	// comparison RFC 9207 §2.4 mandates for `iss`. Changing this is a policy
+	// decision, not a bug fix.
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("HTTPS://ACME.EXAMPLE.COM/mcp/support-bot", canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsDifferentRouteBase(t *testing.T) {
+	t.Parallel()
+	// /mcp and /x/mcp can front the same server but mint different audiences
+	// (urn:toolset vs urn:user-session-issuer), so they are never equivalent
+	// resource identifiers.
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com/x/mcp/support-bot", canonicalResource))
+}
+
+func TestValidateResourceIndicator_RejectsDefaultPortElision(t *testing.T) {
+	t.Parallel()
+	requireInvalidTarget(t, oauthwire.ValidateResourceIndicator("https://acme.example.com:443/mcp/support-bot", canonicalResource))
+}
+
+func TestValidateResourceIndicator_DescriptionNamesExpectedNotSubmitted(t *testing.T) {
+	t.Parallel()
+	// The description travels in a redirect the client renders, so the
+	// submitted value must not be reflected back into it. The expected value is
+	// already public in the protected-resource metadata.
+	submitted := "https://evil.example.com/mcp/<script>"
+	err := oauthwire.ValidateResourceIndicator(submitted, canonicalResource)
+
+	var oauthErr *oauthwire.Error
+	require.ErrorAs(t, err, &oauthErr)
+	require.Contains(t, oauthErr.Description, canonicalResource)
+	require.NotContains(t, oauthErr.Description, submitted)
+}

--- a/server/internal/usersessions/tokenrequest.go
+++ b/server/internal/usersessions/tokenrequest.go
@@ -22,6 +22,12 @@ type AuthCodeTokenRequest struct {
 	Code         string
 	RedirectURI  string
 	CodeVerifier string
+
+	// Resource is the RFC 8707 resource indicator naming the MCP server the
+	// token is being requested for. Optional on the wire; validated against
+	// the addressed endpoint's canonical URI by
+	// oauthwire.ValidateResourceIndicator in the /token handler.
+	Resource string
 }
 
 // AuthCodeTokenRequestFromForm decodes from url.Values (typically
@@ -31,6 +37,7 @@ func AuthCodeTokenRequestFromForm(form url.Values) *AuthCodeTokenRequest {
 		Code:         form.Get("code"),
 		RedirectURI:  form.Get("redirect_uri"),
 		CodeVerifier: form.Get("code_verifier"),
+		Resource:     form.Get("resource"),
 	}
 }
 
@@ -61,6 +68,13 @@ func (r *AuthCodeTokenRequest) Validate() error {
 // state; the /token response likewise doesn't echo scope.
 type RefreshTokenRequest struct {
 	RefreshToken string
+
+	// Resource is the RFC 8707 resource indicator naming the MCP server the
+	// rotated token is being requested for. MCP 2026-07-28 has clients send it
+	// on every token request, refreshes included. Optional on the wire;
+	// validated against the addressed endpoint's canonical URI by
+	// oauthwire.ValidateResourceIndicator in the /token handler.
+	Resource string
 }
 
 // RefreshTokenRequestFromForm decodes from url.Values (typically
@@ -68,6 +82,7 @@ type RefreshTokenRequest struct {
 func RefreshTokenRequestFromForm(form url.Values) *RefreshTokenRequest {
 	return &RefreshTokenRequest{
 		RefreshToken: form.Get("refresh_token"),
+		Resource:     form.Get("resource"),
 	}
 }
 

--- a/server/internal/usersessions/tokenrequest.go
+++ b/server/internal/usersessions/tokenrequest.go
@@ -24,10 +24,11 @@ type AuthCodeTokenRequest struct {
 	CodeVerifier string
 
 	// Resource is the RFC 8707 resource indicator naming the MCP server the
-	// token is being requested for. Optional on the wire; validated against
-	// the addressed endpoint's canonical URI by
-	// oauthwire.ValidateResourceIndicator in the /token handler.
-	Resource string
+	// token is being requested for. Nil when the parameter was absent, which
+	// stays acceptable; a present value is validated against the addressed
+	// endpoint's canonical URI by oauthwire.ValidateResourceIndicator in the
+	// /token handler.
+	Resource *string
 }
 
 // AuthCodeTokenRequestFromForm decodes from url.Values (typically
@@ -37,7 +38,7 @@ func AuthCodeTokenRequestFromForm(form url.Values) *AuthCodeTokenRequest {
 		Code:         form.Get("code"),
 		RedirectURI:  form.Get("redirect_uri"),
 		CodeVerifier: form.Get("code_verifier"),
-		Resource:     form.Get("resource"),
+		Resource:     oauthwire.ResourceIndicatorFrom(form),
 	}
 }
 
@@ -71,10 +72,11 @@ type RefreshTokenRequest struct {
 
 	// Resource is the RFC 8707 resource indicator naming the MCP server the
 	// rotated token is being requested for. MCP 2026-07-28 has clients send it
-	// on every token request, refreshes included. Optional on the wire;
-	// validated against the addressed endpoint's canonical URI by
+	// on every token request, refreshes included. Nil when the parameter was
+	// absent, which stays acceptable; a present value is validated against the
+	// addressed endpoint's canonical URI by
 	// oauthwire.ValidateResourceIndicator in the /token handler.
-	Resource string
+	Resource *string
 }
 
 // RefreshTokenRequestFromForm decodes from url.Values (typically
@@ -82,7 +84,7 @@ type RefreshTokenRequest struct {
 func RefreshTokenRequestFromForm(form url.Values) *RefreshTokenRequest {
 	return &RefreshTokenRequest{
 		RefreshToken: form.Get("refresh_token"),
-		Resource:     form.Get("resource"),
+		Resource:     oauthwire.ResourceIndicatorFrom(form),
 	}
 }
 

--- a/server/internal/usersessions/tokenrequest.go
+++ b/server/internal/usersessions/tokenrequest.go
@@ -23,12 +23,12 @@ type AuthCodeTokenRequest struct {
 	RedirectURI  string
 	CodeVerifier string
 
-	// Resource is the RFC 8707 resource indicator naming the MCP server the
-	// token is being requested for. Nil when the parameter was absent, which
-	// stays acceptable; a present value is validated against the addressed
-	// endpoint's canonical URI by oauthwire.ValidateResourceIndicator in the
-	// /token handler.
-	Resource *string
+	// Resources holds every RFC 8707 `resource` indicator submitted, naming the
+	// MCP server the token is being requested for. Empty when the parameter was
+	// absent, which stays acceptable; every value is validated against the
+	// addressed endpoint's canonical URI by
+	// oauthwire.ValidateResourceIndicators in the /token handler.
+	Resources []string
 }
 
 // AuthCodeTokenRequestFromForm decodes from url.Values (typically
@@ -38,7 +38,7 @@ func AuthCodeTokenRequestFromForm(form url.Values) *AuthCodeTokenRequest {
 		Code:         form.Get("code"),
 		RedirectURI:  form.Get("redirect_uri"),
 		CodeVerifier: form.Get("code_verifier"),
-		Resource:     oauthwire.ResourceIndicatorFrom(form),
+		Resources:    oauthwire.ResourceIndicatorsFrom(form),
 	}
 }
 
@@ -70,13 +70,13 @@ func (r *AuthCodeTokenRequest) Validate() error {
 type RefreshTokenRequest struct {
 	RefreshToken string
 
-	// Resource is the RFC 8707 resource indicator naming the MCP server the
-	// rotated token is being requested for. MCP 2026-07-28 has clients send it
-	// on every token request, refreshes included. Nil when the parameter was
-	// absent, which stays acceptable; a present value is validated against the
-	// addressed endpoint's canonical URI by
-	// oauthwire.ValidateResourceIndicator in the /token handler.
-	Resource *string
+	// Resources holds every RFC 8707 `resource` indicator submitted, naming the
+	// MCP server the rotated token is being requested for. MCP 2026-07-28 has
+	// clients send the parameter on every token request, refreshes included.
+	// Empty when it was absent, which stays acceptable; every value is validated
+	// against the addressed endpoint's canonical URI by
+	// oauthwire.ValidateResourceIndicators in the /token handler.
+	Resources []string
 }
 
 // RefreshTokenRequestFromForm decodes from url.Values (typically
@@ -84,7 +84,7 @@ type RefreshTokenRequest struct {
 func RefreshTokenRequestFromForm(form url.Values) *RefreshTokenRequest {
 	return &RefreshTokenRequest{
 		RefreshToken: form.Get("refresh_token"),
-		Resource:     oauthwire.ResourceIndicatorFrom(form),
+		Resources:    oauthwire.ResourceIndicatorsFrom(form),
 	}
 }
 

--- a/server/internal/usersessions/tokenrequest_test.go
+++ b/server/internal/usersessions/tokenrequest_test.go
@@ -19,8 +19,7 @@ func TestAuthCodeTokenRequestFromForm(t *testing.T) {
 	require.Equal(t, "auth_code_123", req.Code)
 	require.Equal(t, "https://app.acme.test/callback", req.RedirectURI)
 	require.Equal(t, "verifier_xyz", req.CodeVerifier)
-	require.NotNil(t, req.Resource)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
+	require.Equal(t, []string{"https://acme.example.com/mcp/support-bot"}, req.Resources)
 }
 
 func TestAuthCodeTokenRequest_Validate(t *testing.T) {
@@ -68,8 +67,7 @@ func TestRefreshTokenRequestFromForm(t *testing.T) {
 	form.Set("resource", "https://acme.example.com/mcp/support-bot")
 	req := RefreshTokenRequestFromForm(form)
 	require.Equal(t, "refresh_xyz", req.RefreshToken)
-	require.NotNil(t, req.Resource)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
+	require.Equal(t, []string{"https://acme.example.com/mcp/support-bot"}, req.Resources)
 }
 
 func TestRefreshTokenRequest_Validate(t *testing.T) {

--- a/server/internal/usersessions/tokenrequest_test.go
+++ b/server/internal/usersessions/tokenrequest_test.go
@@ -19,7 +19,8 @@ func TestAuthCodeTokenRequestFromForm(t *testing.T) {
 	require.Equal(t, "auth_code_123", req.Code)
 	require.Equal(t, "https://app.acme.test/callback", req.RedirectURI)
 	require.Equal(t, "verifier_xyz", req.CodeVerifier)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
+	require.NotNil(t, req.Resource)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
 }
 
 func TestAuthCodeTokenRequest_Validate(t *testing.T) {
@@ -67,7 +68,8 @@ func TestRefreshTokenRequestFromForm(t *testing.T) {
 	form.Set("resource", "https://acme.example.com/mcp/support-bot")
 	req := RefreshTokenRequestFromForm(form)
 	require.Equal(t, "refresh_xyz", req.RefreshToken)
-	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
+	require.NotNil(t, req.Resource)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", *req.Resource)
 }
 
 func TestRefreshTokenRequest_Validate(t *testing.T) {

--- a/server/internal/usersessions/tokenrequest_test.go
+++ b/server/internal/usersessions/tokenrequest_test.go
@@ -13,11 +13,13 @@ func TestAuthCodeTokenRequestFromForm(t *testing.T) {
 	form.Set("code", "auth_code_123")
 	form.Set("redirect_uri", "https://app.acme.test/callback")
 	form.Set("code_verifier", "verifier_xyz")
+	form.Set("resource", "https://acme.example.com/mcp/support-bot")
 
 	req := AuthCodeTokenRequestFromForm(form)
 	require.Equal(t, "auth_code_123", req.Code)
 	require.Equal(t, "https://app.acme.test/callback", req.RedirectURI)
 	require.Equal(t, "verifier_xyz", req.CodeVerifier)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
 }
 
 func TestAuthCodeTokenRequest_Validate(t *testing.T) {
@@ -62,8 +64,10 @@ func TestRefreshTokenRequestFromForm(t *testing.T) {
 	t.Parallel()
 	form := url.Values{}
 	form.Set("refresh_token", "refresh_xyz")
+	form.Set("resource", "https://acme.example.com/mcp/support-bot")
 	req := RefreshTokenRequestFromForm(form)
 	require.Equal(t, "refresh_xyz", req.RefreshToken)
+	require.Equal(t, "https://acme.example.com/mcp/support-bot", req.Resource)
 }
 
 func TestRefreshTokenRequest_Validate(t *testing.T) {


### PR DESCRIPTION
AIM-56

## Summary

Validates the RFC 8707 `resource` parameter on the user-session OAuth authorization server (`/mcp/{slug}` and `/x/mcp/{slug}`), on both the authorize and token legs. Validation only — no change to token minting, the `aud` claim, or `ValidateBearer`.

- `oauthwire.ValidateResourceIndicator(resource, canonical)` holds the comparison. It lives in `oauthwire` because that package already owns the wire-error shape, and because the authorize and both token grants need the same rule.
- `AuthorizationRequest`, `AuthCodeTokenRequest`, and `RefreshTokenRequest` gain a `Resource` field parsed from the wire. The existing `Validate` / `ValidatePostRedirect` signatures are unchanged, so `internal/platformmcp`, which shares these structs, compiles and behaves exactly as before.
- `ServeAuthorize` hoists `endpoint.RootURL(baseURL)` above the validation block. One value now serves the RFC 9207 `iss`, the error redirect, and the new check, replacing a lazily recomputed copy inside the error branch.
- Both token grants validate after client authentication and before the grant is consumed, so a mismatch never touches the grant cache.

Comparison is byte equality against the endpoint's canonical URI, built from the request's own base URL. That is the same string already published as the AS metadata `issuer` and the RFC 9728 protected-resource `resource`, so a conformant client that echoes what it read matches on the first attempt. An absent `resource` stays acceptable, which RFC 8707 §2 leaves to the authorization server and which pre-`2026-07-28` clients depend on.

Rejections are `invalid_target`: by 302 on the authorize leg, since the check sits past the point where the redirect URI became trustworthy, and as RFC 6749 §5.2 JSON on the token leg. The error description names the expected identifier and never echoes the submitted value, which would otherwise be reflected into a URL the client renders. Both legs log a `resource_mismatch` failure reason alongside the existing `pkce_mismatch`.

## Motivation

The parameter was previously read nowhere on this surface. That is not a specification violation on its own: the MCP resource-server MUST is already satisfied through the "or otherwise verify" allowance, since `aud` is minted from an internal URN and `ValidateBearer` rejects any token addressed elsewhere. The gap is narrower and quieter. Conformant MCP `2026-07-28` clients send `resource` on every authorization and token request, and the server accepted a mismatched value and issued a token anyway. The client came away holding what it believed was an audience-bound token that had never been compared against anything.

Two design points are worth a reviewer's attention.

**The canonical URI is per-address, not per-endpoint.** `RootURL` is `<baseURL>/<RouteBase>/<Slug>`, so a single MCP server is reachable under up to four identifiers — custom domain or platform origin, each under `/mcp` or `/x/mcp` — and the protected-resource document legitimately advertises whichever one the client addressed. There is no single stable URI to compare against, so the check is built from the request being validated rather than from any stored value. This is also why full audience binding was rejected: a URL-valued `aud` would be address-dependent, would break the deliberate portability of `/x/mcp` tokens between toolset-backed and remote-backed servers under one issuer, and would invalidate every token in flight at deploy.

**Strict comparison is a deliberate choice, not an oversight.** MCP `2026-07-28` says implementations SHOULD accept uppercase scheme and host components. This surface declines, holding `resource` to the simple string comparison (RFC 3986 §6.2.1) that RFC 9207 §2.4 mandates for `iss`. Both identifiers are minted from one base URL and published in the same documents, so the tolerance buys little against the cost of a second comparison rule. The decision is recorded at the comparison site and pinned by a test, so revisiting it is a policy change rather than a bug fix.

Two follow-ups fall out of this and are deliberately not addressed here. `internal/platformmcp` is a separate authorization server that reuses these request structs and has the same silent-accept gap; it was outside the ticket's scope. And any client currently sending a non-matching `resource` will begin failing when this deploys — the ticket chose enforcement over a log-only pass, but the change is small enough to invert if the rollout warrants it.
