### PR TITLE
feat(dashboard): vary org-home welcome cards by trial, admin, and data

### DIFF
--- a/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
+++ b/client/dashboard/src/hooks/useOrgWelcomeBanner.ts
@@ -3,11 +3,10 @@ import { useLocation } from "react-router";
 
 /**
  * Whether the org-home welcome banner is on screen. The header's "Finish
- * setup" banner reads it too, so the two never show at once. Route-based for
- * now; the real zero-data rule lands here.
+ * setup" banner reads it too, so the two never show at once.
  *
- * Every org member sees it: the demo org and the project it points at need no
- * admin scope. The setup card inside the banner keeps its own gate.
+ * Route-based: every org member sees the banner on `/:orgSlug`. Card
+ * selection (trial × admin × zero-data) lives inside the banner.
  */
 export function useOrgWelcomeBanner(): { visible: boolean } {
   const { orgSlug, projectSlug } = useSlugs();

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -73,12 +73,6 @@ vi.mock("@/hooks/useProjectFavorites", () => ({
 vi.mock("@/hooks/useRBAC", () => ({
   useRBAC: () => ({ hasScope: () => true }),
 }));
-vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
-  usePlatformMcpDashboardVisibility: () => ({
-    enabled: false,
-    isLoading: false,
-  }),
-}));
 vi.mock(
   "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js",
   () => ({

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/contexts/Auth", () => ({
   useSession: () => ({
     rawGramAccountType: "enterprise",
     hasActiveSubscription: true,
+    trial: null,
   }),
 }));
 vi.mock("@/contexts/Sdk", () => ({
@@ -72,6 +73,18 @@ vi.mock("@/hooks/useProjectFavorites", () => ({
 vi.mock("@/hooks/useRBAC", () => ({
   useRBAC: () => ({ hasScope: () => true }),
 }));
+vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
+  usePlatformMcpDashboardVisibility: () => ({
+    enabled: false,
+    isLoading: false,
+  }),
+}));
+vi.mock(
+  "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js",
+  () => ({
+    useRecordPlatformMCPDashboardCtaEventMutation: () => ({ mutate: vi.fn() }),
+  }),
+);
 vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
     access: {
@@ -87,6 +100,7 @@ vi.mock("@/routes", () => ({
     // Used by the welcome banner's route cards.
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    platformMcp: { href: () => "/acme/platform-mcp" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
     exploreDemo: { href: () => "/explore-demo" },
@@ -112,6 +126,7 @@ vi.mock("@gram/client/react-query/productFeatures.js", () => ({
 vi.mock("@tanstack/react-query", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@tanstack/react-query")>()),
   useQueryClient: () => ({ prefetchQuery: vi.fn() }),
+  useQuery: () => ({ data: undefined, isPending: false }),
 }));
 vi.mock("react-router", () => ({
   Link: ({ children, ...props }: React.ComponentProps<"a">) => (

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -55,15 +55,12 @@ vi.mock("@/hooks/useRBAC", () => ({
 vi.mock("@/hooks/useOrgWelcomeBanner", () => ({
   useOrgWelcomeBanner: () => ({ visible: true }),
 }));
-vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
-  usePlatformMcpDashboardVisibility: () => ({
-    enabled: platformMcpEnabled.current,
-    isLoading: false,
-  }),
-}));
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
   useProductFeatures: () => ({
-    data: { logsEnabled: logsEnabled.current },
+    data: {
+      logsEnabled: logsEnabled.current,
+      platformMcpEnabled: platformMcpEnabled.current,
+    },
   }),
 }));
 vi.mock("@gram/client/react-query/_context.js", () => ({

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -347,7 +347,14 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(
+      (
+        screen.queryByText("Begin rollout") ??
+        screen.getByText("Resume rollout")
+      )
+        .closest("a")
+        ?.getAttribute("href"),
+    ).toBe("/acme/setup");
     expect(screen.queryByText("Open project")).toBeNull();
   });
 

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -3,14 +3,41 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { OrgWelcomeBanner } from "./OrgWelcomeBanner";
 
+const announcementOn = vi.hoisted(() => ({ current: false }));
+const TEST_ANNOUNCEMENT = vi.hoisted(() => ({
+  id: "explore-demo",
+  title: "Explore the demo org",
+  body: "A read-only organization with simulated traffic.",
+  cta: "Enter demo org",
+  to: "/explore-demo",
+}));
+
 const projects = vi.hoisted(() => ({
   current: [{ id: "p1", name: "Alpha", slug: "alpha" }],
 }));
 const setupEligible = vi.hoisted(() => ({ current: true }));
+const isAdmin = vi.hoisted(() => ({ current: true }));
+const trial = vi.hoisted(() => ({
+  current: null as { startedAt: Date; endsAt: Date } | null,
+}));
+const logsEnabled = vi.hoisted(() => ({ current: false }));
+const overview = vi.hoisted(() => ({
+  data: undefined as
+    | { summary: { activeServersCount: number; totalToolCalls: number } }
+    | undefined,
+  isPending: false,
+}));
+const platformMcpEnabled = vi.hoisted(() => ({ current: true }));
+const recordCta = vi.hoisted(() => ({ mutate: vi.fn() }));
 
 vi.mock("@/contexts/Auth", () => ({
   useIsPlatformAdmin: () => true,
-  useOrganization: () => ({ id: "org1", projects: projects.current }),
+  useOrganization: () => ({
+    id: "org1",
+    slug: "acme",
+    projects: projects.current,
+  }),
+  useSession: () => ({ trial: trial.current }),
   useUser: () => ({ id: "user1" }),
 }));
 vi.mock("@/contexts/Sdk", () => ({
@@ -20,16 +47,46 @@ vi.mock("@/hooks/useOnboardingCta", () => ({
   useOnboardingCta: () => ({ eligible: setupEligible.current }),
 }));
 vi.mock("@/hooks/useRBAC", () => ({
-  useRBAC: () => ({ hasScope: () => true }),
+  useRBAC: () => ({
+    hasScope: (scope: string) =>
+      scope === "org:admin" ? isAdmin.current : true,
+  }),
 }));
 vi.mock("@/hooks/useOrgWelcomeBanner", () => ({
   useOrgWelcomeBanner: () => ({ visible: true }),
 }));
-// Resolves the same paths the real hooks build for org "acme".
+vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
+  usePlatformMcpDashboardVisibility: () => ({
+    enabled: platformMcpEnabled.current,
+    isLoading: false,
+  }),
+}));
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  useProductFeatures: () => ({
+    data: { logsEnabled: logsEnabled.current },
+  }),
+}));
+vi.mock("@gram/client/react-query/_context.js", () => ({
+  useGramContext: () => ({}),
+}));
+vi.mock(
+  "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js",
+  () => ({
+    useRecordPlatformMCPDashboardCtaEventMutation: () => recordCta,
+  }),
+);
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQuery: () => ({
+    data: overview.data,
+    isPending: overview.isPending,
+  }),
+}));
 vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    platformMcp: { href: () => "/acme/platform-mcp" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
     exploreDemo: { href: () => "/explore-demo" },
@@ -52,27 +109,209 @@ vi.mock("react-router", () => ({
     </a>
   ),
 }));
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("./orgHomeAnnouncements", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./orgHomeAnnouncements")>();
+  return {
+    ...actual,
+    activeOrgHomeAnnouncement: () =>
+      announcementOn.current ? TEST_ANNOUNCEMENT : null,
+  };
+});
 
 const hrefFor = (cta: string) =>
   screen.getByText(cta).closest("a")?.getAttribute("href");
+
+const activeTrial = () => {
+  const now = Date.now();
+  return {
+    startedAt: new Date(now - 24 * 60 * 60 * 1000),
+    endsAt: new Date(now + 6 * 24 * 60 * 60 * 1000),
+  };
+};
+
+const expiredTrial = () => {
+  const now = Date.now();
+  return {
+    startedAt: new Date(now - 14 * 24 * 60 * 60 * 1000),
+    endsAt: new Date(now - 24 * 60 * 60 * 1000),
+  };
+};
+
+function withData() {
+  logsEnabled.current = true;
+  overview.isPending = false;
+  overview.data = { summary: { activeServersCount: 2, totalToolCalls: 10 } };
+}
 
 afterEach(() => {
   cleanup();
   localStorage.clear();
   projects.current = [{ id: "p1", name: "Alpha", slug: "alpha" }];
   setupEligible.current = true;
+  isAdmin.current = true;
+  trial.current = null;
+  logsEnabled.current = false;
+  overview.data = undefined;
+  overview.isPending = false;
+  platformMcpEnabled.current = true;
+  recordCta.mutate.mockReset();
+  announcementOn.current = false;
 });
 
 describe("OrgWelcomeBanner", () => {
-  it("points each route card at its destination", () => {
+  it("paints the brand mesh on the hero", () => {
+    const { container } = render(<OrgWelcomeBanner />);
+    const section = container.querySelector("section");
+    expect(section?.className).toContain("bg-gradient-to-br");
+    expect(section?.className).toContain("from-card");
+  });
+
+  it("trial admin: demo, guide, enterprise — no announcement", () => {
+    announcementOn.current = true;
+    trial.current = activeTrial();
     render(<OrgWelcomeBanner />);
 
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
-    expect(hrefFor("Start using Speakeasy")).toBe("/guide");
+    expect(hrefFor("Open the guide")).toBe("/guide");
     expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(screen.queryByText("Announcement")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: /Choose your\s+first move/ }),
+    ).toBeTruthy();
+  });
+
+  it("trial member: demo and guide only", () => {
+    announcementOn.current = true;
+    trial.current = activeTrial();
+    isAdmin.current = false;
+    setupEligible.current = false;
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Enter demo org")).toBe("/explore-demo");
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(screen.queryByText("Begin rollout")).toBeNull();
+    expect(screen.queryByText("Announcement")).toBeNull();
+  });
+
+  it("non-trial admin, zero data: guide and enterprise", () => {
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.queryByText("Enter demo org")).toBeNull();
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(screen.queryByText("Announcement")).toBeNull();
+  });
+
+  it("non-trial admin, has data: platform MCP and enterprise", () => {
+    withData();
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Set up Platform MCP")).toBe(
+      "/acme/platform-mcp?setup=1&entrySource=organization_home",
+    );
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(screen.queryByText("Announcement")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: /Pick up where\s+you left off/ }),
+    ).toBeTruthy();
+  });
+
+  it("substitutes guide when Platform MCP is off", () => {
+    withData();
+    platformMcpEnabled.current = false;
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.queryByText("Set up Platform MCP")).toBeNull();
+    expect(hrefFor("Open the guide")).toBe("/guide");
+  });
+
+  it("non-trial member, zero data: guide only", () => {
+    isAdmin.current = false;
+    setupEligible.current = false;
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(screen.queryByText("Begin rollout")).toBeNull();
+    expect(screen.queryByText("Announcement")).toBeNull();
+  });
+
+  it("non-trial member, has data: default project only", () => {
+    isAdmin.current = false;
+    setupEligible.current = false;
+    withData();
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Open project")).toBe("/acme/projects/alpha");
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Announcement")).toBeNull();
+  });
+
+  it("treats an expired trial as non-trial", () => {
+    trial.current = expiredTrial();
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.queryByText("Enter demo org")).toBeNull();
+    expect(hrefFor("Open the guide")).toBe("/guide");
+  });
+
+  it("shows a dismissible announcement when it is enabled", () => {
+    announcementOn.current = true;
+    isAdmin.current = false;
+    setupEligible.current = false;
+    render(<OrgWelcomeBanner />);
+
+    expect(screen.getByText("Announcement")).toBeTruthy();
+    expect(hrefFor(TEST_ANNOUNCEMENT.cta)).toBe("/explore-demo");
+  });
+
+  it("appends the announcement as a third card for a non-trial admin", () => {
+    announcementOn.current = true;
+    render(<OrgWelcomeBanner />);
+
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(screen.getByText("Announcement")).toBeTruthy();
+  });
+
+  it("records a Platform MCP impression and selection from org home", () => {
+    withData();
+    render(<OrgWelcomeBanner />);
+
+    expect(recordCta.mutate).toHaveBeenCalledWith({
+      request: {
+        recordDashboardCtaEventRequestBody: {
+          action: "impression",
+          surface: "organization_home",
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByText("Set up Platform MCP"));
+
+    expect(recordCta.mutate).toHaveBeenCalledWith({
+      request: {
+        recordDashboardCtaEventRequestBody: {
+          action: "selected",
+          surface: "organization_home",
+        },
+      },
+    });
   });
 
   it("records rollout intent when the setup card is clicked", () => {
+    trial.current = activeTrial();
     render(<OrgWelcomeBanner />);
 
     fireEvent.click(screen.getByText("Begin rollout"));
@@ -83,6 +322,7 @@ describe("OrgWelcomeBanner", () => {
   });
 
   it("shows resume copy after rollout intent is recorded", () => {
+    trial.current = activeTrial();
     localStorage.setItem("gram-org-welcome-rollout-started:acme", "true");
     render(<OrgWelcomeBanner />);
 
@@ -91,6 +331,7 @@ describe("OrgWelcomeBanner", () => {
   });
 
   it("drops the setup card when the org cannot run the wizard", () => {
+    trial.current = activeTrial();
     setupEligible.current = false;
     render(<OrgWelcomeBanner />);
 
@@ -98,10 +339,73 @@ describe("OrgWelcomeBanner", () => {
     expect(screen.getByText("Enter demo org")).toBeTruthy();
   });
 
-  it("falls back to org home when the org has no projects", () => {
+  it("treats an org with no projects as zero data", () => {
     projects.current = [];
     render(<OrgWelcomeBanner />);
 
-    expect(hrefFor("Start using Speakeasy")).toBe("/acme");
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(screen.queryByText("Open project")).toBeNull();
+  });
+
+  it("prefers the last-visited project, then default", () => {
+    isAdmin.current = false;
+    setupEligible.current = false;
+    withData();
+    projects.current = [
+      { id: "p1", name: "Alpha", slug: "alpha" },
+      { id: "p2", name: "Default", slug: "default" },
+    ];
+
+    render(<OrgWelcomeBanner />);
+    expect(hrefFor("Open project")).toBe("/acme/projects/default");
+
+    cleanup();
+    localStorage.setItem("preferredProject", "alpha");
+    render(<OrgWelcomeBanner />);
+    expect(hrefFor("Open project")).toBe("/acme/projects/alpha");
+  });
+
+  it("dismisses the announcement without removing path cards", () => {
+    announcementOn.current = true;
+    isAdmin.current = false;
+    setupEligible.current = false;
+    const { container } = render(<OrgWelcomeBanner />);
+
+    fireEvent.click(screen.getByLabelText("Dismiss announcement"));
+
+    expect(screen.queryByText("Announcement")).toBeNull();
+    expect(hrefFor("Open the guide")).toBe("/guide");
+    expect(
+      localStorage.getItem(
+        `gram-org-home-announcement:acme:${TEST_ANNOUNCEMENT.id}`,
+      ),
+    ).toBe("true");
+    const grid = [...container.querySelectorAll("div")].find((el) =>
+      el.className.includes("lg:grid-cols-2"),
+    );
+    expect(grid).toBeTruthy();
+  });
+
+  it("keeps two cards on a 2-col grid and three on a 3-col grid", () => {
+    isAdmin.current = false;
+    setupEligible.current = false;
+    const two = render(<OrgWelcomeBanner />);
+    expect(
+      [...two.container.querySelectorAll("div")].some((el) =>
+        el.className.includes("lg:grid-cols-2"),
+      ),
+    ).toBe(true);
+
+    two.unmount();
+    trial.current = activeTrial();
+    isAdmin.current = true;
+    setupEligible.current = true;
+    const three = render(<OrgWelcomeBanner />);
+    expect(
+      [...three.container.querySelectorAll("div")].some((el) =>
+        el.className.includes("lg:grid-cols-3"),
+      ),
+    ).toBe(true);
   });
 });

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -245,6 +245,9 @@ describe("OrgWelcomeBanner", () => {
     expect(hrefFor("Open the guide")).toBe("/guide");
     expect(screen.queryByText("Begin rollout")).toBeNull();
     expect(screen.queryByText("Announcement")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Let’s get started" }),
+    ).toBeTruthy();
   });
 
   it("non-trial member, has data: default project only", () => {

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -11,7 +11,6 @@ import { useSlugs } from "@/contexts/Sdk";
 import { useOnboardingCta } from "@/hooks/useOnboardingCta";
 import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
-import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useRBAC } from "@/hooks/useRBAC";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { getTrialLifecycleFromDates } from "@/lib/trial-status";
@@ -70,11 +69,11 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   const { hasScope } = useRBAC();
   const { setupStarted, markSetupStarted } = useOrgSetupStarted(orgSlug);
   const { eligible: canSetUpOrg } = useOnboardingCta();
-  const { enabled: platformMcpEnabled } = usePlatformMcpDashboardVisibility();
   const { data: featuresData } = useProductFeatures({
     organizationId: organization.id,
   });
   const logsEnabled = featuresData?.logsEnabled === true;
+  const platformMcpEnabled = featuresData?.platformMcpEnabled === true;
   const recordCta = useRecordPlatformMCPDashboardCtaEventMutation();
   const announcement = activeOrgHomeAnnouncement();
   const { dismissed: announcementDismissed, dismiss: dismissAnnouncement } =

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -224,7 +224,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
         )}
       >
         <span className="text-eyebrow">Welcome to Speakeasy</span>
-        <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] lg:text-[60px]">
+        <h2 className="text-foreground font-display text-[40px] leading-[0.98] font-thin tracking-[-0.04em] lg:text-[60px]">
           {headlineLines.map((line, i) => (
             <Fragment key={line}>
               {i > 0 ? <br /> : null}

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -24,6 +24,7 @@ import {
   isOverviewZeroData,
   recommendedWelcomeCardId,
   selectWelcomeCardIds,
+  welcomeHeadline,
   type WelcomeCardId,
 } from "@/pages/org/orgWelcomeBannerState";
 import { useOrgRoutes, useRoutes } from "@/routes";
@@ -35,7 +36,7 @@ import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useRecordPlatformMCPDashboardCtaEventMutation } from "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { Link } from "react-router";
 
 // Matches the page column OrgHome applies to everything below the banner.
@@ -208,20 +209,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   if (!visible) return null;
 
   const columnCount = cards.length + (showAnnouncement ? 1 : 0);
-  const headline =
-    isTrial || isZeroData ? (
-      <>
-        Choose your
-        <br />
-        first move
-      </>
-    ) : (
-      <>
-        Pick up where
-        <br />
-        you left off
-      </>
-    );
+  const headlineLines = welcomeHeadline({ columnCount, isTrial, isZeroData });
 
   return (
     // Section runs the full width of the content area; the column class below
@@ -237,7 +225,12 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       >
         <span className="text-eyebrow">Welcome to Speakeasy</span>
         <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] lg:text-[60px]">
-          {headline}
+          {headlineLines.map((line, i) => (
+            <Fragment key={line}>
+              {i > 0 ? <br /> : null}
+              {line}
+            </Fragment>
+          ))}
         </h2>
       </div>
 

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -35,7 +35,7 @@ import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useRecordPlatformMCPDashboardCtaEventMutation } from "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Link } from "react-router";
 
 // Matches the page column OrgHome applies to everything below the banner.
@@ -43,19 +43,6 @@ const COLUMN_CLASS = "mx-auto w-full max-w-7xl px-8";
 
 const CARD_SHELL_CLASS =
   "group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 overflow-hidden border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline";
-
-function bannerGridClass(columnCount: number): string {
-  // One card must not stretch the row: keep it on a 2-col grid so the
-  // empty second column caps width at 50%. Two cards fill that grid.
-  // Three sit in thirds, still under the 50% max.
-  switch (columnCount) {
-    case 1:
-    case 2:
-      return "lg:grid-cols-2";
-    default:
-      return "lg:grid-cols-3";
-  }
-}
 
 type RouteCard = {
   id: WelcomeCardId;
@@ -125,96 +112,80 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   const recommendedId = recommendedWelcomeCardId(cardIds);
 
   const projectRoutes = useRoutes({ projectSlug: startProject?.slug });
-
-  const cards: RouteCard[] = useMemo(() => {
-    const pad = (n: number) => String(n).padStart(2, "0");
-    const platformMcpHref = `${orgRoutes.platformMcp.href()}?setup=1&entrySource=organization_home`;
-
-    return cardIds.map((id, i) => {
-      const recommended = id === recommendedId;
-      const index = pad(i + 1);
-      switch (id) {
-        case "demo":
-          return {
-            id,
-            index,
-            title: "Explore the demo org",
-            body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
-            cta: "Enter demo org",
-            meta: "Read-only · simulated data",
-            to: projectRoutes.exploreDemo.href(),
-            recommended,
-          };
-        case "guide":
-          return {
-            id,
-            index,
-            title: "Project guide",
-            body: "Get to one observable win: a governed MCP call, or a prompt you watch get blocked.",
-            cta: "Open the guide",
-            meta: "~5 min · guided tour",
-            to: PROJECT_GUIDE_ENTRY_PATH,
-            recommended,
-          };
-        case "enterprise":
-          return {
-            id,
-            index,
-            title: setupStarted
-              ? "Continue enterprise rollout"
-              : "Start enterprise rollout",
-            body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
-            cta: setupStarted ? "Resume rollout" : "Begin rollout",
-            meta: "8 steps · resumable",
-            to: orgRoutes.setup.href(),
-            recommended,
-            onClick: markSetupStarted,
-          };
-        case "platformMcp":
-          return {
-            id,
-            index,
-            title: "Platform MCP setup",
-            body: "Install Speakeasy in Claude, Cursor, or Codex so the agent can work against this org.",
-            cta: "Set up Platform MCP",
-            meta: "5 agents supported",
-            to: platformMcpHref,
-            recommended,
-            onClick: () => {
-              recordCta.mutate({
-                request: {
-                  recordDashboardCtaEventRequestBody: {
-                    action: Action.Selected,
-                    surface: Surface.OrganizationHome,
-                  },
+  const platformMcpHref = `${orgRoutes.platformMcp.href()}?setup=1&entrySource=organization_home`;
+  const cards: RouteCard[] = cardIds.map((id, i) => {
+    const recommended = id === recommendedId;
+    const index = String(i + 1).padStart(2, "0");
+    switch (id) {
+      case "demo":
+        return {
+          id,
+          index,
+          title: "Explore the demo org",
+          body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
+          cta: "Enter demo org",
+          meta: "Read-only · simulated data",
+          to: projectRoutes.exploreDemo.href(),
+          recommended,
+        };
+      case "guide":
+        return {
+          id,
+          index,
+          title: "Project guide",
+          body: "Get to one observable win: a governed MCP call, or a prompt you watch get blocked.",
+          cta: "Open the guide",
+          meta: "~5 min · guided tour",
+          to: PROJECT_GUIDE_ENTRY_PATH,
+          recommended,
+        };
+      case "enterprise":
+        return {
+          id,
+          index,
+          title: setupStarted
+            ? "Continue enterprise rollout"
+            : "Start enterprise rollout",
+          body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
+          cta: setupStarted ? "Resume rollout" : "Begin rollout",
+          meta: "8 steps · resumable",
+          to: orgRoutes.setup.href(),
+          recommended,
+          onClick: markSetupStarted,
+        };
+      case "platformMcp":
+        return {
+          id,
+          index,
+          title: "Platform MCP setup",
+          body: "Install Speakeasy in Claude, Cursor, or Codex so the agent can work against this org.",
+          cta: "Set up Platform MCP",
+          meta: "5 agents supported",
+          to: platformMcpHref,
+          recommended,
+          onClick: () => {
+            recordCta.mutate({
+              request: {
+                recordDashboardCtaEventRequestBody: {
+                  action: Action.Selected,
+                  surface: Surface.OrganizationHome,
                 },
-              });
-            },
-          };
-        case "defaultProject":
-          return {
-            id,
-            index,
-            title: startProject ? startProject.name : "Your project",
-            body: "Jump back into the project you were last working in.",
-            cta: "Open project",
-            to: startProject
-              ? projectRoutes.home.href()
-              : orgRoutes.home.href(),
-            recommended,
-          };
-      }
-    });
-  }, [
-    cardIds,
-    recommendedId,
-    orgRoutes,
-    projectRoutes,
-    setupStarted,
-    markSetupStarted,
-    startProject,
-    recordCta,
-  ]);
+              },
+            });
+          },
+        };
+      case "defaultProject":
+        return {
+          id,
+          index,
+          title: startProject ? startProject.name : "Your project",
+          body: "Jump back into the project you were last working in.",
+          cta: "Open project",
+          to: startProject ? projectRoutes.home.href() : orgRoutes.home.href(),
+          recommended,
+        };
+    }
+  });
 
   const showAnnouncement =
     announcement !== null && !isTrial && !announcementDismissed;
@@ -275,7 +246,8 @@ export function OrgWelcomeBanner(): JSX.Element | null {
           <div
             className={cn(
               "grid grid-cols-1 gap-4 lg:-mt-20",
-              bannerGridClass(columnCount),
+              // One/two cards stay on 2-col so a lone card caps at 50%.
+              columnCount > 2 ? "lg:grid-cols-3" : "lg:grid-cols-2",
             )}
           >
             {cards.map((card) => (

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -1,95 +1,263 @@
+import {
+  BRAND_MESH_SURFACE_CLASS,
+  BrandMeshLayers,
+} from "@/components/brand-mesh";
+import { DEFAULT_DATE_RANGE_PRESET } from "@/components/observe/useDateRangeFilter";
+import { buildProjectOverviewQuery } from "@/components/project/projectOverviewQuery";
 import { PROJECT_GUIDE_ENTRY_PATH } from "@/components/project-guide/GuideEntryRedirect";
-import { useOrgRoutes, useRoutes } from "@/routes";
-import { Link } from "react-router";
-import { cn } from "@/lib/utils";
-import { getPreferredProject } from "@/lib/preferredProject";
+import { Button } from "@/components/ui/Button";
+import { useOrganization, useSession } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
 import { useOnboardingCta } from "@/hooks/useOnboardingCta";
 import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { useOrgWelcomeBanner } from "@/hooks/useOrgWelcomeBanner";
-import { useOrganization } from "@/contexts/Auth";
-import { useSlugs } from "@/contexts/Sdk";
+import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
+import { useRBAC } from "@/hooks/useRBAC";
+import { getPreferredProject } from "@/lib/preferredProject";
+import { getTrialLifecycleFromDates } from "@/lib/trial-status";
+import { cn } from "@/lib/utils";
+import {
+  activeOrgHomeAnnouncement,
+  useOrgHomeAnnouncement,
+} from "@/pages/org/orgHomeAnnouncements";
+import {
+  isOverviewZeroData,
+  recommendedWelcomeCardId,
+  selectWelcomeCardIds,
+  type WelcomeCardId,
+} from "@/pages/org/orgWelcomeBannerState";
+import { useOrgRoutes, useRoutes } from "@/routes";
+import {
+  Action,
+  Surface,
+} from "@gram/client/models/components/recorddashboardctaeventrequestbody.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { useRecordPlatformMCPDashboardCtaEventMutation } from "@gram/client/react-query/recordPlatformMCPDashboardCtaEvent.js";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+import { Link } from "react-router";
 
 // Matches the page column OrgHome applies to everything below the banner.
 const COLUMN_CLASS = "mx-auto w-full max-w-7xl px-8";
 
+const CARD_SHELL_CLASS =
+  "group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 overflow-hidden border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline";
+
+function bannerGridClass(columnCount: number): string {
+  // One card must not stretch the row: keep it on a 2-col grid so the
+  // empty second column caps width at 50%. Two cards fill that grid.
+  // Three sit in thirds, still under the 50% max.
+  switch (columnCount) {
+    case 1:
+    case 2:
+      return "lg:grid-cols-2";
+    default:
+      return "lg:grid-cols-3";
+  }
+}
+
 type RouteCard = {
+  id: WelcomeCardId;
   index: string;
   title: string;
   body: string;
   cta: string;
-  meta: string;
+  meta?: string;
   to: string;
   recommended?: boolean;
   onClick?: () => void;
 };
 
 /**
- * Zero-data welcome banner for org home: a hero over three first moves — demo
- * org, start in a project, org setup wizard.
+ * Welcome banner for org home: a hero over up to three paths into the
+ * dashboard, chosen from trial × admin × zero-data.
  */
 export function OrgWelcomeBanner(): JSX.Element | null {
   const organization = useOrganization();
+  const { trial } = useSession();
   const { orgSlug } = useSlugs();
   const orgRoutes = useOrgRoutes();
   const { visible } = useOrgWelcomeBanner();
+  const { hasScope } = useRBAC();
   const { setupStarted, markSetupStarted } = useOrgSetupStarted(orgSlug);
-  // Same gate as the header's "Finish setup" banner: the wizard is an
-  // enterprise org-admin surface.
   const { eligible: canSetUpOrg } = useOnboardingCta();
+  const { enabled: platformMcpEnabled } = usePlatformMcpDashboardVisibility();
+  const { data: featuresData } = useProductFeatures({
+    organizationId: organization.id,
+  });
+  const logsEnabled = featuresData?.logsEnabled === true;
+  const recordCta = useRecordPlatformMCPDashboardCtaEventMutation();
+  const announcement = activeOrgHomeAnnouncement();
+  const { dismissed: announcementDismissed, dismiss: dismissAnnouncement } =
+    useOrgHomeAnnouncement(orgSlug, announcement?.id);
 
-  // Same preference order as the overview prefetch on org home.
   const startProject =
     getPreferredProject(organization.projects) ??
     organization.projects.find((project) => project.slug === "default") ??
     organization.projects[0];
 
-  // Org home has no project slug of its own, so the project routes resolve
-  // against the project card 02 points at.
-  const projectRoutes = useRoutes({ projectSlug: startProject?.slug });
-  const cards: RouteCard[] = [
-    {
-      index: "01",
-      title: "Explore the demo org",
-      body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
-      cta: "Enter demo org",
-      meta: "Read-only · simulated data",
-      to: projectRoutes.exploreDemo.href(),
-    },
-    {
-      index: "02",
-      title: "Get started",
-      body: "Start getting your own data into the dashboard. Connect an MCP server, or set a policy and watch it block a call.",
-      cta: "Start using Speakeasy",
-      meta: "~5 minutes · your data",
-      to: startProject ? PROJECT_GUIDE_ENTRY_PATH : orgRoutes.home.href(),
-      recommended: true,
-    },
-  ];
+  const gramClient = useGramContext();
+  const { data: overview, isPending: isOverviewPending } = useQuery({
+    ...buildProjectOverviewQuery(gramClient, {
+      organization: organization.slug,
+      project: startProject?.slug ?? "",
+      range: { preset: DEFAULT_DATE_RANGE_PRESET },
+    }),
+    enabled: logsEnabled && Boolean(organization.slug && startProject?.slug),
+  });
 
-  if (canSetUpOrg) {
-    cards.push({
-      index: "03",
-      title: setupStarted
-        ? "Continue enterprise rollout"
-        : "Start enterprise rollout",
-      body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
-      cta: setupStarted ? "Resume rollout" : "Begin rollout",
-      meta: "5 steps · resumable",
-      to: orgRoutes.setup.href(),
-      onClick: markSetupStarted,
+  const isTrial = getTrialLifecycleFromDates(trial, new Date()) === "active";
+  const isAdmin = hasScope("org:admin");
+  const isZeroData =
+    !startProject ||
+    !logsEnabled ||
+    isOverviewPending ||
+    isOverviewZeroData(overview);
+
+  const cardIds = selectWelcomeCardIds({
+    isTrial,
+    isAdmin,
+    isZeroData,
+    canSetUpOrg,
+    platformMcpEnabled,
+  });
+  const recommendedId = recommendedWelcomeCardId(cardIds);
+
+  const projectRoutes = useRoutes({ projectSlug: startProject?.slug });
+
+  const cards: RouteCard[] = useMemo(() => {
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const platformMcpHref = `${orgRoutes.platformMcp.href()}?setup=1&entrySource=organization_home`;
+
+    return cardIds.map((id, i) => {
+      const recommended = id === recommendedId;
+      const index = pad(i + 1);
+      switch (id) {
+        case "demo":
+          return {
+            id,
+            index,
+            title: "Explore the demo org",
+            body: "A read-only organization with two weeks of simulated agent traffic, spend, and blocked calls.",
+            cta: "Enter demo org",
+            meta: "Read-only · simulated data",
+            to: projectRoutes.exploreDemo.href(),
+            recommended,
+          };
+        case "guide":
+          return {
+            id,
+            index,
+            title: "Project guide",
+            body: "Get to one observable win: a governed MCP call, or a prompt you watch get blocked.",
+            cta: "Open the guide",
+            meta: "~5 min · guided tour",
+            to: PROJECT_GUIDE_ENTRY_PATH,
+            recommended,
+          };
+        case "enterprise":
+          return {
+            id,
+            index,
+            title: setupStarted
+              ? "Continue enterprise rollout"
+              : "Start enterprise rollout",
+            body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
+            cta: setupStarted ? "Resume rollout" : "Begin rollout",
+            meta: "8 steps · resumable",
+            to: orgRoutes.setup.href(),
+            recommended,
+            onClick: markSetupStarted,
+          };
+        case "platformMcp":
+          return {
+            id,
+            index,
+            title: "Platform MCP setup",
+            body: "Install Speakeasy in Claude, Cursor, or Codex so the agent can work against this org.",
+            cta: "Set up Platform MCP",
+            meta: "5 agents supported",
+            to: platformMcpHref,
+            recommended,
+            onClick: () => {
+              recordCta.mutate({
+                request: {
+                  recordDashboardCtaEventRequestBody: {
+                    action: Action.Selected,
+                    surface: Surface.OrganizationHome,
+                  },
+                },
+              });
+            },
+          };
+        case "defaultProject":
+          return {
+            id,
+            index,
+            title: startProject ? startProject.name : "Your project",
+            body: "Jump back into the project you were last working in.",
+            cta: "Open project",
+            to: startProject
+              ? projectRoutes.home.href()
+              : orgRoutes.home.href(),
+            recommended,
+          };
+      }
     });
-  }
+  }, [
+    cardIds,
+    recommendedId,
+    orgRoutes,
+    projectRoutes,
+    setupStarted,
+    markSetupStarted,
+    startProject,
+    recordCta,
+  ]);
+
+  const showAnnouncement =
+    announcement !== null && !isTrial && !announcementDismissed;
+  const recordedImpression = useRef(false);
+
+  useEffect(() => {
+    if (!visible || recordedImpression.current) return;
+    if (!cardIds.includes("platformMcp")) return;
+    recordedImpression.current = true;
+    recordCta.mutate({
+      request: {
+        recordDashboardCtaEventRequestBody: {
+          action: Action.Impression,
+          surface: Surface.OrganizationHome,
+        },
+      },
+    });
+  }, [visible, cardIds, recordCta]);
 
   if (!visible) return null;
+
+  const columnCount = cards.length + (showAnnouncement ? 1 : 0);
+  const headline =
+    isTrial || isZeroData ? (
+      <>
+        Choose your
+        <br />
+        first move
+      </>
+    ) : (
+      <>
+        Pick up where
+        <br />
+        you left off
+      </>
+    );
 
   return (
     // Section runs the full width of the content area; the column class below
     // keeps its contents aligned with the rest of the page.
-    // Flat, not meshed: the brand mesh now belongs to the app chrome (the mode
-    // switcher strip and the tab grid behind it). Repeating it here stacked
-    // three bands — meshed strip, white workspace bar, meshed hero.
-    <section className="bg-background w-full">
-      {/* Deep bottom padding leaves room for the cards to overlap the hero. */}
+    <section className={cn(BRAND_MESH_SURFACE_CLASS, "w-full")}>
+      {/* Mesh spans the whole banner; the gray band below paints over it. */}
+      <BrandMeshLayers />
       <div
         className={cn(
           COLUMN_CLASS,
@@ -98,27 +266,30 @@ export function OrgWelcomeBanner(): JSX.Element | null {
       >
         <span className="text-eyebrow">Welcome to Speakeasy</span>
         <h2 className="text-foreground font-display text-[40px] leading-[0.92] font-thin tracking-[-0.04em] lg:text-[60px]">
-          Choose your
-          <br />
-          first move
+          {headline}
         </h2>
       </div>
 
-      {/* flow-root keeps the cards' negative margin from collapsing out
-          through the band, which would drag the band up over the hero. */}
       <div className="bg-background/50 flow-root w-full border-border border-y">
         <div className={cn(COLUMN_CLASS, "pt-8 lg:pt-0 pb-8")}>
-          {/* Stacked below lg, side by side above — 2 or 3 across depending
-              on whether the setup card is present. */}
           <div
             className={cn(
               "grid grid-cols-1 gap-4 lg:-mt-20",
-              cards.length === 3 ? "lg:grid-cols-3" : "lg:grid-cols-2",
+              bannerGridClass(columnCount),
             )}
           >
             {cards.map((card) => (
-              <RouteCardLink key={card.index} card={card} />
+              <RouteCardLink key={card.id} card={card} />
             ))}
+            {showAnnouncement && announcement ? (
+              <AnnouncementCard
+                onDismiss={dismissAnnouncement}
+                to={announcement.to}
+                title={announcement.title}
+                body={announcement.body}
+                cta={announcement.cta}
+              />
+            ) : null}
           </div>
         </div>
       </div>
@@ -128,11 +299,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
 
 function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
   return (
-    <Link
-      to={card.to}
-      onClick={card.onClick}
-      className="group bg-card border-border hover:border-foreground relative flex min-h-[250px] flex-col gap-3 overflow-hidden border px-6.5 pt-7.5 pb-6.5 no-underline transition-colors hover:no-underline"
-    >
+    <Link to={card.to} onClick={card.onClick} className={CARD_SHELL_CLASS}>
       {card.recommended && (
         <span
           aria-hidden="true"
@@ -167,9 +334,61 @@ function RouteCardLink({ card }: { card: RouteCard }): JSX.Element {
           →
         </span>
       </span>
-      <span className="text-muted-foreground font-mono text-[10.5px] tracking-[0.04em]">
-        {card.meta}
-      </span>
+      {card.meta ? (
+        <span className="text-muted-foreground font-mono text-[10.5px] tracking-[0.04em]">
+          {card.meta}
+        </span>
+      ) : null}
     </Link>
+  );
+}
+
+function AnnouncementCard({
+  title,
+  body,
+  cta,
+  to,
+  onDismiss,
+}: {
+  title: string;
+  body: string;
+  cta: string;
+  to: string;
+  onDismiss: () => void;
+}): JSX.Element {
+  return (
+    <div className="relative">
+      <Link to={to} className={CARD_SHELL_CLASS}>
+        <span className="text-eyebrow">Announcement</span>
+        <span className="text-foreground max-w-[22ch] text-[23px] leading-[1.2]">
+          {title}
+        </span>
+        <span className="text-muted-foreground text-[13px] leading-[1.6]">
+          {body}
+        </span>
+        <span className="text-foreground mt-auto flex items-center gap-2.5 font-mono text-[13px]">
+          {cta}
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground transition-transform group-hover:translate-x-0.5"
+          >
+            →
+          </span>
+        </span>
+      </Link>
+      <Button
+        type="button"
+        variant="tertiary"
+        size="sm"
+        icon="x"
+        aria-label="Dismiss announcement"
+        className="absolute top-3 right-3"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onDismiss();
+        }}
+      />
+    </div>
   );
 }

--- a/client/dashboard/src/pages/org/orgHomeAnnouncements.test.ts
+++ b/client/dashboard/src/pages/org/orgHomeAnnouncements.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ORG_HOME_ANNOUNCEMENT,
+  ORG_HOME_ANNOUNCEMENT_ENABLED,
+  activeOrgHomeAnnouncement,
+  isOrgHomeAnnouncementLive,
+  type OrgHomeAnnouncement,
+} from "./orgHomeAnnouncements";
+
+const filled: OrgHomeAnnouncement = {
+  id: "explore-demo",
+  title: "Explore the demo org",
+  body: "A read-only organization with simulated traffic.",
+  cta: "Enter demo org",
+  to: "/explore-demo",
+};
+
+describe("isOrgHomeAnnouncementLive", () => {
+  it("is off unless enabled and every field is filled", () => {
+    expect(isOrgHomeAnnouncementLive(false, filled)).toBe(false);
+    expect(isOrgHomeAnnouncementLive(true, filled)).toBe(true);
+    expect(isOrgHomeAnnouncementLive(true, { ...filled, title: "  " })).toBe(
+      false,
+    );
+    expect(isOrgHomeAnnouncementLive(true, { ...filled, to: "" })).toBe(false);
+  });
+});
+
+describe("activeOrgHomeAnnouncement", () => {
+  it("is null while the shipped constant is off", () => {
+    expect(ORG_HOME_ANNOUNCEMENT_ENABLED).toBe(false);
+    expect(ORG_HOME_ANNOUNCEMENT.title).toBe("");
+    expect(activeOrgHomeAnnouncement()).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/org/orgHomeAnnouncements.ts
+++ b/client/dashboard/src/pages/org/orgHomeAnnouncements.ts
@@ -1,0 +1,83 @@
+import { createDismissedCtaStore } from "@/hooks/useDismissedCtaStore";
+import { useCallback } from "react";
+
+export type OrgHomeAnnouncement = {
+  id: string;
+  title: string;
+  body: string;
+  cta: string;
+  to: string;
+};
+
+/**
+ * Flip to true after filling in `ORG_HOME_ANNOUNCEMENT`. Off by default so
+ * the bonus card never ships empty or as leftover stub copy.
+ */
+export const ORG_HOME_ANNOUNCEMENT_ENABLED = false;
+
+/**
+ * Copy for the org-home bonus card. Fill every field, then set
+ * `ORG_HOME_ANNOUNCEMENT_ENABLED` to true.
+ *
+ * Example:
+ *   id: "explore-demo"
+ *   title: "Explore the demo org"
+ *   body: "A read-only organization with two weeks of simulated agent traffic."
+ *   cta: "Enter demo org"
+ *   to: "/explore-demo"
+ */
+export const ORG_HOME_ANNOUNCEMENT: OrgHomeAnnouncement = {
+  id: "",
+  title: "",
+  body: "",
+  cta: "",
+  to: "",
+};
+
+export function isOrgHomeAnnouncementLive(
+  enabled: boolean,
+  announcement: OrgHomeAnnouncement,
+): boolean {
+  return (
+    enabled &&
+    announcement.id.trim() !== "" &&
+    announcement.title.trim() !== "" &&
+    announcement.body.trim() !== "" &&
+    announcement.cta.trim() !== "" &&
+    announcement.to.trim() !== ""
+  );
+}
+
+export function activeOrgHomeAnnouncement(): OrgHomeAnnouncement | null {
+  return isOrgHomeAnnouncementLive(
+    ORG_HOME_ANNOUNCEMENT_ENABLED,
+    ORG_HOME_ANNOUNCEMENT,
+  )
+    ? ORG_HOME_ANNOUNCEMENT
+    : null;
+}
+
+const store = createDismissedCtaStore("gram-org-home-announcement");
+
+function announcementKey(
+  orgSlug: string | undefined,
+  announcementId: string | undefined,
+): string | undefined {
+  return orgSlug && announcementId ? `${orgSlug}:${announcementId}` : undefined;
+}
+
+export function useOrgHomeAnnouncement(
+  orgSlug: string | undefined,
+  announcementId: string | undefined,
+): {
+  dismissed: boolean;
+  dismiss: () => void;
+} {
+  const key = announcementKey(orgSlug, announcementId);
+  const dismissed = store.useDismissed(key);
+  const dismiss = useCallback(() => {
+    if (key) store.write(key, true);
+  }, [key]);
+
+  return { dismissed, dismiss };
+}

--- a/client/dashboard/src/pages/org/orgWelcomeBannerState.test.ts
+++ b/client/dashboard/src/pages/org/orgWelcomeBannerState.test.ts
@@ -4,6 +4,7 @@ import {
   isOverviewZeroData,
   recommendedWelcomeCardId,
   selectWelcomeCardIds,
+  welcomeHeadline,
   type WelcomeBannerInputs,
   type WelcomeCardId,
 } from "./orgWelcomeBannerState";
@@ -77,6 +78,26 @@ describe("selectWelcomeCardIds", () => {
 
   it("non-trial member, has data: default project", () => {
     expect(ids({})).toEqual(["defaultProject"]);
+  });
+});
+
+describe("welcomeHeadline", () => {
+  it("uses Let’s get started for a single first-move card", () => {
+    expect(
+      welcomeHeadline({ columnCount: 1, isTrial: false, isZeroData: true }),
+    ).toEqual(["Let’s get started"]);
+  });
+
+  it("keeps Choose your first move when there is more than one card", () => {
+    expect(
+      welcomeHeadline({ columnCount: 2, isTrial: true, isZeroData: false }),
+    ).toEqual(["Choose your", "first move"]);
+  });
+
+  it("keeps Pick up where you left off for a single resume card", () => {
+    expect(
+      welcomeHeadline({ columnCount: 1, isTrial: false, isZeroData: false }),
+    ).toEqual(["Pick up where", "you left off"]);
   });
 });
 

--- a/client/dashboard/src/pages/org/orgWelcomeBannerState.test.ts
+++ b/client/dashboard/src/pages/org/orgWelcomeBannerState.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isOverviewZeroData,
+  recommendedWelcomeCardId,
+  selectWelcomeCardIds,
+  type WelcomeBannerInputs,
+  type WelcomeCardId,
+} from "./orgWelcomeBannerState";
+
+const base: WelcomeBannerInputs = {
+  isTrial: false,
+  isAdmin: false,
+  isZeroData: false,
+  canSetUpOrg: false,
+  platformMcpEnabled: false,
+};
+
+function ids(overrides: Partial<WelcomeBannerInputs>): WelcomeCardId[] {
+  return selectWelcomeCardIds({ ...base, ...overrides });
+}
+
+describe("selectWelcomeCardIds", () => {
+  it("trial admin: demo, guide, enterprise", () => {
+    expect(ids({ isTrial: true, isAdmin: true, canSetUpOrg: true })).toEqual([
+      "demo",
+      "guide",
+      "enterprise",
+    ]);
+  });
+
+  it("trial member: demo, guide", () => {
+    expect(ids({ isTrial: true })).toEqual(["demo", "guide"]);
+  });
+
+  it("drops enterprise on trial when the wizard is ineligible", () => {
+    expect(ids({ isTrial: true, isAdmin: true, canSetUpOrg: false })).toEqual([
+      "demo",
+      "guide",
+    ]);
+  });
+
+  it("non-trial admin, zero data: guide, enterprise", () => {
+    expect(
+      ids({
+        isAdmin: true,
+        isZeroData: true,
+        canSetUpOrg: true,
+        platformMcpEnabled: true,
+      }),
+    ).toEqual(["guide", "enterprise"]);
+  });
+
+  it("non-trial admin, has data: platform MCP, enterprise", () => {
+    expect(
+      ids({
+        isAdmin: true,
+        canSetUpOrg: true,
+        platformMcpEnabled: true,
+      }),
+    ).toEqual(["platformMcp", "enterprise"]);
+  });
+
+  it("substitutes guide when Platform MCP is not enabled", () => {
+    expect(
+      ids({
+        isAdmin: true,
+        canSetUpOrg: true,
+        platformMcpEnabled: false,
+      }),
+    ).toEqual(["guide", "enterprise"]);
+  });
+
+  it("non-trial member, zero data: guide", () => {
+    expect(ids({ isZeroData: true })).toEqual(["guide"]);
+  });
+
+  it("non-trial member, has data: default project", () => {
+    expect(ids({})).toEqual(["defaultProject"]);
+  });
+});
+
+describe("recommendedWelcomeCardId", () => {
+  it("prefers platform MCP, then default project, then guide", () => {
+    expect(recommendedWelcomeCardId(["platformMcp", "enterprise"])).toBe(
+      "platformMcp",
+    );
+    expect(recommendedWelcomeCardId(["defaultProject"])).toBe("defaultProject");
+    expect(recommendedWelcomeCardId(["demo", "guide", "enterprise"])).toBe(
+      "guide",
+    );
+  });
+});
+
+describe("isOverviewZeroData", () => {
+  it("treats a missing overview as zero data", () => {
+    expect(isOverviewZeroData(undefined)).toBe(true);
+    expect(isOverviewZeroData({})).toBe(true);
+  });
+
+  it("is zero data when there are no servers and no tool calls", () => {
+    expect(
+      isOverviewZeroData({
+        summary: { activeServersCount: 0, totalToolCalls: 0 },
+      }),
+    ).toBe(true);
+  });
+
+  it("is not zero data once either signal is non-zero", () => {
+    expect(
+      isOverviewZeroData({
+        summary: { activeServersCount: 1, totalToolCalls: 0 },
+      }),
+    ).toBe(false);
+    expect(
+      isOverviewZeroData({
+        summary: { activeServersCount: 0, totalToolCalls: 4 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
+++ b/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
@@ -43,6 +43,22 @@ export function recommendedWelcomeCardId(
   return ids[0];
 }
 
+/** Display copy above the cards. One card is a prompt, not a choice. */
+export function welcomeHeadline({
+  columnCount,
+  isTrial,
+  isZeroData,
+}: {
+  columnCount: number;
+  isTrial: boolean;
+  isZeroData: boolean;
+}): readonly string[] {
+  if (columnCount === 1 && (isTrial || isZeroData))
+    return ["Let’s get started"];
+  if (isTrial || isZeroData) return ["Choose your", "first move"];
+  return ["Pick up where", "you left off"];
+}
+
 /**
  * Onboarding-biased: missing overview, logs off, or a pending fetch all
  * read as zero data so Platform MCP never flashes in then swaps out.

--- a/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
+++ b/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
@@ -25,26 +25,12 @@ export type OverviewZeroDataSummary = {
 export function selectWelcomeCardIds(
   input: WelcomeBannerInputs,
 ): WelcomeCardId[] {
-  if (input.isTrial) {
-    const cards: WelcomeCardId[] = ["demo", "guide"];
-    if (input.canSetUpOrg) cards.push("enterprise");
-    return cards;
-  }
-
-  if (input.isZeroData) {
-    const cards: WelcomeCardId[] = ["guide"];
-    if (input.canSetUpOrg) cards.push("enterprise");
-    return cards;
-  }
-
+  const enterprise: WelcomeCardId[] = input.canSetUpOrg ? ["enterprise"] : [];
+  if (input.isTrial) return ["demo", "guide", ...enterprise];
+  if (input.isZeroData) return ["guide", ...enterprise];
   if (input.isAdmin) {
-    const cards: WelcomeCardId[] = [
-      input.platformMcpEnabled ? "platformMcp" : "guide",
-    ];
-    if (input.canSetUpOrg) cards.push("enterprise");
-    return cards;
+    return [input.platformMcpEnabled ? "platformMcp" : "guide", ...enterprise];
   }
-
   return ["defaultProject"];
 }
 

--- a/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
+++ b/client/dashboard/src/pages/org/orgWelcomeBannerState.ts
@@ -1,0 +1,70 @@
+export type WelcomeCardId =
+  | "demo"
+  | "guide"
+  | "enterprise"
+  | "platformMcp"
+  | "defaultProject";
+
+export type WelcomeBannerInputs = {
+  isTrial: boolean;
+  isAdmin: boolean;
+  isZeroData: boolean;
+  canSetUpOrg: boolean;
+  platformMcpEnabled: boolean;
+};
+
+export type OverviewZeroDataSummary = {
+  activeServersCount: number;
+  totalToolCalls: number;
+};
+
+/**
+ * Pick the primary path cards for the org-home welcome banner.
+ * Announcements are appended by the banner, not here.
+ */
+export function selectWelcomeCardIds(
+  input: WelcomeBannerInputs,
+): WelcomeCardId[] {
+  if (input.isTrial) {
+    const cards: WelcomeCardId[] = ["demo", "guide"];
+    if (input.canSetUpOrg) cards.push("enterprise");
+    return cards;
+  }
+
+  if (input.isZeroData) {
+    const cards: WelcomeCardId[] = ["guide"];
+    if (input.canSetUpOrg) cards.push("enterprise");
+    return cards;
+  }
+
+  if (input.isAdmin) {
+    const cards: WelcomeCardId[] = [
+      input.platformMcpEnabled ? "platformMcp" : "guide",
+    ];
+    if (input.canSetUpOrg) cards.push("enterprise");
+    return cards;
+  }
+
+  return ["defaultProject"];
+}
+
+export function recommendedWelcomeCardId(
+  ids: readonly WelcomeCardId[],
+): WelcomeCardId | undefined {
+  if (ids.includes("platformMcp")) return "platformMcp";
+  if (ids.includes("defaultProject")) return "defaultProject";
+  if (ids.includes("guide")) return "guide";
+  return ids[0];
+}
+
+/**
+ * Onboarding-biased: missing overview, logs off, or a pending fetch all
+ * read as zero data so Platform MCP never flashes in then swaps out.
+ */
+export function isOverviewZeroData(
+  overview: { summary?: OverviewZeroDataSummary } | undefined,
+): boolean {
+  const summary = overview?.summary;
+  if (summary === undefined) return true;
+  return summary.activeServersCount === 0 && summary.totalToolCalls === 0;
+}


### PR DESCRIPTION
AGE-3240

Stacked on #5619. Merge that first, or retarget this PR to `main` after it lands.

## Motivation

The org-home welcome banner always showed the same demo + get-started cards. Trial and paying orgs looked the same, admins and members got the same CTAs, and orgs already sending data still got first-move copy.

Keep the banner. Change which cards fill it, using trial, admin, and whether the org has data yet.

## Summary

Everyone still sees the welcome banner. The cards come from a selector over trial × admin × zero-data. Zero-data is the preferred (then default, then first) project having no active servers and no tool calls. No projects, logs off, or a pending overview also count as zero data, so Platform MCP does not flash in and then swap out.

| State | Cards |
| --- | --- |
| Trial admin | demo, guide, enterprise setup |
| Trial member | demo, guide |
| Non-trial admin, zero data | guide, enterprise setup |
| Non-trial admin, has data | platform setup, enterprise setup |
| Non-trial member, zero data | guide |
| Non-trial member, has data | default project |

Enterprise is omitted when the org cannot run the setup wizard. If Platform MCP is off, that card becomes guide. Guide CTAs go to `/guide` from #5619.

Headlines follow the cards: one first-move card is “Let’s get started”; two or three stay “Choose your first move”; data-present is “Pick up where you left off”.

A dismissible announcement can sit as a later card for non-trial orgs. It stays off until copy is filled and `ORG_HOME_ANNOUNCEMENT_ENABLED` is flipped.

## Visual

Admin - Trial
<img width="2368" height="1656" alt="org-home-trial-admin" src="https://github.com/user-attachments/assets/4f653cd6-92f3-450d-becb-d650cff93ae5" />

Admin - NO Trial
<img width="2880" height="1800" alt="org-home-not-trial-admin" src="https://github.com/user-attachments/assets/1cba5b9c-9d86-48ef-8309-38ae41da99e2" />

Everyone else - NO data
<img width="2368" height="900" alt="org-home-member-zero-data" src="https://github.com/user-attachments/assets/eaddae87-97ee-4520-9a15-1456b471c049" />

Everyone else - HAS data
<img width="2880" height="1800" alt="org-home-member-has-data" src="https://github.com/user-attachments/assets/077d9d2a-0754-4561-ab76-2cff6ff30e6e" />
