### PR TITLE
feat: monitor Platform MCP risk tools

### DIFF
--- a/docs/runbooks/platform-mcp-risk-monitors.md
+++ b/docs/runbooks/platform-mcp-risk-monitors.md
@@ -1,0 +1,131 @@
+# Platform MCP risk tool monitors
+
+This runbook covers the seven D3 risk-policy and exclusion tools delivered for
+AGE-3168. The application emits low-cardinality OpenTelemetry metrics from
+`gram-server`; Datadog dashboards and monitors are managed in the Datadog UI,
+not as repository IaC.
+
+## Current deployment state
+
+The metric contract and automated allowlist/leak coverage are implemented.
+The dashboard and monitors below are **not verified as deployed**. Create and
+link them before enabling risk mutations beyond the internal cohort.
+
+## Safety boundary
+
+Both metrics use exactly these fixed tags:
+
+- `platform_mcp.risk.tool`
+- `platform_mcp.risk.outcome`
+- `platform_mcp.risk.replay`
+- `platform_mcp.risk.catalog_version`
+- `platform_mcp.risk.reconciliation`
+
+They never include a user, organization, project, connection, client, policy or
+exclusion ID, receipt ID, policy name, prompt, exact/regex match value, filter,
+CEL, principal, URL, error message, or request/result payload.
+
+## Metric contracts
+
+| Metric                            | Type                | Meaning                                                   |
+| --------------------------------- | ------------------- | --------------------------------------------------------- |
+| `platform_mcp.risk.tool_calls`    | counter             | One bounded handler result for any of the seven D3 tools. |
+| `platform_mcp.risk.tool_duration` | histogram (seconds) | Handler duration for the same result and tags.            |
+
+Transport/schema rejections happen before a typed handler runs and are not
+included in these metrics. Protocol and HTTP telemetry remain the source for
+malformed transport traffic.
+
+Allowed values:
+
+- `tool`: `list_risk_policies`, `get_risk_policy`, `create_risk_policy`,
+  `update_risk_policy`, `list_risk_exclusions`, `create_risk_exclusion`, or
+  `update_risk_exclusion`;
+- `outcome`: `succeeded`, `feature_unavailable`, `invalid_request`,
+  `not_found`, `conflict`, `rate_limited`, `repair_required`, or `unavailable`;
+- `replay`: `not_applicable`, `fresh`, `receipt_replay`, or
+  `matched_existing`;
+- `catalog_version`: `risk-policy-catalog-v1`;
+- `reconciliation`: `not_applicable` or `scheduled`.
+
+`receipt_replay` means the same idempotency key returned its stored result.
+`matched_existing` means a fresh create converged on an equivalent existing
+resource. Neither value identifies the resource.
+
+## Dashboard
+
+Create a **Platform MCP risk tools** dashboard scoped to
+`service:gram-server` with:
+
+1. calls and success ratio by fixed tool;
+2. mutation refusals by outcome, highlighting `conflict`, `rate_limited`, and
+   `unavailable`;
+3. p50/p95/p99 duration by tool;
+4. create results split by `fresh`, `receipt_replay`, and `matched_existing`;
+5. exclusion mutation results split by reconciliation state.
+
+Do not add organization, project, user, client, resource, or receipt identity as
+a tag. Keep the active internal cohort in deployment/flag records, not metric
+cardinality.
+
+## Datadog monitors
+
+Initial thresholds require dogfood baseline tuning. Scope every query to
+`service:gram-server` and link notifications to this runbook.
+
+### Mutation failure spike
+
+Monitor the four mutation tools over 15 minutes. Alert when non-success,
+non-client-refusal outcomes rise above the dogfood baseline:
+
+```text
+sum(last_15m):sum:platform_mcp.risk.tool_calls{
+  service:gram-server AND
+  platform_mcp.risk.tool IN (create_risk_policy, update_risk_policy, create_risk_exclusion, update_risk_exclusion) AND
+  platform_mcp.risk.outcome NOT IN (succeeded, invalid_request, not_found, conflict, rate_limited, feature_unavailable)
+}.as_count()
+```
+
+Start with warning `> 5` and alert `> 15`, then tune from internal-cohort
+traffic. Investigate dependencies and the bounded outcome first; use audited
+domain state for a specific report.
+
+### Conflict spike
+
+Conflicts are actionable concurrency/idempotency signals, not server failures:
+
+```text
+sum(last_15m):sum:platform_mcp.risk.tool_calls{
+  service:gram-server AND
+  platform_mcp.risk.tool IN (create_risk_policy, update_risk_policy, create_risk_exclusion, update_risk_exclusion) AND
+  platform_mcp.risk.outcome:conflict
+}.as_count()
+```
+
+Start with warning `> 10` and alert `> 25`. Compare `receipt_replay` and
+`matched_existing` before treating a spike as a defect.
+
+### Latency
+
+Alert on sustained p95 `platform_mcp.risk.tool_duration` above 2.5 seconds for
+mutations or 1 second for reads over 15 minutes after a dogfood baseline exists.
+
+### Reconciliation scheduling
+
+For successful exclusion mutations, monitor the ratio of
+`platform_mcp.risk.reconciliation:scheduled`. The tool metric proves scheduling
+was reported, not that the asynchronous reconciliation completed; use Temporal
+workflow/activity telemetry and audited state to verify completion.
+
+## Rollout evidence
+
+Before broader rollout, record links to the deployed dashboard and monitors in
+the AGE-3168 rollout record, execute the D3 smoke checklist, and verify the
+mutation kill switch restores read-only behavior. Missing or unverified monitors
+block cohort expansion, not deployment of the disabled/read-only code.
+
+## Ownership
+
+- **Owner:** Control Plane / Platform MCP on-call
+- **Service:** `gram-server`
+- **Rollback:** disable `platform-mcp-risk-mutations`; reads remain available

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -261,6 +261,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		return AssistantSurface{}, errors.New("local Platform MCP operation budgets are incomplete")
 	}
 	telemetry := platformmcp.NewLifecycleTelemetry(config.Logger, config.MeterProvider)
+	riskTelemetry := platformmcp.NewRiskTelemetry(config.Logger, config.MeterProvider)
 	readiness := platformmcp.NewReadinessService(
 		store,
 		registrationGate,
@@ -348,7 +349,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		sessionRecall,
 		riskMutations,
 		fixtureConfig.CatalogDescriptor(),
-	).WithOAuthTelemetry(oauthTelemetry)
+	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
 	platformmcp.AttachManagement(config.Mux, platformmcp.NewManagementService(config.Logger, config.TracerProvider, config.DB, config.Sessions, config.Authz, gate, authorizer, config.ServerURL.JoinPath("platform-mcp").String(), registrations, readiness, distributions, config.JWTSigningKey, catalog))
@@ -597,6 +598,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		return AssistantSurface{}, errors.New("platform MCP operation budgets are incomplete")
 	}
 	telemetry := platformmcp.NewLifecycleTelemetry(config.Logger, config.MeterProvider)
+	riskTelemetry := platformmcp.NewRiskTelemetry(config.Logger, config.MeterProvider)
 	readiness := platformmcp.NewReadinessService(
 		store,
 		registrationGate,
@@ -670,7 +672,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		sessionRecall,
 		riskMutations,
 		platformmcp.CatalogDescriptor{},
-	).WithOAuthTelemetry(oauthTelemetry)
+	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
 	platformmcp.AttachManagement(config.Mux, platformmcp.NewManagementService(config.Logger, config.TracerProvider, config.DB, config.Sessions, config.Authz, gate, authorizer, config.ServerURL.JoinPath("platform-mcp").String(), registrations, readiness, distributions, config.JWTSigningKey, catalog))

--- a/server/internal/platformmcp/descriptor.go
+++ b/server/internal/platformmcp/descriptor.go
@@ -82,6 +82,7 @@ type Descriptor struct {
 // returns these as an error result; a direct caller receives this error, so
 // the reason survives instead of being replaced by an empty payload.
 type ToolRefusalError struct {
+	Code    string
 	Payload string
 }
 
@@ -134,13 +135,20 @@ func (d ResourceDescriptor) Read(ctx context.Context) (string, error) {
 // admitted audience are built from a single pass rather than two lists that can
 // drift.
 type Registrar struct {
-	server      *mcp.Server
-	descriptors []Descriptor
-	resources   []ResourceDescriptor
+	server        *mcp.Server
+	descriptors   []Descriptor
+	resources     []ResourceDescriptor
+	riskTelemetry RiskTelemetry
 }
 
 func newRegistrar(server *mcp.Server) *Registrar {
-	return &Registrar{server: server, descriptors: nil, resources: nil}
+	return &Registrar{server: server, descriptors: nil, resources: nil, riskTelemetry: noopRiskTelemetry{}}
+}
+
+func (r *Registrar) withRiskTelemetry(telemetry RiskTelemetry) {
+	if r != nil && telemetry != nil {
+		r.riskTelemetry = telemetry
+	}
 }
 
 // Descriptors returns everything registered, before any audience filter.
@@ -286,10 +294,10 @@ func refusalFromResult(result *mcp.CallToolResult) (*ToolRefusalError, bool) {
 	}
 	for _, content := range result.Content {
 		if text, ok := content.(*mcp.TextContent); ok && text.Text != "" {
-			return &ToolRefusalError{Payload: text.Text}, true
+			return &ToolRefusalError{Code: "", Payload: text.Text}, true
 		}
 	}
-	return &ToolRefusalError{Payload: `{"code":"` + unavailableCode + `"}`}, true
+	return &ToolRefusalError{Code: unavailableCode, Payload: `{"code":"` + unavailableCode + `"}`}, true
 }
 
 // prepareInputSchema returns one schema for all three consumers: MCP transport

--- a/server/internal/platformmcp/risk_mutation_controls.go
+++ b/server/internal/platformmcp/risk_mutation_controls.go
@@ -111,11 +111,17 @@ func (c *RiskMutationControls) Admit(ctx context.Context, principal Principal, p
 		return ResolvedProject{}, riskMutationUnavailableWithCause(err)
 	}
 	organizationSlug, err := c.organizations.OrganizationSlug(ctx, principal.OrganizationID)
-	if err != nil || organizationSlug == "" {
-		return ResolvedProject{}, riskMutationUnavailable()
+	if err != nil {
+		return ResolvedProject{}, riskMutationUnavailableWithCause(err)
+	}
+	if organizationSlug == "" {
+		return ResolvedProject{}, riskMutationUnavailableWithCause(errors.New("organization slug is unavailable"))
 	}
 	evaluation, err := feature.EvaluateFlag(ctx, c.flags, feature.FlagPlatformMCPRiskMutations, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, project.Slug))
-	if err != nil || evaluation != feature.EvaluationEnabled {
+	if err != nil {
+		return ResolvedProject{}, riskMutationUnavailableWithCause(err)
+	}
+	if evaluation != feature.EvaluationEnabled {
 		return ResolvedProject{}, riskMutationUnavailable()
 	}
 	if err := c.budget.AllowConnectionOrOrganization(ctx, principal); err != nil {
@@ -123,7 +129,7 @@ func (c *RiskMutationControls) Admit(ctx context.Context, principal Principal, p
 		case errors.Is(err, ErrOperationRateLimited):
 			return ResolvedProject{}, &RiskMutationError{Code: "rate_limited", Message: "The risk mutation rate limit was reached.", Cause: err}
 		default:
-			return ResolvedProject{}, riskMutationUnavailable()
+			return ResolvedProject{}, riskMutationUnavailableWithCause(err)
 		}
 	}
 	return project, nil
@@ -134,12 +140,10 @@ func riskMutationUnavailable() error {
 }
 
 func riskMutationUnavailableWithCause(cause error) error {
-	if cause != nil {
-		cause = fmt.Errorf("%w: %w", ErrRiskMutationUnavailable, cause)
-	} else {
-		cause = ErrRiskMutationUnavailable
+	if cause == nil {
+		return &RiskMutationError{Code: unavailableCode, Message: "Risk mutations are not enabled for this project.", Cause: ErrRiskMutationUnavailable}
 	}
-	return &RiskMutationError{Code: unavailableCode, Message: "Risk mutations are not enabled for this project.", Cause: cause}
+	return &RiskMutationError{Code: "unavailable", Message: "Risk mutations are temporarily unavailable.", Cause: fmt.Errorf("%w: %w", ErrRiskMutationUnavailable, cause)}
 }
 
 func riskMutationConflict(message string) error {

--- a/server/internal/platformmcp/risk_mutation_controls_test.go
+++ b/server/internal/platformmcp/risk_mutation_controls_test.go
@@ -85,7 +85,7 @@ func TestRiskMutationAdmissionDistinguishesMissingProjectFromResolverOutage(t *t
 		wantErr  error
 	}{
 		{name: "missing project", resolve: ErrRiskReadNotFound, wantCode: "not_found", wantErr: ErrRiskMutationNotFound},
-		{name: "resolver outage", resolve: backendFailure, wantCode: unavailableCode, wantErr: ErrRiskMutationUnavailable},
+		{name: "resolver outage", resolve: backendFailure, wantCode: "unavailable", wantErr: ErrRiskMutationUnavailable},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -101,6 +101,33 @@ func TestRiskMutationAdmissionDistinguishesMissingProjectFromResolverOutage(t *t
 			if errors.Is(test.resolve, backendFailure) {
 				require.ErrorIs(t, err, backendFailure)
 			}
+		})
+	}
+}
+
+func TestRiskMutationAdmissionDistinguishesDisabledFlagFromFlagOutage(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "project"}
+	for _, test := range []struct {
+		name     string
+		flags    *riskMutationFlagProvider
+		wantCode string
+	}{
+		{name: "disabled", flags: &riskMutationFlagProvider{evaluation: feature.EvaluationDisabled}, wantCode: unavailableCode},
+		{name: "provider outage", flags: &riskMutationFlagProvider{err: errors.New("flag provider unavailable")}, wantCode: "unavailable"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			controls := &RiskMutationControls{
+				flags: test.flags, organizations: riskMutationOrganizationResolver{slug: "organization-slug"},
+				projects: &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectSlug: project.Slug}}},
+				budget:   OperationBudget{Connection: &recordingOperationLimiter{}, Organization: &recordingOperationLimiter{}}, receipts: &RiskMutationReceiptStore{}, versions: &riskVersionCodec{key: []byte("key")},
+			}
+			_, err := controls.Admit(t.Context(), Principal{UserID: "user", OrganizationID: "organization"}, project.Slug)
+			var mutationErr *RiskMutationError
+			require.ErrorAs(t, err, &mutationErr)
+			require.Equal(t, test.wantCode, mutationErr.Code)
 		})
 	}
 }

--- a/server/internal/platformmcp/risk_policy_mutations.go
+++ b/server/internal/platformmcp/risk_policy_mutations.go
@@ -865,7 +865,7 @@ func riskMutationToolRefusal[Out any](err error) (*mcp.CallToolResult, Out, erro
 	if marshalErr != nil {
 		return nil, zero, fmt.Errorf("encode risk mutation refusal: %w", marshalErr)
 	}
-	return nil, zero, &ToolRefusalError{Payload: string(payload)}
+	return nil, zero, &ToolRefusalError{Code: mutation.Code, Payload: string(payload)}
 }
 
 func mapRiskPolicyMutationError(err error) error {

--- a/server/internal/platformmcp/risk_telemetry.go
+++ b/server/internal/platformmcp/risk_telemetry.go
@@ -1,0 +1,130 @@
+package platformmcp
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+)
+
+const (
+	platformMCPRiskToolCallMetric     = "platform_mcp.risk.tool_calls"
+	platformMCPRiskToolDurationMetric = "platform_mcp.risk.tool_duration"
+
+	riskTelemetryNotApplicable = "not_applicable"
+	riskTelemetryFresh         = "fresh"
+	riskTelemetryReceiptReplay = "receipt_replay"
+	riskTelemetryMatched       = "matched_existing"
+	riskTelemetryScheduled     = "scheduled"
+)
+
+type RiskToolEvent struct {
+	Tool           string
+	Outcome        string
+	Replay         string
+	CatalogVersion string
+	Reconciliation string
+}
+
+type RiskTelemetry interface {
+	Record(context.Context, RiskToolEvent, time.Duration)
+}
+
+type noopRiskTelemetry struct{}
+
+func (noopRiskTelemetry) Record(context.Context, RiskToolEvent, time.Duration) {}
+
+type riskTelemetry struct {
+	calls    metric.Int64Counter
+	duration metric.Float64Histogram
+}
+
+func NewRiskTelemetry(logger *slog.Logger, meterProvider metric.MeterProvider) RiskTelemetry {
+	if logger == nil || meterProvider == nil {
+		return noopRiskTelemetry{}
+	}
+
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/platformmcp")
+	calls, err := meter.Int64Counter(platformMCPRiskToolCallMetric, metric.WithDescription("Bounded Platform MCP risk tool outcomes"), metric.WithUnit("{call}"))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP risk metric", attr.SlogMetricName(platformMCPRiskToolCallMetric), attr.SlogError(err))
+	}
+	duration, err := meter.Float64Histogram(platformMCPRiskToolDurationMetric, metric.WithDescription("Platform MCP risk tool handler duration"), metric.WithUnit("s"), metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create Platform MCP risk metric", attr.SlogMetricName(platformMCPRiskToolDurationMetric), attr.SlogError(err))
+	}
+	return &riskTelemetry{calls: calls, duration: duration}
+}
+
+func (t *riskTelemetry) Record(ctx context.Context, event RiskToolEvent, duration time.Duration) {
+	if t == nil || !validRiskToolEvent(event) || duration < 0 {
+		return
+	}
+	attributes := metric.WithAttributes(
+		attribute.String("platform_mcp.risk.tool", event.Tool),
+		attribute.String("platform_mcp.risk.outcome", event.Outcome),
+		attribute.String("platform_mcp.risk.replay", event.Replay),
+		attribute.String("platform_mcp.risk.catalog_version", event.CatalogVersion),
+		attribute.String("platform_mcp.risk.reconciliation", event.Reconciliation),
+	)
+	if t.calls != nil {
+		t.calls.Add(ctx, 1, attributes)
+	}
+	if t.duration != nil {
+		t.duration.Record(ctx, duration.Seconds(), attributes)
+	}
+}
+
+func validRiskToolEvent(event RiskToolEvent) bool {
+	return validRiskTelemetryTool(event.Tool) &&
+		validRiskTelemetryOutcome(event.Outcome) &&
+		validRiskTelemetryReplay(event.Replay) &&
+		event.CatalogVersion == policycatalog.SchemaV1 &&
+		validRiskTelemetryReconciliation(event.Reconciliation)
+}
+
+func validRiskTelemetryTool(tool string) bool {
+	switch tool {
+	case "list_risk_policies", "get_risk_policy", "create_risk_policy", "update_risk_policy", "list_risk_exclusions", "create_risk_exclusion", "update_risk_exclusion":
+		return true
+	default:
+		return false
+	}
+}
+
+func validRiskTelemetryOutcome(outcome string) bool {
+	switch outcome {
+	case "succeeded", unavailableCode, "invalid_request", "not_found", "conflict", "rate_limited", "repair_required", "unavailable":
+		return true
+	default:
+		return false
+	}
+}
+
+func validRiskTelemetryReplay(replay string) bool {
+	switch replay {
+	case riskTelemetryNotApplicable, riskTelemetryFresh, riskTelemetryReceiptReplay, riskTelemetryMatched:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRiskTelemetryReconciliation(state string) bool {
+	return state == riskTelemetryNotApplicable || state == riskTelemetryScheduled
+}
+
+func riskTelemetryEvent(tool, outcome string) RiskToolEvent {
+	return RiskToolEvent{
+		Tool:           tool,
+		Outcome:        outcome,
+		Replay:         riskTelemetryNotApplicable,
+		CatalogVersion: policycatalog.SchemaV1,
+		Reconciliation: riskTelemetryNotApplicable,
+	}
+}

--- a/server/internal/platformmcp/risk_telemetry_test.go
+++ b/server/internal/platformmcp/risk_telemetry_test.go
@@ -1,0 +1,144 @@
+package platformmcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestRiskTelemetryUsesOnlyBoundedAttributes(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewRiskTelemetry(testenv.NewLogger(t), provider)
+
+	telemetry.Record(t.Context(), RiskToolEvent{
+		Tool:           "create_risk_exclusion",
+		Outcome:        "conflict",
+		Replay:         riskTelemetryMatched,
+		CatalogVersion: policycatalog.SchemaV1,
+		Reconciliation: riskTelemetryScheduled,
+	}, 250*time.Millisecond)
+	telemetry.Record(t.Context(), RiskToolEvent{
+		Tool:           "sensitive-policy-name",
+		Outcome:        "https://untrusted.example/token",
+		Replay:         "receipt-secret",
+		CatalogVersion: "customer-catalog",
+		Reconciliation: "sensitive-value",
+	}, time.Second)
+
+	var metrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &metrics))
+
+	calls := oauthCounterPoints(t, metrics, platformMCPRiskToolCallMetric)
+	require.Len(t, calls, 1)
+	require.Equal(t, int64(1), calls[0].Value)
+	requireRiskMetricAttributes(t, calls[0].Attributes)
+
+	durations := oauthHistogramPoints(t, metrics, platformMCPRiskToolDurationMetric)
+	require.Len(t, durations, 1)
+	require.Equal(t, uint64(1), durations[0].Count)
+	requireRiskMetricAttributes(t, durations[0].Attributes)
+}
+
+func TestRiskMutationTelemetryClassifiesTypedResultsAndRefusals(t *testing.T) {
+	t.Parallel()
+
+	created := CreateRiskExclusionToolOutput{
+		CreateRiskExclusionReceiptResult: CreateRiskExclusionReceiptResult{MatchedExisting: true, Reconciliation: riskTelemetryScheduled},
+		Receipt:                          RiskMutationToolReceipt{Replayed: false},
+	}
+	event := riskMutationSuccessEvent("create_risk_exclusion", created)
+	require.Equal(t, riskTelemetryMatched, event.Replay)
+	require.Equal(t, riskTelemetryScheduled, event.Reconciliation)
+
+	created.Receipt.Replayed = true
+	event = riskMutationSuccessEvent("create_risk_exclusion", created)
+	require.Equal(t, riskTelemetryReceiptReplay, event.Replay)
+
+	require.Equal(t, "conflict", riskMutationTelemetryOutcome(&ToolRefusalError{Code: "conflict", Payload: "sensitive prompt"}))
+	require.Equal(t, "unavailable", riskMutationTelemetryOutcome(&ToolRefusalError{Code: "", Payload: "sensitive prompt"}))
+}
+
+func TestRiskToolWrappersRecordTypedOutcomes(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingRiskTelemetry{}
+	ctx := ContextWithPrincipal(t.Context(), Principal{UserID: "<USER_ID>", OrganizationID: "<ORG_ID>"})
+	_, _, err := riskReadToolCall(ctx, recorder, "list_risk_policies", func(Principal) (ListRiskPoliciesOutput, error) {
+		return ListRiskPoliciesOutput{}, ErrRiskReadInvalid
+	})
+	require.NoError(t, err)
+	require.Len(t, recorder.events, 1)
+	require.Equal(t, "invalid_request", recorder.events[0].Outcome)
+
+	reg := newRegistrar(newTestMCPServer())
+	reg.withRiskTelemetry(recorder)
+	wrapped := instrumentRiskMutation(reg, "create_risk_exclusion", func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskExclusionToolOutput, error) {
+		return nil, CreateRiskExclusionToolOutput{
+			CreateRiskExclusionReceiptResult: CreateRiskExclusionReceiptResult{MatchedExisting: false, Reconciliation: riskTelemetryScheduled},
+			Receipt:                          RiskMutationToolReceipt{Replayed: true},
+		}, nil
+	})
+	_, _, err = wrapped(ctx, nil, map[string]any{})
+	require.NoError(t, err)
+	require.Len(t, recorder.events, 2)
+	require.Equal(t, "succeeded", recorder.events[1].Outcome)
+	require.Equal(t, riskTelemetryReceiptReplay, recorder.events[1].Replay)
+	require.Equal(t, riskTelemetryScheduled, recorder.events[1].Reconciliation)
+}
+
+func TestRiskTelemetryRejectsUnboundedDimensions(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, validRiskToolEvent(riskTelemetryEvent("list_risk_policies", "succeeded")))
+	for _, event := range []RiskToolEvent{
+		{Tool: "customer-tool", Outcome: "succeeded", Replay: riskTelemetryNotApplicable, CatalogVersion: policycatalog.SchemaV1, Reconciliation: riskTelemetryNotApplicable},
+		{Tool: "list_risk_policies", Outcome: "sensitive prompt", Replay: riskTelemetryNotApplicable, CatalogVersion: policycatalog.SchemaV1, Reconciliation: riskTelemetryNotApplicable},
+		{Tool: "list_risk_policies", Outcome: "succeeded", Replay: "receipt-id", CatalogVersion: policycatalog.SchemaV1, Reconciliation: riskTelemetryNotApplicable},
+		{Tool: "list_risk_policies", Outcome: "succeeded", Replay: riskTelemetryNotApplicable, CatalogVersion: "future-or-user-value", Reconciliation: riskTelemetryNotApplicable},
+		{Tool: "list_risk_policies", Outcome: "succeeded", Replay: riskTelemetryNotApplicable, CatalogVersion: policycatalog.SchemaV1, Reconciliation: "customer-state"},
+	} {
+		require.False(t, validRiskToolEvent(event))
+	}
+}
+
+func requireRiskMetricAttributes(t *testing.T, attributes attribute.Set) {
+	t.Helper()
+
+	want := map[string]string{
+		"platform_mcp.risk.tool":            "create_risk_exclusion",
+		"platform_mcp.risk.outcome":         "conflict",
+		"platform_mcp.risk.replay":          riskTelemetryMatched,
+		"platform_mcp.risk.catalog_version": policycatalog.SchemaV1,
+		"platform_mcp.risk.reconciliation":  riskTelemetryScheduled,
+	}
+	got := attributes.ToSlice()
+	require.Len(t, got, len(want))
+	for _, kv := range got {
+		value, ok := want[string(kv.Key)]
+		require.True(t, ok, "unexpected metric attribute %q", kv.Key)
+		require.Equal(t, value, kv.Value.AsString())
+	}
+}
+
+var _ RiskTelemetry = (*recordingRiskTelemetry)(nil)
+
+type recordingRiskTelemetry struct {
+	events []RiskToolEvent
+}
+
+func (t *recordingRiskTelemetry) Record(_ context.Context, event RiskToolEvent, _ time.Duration) {
+	t.events = append(t.events, event)
+}

--- a/server/internal/platformmcp/risk_telemetry_test.go
+++ b/server/internal/platformmcp/risk_telemetry_test.go
@@ -83,6 +83,17 @@ func TestRiskToolWrappersRecordTypedOutcomes(t *testing.T) {
 	require.Len(t, recorder.events, 1)
 	require.Equal(t, "invalid_request", recorder.events[0].Outcome)
 
+	result, _, err := riskReadToolCall(ctx, recorder, "list_risk_policies", func(Principal) (ListRiskPoliciesOutput, error) {
+		return ListRiskPoliciesOutput{}, ErrUnavailable
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Len(t, recorder.events, 2)
+	require.Equal(t, "unavailable", recorder.events[1].Outcome)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.Contains(t, text.Text, `"code":"feature_unavailable"`, "telemetry classification must not change the client refusal contract")
+
 	reg := newRegistrar(newTestMCPServer())
 	reg.withRiskTelemetry(recorder)
 	wrapped := instrumentRiskMutation(reg, "create_risk_exclusion", func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, CreateRiskExclusionToolOutput, error) {
@@ -93,10 +104,10 @@ func TestRiskToolWrappersRecordTypedOutcomes(t *testing.T) {
 	})
 	_, _, err = wrapped(ctx, nil, map[string]any{})
 	require.NoError(t, err)
-	require.Len(t, recorder.events, 2)
-	require.Equal(t, "succeeded", recorder.events[1].Outcome)
-	require.Equal(t, riskTelemetryReceiptReplay, recorder.events[1].Replay)
-	require.Equal(t, riskTelemetryScheduled, recorder.events[1].Reconciliation)
+	require.Len(t, recorder.events, 3)
+	require.Equal(t, "succeeded", recorder.events[2].Outcome)
+	require.Equal(t, riskTelemetryReceiptReplay, recorder.events[2].Replay)
+	require.Equal(t, riskTelemetryScheduled, recorder.events[2].Reconciliation)
 }
 
 func TestRiskTelemetryRejectsUnboundedDimensions(t *testing.T) {

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -172,6 +172,13 @@ func (r *Runtime) WithOAuthTelemetry(telemetry OAuthTelemetry) *Runtime {
 	return r
 }
 
+func (r *Runtime) WithRiskTelemetry(telemetry RiskTelemetry) *Runtime {
+	if r != nil && r.registrar != nil {
+		r.registrar.withRiskTelemetry(telemetry)
+	}
+	return r
+}
+
 func (r *Runtime) recordAuthOutcome(ctx context.Context, outcome, reason string) {
 	if r.telemetry != nil {
 		r.telemetry.Record(ctx, OAuthEvent{Operation: "runtime_auth", Outcome: outcome, Reason: reason})

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -29,7 +30,7 @@ func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutat
 		Annotations: readOnlyAnnotations(),
 		InputSchema: riskListSchema(false),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListRiskPoliciesInput) (*mcp.CallToolResult, ListRiskPoliciesOutput, error) {
-		return riskReadToolCall(ctx, func(principal Principal) (ListRiskPoliciesOutput, error) {
+		return riskReadToolCall(ctx, reg.riskTelemetry, "list_risk_policies", func(principal Principal) (ListRiskPoliciesOutput, error) {
 			return risk.ListPolicies(ctx, principal, input)
 		})
 	})
@@ -40,7 +41,7 @@ func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutat
 		Annotations: readOnlyAnnotations(),
 		InputSchema: riskGetPolicySchema(),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetRiskPolicyInput) (*mcp.CallToolResult, GetRiskPolicyOutput, error) {
-		return riskReadToolCall(ctx, func(principal Principal) (GetRiskPolicyOutput, error) {
+		return riskReadToolCall(ctx, reg.riskTelemetry, "get_risk_policy", func(principal Principal) (GetRiskPolicyOutput, error) {
 			return risk.GetPolicy(ctx, principal, input)
 		})
 	})
@@ -51,7 +52,7 @@ func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutat
 		Annotations: readOnlyAnnotations(),
 		InputSchema: riskListSchema(true),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListRiskExclusionsInput) (*mcp.CallToolResult, ListRiskExclusionsOutput, error) {
-		return riskReadToolCall(ctx, func(principal Principal) (ListRiskExclusionsOutput, error) {
+		return riskReadToolCall(ctx, reg.riskTelemetry, "list_risk_exclusions", func(principal Principal) (ListRiskExclusionsOutput, error) {
 			return risk.ListExclusions(ctx, principal, input)
 		})
 	})
@@ -79,7 +80,7 @@ func registerUnavailableRiskToolsWithCatalogAndMutations(reg *Registrar, buildCa
 		{"get_risk_policy", "Get Risk Policy", "Read one risk policy. Risk reads are unavailable in this deployment.", riskGetPolicySchema()},
 		{"list_risk_exclusions", "List Risk Exclusions", "List risk exclusions. Risk reads are unavailable in this deployment.", riskListSchema(true)},
 	} {
-		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, Annotations: readOnlyAnnotations(), InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, unavailableTool("risk_reads"))
+		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, Annotations: readOnlyAnnotations(), InputSchema: tool.schema}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, unavailableRiskReadTool(reg, tool.name))
 	}
 	catalog, err := buildCatalog()
 	registerRiskMutationHandlers(reg, catalog, err == nil, mutations)
@@ -157,10 +158,10 @@ func registerRiskMutationHandlers(reg *Registrar, catalog policycatalog.Catalog,
 		}
 	}
 	meta := ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}
-	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: createPolicyDescription, InputSchema: createPolicySchema}, meta, createPolicy)
-	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: updatePolicyDescription, InputSchema: updatePolicySchema}, meta, updatePolicy)
-	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: createExclusionDescription, InputSchema: createExclusionSchema}, meta, createExclusion)
-	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: updateExclusionDescription, InputSchema: updateRiskExclusionSchema()}, meta, updateExclusion)
+	addTool(reg, &mcp.Tool{Name: "create_risk_policy", Title: "Create Risk Policy", Description: createPolicyDescription, InputSchema: createPolicySchema}, meta, instrumentRiskMutation(reg, "create_risk_policy", createPolicy))
+	addTool(reg, &mcp.Tool{Name: "update_risk_policy", Title: "Update Risk Policy", Description: updatePolicyDescription, InputSchema: updatePolicySchema}, meta, instrumentRiskMutation(reg, "update_risk_policy", updatePolicy))
+	addTool(reg, &mcp.Tool{Name: "create_risk_exclusion", Title: "Create Risk Exclusion", Description: createExclusionDescription, InputSchema: createExclusionSchema}, meta, instrumentRiskMutation(reg, "create_risk_exclusion", createExclusion))
+	addTool(reg, &mcp.Tool{Name: "update_risk_exclusion", Title: "Update Risk Exclusion", Description: updateExclusionDescription, InputSchema: updateRiskExclusionSchema()}, meta, instrumentRiskMutation(reg, "update_risk_exclusion", updateExclusion))
 }
 
 func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, Out] {
@@ -174,11 +175,85 @@ func unavailableRiskMutationTool[Out any]() mcp.ToolHandlerFor[map[string]any, O
 		// Return a tool error rather than an existing IsError result. The MCP SDK
 		// short-circuits on errors before marshaling the typed zero Out value, so
 		// disabled tools emit no empty structured success fields.
-		return nil, zero, &ToolRefusalError{Payload: string(content)}
+		return nil, zero, &ToolRefusalError{Code: unavailableCode, Payload: string(content)}
 	}
 }
 
-func riskReadToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+func instrumentRiskMutation[Out any](reg *Registrar, tool string, handler mcp.ToolHandlerFor[map[string]any, Out]) mcp.ToolHandlerFor[map[string]any, Out] {
+	return func(ctx context.Context, request *mcp.CallToolRequest, input map[string]any) (*mcp.CallToolResult, Out, error) {
+		started := time.Now()
+		result, output, err := handler(ctx, request, input)
+		event := riskTelemetryEvent(tool, riskMutationTelemetryOutcome(err))
+		if err == nil {
+			event = riskMutationSuccessEvent(tool, output)
+		}
+		reg.riskTelemetry.Record(ctx, event, time.Since(started))
+		return result, output, err
+	}
+}
+
+func riskMutationTelemetryOutcome(err error) string {
+	if err == nil {
+		return "succeeded"
+	}
+	var refusal *ToolRefusalError
+	if errors.As(err, &refusal) && validRiskTelemetryOutcome(refusal.Code) {
+		return refusal.Code
+	}
+	var mutation *RiskMutationError
+	if errors.As(err, &mutation) && validRiskTelemetryOutcome(mutation.Code) {
+		return mutation.Code
+	}
+	return "unavailable"
+}
+
+func riskMutationSuccessEvent[Out any](tool string, output Out) RiskToolEvent {
+	event := riskTelemetryEvent(tool, "succeeded")
+	event.Replay = riskTelemetryFresh
+	switch typed := any(output).(type) {
+	case CreateRiskPolicyToolOutput:
+		event.Replay = riskMutationReplayState(typed.Receipt.Replayed, typed.MatchedExisting)
+	case UpdateRiskPolicyToolOutput:
+		event.Replay = riskMutationReplayState(typed.Receipt.Replayed, false)
+	case CreateRiskExclusionToolOutput:
+		event.Replay = riskMutationReplayState(typed.Receipt.Replayed, typed.MatchedExisting)
+		event.Reconciliation = typed.Reconciliation
+	case UpdateRiskExclusionToolOutput:
+		event.Replay = riskMutationReplayState(typed.Receipt.Replayed, false)
+		event.Reconciliation = typed.Reconciliation
+	}
+	return event
+}
+
+func riskMutationReplayState(replayed, matched bool) string {
+	switch {
+	case replayed:
+		return riskTelemetryReceiptReplay
+	case matched:
+		return riskTelemetryMatched
+	default:
+		return riskTelemetryFresh
+	}
+}
+
+func unavailableRiskReadTool(reg *Registrar, tool string) mcp.ToolHandlerFor[map[string]any, featureUnavailableResult] {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, featureUnavailableResult, error) {
+		started := time.Now()
+		result := featureUnavailableResult{Code: unavailableCode, Feature: "risk_reads", Message: "This is not switched on for your organization yet."}
+		reg.riskTelemetry.Record(ctx, riskTelemetryEvent(tool, result.Code), time.Since(started))
+		content, err := json.Marshal(result)
+		if err != nil {
+			return nil, featureUnavailableResult{}, fmt.Errorf("encode unavailable risk read result: %w", err)
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, result, nil
+	}
+}
+
+func riskReadToolCall[Out any](ctx context.Context, telemetry RiskTelemetry, tool string, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	started := time.Now()
+	event := riskTelemetryEvent(tool, "unavailable")
+	defer func() { telemetry.Record(ctx, event, time.Since(started)) }()
+
 	var zero Out
 	principal, err := principalFromToolContext(ctx)
 	if err != nil {
@@ -186,6 +261,7 @@ func riskReadToolCall[Out any](ctx context.Context, call func(principal Principa
 	}
 	output, err := call(principal)
 	if err == nil {
+		event.Outcome = "succeeded"
 		return nil, output, nil
 	}
 	var refusal featureUnavailableResult
@@ -199,8 +275,10 @@ func riskReadToolCall[Out any](ctx context.Context, call func(principal Principa
 	default:
 		return nil, zero, err
 	}
+	event.Outcome = refusal.Code
 	content, marshalErr := json.Marshal(refusal)
 	if marshalErr != nil {
+		event.Outcome = "unavailable"
 		return nil, zero, fmt.Errorf("encode risk read refusal: %w", marshalErr)
 	}
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, zero, nil

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -276,6 +276,9 @@ func riskReadToolCall[Out any](ctx context.Context, telemetry RiskTelemetry, too
 		return nil, zero, err
 	}
 	event.Outcome = refusal.Code
+	if errors.Is(err, ErrUnavailable) {
+		event.Outcome = "unavailable"
+	}
 	content, marshalErr := json.Marshal(refusal)
 	if marshalErr != nil {
 		event.Outcome = "unavailable"


### PR DESCRIPTION
## Why

Complete the remaining AGE-3168 implementation gap by making D3 risk-tool outcomes observable without exposing policy, prompt, exclusion, tenant, or receipt content.

## What changed

- emit `platform_mcp.risk.tool_calls` and `platform_mcp.risk.tool_duration` for typed handler results across all seven fixed D3 tools
- share the same instrumentation between the external Platform MCP and Project Assistant descriptor path
- classify bounded outcomes, including a distinct operational `unavailable` outcome versus rollout `feature_unavailable`
- report fresh writes, receipt replays, create convergence, catalog version, and exclusion reconciliation scheduling with closed enums
- reject any unallowlisted telemetry dimensions and cover metric keys/values with leak tests
- add the UI-managed Datadog dashboard/monitor contract and initial mutation-failure, conflict, latency, and reconciliation guidance

## Review notes

This PR is stacked on #5786. Review only commit `b4cce75d8` until the parent merges.

The metrics intentionally cover typed handler results. MCP/direct schema rejections happen before a typed handler and remain protocol/HTTP telemetry, as documented in the runbook.

The clone-local `plans/` records are excluded by `.git/info/exclude`; they were updated locally but are not force-added. This PR description is the tracked implementation checkpoint.

## Validation

- [x] `hk run pre-commit -j 1`
- [x] `mise lint:server`
- [x] `mise build:server`
- [x] Platform MCP test package compiles with `go test -c`
- [x] strict metric attribute allowlist/leak tests added
- [x] independent review completed; operational outage taxonomy, handler-result scope, and Datadog query syntax findings fixed
- [ ] local focused test execution: package-global Docker infrastructure starts before test filtering and local Postgres readiness/access prevented execution; CI remains authoritative

## Remaining rollout gates

- [ ] create and link the Datadog dashboard/monitors from `docs/runbooks/platform-mcp-risk-monitors.md`
- [ ] run the external Platform MCP and Project Assistant D3 smoke checklist
- [ ] dogfood policy/exclusion writes, replay/conflicts, dashboard version invalidation, and reconciliation completion in the internal cohort
- [ ] record deployed rollout and rollback evidence before broader cohort expansion

Linear: AGE-3168

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the seven D3 risk-policy and exclusion tool outcomes observable without exposing policy, prompt, exclusion, tenant, or receipt content. Emits `platform_mcp.risk.tool_calls` and `platform_mcp.risk.tool_duration` for bounded handler results shared across the external Platform MCP and Project Assistant paths, including deployments where risk reads are disabled.

**Telemetry**
- Classifies bounded outcomes with closed enums, distinguishing operational `unavailable` from rollout `feature_unavailable` across read paths, unavailable-read deployments, and admission control; the client-facing refusal response still returns `feature_unavailable`.
- Records replay state, catalog version, and reconciliation scheduling for typed handler results and refusals.
- Refusals carry a bounded outcome code so client-facing payloads stay out of metrics; leak tests reject any non-allowlisted attribute.
- Schema rejections before a typed handler remain protocol/HTTP telemetry, not these metrics.

**Rollout**
- Datadog dashboard and monitors are not yet verified as deployed; create and link them before enabling risk mutations beyond the internal cohort.

<sup>Written for commit a33eb91912bc4cbc83739594e2121d47898e07dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

