### PR TITLE
feat: expose OpenRouter disable causes to admins (AGE-3219)

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -3301,7 +3301,7 @@ paths:
         name: DisableAdminOpenRouterKey
   /rpc/adminOpenRouterKeys.enableKey:
     post:
-      description: Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.
+      description: Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.
       operationId: enableAdminOpenRouterKey
       parameters:
         - allowEmptyValue: true
@@ -61154,9 +61154,14 @@ components:
           type: string
           description: When the key row was created.
           format: date-time
+        disable_causes:
+          type: array
+          items:
+            type: string
+          description: Independent reasons that keep the key disabled.
         disabled:
           type: boolean
-          description: Whether the key is locked down (refused locally and disabled upstream).
+          description: Whether one or more active causes keep the key disabled.
         gram_account_type:
           type: string
           description: The organization's Gram account type (e.g. free, pro, enterprise).
@@ -61189,6 +61194,7 @@ components:
         - key_type
         - monthly_credits
         - disabled
+        - disable_causes
         - created_at
         - updated_at
     AdminOrganization:
@@ -66332,7 +66338,7 @@ components:
       properties:
         key_type:
           type: string
-          description: Key type to enable.
+          description: Key type from which to remove the platform-admin lock.
           enum:
             - chat
             - internal

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
@@ -1,0 +1,219 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  disableMutate: vi.fn(),
+  disableOptions: undefined as any,
+  enableMutate: vi.fn(),
+  enableOptions: undefined as any,
+  invalidate: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useIsPlatformAdmin: () => true,
+}));
+
+vi.mock("@/components/page-layout", () => {
+  const Wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    Page: Object.assign(Wrapper, {
+      Header: Object.assign(Wrapper, { Breadcrumbs: Wrapper }),
+      Body: Wrapper,
+      Section: Object.assign(Wrapper, {
+        Title: Wrapper,
+        Description: Wrapper,
+        Body: Wrapper,
+      }),
+    }),
+  };
+});
+
+vi.mock("@/components/ui/Table", () => ({
+  Table: ({ columns, data }: { columns: any[]; data: any[] }) => (
+    <div>
+      {data.map((row) => (
+        <div key={row.organizationSlug} data-testid={row.organizationSlug}>
+          {columns.map((column) => (
+            <div key={column.key}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/MoreActions", () => ({
+  MoreActions: ({ actions }: { actions: any[] }) => (
+    <div>
+      {actions.map((action) => (
+        <button key={action.label} onClick={action.onClick}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/Tooltip", () => ({
+  SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@gram/client/react-query/adminOpenRouterKeys.js", () => ({
+  invalidateAllAdminOpenRouterKeys: mocks.invalidate,
+  useAdminOpenRouterKeys: () => ({
+    data: {
+      keys: [
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          disableCauses: ["trial_demotion"],
+          gramAccountType: "free",
+          keyType: "chat",
+          monthlyCredits: 10,
+          organizationId: "automatic-id",
+          organizationName: "Automatic cause",
+          organizationSlug: "automatic-cause",
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          disableCauses: ["admin_lock", "billing_inactive"],
+          gramAccountType: "pro",
+          keyType: "internal",
+          monthlyCredits: 20,
+          organizationId: "combined-id",
+          organizationName: "Combined causes",
+          organizationSlug: "combined-causes",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/adminOpenRouterKeyUsage.js", () => ({
+  useAdminOpenRouterKeyUsage: () => ({ data: undefined, isLoading: false }),
+}));
+
+vi.mock("@gram/client/react-query/disableAdminOpenRouterKey.js", () => ({
+  useDisableAdminOpenRouterKeyMutation: (options: any) => {
+    mocks.disableOptions = options;
+    return { mutate: mocks.disableMutate, isPending: false };
+  },
+}));
+
+vi.mock("@gram/client/react-query/enableAdminOpenRouterKey.js", () => ({
+  useEnableAdminOpenRouterKeyMutation: (options: any) => {
+    mocks.enableOptions = options;
+    return { mutate: mocks.enableMutate, isPending: false };
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: vi.fn() },
+}));
+
+import PlatformAdminOpenRouterKeys from "./OpenRouterKeys";
+
+describe("PlatformAdminOpenRouterKeys", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows combined causes and never offers removing an automatic cause", () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <PlatformAdminOpenRouterKeys />
+      </QueryClientProvider>,
+    );
+
+    const automatic = within(screen.getByTestId("automatic-cause"));
+    expect(automatic.getByText("Trial demotion")).toBeDefined();
+    expect(
+      automatic.getByRole("button", { name: "Disable key" }),
+    ).toBeDefined();
+    expect(
+      automatic.queryByRole("button", { name: "Remove admin lock" }),
+    ).toBeNull();
+
+    const combined = within(screen.getByTestId("combined-causes"));
+    expect(combined.getByText("Admin lock")).toBeDefined();
+    expect(combined.getByText("Billing inactive")).toBeDefined();
+    expect(
+      combined.getByRole("button", { name: "Remove admin lock" }),
+    ).toBeDefined();
+    expect(combined.queryByRole("button", { name: "Disable key" })).toBeNull();
+  });
+
+  it("uses the generated admin mutations for the eligible action", () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PlatformAdminOpenRouterKeys />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(
+      within(screen.getByTestId("automatic-cause")).getByRole("button", {
+        name: "Disable key",
+      }),
+    );
+    expect(mocks.disableMutate).toHaveBeenCalledWith({
+      request: {
+        disableOpenRouterKeyRequestBody: {
+          organizationId: "automatic-id",
+          keyType: "chat",
+        },
+      },
+    });
+
+    fireEvent.click(
+      within(screen.getByTestId("combined-causes")).getByRole("button", {
+        name: "Remove admin lock",
+      }),
+    );
+    expect(mocks.enableMutate).toHaveBeenCalledWith({
+      request: {
+        enableOpenRouterKeyRequestBody: {
+          organizationId: "combined-id",
+          keyType: "internal",
+        },
+      },
+    });
+
+    const automaticKey = {
+      keyType: "chat",
+      organizationName: "Automatic cause",
+    };
+    mocks.disableOptions.onSuccess(automaticKey);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Admin lock added to the chat key for Automatic cause.",
+    );
+    expect(mocks.invalidate).toHaveBeenCalledWith(queryClient);
+
+    const combinedKey = {
+      keyType: "internal",
+      organizationName: "Combined causes",
+    };
+    mocks.enableOptions.onSuccess(combinedKey);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Admin lock removed from the internal key for Combined causes.",
+    );
+    expect(mocks.invalidate).toHaveBeenCalledTimes(2);
+    expect(mocks.invalidate).toHaveBeenLastCalledWith(queryClient);
+  });
+});

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
@@ -8,12 +8,21 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Action } from "@/components/ui/MoreActions";
+import type { Column } from "@/components/ui/Table";
+import type { AdminOpenRouterKey } from "@gram/client/models/components/adminopenrouterkey.js";
+
+type MutationOptions = {
+  onSuccess: (
+    key: Pick<AdminOpenRouterKey, "keyType" | "organizationName">,
+  ) => void;
+};
 
 const mocks = vi.hoisted(() => ({
   disableMutate: vi.fn(),
-  disableOptions: undefined as any,
+  disableOptions: undefined as MutationOptions | undefined,
   enableMutate: vi.fn(),
-  enableOptions: undefined as any,
+  enableOptions: undefined as MutationOptions | undefined,
   invalidate: vi.fn(),
   toastSuccess: vi.fn(),
 }));
@@ -38,12 +47,18 @@ vi.mock("@/components/page-layout", () => {
 });
 
 vi.mock("@/components/ui/Table", () => ({
-  Table: ({ columns, data }: { columns: any[]; data: any[] }) => (
+  Table: ({
+    columns,
+    data,
+  }: {
+    columns: Column<AdminOpenRouterKey>[];
+    data: AdminOpenRouterKey[];
+  }) => (
     <div>
       {data.map((row) => (
         <div key={row.organizationSlug} data-testid={row.organizationSlug}>
           {columns.map((column) => (
-            <div key={column.key}>{column.render?.(row)}</div>
+            <div key={String(column.key)}>{column.render?.(row)}</div>
           ))}
         </div>
       ))}
@@ -52,7 +67,7 @@ vi.mock("@/components/ui/Table", () => ({
 }));
 
 vi.mock("@/components/ui/MoreActions", () => ({
-  MoreActions: ({ actions }: { actions: any[] }) => (
+  MoreActions: ({ actions }: { actions: Action[] }) => (
     <div>
       {actions.map((action) => (
         <button key={action.label} onClick={action.onClick}>
@@ -108,14 +123,14 @@ vi.mock("@gram/client/react-query/adminOpenRouterKeyUsage.js", () => ({
 }));
 
 vi.mock("@gram/client/react-query/disableAdminOpenRouterKey.js", () => ({
-  useDisableAdminOpenRouterKeyMutation: (options: any) => {
+  useDisableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
     mocks.disableOptions = options;
     return { mutate: mocks.disableMutate, isPending: false };
   },
 }));
 
 vi.mock("@gram/client/react-query/enableAdminOpenRouterKey.js", () => ({
-  useEnableAdminOpenRouterKeyMutation: (options: any) => {
+  useEnableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
     mocks.enableOptions = options;
     return { mutate: mocks.enableMutate, isPending: false };
   },
@@ -199,7 +214,7 @@ describe("PlatformAdminOpenRouterKeys", () => {
       keyType: "chat",
       organizationName: "Automatic cause",
     };
-    mocks.disableOptions.onSuccess(automaticKey);
+    mocks.disableOptions?.onSuccess(automaticKey);
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Admin lock added to the chat key for Automatic cause.",
     );
@@ -209,7 +224,7 @@ describe("PlatformAdminOpenRouterKeys", () => {
       keyType: "internal",
       organizationName: "Combined causes",
     };
-    mocks.enableOptions.onSuccess(combinedKey);
+    mocks.enableOptions?.onSuccess(combinedKey);
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Admin lock removed from the internal key for Combined causes.",
     );

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
@@ -20,6 +20,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
+import { causeLabels, keyAction } from "./openRouterKeyState";
 
 // Rows per page; also the ceiling on concurrent live usage fetches, since
 // only mounted rows request usage.
@@ -135,7 +136,7 @@ function KeysTable(): JSX.Element {
   const disable = useDisableAdminOpenRouterKeyMutation({
     onSuccess: (key) => {
       toast.success(
-        `Disabled the ${key.keyType} key for ${key.organizationName}.`,
+        `Admin lock added to the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
     },
@@ -148,7 +149,7 @@ function KeysTable(): JSX.Element {
   const enable = useEnableAdminOpenRouterKeyMutation({
     onSuccess: (key) => {
       toast.success(
-        `Enabled the ${key.keyType} key for ${key.organizationName}.`,
+        `Admin lock removed from the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
     },
@@ -184,10 +185,10 @@ function KeysTable(): JSX.Element {
     const keyType = row.keyType === "internal" ? "internal" : "chat";
     const body = { organizationId: row.organizationId, keyType } as const;
     const actions: Action[] = [];
-    if (row.disabled) {
+    if (keyAction(row.disableCauses) === "remove-admin-lock") {
       actions.push({
         icon: "play",
-        label: "Enable key",
+        label: "Remove admin lock",
         disabled: enable.isPending,
         onClick: () =>
           enable.mutate({
@@ -266,6 +267,27 @@ function KeysTable(): JSX.Element {
             <Badge.Text>Enabled</Badge.Text>
           </Badge>
         ),
+    },
+    {
+      key: "causes",
+      header: "Causes",
+      width: "180px",
+      render: (row) => {
+        const labels = causeLabels(row.disableCauses);
+        return labels.length > 0 ? (
+          <div className="space-y-1">
+            {labels.map((label) => (
+              <Text key={label} small>
+                {label}
+              </Text>
+            ))}
+          </div>
+        ) : (
+          <Text muted small>
+            —
+          </Text>
+        );
+      },
     },
     {
       key: "actions",

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
@@ -1,3 +1,4 @@
+import { adminOpenRouterKeyFromJSON } from "@gram/client/models/components/adminopenrouterkey.js";
 import { describe, expect, it } from "vitest";
 import { causeLabels, keyAction } from "./openRouterKeyState";
 
@@ -11,6 +12,27 @@ describe("OpenRouter key state", () => {
       "Billing inactive",
       "future_cause",
     ]);
+  });
+
+  it("preserves an unknown cause through SDK response decoding", () => {
+    const result = adminOpenRouterKeyFromJSON(
+      JSON.stringify({
+        created_at: "2026-01-01T00:00:00Z",
+        disable_causes: ["future_cause"],
+        disabled: true,
+        gram_account_type: "pro",
+        key_type: "chat",
+        monthly_credits: 10,
+        organization_id: "organization-id",
+        organization_name: "Example organization",
+        organization_slug: "example-organization",
+        updated_at: "2026-01-01T00:00:00Z",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    expect(causeLabels(result.value.disableCauses)).toEqual(["future_cause"]);
   });
 
   it("bases the admin action only on the admin lock cause", () => {

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { causeLabels, keyAction } from "./openRouterKeyState";
+
+describe("OpenRouter key state", () => {
+  it("renders every known and unknown disable cause", () => {
+    expect(causeLabels(["admin_lock", "trial_demotion"])).toEqual([
+      "Admin lock",
+      "Trial demotion",
+    ]);
+    expect(causeLabels(["billing_inactive", "future_cause"])).toEqual([
+      "Billing inactive",
+      "future_cause",
+    ]);
+  });
+
+  it("bases the admin action only on the admin lock cause", () => {
+    expect(keyAction([])).toBe("disable");
+    expect(keyAction(["trial_demotion"])).toBe("disable");
+    expect(keyAction(["admin_lock"])).toBe("remove-admin-lock");
+    expect(keyAction(["admin_lock", "billing_inactive"])).toBe(
+      "remove-admin-lock",
+    );
+  });
+});

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
@@ -1,0 +1,18 @@
+export const DISABLE_CAUSE_LABELS = {
+  admin_lock: "Admin lock",
+  trial_demotion: "Trial demotion",
+  billing_inactive: "Billing inactive",
+} as const;
+
+export function causeLabels(causes: readonly string[]): string[] {
+  return causes.map(
+    (cause) =>
+      DISABLE_CAUSE_LABELS[cause as keyof typeof DISABLE_CAUSE_LABELS] ?? cause,
+  );
+}
+
+export function keyAction(
+  causes: readonly string[],
+): "disable" | "remove-admin-lock" {
+  return causes.includes("admin_lock") ? "remove-admin-lock" : "disable";
+}

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
@@ -1,4 +1,4 @@
-export const DISABLE_CAUSE_LABELS = {
+const DISABLE_CAUSE_LABELS = {
   admin_lock: "Admin lock",
   trial_demotion: "Trial demotion",
   billing_inactive: "Billing inactive",

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -4643,7 +4643,7 @@ examples:
         application/json: {"key_type": "chat", "organization_id": "<id>"}
       responses:
         "200":
-          application/json: {"created_at": "2024-08-21T13:21:54.974Z", "disabled": true, "gram_account_type": "<value>", "key_type": "<value>", "monthly_credits": 166947, "organization_id": "<id>", "organization_name": "<value>", "organization_slug": "<value>", "updated_at": "2026-04-19T14:12:31.155Z"}
+          application/json: {"created_at": "2024-08-21T13:21:54.974Z", "disable_causes": [], "disabled": true, "gram_account_type": "<value>", "key_type": "<value>", "monthly_credits": 166947, "organization_id": "<id>", "organization_name": "<value>", "organization_slug": "<value>", "updated_at": "2026-04-19T14:12:31.155Z"}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": false}
         "500":
@@ -4776,7 +4776,7 @@ examples:
         application/json: {"key_type": "internal", "organization_id": "<id>"}
       responses:
         "200":
-          application/json: {"created_at": "2025-07-27T03:56:09.631Z", "disabled": true, "gram_account_type": "<value>", "key_type": "<value>", "monthly_credits": 945065, "organization_id": "<id>", "organization_name": "<value>", "organization_slug": "<value>", "updated_at": "2026-03-30T05:03:57.632Z"}
+          application/json: {"created_at": "2025-07-27T03:56:09.631Z", "disable_causes": ["trial_demotion"], "disabled": true, "gram_account_type": "<value>", "key_type": "<value>", "monthly_credits": 945065, "organization_id": "<id>", "organization_name": "<value>", "organization_slug": "<value>", "updated_at": "2026-03-30T05:03:57.632Z"}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": false}
         "500":

--- a/client/dashboard/src/sdk/src/funcs/adminOpenRouterKeysEnableKey.ts
+++ b/client/dashboard/src/sdk/src/funcs/adminOpenRouterKeysEnableKey.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * enableKey adminOpenRouterKeys
  *
  * @remarks
- * Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.
+ * Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.
  */
 export function adminOpenRouterKeysEnableKey(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/models/components/adminopenrouterkey.ts
+++ b/client/dashboard/src/sdk/src/models/components/adminopenrouterkey.ts
@@ -5,16 +5,8 @@
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
 import { safeParse } from "../../lib/schemas.js";
-import { ClosedEnum } from "../../types/enums.js";
 import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
-
-export const DisableCauses = {
-  AdminLock: "admin_lock",
-  TrialDemotion: "trial_demotion",
-  BillingInactive: "billing_inactive",
-} as const;
-export type DisableCauses = ClosedEnum<typeof DisableCauses>;
 
 /**
  * One organization's platform OpenRouter key of a given type, without its key material.
@@ -27,7 +19,7 @@ export type AdminOpenRouterKey = {
   /**
    * Independent reasons that keep the key disabled.
    */
-  disableCauses: Array<DisableCauses>;
+  disableCauses: Array<string>;
   /**
    * Whether one or more active causes keep the key disabled.
    */
@@ -63,10 +55,6 @@ export type AdminOpenRouterKey = {
 };
 
 /** @internal */
-export const DisableCauses$inboundSchema: z.ZodMiniEnum<typeof DisableCauses> =
-  z.enum(DisableCauses);
-
-/** @internal */
 export const AdminOpenRouterKey$inboundSchema: z.ZodMiniType<
   AdminOpenRouterKey,
   unknown
@@ -76,7 +64,7 @@ export const AdminOpenRouterKey$inboundSchema: z.ZodMiniType<
       z.iso.datetime({ offset: true }),
       z.transform(v => new Date(v)),
     ),
-    disable_causes: z.array(DisableCauses$inboundSchema),
+    disable_causes: z.array(z.string()),
     disabled: z.boolean(),
     gram_account_type: z.string(),
     key_type: z.string(),

--- a/client/dashboard/src/sdk/src/models/components/adminopenrouterkey.ts
+++ b/client/dashboard/src/sdk/src/models/components/adminopenrouterkey.ts
@@ -5,8 +5,16 @@
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
 import { safeParse } from "../../lib/schemas.js";
+import { ClosedEnum } from "../../types/enums.js";
 import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
+
+export const DisableCauses = {
+  AdminLock: "admin_lock",
+  TrialDemotion: "trial_demotion",
+  BillingInactive: "billing_inactive",
+} as const;
+export type DisableCauses = ClosedEnum<typeof DisableCauses>;
 
 /**
  * One organization's platform OpenRouter key of a given type, without its key material.
@@ -17,7 +25,11 @@ export type AdminOpenRouterKey = {
    */
   createdAt: Date;
   /**
-   * Whether the key is locked down (refused locally and disabled upstream).
+   * Independent reasons that keep the key disabled.
+   */
+  disableCauses: Array<DisableCauses>;
+  /**
+   * Whether one or more active causes keep the key disabled.
    */
   disabled: boolean;
   /**
@@ -51,6 +63,10 @@ export type AdminOpenRouterKey = {
 };
 
 /** @internal */
+export const DisableCauses$inboundSchema: z.ZodMiniEnum<typeof DisableCauses> =
+  z.enum(DisableCauses);
+
+/** @internal */
 export const AdminOpenRouterKey$inboundSchema: z.ZodMiniType<
   AdminOpenRouterKey,
   unknown
@@ -60,6 +76,7 @@ export const AdminOpenRouterKey$inboundSchema: z.ZodMiniType<
       z.iso.datetime({ offset: true }),
       z.transform(v => new Date(v)),
     ),
+    disable_causes: z.array(DisableCauses$inboundSchema),
     disabled: z.boolean(),
     gram_account_type: z.string(),
     key_type: z.string(),
@@ -75,6 +92,7 @@ export const AdminOpenRouterKey$inboundSchema: z.ZodMiniType<
   z.transform((v) => {
     return remap$(v, {
       "created_at": "createdAt",
+      "disable_causes": "disableCauses",
       "gram_account_type": "gramAccountType",
       "key_type": "keyType",
       "monthly_credits": "monthlyCredits",

--- a/client/dashboard/src/sdk/src/models/components/enableopenrouterkeyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/enableopenrouterkeyrequestbody.ts
@@ -7,14 +7,14 @@ import { remap as remap$ } from "../../lib/primitives.js";
 import { ClosedEnum } from "../../types/enums.js";
 
 /**
- * Key type to enable.
+ * Key type from which to remove the platform-admin lock.
  */
 export const EnableOpenRouterKeyRequestBodyKeyType = {
   Chat: "chat",
   Internal: "internal",
 } as const;
 /**
- * Key type to enable.
+ * Key type from which to remove the platform-admin lock.
  */
 export type EnableOpenRouterKeyRequestBodyKeyType = ClosedEnum<
   typeof EnableOpenRouterKeyRequestBodyKeyType
@@ -22,7 +22,7 @@ export type EnableOpenRouterKeyRequestBodyKeyType = ClosedEnum<
 
 export type EnableOpenRouterKeyRequestBody = {
   /**
-   * Key type to enable.
+   * Key type from which to remove the platform-admin lock.
    */
   keyType: EnableOpenRouterKeyRequestBodyKeyType;
   /**

--- a/client/dashboard/src/sdk/src/react-query/enableAdminOpenRouterKey.ts
+++ b/client/dashboard/src/sdk/src/react-query/enableAdminOpenRouterKey.ts
@@ -54,7 +54,7 @@ export type EnableAdminOpenRouterKeyMutationError =
  * enableKey adminOpenRouterKeys
  *
  * @remarks
- * Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.
+ * Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.
  */
 export function useEnableAdminOpenRouterKeyMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/adminopenrouterkeys.ts
+++ b/client/dashboard/src/sdk/src/sdk/adminopenrouterkeys.ts
@@ -52,7 +52,7 @@ export class AdminOpenRouterKeys extends ClientSDK {
    * enableKey adminOpenRouterKeys
    *
    * @remarks
-   * Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.
+   * Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.
    */
   async enableKey(
     request: EnableAdminOpenRouterKeyRequest,

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -733,19 +733,19 @@ func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openr
 	return 0, fmt.Errorf("not implemented in bench")
 }
 func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+	return openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (*devProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+	return openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+	return 0, openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (*devProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+	return 0, openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openrouter.KeyType) (float64, int, error) {

--- a/server/design/platformadmin/openrouterkeys/design.go
+++ b/server/design/platformadmin/openrouterkeys/design.go
@@ -23,9 +23,7 @@ var AdminKey = Type("AdminOpenRouterKey", func() {
 	Attribute("key_type", String, "Which upstream key this row provisions: 'chat' pays for customer-facing completions, 'internal' pays for platform-initiated LLM usage.")
 	Attribute("monthly_credits", Int64, "Monthly credit ceiling last mirrored from OpenRouter.")
 	Attribute("disabled", Boolean, "Whether one or more active causes keep the key disabled.")
-	Attribute("disable_causes", ArrayOf(String, func() {
-		Enum("admin_lock", "trial_demotion", "billing_inactive")
-	}), "Independent reasons that keep the key disabled.")
+	Attribute("disable_causes", ArrayOf(String), "Independent reasons that keep the key disabled.")
 	Attribute("created_at", String, "When the key row was created.", func() { Format(FormatDateTime) })
 	Attribute("updated_at", String, "When the key row was last updated.", func() { Format(FormatDateTime) })
 })

--- a/server/gen/http/admin_open_router_keys/client/types.go
+++ b/server/gen/http/admin_open_router_keys/client/types.go
@@ -1615,11 +1615,6 @@ func ValidateDisableKeyResponseBody(body *DisableKeyResponseBody) (err error) {
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
 	}
-	for _, e := range body.DisableCauses {
-		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
-		}
-	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
 	}
@@ -1661,11 +1656,6 @@ func ValidateEnableKeyResponseBody(body *EnableKeyResponseBody) (err error) {
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
-	}
-	for _, e := range body.DisableCauses {
-		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
-		}
 	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
@@ -2668,11 +2658,6 @@ func ValidateAdminOpenRouterKeyResponseBody(body *AdminOpenRouterKeyResponseBody
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
-	}
-	for _, e := range body.DisableCauses {
-		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
-		}
 	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -62542,10 +62542,6 @@ components:
                     type: array
                     items:
                         type: string
-                        enum:
-                            - admin_lock
-                            - trial_demotion
-                            - billing_inactive
                     description: Independent reasons that keep the key disabled.
                 disabled:
                     type: boolean

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -385,3 +385,7 @@ WHERE om.id = sqlc.arg('id')::text
    OR (sqlc.arg('allow_slug')::boolean AND om.slug = sqlc.arg('id')::text)
 ORDER BY (om.id = sqlc.arg('id')::text) DESC
 LIMIT 1;
+
+-- name: LockTrialForUpdate :one
+-- Test synchronization helper: hold the trial row while a concurrent re-arm blocks.
+SELECT organization_id FROM trials WHERE organization_id = @organization_id FOR UPDATE;

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -18,6 +18,7 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	adminrepo "github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
@@ -76,7 +77,7 @@ func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, d
 		return 0, openrouter.DisableCauseChange{}, nil
 	}
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	hadCause := slices.Contains(row.DisableCauses, string(cause))
 	refreshed, err := p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
@@ -85,7 +86,7 @@ func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, d
 	}
 	updated, err := orrepo.New(db).RemoveOpenRouterAPIKeyDisableCause(ctx, orrepo.RemoveOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(keyType), DisableCause: string(cause)})
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	return refreshed, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: row.Disabled && !updated.Disabled}, nil
 }
@@ -325,6 +326,7 @@ func TestRearmTrial_RemovesOnlyTrialDemotionCause(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, svc, conn, _ := newRearmService(t)
 			orgID := "org_rearm_" + strings.ReplaceAll(tt.name, " ", "_")
 			seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
@@ -441,11 +443,9 @@ func TestRearmTrial_TrialRowLockPrecedesKeyLocks(t *testing.T) { //nolint:parall
 	const orgID = "org_rearm_lock_order"
 	seedDemotedTrial(t, ctx, pool, orgID, "enterprise")
 
-	trialOwnerTx, err := pool.Begin(ctx)
+	trialOwnerTx := testenv.BeginTx(t, ctx, pool)
+	lockedOrgID, err := adminrepo.New(trialOwnerTx).LockTrialForUpdate(ctx, orgID)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = trialOwnerTx.Rollback(context.WithoutCancel(ctx)) })
-	var lockedOrgID string
-	require.NoError(t, trialOwnerTx.QueryRow(ctx, `SELECT organization_id FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID).Scan(&lockedOrgID))
 	require.Equal(t, orgID, lockedOrgID)
 
 	type rearmResult struct {
@@ -457,9 +457,7 @@ func TestRearmTrial_TrialRowLockPrecedesKeyLocks(t *testing.T) { //nolint:parall
 		rearmed <- rearmResult{err: rearmErr}
 	}()
 
-	blockedPID := waitForBlockedTrialRearm(t, ctx, pool)
-	var advisoryLocks int
-	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM pg_locks WHERE pid = $1 AND locktype = 'advisory' AND granted`, blockedPID).Scan(&advisoryLocks))
+	testenv.WaitForBlockedBackend(t, ctx, pool)
 
 	logger := testenv.NewLogger(t)
 	trialOwnerErr := keybillinglock.WithAcquireTimeout(ctx, logger, pool, orgID, openrouter.KeyTypeChat, time.Second, func(_ *pgxpool.Conn) error {
@@ -477,7 +475,6 @@ func TestRearmTrial_TrialRowLockPrecedesKeyLocks(t *testing.T) { //nolint:parall
 	case <-time.After(5 * time.Second):
 		t.Fatal("concurrent trial demotion and re-arm did not complete")
 	}
-	require.Zero(t, advisoryLocks, "re-arm must not hold key locks while waiting for the trial row")
 	require.NoError(t, trialOwnerErr)
 	require.NoError(t, result.err)
 	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
@@ -485,43 +482,6 @@ func TestRearmTrial_TrialRowLockPrecedesKeyLocks(t *testing.T) { //nolint:parall
 		require.Equal(t, "free", revival.accountTypeSeen, "key work must finish before organization restoration commits")
 		require.True(t, revival.demotedSeen, "key work must observe the demoted trial before re-arm commits")
 	}
-}
-
-func waitForBlockedTrialRearm(t *testing.T, ctx context.Context, pool *pgxpool.Pool) int32 {
-	t.Helper()
-
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		var pid int32
-		err := pool.QueryRow(ctx, `
-			SELECT pid
-			FROM pg_stat_activity
-			WHERE datname = current_database()
-			  AND pid <> pg_backend_pid()
-			  AND query LIKE '%SET demoted_at = NULL%'
-			  AND wait_event_type = 'Lock'
-			LIMIT 1
-		`).Scan(&pid)
-		if err == nil {
-			return pid
-		}
-		if !errors.Is(err, pgx.ErrNoRows) {
-			require.NoError(t, err)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	rows, err := pool.Query(ctx, `SELECT pid, state, coalesce(wait_event_type, ''), left(query, 160) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid()`)
-	require.NoError(t, err)
-	defer rows.Close()
-	var activity []string
-	for rows.Next() {
-		var pid int32
-		var state, waitType, query string
-		require.NoError(t, rows.Scan(&pid, &state, &waitType, &query))
-		activity = append(activity, fmt.Sprintf("pid=%d state=%s wait=%s query=%q", pid, state, waitType, query))
-	}
-	t.Fatalf("re-arm never blocked on the trial row lock: %v", activity)
-	return 0
 }
 
 func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) {

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -788,3 +788,15 @@ func (q *Queries) GetProjectBySlug(ctx context.Context, slug string) (GetProject
 	err := row.Scan(&i.ID, &i.Slug)
 	return i, err
 }
+
+const lockTrialForUpdate = `-- name: LockTrialForUpdate :one
+SELECT organization_id FROM trials WHERE organization_id = $1 FOR UPDATE
+`
+
+// Test synchronization helper: hold the trial row while a concurrent re-arm blocks.
+func (q *Queries) LockTrialForUpdate(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, lockTrialForUpdate, organizationID)
+	var organization_id string
+	err := row.Scan(&organization_id)
+	return organization_id, err
+}

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"sync"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -76,7 +78,7 @@ func (m *mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.
 		return 0, openrouter.DisableCauseChange{}, nil
 	}
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	if limit != nil && key.MonthlyCredits == int64(*limit) && !slices.Contains(key.DisableCauses, string(cause)) {
 		return *limit, openrouter.DisableCauseChange{}, nil
@@ -300,7 +302,15 @@ func TestReconcilePaygOpenRouterChatKeyStripeConversionRemovesTrialDemotionFromB
 	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
 	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
 	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeInternal, 37)
-	_, err := db.Exec(t.Context(), `INSERT INTO trials (organization_id, tier, ends_at, demoted_at, converted_at) VALUES ($1, 'enterprise', clock_timestamp() - interval '2 days', clock_timestamp() - interval '1 day', clock_timestamp())`, organizationID)
+	now := time.Now().UTC()
+	err := trialsrepo.New(db).InsertTrialFixture(t.Context(), trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: organizationID,
+		Tier:           "enterprise",
+		CreatedAt:      pgtype.Timestamptz{Time: now.Add(-3 * 24 * time.Hour), Valid: true},
+		EndsAt:         pgtype.Timestamptz{Time: now.Add(-2 * 24 * time.Hour), Valid: true},
+		ConvertedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		DemotedAt:      pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+	})
 	require.NoError(t, err)
 	for _, keyType := range openrouter.AllKeyTypes {
 		_, err = openrouterrepo.New(db).AddOpenRouterAPIKeyDisableCause(t.Context(), openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(openrouter.DisableCauseTrialDemotion)})
@@ -343,6 +353,7 @@ func TestReconcilePaygOpenRouterChatKeyBillingLossOwnsOnlyBillingInactive(t *tes
 	t.Parallel()
 
 	t.Run("enabled chat key changes effective access", func(t *testing.T) {
+		t.Parallel()
 		reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
 		provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
@@ -352,6 +363,7 @@ func TestReconcilePaygOpenRouterChatKeyBillingLossOwnsOnlyBillingInactive(t *tes
 	})
 
 	t.Run("admin locked chat key stays disabled without another state patch", func(t *testing.T) {
+		t.Parallel()
 		reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
 		provisioner.layeredAdd = true
 

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -100,8 +100,11 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 				return errors.New("OpenRouter key provisioner cannot use the locked database session")
 			}
 			change, err := dbProvisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, args.OrganizationID, keyType, openrouter.DisableCauseTrialDemotion)
+			if err != nil {
+				return fmt.Errorf("add trial demotion disable cause: %w", err)
+			}
 			keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
-			return err
+			return nil
 		}); err != nil {
 			return fmt.Errorf("disable openrouter %s key: %w", keyType, err)
 		}

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -115,7 +115,7 @@ func (s *stubProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db op
 	queries := orgrepo.New(db)
 	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	if err != nil {
-		return openrouter.DisableCauseChange{}, err
+		return openrouter.DisableCauseChange{}, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	call := orgID + "/" + string(keyType) + "/" + string(cause)
 	s.mu.Lock()
@@ -125,7 +125,7 @@ func (s *stubProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db op
 		return openrouter.DisableCauseChange{}, nil
 	}
 	if _, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{DisableCause: string(cause), OrganizationID: orgID, KeyType: string(keyType)}); err != nil {
-		return openrouter.DisableCauseChange{}, err
+		return openrouter.DisableCauseChange{}, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
 	}
 	change := openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: !key.Disabled}
 	if change.KeyAccessChanged {
@@ -144,7 +144,7 @@ func (s *stubProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db
 	queries := orgrepo.New(db)
 	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	call := orgID + "/" + string(keyType) + "/" + string(cause)
 	s.mu.Lock()
@@ -164,12 +164,12 @@ func (s *stubProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db
 			MonthlyCredits: int64(resultLimit),
 			KeyHash:        key.KeyHash,
 		}); err != nil {
-			return 0, openrouter.DisableCauseChange{}, err
+			return 0, openrouter.DisableCauseChange{}, fmt.Errorf("update OpenRouter API key: %w", err)
 		}
 	}
 	updated, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, orgrepo.RemoveOpenRouterAPIKeyDisableCauseParams{DisableCause: string(cause), OrganizationID: orgID, KeyType: string(keyType)})
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	change := openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: !updated.Disabled}
 	if change.KeyAccessChanged {

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -31,7 +31,7 @@ func (o *Development) RefreshAPIKeyLimitWithDB(ctx context.Context, db DBTX, org
 }
 
 func (*Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
-	return DisableCauseChange{}, nil
+	return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (o *Development) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
@@ -39,7 +39,7 @@ func (o *Development) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, o
 }
 
 func (*Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
-	return 0, DisableCauseChange{}, nil
+	return 0, DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (o *Development) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -676,19 +676,19 @@ func (o *OpenRouter) addAPIKeyDisableCause(ctx context.Context, db DBTX, orgID s
 	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return DisableCauseChange{}, nil
+		return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 	case err != nil:
 		return DisableCauseChange{}, fmt.Errorf("get OpenRouter API key to add disable cause: %w", err)
 	}
 	if slices.Contains(key.DisableCauses, string(cause)) {
-		return DisableCauseChange{}, nil
+		return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 	}
 
 	accessChanged := len(key.DisableCauses) == 0
 	if accessChanged {
 		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
 		defer cancel()
-		if _, err := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Disabled: new(true)}); err != nil {
+		if _, err := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)}); err != nil {
 			return DisableCauseChange{}, fmt.Errorf("disable upstream OpenRouter API key: %w", err)
 		}
 	}
@@ -724,15 +724,15 @@ func (o *OpenRouter) removeAPIKeyDisableCause(ctx context.Context, db DBTX, orgI
 	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return 0, DisableCauseChange{}, nil
+		return 0, DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 	case err != nil:
 		return 0, DisableCauseChange{}, fmt.Errorf("get OpenRouter API key to remove disable cause: %w", err)
 	}
 	if !slices.Contains(key.DisableCauses, string(cause)) {
-		return 0, DisableCauseChange{}, nil
+		return 0, DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 	}
 
-	keyLimit := int(key.MonthlyCredits)
+	var keyLimit int
 	if limit != nil {
 		keyLimit = *limit
 	} else {
@@ -745,7 +745,7 @@ func (o *OpenRouter) removeAPIKeyDisableCause(ctx context.Context, db DBTX, orgI
 
 	accessChanged := len(key.DisableCauses) == 1
 	limitChanged := int64(keyLimit) != key.MonthlyCredits
-	patch := updateKeyRequest{}
+	patch := updateKeyRequest{Limit: nil, LimitReset: "", Disabled: nil}
 	if limitChanged {
 		creditLimit := float64(keyLimit)
 		patch.Limit = &creditLimit

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -149,7 +149,10 @@ func (p *m3OpenRouterProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Contex
 func (p *m3OpenRouterProvisioner) addAPIKeyDisableCause(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
 	p.disableCalls = append(p.disableCalls, keyType)
 	_, err := openrouterrepo.New(db).AddOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(cause)})
-	return openrouter.DisableCauseChange{CauseChanged: err == nil}, err
+	if err != nil {
+		return openrouter.DisableCauseChange{}, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+	return openrouter.DisableCauseChange{CauseChanged: true}, nil
 }
 
 func (p *m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(ctx context.Context, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
@@ -166,7 +169,10 @@ func (p *m3OpenRouterProvisioner) removeAPIKeyDisableCause(ctx context.Context, 
 		return 0, openrouter.DisableCauseChange{}, err
 	}
 	_, err = openrouterrepo.New(db).RemoveOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.RemoveOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(cause)})
-	return refreshed, openrouter.DisableCauseChange{CauseChanged: err == nil}, err
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	return refreshed, openrouter.DisableCauseChange{CauseChanged: true}, nil
 }
 
 func (*m3OpenRouterProvisioner) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {


### PR DESCRIPTION
## Rationale

AGE-3219 needs platform admins to understand why an OpenRouter key is disabled and to remove only an explicit admin lock. This final stack part adds that UI while keeping clients forward-compatible with future cause values.

## Scope

- show disable causes and explicit **Disable key** / **Remove admin lock** actions in the platform-admin UI
- update generated dashboard SDK artifacts and focused UI/state tests
- accept future OpenRouter disable cause values without breaking existing clients
- include final server lint fixes for the completed stack

## Testing

No commits or branch head were rewritten for this split. Current head remains `29be69240`. Evidence inherited from the reviewed full stack: focused server gate (1,063 tests), aggregate server gate (12,996 tests), `mise lint:server`, repository compile-only check, five focused dashboard tests, dashboard type-check/generated SDK check, and Playwright at desktop, 768px, and 390px with no product console errors or failed requests.

Local development uses the no-op OpenRouter provisioner, so browser QA verified mutation/refetch behavior while server tests cover canonical cause transitions.

## Stack order

1. [Core #5812](https://github.com/speakeasy-api/gram/pull/5812)
2. [Admin API #5813](https://github.com/speakeasy-api/gram/pull/5813)
3. [Lifecycle #5814](https://github.com/speakeasy-api/gram/pull/5814)
4. [**UI / forward compatibility / final lint #5789 (this PR)**](https://github.com/speakeasy-api/gram/pull/5789) — depends on Lifecycle

Linear: AGE-3219
