### PR TITLE
chore: make the local seed survive a login-first database

### DIFF
--- a/dev-idp/internal/modes/mockworkos/workos.go
+++ b/dev-idp/internal/modes/mockworkos/workos.go
@@ -48,6 +48,7 @@ import (
 
 	"github.com/speakeasy-api/gram/dev-idp/internal/database/repo"
 	"github.com/speakeasy-api/gram/dev-idp/internal/defaultuser"
+	"github.com/speakeasy-api/gram/dev-idp/pkg/devidentity"
 )
 
 // invitationLifetime is how long an emulated invitation stays in the
@@ -1556,7 +1557,9 @@ func nullableString(s string) sql.NullString {
 	return sql.NullString{String: s, Valid: true}
 }
 
-const workosUserIDPrefix = "user_devidp_"
+// The prefix lives in devidentity because the Gram local seed writes the same
+// subject into users.workos_id before anyone has logged in.
+const workosUserIDPrefix = devidentity.WorkOSUserIDPrefix
 
 const workosOrgIDPrefix = "org_devidp_"
 
@@ -1581,7 +1584,7 @@ func orgSlug(name string) string {
 // workosUserID formats an internal UUID as a WorkOS-style user ID.
 // Real WorkOS returns IDs like "user_01J5C09..."; we use "user_devidp_<hex>".
 func workosUserID(id uuid.UUID) string {
-	return workosUserIDPrefix + strings.ReplaceAll(id.String(), "-", "")
+	return devidentity.WorkOSUserID(id)
 }
 
 // resolveUserID parses a WorkOS-style user ID back to a UUID.

--- a/dev-idp/pkg/devidentity/devidentity.go
+++ b/dev-idp/pkg/devidentity/devidentity.go
@@ -9,7 +9,11 @@
 // and leave a freshly seeded developer staring at an empty org.
 package devidentity
 
-import "github.com/google/uuid"
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
 
 const (
 	// DefaultOrgName is the display name of the dev-idp's default org.
@@ -32,4 +36,16 @@ var userIDNamespace = uuid.MustParse("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")
 // DeterministicUserID returns a stable UUID v5 derived from the given email.
 func DeterministicUserID(email string) uuid.UUID {
 	return uuid.NewSHA1(userIDNamespace, []byte(email))
+}
+
+// WorkOSUserIDPrefix is the prefix the dev-idp puts on the WorkOS-style user
+// ids it presents as the OIDC subject. Real WorkOS returns "user_01J5C09...".
+const WorkOSUserIDPrefix = "user_devidp_"
+
+// WorkOSUserID formats an internal user UUID the way the dev-idp presents it
+// as the login subject. The local seed writes it into users.workos_id so the
+// row a developer's first login finds is already linked, rather than a bare
+// UUID that no login will ever match.
+func WorkOSUserID(id uuid.UUID) string {
+	return WorkOSUserIDPrefix + strings.ReplaceAll(id.String(), "-", "")
 }

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -291,3 +291,86 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 	}
 	return nil
 }
+
+// LoginArtifacts is the state a developer's first login leaves in Postgres
+// before the local seed has ever run: the organization (created
+// un-whitelisted) and the user row, whose id the auth callback derives from
+// the IDP subject rather than from the email the seed keys on.
+type LoginArtifacts struct {
+	OrgID    string
+	OrgName  string
+	OrgSlug  string
+	UserID   string
+	Email    string
+	WorkOSID string
+}
+
+// PlantLoginArtifacts writes what logging in before seeding would have
+// written.
+func PlantLoginArtifacts(ctx context.Context, db *pgxpool.Pool, a LoginArtifacts) error {
+	if _, err := db.Exec(ctx, `
+		INSERT INTO organization_metadata (id, name, slug, whitelisted)
+		VALUES ($1, $2, $3, FALSE)`, a.OrgID, a.OrgName, a.OrgSlug); err != nil {
+		return fmt.Errorf("plant organization: %w", err)
+	}
+	if _, err := db.Exec(ctx, `
+		INSERT INTO users (id, email, display_name, workos_id)
+		VALUES ($1, $2, 'Dev', $3)`, a.UserID, a.Email, a.WorkOSID); err != nil {
+		return fmt.Errorf("plant user: %w", err)
+	}
+	return nil
+}
+
+// DeveloperState is what the local fixtures are expected to converge on for
+// the developer they adopt, however the database got there.
+type DeveloperState struct {
+	// Users counts the rows holding the developer's email: more than one
+	// means a second identity was minted.
+	Users int
+	// UserID and WorkOSID come from the single row when Users == 1.
+	UserID   string
+	WorkOSID string
+	// Whitelisted is the organization's gate flag.
+	Whitelisted bool
+	// Memberships and RoleAssignments count the live rows tying UserID to the
+	// organization.
+	Memberships     int
+	RoleAssignments int
+}
+
+// ReadDeveloperState collects the rows the local fixtures are responsible for.
+func ReadDeveloperState(ctx context.Context, db *pgxpool.Pool, orgID, email string) (DeveloperState, error) {
+	var state DeveloperState
+
+	if err := db.QueryRow(ctx,
+		`SELECT count(*) FROM users WHERE email = $1`, email).Scan(&state.Users); err != nil {
+		return state, fmt.Errorf("count users: %w", err)
+	}
+	if state.Users != 1 {
+		return state, nil
+	}
+
+	if err := db.QueryRow(ctx,
+		`SELECT id, coalesce(workos_id, '') FROM users WHERE email = $1`, email,
+	).Scan(&state.UserID, &state.WorkOSID); err != nil {
+		return state, fmt.Errorf("read user: %w", err)
+	}
+	if err := db.QueryRow(ctx,
+		`SELECT whitelisted FROM organization_metadata WHERE id = $1`, orgID,
+	).Scan(&state.Whitelisted); err != nil {
+		return state, fmt.Errorf("read organization: %w", err)
+	}
+	if err := db.QueryRow(ctx, `
+		SELECT count(*) FROM organization_user_relationships
+		WHERE organization_id = $1 AND user_id = $2 AND deleted IS FALSE`,
+		orgID, state.UserID).Scan(&state.Memberships); err != nil {
+		return state, fmt.Errorf("count memberships: %w", err)
+	}
+	if err := db.QueryRow(ctx, `
+		SELECT count(*) FROM organization_role_assignments
+		WHERE organization_id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+		orgID, state.UserID).Scan(&state.RoleAssignments); err != nil {
+		return state, fmt.Errorf("count role assignments: %w", err)
+	}
+	return state, nil
+}

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -294,29 +294,45 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 
 // LoginArtifacts is the state a developer's first login leaves in Postgres
 // before the local seed has ever run: the organization (created
-// un-whitelisted) and the user row, whose id the auth callback derives from
-// the IDP subject rather than from the email the seed keys on.
+// un-whitelisted, already linked to WorkOS), the user row — whose id the auth
+// callback derives from the IDP subject rather than from the email the seed
+// keys on — and the membership tying the two together.
 type LoginArtifacts struct {
-	OrgID    string
-	OrgName  string
-	OrgSlug  string
-	UserID   string
-	Email    string
+	OrgID string
+	// OrgWorkOSID is the WorkOS organization the callback linked the org to,
+	// so the seed meets an already-linked row rather than a bare one.
+	OrgWorkOSID string
+	OrgName     string
+	OrgSlug     string
+	UserID      string
+	Email       string
+	// WorkOSID is the login subject, which the callback also records on the
+	// membership.
 	WorkOSID string
+	// MembershipID is the WorkOS membership id the callback recorded. It is
+	// deliberately not the 'devidp_mem_'-prefixed one the seed writes: the
+	// seed has to adopt the membership it finds, not only one it made.
+	MembershipID string
 }
 
 // PlantLoginArtifacts writes what logging in before seeding would have
 // written.
 func PlantLoginArtifacts(ctx context.Context, db *pgxpool.Pool, a LoginArtifacts) error {
 	if _, err := db.Exec(ctx, `
-		INSERT INTO organization_metadata (id, name, slug, whitelisted)
-		VALUES ($1, $2, $3, FALSE)`, a.OrgID, a.OrgName, a.OrgSlug); err != nil {
+		INSERT INTO organization_metadata (id, name, slug, workos_id, whitelisted)
+		VALUES ($1, $2, $3, $4, FALSE)`, a.OrgID, a.OrgName, a.OrgSlug, a.OrgWorkOSID); err != nil {
 		return fmt.Errorf("plant organization: %w", err)
 	}
 	if _, err := db.Exec(ctx, `
 		INSERT INTO users (id, email, display_name, workos_id)
 		VALUES ($1, $2, 'Dev', $3)`, a.UserID, a.Email, a.WorkOSID); err != nil {
 		return fmt.Errorf("plant user: %w", err)
+	}
+	if _, err := db.Exec(ctx, `
+		INSERT INTO organization_user_relationships
+			(organization_id, user_id, workos_user_id, workos_membership_id)
+		VALUES ($1, $2, $3, $4)`, a.OrgID, a.UserID, a.WorkOSID, a.MembershipID); err != nil {
+		return fmt.Errorf("plant membership: %w", err)
 	}
 	return nil
 }
@@ -330,8 +346,10 @@ type DeveloperState struct {
 	// UserID and WorkOSID come from the single row when Users == 1.
 	UserID   string
 	WorkOSID string
-	// Whitelisted is the organization's gate flag.
+	// Whitelisted is the organization's gate flag, and OrgWorkOSID its link
+	// to the IDP.
 	Whitelisted bool
+	OrgWorkOSID string
 	// Memberships and RoleAssignments count the live rows tying UserID to the
 	// organization.
 	Memberships     int
@@ -356,8 +374,8 @@ func ReadDeveloperState(ctx context.Context, db *pgxpool.Pool, orgID, email stri
 		return state, fmt.Errorf("read user: %w", err)
 	}
 	if err := db.QueryRow(ctx,
-		`SELECT whitelisted FROM organization_metadata WHERE id = $1`, orgID,
-	).Scan(&state.Whitelisted); err != nil {
+		`SELECT whitelisted, coalesce(workos_id, '') FROM organization_metadata WHERE id = $1`, orgID,
+	).Scan(&state.Whitelisted, &state.OrgWorkOSID); err != nil {
 		return state, fmt.Errorf("read organization: %w", err)
 	}
 	if err := db.QueryRow(ctx, `

--- a/server/internal/demoseed/local.go
+++ b/server/internal/demoseed/local.go
@@ -80,8 +80,6 @@ func RunLocalFixtures(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 	if err != nil {
 		return err
 	}
-	logger.InfoContext(ctx, "adopting developer into the local org", attr.SlogUserID(dev.ID))
-
 	// The system roles are a prerequisite for the Admin assignment below and
 	// are not org-specific data the seed can fabricate — provisioning owns
 	// them in every other environment, so reuse its seeder rather than
@@ -117,13 +115,22 @@ func RunLocalFixtures(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 		}
 	}()
 
+	// Resolve the developer's user row before anything references it: a login
+	// that happened before this seed owns an id we cannot predict.
+	var workosID string
+	if err := tx.QueryRow(ctx, localUpsertDeveloperSQL, dev.ID, dev.Email, dev.Name, dev.WorkOSID).
+		Scan(&dev.ID, &workosID); err != nil {
+		return fmt.Errorf("local fixture %q: %w", "upsert developer", err)
+	}
+	logger.InfoContext(ctx, "adopting developer into the local org", attr.SlogUserID(dev.ID))
+
 	for _, step := range []struct {
 		name string
 		sql  string
 		args []any
 	}{
 		{"link org to the dev-idp", localLinkWorkOSOrgSQL, []any{spec.OrgID, spec.WorkOSOrgID}},
-		{"adopt developer", localAdoptDeveloperSQL, []any{spec.OrgID, dev.ID, dev.Email, dev.Name}},
+		{"adopt developer", localAdoptDeveloperSQL, []any{spec.OrgID, dev.ID, workosID}},
 		{"grant session visibility", localSessionVisibilitySQL, []any{spec.OrgID, dev.ID}},
 		{"enable platform mcp", localPlatformMCPFeatureSQL, []any{spec.OrgID}},
 		{"api key", localAPIKeySQL, []any{spec.OrgID, spec.ProjectID(), dev.ID, localAPIKeyID(), LocalAPIKeyName, apiKeyHash, apiKey[:len(auth.APIKeyPrefix(env))+5]}},
@@ -186,9 +193,14 @@ func StaleOverrideVars() []string {
 
 // developer is the local user the fixtures adopt into the org.
 type developer struct {
-	ID    string
-	Email string
-	Name  string
+	// ID is the id a user row would get if none exists yet. An earlier login
+	// may already have created one under a different id, in which case
+	// localUpsertDeveloperSQL returns that one instead.
+	ID string
+	// WorkOSID is the subject the dev-idp presents for this developer.
+	WorkOSID string
+	Email    string
+	Name     string
 }
 
 // resolveDeveloper mirrors the dev-idp's default-user bootstrap: the git
@@ -214,10 +226,12 @@ func resolveDeveloper(ctx context.Context, email string) (developer, error) {
 		}
 	}
 
+	uid := devidentity.DeterministicUserID(email)
 	return developer{
-		ID:    devidentity.DeterministicUserID(email).String(),
-		Email: email,
-		Name:  name,
+		ID:       uid.String(),
+		WorkOSID: devidentity.WorkOSUserID(uid),
+		Email:    email,
+		Name:     name,
 	}, nil
 }
 
@@ -258,24 +272,37 @@ SET workos_id = $2, updated_at = clock_timestamp()
 WHERE id = $1 AND workos_id IS DISTINCT FROM $2
 `
 
-// You, as a real member. users.workos_id doubles as the WorkOS subject the
-// dev-idp will present at login, and the dev-idp uses the same user id there,
-// so the row survives your first real login unchanged.
+// You, as a real member.
+//
+// Keyed on email, not id: a developer who logged in before seeding already has
+// a row whose id the auth callback derived from the dev-idp subject
+// (users.UserIDFromWorkOSID), which is not the id derived here from the email.
+// ON CONFLICT (id) would miss that row and collide on users_email_key instead,
+// so the statement returns the id that actually exists and the rest of the
+// fixtures use it. Login-first and seed-first therefore converge on one row:
+// the auth callback resolves an existing user by email too (see
+// identity.resolveGramUserID).
+//
+// users.workos_id is the subject the dev-idp will present at login. It has to
+// be the WorkOS-shaped form, not a bare UUID — a mismatch there is invisible
+// until login mints a second user.
+const localUpsertDeveloperSQL = `
+INSERT INTO users (id, email, display_name, workos_id, admin)
+VALUES ($1, $2, $3, $4, TRUE)
+ON CONFLICT (email) DO UPDATE
+  SET display_name = EXCLUDED.display_name,
+      workos_id = EXCLUDED.workos_id,
+      admin = TRUE, deleted_at = NULL, updated_at = clock_timestamp()
+RETURNING id, workos_id
+`
+
+// Your membership and Admin role assignment, against the user id
+// localUpsertDeveloperSQL resolved.
 const localAdoptDeveloperSQL = `
-WITH dev AS (
-  INSERT INTO users (id, email, display_name, workos_id, admin)
-  VALUES ($2, $3, $4, $2, TRUE)
-  ON CONFLICT (id) DO UPDATE
-    SET email = EXCLUDED.email, display_name = EXCLUDED.display_name,
-        workos_id = COALESCE(users.workos_id, EXCLUDED.workos_id),
-        admin = TRUE, updated_at = clock_timestamp()
-  RETURNING id, workos_id
-),
-membership AS (
+WITH membership AS (
   INSERT INTO organization_user_relationships
     (organization_id, user_id, workos_user_id, workos_membership_id)
-  SELECT $1, dev.id, dev.workos_id, 'devidp_mem_' || dev.id
-  FROM dev
+  VALUES ($1, $2, $3, 'devidp_mem_' || $2)
   ON CONFLICT (organization_id, user_id) WHERE deleted IS FALSE
   DO UPDATE SET
     workos_user_id = EXCLUDED.workos_user_id,

--- a/server/internal/demoseed/local_test.go
+++ b/server/internal/demoseed/local_test.go
@@ -1,0 +1,110 @@
+//go:build demoseed_safety
+
+package demoseed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/dev-idp/pkg/devidentity"
+	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/demoseed/demoseedtest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/users"
+)
+
+const testDeveloperEmail = "dev@example.com"
+
+// seedLocalPostgres applies the tenant seed the way demoseed.Run does, minus
+// ClickHouse: the local fixtures are a Postgres-only concern, and the shared
+// ClickHouse container would make these tests trample the row counts
+// TestDemoSeedSafety holds fixed.
+func seedLocalPostgres(ctx context.Context, t *testing.T, db *pgxpool.Pool, spec Spec) {
+	t.Helper()
+
+	require.NoError(t, demoseedtest.ExecPostgresScript(ctx, db, spec.Rewrite(postgresSQL)))
+}
+
+// TestLocalFixturesAfterLogin covers the database a developer actually has
+// when they run the seed for the first time: one where they have already
+// logged in. The auth callback creates the org (un-whitelisted) and a user row
+// whose id it derives from the dev-idp subject — neither of which the seed can
+// predict — so a seed that keys on its own derived ids collides on
+// users_email_key and leaves the org behind the BookDemo gate.
+func TestLocalFixturesAfterLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	spec := LocalSpec()
+
+	db, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	blob := assetstest.NewTestBlobStore(t)
+
+	subject := devidentity.WorkOSUserID(devidentity.DeterministicUserID(testDeveloperEmail))
+	loginUserID := users.UserIDFromWorkOSID(subject)
+	require.NotEqual(t, loginUserID, devidentity.DeterministicUserID(testDeveloperEmail).String(),
+		"the two id derivations coincide; this test would be vacuous")
+
+	require.NoError(t, demoseedtest.PlantLoginArtifacts(ctx, db, demoseedtest.LoginArtifacts{
+		OrgID:    spec.OrgID,
+		OrgName:  spec.OrgName,
+		OrgSlug:  spec.OrgSlug,
+		UserID:   loginUserID,
+		Email:    testDeveloperEmail,
+		WorkOSID: subject,
+	}))
+
+	seedLocalPostgres(ctx, t, db, spec)
+	require.NoError(t, RunLocalFixtures(ctx, logger, db, blob, nil, LocalFixturesOptions{
+		DeveloperEmail: testDeveloperEmail,
+		Environment:    "local",
+	}))
+
+	state, err := demoseedtest.ReadDeveloperState(ctx, db, spec.OrgID, testDeveloperEmail)
+	require.NoError(t, err)
+	require.Equal(t, demoseedtest.DeveloperState{
+		Users:           1,
+		UserID:          loginUserID,
+		WorkOSID:        subject,
+		Whitelisted:     true,
+		Memberships:     1,
+		RoleAssignments: 1,
+	}, state)
+}
+
+// TestLocalFixturesReseed is the ordinary case — seed first, then seed again —
+// which must stay idempotent now that the developer row is keyed on email.
+func TestLocalFixturesReseed(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	spec := LocalSpec()
+
+	db, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	blob := assetstest.NewTestBlobStore(t)
+
+	opts := LocalFixturesOptions{DeveloperEmail: testDeveloperEmail, Environment: "local"}
+	for range 2 {
+		seedLocalPostgres(ctx, t, db, spec)
+		require.NoError(t, RunLocalFixtures(ctx, logger, db, blob, nil, opts))
+	}
+
+	seedUserID := devidentity.DeterministicUserID(testDeveloperEmail)
+	state, err := demoseedtest.ReadDeveloperState(ctx, db, spec.OrgID, testDeveloperEmail)
+	require.NoError(t, err)
+	require.Equal(t, demoseedtest.DeveloperState{
+		Users:           1,
+		UserID:          seedUserID.String(),
+		WorkOSID:        devidentity.WorkOSUserID(seedUserID),
+		Whitelisted:     true,
+		Memberships:     1,
+		RoleAssignments: 1,
+	}, state)
+}

--- a/server/internal/demoseed/local_test.go
+++ b/server/internal/demoseed/local_test.go
@@ -51,12 +51,14 @@ func TestLocalFixturesAfterLogin(t *testing.T) {
 		"the two id derivations coincide; this test would be vacuous")
 
 	require.NoError(t, demoseedtest.PlantLoginArtifacts(ctx, db, demoseedtest.LoginArtifacts{
-		OrgID:    spec.OrgID,
-		OrgName:  spec.OrgName,
-		OrgSlug:  spec.OrgSlug,
-		UserID:   loginUserID,
-		Email:    testDeveloperEmail,
-		WorkOSID: subject,
+		OrgID:        spec.OrgID,
+		OrgWorkOSID:  spec.WorkOSOrgID,
+		OrgName:      spec.OrgName,
+		OrgSlug:      spec.OrgSlug,
+		UserID:       loginUserID,
+		Email:        testDeveloperEmail,
+		WorkOSID:     subject,
+		MembershipID: "devidp_mem_from_login",
 	}))
 
 	seedLocalPostgres(ctx, t, db, spec)
@@ -72,6 +74,7 @@ func TestLocalFixturesAfterLogin(t *testing.T) {
 		UserID:          loginUserID,
 		WorkOSID:        subject,
 		Whitelisted:     true,
+		OrgWorkOSID:     spec.WorkOSOrgID,
 		Memberships:     1,
 		RoleAssignments: 1,
 	}, state)
@@ -104,6 +107,7 @@ func TestLocalFixturesReseed(t *testing.T) {
 		UserID:          seedUserID.String(),
 		WorkOSID:        devidentity.WorkOSUserID(seedUserID),
 		Whitelisted:     true,
+		OrgWorkOSID:     spec.WorkOSOrgID,
 		Memberships:     1,
 		RoleAssignments: 1,
 	}, state)

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -351,8 +351,13 @@ BEGIN
   INSERT INTO organization_metadata (id, name, slug, gram_account_type, whitelisted)
   VALUES (demo_org, 'Acme Demo Org', 'acme-demo', 'enterprise', TRUE)
   ON CONFLICT (id) DO UPDATE
+    -- whitelisted is repaired, not just set on insert: a developer who logged
+    -- in before seeding already has this row, created un-whitelisted by the
+    -- auth callback, and without this the seed leaves them on the BookDemo
+    -- gate.
     SET name = EXCLUDED.name, slug = EXCLUDED.slug,
-        gram_account_type = EXCLUDED.gram_account_type;
+        gram_account_type = EXCLUDED.gram_account_type,
+        whitelisted = EXCLUDED.whitelisted;
 
   DELETE FROM toolsets WHERE organization_id = demo_org;
   -- environments.project_id is NOT NULL but its FK is ON DELETE SET NULL, so


### PR DESCRIPTION
## Summary

Makes `RunLocalFixtures` and the tenant seed idempotent against a database where the developer has already logged in.

- **Developer row keyed on email, not id.** Split `localUpsertDeveloperSQL` out of `localAdoptDeveloperSQL`: it upserts `users` with `ON CONFLICT (email)` and returns the id that actually exists. That id then drives the membership, the Admin assignment, the `chat:read` grant, the API key owner and the cache bust, so login-first and seed-first converge on one row (the auth callback resolves an existing user by email too — `identity.resolveGramUserID`).
- **`users.workos_id` is now the subject the dev-idp presents** (`user_devidp_<hex>`), not a bare UUID. Adds `devidentity.WorkOSUserID`, and `mockworkos` now formats its ids through it so the two sides cannot drift.
- **`whitelisted` is repaired on conflict** in the `organization_metadata` upsert, not only set on insert.
- **Regression coverage** in the existing `demoseed_safety` job: one test plants exactly what a first login leaves behind and asserts the seed adopts it; one re-runs the seed twice for idempotence. Both are Postgres-only so they stay parallel-safe with `TestDemoSeedSafety`. Their row reads live in `demoseedtest` rather than raw SQL in `_test.go`.

## Motivation

The local seed derived every identifier it wrote, on the assumption that it runs before anything else. It usually does not: developers log in first, see an empty product, and only then reach for `mise run seed`.

By then the auth callback has created two rows the seed cannot predict. The user id comes from `users.UserIDFromWorkOSID(subject)`, not from the email the seed derives its id from, so `ON CONFLICT (id)` missed the existing row entirely and the insert died on `users_email_key`. The tenant seed had already applied at that point, so the run left a half-seeded org with no API key, no environment and no `platform_mcp`. Separately, the organization row was created un-whitelisted, and the upsert's `DO UPDATE` never touched `whitelisted` — so even a successful reseed left the developer on the BookDemo gate.

Deriving ids stays right for the fresh-database case, which is why the fix keeps the derivation and adds a resolution step rather than replacing it: the seed now asks the database which row exists instead of asserting one. Writing the WorkOS-shaped subject closes the other half — with a bare UUID in `workos_id`, the next login would have minted a second user regardless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local seed so it runs cleanly against a database where the developer has already logged in, instead of failing on a duplicate user key and leaving the org behind the BookDemo gate.

- Keys the developer row on email, adopting the id an earlier login created, so login-first and seed-first converge on one user.
- Writes the dev-idp's WorkOS-shaped subject into `users.workos_id` so a subsequent login links to the seeded row instead of minting a second user.
- Repairs `whitelisted` on the organization upsert conflict, not just on insert.
- Adds `demoseed_safety` regression tests, with the login-first fixture planting the org's WorkOS link and the developer membership alongside the user row.

**Migration**
- No migration steps or rollout actions needed; the change is confined to local dev seeding and its tests.

<sup>Written for commit c17a3d03c93a3baf195ca68b4dbb649c205a60c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

