### PR TITLE
feat: add a catch-all agent to the Platform MCP connect flow

### DIFF
--- a/.changeset/platform-mcp-other-agent.md
+++ b/.changeset/platform-mcp-other-agent.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Add a catch-all "Other agent" option to the Platform MCP connect flow, for agents outside the certified set. `client_family` accepts `other`, so an install on an uncertified agent is recorded as itself rather than mislabelled as a certified agent or left untracked.
+
+No reviewed plugin package is built for such an agent, so both packaged install routes are closed for it and the walkthrough offers the remote MCP configuration alone. The install-method step lists only that route instead of showing the packaged ones greyed out, which read as an organization problem rather than what it is.
+
+The agent list on the headless connect page also sets its own text color, so the marks drawn in `currentColor` — Cursor, Codex, opencode, and the new catch-all globe — no longer inherit the ink foreground and disappear into the dark panel.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -75337,6 +75337,7 @@ components:
             - codex
             - cursor
             - opencode
+            - other
       required:
         - client_family
     RecordSkillResult:

--- a/client/dashboard/src/components/agent-providers/AgentProviderIcon.tsx
+++ b/client/dashboard/src/components/agent-providers/AgentProviderIcon.tsx
@@ -407,6 +407,7 @@ export function AgentProviderIcon({
       return <GleanIcon className={className} />;
     case "bedrock":
       return <BedrockIcon className={className} />;
+    case "catchall":
     case "unknown":
       return <GlobeIcon className={className} />;
   }

--- a/client/dashboard/src/components/agent-providers/agent-provider-icon-kind.ts
+++ b/client/dashboard/src/components/agent-providers/agent-provider-icon-kind.ts
@@ -11,6 +11,7 @@ export type AgentProviderIconKind =
   | "gemini"
   | "glean"
   | "bedrock"
+  | "catchall"
   | "unknown";
 
 export function agentProviderIconKind(source?: string): AgentProviderIconKind {
@@ -55,6 +56,9 @@ export function agentProviderIconKind(source?: string): AgentProviderIconKind {
   ) {
     return "bedrock";
   }
+  // The catch-all agent has no vendor mark to carry, so the globe is its
+  // deliberate icon rather than the fallback an unrecognised source lands on.
+  if (normalizedSource === "other") return "catchall";
 
   return "unknown";
 }

--- a/client/dashboard/src/components/agent-providers/agent-providers.ts
+++ b/client/dashboard/src/components/agent-providers/agent-providers.ts
@@ -34,6 +34,13 @@ export const AGENT_PROVIDERS = {
     description: "Open-source personal AI agent gateway",
     iconSource: "openclaw",
   },
+  other: {
+    name: "Other agent",
+    description: "Any MCP-capable agent",
+    // No vendor mark exists for "whatever you use" — the icon resolver falls
+    // through to its globe for an unrecognised source.
+    iconSource: "other",
+  },
   copilot: {
     name: "GitHub Copilot",
     description: "Microsoft / GitHub AI pair programmer",

--- a/client/dashboard/src/pages/org/HeadlessContent.test.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { HeadlessContent } from "./HeadlessContent";
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+vi.mock("@/components/mode-switch-starfield", () => ({
+  ModeSwitchStarfield: () => null,
+}));
+vi.mock("@/components/gram-logo/variants/icon", () => ({
+  GramIcon: () => null,
+}));
+// The wizard is a stack of sheets over live onboarding queries; this page's
+// own job is the list that opens it.
+vi.mock("./PlatformMCP", () => ({
+  PlatformMCPOnboardingContent: () => null,
+}));
+
+afterEach(cleanup);
+
+// The agent list is the page's only <ul>; the numbered steps below it are an
+// <ol>, so this stays scoped to the rows under test.
+const agentNames = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll("ul li")).map(
+    (item) => item.querySelector("span > span")?.textContent,
+  );
+
+describe("HeadlessContent", () => {
+  it("offers a catch-all agent last", () => {
+    const { container } = render(<HeadlessContent />);
+
+    const names = agentNames(container);
+    expect(names).toContain("Other agent");
+    expect(names.at(-1)).toBe("Other agent");
+    expect(screen.getByText("Any MCP-capable agent")).toBeTruthy();
+  });
+
+  it("still lists the certified agents ahead of it", () => {
+    const { container } = render(<HeadlessContent />);
+
+    expect(agentNames(container).slice(0, -1)).toEqual([
+      "Claude Code",
+      "Claude Cowork",
+      "Cursor",
+      "OpenAI Codex",
+      "opencode",
+      "OpenClaw",
+    ]);
+  });
+});

--- a/client/dashboard/src/pages/org/HeadlessContent.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.tsx
@@ -1,5 +1,8 @@
 import { AgentProviderIcon } from "@/components/agent-providers/AgentProviderIcon";
-import { agentProvidersForSurface } from "@/components/agent-providers/agent-providers";
+import {
+  AGENT_PROVIDERS,
+  agentProvidersForSurface,
+} from "@/components/agent-providers/agent-providers";
 import { GramIcon } from "@/components/gram-logo/variants/icon";
 import { ModeSwitchStarfield } from "@/components/mode-switch-starfield";
 import { RequireScope } from "@/components/require-scope";
@@ -10,10 +13,16 @@ import { useState } from "react";
 import { PlatformMCPOnboardingContent } from "./PlatformMCP";
 
 // The agents the Platform MCP walkthrough supports, with the same brand marks
-// and copy the setup wizard uses.
-const AGENTS = agentProvidersForSurface("plugins").filter(
-  (provider) => provider.available,
-);
+// and copy the setup wizard uses, and a catch-all last. The catch-all is
+// appended here rather than added to the "plugins" surface because that surface
+// also drives the marketplace install dialog, which has per-agent plugin
+// instructions an uncertified agent has no answer for.
+const AGENTS = [
+  ...agentProvidersForSurface("plugins").filter(
+    (provider) => provider.available,
+  ),
+  { id: "other" as const, ...AGENT_PROVIDERS.other },
+];
 
 const STEPS = [
   { index: "01", label: "Pick your agent" },
@@ -122,8 +131,13 @@ function HeadlessHero(): JSX.Element {
                   {/* The vendor marks clash out of the box — an orange
                       squircle next to a flat black cube next to a line glyph.
                       Desaturated they read as one set; the row's own hover
-                      brings the brand color back. */}
-                  <span className="border-neutral-softest flex h-8 w-8 shrink-0 items-center justify-center border bg-white/5">
+                      brings the brand color back.
+
+                      The color is set here because the monochrome marks
+                      (Cursor, Codex, opencode, the catch-all globe) are drawn
+                      in currentColor: without it they inherit the page's ink
+                      foreground and disappear into this dark panel. */}
+                  <span className="text-default-fixed-light border-neutral-softest flex h-8 w-8 shrink-0 items-center justify-center border bg-white/5">
                     <AgentProviderIcon
                       source={agent.iconSource}
                       className="h-4 w-4 opacity-80 grayscale transition group-hover:opacity-100 group-hover:grayscale-0"

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -79,6 +79,11 @@ const clients: Array<{
     label: "opencode",
     description: "Open-source terminal coding agent",
   },
+  {
+    id: "other",
+    label: "Other agent",
+    description: "Any MCP-capable agent",
+  },
 ];
 
 function starterPrompt(currentProjectSlug?: string): string {
@@ -1097,39 +1102,55 @@ function PlatformMCPInstallMethodSheet({
     refetchInterval: 5_000,
   });
   const packageStatus = status.data;
-  const supportsMarketplace = client.id !== "opencode";
+  // No reviewed plugin package is built for an agent we have not certified, so
+  // both packaged routes are closed and only the remote MCP config is offered.
+  const supportsPackages = client.id !== "other";
+  const supportsMarketplace = supportsPackages && client.id !== "opencode";
   const marketplaceAvailable =
     supportsMarketplace &&
     (packageStatus?.freshness === "current" ||
       packageStatus?.repairAllowed === true);
-  const downloadAvailable = packageStatus?.directDownloadAvailable === true;
+  const downloadAvailable =
+    supportsPackages && packageStatus?.directDownloadAvailable === true;
   const methods: Array<{
     id: PlatformMCPInstallMethod;
     title: string;
     description: string;
     disabled?: boolean;
-  }> = [
-    {
-      id: "marketplace",
-      title: "Install from your organization marketplace",
-      description:
-        "Recommended. Install the reviewed plugin and receive future updates from the canonical GitHub marketplace.",
-      disabled: !marketplaceAvailable,
-    },
-    {
-      id: "download",
-      title: `Download the ${client.label} plugin`,
-      description:
-        "Download a credential-free ZIP for your account. Direct packages must be updated manually.",
-      disabled: !downloadAvailable,
-    },
-    {
-      id: "manual",
-      title: "Connect the MCP manually",
-      description:
-        "Recovery option. Configure only the remote MCP without the reviewed catalogue workflow skill.",
-    },
-  ];
+  }> = supportsPackages
+    ? [
+        {
+          id: "marketplace",
+          title: "Install from your organization marketplace",
+          description:
+            "Recommended. Install the reviewed plugin and receive future updates from the canonical GitHub marketplace.",
+          disabled: !marketplaceAvailable,
+        },
+        {
+          id: "download",
+          title: `Download the ${client.label} plugin`,
+          description:
+            "Download a credential-free ZIP for your account. Direct packages must be updated manually.",
+          disabled: !downloadAvailable,
+        },
+        {
+          id: "manual",
+          title: "Connect the MCP manually",
+          description:
+            "Recovery option. Configure only the remote MCP without the reviewed catalogue workflow skill.",
+        },
+      ]
+    : // The packaged routes are listed only where a reviewed package exists.
+      // Offering them greyed out here would read as an organization problem
+      // rather than what it is: no plugin is built for an uncertified agent.
+      [
+        {
+          id: "manual",
+          title: "Connect the MCP manually",
+          description:
+            "Configure the remote MCP in your agent's own configuration. The reviewed catalogue workflow skill is not installed.",
+        },
+      ];
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>

--- a/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.test.tsx
+++ b/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { PlatformMCPInstallWalkthrough } from "./platform-mcp-install-walkthrough";
+
+// A fully provisioned organization: both packaged routes are on offer, so a
+// closed route in these tests is the agent's doing rather than the org's.
+const packageStatus = vi.hoisted(() => ({
+  current: {
+    freshness: "current",
+    marketplaceName: "acme",
+    marketplaceUrl: "https://github.com/acme/marketplace",
+    repoUrl: "https://github.com/acme/marketplace",
+    directDownloadAvailable: true,
+    repairAllowed: false,
+    admission: "admitted",
+  } as Record<string, unknown>,
+}));
+
+vi.mock("@gram/client/react-query/platformMCPPackageStatus.js", () => ({
+  usePlatformMCPPackageStatus: () => ({
+    data: packageStatus.current,
+    isLoading: false,
+  }),
+  invalidateAllPlatformMCPPackageStatus: vi.fn(),
+}));
+vi.mock("@gram/client/react-query/repairPlatformMCPPackage.js", () => ({
+  useRepairPlatformMCPPackageMutation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+vi.mock("@tanstack/react-query", () => ({ useQueryClient: () => ({}) }));
+vi.mock("@/contexts/Fetcher", () => ({
+  useFetcher: () => ({ fetch: vi.fn() }),
+}));
+vi.mock("../plugins/downloadPluginPackage", () => ({
+  downloadResponse: vi.fn(),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// The real CodeBlock reads theme config from a provider this unit test has no
+// reason to mount; the snippet text is what the assertions are about.
+vi.mock("@/components/code", () => ({
+  CodeBlock: ({ children }: { children: string }) => <pre>{children}</pre>,
+}));
+
+const MCP_URL = "https://app.example.com/mcp/platform";
+
+const methodButton = (label: string | RegExp) =>
+  screen.getByRole("button", { name: label }) as HTMLButtonElement;
+
+afterEach(cleanup);
+
+describe("PlatformMCPInstallWalkthrough", () => {
+  it("offers the other agent only the remote MCP configuration", () => {
+    render(
+      <PlatformMCPInstallWalkthrough initialClient="other" mcpUrl={MCP_URL} />,
+    );
+
+    // No reviewed package is built for an uncertified agent, so neither
+    // packaged route is selectable even though the organization has both.
+    expect(methodButton(/GitHub installation/).disabled).toBe(true);
+    expect(methodButton(/Direct .* ZIP/).disabled).toBe(true);
+
+    expect(
+      screen.getByText("Add Platform MCP as a remote MCP server"),
+    ).toBeTruthy();
+    expect(screen.getByText(new RegExp(MCP_URL))).toBeTruthy();
+  });
+
+  it("tells the other agent no certified package exists at all", () => {
+    render(
+      <PlatformMCPInstallWalkthrough initialClient="other" mcpUrl={MCP_URL} />,
+    );
+
+    expect(
+      screen.getByText(/This agent has no certified plugin package/),
+    ).toBeTruthy();
+  });
+
+  it("keeps the packaged routes open for a certified agent", () => {
+    render(
+      <PlatformMCPInstallWalkthrough
+        initialClient="claude_code"
+        mcpUrl={MCP_URL}
+      />,
+    );
+
+    expect(methodButton(/GitHub installation/).disabled).toBe(false);
+    expect(methodButton(/Direct .* ZIP/).disabled).toBe(false);
+  });
+});

--- a/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.test.tsx
+++ b/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.test.tsx
@@ -78,6 +78,25 @@ describe("PlatformMCPInstallWalkthrough", () => {
     ).toBeTruthy();
   });
 
+  it("keeps the other agent on the MCP config even when asked for a package", () => {
+    // initialMethod names a packaged route the agent has no package for. The
+    // walkthrough must not honour it — doing so rendered a download step for a
+    // "platform-mcp-null.zip" that no endpoint serves.
+    render(
+      <PlatformMCPInstallWalkthrough
+        initialClient="other"
+        initialMethod="download"
+        mcpUrl={MCP_URL}
+      />,
+    );
+
+    expect(
+      screen.getByText("Add Platform MCP as a remote MCP server"),
+    ).toBeTruthy();
+    expect(screen.queryByText(/\.zip/)).toBeNull();
+    expect(screen.queryByText(/marketplace add/)).toBeNull();
+  });
+
   it("keeps the packaged routes open for a certified agent", () => {
     render(
       <PlatformMCPInstallWalkthrough

--- a/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
+++ b/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
@@ -327,7 +327,7 @@ export function PlatformMCPInstallWalkthrough({
   const queryClient = useQueryClient();
   const { fetch: authFetch } = useFetcher();
   const [client, setClient] = useState<ClientFamily>(initialClient);
-  const [method, setMethod] = useState<PlatformMCPInstallMethod>(
+  const [selectedMethod, setMethod] = useState<PlatformMCPInstallMethod>(
     initialMethod ?? "marketplace",
   );
   const [isDownloading, setIsDownloading] = useState(false);
@@ -357,6 +357,12 @@ export function PlatformMCPInstallWalkthrough({
   }, [initialMethod]);
 
   const packageStatus = status.data;
+  // An agent with no reviewed package has exactly one route, so the packaged
+  // methods stay unreachable for it however the state got there: while the
+  // package status is still loading, on an explicit initialMethod, or in the
+  // render before the effect below settles. Deriving the method closes all
+  // three at once instead of guarding each place one is read.
+  const method = supportsPackages(client) ? selectedMethod : "manual";
   const supportsMarketplace = supportsPackages(client) && client !== "opencode";
   const marketplaceReady =
     supportsMarketplace &&
@@ -383,16 +389,12 @@ export function PlatformMCPInstallWalkthrough({
       setMethod("marketplace");
     } else if (marketplaceReady) {
       setMethod("marketplace");
-    } else if (
-      supportsPackages(client) &&
-      packageStatus?.directDownloadAvailable
-    ) {
+    } else if (packageStatus?.directDownloadAvailable) {
       setMethod("download");
     } else {
       setMethod("manual");
     }
   }, [
-    client,
     initialMethod,
     marketplaceReady,
     packageStatus?.directDownloadAvailable,

--- a/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
+++ b/client/dashboard/src/pages/org/platform-mcp-install-walkthrough.tsx
@@ -47,6 +47,11 @@ const PLATFORM_MCP_INSTALL_CLIENTS: PlatformMCPInstallClient[] = [
     label: "OpenCode",
     description: "Extract the OpenCode package into your config directory",
   },
+  {
+    id: "other",
+    label: "Other agent",
+    description: "Point any MCP-capable agent at the remote endpoint",
+  },
 ];
 
 export type PlatformMCPInstallMethod = "marketplace" | "download" | "manual";
@@ -54,13 +59,22 @@ type PackagePlatform = "claude" | "cursor" | "codex" | "opencode";
 
 const PLATFORM_MCP_PLUGIN_NAME = "platform-mcp";
 
-function packagePlatform(client: ClientFamily): PackagePlatform {
+function packagePlatform(client: ClientFamily): PackagePlatform | null {
   if (client === "claude_code" || client === "claude_cowork") return "claude";
+  // No reviewed package is built for an uncertified agent, so it has no
+  // platform to download or extract.
+  if (client === "other") return null;
   return client;
 }
 
 function packageFilename(client: ClientFamily): string {
   return `${PLATFORM_MCP_PLUGIN_NAME}-${packagePlatform(client)}.zip`;
+}
+
+// Whether a reviewed plugin package exists for this agent at all. Both packaged
+// install routes are closed without one, leaving the remote MCP configuration.
+function supportsPackages(client: ClientFamily): boolean {
+  return client !== "other";
 }
 
 type PlatformMCPInstallWalkthroughProps = {
@@ -165,6 +179,21 @@ function manualSteps(client: ClientFamily, mcpUrl: string): InstallStep[] {
           title: "Restart Cursor and complete OAuth",
           description:
             "Open a new Cursor agent session under your account, use Platform MCP, and complete AI Control Plane browser authorization when prompted.",
+        },
+      ];
+    case "other":
+      return [
+        {
+          title: "Add Platform MCP as a remote MCP server",
+          description:
+            "Add this remote server to your agent's MCP configuration. Most agents use this shape; if yours expects a different one, keep the URL and match its own format. Platform MCP speaks streamable HTTP with OAuth.",
+          code: manualConfig(client, mcpUrl),
+          language: "json",
+        },
+        {
+          title: "Restart your agent and complete OAuth",
+          description:
+            "Start a new session under your account, use Platform MCP, and complete AI Control Plane browser authorization when prompted.",
         },
       ];
     case "opencode":
@@ -328,7 +357,7 @@ export function PlatformMCPInstallWalkthrough({
   }, [initialMethod]);
 
   const packageStatus = status.data;
-  const supportsMarketplace = client !== "opencode";
+  const supportsMarketplace = supportsPackages(client) && client !== "opencode";
   const marketplaceReady =
     supportsMarketplace &&
     packageStatus?.freshness === "current" &&
@@ -354,12 +383,16 @@ export function PlatformMCPInstallWalkthrough({
       setMethod("marketplace");
     } else if (marketplaceReady) {
       setMethod("marketplace");
-    } else if (packageStatus?.directDownloadAvailable) {
+    } else if (
+      supportsPackages(client) &&
+      packageStatus?.directDownloadAvailable
+    ) {
       setMethod("download");
     } else {
       setMethod("manual");
     }
   }, [
+    client,
     initialMethod,
     marketplaceReady,
     packageStatus?.directDownloadAvailable,
@@ -419,6 +452,13 @@ export function PlatformMCPInstallWalkthrough({
               description:
                 "Extract the ZIP contents directly into ~/.config/opencode for your account, or into .opencode for one repository. The package installs both the loader and reviewed skill path.",
             };
+          case "other":
+            // Unreachable: no package exists, so this agent never reaches the
+            // download method. Kept so the switch stays total over the enum.
+            return {
+              title: "No package is available for this agent",
+              description: "Connect the remote MCP manually instead.",
+            };
         }
       })();
       return [
@@ -447,6 +487,7 @@ export function PlatformMCPInstallWalkthrough({
     onInstructionIntent?.();
     try {
       const platform = packagePlatform(client);
+      if (!platform) throw new Error("no package for this agent");
       const response = await authFetch(
         `/rpc/plugins.downloadPlatformMCPPlugin?platform=${platform}`,
         {},
@@ -549,7 +590,10 @@ export function PlatformMCPInstallWalkthrough({
             <Button
               size="sm"
               variant={method === "download" ? "primary" : "secondary"}
-              disabled={!packageStatus?.directDownloadAvailable}
+              disabled={
+                !supportsPackages(client) ||
+                !packageStatus?.directDownloadAvailable
+              }
               onClick={() => {
                 explicitMethodRef.current = true;
                 setMethod("download");
@@ -581,8 +625,9 @@ export function PlatformMCPInstallWalkthrough({
           <div>
             <AlertTitle>MCP only—reviewed skills are not installed</AlertTitle>
             <AlertDescription>
-              This recovery route connects only the remote MCP. Use a certified
-              plugin package to install the reviewed catalog workflow skill too.
+              {supportsPackages(client)
+                ? "This recovery route connects only the remote MCP. Use a certified plugin package to install the reviewed catalog workflow skill too."
+                : "This agent has no certified plugin package, so only the remote MCP is connected. Pick a certified agent if you also want the reviewed catalog workflow skill."}
             </AlertDescription>
           </div>
         </Alert>

--- a/client/dashboard/src/sdk/src/models/components/recordinstallintentrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/recordinstallintentrequestbody.ts
@@ -15,6 +15,7 @@ export const ClientFamily = {
   Codex: "codex",
   Cursor: "cursor",
   Opencode: "opencode",
+  Other: "other",
 } as const;
 /**
  * Manual-install client family.

--- a/server/design/platformmcp/design.go
+++ b/server/design/platformmcp/design.go
@@ -121,7 +121,7 @@ var _ = Service("platformMcp", func() {
 		Description("Record a selected manual-install client family for the current user's Platform MCP workflow.")
 		Payload(func() {
 			Attribute("client_family", String, "Manual-install client family.", func() {
-				Enum("claude_code", "claude_cowork", "codex", "cursor", "opencode")
+				Enum("claude_code", "claude_cowork", "codex", "cursor", "opencode", "other")
 			})
 			Required("client_family")
 			security.SessionPayload()

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -76716,6 +76716,7 @@ components:
                         - codex
                         - cursor
                         - opencode
+                        - other
             required:
                 - client_family
         RecordSkillResult:

--- a/server/gen/http/platform_mcp/client/cli.go
+++ b/server/gen/http/platform_mcp/client/cli.go
@@ -100,8 +100,8 @@ func BuildRecordInstallIntentPayload(platformMcpRecordInstallIntentBody string, 
 		if err != nil {
 			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"client_family\": \"claude_cowork\"\n   }'")
 		}
-		if !(body.ClientFamily == "claude_code" || body.ClientFamily == "claude_cowork" || body.ClientFamily == "codex" || body.ClientFamily == "cursor" || body.ClientFamily == "opencode") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.client_family", body.ClientFamily, []any{"claude_code", "claude_cowork", "codex", "cursor", "opencode"}))
+		if !(body.ClientFamily == "claude_code" || body.ClientFamily == "claude_cowork" || body.ClientFamily == "codex" || body.ClientFamily == "cursor" || body.ClientFamily == "opencode" || body.ClientFamily == "other") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.client_family", body.ClientFamily, []any{"claude_code", "claude_cowork", "codex", "cursor", "opencode", "other"}))
 		}
 		if err != nil {
 			return nil, err

--- a/server/gen/http/platform_mcp/server/types.go
+++ b/server/gen/http/platform_mcp/server/types.go
@@ -4793,8 +4793,8 @@ func ValidateRecordInstallIntentRequestBody(body *RecordInstallIntentRequestBody
 		err = goa.MergeErrors(err, goa.MissingFieldError("client_family", "body"))
 	}
 	if body.ClientFamily != nil {
-		if !(*body.ClientFamily == "claude_code" || *body.ClientFamily == "claude_cowork" || *body.ClientFamily == "codex" || *body.ClientFamily == "cursor" || *body.ClientFamily == "opencode") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.client_family", *body.ClientFamily, []any{"claude_code", "claude_cowork", "codex", "cursor", "opencode"}))
+		if !(*body.ClientFamily == "claude_code" || *body.ClientFamily == "claude_cowork" || *body.ClientFamily == "codex" || *body.ClientFamily == "cursor" || *body.ClientFamily == "opencode" || *body.ClientFamily == "other") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.client_family", *body.ClientFamily, []any{"claude_code", "claude_cowork", "codex", "cursor", "opencode", "other"}))
 		}
 	}
 	return

--- a/server/internal/platformmcp/onboarding.go
+++ b/server/internal/platformmcp/onboarding.go
@@ -55,6 +55,9 @@ const (
 	OnboardingClientCodex        OnboardingClientFamily = "codex"
 	OnboardingClientCursor       OnboardingClientFamily = "cursor"
 	OnboardingClientOpencode     OnboardingClientFamily = "opencode"
+	// Any agent outside the certified set. It has no plugin package, so its
+	// walkthrough offers the remote MCP configuration only.
+	OnboardingClientOther OnboardingClientFamily = "other"
 )
 
 type OnboardingWorkflow struct {
@@ -652,7 +655,7 @@ func validOnboardingSource(surface OnboardingSourceSurface) bool {
 
 func validOnboardingClient(client OnboardingClientFamily) bool {
 	switch client {
-	case OnboardingClientClaudeCode, OnboardingClientClaudeCowork, OnboardingClientCodex, OnboardingClientCursor, OnboardingClientOpencode:
+	case OnboardingClientClaudeCode, OnboardingClientClaudeCowork, OnboardingClientCodex, OnboardingClientCursor, OnboardingClientOpencode, OnboardingClientOther:
 		return true
 	default:
 		return false

--- a/server/internal/platformmcp/onboarding_integration_test.go
+++ b/server/internal/platformmcp/onboarding_integration_test.go
@@ -186,4 +186,17 @@ func TestOnboardingServiceValidatesClientFamily(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, string(OnboardingClientOpencode), workflow.ClientFamily)
+
+	// The catch-all is a real client family, not a rejected one: an install on
+	// an uncertified agent is recorded as itself rather than mislabelled as a
+	// certified agent or dropped from the workflow entirely.
+	_, err = service.RecordInstallIntent(ctx, principal.OrganizationID, principal.UserID, OnboardingClientOther)
+	require.NoError(t, err)
+
+	workflow, err = platformrepo.New(conn).GetActivePlatformMCPOnboardingWorkflow(ctx, platformrepo.GetActivePlatformMCPOnboardingWorkflowParams{
+		OrganizationID:       principal.OrganizationID,
+		InitiatingSubjectUrn: userSubjectURN(principal.UserID),
+	})
+	require.NoError(t, err)
+	require.Equal(t, string(OnboardingClientOther), workflow.ClientFamily)
 }


### PR DESCRIPTION
## Summary

Adds a catch-all "Other agent" option to the Platform MCP connect flow, for agents outside the certified set.

`client_family` is a closed enum, so it gains an `other` value end to end — Goa design, `OnboardingClientFamily`, and the regenerated SDK. The catch-all therefore goes through the same wizard as every other agent and is recorded as itself, rather than being a client-side path around `recordInstallIntent`.

No reviewed plugin package is built for an uncertified agent, so both packaged install routes are closed for it and the walkthrough offers the remote MCP configuration alone. The install-method step lists only that route instead of rendering the packaged ones greyed out under "Not currently available for this organization" — that copy names the wrong cause. The generic step ships the de-facto `mcpServers` JSON shape and tells the reader to keep the URL and match their agent's own format if it differs.

The row is appended to the headless list directly rather than added to the `plugins` provider surface, because that surface also drives the marketplace install dialog, which has per-agent plugin instructions an uncertified agent has no answer for.

Separately, the headless agent list now sets its own text color. The marks drawn in `currentColor` — Cursor, Codex, opencode, and the new catch-all globe — were inheriting the page's ink foreground and rendering near-black on the dark panel, and hover's `grayscale-0` cannot restore a color a monochrome mark never had. They now sit light and brighten on hover, while the full-color marks recover their brand color as before.

## Motivation

The connect flow listed only agents we have certified a plugin package for, so anyone working in anything else had no route through it at all — the page's entire job is getting an agent connected, and it silently excluded them.

Widening the enum rather than special-casing the client keeps the install honest in the data: an install on an uncertified agent is neither mislabelled as a certified agent nor dropped from the workflow, so the packaged and unpackaged populations stay distinguishable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a catch-all "Other agent" option to the Platform MCP connect flow so agents outside the certified set can get connected instead of being silently excluded. `client_family` now accepts `other` end to end, so an install on an uncertified agent is recorded as itself rather than mislabelled or dropped.

**Behavior**
- Both packaged install routes are closed for `other`; the walkthrough offers the remote MCP configuration alone.
- The effective install method is derived from whether a package exists, so an uncertified agent never lands on a packaged step during a loading state or an explicit initial method.
- The install-method step lists only the manual route instead of showing the packaged ones greyed out, which read as an organization problem.
- The catch-all is appended to the headless list directly rather than the "plugins" surface, which also drives the marketplace install dialog with per-agent instructions.
- The headless agent list now sets its own text color so the monochrome marks no longer inherit the ink foreground and disappear into the dark panel.
- The catch-all's globe now has its own `catchall` icon kind instead of the `unknown` fallback, keeping each catalog provider mapped to a deliberate mark.

<sup>Written for commit 72268a7c96062d0a8f67854ae5a34cc5686ddf14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

