### PR TITLE
fix: drop session-pinned tunnel traffic on dead gateway dials

### DIFF
--- a/.changeset/ais-662-stale-gateway-pin.md
+++ b/.changeset/ais-662-stale-gateway-pin.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Treat dial failures to a session-pinned tunnel-gateway as session-gone (HTTP 404) with a short cluster-internal connect timeout, and unpublish the dying pod's routes on SIGTERM, so gateway rollouts no longer stall clients for 30s and burst 502s.

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -143,6 +143,7 @@ type httpClientOptions struct {
 	resolver          *net.Resolver
 	allowedCIDRBlocks []*net.IPNet
 	resilience        *resilienceOptions
+	dialTimeout       time.Duration
 }
 
 // ClientOption configures a single [Policy.Client] / [Policy.PooledClient]
@@ -192,6 +193,20 @@ func WithAllowedCIDRBlocks(cidrs ...string) func(*httpClientOptions) {
 func WithRetryConfig(config *RetryConfig) func(*httpClientOptions) {
 	return func(o *httpClientOptions) {
 		o.retryConfig = config
+	}
+}
+
+// defaultDialTimeout is the TCP connect bound used when a caller does not
+// set [WithDialTimeout]. It matches Go's historical [net.Dialer] default.
+const defaultDialTimeout = 30 * time.Second
+
+// WithDialTimeout sets the TCP connect timeout for this client. Use a short
+// value for destinations that are expected to accept in milliseconds (e.g.
+// cluster-internal pod IPs) so a dead peer fails fast instead of waiting
+// for the 30s default. Zero or negative leaves the default in place.
+func WithDialTimeout(d time.Duration) func(*httpClientOptions) {
+	return func(o *httpClientOptions) {
+		o.dialTimeout = d
 	}
 }
 
@@ -336,6 +351,9 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 	if len(opts.allowedCIDRBlocks) > 0 {
 		dialOpts = append(dialOpts, WithDialerAllowedCIDRBlocks(opts.allowedCIDRBlocks))
 	}
+	if opts.dialTimeout > 0 {
+		dialOpts = append(dialOpts, WithDialerTimeout(opts.dialTimeout))
+	}
 	transport.DialContext = p.Dialer(dialOpts...).DialContext
 
 	// Merge into any existing transport TLS config rather than replacing
@@ -419,6 +437,7 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 type dialerOptions struct {
 	resolver          *net.Resolver
 	allowedCIDRBlocks []*net.IPNet
+	timeout           time.Duration
 }
 
 func WithDialerResolver(resolver *net.Resolver) func(*dialerOptions) {
@@ -433,6 +452,14 @@ func WithDialerResolver(resolver *net.Resolver) func(*dialerOptions) {
 func WithDialerAllowedCIDRBlocks(blocks []*net.IPNet) func(*dialerOptions) {
 	return func(o *dialerOptions) {
 		o.allowedCIDRBlocks = blocks
+	}
+}
+
+// WithDialerTimeout sets the TCP connect timeout on a [Policy.Dialer].
+// Zero or negative leaves [defaultDialTimeout] in place.
+func WithDialerTimeout(d time.Duration) func(*dialerOptions) {
+	return func(o *dialerOptions) {
+		o.timeout = d
 	}
 }
 
@@ -455,8 +482,13 @@ func (p *Policy) Dialer(options ...func(*dialerOptions)) *net.Dialer {
 		resolver = p.resolver.Resolver()
 	}
 
+	timeout := defaultDialTimeout
+	if opts.timeout > 0 {
+		timeout = opts.timeout
+	}
+
 	return &net.Dialer{
-		Timeout:   30 * time.Second,
+		Timeout:   timeout,
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 		Resolver:  resolver,

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -80,6 +80,28 @@ func TestPolicy_Dialer(t *testing.T) {
 	require.NotNil(t, dialer.ControlContext)
 }
 
+func TestPolicy_DialerCustomTimeout(t *testing.T) {
+	t.Parallel()
+	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))
+	dialer := policy.Dialer(guardian.WithDialerTimeout(2 * time.Second))
+
+	require.Equal(t, 2*time.Second, dialer.Timeout)
+}
+
+func TestPolicy_ClientHonorsDialTimeout(t *testing.T) {
+	t.Parallel()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+
+	client := policy.Client(guardian.WithDialTimeout(100 * time.Millisecond))
+	start := time.Now()
+	// TEST-NET-1 is unroutable; without a short dial timeout this hangs for ~30s.
+	_, err = client.Get("http://192.0.2.1:9/")
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Less(t, elapsed, 500*time.Millisecond, "dial timeout must fail fast, took %s", elapsed)
+}
+
 func TestPolicy_DialerControlContext(t *testing.T) {
 	t.Parallel()
 	policy := guardian.NewDefaultPolicy(testenv.NewTracerProvider(t))

--- a/server/internal/guardian/policy_test.go
+++ b/server/internal/guardian/policy_test.go
@@ -96,7 +96,10 @@ func TestPolicy_ClientHonorsDialTimeout(t *testing.T) {
 	client := policy.Client(guardian.WithDialTimeout(100 * time.Millisecond))
 	start := time.Now()
 	// TEST-NET-1 is unroutable; without a short dial timeout this hangs for ~30s.
-	_, err = client.Get("http://192.0.2.1:9/")
+	resp, err := client.Get("http://192.0.2.1:9/")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	elapsed := time.Since(start)
 	require.Error(t, err)
 	require.Less(t, elapsed, 500*time.Millisecond, "dial timeout must fail fast, took %s", elapsed)

--- a/server/internal/mcp/servepublic_tunneled_test.go
+++ b/server/internal/mcp/servepublic_tunneled_test.go
@@ -117,9 +117,10 @@ func (g *fakeTunnelGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type publicTunnelFixture struct {
-	endpointSlug string
-	tunnelID     uuid.UUID
-	gateway      *fakeTunnelGateway
+	endpointSlug  string
+	tunnelID      uuid.UUID
+	gateway       *fakeTunnelGateway
+	gatewayServer *httptest.Server
 }
 
 func newPublicTunnelFixture(t *testing.T, ctx context.Context, ti *testInstance, gateway *fakeTunnelGateway, allowPublic bool) publicTunnelFixture {
@@ -181,9 +182,10 @@ func newPublicTunnelFixture(t *testing.T, ctx context.Context, ti *testInstance,
 	require.NoError(t, ti.tunnelRoutes.Publish(ctx, tunneledServer.ID.String(), gatewayServer.URL, time.Hour))
 
 	return publicTunnelFixture{
-		endpointSlug: endpointSlug,
-		tunnelID:     tunneledServer.ID,
-		gateway:      gateway,
+		endpointSlug:  endpointSlug,
+		tunnelID:      tunneledServer.ID,
+		gateway:       gateway,
+		gatewayServer: gatewayServer,
 	}
 }
 
@@ -330,6 +332,59 @@ func TestServePublic_Tunneled_DeadAgentSessionTranslatesTo404(t *testing.T) {
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 	require.Equal(t, before, gateway.forwardCount(), "dropped session must not be re-forwarded")
+}
+
+// A pinned gateway that is still in the route table but no longer accepting
+// connections (pod IP after listener stop / crash) must surface as 404 and
+// drop the mapping — not hang for the 30s dial timeout and return 502.
+func TestServePublic_Tunneled_PinnedGatewayDialFailureIs404(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
+
+	sid := initializeTunneledPublicSession(t, ti, fixture)
+	forwardsAfterInit := gateway.forwardCount()
+
+	fixture.gatewayServer.Close()
+
+	start := time.Now()
+	_, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeToolsListBody(), sid)
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+	require.Less(t, elapsed, 5*time.Second, "dial to a dead pinned gateway must not wait for the 30s default")
+
+	_, err = serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeToolsListBody(), sid)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+	require.Equal(t, forwardsAfterInit, gateway.forwardCount(), "dropped session must not be re-forwarded")
+}
+
+// A session pin whose recorded gateway has left the candidate set (route
+// unpublished or TTL expired) must 404 without forwarding.
+func TestServePublic_Tunneled_PinnedGatewayGoneFromCandidatesIs404(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
+
+	sid := initializeTunneledPublicSession(t, ti, fixture)
+	forwardsAfterInit := gateway.forwardCount()
+
+	require.NoError(t, ti.tunnelRoutes.Delete(ctx, fixture.tunnelID.String()))
+
+	_, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeToolsListBody(), sid)
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+	require.Equal(t, forwardsAfterInit, gateway.forwardCount(), "dead-gateway session must not be forwarded")
 }
 
 func TestServePublic_Tunneled_DeleteTerminatesSession(t *testing.T) {

--- a/server/internal/mcp/servepublic_tunneled_test.go
+++ b/server/internal/mcp/servepublic_tunneled_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/tunnelsessions"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -119,6 +120,7 @@ func (g *fakeTunnelGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type publicTunnelFixture struct {
 	endpointSlug  string
 	tunnelID      uuid.UUID
+	mcpServerID   uuid.UUID
 	gateway       *fakeTunnelGateway
 	gatewayServer *httptest.Server
 }
@@ -184,6 +186,7 @@ func newPublicTunnelFixture(t *testing.T, ctx context.Context, ti *testInstance,
 	return publicTunnelFixture{
 		endpointSlug:  endpointSlug,
 		tunnelID:      tunneledServer.ID,
+		mcpServerID:   mcpServer.ID,
 		gateway:       gateway,
 		gatewayServer: gatewayServer,
 	}
@@ -357,12 +360,13 @@ func TestServePublic_Tunneled_PinnedGatewayDialFailureIs404(t *testing.T) {
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 	require.Less(t, elapsed, 5*time.Second, "dial to a dead pinned gateway must not wait for the 30s default")
+	require.Equal(t, forwardsAfterInit, gateway.forwardCount(), "closed gateway must not receive the pinned request")
 
-	_, err = serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeToolsListBody(), sid)
-	require.Error(t, err)
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
-	require.Equal(t, forwardsAfterInit, gateway.forwardCount(), "dropped session must not be re-forwarded")
+	redisClient, redisErr := infra.NewRedisClient(t, 0)
+	require.NoError(t, redisErr)
+	sessions := tunnelsessions.NewStore(redisClient, 24*time.Hour, 10000)
+	_, err = sessions.Resolve(ctx, fixture.tunnelID.String(), fixture.mcpServerID.String(), sid, false)
+	require.ErrorIs(t, err, tunnelsessions.ErrNotFound, "dial failure must drop the session mapping")
 }
 
 // A session pin whose recorded gateway has left the candidate set (route

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -37,6 +38,19 @@ func newTunnelManager(routes route.Store, forwardToken string, proxyManager *rem
 		proxyManager: proxyManager,
 		gatewayCIDRs: gatewayCIDRs,
 	}
+}
+
+// gatewayDialTimeout bounds TCP connect to a cluster-internal tunnel
+// gateway. A healthy gateway accepts in milliseconds; the guardian default
+// of 30s only prolongs dials to dead pod IPs after a rollout.
+const gatewayDialTimeout = 2 * time.Second
+
+func (m *tunnelManager) gatewayClientOptions() []guardian.ClientOption {
+	opts := []guardian.ClientOption{guardian.WithDialTimeout(gatewayDialTimeout)}
+	if len(m.gatewayCIDRs) > 0 {
+		opts = append(opts, guardian.WithAllowedCIDRBlocks(m.gatewayCIDRs...))
+	}
+	return opts
 }
 
 // buildProxy constructs the tunnel-backed proxy for one request.
@@ -102,8 +116,6 @@ func (m *tunnelManager) buildProxy(
 	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	// Redirects won't work across a tunnel boundary; disable.
 	p.DisableRedirects = true
-	if len(m.gatewayCIDRs) > 0 {
-		p.GuardianClientOptions = []guardian.ClientOption{guardian.WithAllowedCIDRBlocks(m.gatewayCIDRs...)}
-	}
+	p.GuardianClientOptions = m.gatewayClientOptions()
 	return p, nil
 }

--- a/server/internal/mcp/tunnelpublic.go
+++ b/server/internal/mcp/tunnelpublic.go
@@ -33,7 +33,6 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/tunnelrouting"
 	"github.com/speakeasy-api/gram/server/internal/mcp/tunnelsessions"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -438,9 +437,10 @@ func isValidBackendSessionID(sid string) bool {
 // serveTunneledPublicSession serves an anonymous request that carries a
 // Gram-owned session id: resolve the Redis mapping, pin the forward to the
 // exact recorded gateway + agent session, and translate the session header in
-// both directions. A lost mapping or dead target surfaces as HTTP 404 so MCP
-// clients re-initialize; the cross-gateway retryer is never used because the
-// backend session exists on exactly one agent.
+// both directions. A lost mapping, unpublished route, unreachable pinned
+// gateway, or dead agent surfaces as HTTP 404 so MCP clients re-initialize;
+// the cross-gateway retryer is never used because the backend session exists
+// on exactly one agent.
 func (s *Service) serveTunneledPublicSession(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -529,9 +529,7 @@ func (s *Service) serveTunneledPublicSession(
 	)
 	// Redirects won't work across a tunnel boundary; disable.
 	p.DisableRedirects = true
-	if len(m.gatewayCIDRs) > 0 {
-		p.GuardianClientOptions = []guardian.ClientOption{guardian.WithAllowedCIDRBlocks(m.gatewayCIDRs...)}
-	}
+	p.GuardianClientOptions = m.gatewayClientOptions()
 
 	isDelete := r.Method == http.MethodDelete
 	p.UpstreamResponseInterceptor = func(ctx context.Context, resp *http.Response) error {
@@ -567,6 +565,12 @@ func (s *Service) serveTunneledPublicSession(
 	}
 
 	if err := serveProxyBackend(w, r, p); err != nil {
+		if errors.Is(err, proxy.ErrUpstreamUnreachable) {
+			if delErr := rt.sessions.Delete(ctx, tunnelID, mcpServerID, sid); delErr != nil {
+				logger.ErrorContext(ctx, "drop anonymous tunnel session for unreachable gateway", attr.SlogError(delErr))
+			}
+			return oops.E(oops.CodeNotFound, err, "session not found").LogWarn(ctx, logger.With(attr.SlogErrorMessage("pinned tunnel gateway is unreachable")))
+		}
 		return fmt.Errorf("serve public tunneled session: %w", err)
 	}
 	return nil

--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -34,7 +34,9 @@ var ErrBatchRequest = errors.New("batch requests are not supported")
 // failures that never produced response headers because the peer could not
 // be reached: dial timeout, connection refused, reset, DNS. A headers-phase
 // timeout after a successful TCP connect does not wrap this error — the
-// peer accepted the connection, so it is not gone.
+// peer accepted the connection, so it is not gone. A parent-request
+// deadline that expires during dial is also not this error: the peer was
+// not shown to be gone.
 var ErrUpstreamUnreachable = errors.New("remote mcp server unreachable")
 
 // classifyForwardError maps a [http.Client.Do] failure into a typed proxy
@@ -47,6 +49,11 @@ func (p *Proxy) classifyForwardError(ctx context.Context, err error, timedOut bo
 	case timedOut:
 		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
 	case errors.Is(err, context.DeadlineExceeded):
+		// A parent-request deadline is not a dead peer: the client (or
+		// MaxRequestLifetime) expired while we were still connecting.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
+		}
 		// Transport-level deadline (dial timeout, TLSHandshakeTimeout)
 		// before any headers. The peer was never reached.
 		return oops.E(oops.CodeGatewayError, fmt.Errorf("%w: %w", ErrUpstreamUnreachable, err), "remote mcp server timed out").LogError(ctx, p.Logger)

--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
@@ -29,6 +30,13 @@ var ErrUndecodableJSONRPCBody = errors.New("upstream response is not a json-rpc 
 // supported") rather than a generic decode failure.
 var ErrBatchRequest = errors.New("batch requests are not supported")
 
+// ErrUpstreamUnreachable is wrapped into connect-phase [http.Client.Do]
+// failures that never produced response headers because the peer could not
+// be reached: dial timeout, connection refused, reset, DNS. A headers-phase
+// timeout after a successful TCP connect does not wrap this error — the
+// peer accepted the connection, so it is not gone.
+var ErrUpstreamUnreachable = errors.New("remote mcp server unreachable")
+
 // classifyForwardError maps a [http.Client.Do] failure into a typed proxy
 // error. timedOut is true when the failure was caused by the proxy's own
 // phase-1 timer firing (vs. a parent-context cancellation from the user
@@ -39,12 +47,12 @@ func (p *Proxy) classifyForwardError(ctx context.Context, err error, timedOut bo
 	case timedOut:
 		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
 	case errors.Is(err, context.DeadlineExceeded):
-		// Backstop in case any transport-level deadline (e.g.
-		// TLSHandshakeTimeout) fires before our phase timer.
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
+		// Transport-level deadline (dial timeout, TLSHandshakeTimeout)
+		// before any headers. The peer was never reached.
+		return oops.E(oops.CodeGatewayError, fmt.Errorf("%w: %w", ErrUpstreamUnreachable, err), "remote mcp server timed out").LogError(ctx, p.Logger)
 	case errors.Is(err, context.Canceled):
 		return oops.E(oops.CodeBadRequest, err, "client cancelled request").LogError(ctx, p.Logger)
 	default:
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server unreachable").LogError(ctx, p.Logger)
+		return oops.E(oops.CodeGatewayError, fmt.Errorf("%w: %w", ErrUpstreamUnreachable, err), "remote mcp server unreachable").LogError(ctx, p.Logger)
 	}
 }

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -673,6 +673,7 @@ func TestProxy_Post_HeadersPhaseTimeoutReturnsGatewayError(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeGatewayError, oopsErr.Code)
+	require.NotErrorIs(t, err, proxy.ErrUpstreamUnreachable, "headers-phase timeout is not a connect failure")
 }
 
 func TestProxy_Post_NonStreamingBodyPhaseTimeoutReturnsGatewayError(t *testing.T) {
@@ -872,6 +873,7 @@ func TestProxy_Post_UpstreamUnreachableReturnsGatewayError(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeGatewayError, oopsErr.Code)
+	require.ErrorIs(t, err, proxy.ErrUpstreamUnreachable)
 }
 
 func TestProxy_Post_OversizedUpstreamBodyReturnsError(t *testing.T) {

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -876,6 +876,27 @@ func TestProxy_Post_UpstreamUnreachableReturnsGatewayError(t *testing.T) {
 	require.ErrorIs(t, err, proxy.ErrUpstreamUnreachable)
 }
 
+func TestProxy_Post_ParentDeadlineIsNotUnreachable(t *testing.T) {
+	t.Parallel()
+
+	p := newProxyForTest(t, "http://192.0.2.1:9")
+	p.GuardianClientOptions = []guardian.ClientOption{guardian.WithDialTimeout(5 * time.Second)}
+	p.NonStreamingTimeout = 5 * time.Second
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	err := p.Post(rr, req)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeGatewayError, oopsErr.Code)
+	require.NotErrorIs(t, err, proxy.ErrUpstreamUnreachable, "parent request deadline is not a dead peer")
+}
+
 func TestProxy_Post_OversizedUpstreamBodyReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/tunnel/cmd/tunnel-gateway/main.go
+++ b/tunnel/cmd/tunnel-gateway/main.go
@@ -78,12 +78,19 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	go func() {
-		<-ctx.Done()
+	drain := func() {
+		unpubCtx, unpubCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		gw.UnpublishAll(unpubCtx)
+		unpubCancel()
 		shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
-		defer cancel()
 		_ = publicSrv.Shutdown(shutCtx)
 		_ = forwardSrv.Shutdown(shutCtx)
+		cancel()
+	}
+
+	go func() {
+		<-ctx.Done()
+		drain()
 	}()
 
 	errCh := make(chan error, 2)
@@ -97,10 +104,7 @@ func main() {
 	for range 2 {
 		if err := <-errCh; err != nil {
 			stop()
-			shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
-			_ = publicSrv.Shutdown(shutCtx)
-			_ = forwardSrv.Shutdown(shutCtx)
-			cancel()
+			drain()
 			logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", err))
 			os.Exit(1)
 		}

--- a/tunnel/gateway/gateway.go
+++ b/tunnel/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -56,6 +57,9 @@ type Gateway struct {
 	routes route.Store
 	reg    *registry
 	logger *slog.Logger
+	// routeMu serializes this process's Publish against UnpublishAll so a
+	// refresh or in-flight connect cannot republish a route after drain.
+	routeMu sync.Mutex
 }
 
 func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) (*Gateway, error) {
@@ -70,11 +74,12 @@ func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) 
 		cfg.MaxSessions = defaultMaxSessions
 	}
 	return &Gateway{
-		cfg:    cfg,
-		keys:   keys,
-		routes: routes,
-		reg:    newRegistry(),
-		logger: logger,
+		cfg:     cfg,
+		keys:    keys,
+		routes:  routes,
+		reg:     newRegistry(),
+		logger:  logger,
+		routeMu: sync.Mutex{},
 	}, nil
 }
 
@@ -102,10 +107,15 @@ func (g *Gateway) ActiveSessions() int { return g.reg.activeSessions() }
 // SetAdvertiseAddr lets tests publish listener addresses known only after bind.
 func (g *Gateway) SetAdvertiseAddr(addr string) { g.cfg.AdvertiseAddr = addr }
 
-// UnpublishAll drops every route and connection snapshot this gateway currently
-// owns. Called on SIGTERM before listeners stop so gram-server stops pinning
-// new traffic here immediately, rather than waiting for the route TTL.
+// UnpublishAll marks the gateway draining (new connects and route publishes
+// are refused) and drops every route and connection snapshot this process
+// currently owns. Called on SIGTERM before listeners stop so gram-server
+// stops pinning new traffic here immediately, rather than waiting for the
+// route TTL.
 func (g *Gateway) UnpublishAll(ctx context.Context) {
+	g.reg.beginDrain()
+	g.routeMu.Lock()
+	defer g.routeMu.Unlock()
 	stateCtx, cancel := routeOperationContext(ctx)
 	defer cancel()
 	for _, tunnelID := range g.reg.tunnelIDs() {
@@ -117,7 +127,24 @@ func (g *Gateway) UnpublishAll(ctx context.Context) {
 	}
 }
 
+// publishOwnRoute publishes this gateway as an owner of tunnelID unless the
+// process is draining. Holding routeMu with UnpublishAll closes the window
+// where a refresh could republish after the drain snapshot.
+func (g *Gateway) publishOwnRoute(ctx context.Context, tunnelID string) error {
+	g.routeMu.Lock()
+	defer g.routeMu.Unlock()
+	if g.reg.isDraining() {
+		return nil
+	}
+	return g.routes.Publish(ctx, tunnelID, g.cfg.AdvertiseAddr, routeTTL)
+}
+
 func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
+	if g.reg.isDraining() {
+		g.logger.WarnContext(r.Context(), "tunnel connect rejected", slog.String("reason", "draining"))
+		http.Error(w, "tunnel gateway is draining", http.StatusServiceUnavailable)
+		return
+	}
 	// Shed before key lookup so a connect storm cannot load the key resolver.
 	if g.reg.activeSessions() >= g.cfg.MaxSessions {
 		g.logger.WarnContext(r.Context(), "tunnel connect rejected",
@@ -195,7 +222,7 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	sessionID := uuid.NewString()
 	now := time.Now().UTC()
-	remove := g.reg.add(tunnelID, sessionID, session, g.newSessionProxy(tunnelID, session), route.Connection{
+	remove, ok := g.reg.add(tunnelID, sessionID, session, g.newSessionProxy(tunnelID, session), route.Connection{
 		GatewaySessionID:       sessionID,
 		ServiceVersion:         serviceVersion,
 		AgentVersion:           agentVersion,
@@ -206,8 +233,14 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 		ActiveConsumerSessions: 0,
 		Metadata:               metadata,
 	})
+	if !ok {
+		g.logger.WarnContext(r.Context(), "tunnel connect rejected",
+			slog.String("reason", "draining"), slog.String("tunnel_id", tunnelID))
+		_ = session.Close()
+		return
+	}
 	stateCtx, cancelState := routeOperationContext(r.Context())
-	if err := g.routes.Publish(stateCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
+	if err := g.publishOwnRoute(stateCtx, tunnelID); err != nil {
 		g.logger.WarnContext(r.Context(), "tunnel route publish failed", slog.Any("error", err))
 	}
 	g.publishConnectionSnapshot(stateCtx, tunnelID, now)
@@ -236,7 +269,9 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 // just published; after unpublishing we re-check the registry and republish if
 // a session appeared. Any connect that adds itself after the re-check performs
 // its own Publish after our Unpublish, so every interleaving converges on a
-// published route while live sessions exist.
+// published route while live sessions exist. Drain is the exception: once
+// UnpublishAll has begun, add() and publishOwnRoute refuse, and this heal
+// must not put the departing gateway back in the table.
 func (g *Gateway) cleanupSessionState(tunnelID string) {
 	stateCtx, cancelState := routeOperationContext(context.Background())
 	defer cancelState()
@@ -244,10 +279,15 @@ func (g *Gateway) cleanupSessionState(tunnelID string) {
 		g.publishConnectionSnapshot(stateCtx, tunnelID, time.Now().UTC())
 		return
 	}
+	g.routeMu.Lock()
+	defer g.routeMu.Unlock()
 	if err := g.routes.Unpublish(stateCtx, tunnelID, g.cfg.AdvertiseAddr); err != nil {
 		g.logger.WarnContext(stateCtx, "tunnel route unpublish failed", slog.Any("error", err))
 	}
 	g.deleteConnectionSnapshot(stateCtx, tunnelID)
+	if g.reg.isDraining() {
+		return
+	}
 	if g.reg.tunnelSessionCount(tunnelID) > 0 {
 		if err := g.routes.Publish(stateCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
 			g.logger.WarnContext(stateCtx, "tunnel route republish after reconnect race failed", slog.Any("error", err))
@@ -264,6 +304,9 @@ func (g *Gateway) refreshSessionState(tunnelID, keyHash string, session *yamux.S
 		case <-stop:
 			return
 		case <-t.C:
+			if g.reg.isDraining() {
+				continue
+			}
 			if checker, ok := g.keys.(ActiveTunnelChecker); ok {
 				opCtx, cancel := routeOperationContext(context.Background())
 				active, err := checker.IsActive(opCtx, tunnelID, keyHash)
@@ -281,7 +324,7 @@ func (g *Gateway) refreshSessionState(tunnelID, keyHash string, session *yamux.S
 				}
 			}
 			opCtx, cancel := routeOperationContext(context.Background())
-			if err := g.routes.Publish(opCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
+			if err := g.publishOwnRoute(opCtx, tunnelID); err != nil {
 				g.logger.WarnContext(opCtx, "tunnel route refresh failed",
 					slog.String("tunnel_id", tunnelID), slog.Any("error", err))
 			}

--- a/tunnel/gateway/gateway.go
+++ b/tunnel/gateway/gateway.go
@@ -102,6 +102,21 @@ func (g *Gateway) ActiveSessions() int { return g.reg.activeSessions() }
 // SetAdvertiseAddr lets tests publish listener addresses known only after bind.
 func (g *Gateway) SetAdvertiseAddr(addr string) { g.cfg.AdvertiseAddr = addr }
 
+// UnpublishAll drops every route and connection snapshot this gateway currently
+// owns. Called on SIGTERM before listeners stop so gram-server stops pinning
+// new traffic here immediately, rather than waiting for the route TTL.
+func (g *Gateway) UnpublishAll(ctx context.Context) {
+	stateCtx, cancel := routeOperationContext(ctx)
+	defer cancel()
+	for _, tunnelID := range g.reg.tunnelIDs() {
+		if err := g.routes.Unpublish(stateCtx, tunnelID, g.cfg.AdvertiseAddr); err != nil {
+			g.logger.WarnContext(stateCtx, "tunnel route unpublish on shutdown failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+		}
+		g.deleteConnectionSnapshot(stateCtx, tunnelID)
+	}
+}
+
 func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Shed before key lookup so a connect storm cannot load the key resolver.
 	if g.reg.activeSessions() >= g.cfg.MaxSessions {

--- a/tunnel/gateway/gateway_test.go
+++ b/tunnel/gateway/gateway_test.go
@@ -39,6 +39,13 @@ func newForwardTestGateway(t *testing.T, cfg Config) *Gateway {
 	return gw
 }
 
+func mustAdd(t *testing.T, reg *registry, tunnelID, sessionID string, s *yamux.Session, proxy http.Handler, connection route.Connection) func() {
+	t.Helper()
+	remove, ok := reg.add(tunnelID, sessionID, s, proxy, connection)
+	require.True(t, ok, "registry add rejected")
+	return remove
+}
+
 func TestNewRejectsMissingForwardToken(t *testing.T) {
 	t.Parallel()
 
@@ -126,8 +133,8 @@ func TestRegistryBeginForwardRoundRobinsWithoutConsumerSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := mustAdd(t, reg, "tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -143,8 +150,8 @@ func TestRegistryBeginForwardSticksStableConsumerSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := mustAdd(t, reg, "tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -161,8 +168,8 @@ func TestRegistryBeginForwardUsesNextRankedEligibleSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := mustAdd(t, reg, "tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -185,7 +192,7 @@ func TestRegistryBeginForwardDistinguishesBusyFromNoSession(t *testing.T) {
 	require.Equal(t, forwardNoSession, failure)
 
 	session := newYamuxSession(t)
-	remove := reg.add("tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := mustAdd(t, reg, "tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	entry, failure := reg.beginForward("tunnel-1", "", "", time.Now().UTC(), 1)
@@ -204,7 +211,7 @@ func TestForwardHandlerReportsTunnelBusyAtCap(t *testing.T) {
 
 	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", MaxStreamsPerTunnel: 1})
 	session := newYamuxSession(t)
-	remove := gw.reg.add("tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := mustAdd(t, gw.reg, "tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	// Occupy the single substream slot so the next forward hits the cap.
@@ -256,7 +263,7 @@ func TestCleanupSessionStateHealsReconnectRace(t *testing.T) {
 	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-1:8091", time.Minute))
 	sessionB := newYamuxSession(t)
 	hooked.beforeUnpublish = func() {
-		remove := gw.reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+		remove := mustAdd(t, gw.reg, "tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 		t.Cleanup(remove)
 	}
 
@@ -300,10 +307,10 @@ func TestUnpublishAllDropsHostedRoutes(t *testing.T) {
 	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-2:8091", time.Minute))
 
 	session1 := newYamuxSession(t)
-	remove1 := gw.reg.add("tunnel-1", "session-a", session1, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove1 := mustAdd(t, gw.reg, "tunnel-1", "session-a", session1, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove1)
 	session2 := newYamuxSession(t)
-	remove2 := gw.reg.add("tunnel-2", "session-b", session2, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	remove2 := mustAdd(t, gw.reg, "tunnel-2", "session-b", session2, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(remove2)
 
 	gw.UnpublishAll(ctx)
@@ -315,6 +322,46 @@ func TestUnpublishAllDropsHostedRoutes(t *testing.T) {
 	candidates, err = table.Candidates(ctx, "tunnel-2")
 	require.NoError(t, err)
 	require.Empty(t, candidates)
+}
+
+// After SIGTERM drain, a live session, refresh ticker, or new connect must
+// not put this gateway back in the route table.
+func TestUnpublishAllStopsRepublishAndNewConnects(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	table := route.NewRouteTable()
+	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", AdvertiseAddr: "gw-1:8091"})
+	gw.routes = table
+
+	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-1:8091", time.Minute))
+	session := newYamuxSession(t)
+	remove := mustAdd(t, gw.reg, "tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	t.Cleanup(remove)
+
+	gw.UnpublishAll(ctx)
+
+	candidates, err := table.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+
+	_, ok := gw.reg.add("tunnel-1", "session-b", newYamuxSession(t), http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	require.False(t, ok, "drain must refuse new sessions")
+
+	require.NoError(t, gw.publishOwnRoute(ctx, "tunnel-1"))
+	candidates, err = table.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Empty(t, candidates, "refresh must not republish after drain")
+
+	gw.cleanupSessionState("tunnel-1")
+	candidates, err = table.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Empty(t, candidates, "disconnect cleanup must not republish after drain")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/connect", nil)
+	gw.PublicHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 // recordingKeyStore wraps StaticKeyStore with a MarkConnected spy.
@@ -369,8 +416,8 @@ func TestRegistryBeginForwardExactSessionHitsOnlyThatSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := mustAdd(t, reg, "tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -386,7 +433,7 @@ func TestRegistryBeginForwardExactSessionHitsOnlyThatSession(t *testing.T) {
 func TestRegistryBeginForwardExactSessionMissingIsNoSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 
 	_, failure := reg.beginForward("tunnel-1", "", "session-gone", time.Now().UTC(), 0)
@@ -398,7 +445,7 @@ func TestRegistryBeginForwardExactSessionMissingIsNoSession(t *testing.T) {
 func TestRegistryBeginForwardExactSessionAtCapIsBusy(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeA := mustAdd(t, reg, "tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 
 	entry, failure := reg.beginForward("tunnel-1", "", "session-a", time.Now().UTC(), 1)
@@ -421,7 +468,7 @@ func TestForwardHandlerReportsAgentSessionAndStripsExactHeader(t *testing.T) {
 		forwarded = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
 	})
-	remove := gw.reg.add("tunnel-1", "session-a", session, captureProxy, route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := mustAdd(t, gw.reg, "tunnel-1", "session-a", session, captureProxy, route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	rec := httptest.NewRecorder()

--- a/tunnel/gateway/gateway_test.go
+++ b/tunnel/gateway/gateway_test.go
@@ -287,6 +287,36 @@ func TestCleanupSessionStateRemovesRouteWhenLastSessionCloses(t *testing.T) {
 	require.Empty(t, candidates)
 }
 
+func TestUnpublishAllDropsHostedRoutes(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	table := route.NewRouteTable()
+	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", AdvertiseAddr: "gw-1:8091"})
+	gw.routes = table
+
+	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-1:8091", time.Minute))
+	require.NoError(t, table.Publish(ctx, "tunnel-2", "gw-1:8091", time.Minute))
+	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-2:8091", time.Minute))
+
+	session1 := newYamuxSession(t)
+	remove1 := gw.reg.add("tunnel-1", "session-a", session1, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	t.Cleanup(remove1)
+	session2 := newYamuxSession(t)
+	remove2 := gw.reg.add("tunnel-2", "session-b", session2, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	t.Cleanup(remove2)
+
+	gw.UnpublishAll(ctx)
+
+	candidates, err := table.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"gw-2:8091"}, candidates, "other owners must survive drain")
+
+	candidates, err = table.Candidates(ctx, "tunnel-2")
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}
+
 // recordingKeyStore wraps StaticKeyStore with a MarkConnected spy.
 type recordingKeyStore struct {
 	*StaticKeyStore

--- a/tunnel/gateway/registry.go
+++ b/tunnel/gateway/registry.go
@@ -233,3 +233,13 @@ func (r *registry) activeSessions() int {
 	}
 	return n
 }
+
+func (r *registry) tunnelIDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.sessions))
+	for id := range r.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}

--- a/tunnel/gateway/registry.go
+++ b/tunnel/gateway/registry.go
@@ -19,7 +19,10 @@ const consumerSessionTTL = 5 * time.Minute
 // Multiple agents may share a tunnel key. Stable consumer keys stick to one live session;
 // requests without a consumer key round-robin across live sessions.
 type registry struct {
-	mu       sync.RWMutex
+	mu sync.RWMutex
+	// draining is set on SIGTERM. Once true, add() refuses new sessions so
+	// UnpublishAll cannot race with a connect that would republish a route.
+	draining bool
 	sessions map[string][]*sessEntry
 	rr       map[string]uint64 // round-robin cursor per tunnel
 }
@@ -38,12 +41,25 @@ type sessEntry struct {
 
 func newRegistry() *registry {
 	return &registry{
+		draining: false,
 		sessions: make(map[string][]*sessEntry),
 		rr:       make(map[string]uint64),
 	}
 }
 
-func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.Handler, connection route.Connection) func() {
+func (r *registry) beginDrain() {
+	r.mu.Lock()
+	r.draining = true
+	r.mu.Unlock()
+}
+
+func (r *registry) isDraining() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.draining
+}
+
+func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.Handler, connection route.Connection) (func(), bool) {
 	entry := &sessEntry{
 		id:               sessionID,
 		session:          s,
@@ -53,11 +69,14 @@ func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.
 		consumerSessions: make(map[string]time.Time),
 	}
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.draining {
+		return nil, false
+	}
 	r.sessions[tunnelID] = append(r.sessions[tunnelID], entry)
 	if _, ok := r.rr[tunnelID]; !ok {
 		r.rr[tunnelID] = 0
 	}
-	r.mu.Unlock()
 
 	return func() {
 		r.mu.Lock()
@@ -73,7 +92,7 @@ func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.
 			delete(r.sessions, tunnelID)
 			delete(r.rr, tunnelID)
 		}
-	}
+	}, true
 }
 
 func (r *registry) tunnelSessionCount(tunnelID string) int {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes AIS-662: tunnel-gateway rollouts were paging oncall with 30s stalls and 502 bursts because anonymous MCP sessions stay pinned to the pod IP that served `initialize`.

When that pod goes away, the pin's sliding TTL keeps the dead address alive, and the stale-owner retryer never runs — a dial to a dead pod IP produces no headers, so clients wait the full ~30s connect timeout then get `remote mcp server timed out` → 502.

## Summary

- Connect-phase failure to a pinned `GatewayAddr` deletes the Redis mapping and returns HTTP 404 (`session not found`). MCP clients already re-initialize on that contract. A headers-phase timeout after a successful TCP connect is not treated as gone, and neither is a parent-request deadline that expires during dial.
- Tunnel-gateway proxies use a 2s cluster-internal dial timeout instead of the 30s default.
- On SIGTERM, `tunnel-gateway` marks itself draining (new connects and route publishes are refused), then drops every route it currently owns before listeners stop. That closes the race where an in-flight connect or refresh could republish the departing pod.

Defense in depth: SIGTERM drain+unpublish closes the deploy window; short timeout + 404 covers crash/OOM where there is no drain.

Related: AIS-578 (no live tunnel route → 404) and AIS-121 (gram-server deploy drain).

## Motivation

Every tunnel-gateway restart produced a burst of 30-second stalls and 502s for clients with live pinned sessions, until each client gave up its session and re-initialized. The 5XX ingress monitor pages on those bursts because custom-domain MCP is served at `/`, outside the `/mcp/*` exclusion.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-662](https://linear.app/speakeasy/issue/AIS-662/bug-tunnel-gateway-restarts-leave-session-pinned-requests-dialing-dead)

<div><a href="https://cursor.com/agents/bc-323d45a4-47f4-4430-89f1-344ea57f803b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323d45a4-47f4-4430-89f1-344ea57f803b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AIS-662: gateway pod restarts left anonymous MCP sessions pinned to dead pod IPs, producing ~30 s stalls and 502 bursts. Dial failures to a pinned gateway now delete the Redis session mapping and return HTTP 404 so clients re-initialize immediately instead of waiting out the connect timeout.

**Bug Fixes**
- Connect-phase dial failures wrapped in new `proxy.ErrUpstreamUnreachable` drop the mapping and return 404; headers-phase timeouts and parent-request deadline expiry do not.
- Tunnel-gateway proxies now use a 2-second cluster-internal dial timeout (`guardian.WithDialTimeout`) instead of the 30-second default.
- `tunnel-gateway` marks itself draining on SIGTERM — refusing new connects and route publishes — and unpublishes its owned routes before listeners stop, closing the deploy window immediately instead of waiting for the 30-second route TTL.

<sup>Written for commit 85077a913fdc7a47d5a732478f4a90b209a43bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

