### PR TITLE
mig: add durable killswitch prescription schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -7695,3 +7695,89 @@ CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_subject_created_at
 CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_connection_created_at_idx ON platform_mcp_feedback (organization_id, connection_id, created_at DESC) WHERE connection_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_workflow_created_at_idx ON platform_mcp_feedback (organization_id, workflow_id, created_at DESC) WHERE workflow_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS platform_mcp_feedback_expires_at_idx ON platform_mcp_feedback (expires_at);
+
+CREATE TABLE IF NOT EXISTS killswitch_prescriptions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  definition_key TEXT NOT NULL,
+  principal_kind TEXT NOT NULL,
+  principal_key TEXT NOT NULL,
+  resource_kind TEXT NOT NULL,
+  current_version BIGINT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT killswitch_prescriptions_pkey PRIMARY KEY (id),
+  CONSTRAINT killswitch_prescriptions_definition_key_check CHECK (definition_key <> ''),
+  CONSTRAINT killswitch_prescriptions_principal_kind_check CHECK (principal_kind <> ''),
+  CONSTRAINT killswitch_prescriptions_principal_key_check CHECK (principal_key <> ''),
+  CONSTRAINT killswitch_prescriptions_resource_kind_check CHECK (resource_kind <> ''),
+  CONSTRAINT killswitch_prescriptions_current_version_check CHECK (current_version > 0),
+  CONSTRAINT killswitch_prescriptions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescriptions_organization_id_id_key ON killswitch_prescriptions (organization_id, id);
+CREATE INDEX IF NOT EXISTS killswitch_prescriptions_evaluator_idx ON killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, id);
+
+CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
+  organization_id TEXT NOT NULL,
+  prescription_id uuid NOT NULL,
+  version BIGINT NOT NULL,
+  state TEXT NOT NULL,
+  resource_scope TEXT NOT NULL,
+  starts_at timestamptz NOT NULL,
+  expires_at timestamptz,
+  activated_at timestamptz,
+  superseded_at timestamptz,
+  internal_note TEXT NOT NULL,
+  external_note TEXT NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT killswitch_prescription_versions_pkey PRIMARY KEY (prescription_id, version),
+  CONSTRAINT killswitch_prescription_versions_prescription_fkey FOREIGN KEY (organization_id, prescription_id) REFERENCES killswitch_prescriptions (organization_id, id) ON DELETE CASCADE,
+  CONSTRAINT killswitch_prescription_versions_version_check CHECK (version > 0),
+  CONSTRAINT killswitch_prescription_versions_state_check CHECK (state <> ''),
+  CONSTRAINT killswitch_prescription_versions_resource_scope_check CHECK (resource_scope IN ('all', 'selected')),
+  CONSTRAINT killswitch_prescription_versions_interval_check CHECK (expires_at IS NULL OR expires_at > starts_at),
+  CONSTRAINT killswitch_prescription_versions_external_note_check CHECK (char_length(external_note) BETWEEN 1 AND 500),
+  CONSTRAINT killswitch_prescription_versions_internal_note_check CHECK (char_length(internal_note) BETWEEN 1 AND 4000)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescription_versions_org_prescription_version_key ON killswitch_prescription_versions (organization_id, prescription_id, version);
+
+CREATE TABLE IF NOT EXISTS killswitch_prescription_version_resources (
+  organization_id TEXT NOT NULL,
+  prescription_id uuid NOT NULL,
+  version BIGINT NOT NULL,
+  resource_key TEXT NOT NULL,
+  CONSTRAINT killswitch_prescription_version_resources_pkey PRIMARY KEY (prescription_id, version, resource_key),
+  CONSTRAINT killswitch_prescription_version_resources_version_fkey FOREIGN KEY (organization_id, prescription_id, version) REFERENCES killswitch_prescription_versions (organization_id, prescription_id, version) ON DELETE CASCADE,
+  CONSTRAINT killswitch_prescription_version_resources_resource_key_check CHECK (resource_key <> '')
+);
+CREATE INDEX IF NOT EXISTS killswitch_prescription_version_resources_lookup_idx ON killswitch_prescription_version_resources (organization_id, resource_key, prescription_id, version);
+
+CREATE TABLE IF NOT EXISTS killswitch_expiry_events (
+  organization_id TEXT NOT NULL,
+  prescription_id uuid NOT NULL,
+  version BIGINT NOT NULL,
+  recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT killswitch_expiry_events_pkey PRIMARY KEY (prescription_id, version),
+  CONSTRAINT killswitch_expiry_events_prescription_version_fkey FOREIGN KEY (organization_id, prescription_id, version) REFERENCES killswitch_prescription_versions (organization_id, prescription_id, version) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS killswitch_operations (
+  organization_id TEXT NOT NULL,
+  operation_id uuid NOT NULL,
+  actor_user_id TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  response JSONB,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT killswitch_operations_pkey PRIMARY KEY (organization_id, operation_id),
+  CONSTRAINT killswitch_operations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT killswitch_operations_actor_user_id_check CHECK (actor_user_id <> ''),
+  CONSTRAINT killswitch_operations_operation_check CHECK (operation <> ''),
+  CONSTRAINT killswitch_operations_request_hash_check CHECK (request_hash <> ''),
+  CONSTRAINT killswitch_operations_status_check CHECK (status IN ('pending', 'completed')),
+  CONSTRAINT killswitch_operations_completed_response_check CHECK ((status = 'pending' AND response IS NULL) OR (status = 'completed' AND response IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS killswitch_operations_expires_at_idx ON killswitch_operations (expires_at);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1091,6 +1091,60 @@ type JsonWebKeySet struct {
 	Deleted        bool
 }
 
+type KillswitchExpiryEvent struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+	RecordedAt     pgtype.Timestamptz
+}
+
+type KillswitchOperation struct {
+	OrganizationID string
+	OperationID    uuid.UUID
+	ActorUserID    string
+	Operation      string
+	RequestHash    string
+	Status         string
+	Response       []byte
+	ExpiresAt      pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+type KillswitchPrescription struct {
+	ID             uuid.UUID
+	OrganizationID string
+	DefinitionKey  string
+	PrincipalKind  string
+	PrincipalKey   string
+	ResourceKind   string
+	CurrentVersion int64
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+type KillswitchPrescriptionVersion struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+	State          string
+	ResourceScope  string
+	StartsAt       pgtype.Timestamptz
+	ExpiresAt      pgtype.Timestamptz
+	ActivatedAt    pgtype.Timestamptz
+	SupersededAt   pgtype.Timestamptz
+	InternalNote   string
+	ExternalNote   string
+	CreatedAt      pgtype.Timestamptz
+}
+
+type KillswitchPrescriptionVersionResource struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+	ResourceKey    string
+}
+
 type LitellmInstance struct {
 	ID                       uuid.UUID
 	OrganizationID           string

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -1,0 +1,307 @@
+//nolint:glint // Constraint tests require invalid raw writes that production SQLc methods cannot express.
+package killswitches
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillswitchSchemaConstraintsAndCascade(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "killswitch_schema")
+	require.NoError(t, err)
+
+	orgID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, orgID)
+
+	prescriptionID := uuid.New()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescriptions (
+			id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version
+		) VALUES ($1, $2, 'test_capability', 'user', 'user_1', 'test_resource', 1)
+	`, prescriptionID, orgID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', clock_timestamp(), clock_timestamp() + interval '1 hour', clock_timestamp(), 'internal', 'external')
+	`, orgID, prescriptionID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		VALUES ($1, $2, 1, 'resource_1')
+	`, orgID, prescriptionID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
+		VALUES ($1, $2, 1)
+	`, orgID, prescriptionID)
+	require.NoError(t, err)
+
+	operationID := uuid.New()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, expires_at)
+		VALUES ($1, $2, 'user_1', 'activate', 'request_hash', clock_timestamp() + interval '30 days')
+	`, orgID, operationID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `DELETE FROM organization_metadata WHERE id = $1`, orgID)
+	require.NoError(t, err)
+
+	var remainingRows int
+	err = conn.QueryRow(ctx, `
+		SELECT
+		  (SELECT count(*) FROM killswitch_prescriptions)
+		  + (SELECT count(*) FROM killswitch_prescription_versions)
+		  + (SELECT count(*) FROM killswitch_prescription_version_resources)
+		  + (SELECT count(*) FROM killswitch_expiry_events)
+		  + (SELECT count(*) FROM killswitch_operations)
+	`).Scan(&remainingRows)
+	require.NoError(t, err)
+	require.Zero(t, remainingRows)
+}
+
+func TestKillswitchSchemaRejectsInvalidRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "killswitch_constraints")
+	require.NoError(t, err)
+
+	orgID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, orgID)
+
+	prescriptionCases := []struct {
+		definitionKey  string
+		principalKind  string
+		principalKey   string
+		resourceKind   string
+		currentVersion int64
+		constraint     string
+	}{
+		{"", "user", "user_1", "test_resource", 1, "killswitch_prescriptions_definition_key_check"},
+		{"test_capability", "", "user_1", "test_resource", 1, "killswitch_prescriptions_principal_kind_check"},
+		{"test_capability", "user", "", "test_resource", 1, "killswitch_prescriptions_principal_key_check"},
+		{"test_capability", "user", "user_1", "", 1, "killswitch_prescriptions_resource_kind_check"},
+		{"test_capability", "user", "user_1", "test_resource", 0, "killswitch_prescriptions_current_version_check"},
+	}
+	for _, tc := range prescriptionCases {
+		_, err := conn.Exec(ctx, `
+			INSERT INTO killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, orgID, tc.definitionKey, tc.principalKind, tc.principalKey, tc.resourceKind, tc.currentVersion)
+		requireConstraint(t, err, tc.constraint)
+	}
+
+	prescriptionID := uuid.New()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescriptions (id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		VALUES ($1, $2, 'test_capability', 'user', 'user_1', 'test_resource', 1)
+	`, prescriptionID, orgID)
+	require.NoError(t, err)
+
+	startsAt := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	versionCases := []struct {
+		version       int64
+		state         string
+		resourceScope string
+		expiresAt     any
+		internalNote  string
+		externalNote  string
+		constraint    string
+	}{
+		{0, "active", "selected", nil, "internal", "external", "killswitch_prescription_versions_version_check"},
+		{1, "", "selected", nil, "internal", "external", "killswitch_prescription_versions_state_check"},
+		{1, "active", "some", nil, "internal", "external", "killswitch_prescription_versions_resource_scope_check"},
+		{1, "active", "selected", startsAt, "internal", "external", "killswitch_prescription_versions_interval_check"},
+		{1, "active", "selected", nil, "", "external", "killswitch_prescription_versions_internal_note_check"},
+		{1, "active", "selected", nil, strings.Repeat("i", 4001), "external", "killswitch_prescription_versions_internal_note_check"},
+		{1, "active", "selected", nil, "internal", "", "killswitch_prescription_versions_external_note_check"},
+		{1, "active", "selected", nil, "internal", strings.Repeat("e", 501), "killswitch_prescription_versions_external_note_check"},
+	}
+	for _, tc := range versionCases {
+		_, err := conn.Exec(ctx, `
+			INSERT INTO killswitch_prescription_versions (
+				organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, internal_note, external_note
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		`, orgID, prescriptionID, tc.version, tc.state, tc.resourceScope, startsAt, tc.expiresAt, tc.internalNote, tc.externalNote)
+		requireConstraint(t, err, tc.constraint)
+	}
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', $3, 'internal', 'external')
+	`, orgID, prescriptionID, startsAt)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		VALUES ($1, $2, 1, '')
+	`, orgID, prescriptionID)
+	requireConstraint(t, err, "killswitch_prescription_version_resources_resource_key_check")
+
+	operationCases := []struct {
+		actorUserID string
+		operation   string
+		requestHash string
+		constraint  string
+	}{
+		{"", "activate", "request_hash", "killswitch_operations_actor_user_id_check"},
+		{"user_1", "", "request_hash", "killswitch_operations_operation_check"},
+		{"user_1", "activate", "", "killswitch_operations_request_hash_check"},
+	}
+	for _, tc := range operationCases {
+		_, err := conn.Exec(ctx, `
+			INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, expires_at)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, orgID, uuid.New(), tc.actorUserID, tc.operation, tc.requestHash, startsAt.Add(30*24*time.Hour))
+		requireConstraint(t, err, tc.constraint)
+	}
+
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, `ALTER TABLE killswitch_operations DROP CONSTRAINT killswitch_operations_completed_response_check`)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, `
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, status, expires_at)
+		VALUES ($1, $2, 'user_1', 'activate', 'request_hash', 'unknown', $3)
+	`, orgID, uuid.New(), startsAt.Add(30*24*time.Hour))
+	requireConstraint(t, err, "killswitch_operations_status_check")
+	require.NoError(t, tx.Rollback(ctx))
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, status, response, expires_at)
+		VALUES ($1, $2, 'user_1', 'activate', 'request_hash', 'completed', NULL, $3)
+	`, orgID, uuid.New(), startsAt.Add(30*24*time.Hour))
+	requireConstraint(t, err, "killswitch_operations_completed_response_check")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, status, response, expires_at)
+		VALUES ($1, $2, 'user_1', 'activate', 'request_hash', 'pending', jsonb_build_object('ok', true), $3)
+	`, orgID, uuid.New(), startsAt.Add(30*24*time.Hour))
+	requireConstraint(t, err, "killswitch_operations_completed_response_check")
+}
+
+func TestKillswitchSchemaPinsTenancyAndIdempotency(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "killswitch_tenancy")
+	require.NoError(t, err)
+
+	orgA := "org_" + uuid.NewString()
+	orgB := "org_" + uuid.NewString()
+	insertOrganization(t, conn, orgA)
+	insertOrganization(t, conn, orgB)
+
+	prescriptionID := uuid.New()
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescriptions (id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		VALUES ($1, $2, 'test_capability', 'user', 'user_1', 'test_resource', 1)
+	`, prescriptionID, orgA)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', clock_timestamp(), 'internal', 'external')
+	`, orgB, prescriptionID)
+	requireConstraint(t, err, "killswitch_prescription_versions_prescription_fkey")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', clock_timestamp(), 'internal', 'external')
+	`, orgA, prescriptionID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', clock_timestamp(), 'internal', 'external')
+	`, orgA, prescriptionID)
+	requireConstraint(t, err, "killswitch_prescription_versions_pkey")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		VALUES ($1, $2, 1, 'resource_1')
+	`, orgB, prescriptionID)
+	requireConstraint(t, err, "killswitch_prescription_version_resources_version_fkey")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		VALUES ($1, $2, 1, 'resource_1')
+	`, orgA, prescriptionID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		VALUES ($1, $2, 1, 'resource_1')
+	`, orgA, prescriptionID)
+	requireConstraint(t, err, "killswitch_prescription_version_resources_pkey")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
+		VALUES ($1, $2, 1)
+	`, orgB, prescriptionID)
+	requireConstraint(t, err, "killswitch_expiry_events_prescription_version_fkey")
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
+		VALUES ($1, $2, 1)
+	`, orgA, prescriptionID)
+	require.NoError(t, err)
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
+		VALUES ($1, $2, 1)
+	`, orgA, prescriptionID)
+	requireConstraint(t, err, "killswitch_expiry_events_pkey")
+
+	operationID := uuid.New()
+	for _, orgID := range []string{orgA, orgB} {
+		_, err = conn.Exec(ctx, `
+			INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, expires_at)
+			VALUES ($1, $2, 'user_1', 'activate', 'request_hash', clock_timestamp() + interval '30 days')
+		`, orgID, operationID)
+		require.NoError(t, err)
+	}
+
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, expires_at)
+		VALUES ($1, $2, 'user_1', 'activate', 'request_hash', clock_timestamp() + interval '30 days')
+	`, orgA, operationID)
+	requireConstraint(t, err, "killswitch_operations_pkey")
+}
+
+func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {
+	t.Helper()
+
+	err := repo.New(conn).CreateOrganizationMetadata(t.Context(), repo.CreateOrganizationMetadataParams{
+		ID:   organizationID,
+		Name: "Test Organization",
+		Slug: organizationID,
+	})
+	require.NoError(t, err)
+}
+
+func requireConstraint(t *testing.T, err error, constraint string) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, constraint, pgErr.ConstraintName)
+}

--- a/server/internal/killswitches/setup_test.go
+++ b/server/internal/killswitches/setup_test.go
@@ -1,0 +1,28 @@
+package killswitches
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("clean up test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}

--- a/server/migrations/20260828145942_dno-974-durable-killswitch-prescriptions.sql
+++ b/server/migrations/20260828145942_dno-974-durable-killswitch-prescriptions.sql
@@ -1,0 +1,91 @@
+-- Create "killswitch_prescriptions" table
+CREATE TABLE "killswitch_prescriptions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "definition_key" text NOT NULL,
+  "principal_kind" text NOT NULL,
+  "principal_key" text NOT NULL,
+  "resource_kind" text NOT NULL,
+  "current_version" bigint NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "killswitch_prescriptions_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "killswitch_prescriptions_current_version_check" CHECK (current_version > 0),
+  CONSTRAINT "killswitch_prescriptions_definition_key_check" CHECK (definition_key <> ''::text),
+  CONSTRAINT "killswitch_prescriptions_principal_key_check" CHECK (principal_key <> ''::text),
+  CONSTRAINT "killswitch_prescriptions_principal_kind_check" CHECK (principal_kind <> ''::text),
+  CONSTRAINT "killswitch_prescriptions_resource_kind_check" CHECK (resource_kind <> ''::text)
+);
+-- Create index "killswitch_prescriptions_evaluator_idx" to table: "killswitch_prescriptions"
+CREATE INDEX "killswitch_prescriptions_evaluator_idx" ON "killswitch_prescriptions" ("organization_id", "definition_key", "principal_kind", "principal_key", "resource_kind", "id");
+-- Create index "killswitch_prescriptions_organization_id_id_key" to table: "killswitch_prescriptions"
+CREATE UNIQUE INDEX "killswitch_prescriptions_organization_id_id_key" ON "killswitch_prescriptions" ("organization_id", "id");
+-- Create "killswitch_prescription_versions" table
+CREATE TABLE "killswitch_prescription_versions" (
+  "organization_id" text NOT NULL,
+  "prescription_id" uuid NOT NULL,
+  "version" bigint NOT NULL,
+  "state" text NOT NULL,
+  "resource_scope" text NOT NULL,
+  "starts_at" timestamptz NOT NULL,
+  "expires_at" timestamptz NULL,
+  "activated_at" timestamptz NULL,
+  "superseded_at" timestamptz NULL,
+  "internal_note" text NOT NULL,
+  "external_note" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("prescription_id", "version"),
+  CONSTRAINT "killswitch_prescription_versions_prescription_fkey" FOREIGN KEY ("organization_id", "prescription_id") REFERENCES "killswitch_prescriptions" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "killswitch_prescription_versions_external_note_check" CHECK ((char_length(external_note) >= 1) AND (char_length(external_note) <= 500)),
+  CONSTRAINT "killswitch_prescription_versions_internal_note_check" CHECK ((char_length(internal_note) >= 1) AND (char_length(internal_note) <= 4000)),
+  CONSTRAINT "killswitch_prescription_versions_interval_check" CHECK ((expires_at IS NULL) OR (expires_at > starts_at)),
+  CONSTRAINT "killswitch_prescription_versions_resource_scope_check" CHECK (resource_scope = ANY (ARRAY['all'::text, 'selected'::text])),
+  CONSTRAINT "killswitch_prescription_versions_state_check" CHECK (state <> ''::text),
+  CONSTRAINT "killswitch_prescription_versions_version_check" CHECK (version > 0)
+);
+-- Create index "killswitch_prescription_versions_org_prescription_version_key" to table: "killswitch_prescription_versions"
+CREATE UNIQUE INDEX "killswitch_prescription_versions_org_prescription_version_key" ON "killswitch_prescription_versions" ("organization_id", "prescription_id", "version");
+-- Create "killswitch_expiry_events" table
+CREATE TABLE "killswitch_expiry_events" (
+  "organization_id" text NOT NULL,
+  "prescription_id" uuid NOT NULL,
+  "version" bigint NOT NULL,
+  "recorded_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("prescription_id", "version"),
+  CONSTRAINT "killswitch_expiry_events_prescription_version_fkey" FOREIGN KEY ("organization_id", "prescription_id", "version") REFERENCES "killswitch_prescription_versions" ("organization_id", "prescription_id", "version") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create "killswitch_operations" table
+CREATE TABLE "killswitch_operations" (
+  "organization_id" text NOT NULL,
+  "operation_id" uuid NOT NULL,
+  "actor_user_id" text NOT NULL,
+  "operation" text NOT NULL,
+  "request_hash" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'pending',
+  "response" jsonb NULL,
+  "expires_at" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("organization_id", "operation_id"),
+  CONSTRAINT "killswitch_operations_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "killswitch_operations_actor_user_id_check" CHECK (actor_user_id <> ''::text),
+  CONSTRAINT "killswitch_operations_completed_response_check" CHECK (((status = 'pending'::text) AND (response IS NULL)) OR ((status = 'completed'::text) AND (response IS NOT NULL))),
+  CONSTRAINT "killswitch_operations_operation_check" CHECK (operation <> ''::text),
+  CONSTRAINT "killswitch_operations_request_hash_check" CHECK (request_hash <> ''::text),
+  CONSTRAINT "killswitch_operations_status_check" CHECK (status = ANY (ARRAY['pending'::text, 'completed'::text]))
+);
+-- Create index "killswitch_operations_expires_at_idx" to table: "killswitch_operations"
+CREATE INDEX "killswitch_operations_expires_at_idx" ON "killswitch_operations" ("expires_at");
+-- Create "killswitch_prescription_version_resources" table
+CREATE TABLE "killswitch_prescription_version_resources" (
+  "organization_id" text NOT NULL,
+  "prescription_id" uuid NOT NULL,
+  "version" bigint NOT NULL,
+  "resource_key" text NOT NULL,
+  PRIMARY KEY ("prescription_id", "version", "resource_key"),
+  CONSTRAINT "killswitch_prescription_version_resources_version_fkey" FOREIGN KEY ("organization_id", "prescription_id", "version") REFERENCES "killswitch_prescription_versions" ("organization_id", "prescription_id", "version") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "killswitch_prescription_version_resources_resource_key_check" CHECK (resource_key <> ''::text)
+);
+-- Create index "killswitch_prescription_version_resources_lookup_idx" to table: "killswitch_prescription_version_resources"
+CREATE INDEX "killswitch_prescription_version_resources_lookup_idx" ON "killswitch_prescription_version_resources" ("organization_id", "resource_key", "prescription_id", "version");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lb40cA7pY12pxHzHw9f9CmtMcc+xAPef3qNMVhl36/Q=
+h1:ZULnNpKC6tJeSLOohYGzL+arYtf0CIHCYd1MkKWLXyg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -373,3 +373,4 @@ h1:lb40cA7pY12pxHzHw9f9CmtMcc+xAPef3qNMVhl36/Q=
 20260828004317_risk-pagination-indexes.sql h1:Kt04zUHm8wQchZZL6gWP/+3fknMyhlAuiMCClo6MZGQ=
 20260828092510_data_exports_fanout.sql h1:qObwb6bsBowCBl4kdIM+xv+QuTDJ1velUTNWleNk5q8=
 20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=
+20260828145942_dno-974-durable-killswitch-prescriptions.sql h1:qPmCeNHQURcvp4RrbtPz9t+vs8iyLy0B5LPcEgO2ejY=


### PR DESCRIPTION
## Summary

Adds the organization-scoped PostgreSQL foundation for durable killswitch prescriptions, immutable version snapshots, version-specific expiry markers, and replay-safe operations. The schema supports overlapping selected-resource and dynamic all-resource scopes while preserving tenant-qualified lineage and cascade behavior.

## Technical details

### Constraint coverage

Schema tests exercise tenant pinning, structural and note constraints, idempotency keys, and organization-lifetime cascades across all five tables.

Closes [DNO-974](https://linear.app/speakeasy/issue/DNO-974/chore-add-durable-killswitch-prescription-schema)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the expand-only PostgreSQL schema and its generated Go models for durable killswitch prescriptions so scheduled, overlapping, resource-scoped killswitches can be stored and evaluated later. Still schema-only: no readers or writers consume these tables yet, and runtime behavior is unchanged. Closes DNO-974.

**Details**
- Five tables model prescription headers, immutable version snapshots, selected-resource snapshots, per-version expiry markers, and 30-day operation receipts.
- Tables are organization-scoped with cascade deletion, explicit `selected`/`all` scopes, and no `project_id`.
- Schema tests verify tenant pinning, non-empty identifiers, idempotency keys, and organization-lifetime cascade cleanup.

<sup>Written for commit f9b032e495fd87c7594583f08ce81728831e6139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

[skip migration check]
