### PR TITLE
feat: list Salesforce remote MCP in the catalog

### DIFF
--- a/.changeset/salesforce-catalog-remote.md
+++ b/.changeset/salesforce-catalog-remote.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Pin Salesforce's official hosted MCP in the catalog so it stays listed even when it ranks below the Pulse crawl cap, and label its GA remote endpoints.

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -43,6 +43,10 @@ const SERVER_WEBSITE_MAP: Record<string, string> = {
   "io.github.getsentry/sentry-mcp": "sentry.io",
   "io.github.github/github-mcp-server": "github.com",
   "com.notion/mcp": "notion.so",
+  "com.pulsemcp.mirror/salesforce-platform": "salesforce.com",
+  "com.pulsemcp.mirror/salesforce-invocable-actions": "salesforce.com",
+  "com.pulsemcp.mirror/salesforce-flows": "salesforce.com",
+  "com.pulsemcp.mirror/salesforce-tableau-next": "salesforce.com",
 };
 
 export function CatalogDetailRoot(): JSX.Element {

--- a/client/dashboard/src/pages/catalog/remotes.test.ts
+++ b/client/dashboard/src/pages/catalog/remotes.test.ts
@@ -8,6 +8,7 @@ import {
   collectibleHeaders,
   dedupeRemotesByUrl,
   filterToHttpRemotes,
+  getRemoteDisplayInfo,
   isFigmaCatalogServer,
   normalizeRemoteUrl,
 } from "./remotes";
@@ -236,5 +237,42 @@ describe("catalogHeadersForRemoteUrl", () => {
         "https://other.example/mcp",
       ),
     ).toEqual([]);
+  });
+});
+
+describe("getRemoteDisplayInfo", () => {
+  it("uses friendly names for Salesforce hosted MCP endpoints", () => {
+    expect(
+      getRemoteDisplayInfo(
+        "https://api.salesforce.com/platform/mcp/v1/platform/sobject-all",
+      ),
+    ).toEqual({
+      name: "SObject All",
+      description: "Full CRUD access to all Salesforce objects",
+    });
+    expect(
+      getRemoteDisplayInfo(
+        "https://api.salesforce.com/platform/mcp/v1/sandbox/platform/flows",
+      ),
+    ).toEqual({
+      name: "Flows",
+      description: "Lightning Flows exposed as MCP tools",
+    });
+    expect(
+      getRemoteDisplayInfo(
+        "https://api.salesforce.com/platform/mcp/v1/platform/api-catalog",
+      ),
+    ).toEqual({
+      name: "API Catalog",
+      description: "REST endpoints published as custom MCP tools",
+    });
+    expect(
+      getRemoteDisplayInfo(
+        "https://api.salesforce.com/platform/mcp/v1/platform/data-360",
+      ),
+    ).toEqual({
+      name: "Data 360",
+      description: "Unified Data Cloud queries",
+    });
   });
 });

--- a/client/dashboard/src/pages/catalog/remotes.ts
+++ b/client/dashboard/src/pages/catalog/remotes.ts
@@ -170,6 +170,26 @@ const REMOTE_DISPLAY_INFO: Record<
     name: "SObject Deletes",
     description: "Delete Salesforce records",
   },
+  flows: {
+    name: "Flows",
+    description: "Lightning Flows exposed as MCP tools",
+  },
+  "api-catalog": {
+    name: "API Catalog",
+    description: "REST endpoints published as custom MCP tools",
+  },
+  "custom-servers": {
+    name: "Custom Servers",
+    description: "Org-built MCP servers and custom tools",
+  },
+  "prompt-builder": {
+    name: "Prompt Builder",
+    description: "Prompt templates exposed as MCP resources",
+  },
+  "data-360": {
+    name: "Data 360",
+    description: "Unified Data Cloud queries",
+  },
   "invocable-actions": {
     name: "Invocable Actions",
     description: "Execute Flows, Apex actions, and quick actions",

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -181,12 +181,14 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 	}
 
 	// Preserve the existing public cap until cursor pagination is upgraded.
-	if len(servers) > 100 {
+	// Pinned official remotes (e.g. Salesforce) stay in the window even when
+	// they sort past the cap.
+	if len(servers) > catalogListCap {
 		s.logger.WarnContext(ctx, "catalog result truncated to cap",
 			attr.SlogStatsMCPServerCount(len(servers)),
-			attr.SlogPaginationLimit(100),
+			attr.SlogPaginationLimit(catalogListCap),
 		)
-		servers = servers[:100]
+		servers = capCatalogServers(servers, catalogListCap)
 	}
 	return &gen.ListCatalogResult{Servers: servers, NextCursor: nil}, nil
 }

--- a/server/internal/externalmcp/pinned.go
+++ b/server/internal/externalmcp/pinned.go
@@ -1,0 +1,126 @@
+package externalmcp
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+const (
+	pulseCatalogHost = "api.pulsemcp.com"
+	catalogListCap   = 100
+)
+
+// pinnedRegistrySpecifiers are always merged into a Pulse catalogue listing
+// even when they fall outside the page-bound crawl. Newly launched official
+// remotes often rank below the ~100-server cap; pinning keeps them installable
+// from the dashboard without waiting on popularity.
+var pinnedRegistrySpecifiers = []string{
+	"com.pulsemcp.mirror/salesforce-platform",
+}
+
+func pinnedSpecifierSet() map[string]struct{} {
+	set := make(map[string]struct{}, len(pinnedRegistrySpecifiers))
+	for _, specifier := range pinnedRegistrySpecifiers {
+		set[specifier] = struct{}{}
+	}
+	return set
+}
+
+func isPulseCatalogRegistry(rawURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Hostname(), pulseCatalogHost)
+}
+
+func isPinnedRegistrySpecifier(specifier string) bool {
+	_, ok := pinnedSpecifierSet()[specifier]
+	return ok
+}
+
+// mergePinnedServers appends any missing pinned specifiers fetched by fetch.
+// A fetch error leaves that specifier out; the rest of the catalogue is
+// unchanged. fetch is not called for specifiers already present.
+func mergePinnedServers(existing []*types.ExternalMCPServerEntry, fetch func(specifier string) (*types.ExternalMCPServerEntry, error)) []*types.ExternalMCPServerEntry {
+	present := make(map[string]struct{}, len(existing))
+	for _, server := range existing {
+		if server == nil {
+			continue
+		}
+		present[server.RegistrySpecifier] = struct{}{}
+	}
+
+	out := existing
+	for _, specifier := range pinnedRegistrySpecifiers {
+		if _, ok := present[specifier]; ok {
+			continue
+		}
+		entry, err := fetch(specifier)
+		if err != nil || entry == nil || entry.RegistrySpecifier != specifier {
+			continue
+		}
+		out = append(out, entry)
+		present[specifier] = struct{}{}
+	}
+	return out
+}
+
+// capCatalogServers trims a sorted catalogue to limit while keeping every
+// pinned specifier that the listing actually contains. Pinned overflow
+// displaces trailing non-pinned entries so a newly launched official remote
+// cannot fall off the public cap.
+func capCatalogServers(servers []*types.ExternalMCPServerEntry, limit int) []*types.ExternalMCPServerEntry {
+	if limit <= 0 || len(servers) <= limit {
+		return servers
+	}
+
+	pinned := pinnedSpecifierSet()
+	overflow := 0
+	for _, server := range servers[limit:] {
+		if server != nil {
+			if _, ok := pinned[server.RegistrySpecifier]; ok {
+				overflow++
+			}
+		}
+	}
+	if overflow == 0 {
+		return servers[:limit]
+	}
+
+	window := servers[:limit]
+	dropIdx := make(map[int]struct{}, overflow)
+	dropped := 0
+	for i := len(window) - 1; i >= 0 && dropped < overflow; i-- {
+		if window[i] == nil {
+			continue
+		}
+		if _, ok := pinned[window[i].RegistrySpecifier]; ok {
+			continue
+		}
+		dropIdx[i] = struct{}{}
+		dropped++
+	}
+
+	kept := make([]*types.ExternalMCPServerEntry, 0, limit)
+	for i, server := range window {
+		if _, ok := dropIdx[i]; ok {
+			continue
+		}
+		kept = append(kept, server)
+	}
+	for _, server := range servers[limit:] {
+		if server == nil {
+			continue
+		}
+		if _, ok := pinned[server.RegistrySpecifier]; ok {
+			kept = append(kept, server)
+		}
+	}
+	if len(kept) > limit {
+		return kept[:limit]
+	}
+	return kept
+}

--- a/server/internal/externalmcp/pinned_test.go
+++ b/server/internal/externalmcp/pinned_test.go
@@ -1,0 +1,132 @@
+package externalmcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+func TestIsPulseCatalogRegistry(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isPulseCatalogRegistry("https://api.pulsemcp.com"))
+	require.True(t, isPulseCatalogRegistry("https://api.pulsemcp.com/"))
+	require.False(t, isPulseCatalogRegistry("https://api.pulsemcp.com.evil.test"))
+	require.False(t, isPulseCatalogRegistry("http://127.0.0.1:9"))
+	require.False(t, isPulseCatalogRegistry("not a url"))
+}
+
+func TestMergePinnedServersAddsMissingSpecifier(t *testing.T) {
+	t.Parallel()
+
+	existing := []*types.ExternalMCPServerEntry{
+		listEntry("com.pulsemcp.mirror/github"),
+	}
+	fetched := 0
+	result := mergePinnedServers(existing, func(specifier string) (*types.ExternalMCPServerEntry, error) {
+		fetched++
+		return listEntry(specifier), nil
+	})
+
+	require.Equal(t, 1, fetched)
+	require.Equal(t, []string{
+		"com.pulsemcp.mirror/github",
+		"com.pulsemcp.mirror/salesforce-platform",
+	}, registrySpecifiers(result))
+}
+
+func TestMergePinnedServersSkipsSpecifierAlreadyPresent(t *testing.T) {
+	t.Parallel()
+
+	existing := []*types.ExternalMCPServerEntry{
+		listEntry("com.pulsemcp.mirror/salesforce-platform"),
+	}
+	result := mergePinnedServers(existing, func(string) (*types.ExternalMCPServerEntry, error) {
+		t.Fatal("fetch must not run when the pin is already listed")
+		return nil, nil
+	})
+
+	require.Equal(t, existing, result)
+}
+
+func TestMergePinnedServersIgnoresFetchErrors(t *testing.T) {
+	t.Parallel()
+
+	existing := []*types.ExternalMCPServerEntry{
+		listEntry("com.pulsemcp.mirror/github"),
+	}
+	result := mergePinnedServers(existing, func(string) (*types.ExternalMCPServerEntry, error) {
+		return nil, fmt.Errorf("registry unavailable")
+	})
+
+	require.Equal(t, existing, result)
+}
+
+func TestMergePinnedServersIgnoresMismatchedSpecifier(t *testing.T) {
+	t.Parallel()
+
+	existing := []*types.ExternalMCPServerEntry{
+		listEntry("com.pulsemcp.mirror/github"),
+	}
+	result := mergePinnedServers(existing, func(string) (*types.ExternalMCPServerEntry, error) {
+		return listEntry("com.pulsemcp.mirror/someone-else"), nil
+	})
+
+	require.Equal(t, existing, result)
+}
+
+func TestCapCatalogServersPreservesPinnedOverflow(t *testing.T) {
+	t.Parallel()
+
+	servers := make([]*types.ExternalMCPServerEntry, 0, catalogListCap+1)
+	for i := range catalogListCap {
+		servers = append(servers, listEntry(fmt.Sprintf("com.pulsemcp.mirror/server-%02d", i)))
+	}
+	servers = append(servers, listEntry("com.pulsemcp.mirror/salesforce-platform"))
+
+	capped := capCatalogServers(servers, catalogListCap)
+	require.Len(t, capped, catalogListCap)
+	require.Contains(t, registrySpecifiers(capped), "com.pulsemcp.mirror/salesforce-platform")
+	require.NotContains(t, registrySpecifiers(capped), "com.pulsemcp.mirror/server-99")
+}
+
+func TestCapCatalogServersLeavesShortListsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	servers := []*types.ExternalMCPServerEntry{
+		listEntry("com.pulsemcp.mirror/github"),
+		listEntry("com.pulsemcp.mirror/salesforce-platform"),
+	}
+	require.Equal(t, servers, capCatalogServers(servers, catalogListCap))
+}
+
+func TestIsPinnedRegistrySpecifier(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isPinnedRegistrySpecifier("com.pulsemcp.mirror/salesforce-platform"))
+	require.False(t, isPinnedRegistrySpecifier("com.pulsemcp.mirror/github"))
+}
+
+func listEntry(specifier string) *types.ExternalMCPServerEntry {
+	return &types.ExternalMCPServerEntry{
+		RegistrySpecifier:                   specifier,
+		Version:                             "1.0.0",
+		Description:                         specifier,
+		ToolsetID:                           nil,
+		McpServerID:                         nil,
+		RegistryID:                          nil,
+		OrganizationMcpCollectionRegistryID: nil,
+		Title:                               nil,
+		IconURL:                             nil,
+		Meta:                                nil,
+		ToolCount:                           0,
+		IsReadOnly:                          false,
+		SupportsDcr:                         false,
+		Remotes:                             nil,
+		Repository:                          nil,
+		Packages:                            nil,
+	}
+}

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -127,10 +127,11 @@ func readBoundedBody(body io.Reader) ([]byte, error) {
 const (
 	registryListPageSize = 50
 	// registryListMaxPages bounds the catalog crawl to the expected catalog size
-	// (~100 servers = two pages), matching the multi-registry cap in the
-	// ListCatalog handler. If a registry returns more, fetchAllServers serves the
-	// first registryListMaxPages*registryListPageSize and logs a warning, so
-	// growth past the assumption surfaces loudly instead of truncating silently.
+	// (~100 servers = two pages), matching catalogListCap in the ListCatalog
+	// handler. If a registry returns more, fetchAllServers serves the first
+	// registryListMaxPages*registryListPageSize and logs a warning, so growth
+	// past the assumption surfaces loudly instead of truncating silently.
+	// Pinned specifiers are merged in after the crawl so they still appear.
 	registryListMaxPages = 2
 )
 
@@ -381,6 +382,7 @@ func (c *RegistryClient) ListServers(ctx context.Context, registry Registry, par
 		if err != nil {
 			return CachedListServers{}, err
 		}
+		list.Servers = c.mergePinnedPulseServers(ctx, registry, list.Servers)
 
 		// A truncated list is a partial catalog: the registry outgrew the page
 		// bound. Serve it so the page still renders, but do not freeze a partial
@@ -494,6 +496,75 @@ func (c *RegistryClient) fetchAllServers(ctx context.Context, registry Registry,
 	}
 
 	return CachedListServers{Key: cacheKey, Servers: servers}, truncated, nil
+}
+
+func (c *RegistryClient) mergePinnedPulseServers(ctx context.Context, registry Registry, servers []*types.ExternalMCPServerEntry) []*types.ExternalMCPServerEntry {
+	if c == nil || !isPulseCatalogRegistry(registry.URL) {
+		return servers
+	}
+	return mergePinnedServers(servers, func(specifier string) (*types.ExternalMCPServerEntry, error) {
+		entry, err := c.fetchServerListEntry(ctx, registry, specifier)
+		if err != nil {
+			c.logger.WarnContext(ctx, "pinned catalog server could not be fetched",
+				attr.SlogName(specifier),
+				attr.SlogMCPRegistryURL(registry.URL),
+				attr.SlogError(err),
+			)
+			return nil, err
+		}
+		return entry, nil
+	})
+}
+
+func (c *RegistryClient) fetchServerListEntry(ctx context.Context, registry Registry, serverName string) (*types.ExternalMCPServerEntry, error) {
+	parsed, err := url.Parse(strings.TrimRight(registry.URL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("parse registry url: %w", err)
+	}
+	requestURL := parsed.JoinPath("v0.1", "servers", serverName, "versions", "latest")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create pinned catalog request: %w", err)
+	}
+	if c.backend.Match(req) {
+		if err := c.backend.Authorize(req); err != nil {
+			return nil, fmt.Errorf("authorize pinned catalog request: %w", err)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch pinned catalog server: %w", err)
+	}
+	defer o11y.LogDefer(ctx, c.logger, func() error {
+		return resp.Body.Close()
+	})
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned status %d", resp.StatusCode)
+	}
+
+	body, err := readBoundedBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read pinned catalog server: %w", err)
+	}
+
+	var entry serverEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return nil, fmt.Errorf("decode pinned catalog server: %w", err)
+	}
+	if entry.Server.Name != serverName {
+		return nil, fmt.Errorf("pinned catalog server name %q does not match %q", entry.Server.Name, serverName)
+	}
+
+	converted, err := convertListServers(registry.ID, []serverEntry{entry})
+	if err != nil {
+		return nil, err
+	}
+	if len(converted) != 1 {
+		return nil, fmt.Errorf("pinned catalog server %q was not convertible", serverName)
+	}
+	return converted[0], nil
 }
 
 func (c *RegistryClient) newListServersRequest(ctx context.Context, registryURL string, cursor string) (*http.Request, error) {

--- a/server/internal/externalmcp/registryclient_test.go
+++ b/server/internal/externalmcp/registryclient_test.go
@@ -538,6 +538,79 @@ func TestListServers_DoesNotCacheTruncatedCatalog(t *testing.T) {
 	require.Equal(t, []string{"", pageOneCursor, "", pageOneCursor}, gotCursors)
 }
 
+func TestFetchServerListEntry_ConvertsDetailsPayload(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	specifier := "com.pulsemcp.mirror/salesforce-platform"
+	title := "Salesforce Platform"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.EscapedPath(), "salesforce-platform")
+		assert.Contains(t, r.URL.EscapedPath(), "versions/latest")
+		response := serverEntry{
+			Server: serverJSON{
+				Name:        specifier,
+				Description: "Hosted Salesforce MCP servers",
+				Version:     "1.0.0",
+				Title:       &title,
+				WebsiteURL:  nil,
+				Icons:       nil,
+				Remotes: []serverRemoteJSON{
+					{URL: "https://api.salesforce.com/platform/mcp/v1/platform/sobject-all", Type: "streamable-http", Headers: nil, Variables: nil},
+				},
+				Repository: nil,
+				Packages:   nil,
+			},
+			Meta: pulseMCPServerMeta{
+				Server: serverMetaServer{IsOfficial: true},
+				Version: serverMetaVersion{
+					Status:   "active",
+					IsLatest: true,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		assert.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer server.Close()
+
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, cache.NoopCache)
+	client.httpClient = server.Client()
+	registry := Registry{ID: uuid.New(), URL: server.URL}
+
+	entry, err := client.fetchServerListEntry(ctx, registry, specifier)
+	require.NoError(t, err)
+	require.Equal(t, specifier, entry.RegistrySpecifier)
+	require.Equal(t, title, *entry.Title)
+	require.Len(t, entry.Remotes, 1)
+	require.Equal(t, "https://api.salesforce.com/platform/mcp/v1/platform/sobject-all", entry.Remotes[0].URL)
+}
+
+func TestFetchServerListEntry_RejectsNameMismatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewEncoder(w).Encode(activeServerEntry("other-server")))
+	}))
+	defer server.Close()
+
+	client := NewRegistryClient(logger, tracerProvider, guardianPolicy, &PassthroughBackend{}, cache.NoopCache)
+	client.httpClient = server.Client()
+
+	_, err = client.fetchServerListEntry(ctx, Registry{ID: uuid.New(), URL: server.URL}, "com.pulsemcp.mirror/salesforce-platform")
+	require.Error(t, err)
+}
+
 func TestGetServerDetails_OnlyStreamableHTTP(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
AIM-141

## Summary

Salesforce’s official hosted MCP is in Pulse but often ranks below Gram’s ~100-server catalog crawl, so it never appears in the dashboard. This change pins `com.pulsemcp.mirror/salesforce-platform` into Pulse listings, keeps that pin inside the public cap, and adds website plus GA endpoint labels (Flows, API Catalog, Data 360, and related remotes) used when installing.

Pinned fetches are best-effort and Pulse-host only, so a registry miss does not fail the rest of the catalog.

## Motivation

The catalog crawl stops at two Pulse pages. Newly launched official remotes can sit outside that window even when they are worth listing. Pinning Salesforce makes the hosted MCP installable from the catalog without waiting on popularity or raising the global cap.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIM-141](https://linear.app/speakeasy/issue/AIM-141/feat-list-salesforce-remote-mcp-in-catalog)

<div><a href="https://cursor.com/agents/bc-af704a18-c309-47f1-b574-731d68392536?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af704a18-c309-47f1-b574-731d68392536&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Salesforce's official hosted MCP so it stays in the catalog even when popularity ranking drops it below the two-page Pulse crawl cap.

- Merges `com.pulsemcp.mirror/salesforce-platform` into Pulse-hosted listings with best-effort fetches; a registry miss leaves other catalog entries unchanged.
- Keeps pinned servers inside the existing 100-server cap by displacing trailing non-pinned entries.
- Adds `salesforce.com` website links and friendly names for the Salesforce GA endpoints (Flows, API Catalog, Data 360, Custom Servers, Prompt Builder) shown when installing.

<sup>Written for commit d273cf220236cb69941b42fc984df1b7e68bc543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

