### PR TITLE
feat: define killswitch registries and coverage contracts

### DIFF
--- a/server/internal/killswitches/canonical.go
+++ b/server/internal/killswitches/canonical.go
@@ -1,0 +1,400 @@
+package killswitches
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+const (
+	canonicalMutationEncodingV1 = "killswitch-mutation-v1"
+	maxExternalNoteRunes        = 500
+	maxInternalNoteRunes        = 4000
+
+	// noteTrimCutsetV1 is part of the V1 canonical encoding contract. Do not derive it from
+	// unicode.IsSpace or strings.TrimSpace: toolchain Unicode tables may change over time.
+	noteTrimCutsetV1 = "\t\n\r \u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000"
+)
+
+// CanonicalMutationV1 contains only client-supplied fields included in a V1 request hash.
+// Activate supplies immutable identity and the full desired mutable payload. Change and
+// reactivate supply a target, expected version, and the full desired mutable payload without
+// immutable identity. Deactivate supplies only a target and expected version. A nil ExpiresAt
+// in a desired payload explicitly means no expiry.
+type CanonicalMutationV1 struct {
+	Operation            MutationOperation
+	PrescriptionID       *PrescriptionID
+	Definition           *DefinitionKey
+	PrincipalKind        *PrincipalKind
+	PrincipalKey         *PrincipalKey
+	ResourceKind         *ResourceKind
+	ResourceScope        *ResourceScope
+	SelectedResourceKeys []ResourceKey
+	StartMode            *StartMode
+	StartsAt             *time.Time
+	ExpiresAt            *time.Time
+	ExternalNote         *string
+	InternalNote         *string
+	ExpectedVersion      *int64
+}
+
+type canonicalMutationWireV1 struct {
+	EncodingVersion      string            `json:"encoding_version"`
+	Operation            MutationOperation `json:"operation"`
+	PrescriptionID       *PrescriptionID   `json:"prescription_id"`
+	Definition           *DefinitionKey    `json:"definition_key"`
+	PrincipalKind        *PrincipalKind    `json:"principal_kind"`
+	PrincipalKey         *PrincipalKey     `json:"principal_key"`
+	ResourceKind         *ResourceKind     `json:"resource_kind"`
+	ResourceScope        *ResourceScope    `json:"resource_scope"`
+	SelectedResourceKeys []ResourceKey     `json:"selected_resource_keys"`
+	StartMode            *StartMode        `json:"start_mode"`
+	StartsAt             *string           `json:"starts_at"`
+	ExpiresAt            *string           `json:"expires_at"`
+	ExternalNote         *string           `json:"external_note"`
+	InternalNote         *string           `json:"internal_note"`
+	ExpectedVersion      *int64            `json:"expected_version"`
+}
+
+// NormalizeExternalNote trims and validates a present external note.
+func NormalizeExternalNote(note string) (string, error) {
+	return normalizeNote(note, maxExternalNoteRunes)
+}
+
+// NormalizeInternalNote trims and validates a present internal note.
+func NormalizeInternalNote(note string) (string, error) {
+	return normalizeNote(note, maxInternalNoteRunes)
+}
+
+func normalizeNote(note string, limit int) (string, error) {
+	if !utf8.ValidString(note) {
+		return "", fmt.Errorf("must be valid UTF-8")
+	}
+	for _, r := range note {
+		if isDisallowedNoteControl(r) {
+			return "", fmt.Errorf("contains a disallowed control character U+%04X", r)
+		}
+	}
+	normalized := strings.Trim(note, noteTrimCutsetV1)
+	length := utf8.RuneCountInString(normalized)
+	if length == 0 {
+		return "", fmt.Errorf("must not be empty")
+	}
+	if length > limit {
+		return "", fmt.Errorf("must be at most %d characters", limit)
+	}
+	return normalized, nil
+}
+
+func isDisallowedNoteControl(r rune) bool {
+	if r == '\t' || r == '\n' || r == '\r' {
+		return false
+	}
+	return r <= '\x1f' || (r >= '\x7f' && r <= '\x9f')
+}
+
+func canonicalMutationJSONV1(input CanonicalMutationV1) ([]byte, error) {
+	wire, err := canonicalizeMutationV1(input)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical mutation V1: %w", err)
+	}
+	return encoded, nil
+}
+
+// CanonicalMutationHashV1 returns the SHA-256 digest of the canonical V1 request fields as
+// sha256 followed by a colon and 64 lowercase hexadecimal characters.
+func CanonicalMutationHashV1(input CanonicalMutationV1) (string, error) {
+	encoded, err := canonicalMutationJSONV1(input)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
+func canonicalizeMutationV1(input CanonicalMutationV1) (canonicalMutationWireV1, error) {
+	if !validMutationOperation(input.Operation) {
+		return canonicalMutationWireV1{}, fmt.Errorf("invalid mutation operation %q", input.Operation)
+	}
+
+	switch input.Operation {
+	case MutationOperationActivate:
+		if input.PrescriptionID != nil {
+			return canonicalMutationWireV1{}, fmt.Errorf("activate must not target a prescription ID")
+		}
+		if input.ExpectedVersion != nil {
+			return canonicalMutationWireV1{}, fmt.Errorf("activate must not include an expected version")
+		}
+		if err := validateActivationIdentity(input); err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+		if err := validateDesiredMutablePayload(input); err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+	case MutationOperationChange, MutationOperationReactivate:
+		if err := validateExistingTarget(input); err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+		if hasImmutableIdentity(input) {
+			return canonicalMutationWireV1{}, fmt.Errorf("%s must not include immutable identity fields", input.Operation)
+		}
+		if err := validateDesiredMutablePayload(input); err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+	case MutationOperationDeactivate:
+		if err := validateExistingTarget(input); err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+		if hasNonTargetFields(input) {
+			return canonicalMutationWireV1{}, fmt.Errorf("deactivate must not include fields other than target and expected version")
+		}
+		prescriptionID, err := canonicalPrescriptionID(input.PrescriptionID)
+		if err != nil {
+			return canonicalMutationWireV1{}, err
+		}
+		return canonicalMutationWireV1{
+			EncodingVersion:      canonicalMutationEncodingV1,
+			Operation:            input.Operation,
+			PrescriptionID:       prescriptionID,
+			Definition:           nil,
+			PrincipalKind:        nil,
+			PrincipalKey:         nil,
+			ResourceKind:         nil,
+			ResourceScope:        nil,
+			SelectedResourceKeys: []ResourceKey{},
+			StartMode:            nil,
+			StartsAt:             nil,
+			ExpiresAt:            nil,
+			ExternalNote:         nil,
+			InternalNote:         nil,
+			ExpectedVersion:      input.ExpectedVersion,
+		}, nil
+	}
+
+	if err := validateOptionalIdentifier("definition key", input.Definition); err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	if err := validateOptionalIdentifier("principal kind", input.PrincipalKind); err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	if err := validateOptionalIdentifier("principal key", input.PrincipalKey); err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	if err := validateOptionalIdentifier("resource kind", input.ResourceKind); err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+
+	prescriptionID, err := canonicalPrescriptionID(input.PrescriptionID)
+	if err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	selected, err := canonicalSelectedResources(input.ResourceScope, input.SelectedResourceKeys)
+	if err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	startsAt, err := canonicalStart(input.StartMode, input.StartsAt)
+	if err != nil {
+		return canonicalMutationWireV1{}, err
+	}
+	if input.StartsAt != nil && input.ExpiresAt != nil && !input.StartsAt.Before(*input.ExpiresAt) {
+		return canonicalMutationWireV1{}, fmt.Errorf("expires at must be after starts at")
+	}
+
+	var expiresAt *string
+	if input.ExpiresAt != nil {
+		value := input.ExpiresAt.UTC().Format(time.RFC3339Nano)
+		expiresAt = &value
+	}
+	externalNote, err := normalizeOptionalNote(input.ExternalNote, NormalizeExternalNote)
+	if err != nil {
+		return canonicalMutationWireV1{}, fmt.Errorf("external note: %w", err)
+	}
+	internalNote, err := normalizeOptionalNote(input.InternalNote, NormalizeInternalNote)
+	if err != nil {
+		return canonicalMutationWireV1{}, fmt.Errorf("internal note: %w", err)
+	}
+
+	return canonicalMutationWireV1{
+		EncodingVersion:      canonicalMutationEncodingV1,
+		Operation:            input.Operation,
+		PrescriptionID:       prescriptionID,
+		Definition:           input.Definition,
+		PrincipalKind:        input.PrincipalKind,
+		PrincipalKey:         input.PrincipalKey,
+		ResourceKind:         input.ResourceKind,
+		ResourceScope:        input.ResourceScope,
+		SelectedResourceKeys: selected,
+		StartMode:            input.StartMode,
+		StartsAt:             startsAt,
+		ExpiresAt:            expiresAt,
+		ExternalNote:         externalNote,
+		InternalNote:         internalNote,
+		ExpectedVersion:      input.ExpectedVersion,
+	}, nil
+}
+
+func validateActivationIdentity(input CanonicalMutationV1) error {
+	if input.Definition == nil {
+		return fmt.Errorf("activate requires a definition key")
+	}
+	if input.PrincipalKind == nil {
+		return fmt.Errorf("activate requires a principal kind")
+	}
+	if input.PrincipalKey == nil {
+		return fmt.Errorf("activate requires a principal key")
+	}
+	if input.ResourceKind == nil {
+		return fmt.Errorf("activate requires a resource kind")
+	}
+	return nil
+}
+
+func validateDesiredMutablePayload(input CanonicalMutationV1) error {
+	if input.ResourceScope == nil {
+		return fmt.Errorf("%s requires a resource scope", input.Operation)
+	}
+	if input.StartMode == nil {
+		return fmt.Errorf("%s requires a start mode", input.Operation)
+	}
+	if input.ExternalNote == nil {
+		return fmt.Errorf("%s requires an external note", input.Operation)
+	}
+	if input.InternalNote == nil {
+		return fmt.Errorf("%s requires an internal note", input.Operation)
+	}
+	return nil
+}
+
+func validateExistingTarget(input CanonicalMutationV1) error {
+	if input.PrescriptionID == nil {
+		return fmt.Errorf("%s requires a target prescription ID", input.Operation)
+	}
+	if input.ExpectedVersion == nil {
+		return fmt.Errorf("%s requires an expected version", input.Operation)
+	}
+	if *input.ExpectedVersion < 1 {
+		return fmt.Errorf("expected version must be positive")
+	}
+	return nil
+}
+
+func hasImmutableIdentity(input CanonicalMutationV1) bool {
+	return input.Definition != nil || input.PrincipalKind != nil || input.PrincipalKey != nil || input.ResourceKind != nil
+}
+
+func hasNonTargetFields(input CanonicalMutationV1) bool {
+	return input.Definition != nil ||
+		input.PrincipalKind != nil ||
+		input.PrincipalKey != nil ||
+		input.ResourceKind != nil ||
+		input.ResourceScope != nil ||
+		len(input.SelectedResourceKeys) != 0 ||
+		input.StartMode != nil ||
+		input.StartsAt != nil ||
+		input.ExpiresAt != nil ||
+		input.ExternalNote != nil ||
+		input.InternalNote != nil
+}
+
+func validateOptionalIdentifier[T ~string](label string, value *T) error {
+	if value == nil {
+		return nil
+	}
+	return validateIdentifier(label, string(*value))
+}
+
+func canonicalSelectedResources(scope *ResourceScope, keys []ResourceKey) ([]ResourceKey, error) {
+	selected := slices.Clone(keys)
+	for _, key := range selected {
+		if err := validateIdentifier("selected resource key", string(key)); err != nil {
+			return nil, err
+		}
+	}
+	slices.Sort(selected)
+	selected = slices.Compact(selected)
+	if selected == nil {
+		selected = []ResourceKey{}
+	}
+
+	if scope == nil {
+		if len(selected) != 0 {
+			return nil, fmt.Errorf("selected resource keys require a resource scope")
+		}
+		return selected, nil
+	}
+	switch *scope {
+	case ResourceScopeAll:
+		if len(selected) != 0 {
+			return nil, fmt.Errorf("all resource scope must not include selected resource keys")
+		}
+	case ResourceScopeSelected:
+		if len(selected) == 0 {
+			return nil, fmt.Errorf("selected resource scope requires at least one resource key")
+		}
+	default:
+		return nil, fmt.Errorf("invalid resource scope %q", *scope)
+	}
+	return selected, nil
+}
+
+func canonicalStart(mode *StartMode, startsAt *time.Time) (*string, error) {
+	if mode == nil {
+		if startsAt != nil {
+			return nil, fmt.Errorf("start time requires a start mode")
+		}
+		return nil, nil
+	}
+	switch *mode {
+	case StartModeNow:
+		if startsAt != nil {
+			return nil, fmt.Errorf("now start mode requires a null start time")
+		}
+		return nil, nil
+	case StartModeAt:
+		if startsAt == nil {
+			return nil, fmt.Errorf("at start mode requires a start time")
+		}
+		value := startsAt.UTC().Format(time.RFC3339Nano)
+		return &value, nil
+	default:
+		return nil, fmt.Errorf("invalid start mode %q", *mode)
+	}
+}
+
+func normalizeOptionalNote(note *string, normalize func(string) (string, error)) (*string, error) {
+	if note == nil {
+		return nil, nil
+	}
+	value, err := normalize(*note)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func canonicalPrescriptionID(value *PrescriptionID) (*PrescriptionID, error) {
+	if value == nil {
+		return nil, nil
+	}
+	parsed, err := uuid.Parse(string(*value))
+	if err != nil {
+		return nil, fmt.Errorf("prescription ID must be a UUID: %w", err)
+	}
+	canonical := PrescriptionID(parsed.String())
+	return &canonical, nil
+}
+
+func validMutationOperation(operation MutationOperation) bool {
+	return operation == MutationOperationActivate || operation == MutationOperationChange || operation == MutationOperationDeactivate || operation == MutationOperationReactivate
+}

--- a/server/internal/killswitches/canonical_test.go
+++ b/server/internal/killswitches/canonical_test.go
@@ -1,0 +1,399 @@
+package killswitches
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testPrescriptionID PrescriptionID = "018f1e78-7c4a-7b2c-9d3e-123456789abc"
+
+func TestNormalizeNotes(t *testing.T) {
+	t.Parallel()
+
+	invalidUTF8 := string([]byte{0xff})
+	tests := []struct {
+		name      string
+		normalize func(string) (string, error)
+		input     string
+		want      string
+		wantError bool
+	}{
+		{name: "external trims unicode whitespace", normalize: NormalizeExternalNote, input: "\u2003  paused\t \u2003", want: "paused"},
+		{name: "internal preserves whitespace and line endings", normalize: NormalizeInternalNote, input: "  first  line\r\nsecond\tline  ", want: "first  line\r\nsecond\tline"},
+		{name: "multibyte rune limit", normalize: NormalizeExternalNote, input: strings.Repeat("界", maxExternalNoteRunes), want: strings.Repeat("界", maxExternalNoteRunes)},
+		{name: "external over rune limit", normalize: NormalizeExternalNote, input: strings.Repeat("界", maxExternalNoteRunes+1), wantError: true},
+		{name: "internal boundary", normalize: NormalizeInternalNote, input: strings.Repeat("a", maxInternalNoteRunes), want: strings.Repeat("a", maxInternalNoteRunes)},
+		{name: "internal over limit", normalize: NormalizeInternalNote, input: strings.Repeat("a", maxInternalNoteRunes+1), wantError: true},
+		{name: "empty", normalize: NormalizeExternalNote, input: " \t\r\n", wantError: true},
+		{name: "invalid UTF-8", normalize: NormalizeExternalNote, input: invalidUTF8, wantError: true},
+		{name: "tab LF CR preserved", normalize: NormalizeExternalNote, input: "a\tb\nc\rd", want: "a\tb\nc\rd"},
+		{name: "zero width space is not edge trimmed", normalize: NormalizeExternalNote, input: "\u200bnote\u200b", want: "\u200bnote\u200b"},
+		{name: "byte order mark is not edge trimmed", normalize: NormalizeExternalNote, input: "\ufeffnote\ufeff", want: "\ufeffnote\ufeff"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.normalize(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalize: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeNotesRejectsC0AndC1ControlsBeforeTrimming(t *testing.T) {
+	t.Parallel()
+
+	for _, control := range []rune{'\x00', '\x08', '\x0b', '\x0c', '\x1f', '\x7f', '\u0080', '\u0085', '\u009f'} {
+		for _, input := range []string{string(control) + "note", "note" + string(control), "a" + string(control) + "b"} {
+			t.Run(fmt.Sprintf("U+%04X/%q", control, input), func(t *testing.T) {
+				t.Parallel()
+				if _, err := NormalizeExternalNote(input); err == nil {
+					t.Fatal("expected disallowed control error")
+				}
+			})
+		}
+	}
+}
+
+func TestNormalizeNotesV1TrimSetIsFrozen(t *testing.T) {
+	t.Parallel()
+
+	const expectedTrimCutsetV1 = "\t\n\r \u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000"
+	if noteTrimCutsetV1 != expectedTrimCutsetV1 {
+		t.Fatalf("V1 trim cutset changed: %q", noteTrimCutsetV1)
+	}
+
+	seen := map[rune]struct{}{}
+	for _, trimRune := range noteTrimCutsetV1 {
+		if _, duplicate := seen[trimRune]; duplicate {
+			t.Fatalf("duplicate trim rune U+%04X", trimRune)
+		}
+		seen[trimRune] = struct{}{}
+		got, err := NormalizeExternalNote(string(trimRune) + "note" + string(trimRune))
+		if err != nil {
+			t.Fatalf("trim U+%04X: %v", trimRune, err)
+		}
+		if got != "note" {
+			t.Fatalf("trim U+%04X got %q", trimRune, got)
+		}
+	}
+}
+
+func TestCanonicalMutationGoldenVectorsV1(t *testing.T) {
+	t.Parallel()
+
+	prescriptionID := PrescriptionID("018F1E78-7C4A-7B2C-9D3E-123456789ABC")
+	version7, version8, version9 := int64(7), int64(8), int64(9)
+	scopeSelected := ResourceScopeSelected
+	startAt := StartModeAt
+	startsAt := mustParseTime(t, "2026-03-01T05:15:30.123456789-05:00")
+	expiresAt := mustParseTime(t, "2026-03-02T12:16:31+01:00")
+	updatedExternal, updatedInternal := "  Updated. ", ` change
+request `
+	reactivationExternal, reactivationInternal := " Paused — contact support. ", " operator request "
+	unicodeNotes := baseActivationV1()
+	unicodeExternal, unicodeInternal := "\u3000暂停 — contactez-nous.\u00a0", "\u2003操作\tone\n二\rtres\u202f"
+	unicodeNotes.ExternalNote, unicodeNotes.InternalNote = &unicodeExternal, &unicodeInternal
+
+	change := baseExistingMutationV1(MutationOperationChange)
+	change.PrescriptionID, change.ExpectedVersion = &prescriptionID, &version7
+	change.ResourceScope = &scopeSelected
+	change.SelectedResourceKeys = []ResourceKey{"tool:b", "tool:a", "tool:b"}
+	change.StartMode, change.StartsAt = &startAt, &startsAt
+	change.ExternalNote, change.InternalNote = &updatedExternal, &updatedInternal
+
+	reactivate := baseExistingMutationV1(MutationOperationReactivate)
+	reactivate.PrescriptionID, reactivate.ExpectedVersion = &prescriptionID, &version9
+	reactivate.ExpiresAt = &expiresAt
+	reactivate.ExternalNote, reactivate.InternalNote = &reactivationExternal, &reactivationInternal
+
+	tests := []struct {
+		name     string
+		input    CanonicalMutationV1
+		wantJSON string
+		wantHash string
+	}{
+		{
+			name: "activate", input: baseActivationV1(),
+			wantJSON: `{"encoding_version":"killswitch-mutation-v1","operation":"activate","prescription_id":null,"definition_key":"block-tools","principal_kind":"user","principal_key":"user:alpha","resource_kind":"tool","resource_scope":"all","selected_resource_keys":[],"start_mode":"now","starts_at":null,"expires_at":null,"external_note":"Access paused.","internal_note":"operator request","expected_version":null}`,
+			wantHash: "sha256:9de637b150d7167da07ad87867cba5ae64ec13d5ad97703ef0c808c39b05409d",
+		},
+		{
+			name: "activate frozen unicode notes", input: unicodeNotes,
+			wantJSON: `{"encoding_version":"killswitch-mutation-v1","operation":"activate","prescription_id":null,"definition_key":"block-tools","principal_kind":"user","principal_key":"user:alpha","resource_kind":"tool","resource_scope":"all","selected_resource_keys":[],"start_mode":"now","starts_at":null,"expires_at":null,"external_note":"暂停 — contactez-nous.","internal_note":"操作\tone\n二\rtres","expected_version":null}`,
+			wantHash: "sha256:fb4bf0dd3c466d203eff38f3e4994dd4c83bbf3a4ed0077c034b0ca5e9e5a552",
+		},
+		{
+			name: "change", input: change,
+			wantJSON: `{"encoding_version":"killswitch-mutation-v1","operation":"change","prescription_id":"018f1e78-7c4a-7b2c-9d3e-123456789abc","definition_key":null,"principal_kind":null,"principal_key":null,"resource_kind":null,"resource_scope":"selected","selected_resource_keys":["tool:a","tool:b"],"start_mode":"at","starts_at":"2026-03-01T10:15:30.123456789Z","expires_at":null,"external_note":"Updated.","internal_note":"change\nrequest","expected_version":7}`,
+			wantHash: "sha256:94311b264e32116085420ef8f86816499a2d1f36c79f2ea73ea72215de14aa0d",
+		},
+		{
+			name: "deactivate", input: CanonicalMutationV1{Operation: MutationOperationDeactivate, PrescriptionID: &prescriptionID, ExpectedVersion: &version8},
+			wantJSON: `{"encoding_version":"killswitch-mutation-v1","operation":"deactivate","prescription_id":"018f1e78-7c4a-7b2c-9d3e-123456789abc","definition_key":null,"principal_kind":null,"principal_key":null,"resource_kind":null,"resource_scope":null,"selected_resource_keys":[],"start_mode":null,"starts_at":null,"expires_at":null,"external_note":null,"internal_note":null,"expected_version":8}`,
+			wantHash: "sha256:784adf9cee2d4140fba610a8bec3d886cdf133c59e7b5feb15891ca96e8a3222",
+		},
+		{
+			name: "reactivate", input: reactivate,
+			wantJSON: `{"encoding_version":"killswitch-mutation-v1","operation":"reactivate","prescription_id":"018f1e78-7c4a-7b2c-9d3e-123456789abc","definition_key":null,"principal_kind":null,"principal_key":null,"resource_kind":null,"resource_scope":"all","selected_resource_keys":[],"start_mode":"now","starts_at":null,"expires_at":"2026-03-02T11:16:31Z","external_note":"Paused — contact support.","internal_note":"operator request","expected_version":9}`,
+			wantHash: "sha256:7ddc06a135715966424f1da565546157301a42fe5e46c264a5452361dcfa4732",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, err := canonicalMutationJSONV1(tt.input)
+			if err != nil {
+				t.Fatalf("canonical JSON V1: %v", err)
+			}
+			if string(encoded) != tt.wantJSON {
+				t.Fatalf("canonical JSON mismatch\n got: %s\nwant: %s", encoded, tt.wantJSON)
+			}
+			hash, err := CanonicalMutationHashV1(tt.input)
+			if err != nil {
+				t.Fatalf("canonical hash V1: %v", err)
+			}
+			if hash != tt.wantHash {
+				t.Fatalf("hash got %q, want %q", hash, tt.wantHash)
+			}
+		})
+	}
+}
+
+func TestCanonicalMutationExistingOperationsRequireRequestPayloadWithoutStoredIdentityV1(t *testing.T) {
+	t.Parallel()
+
+	for _, operation := range []MutationOperation{MutationOperationChange, MutationOperationReactivate} {
+		t.Run(string(operation), func(t *testing.T) {
+			t.Parallel()
+			input := baseExistingMutationV1(operation)
+			targetOnly := CanonicalMutationV1{Operation: operation, PrescriptionID: input.PrescriptionID, ExpectedVersion: input.ExpectedVersion}
+			if _, err := canonicalMutationJSONV1(targetOnly); err == nil {
+				t.Fatal("target and expected version accepted without full desired payload")
+			}
+		})
+	}
+}
+
+func TestCanonicalMutationEquivalenceAndPreservationV1(t *testing.T) {
+	t.Parallel()
+
+	scope := ResourceScopeSelected
+	mode := StartModeAt
+	noteA, noteB := "\u2003Access paused. ", "Access paused."
+	internalCRLF, internalLF := "one\r\ntwo", "one\ntwo"
+	composed, decomposed := "café", "cafe\u0301"
+	timeA := mustParseTime(t, "2026-03-01T10:15:30Z")
+	timeB := mustParseTime(t, "2026-03-01T05:15:30-05:00")
+
+	first := baseExistingMutationV1(MutationOperationChange)
+	first.ResourceScope = &scope
+	first.SelectedResourceKeys = []ResourceKey{"tool:b", "tool:a", "tool:b"}
+	first.StartMode, first.StartsAt, first.ExternalNote = &mode, &timeA, &noteA
+	second := first
+	second.SelectedResourceKeys = []ResourceKey{"tool:a", "tool:b"}
+	second.StartsAt, second.ExternalNote = &timeB, &noteB
+	assertSameHashV1(t, first, second)
+
+	first.InternalNote, second.InternalNote = &internalCRLF, &internalLF
+	assertDifferentHashV1(t, first, second, "line endings must be preserved")
+
+	first.InternalNote, second.InternalNote = new("operator request"), new("operator request")
+	first.ExternalNote, second.ExternalNote = &composed, &decomposed
+	assertDifferentHashV1(t, first, second, "Unicode normalization must not be applied")
+
+	originalKeys := []ResourceKey{"tool:b", "tool:a", "tool:b"}
+	first.SelectedResourceKeys = originalKeys
+	if _, err := canonicalMutationJSONV1(first); err != nil {
+		t.Fatalf("canonical JSON V1: %v", err)
+	}
+	if strings.Join([]string{string(originalKeys[0]), string(originalKeys[1]), string(originalKeys[2])}, ",") != "tool:b,tool:a,tool:b" {
+		t.Fatal("canonicalization mutated caller-owned resource keys")
+	}
+}
+
+func TestCanonicalMutationValidationV1(t *testing.T) {
+	t.Parallel()
+
+	now := mustParseTime(t, "2026-03-01T10:00:00Z")
+	later := mustParseTime(t, "2026-03-01T11:00:00Z")
+	scopeSelected := ResourceScopeSelected
+	startAt := StartModeAt
+
+	tests := []struct {
+		name   string
+		base   func() CanonicalMutationV1
+		mutate func(*CanonicalMutationV1)
+	}{
+		{name: "unknown operation", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.Operation = "unknown" }},
+		{name: "activate target", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.PrescriptionID = new(testPrescriptionID) }},
+		{name: "activate expected version", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.ExpectedVersion = new(int64(1)) }},
+		{name: "activate missing definition", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.Definition = nil }},
+		{name: "activate missing principal kind", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.PrincipalKind = nil }},
+		{name: "activate missing principal key", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.PrincipalKey = nil }},
+		{name: "activate missing resource kind", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.ResourceKind = nil }},
+		{name: "activate missing scope", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.ResourceScope = nil }},
+		{name: "activate missing start mode", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = nil }},
+		{name: "activate missing external note", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.ExternalNote = nil }},
+		{name: "activate missing internal note", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.InternalNote = nil }},
+		{name: "activate blank definition", base: baseActivationV1, mutate: func(m *CanonicalMutationV1) { m.Definition = new(DefinitionKey(" ")) }},
+		{name: "change missing target", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.PrescriptionID = nil }},
+		{name: "change invalid target UUID", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.PrescriptionID = new(PrescriptionID("not-a-uuid")) }},
+		{name: "change missing expected version", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ExpectedVersion = nil }},
+		{name: "change nonpositive expected version", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ExpectedVersion = new(int64(0)) }},
+		{name: "change definition", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.Definition = new(DefinitionKey("block-tools")) }},
+		{name: "change principal kind", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.PrincipalKind = new(PrincipalKind("user")) }},
+		{name: "change principal key", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.PrincipalKey = new(PrincipalKey("user:alpha")) }},
+		{name: "change resource kind", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ResourceKind = new(ResourceKind("tool")) }},
+		{name: "change missing scope", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ResourceScope = nil }},
+		{name: "change invalid scope", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ResourceScope = new(ResourceScope("invalid")) }},
+		{name: "all scope with selected keys", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.SelectedResourceKeys = []ResourceKey{"tool:a"} }},
+		{name: "selected scope without keys", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ResourceScope = &scopeSelected }},
+		{name: "blank selected resource key", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) {
+			m.ResourceScope = &scopeSelected
+			m.SelectedResourceKeys = []ResourceKey{" "}
+		}},
+		{name: "change missing start mode", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = nil }},
+		{name: "now with timestamp", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartsAt = &now }},
+		{name: "at without timestamp", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = &startAt }},
+		{name: "invalid start mode", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = new(StartMode("later")) }},
+		{name: "expiry equal to start", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = &startAt; m.StartsAt = &now; m.ExpiresAt = &now }},
+		{name: "expiry before start", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.StartMode = &startAt; m.StartsAt = &later; m.ExpiresAt = &now }},
+		{name: "missing external note", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ExternalNote = nil }},
+		{name: "blank external note", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.ExternalNote = new(" ") }},
+		{name: "missing internal note", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.InternalNote = nil }},
+		{name: "blank internal note", base: baseChangeV1, mutate: func(m *CanonicalMutationV1) { m.InternalNote = new(" ") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := tt.base()
+			tt.mutate(&input)
+			if _, err := canonicalMutationJSONV1(input); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestDeactivateRejectsEveryOtherFieldV1(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tests := []struct {
+		name   string
+		mutate func(*CanonicalMutationV1)
+	}{
+		{name: "definition", mutate: func(m *CanonicalMutationV1) { m.Definition = new(DefinitionKey("block-tools")) }},
+		{name: "principal kind", mutate: func(m *CanonicalMutationV1) { m.PrincipalKind = new(PrincipalKind("user")) }},
+		{name: "principal key", mutate: func(m *CanonicalMutationV1) { m.PrincipalKey = new(PrincipalKey("user:alpha")) }},
+		{name: "resource kind", mutate: func(m *CanonicalMutationV1) { m.ResourceKind = new(ResourceKind("tool")) }},
+		{name: "resource scope", mutate: func(m *CanonicalMutationV1) { m.ResourceScope = new(ResourceScopeAll) }},
+		{name: "selected resources", mutate: func(m *CanonicalMutationV1) { m.SelectedResourceKeys = []ResourceKey{"tool:a"} }},
+		{name: "start mode", mutate: func(m *CanonicalMutationV1) { m.StartMode = new(StartModeNow) }},
+		{name: "starts at", mutate: func(m *CanonicalMutationV1) { m.StartsAt = &now }},
+		{name: "expires at", mutate: func(m *CanonicalMutationV1) { m.ExpiresAt = &now }},
+		{name: "external note", mutate: func(m *CanonicalMutationV1) { m.ExternalNote = new("note") }},
+		{name: "internal note", mutate: func(m *CanonicalMutationV1) { m.InternalNote = new("note") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := baseDeactivationV1()
+			tt.mutate(&input)
+			if _, err := canonicalMutationJSONV1(input); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func baseActivationV1() CanonicalMutationV1 {
+	definition := DefinitionKey("block-tools")
+	principalKind := PrincipalKind("user")
+	principalKey := PrincipalKey("user:alpha")
+	resourceKind := ResourceKind("tool")
+	scope := ResourceScopeAll
+	startMode := StartModeNow
+	external := "Access paused."
+	internal := "operator request"
+	return CanonicalMutationV1{
+		Operation: MutationOperationActivate, Definition: &definition, PrincipalKind: &principalKind, PrincipalKey: &principalKey,
+		ResourceKind: &resourceKind, ResourceScope: &scope, StartMode: &startMode, ExternalNote: &external, InternalNote: &internal,
+	}
+}
+
+func baseExistingMutationV1(operation MutationOperation) CanonicalMutationV1 {
+	input := baseDeactivationV1()
+	input.Operation = operation
+	input.ResourceScope = new(ResourceScopeAll)
+	input.StartMode = new(StartModeNow)
+	input.ExternalNote = new("Access paused.")
+	input.InternalNote = new("operator request")
+	return input
+}
+
+func baseChangeV1() CanonicalMutationV1 {
+	return baseExistingMutationV1(MutationOperationChange)
+}
+
+func baseDeactivationV1() CanonicalMutationV1 {
+	return CanonicalMutationV1{
+		Operation:       MutationOperationDeactivate,
+		PrescriptionID:  new(testPrescriptionID),
+		ExpectedVersion: new(int64(1)),
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	return parsed
+}
+
+func assertSameHashV1(t *testing.T, first, second CanonicalMutationV1) {
+	t.Helper()
+	firstHash, err := CanonicalMutationHashV1(first)
+	if err != nil {
+		t.Fatalf("first hash: %v", err)
+	}
+	secondHash, err := CanonicalMutationHashV1(second)
+	if err != nil {
+		t.Fatalf("second hash: %v", err)
+	}
+	if firstHash != secondHash {
+		t.Fatalf("hashes differ: %s != %s", firstHash, secondHash)
+	}
+}
+
+func assertDifferentHashV1(t *testing.T, first, second CanonicalMutationV1, message string) {
+	t.Helper()
+	firstHash, err := CanonicalMutationHashV1(first)
+	if err != nil {
+		t.Fatalf("first hash: %v", err)
+	}
+	secondHash, err := CanonicalMutationHashV1(second)
+	if err != nil {
+		t.Fatalf("second hash: %v", err)
+	}
+	if firstHash == secondHash {
+		t.Fatal(message)
+	}
+}

--- a/server/internal/killswitches/contracts.go
+++ b/server/internal/killswitches/contracts.go
@@ -1,0 +1,487 @@
+// Package killswitches defines dependency-light contracts for kill-switch registration,
+// identity adaptation, evaluation results, and mutation hashing.
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// DefinitionKey identifies a code-owned kill-switch definition.
+type DefinitionKey string
+
+// IdentityContractKey identifies a principal and resource identity contract.
+type IdentityContractKey string
+
+// PrincipalKind identifies a canonical principal namespace.
+type PrincipalKind string
+
+// PrincipalKey identifies a principal within a principal namespace.
+type PrincipalKey string
+
+// ResourceKind identifies a canonical resource namespace.
+type ResourceKind string
+
+// ResourceKey identifies a resource within a resource namespace.
+type ResourceKey string
+
+type canonicalizationResultState uint8
+
+const (
+	canonicalizationResultInvalid canonicalizationResultState = iota
+	canonicalizationResultSupported
+	canonicalizationResultUnsupported
+)
+
+// CanonicalizationResult is an immutable supported or deliberately unsupported
+// canonicalization result. Infrastructure failures are returned separately as errors.
+// Its zero value is invalid and is rejected by Key and registered adapter wrappers.
+type CanonicalizationResult[T ~string] struct {
+	key   T
+	state canonicalizationResultState
+}
+
+// NewCanonicalizationResult constructs a supported result with a nonempty canonical key.
+func NewCanonicalizationResult[T ~string](key T) (CanonicalizationResult[T], error) {
+	if err := validateIdentifier("canonical key", string(key)); err != nil {
+		return CanonicalizationResult[T]{}, err
+	}
+	return CanonicalizationResult[T]{key: key, state: canonicalizationResultSupported}, nil
+}
+
+// UnsupportedCanonicalizationResult reports deliberate absence of supported input.
+func UnsupportedCanonicalizationResult[T ~string]() CanonicalizationResult[T] {
+	return CanonicalizationResult[T]{key: "", state: canonicalizationResultUnsupported}
+}
+
+// Key returns a canonical key for supported input, no key for deliberately unsupported input,
+// or an error for an invalid result such as the zero value.
+func (r CanonicalizationResult[T]) Key() (T, bool, error) {
+	switch r.state {
+	case canonicalizationResultSupported:
+		return r.key, true, nil
+	case canonicalizationResultUnsupported:
+		return r.key, false, nil
+	default:
+		return r.key, false, errors.New("invalid canonicalization result")
+	}
+}
+
+// OrganizationID identifies the organization against which current references are validated.
+type OrganizationID string
+
+// PrescriptionID identifies an existing kill-switch prescription.
+type PrescriptionID string
+
+// Surface identifies an enforcement surface.
+type Surface string
+
+// TransportAdapterKey identifies a transport-specific result adapter.
+type TransportAdapterKey string
+
+// FailurePolicy controls the posture used when evaluation infrastructure fails.
+type FailurePolicy string
+
+const (
+	// FailurePolicyFailOpen permits protected work when evaluation infrastructure fails.
+	FailurePolicyFailOpen FailurePolicy = "fail_open"
+	// FailurePolicyFailClosed denies protected work when evaluation infrastructure fails.
+	FailurePolicyFailClosed FailurePolicy = "fail_closed"
+)
+
+// ResourceScope controls whether a prescription covers all resources or selected resources.
+type ResourceScope string
+
+const (
+	// ResourceScopeAll covers all resources of the declared resource kind.
+	ResourceScopeAll ResourceScope = "all"
+	// ResourceScopeSelected covers an explicit nonempty set of resource keys.
+	ResourceScopeSelected ResourceScope = "selected"
+)
+
+// MutationOperation identifies a lifecycle request in the canonical mutation contract.
+type MutationOperation string
+
+const (
+	// MutationOperationActivate creates a new active prescription.
+	MutationOperationActivate MutationOperation = "activate"
+	// MutationOperationChange changes an existing prescription.
+	MutationOperationChange MutationOperation = "change"
+	// MutationOperationDeactivate deactivates an existing prescription.
+	MutationOperationDeactivate MutationOperation = "deactivate"
+	// MutationOperationReactivate reactivates an existing prescription.
+	MutationOperationReactivate MutationOperation = "reactivate"
+)
+
+// StartMode distinguishes a stable "now" request from an explicit start instant.
+type StartMode string
+
+const (
+	// StartModeNow asks the lifecycle service to resolve the start time after replay matching.
+	StartModeNow StartMode = "now"
+	// StartModeAt supplies an explicit start instant.
+	StartModeAt StartMode = "at"
+)
+
+// Definition declares one code-owned kill-switch capability.
+type Definition struct {
+	Key                 DefinitionKey
+	PrincipalKinds      []PrincipalKind
+	ResourceKinds       []ResourceKind
+	FailurePolicy       FailurePolicy
+	DefaultExternalNote string
+	EnforcementOwner    string
+	IdentityContract    IdentityContractKey
+	Surfaces            []Surface
+	TransportAdapters   []TransportAdapterKey
+}
+
+// IdentityContract declares the principal and resource namespaces a definition may use.
+type IdentityContract struct {
+	Key            IdentityContractKey
+	PrincipalKinds []PrincipalKind
+	ResourceKinds  []ResourceKind
+}
+
+// CoverageContract inventories one definition's enforcement coverage on one surface.
+type CoverageContract struct {
+	Definition       DefinitionKey
+	Surface          Surface
+	PrincipalSource  string
+	ResourceSource   string
+	Checkpoint       string
+	ProtectedWork    string
+	FailurePolicy    FailurePolicy
+	TransportAdapter TransportAdapterKey
+	EnforcementOwner string
+	IdentityContract IdentityContractKey
+}
+
+// PrincipalCandidate is a canonical principal derived from an enforcement request.
+type PrincipalCandidate struct {
+	Kind PrincipalKind
+	Key  PrincipalKey
+}
+
+// PrincipalCandidateResultKind identifies a successful or deliberately unsupported derivation.
+type PrincipalCandidateResultKind string
+
+const (
+	// PrincipalCandidateResultCandidates indicates that one or more candidates were derived.
+	PrincipalCandidateResultCandidates PrincipalCandidateResultKind = "candidates"
+	// PrincipalCandidateResultUnsupported indicates that the source deliberately has no supported identity.
+	PrincipalCandidateResultUnsupported PrincipalCandidateResultKind = "unsupported_identity"
+)
+
+// PrincipalCandidateResult is an immutable candidate-derivation result. Adapter errors are
+// reserved for infrastructure failures and are returned separately by PrincipalAdapter.
+// Its zero value is invalid; use one of its constructors.
+type PrincipalCandidateResult struct {
+	kind       PrincipalCandidateResultKind
+	candidates []PrincipalCandidate
+}
+
+// NewPrincipalCandidateResult validates and stably deduplicates a nonempty ordered candidate set.
+// Candidate order expresses surface precedence and is preserved across principal kinds.
+func NewPrincipalCandidateResult(candidates []PrincipalCandidate) (PrincipalCandidateResult, error) {
+	if len(candidates) == 0 {
+		return PrincipalCandidateResult{}, errors.New("principal candidates must not be empty")
+	}
+
+	result := make([]PrincipalCandidate, 0, len(candidates))
+	seen := make(map[PrincipalCandidate]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if err := validateIdentifier("principal candidate kind", string(candidate.Kind)); err != nil {
+			return PrincipalCandidateResult{}, err
+		}
+		if err := validateIdentifier("principal candidate key", string(candidate.Key)); err != nil {
+			return PrincipalCandidateResult{}, err
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		result = append(result, candidate)
+	}
+
+	return PrincipalCandidateResult{kind: PrincipalCandidateResultCandidates, candidates: result}, nil
+}
+
+// UnsupportedPrincipalCandidateResult reports deliberate absence of a supported identity.
+func UnsupportedPrincipalCandidateResult() PrincipalCandidateResult {
+	return PrincipalCandidateResult{kind: PrincipalCandidateResultUnsupported, candidates: []PrincipalCandidate{}}
+}
+
+// Kind returns the candidate derivation outcome.
+func (r PrincipalCandidateResult) Kind() PrincipalCandidateResultKind { return r.kind }
+
+// Candidates returns a defensive copy of the canonical candidates.
+func (r PrincipalCandidateResult) Candidates() []PrincipalCandidate {
+	return slices.Clone(r.candidates)
+}
+
+// PrincipalAdapter defines principal canonicalization, current-organization validation,
+// and request candidate derivation. Canonicalize must be pure: it must not perform I/O.
+// DeriveCandidates accepts only authoritative context established by the enforcement surface;
+// implementations must type-check unsupported source values and must not trust caller-provided
+// identity. An unsupported result means deliberate absence of supported input; a non-nil error
+// means infrastructure failure. Current validation is intentionally separate so stored canonical
+// keys can be used without requiring a deleted principal to still exist.
+type PrincipalAdapter interface {
+	Kind() PrincipalKind
+	Canonicalize(organizationID OrganizationID, input string) (CanonicalizationResult[PrincipalKey], error)
+	ValidateCurrentOrganization(ctx context.Context, organizationID OrganizationID, key PrincipalKey) (valid bool, err error)
+	DeriveCandidates(ctx context.Context, organizationID OrganizationID, source any) (PrincipalCandidateResult, error)
+}
+
+// ResourceAdapter defines pure, organization-bound resource canonicalization separately
+// from current existence and organization validation. Derive accepts only authoritative context
+// established by the enforcement surface and must reject caller-controlled identifiers. A
+// deliberately unsupported source returns an unsupported result and nil error; failures to derive
+// an expected resource return an infrastructure error.
+type ResourceAdapter interface {
+	Kind() ResourceKind
+	Canonicalize(organizationID OrganizationID, input string) (CanonicalizationResult[ResourceKey], error)
+	ValidateCurrentOrganization(ctx context.Context, organizationID OrganizationID, key ResourceKey) (valid bool, err error)
+	Derive(ctx context.Context, organizationID OrganizationID, source any) (CanonicalizationResult[ResourceKey], error)
+}
+
+// PrincipalCanonicalizationFixture freezes one representative principal adapter call vector.
+type PrincipalCanonicalizationFixture struct {
+	OrganizationID OrganizationID
+	Input          string
+	Expected       CanonicalizationResult[PrincipalKey]
+}
+
+// PrincipalAdapterRegistration pairs an adapter with startup-validated canonicalization fixtures.
+type PrincipalAdapterRegistration struct {
+	Adapter  PrincipalAdapter
+	Fixtures []PrincipalCanonicalizationFixture
+}
+
+// ResourceCanonicalizationFixture freezes one representative resource adapter call vector.
+type ResourceCanonicalizationFixture struct {
+	OrganizationID OrganizationID
+	Input          string
+	Expected       CanonicalizationResult[ResourceKey]
+}
+
+// ResourceAdapterRegistration pairs an adapter with startup-validated canonicalization fixtures.
+type ResourceAdapterRegistration struct {
+	Adapter  ResourceAdapter
+	Fixtures []ResourceCanonicalizationFixture
+}
+
+// EvaluationResultKind identifies a transport-neutral evaluator outcome.
+type EvaluationResultKind string
+
+const (
+	// EvaluationResultMatch means a prescription matched and protected work is denied.
+	EvaluationResultMatch EvaluationResultKind = "match"
+	// EvaluationResultNoMatch means no prescription matched.
+	EvaluationResultNoMatch EvaluationResultKind = "no_match"
+	// EvaluationResultInfrastructureFailure means evaluation could not complete.
+	EvaluationResultInfrastructureFailure EvaluationResultKind = "infrastructure_failure"
+)
+
+// NoMatchReason preserves bounded internal observability without exposing denial language.
+type NoMatchReason string
+
+const (
+	// NoMatchReasonNoPrescription means evaluation completed without a matching prescription.
+	NoMatchReasonNoPrescription NoMatchReason = "no_prescription"
+	// NoMatchReasonUnsupportedIdentity means the surface deliberately lacked a supported identity.
+	NoMatchReasonUnsupportedIdentity NoMatchReason = "unsupported_identity"
+	// NoMatchReasonUnsupportedResource means the surface deliberately lacked a supported resource.
+	NoMatchReasonUnsupportedResource NoMatchReason = "unsupported_resource"
+)
+
+// EvaluationResult is an immutable transport-neutral evaluation result. Its zero value is
+// invalid; use one of its constructors.
+type EvaluationResult struct {
+	kind              EvaluationResultKind
+	prescriptionID    PrescriptionID
+	externalNote      string
+	noMatchReason     NoMatchReason
+	infrastructureErr error
+}
+
+// NewMatchResult constructs a matched result with customer-safe denial language.
+func NewMatchResult(prescriptionID PrescriptionID, externalNote string) (EvaluationResult, error) {
+	canonicalID, err := canonicalPrescriptionID(&prescriptionID)
+	if err != nil {
+		return EvaluationResult{}, fmt.Errorf("prescription ID: %w", err)
+	}
+	note, err := NormalizeExternalNote(externalNote)
+	if err != nil {
+		return EvaluationResult{}, fmt.Errorf("external note: %w", err)
+	}
+	return EvaluationResult{
+		kind:              EvaluationResultMatch,
+		prescriptionID:    *canonicalID,
+		externalNote:      note,
+		noMatchReason:     "",
+		infrastructureErr: nil,
+	}, nil
+}
+
+// NewNoMatchResult constructs a completed evaluation with no match.
+func NewNoMatchResult(reason NoMatchReason) (EvaluationResult, error) {
+	if reason != NoMatchReasonNoPrescription && reason != NoMatchReasonUnsupportedIdentity && reason != NoMatchReasonUnsupportedResource {
+		return EvaluationResult{}, fmt.Errorf("invalid no-match reason %q", reason)
+	}
+	return EvaluationResult{
+		kind:              EvaluationResultNoMatch,
+		prescriptionID:    "",
+		externalNote:      "",
+		noMatchReason:     reason,
+		infrastructureErr: nil,
+	}, nil
+}
+
+// NewInfrastructureFailureResult constructs an infrastructure failure without match metadata.
+func NewInfrastructureFailureResult(cause error) (EvaluationResult, error) {
+	if isNilInterface(cause) {
+		return EvaluationResult{}, errors.New("infrastructure failure cause is required")
+	}
+	return EvaluationResult{
+		kind:              EvaluationResultInfrastructureFailure,
+		prescriptionID:    "",
+		externalNote:      "",
+		noMatchReason:     "",
+		infrastructureErr: cause,
+	}, nil
+}
+
+// Kind returns the result discriminator.
+func (r EvaluationResult) Kind() EvaluationResultKind { return r.kind }
+
+// PrescriptionID returns matched prescription metadata only for a match.
+func (r EvaluationResult) PrescriptionID() (PrescriptionID, bool) {
+	return r.prescriptionID, r.kind == EvaluationResultMatch
+}
+
+// ExternalNote returns public denial language only for a match.
+func (r EvaluationResult) ExternalNote() (string, bool) {
+	return r.externalNote, r.kind == EvaluationResultMatch
+}
+
+// NoMatchReason returns the bounded reason only for a no-match result.
+func (r EvaluationResult) NoMatchReason() (NoMatchReason, bool) {
+	return r.noMatchReason, r.kind == EvaluationResultNoMatch
+}
+
+// InfrastructureError returns the cause only for an infrastructure failure.
+func (r EvaluationResult) InfrastructureError() error {
+	if r.kind != EvaluationResultInfrastructureFailure {
+		return nil
+	}
+	return r.infrastructureErr
+}
+
+// TransportDispositionKind identifies the neutral action selected before concrete transport mapping.
+type TransportDispositionKind string
+
+const (
+	// TransportDispositionContinue permits protected work to continue.
+	TransportDispositionContinue TransportDispositionKind = "continue"
+	// TransportDispositionMatchedDenial denies work with the matched prescription's external note.
+	TransportDispositionMatchedDenial TransportDispositionKind = "matched_denial"
+	// TransportDispositionInfrastructureRejection denies work without match language.
+	TransportDispositionInfrastructureRejection TransportDispositionKind = "infrastructure_rejection"
+)
+
+// TransportDisposition is an immutable transport-neutral action. Its zero value is invalid.
+type TransportDisposition struct {
+	kind         TransportDispositionKind
+	externalNote string
+}
+
+// NewContinueDisposition constructs a neutral continue action.
+func NewContinueDisposition() TransportDisposition {
+	return TransportDisposition{kind: TransportDispositionContinue, externalNote: ""}
+}
+
+// NewMatchedDenialDisposition constructs a denial that preserves an already-normalized external note.
+func NewMatchedDenialDisposition(externalNote string) (TransportDisposition, error) {
+	normalized, err := NormalizeExternalNote(externalNote)
+	if err != nil {
+		return TransportDisposition{}, fmt.Errorf("external note: %w", err)
+	}
+	if normalized != externalNote {
+		return TransportDisposition{}, errors.New("external note must be normalized")
+	}
+	return TransportDisposition{kind: TransportDispositionMatchedDenial, externalNote: externalNote}, nil
+}
+
+// NewInfrastructureRejectionDisposition constructs a denial with no match language.
+func NewInfrastructureRejectionDisposition() TransportDisposition {
+	return TransportDisposition{kind: TransportDispositionInfrastructureRejection, externalNote: ""}
+}
+
+// Kind returns the neutral disposition discriminator.
+func (d TransportDisposition) Kind() TransportDispositionKind { return d.kind }
+
+// ExternalNote returns public denial language only for a matched denial.
+func (d TransportDisposition) ExternalNote() (string, bool) {
+	return d.externalNote, d.kind == TransportDispositionMatchedDenial
+}
+
+// TransportAdapter consumes neutral evaluation data and failure policy. Concrete HTTP and
+// JSON-RPC mapping remains the responsibility of transport-specific packages.
+type TransportAdapter func(EvaluationResult, FailurePolicy) (TransportDisposition, error)
+
+// TransportAdapterRegistration pairs a code-owned transport key with neutral behavior.
+type TransportAdapterRegistration struct {
+	Key     TransportAdapterKey
+	Adapter TransportAdapter
+}
+
+// ResolveTransportDisposition applies the shared transport-neutral evaluation matrix.
+func ResolveTransportDisposition(result EvaluationResult, failurePolicy FailurePolicy) (TransportDisposition, error) {
+	if err := validateEvaluationResult(result); err != nil {
+		return TransportDisposition{}, err
+	}
+	if failurePolicy != FailurePolicyFailOpen && failurePolicy != FailurePolicyFailClosed {
+		return TransportDisposition{}, fmt.Errorf("invalid failure policy %q", failurePolicy)
+	}
+
+	switch result.kind {
+	case EvaluationResultMatch:
+		return NewMatchedDenialDisposition(result.externalNote)
+	case EvaluationResultNoMatch:
+		return NewContinueDisposition(), nil
+	case EvaluationResultInfrastructureFailure:
+		if failurePolicy == FailurePolicyFailOpen {
+			return NewContinueDisposition(), nil
+		}
+		return NewInfrastructureRejectionDisposition(), nil
+	default:
+		return TransportDisposition{}, errors.New("invalid evaluation result")
+	}
+}
+
+func validateEvaluationResult(result EvaluationResult) error {
+	switch result.kind {
+	case EvaluationResultMatch:
+		if result.prescriptionID == "" || result.externalNote == "" || result.noMatchReason != "" || result.infrastructureErr != nil {
+			return errors.New("invalid match evaluation result")
+		}
+	case EvaluationResultNoMatch:
+		if result.prescriptionID != "" || result.externalNote != "" || result.infrastructureErr != nil {
+			return errors.New("invalid no-match evaluation result")
+		}
+		if result.noMatchReason != NoMatchReasonNoPrescription && result.noMatchReason != NoMatchReasonUnsupportedIdentity && result.noMatchReason != NoMatchReasonUnsupportedResource {
+			return errors.New("invalid no-match evaluation result")
+		}
+	case EvaluationResultInfrastructureFailure:
+		if result.prescriptionID != "" || result.externalNote != "" || result.noMatchReason != "" || isNilInterface(result.infrastructureErr) {
+			return errors.New("invalid infrastructure-failure evaluation result")
+		}
+	default:
+		return errors.New("invalid evaluation result")
+	}
+	return nil
+}

--- a/server/internal/killswitches/registry.go
+++ b/server/internal/killswitches/registry.go
@@ -1,0 +1,696 @@
+package killswitches
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Registration contains all code-owned contracts finalized into a Registry. Registered adapter
+// implementations are retained behind interfaces because they cannot be deep-copied. They must
+// therefore be immutable, return a stable Kind, and be safe for concurrent use after registration.
+type Registration struct {
+	Definitions       []Definition
+	IdentityContracts []IdentityContract
+	PrincipalAdapters []PrincipalAdapterRegistration
+	ResourceAdapters  []ResourceAdapterRegistration
+	Surfaces          []Surface
+	TransportAdapters []TransportAdapterRegistration
+	Coverage          []CoverageContract
+}
+
+// Registry is a finalized snapshot of code-owned kill-switch contract values. Adapter registration
+// keys are snapshotted, while adapter behavior relies on Registration's immutability and concurrency
+// contract.
+type Registry struct {
+	definitions       map[DefinitionKey]Definition
+	identityContracts map[IdentityContractKey]IdentityContract
+	principalAdapters map[PrincipalKind]PrincipalAdapter
+	resourceAdapters  map[ResourceKind]ResourceAdapter
+	surfaces          map[Surface]struct{}
+	transportAdapters map[TransportAdapterKey]TransportAdapter
+	coverage          map[coverageKey]CoverageContract
+}
+
+type coverageKey struct {
+	definition DefinitionKey
+	surface    Surface
+}
+
+// BuildRegistry validates a complete registration and returns a finalized snapshot.
+func BuildRegistry(input Registration) (*Registry, error) {
+	registry := &Registry{
+		definitions:       make(map[DefinitionKey]Definition, len(input.Definitions)),
+		identityContracts: make(map[IdentityContractKey]IdentityContract, len(input.IdentityContracts)),
+		principalAdapters: make(map[PrincipalKind]PrincipalAdapter, len(input.PrincipalAdapters)),
+		resourceAdapters:  make(map[ResourceKind]ResourceAdapter, len(input.ResourceAdapters)),
+		surfaces:          make(map[Surface]struct{}, len(input.Surfaces)),
+		transportAdapters: make(map[TransportAdapterKey]TransportAdapter, len(input.TransportAdapters)),
+		coverage:          make(map[coverageKey]CoverageContract, len(input.Coverage)),
+	}
+
+	for _, surface := range input.Surfaces {
+		if err := validateIdentifier("surface", string(surface)); err != nil {
+			return nil, err
+		}
+		if _, exists := registry.surfaces[surface]; exists {
+			return nil, fmt.Errorf("duplicate surface %q", surface)
+		}
+		registry.surfaces[surface] = struct{}{}
+	}
+	for _, registration := range input.TransportAdapters {
+		if err := validateIdentifier("transport adapter key", string(registration.Key)); err != nil {
+			return nil, err
+		}
+		if isNilInterface(registration.Adapter) {
+			return nil, fmt.Errorf("transport adapter %q must not be nil", registration.Key)
+		}
+		if _, exists := registry.transportAdapters[registration.Key]; exists {
+			return nil, fmt.Errorf("duplicate transport adapter %q", registration.Key)
+		}
+		registry.transportAdapters[registration.Key] = wrapTransportAdapter(registration.Key, registration.Adapter)
+	}
+	for _, registration := range input.PrincipalAdapters {
+		adapter := registration.Adapter
+		if isNilInterface(adapter) {
+			return nil, fmt.Errorf("principal adapter must not be nil")
+		}
+		kind := adapter.Kind()
+		if err := validateIdentifier("principal adapter kind", string(kind)); err != nil {
+			return nil, err
+		}
+		if _, exists := registry.principalAdapters[kind]; exists {
+			return nil, fmt.Errorf("duplicate principal adapter %q", kind)
+		}
+		if err := validatePrincipalCanonicalizationFixtures(kind, adapter, registration.Fixtures); err != nil {
+			return nil, err
+		}
+		registry.principalAdapters[kind] = adapter
+	}
+	for _, registration := range input.ResourceAdapters {
+		adapter := registration.Adapter
+		if isNilInterface(adapter) {
+			return nil, fmt.Errorf("resource adapter must not be nil")
+		}
+		kind := adapter.Kind()
+		if err := validateIdentifier("resource adapter kind", string(kind)); err != nil {
+			return nil, err
+		}
+		if _, exists := registry.resourceAdapters[kind]; exists {
+			return nil, fmt.Errorf("duplicate resource adapter %q", kind)
+		}
+		if err := validateResourceCanonicalizationFixtures(kind, adapter, registration.Fixtures); err != nil {
+			return nil, err
+		}
+		registry.resourceAdapters[kind] = adapter
+	}
+	for _, contract := range input.IdentityContracts {
+		if err := validateIdentityContract(contract, registry); err != nil {
+			return nil, err
+		}
+		if _, exists := registry.identityContracts[contract.Key]; exists {
+			return nil, fmt.Errorf("duplicate identity contract %q", contract.Key)
+		}
+		registry.identityContracts[contract.Key] = normalizeIdentityContract(contract)
+	}
+	for _, definition := range input.Definitions {
+		normalized, err := validateDefinition(definition, registry)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := registry.definitions[definition.Key]; exists {
+			return nil, fmt.Errorf("duplicate definition %q", definition.Key)
+		}
+		registry.definitions[definition.Key] = normalized
+	}
+	for _, contract := range input.Coverage {
+		normalized, err := validateCoverage(contract, registry)
+		if err != nil {
+			return nil, err
+		}
+		key := coverageKey{definition: contract.Definition, surface: contract.Surface}
+		if _, exists := registry.coverage[key]; exists {
+			return nil, fmt.Errorf("duplicate coverage for definition %q and surface %q", contract.Definition, contract.Surface)
+		}
+		registry.coverage[key] = normalized
+	}
+	if err := validateCoverageCompleteness(registry); err != nil {
+		return nil, err
+	}
+	for kind, adapter := range registry.principalAdapters {
+		registry.principalAdapters[kind] = registeredPrincipalAdapter{kind: kind, adapter: adapter, registry: registry}
+	}
+	for kind, adapter := range registry.resourceAdapters {
+		registry.resourceAdapters[kind] = registeredResourceAdapter{kind: kind, adapter: adapter}
+	}
+	return registry, nil
+}
+
+const canonicalizationFixtureAttempts = 3
+
+func validatePrincipalCanonicalizationFixtures(kind PrincipalKind, adapter PrincipalAdapter, fixtures []PrincipalCanonicalizationFixture) error {
+	if len(fixtures) == 0 {
+		return fmt.Errorf("principal adapter %q requires canonicalization fixtures", kind)
+	}
+	for index, fixture := range fixtures {
+		if err := validateCanonicalizationFixture(
+			fmt.Sprintf("principal adapter %q fixture %d", kind, index),
+			fixture.OrganizationID,
+			fixture.Input,
+			fixture.Expected,
+			adapter.Canonicalize,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateResourceCanonicalizationFixtures(kind ResourceKind, adapter ResourceAdapter, fixtures []ResourceCanonicalizationFixture) error {
+	if len(fixtures) == 0 {
+		return fmt.Errorf("resource adapter %q requires canonicalization fixtures", kind)
+	}
+	for index, fixture := range fixtures {
+		if err := validateCanonicalizationFixture(
+			fmt.Sprintf("resource adapter %q fixture %d", kind, index),
+			fixture.OrganizationID,
+			fixture.Input,
+			fixture.Expected,
+			adapter.Canonicalize,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCanonicalizationFixture[T ~string](
+	label string,
+	organizationID OrganizationID,
+	input string,
+	expected CanonicalizationResult[T],
+	canonicalize func(OrganizationID, string) (CanonicalizationResult[T], error),
+) error {
+	if err := validateIdentifier("canonicalization fixture organization ID", string(organizationID)); err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	expectedKey, expectedSupported, err := expected.Key()
+	if err != nil {
+		return fmt.Errorf("%s has an invalid expected result: %w", label, err)
+	}
+
+	var firstKey T
+	var firstSupported bool
+	for attempt := range canonicalizationFixtureAttempts {
+		result, err := canonicalize(organizationID, input)
+		if err != nil {
+			return fmt.Errorf("%s attempt %d: %w", label, attempt+1, err)
+		}
+		key, supported, err := result.Key()
+		if err != nil {
+			return fmt.Errorf("%s attempt %d returned an invalid result: %w", label, attempt+1, err)
+		}
+		if attempt == 0 {
+			firstKey, firstSupported = key, supported
+		} else if key != firstKey || supported != firstSupported {
+			return fmt.Errorf("%s canonicalization is unstable across repeated calls", label)
+		}
+	}
+	if firstKey != expectedKey || firstSupported != expectedSupported {
+		return fmt.Errorf("%s returned key %q supported=%t, expected key %q supported=%t", label, firstKey, firstSupported, expectedKey, expectedSupported)
+	}
+	return nil
+}
+
+func wrapTransportAdapter(key TransportAdapterKey, adapter TransportAdapter) TransportAdapter {
+	return func(result EvaluationResult, failurePolicy FailurePolicy) (TransportDisposition, error) {
+		expected, err := ResolveTransportDisposition(result, failurePolicy)
+		if err != nil {
+			return TransportDisposition{}, fmt.Errorf("transport adapter %q: %w", key, err)
+		}
+		disposition, err := adapter(result, failurePolicy)
+		if err != nil {
+			return TransportDisposition{}, fmt.Errorf("transport adapter %q: %w", key, err)
+		}
+		if disposition.kind != expected.kind {
+			return TransportDisposition{}, fmt.Errorf("transport adapter %q returned disposition %q, expected %q for the result/policy matrix", key, disposition.kind, expected.kind)
+		}
+		if disposition.externalNote != expected.externalNote {
+			return TransportDisposition{}, fmt.Errorf("transport adapter %q did not preserve the result/policy matrix external note", key)
+		}
+		return disposition, nil
+	}
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+type registeredPrincipalAdapter struct {
+	kind     PrincipalKind
+	adapter  PrincipalAdapter
+	registry *Registry
+}
+
+func (a registeredPrincipalAdapter) Kind() PrincipalKind { return a.kind }
+
+func (a registeredPrincipalAdapter) Canonicalize(organizationID OrganizationID, input string) (CanonicalizationResult[PrincipalKey], error) {
+	result, err := a.adapter.Canonicalize(organizationID, input)
+	if err != nil {
+		return CanonicalizationResult[PrincipalKey]{}, fmt.Errorf("principal adapter %q canonicalize: %w", a.kind, err)
+	}
+	if _, _, err := result.Key(); err != nil {
+		return CanonicalizationResult[PrincipalKey]{}, fmt.Errorf("principal adapter %q: %w", a.kind, err)
+	}
+	return result, nil
+}
+
+func (a registeredPrincipalAdapter) ValidateCurrentOrganization(ctx context.Context, organizationID OrganizationID, key PrincipalKey) (bool, error) {
+	valid, err := a.adapter.ValidateCurrentOrganization(ctx, organizationID, key)
+	if err != nil {
+		return false, fmt.Errorf("principal adapter %q validate current organization: %w", a.kind, err)
+	}
+	return valid, nil
+}
+
+func (a registeredPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID OrganizationID, source any) (PrincipalCandidateResult, error) {
+	result, err := a.adapter.DeriveCandidates(ctx, organizationID, source)
+	if err != nil {
+		return PrincipalCandidateResult{}, fmt.Errorf("principal adapter %q derive candidates: %w", a.kind, err)
+	}
+	switch result.Kind() {
+	case PrincipalCandidateResultUnsupported:
+		return result, nil
+	case PrincipalCandidateResultCandidates:
+		candidates := result.Candidates()
+		if len(candidates) == 0 {
+			return PrincipalCandidateResult{}, fmt.Errorf("principal adapter %q returned no candidates", a.kind)
+		}
+		for _, candidate := range candidates {
+			if _, ok := a.registry.principalAdapters[candidate.Kind]; !ok {
+				return PrincipalCandidateResult{}, fmt.Errorf("principal adapter %q returned candidate with unregistered kind %q", a.kind, candidate.Kind)
+			}
+		}
+		return result, nil
+	default:
+		return PrincipalCandidateResult{}, fmt.Errorf("principal adapter %q returned an invalid candidate result", a.kind)
+	}
+}
+
+type registeredResourceAdapter struct {
+	kind    ResourceKind
+	adapter ResourceAdapter
+}
+
+func (a registeredResourceAdapter) Kind() ResourceKind { return a.kind }
+
+func (a registeredResourceAdapter) Canonicalize(organizationID OrganizationID, input string) (CanonicalizationResult[ResourceKey], error) {
+	result, err := a.adapter.Canonicalize(organizationID, input)
+	return a.validateResult("canonicalize", result, err)
+}
+
+func (a registeredResourceAdapter) ValidateCurrentOrganization(ctx context.Context, organizationID OrganizationID, key ResourceKey) (bool, error) {
+	valid, err := a.adapter.ValidateCurrentOrganization(ctx, organizationID, key)
+	if err != nil {
+		return false, fmt.Errorf("resource adapter %q validate current organization: %w", a.kind, err)
+	}
+	return valid, nil
+}
+
+func (a registeredResourceAdapter) Derive(ctx context.Context, organizationID OrganizationID, source any) (CanonicalizationResult[ResourceKey], error) {
+	result, err := a.adapter.Derive(ctx, organizationID, source)
+	return a.validateResult("derive", result, err)
+}
+
+func (a registeredResourceAdapter) validateResult(operation string, result CanonicalizationResult[ResourceKey], err error) (CanonicalizationResult[ResourceKey], error) {
+	if err != nil {
+		return CanonicalizationResult[ResourceKey]{}, err
+	}
+	if _, _, err := result.Key(); err != nil {
+		return CanonicalizationResult[ResourceKey]{}, fmt.Errorf("resource adapter %q %s: %w", a.kind, operation, err)
+	}
+	return result, nil
+}
+
+func validateIdentityContract(contract IdentityContract, registry *Registry) error {
+	if err := validateIdentifier("identity contract key", string(contract.Key)); err != nil {
+		return err
+	}
+	if len(contract.PrincipalKinds) == 0 {
+		return fmt.Errorf("identity contract %q requires principal kinds", contract.Key)
+	}
+	if len(contract.ResourceKinds) == 0 {
+		return fmt.Errorf("identity contract %q requires resource kinds", contract.Key)
+	}
+	if err := validateUniqueIdentifiers("principal kind", contract.PrincipalKinds, func(v PrincipalKind) string { return string(v) }); err != nil {
+		return fmt.Errorf("identity contract %q: %w", contract.Key, err)
+	}
+	if err := validateUniqueIdentifiers("resource kind", contract.ResourceKinds, func(v ResourceKind) string { return string(v) }); err != nil {
+		return fmt.Errorf("identity contract %q: %w", contract.Key, err)
+	}
+	for _, kind := range contract.PrincipalKinds {
+		if _, ok := registry.principalAdapters[kind]; !ok {
+			return fmt.Errorf("identity contract %q references unknown principal adapter %q", contract.Key, kind)
+		}
+	}
+	for _, kind := range contract.ResourceKinds {
+		if _, ok := registry.resourceAdapters[kind]; !ok {
+			return fmt.Errorf("identity contract %q references unknown resource adapter %q", contract.Key, kind)
+		}
+	}
+	return nil
+}
+
+func validateDefinition(definition Definition, registry *Registry) (Definition, error) {
+	if err := validateIdentifier("definition key", string(definition.Key)); err != nil {
+		return Definition{}, err
+	}
+	if len(definition.PrincipalKinds) == 0 || len(definition.ResourceKinds) == 0 {
+		return Definition{}, fmt.Errorf("definition %q requires principal and resource kinds", definition.Key)
+	}
+	if definition.FailurePolicy != FailurePolicyFailOpen && definition.FailurePolicy != FailurePolicyFailClosed {
+		return Definition{}, fmt.Errorf("definition %q has invalid failure policy %q", definition.Key, definition.FailurePolicy)
+	}
+	note, err := NormalizeExternalNote(definition.DefaultExternalNote)
+	if err != nil {
+		return Definition{}, fmt.Errorf("definition %q default external note: %w", definition.Key, err)
+	}
+	owner := strings.TrimSpace(definition.EnforcementOwner)
+	if err := validateRequiredText("enforcement owner", owner); err != nil {
+		return Definition{}, fmt.Errorf("definition %q: %w", definition.Key, err)
+	}
+	identity, ok := registry.identityContracts[definition.IdentityContract]
+	if !ok {
+		return Definition{}, fmt.Errorf("definition %q references unknown identity contract %q", definition.Key, definition.IdentityContract)
+	}
+	if len(definition.Surfaces) == 0 || len(definition.TransportAdapters) == 0 {
+		return Definition{}, fmt.Errorf("definition %q requires surfaces and transport adapters", definition.Key)
+	}
+	if err := validateUniqueIdentifiers("principal kind", definition.PrincipalKinds, func(v PrincipalKind) string { return string(v) }); err != nil {
+		return Definition{}, fmt.Errorf("definition %q: %w", definition.Key, err)
+	}
+	if err := validateUniqueIdentifiers("resource kind", definition.ResourceKinds, func(v ResourceKind) string { return string(v) }); err != nil {
+		return Definition{}, fmt.Errorf("definition %q: %w", definition.Key, err)
+	}
+	if err := validateUniqueIdentifiers("surface", definition.Surfaces, func(v Surface) string { return string(v) }); err != nil {
+		return Definition{}, fmt.Errorf("definition %q: %w", definition.Key, err)
+	}
+	if err := validateUniqueIdentifiers("transport adapter", definition.TransportAdapters, func(v TransportAdapterKey) string { return string(v) }); err != nil {
+		return Definition{}, fmt.Errorf("definition %q: %w", definition.Key, err)
+	}
+	for _, kind := range definition.PrincipalKinds {
+		if !slices.Contains(identity.PrincipalKinds, kind) {
+			return Definition{}, fmt.Errorf("definition %q principal kind %q is outside identity contract %q", definition.Key, kind, identity.Key)
+		}
+	}
+	for _, kind := range definition.ResourceKinds {
+		if !slices.Contains(identity.ResourceKinds, kind) {
+			return Definition{}, fmt.Errorf("definition %q resource kind %q is outside identity contract %q", definition.Key, kind, identity.Key)
+		}
+	}
+	for _, surface := range definition.Surfaces {
+		if _, ok := registry.surfaces[surface]; !ok {
+			return Definition{}, fmt.Errorf("definition %q references unknown surface %q", definition.Key, surface)
+		}
+	}
+	for _, adapter := range definition.TransportAdapters {
+		if _, ok := registry.transportAdapters[adapter]; !ok {
+			return Definition{}, fmt.Errorf("definition %q references unknown transport adapter %q", definition.Key, adapter)
+		}
+	}
+	definition.DefaultExternalNote = note
+	definition.EnforcementOwner = owner
+	definition.PrincipalKinds = sortedClone(definition.PrincipalKinds)
+	definition.ResourceKinds = sortedClone(definition.ResourceKinds)
+	definition.Surfaces = sortedClone(definition.Surfaces)
+	definition.TransportAdapters = sortedClone(definition.TransportAdapters)
+	return definition, nil
+}
+
+func validateCoverage(contract CoverageContract, registry *Registry) (CoverageContract, error) {
+	definition, ok := registry.definitions[contract.Definition]
+	if !ok {
+		return CoverageContract{}, fmt.Errorf("coverage references unknown definition %q", contract.Definition)
+	}
+	if _, ok := registry.surfaces[contract.Surface]; !ok {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q references unknown surface %q", contract.Definition, contract.Surface)
+	}
+	if !slices.Contains(definition.Surfaces, contract.Surface) {
+		return CoverageContract{}, fmt.Errorf("coverage surface %q is not declared by definition %q", contract.Surface, contract.Definition)
+	}
+	if _, ok := registry.transportAdapters[contract.TransportAdapter]; !ok {
+		return CoverageContract{}, fmt.Errorf("coverage references unknown transport adapter %q", contract.TransportAdapter)
+	}
+	if !slices.Contains(definition.TransportAdapters, contract.TransportAdapter) {
+		return CoverageContract{}, fmt.Errorf("coverage transport adapter %q is not declared by definition %q", contract.TransportAdapter, contract.Definition)
+	}
+	if contract.FailurePolicy != definition.FailurePolicy {
+		return CoverageContract{}, fmt.Errorf("coverage failure policy does not match definition %q", contract.Definition)
+	}
+	identity, ok := registry.identityContracts[contract.IdentityContract]
+	if !ok {
+		return CoverageContract{}, fmt.Errorf("coverage references unknown identity contract %q", contract.IdentityContract)
+	}
+	for _, kind := range definition.PrincipalKinds {
+		if !slices.Contains(identity.PrincipalKinds, kind) {
+			return CoverageContract{}, fmt.Errorf("coverage identity contract %q does not support principal kind %q for definition %q", identity.Key, kind, definition.Key)
+		}
+	}
+	for _, kind := range definition.ResourceKinds {
+		if !slices.Contains(identity.ResourceKinds, kind) {
+			return CoverageContract{}, fmt.Errorf("coverage identity contract %q does not support resource kind %q for definition %q", identity.Key, kind, definition.Key)
+		}
+	}
+
+	contract.EnforcementOwner = strings.TrimSpace(contract.EnforcementOwner)
+	if err := validateRequiredText("enforcement owner", contract.EnforcementOwner); err != nil {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q and surface %q: %w", contract.Definition, contract.Surface, err)
+	}
+	contract.PrincipalSource = strings.TrimSpace(contract.PrincipalSource)
+	if err := validateRequiredText("principal source", contract.PrincipalSource); err != nil {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q and surface %q: %w", contract.Definition, contract.Surface, err)
+	}
+	contract.ResourceSource = strings.TrimSpace(contract.ResourceSource)
+	if err := validateRequiredText("resource source", contract.ResourceSource); err != nil {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q and surface %q: %w", contract.Definition, contract.Surface, err)
+	}
+	contract.Checkpoint = strings.TrimSpace(contract.Checkpoint)
+	if err := validateRequiredText("checkpoint", contract.Checkpoint); err != nil {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q and surface %q: %w", contract.Definition, contract.Surface, err)
+	}
+	contract.ProtectedWork = strings.TrimSpace(contract.ProtectedWork)
+	if err := validateRequiredText("protected work", contract.ProtectedWork); err != nil {
+		return CoverageContract{}, fmt.Errorf("coverage for definition %q and surface %q: %w", contract.Definition, contract.Surface, err)
+	}
+	return contract, nil
+}
+
+func validateCoverageCompleteness(registry *Registry) error {
+	for _, definition := range registry.Definitions() {
+		usedAdapters := make(map[TransportAdapterKey]struct{}, len(definition.TransportAdapters))
+		for _, surface := range definition.Surfaces {
+			contract, ok := registry.coverage[coverageKey{definition: definition.Key, surface: surface}]
+			if !ok {
+				return fmt.Errorf("definition %q has no coverage inventory for surface %q", definition.Key, surface)
+			}
+			usedAdapters[contract.TransportAdapter] = struct{}{}
+		}
+		for _, adapter := range definition.TransportAdapters {
+			if _, ok := usedAdapters[adapter]; !ok {
+				return fmt.Errorf("definition %q transport adapter %q has no coverage inventory", definition.Key, adapter)
+			}
+		}
+	}
+	return nil
+}
+
+// Definition returns a defensive copy of a definition.
+func (r *Registry) Definition(key DefinitionKey) (Definition, bool) {
+	definition, ok := r.definitions[key]
+	return cloneDefinition(definition), ok
+}
+
+// Definitions returns sorted defensive copies of all definitions.
+func (r *Registry) Definitions() []Definition {
+	result := make([]Definition, 0, len(r.definitions))
+	for _, definition := range r.definitions {
+		result = append(result, cloneDefinition(definition))
+	}
+	slices.SortFunc(result, func(a, b Definition) int { return cmp.Compare(a.Key, b.Key) })
+	return result
+}
+
+// IdentityContract returns a defensive copy of an identity contract.
+func (r *Registry) IdentityContract(key IdentityContractKey) (IdentityContract, bool) {
+	contract, ok := r.identityContracts[key]
+	return cloneIdentityContract(contract), ok
+}
+
+// IdentityContracts returns sorted defensive copies of all identity contracts.
+func (r *Registry) IdentityContracts() []IdentityContract {
+	result := make([]IdentityContract, 0, len(r.identityContracts))
+	for _, contract := range r.identityContracts {
+		result = append(result, cloneIdentityContract(contract))
+	}
+	slices.SortFunc(result, func(a, b IdentityContract) int { return cmp.Compare(a.Key, b.Key) })
+	return result
+}
+
+// PrincipalAdapter returns the registered adapter for a principal kind.
+func (r *Registry) PrincipalAdapter(kind PrincipalKind) (PrincipalAdapter, bool) {
+	adapter, ok := r.principalAdapters[kind]
+	return adapter, ok
+}
+
+// PrincipalKinds returns all registered principal adapter kinds in sorted order.
+func (r *Registry) PrincipalKinds() []PrincipalKind {
+	return slices.Sorted(maps.Keys(r.principalAdapters))
+}
+
+// ResourceAdapter returns the registered adapter for a resource kind.
+func (r *Registry) ResourceAdapter(kind ResourceKind) (ResourceAdapter, bool) {
+	adapter, ok := r.resourceAdapters[kind]
+	return adapter, ok
+}
+
+// ResourceKinds returns all registered resource adapter kinds in sorted order.
+func (r *Registry) ResourceKinds() []ResourceKind {
+	return slices.Sorted(maps.Keys(r.resourceAdapters))
+}
+
+// Surfaces returns all registered surfaces in sorted order.
+func (r *Registry) Surfaces() []Surface {
+	return slices.Sorted(maps.Keys(r.surfaces))
+}
+
+// HasSurface reports whether a surface is registered.
+func (r *Registry) HasSurface(surface Surface) bool {
+	_, ok := r.surfaces[surface]
+	return ok
+}
+
+// TransportAdapters returns all registered transport adapter keys in sorted order.
+func (r *Registry) TransportAdapters() []TransportAdapterKey {
+	return slices.Sorted(maps.Keys(r.transportAdapters))
+}
+
+// TransportAdapter returns registered neutral transport behavior.
+func (r *Registry) TransportAdapter(key TransportAdapterKey) (TransportAdapter, bool) {
+	adapter, ok := r.transportAdapters[key]
+	return adapter, ok
+}
+
+// HasTransportAdapter reports whether a transport adapter is registered.
+func (r *Registry) HasTransportAdapter(adapter TransportAdapterKey) bool {
+	_, ok := r.transportAdapters[adapter]
+	return ok
+}
+
+// Coverage returns the inventory entry for a definition and surface.
+func (r *Registry) Coverage(definition DefinitionKey, surface Surface) (CoverageContract, bool) {
+	contract, ok := r.coverage[coverageKey{definition: definition, surface: surface}]
+	return contract, ok
+}
+
+// CoverageInventory returns all inventory entries sorted by definition and surface.
+func (r *Registry) CoverageInventory() []CoverageContract {
+	result := make([]CoverageContract, 0, len(r.coverage))
+	for _, contract := range r.coverage {
+		result = append(result, contract)
+	}
+	slices.SortFunc(result, func(a, b CoverageContract) int {
+		if order := cmp.Compare(a.Definition, b.Definition); order != 0 {
+			return order
+		}
+		return cmp.Compare(a.Surface, b.Surface)
+	})
+	return result
+}
+
+func cloneDefinition(definition Definition) Definition {
+	definition.PrincipalKinds = slices.Clone(definition.PrincipalKinds)
+	definition.ResourceKinds = slices.Clone(definition.ResourceKinds)
+	definition.Surfaces = slices.Clone(definition.Surfaces)
+	definition.TransportAdapters = slices.Clone(definition.TransportAdapters)
+	return definition
+}
+
+func normalizeIdentityContract(contract IdentityContract) IdentityContract {
+	contract.PrincipalKinds = sortedClone(contract.PrincipalKinds)
+	contract.ResourceKinds = sortedClone(contract.ResourceKinds)
+	return contract
+}
+
+func cloneIdentityContract(contract IdentityContract) IdentityContract {
+	contract.PrincipalKinds = slices.Clone(contract.PrincipalKinds)
+	contract.ResourceKinds = slices.Clone(contract.ResourceKinds)
+	return contract
+}
+
+func sortedClone[S ~[]E, E ~string](values S) S {
+	result := slices.Clone(values)
+	slices.Sort(result)
+	return result
+}
+
+func validateUniqueIdentifiers[T comparable](label string, values []T, stringify func(T) string) error {
+	seen := make(map[T]struct{}, len(values))
+	for _, value := range values {
+		if err := validateIdentifier(label, stringify(value)); err != nil {
+			return err
+		}
+		if _, ok := seen[value]; ok {
+			return fmt.Errorf("duplicate %s %q", label, stringify(value))
+		}
+		seen[value] = struct{}{}
+	}
+	return nil
+}
+
+func validateIdentifier(label, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", label)
+	}
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	if strings.TrimSpace(value) != value {
+		return fmt.Errorf("%s must not have surrounding whitespace", label)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%s contains a control character", label)
+		}
+	}
+	return nil
+}
+
+func validateRequiredText(label, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s must be valid UTF-8", label)
+	}
+	if value == "" {
+		return fmt.Errorf("%s is required", label)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) && r != '\t' && r != '\n' && r != '\r' {
+			return fmt.Errorf("%s contains a disallowed control character", label)
+		}
+	}
+	return nil
+}

--- a/server/internal/killswitches/registry.go
+++ b/server/internal/killswitches/registry.go
@@ -45,6 +45,10 @@ type coverageKey struct {
 
 // BuildRegistry validates a complete registration and returns a finalized snapshot.
 func BuildRegistry(input Registration) (*Registry, error) {
+	if len(input.Definitions) == 0 {
+		return nil, fmt.Errorf("at least one definition is required")
+	}
+
 	registry := &Registry{
 		definitions:       make(map[DefinitionKey]Definition, len(input.Definitions)),
 		identityContracts: make(map[IdentityContractKey]IdentityContract, len(input.IdentityContracts)),

--- a/server/internal/killswitches/registry_test.go
+++ b/server/internal/killswitches/registry_test.go
@@ -1,0 +1,713 @@
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type fakePrincipalAdapter struct {
+	kind             PrincipalKind
+	canonicalize     func(OrganizationID, string) (CanonicalizationResult[PrincipalKey], error)
+	validate         func(context.Context, OrganizationID, PrincipalKey) (bool, error)
+	deriveCandidates func(context.Context, OrganizationID, any) (PrincipalCandidateResult, error)
+}
+
+func (f *fakePrincipalAdapter) Kind() PrincipalKind { return f.kind }
+func (f *fakePrincipalAdapter) Canonicalize(org OrganizationID, input string) (CanonicalizationResult[PrincipalKey], error) {
+	if f.canonicalize != nil {
+		return f.canonicalize(org, input)
+	}
+	return NewCanonicalizationResult(PrincipalKey(strings.ToLower(strings.TrimSpace(input))))
+}
+func (f *fakePrincipalAdapter) ValidateCurrentOrganization(ctx context.Context, org OrganizationID, key PrincipalKey) (bool, error) {
+	if f.validate != nil {
+		return f.validate(ctx, org, key)
+	}
+	return true, nil
+}
+func (f *fakePrincipalAdapter) DeriveCandidates(ctx context.Context, org OrganizationID, source any) (PrincipalCandidateResult, error) {
+	if f.deriveCandidates != nil {
+		return f.deriveCandidates(ctx, org, source)
+	}
+	return NewPrincipalCandidateResult([]PrincipalCandidate{{Kind: f.kind, Key: "user:alpha"}})
+}
+
+type fakeResourceAdapter struct {
+	kind         ResourceKind
+	canonicalize func(OrganizationID, string) (CanonicalizationResult[ResourceKey], error)
+	validate     func(context.Context, OrganizationID, ResourceKey) (bool, error)
+	derive       func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error)
+}
+
+func (f *fakeResourceAdapter) Kind() ResourceKind { return f.kind }
+func (f *fakeResourceAdapter) Canonicalize(org OrganizationID, input string) (CanonicalizationResult[ResourceKey], error) {
+	if f.canonicalize != nil {
+		return f.canonicalize(org, input)
+	}
+	return NewCanonicalizationResult(ResourceKey(string(org) + ":" + strings.ToLower(strings.TrimSpace(input))))
+}
+func (f *fakeResourceAdapter) ValidateCurrentOrganization(ctx context.Context, org OrganizationID, key ResourceKey) (bool, error) {
+	if f.validate != nil {
+		return f.validate(ctx, org, key)
+	}
+	return true, nil
+}
+func (f *fakeResourceAdapter) Derive(ctx context.Context, org OrganizationID, source any) (CanonicalizationResult[ResourceKey], error) {
+	if f.derive != nil {
+		return f.derive(ctx, org, source)
+	}
+	return NewCanonicalizationResult(ResourceKey(string(org) + ":derived"))
+}
+
+func TestBuildRegistryFinalizesImmutableSortedInventory(t *testing.T) {
+	t.Parallel()
+
+	input := validRegistration()
+	input.IdentityContracts = append(input.IdentityContracts, IdentityContract{
+		Key: "surface-actor-tool", PrincipalKinds: []PrincipalKind{"service", "user"}, ResourceKinds: []ResourceKind{"tool"},
+	})
+	input.Coverage[0].IdentityContract = "surface-actor-tool"
+	input.Coverage[0].EnforcementOwner = "mcp-enforcement"
+	registry, err := BuildRegistry(input)
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+
+	input.Definitions[0].PrincipalKinds[0] = "mutated"
+	input.Definitions[0].Surfaces[0] = "mutated"
+	input.IdentityContracts[0].ResourceKinds[0] = "mutated"
+	input.Coverage[0].Checkpoint = "mutated"
+
+	definition, ok := registry.Definition("block-tools")
+	if !ok {
+		t.Fatal("definition not found")
+	}
+	if !slices.Equal(definition.PrincipalKinds, []PrincipalKind{"service", "user"}) {
+		t.Fatalf("principal kinds not sorted and immutable: %v", definition.PrincipalKinds)
+	}
+	if !slices.Equal(definition.Surfaces, []Surface{"api", "mcp"}) {
+		t.Fatalf("surfaces not sorted and immutable: %v", definition.Surfaces)
+	}
+	if definition.DefaultExternalNote != "Access paused." || definition.EnforcementOwner != "security" {
+		t.Fatalf("normalized definition mismatch: %+v", definition)
+	}
+	definition.PrincipalKinds[0] = "again"
+	again, _ := registry.Definition("block-tools")
+	if again.PrincipalKinds[0] != "service" {
+		t.Fatal("definition lookup leaked a mutable slice")
+	}
+
+	identity, ok := registry.IdentityContract("actor-tool")
+	if !ok || !slices.Equal(identity.ResourceKinds, []ResourceKind{"tool"}) {
+		t.Fatalf("identity contract mismatch: %+v", identity)
+	}
+	identity.ResourceKinds[0] = "again"
+	againIdentity, _ := registry.IdentityContract("actor-tool")
+	if againIdentity.ResourceKinds[0] != "tool" {
+		t.Fatal("identity lookup leaked a mutable slice")
+	}
+
+	definitions := registry.Definitions()
+	definitions[0].Surfaces[0] = "again"
+	if after, _ := registry.Definition("block-tools"); after.Surfaces[0] != "api" {
+		t.Fatal("definitions list leaked a mutable slice")
+	}
+	if got := registry.PrincipalKinds(); !slices.Equal(got, []PrincipalKind{"service", "user"}) {
+		t.Fatalf("principal kinds not sorted: %v", got)
+	}
+	if got := registry.ResourceKinds(); !slices.Equal(got, []ResourceKind{"tool"}) {
+		t.Fatalf("resource kinds mismatch: %v", got)
+	}
+	if got := registry.Surfaces(); !slices.Equal(got, []Surface{"api", "mcp"}) {
+		t.Fatalf("surfaces not sorted: %v", got)
+	}
+	if got := registry.TransportAdapters(); !slices.Equal(got, []TransportAdapterKey{"http", "jsonrpc"}) {
+		t.Fatalf("transport adapters not sorted: %v", got)
+	}
+	if !registry.HasSurface("mcp") || registry.HasSurface("unknown") {
+		t.Fatal("surface lookup mismatch")
+	}
+	if !registry.HasTransportAdapter("jsonrpc") || registry.HasTransportAdapter("unknown") {
+		t.Fatal("transport adapter lookup mismatch")
+	}
+	contracts := registry.IdentityContracts()
+	contracts[0].PrincipalKinds[0] = "again"
+	if after := registry.IdentityContracts(); after[0].PrincipalKinds[0] != "service" {
+		t.Fatal("identity contracts list leaked a mutable slice")
+	}
+
+	coverage := registry.CoverageInventory()
+	if len(coverage) != 2 || coverage[0].Surface != "api" || coverage[1].Surface != "mcp" {
+		t.Fatalf("coverage inventory is not sorted: %+v", coverage)
+	}
+	if coverage[0].Checkpoint == "mutated" {
+		t.Fatal("coverage retained caller mutation")
+	}
+	mcpCoverage, ok := registry.Coverage("block-tools", "mcp")
+	if !ok || mcpCoverage.EnforcementOwner != "mcp-enforcement" || mcpCoverage.IdentityContract != "surface-actor-tool" {
+		t.Fatalf("surface-specific owner or identity contract was not preserved: %+v", mcpCoverage)
+	}
+	if _, ok := registry.Definition("unknown"); ok {
+		t.Fatal("unknown definition found")
+	}
+	if _, ok := registry.Coverage("block-tools", "unknown"); ok {
+		t.Fatal("unknown coverage found")
+	}
+}
+
+func TestBuildRegistryRejectsInvalidRegistration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Registration)
+	}{
+		{name: "duplicate definition", mutate: func(r *Registration) { r.Definitions = append(r.Definitions, r.Definitions[0]) }},
+		{name: "duplicate identity contract", mutate: func(r *Registration) { r.IdentityContracts = append(r.IdentityContracts, r.IdentityContracts[0]) }},
+		{name: "duplicate principal adapter", mutate: func(r *Registration) { r.PrincipalAdapters = append(r.PrincipalAdapters, r.PrincipalAdapters[0]) }},
+		{name: "duplicate resource adapter", mutate: func(r *Registration) { r.ResourceAdapters = append(r.ResourceAdapters, r.ResourceAdapters[0]) }},
+		{name: "duplicate surface", mutate: func(r *Registration) { r.Surfaces = append(r.Surfaces, r.Surfaces[0]) }},
+		{name: "duplicate transport", mutate: func(r *Registration) { r.TransportAdapters = append(r.TransportAdapters, r.TransportAdapters[0]) }},
+		{name: "duplicate coverage", mutate: func(r *Registration) { r.Coverage = append(r.Coverage, r.Coverage[0]) }},
+		{name: "nil principal adapter", mutate: func(r *Registration) { r.PrincipalAdapters[0].Adapter = nil }},
+		{name: "typed nil principal adapter", mutate: func(r *Registration) { r.PrincipalAdapters[0].Adapter = (*fakePrincipalAdapter)(nil) }},
+		{name: "nil resource adapter", mutate: func(r *Registration) { r.ResourceAdapters[0].Adapter = nil }},
+		{name: "typed nil resource adapter", mutate: func(r *Registration) { r.ResourceAdapters[0].Adapter = (*fakeResourceAdapter)(nil) }},
+		{name: "empty principal adapter key", mutate: func(r *Registration) { r.PrincipalAdapters[0].Adapter = &fakePrincipalAdapter{} }},
+		{name: "empty resource adapter key", mutate: func(r *Registration) { r.ResourceAdapters[0].Adapter = &fakeResourceAdapter{} }},
+		{name: "principal adapter no fixtures", mutate: func(r *Registration) { r.PrincipalAdapters[0].Fixtures = nil }},
+		{name: "resource adapter no fixtures", mutate: func(r *Registration) { r.ResourceAdapters[0].Fixtures = nil }},
+		{name: "principal fixture invalid organization", mutate: func(r *Registration) { r.PrincipalAdapters[0].Fixtures[0].OrganizationID = "" }},
+		{name: "resource fixture invalid expected result", mutate: func(r *Registration) {
+			r.ResourceAdapters[0].Fixtures[0].Expected = CanonicalizationResult[ResourceKey]{}
+		}},
+		{name: "empty surface", mutate: func(r *Registration) { r.Surfaces[0] = "" }},
+		{name: "empty transport", mutate: func(r *Registration) { r.TransportAdapters[0].Key = "" }},
+		{name: "nil transport behavior", mutate: func(r *Registration) { r.TransportAdapters[0].Adapter = nil }},
+		{name: "identity empty key", mutate: func(r *Registration) { r.IdentityContracts[0].Key = "" }},
+		{name: "identity no principal kinds", mutate: func(r *Registration) { r.IdentityContracts[0].PrincipalKinds = nil }},
+		{name: "identity no resource kinds", mutate: func(r *Registration) { r.IdentityContracts[0].ResourceKinds = nil }},
+		{name: "identity unknown principal", mutate: func(r *Registration) { r.IdentityContracts[0].PrincipalKinds[0] = "missing" }},
+		{name: "identity unknown resource", mutate: func(r *Registration) { r.IdentityContracts[0].ResourceKinds[0] = "missing" }},
+		{name: "definition empty key", mutate: func(r *Registration) { r.Definitions[0].Key = "" }},
+		{name: "definition no principal kinds", mutate: func(r *Registration) { r.Definitions[0].PrincipalKinds = nil }},
+		{name: "definition no resource kinds", mutate: func(r *Registration) { r.Definitions[0].ResourceKinds = nil }},
+		{name: "definition invalid policy", mutate: func(r *Registration) { r.Definitions[0].FailurePolicy = "" }},
+		{name: "definition blank note", mutate: func(r *Registration) { r.Definitions[0].DefaultExternalNote = " " }},
+		{name: "definition blank owner", mutate: func(r *Registration) { r.Definitions[0].EnforcementOwner = " " }},
+		{name: "definition unknown identity", mutate: func(r *Registration) { r.Definitions[0].IdentityContract = "missing" }},
+		{name: "definition no surfaces", mutate: func(r *Registration) { r.Definitions[0].Surfaces = nil }},
+		{name: "definition unknown surface", mutate: func(r *Registration) { r.Definitions[0].Surfaces[0] = "missing" }},
+		{name: "definition no transports", mutate: func(r *Registration) { r.Definitions[0].TransportAdapters = nil }},
+		{name: "definition unknown transport", mutate: func(r *Registration) { r.Definitions[0].TransportAdapters[0] = "missing" }},
+		{name: "definition principal outside identity", mutate: func(r *Registration) { r.Definitions[0].PrincipalKinds[0] = "other" }},
+		{name: "coverage unknown definition", mutate: func(r *Registration) { r.Coverage[0].Definition = "missing" }},
+		{name: "coverage unknown surface", mutate: func(r *Registration) { r.Coverage[0].Surface = "missing" }},
+		{name: "coverage undeclared surface", mutate: func(r *Registration) { r.Surfaces = append(r.Surfaces, "other"); r.Coverage[0].Surface = "other" }},
+		{name: "coverage unknown transport", mutate: func(r *Registration) { r.Coverage[0].TransportAdapter = "missing" }},
+		{name: "coverage wrong policy", mutate: func(r *Registration) { r.Coverage[0].FailurePolicy = FailurePolicyFailClosed }},
+		{name: "coverage unknown identity", mutate: func(r *Registration) { r.Coverage[0].IdentityContract = "missing" }},
+		{name: "coverage identity lacks definition kind", mutate: func(r *Registration) {
+			r.IdentityContracts = append(r.IdentityContracts, IdentityContract{Key: "user-tool", PrincipalKinds: []PrincipalKind{"user"}, ResourceKinds: []ResourceKind{"tool"}})
+			r.Coverage[0].IdentityContract = "user-tool"
+		}},
+		{name: "coverage no owner", mutate: func(r *Registration) { r.Coverage[0].EnforcementOwner = " " }},
+		{name: "coverage no principal source", mutate: func(r *Registration) { r.Coverage[0].PrincipalSource = " " }},
+		{name: "coverage no resource source", mutate: func(r *Registration) { r.Coverage[0].ResourceSource = " " }},
+		{name: "coverage no checkpoint", mutate: func(r *Registration) { r.Coverage[0].Checkpoint = " " }},
+		{name: "coverage no protected work", mutate: func(r *Registration) { r.Coverage[0].ProtectedWork = " " }},
+		{name: "missing surface coverage", mutate: func(r *Registration) { r.Coverage = r.Coverage[:1] }},
+		{name: "unused definition transport", mutate: func(r *Registration) {
+			r.TransportAdapters = append(r.TransportAdapters, TransportAdapterRegistration{Key: "unused", Adapter: ResolveTransportDisposition})
+			r.Definitions[0].TransportAdapters = append(r.Definitions[0].TransportAdapters, "unused")
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := validRegistration()
+			tt.mutate(&input)
+			if _, err := BuildRegistry(input); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestBuildRegistryValidatesCanonicalizationFixturesRepeatedly(t *testing.T) {
+	t.Parallel()
+
+	principalCalls, resourceCalls := 0, 0
+	input := validRegistration()
+	principal := registeredFakePrincipal(input.PrincipalAdapters[0])
+	principal.canonicalize = func(OrganizationID, string) (CanonicalizationResult[PrincipalKey], error) {
+		principalCalls++
+		return NewCanonicalizationResult(PrincipalKey("user:alpha"))
+	}
+	resource := registeredFakeResource(input.ResourceAdapters[0])
+	resource.canonicalize = func(OrganizationID, string) (CanonicalizationResult[ResourceKey], error) {
+		resourceCalls++
+		return NewCanonicalizationResult(ResourceKey("org:test:tool:alpha"))
+	}
+
+	if _, err := BuildRegistry(input); err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+	if principalCalls != canonicalizationFixtureAttempts || resourceCalls != canonicalizationFixtureAttempts {
+		t.Fatalf("fixture calls principal=%d resource=%d, want %d each", principalCalls, resourceCalls, canonicalizationFixtureAttempts)
+	}
+}
+
+func TestBuildRegistryAcceptsSupportedAndUnsupportedCanonicalizationFixtures(t *testing.T) {
+	t.Parallel()
+
+	input := validRegistration()
+	principal := registeredFakePrincipal(input.PrincipalAdapters[0])
+	principal.canonicalize = func(OrganizationID, string) (CanonicalizationResult[PrincipalKey], error) {
+		return UnsupportedCanonicalizationResult[PrincipalKey](), nil
+	}
+	input.PrincipalAdapters[0].Fixtures[0].Expected = UnsupportedCanonicalizationResult[PrincipalKey]()
+	resource := registeredFakeResource(input.ResourceAdapters[0])
+	resource.canonicalize = func(OrganizationID, string) (CanonicalizationResult[ResourceKey], error) {
+		return UnsupportedCanonicalizationResult[ResourceKey](), nil
+	}
+	input.ResourceAdapters[0].Fixtures[0].Expected = UnsupportedCanonicalizationResult[ResourceKey]()
+
+	if _, err := BuildRegistry(input); err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+}
+
+func TestBuildRegistryRejectsBadCanonicalizationFixtureBehavior(t *testing.T) {
+	t.Parallel()
+
+	infrastructureErr := errors.New("canonicalization unavailable")
+	tests := []struct {
+		name   string
+		mutate func(*Registration)
+	}{
+		{name: "principal expected mismatch", mutate: func(r *Registration) {
+			r.PrincipalAdapters[0].Fixtures[0].Expected = UnsupportedCanonicalizationResult[PrincipalKey]()
+		}},
+		{name: "resource expected mismatch", mutate: func(r *Registration) {
+			r.ResourceAdapters[0].Fixtures[0].Expected = UnsupportedCanonicalizationResult[ResourceKey]()
+		}},
+		{name: "principal error", mutate: func(r *Registration) {
+			registeredFakePrincipal(r.PrincipalAdapters[0]).canonicalize = func(OrganizationID, string) (CanonicalizationResult[PrincipalKey], error) {
+				return CanonicalizationResult[PrincipalKey]{}, infrastructureErr
+			}
+		}},
+		{name: "resource invalid zero result", mutate: func(r *Registration) {
+			registeredFakeResource(r.ResourceAdapters[0]).canonicalize = func(OrganizationID, string) (CanonicalizationResult[ResourceKey], error) {
+				return CanonicalizationResult[ResourceKey]{}, nil
+			}
+		}},
+		{name: "principal unstable supported state", mutate: func(r *Registration) {
+			calls := 0
+			registeredFakePrincipal(r.PrincipalAdapters[0]).canonicalize = func(OrganizationID, string) (CanonicalizationResult[PrincipalKey], error) {
+				calls++
+				if calls%2 == 0 {
+					return UnsupportedCanonicalizationResult[PrincipalKey](), nil
+				}
+				return NewCanonicalizationResult(PrincipalKey("user:alpha"))
+			}
+		}},
+		{name: "resource unstable key", mutate: func(r *Registration) {
+			calls := 0
+			registeredFakeResource(r.ResourceAdapters[0]).canonicalize = func(OrganizationID, string) (CanonicalizationResult[ResourceKey], error) {
+				calls++
+				return NewCanonicalizationResult(ResourceKey(fmt.Sprintf("org:test:tool:%d", calls%2)))
+			}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := validRegistration()
+			tt.mutate(&input)
+			if _, err := BuildRegistry(input); err == nil {
+				t.Fatal("expected canonicalization fixture error")
+			}
+		})
+	}
+}
+
+func TestAdapterResultContracts(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := NewCanonicalizationResult(PrincipalKey("user:alpha"))
+	if err != nil {
+		t.Fatalf("canonical result: %v", err)
+	}
+	key, supported, err := canonical.Key()
+	if err != nil || !supported || key != "user:alpha" {
+		t.Fatalf("canonical key=%q supported=%v err=%v", key, supported, err)
+	}
+	if _, err := NewCanonicalizationResult(PrincipalKey("")); err == nil {
+		t.Fatal("empty canonical principal key accepted")
+	}
+	if _, supported, err := UnsupportedCanonicalizationResult[PrincipalKey]().Key(); err != nil || supported {
+		t.Fatalf("unsupported canonicalization supported=%v err=%v", supported, err)
+	}
+	if _, _, err := (CanonicalizationResult[PrincipalKey]{}).Key(); err == nil {
+		t.Fatal("zero canonicalization result accepted")
+	}
+
+	if _, err := NewPrincipalCandidateResult(nil); err == nil {
+		t.Fatal("empty successful candidate result accepted")
+	}
+	candidates, err := NewPrincipalCandidateResult([]PrincipalCandidate{
+		{Kind: "service", Key: "service:b"},
+		{Kind: "user", Key: "user:a"},
+		{Kind: "service", Key: "service:b"},
+	})
+	if err != nil {
+		t.Fatalf("candidate result: %v", err)
+	}
+	want := []PrincipalCandidate{{Kind: "service", Key: "service:b"}, {Kind: "user", Key: "user:a"}}
+	got := candidates.Candidates()
+	if !slices.Equal(got, want) {
+		t.Fatalf("candidate order got %+v, want %+v", got, want)
+	}
+	got[0].Key = "mutated"
+	if candidates.Candidates()[0].Key != "service:b" {
+		t.Fatal("candidate result leaked mutable slice")
+	}
+}
+
+func TestRegisteredAdaptersValidateDerivedResults(t *testing.T) {
+	t.Parallel()
+
+	input := validRegistration()
+	principal, ok := input.PrincipalAdapters[0].Adapter.(*fakePrincipalAdapter)
+	if !ok {
+		t.Fatal("principal adapter has unexpected type")
+	}
+	principal.deriveCandidates = func(context.Context, OrganizationID, any) (PrincipalCandidateResult, error) {
+		return NewPrincipalCandidateResult([]PrincipalCandidate{
+			{Kind: "service", Key: "service:first"},
+			{Kind: "user", Key: "user:second"},
+		})
+	}
+	registry, err := BuildRegistry(input)
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+	registeredPrincipal, _ := registry.PrincipalAdapter("user")
+	result, err := registeredPrincipal.DeriveCandidates(context.Background(), "org:test", struct{}{})
+	if err != nil {
+		t.Fatalf("derive registered candidates: %v", err)
+	}
+	want := []PrincipalCandidate{{Kind: "service", Key: "service:first"}, {Kind: "user", Key: "user:second"}}
+	if got := result.Candidates(); !slices.Equal(got, want) {
+		t.Fatalf("candidate order got %+v, want %+v", got, want)
+	}
+
+	badInput := validRegistration()
+	badPrincipal, ok := badInput.PrincipalAdapters[0].Adapter.(*fakePrincipalAdapter)
+	if !ok {
+		t.Fatal("principal adapter has unexpected type")
+	}
+	badPrincipal.deriveCandidates = func(context.Context, OrganizationID, any) (PrincipalCandidateResult, error) {
+		return NewPrincipalCandidateResult([]PrincipalCandidate{{Kind: "unknown", Key: "unknown:key"}})
+	}
+	badRegistry, err := BuildRegistry(badInput)
+	if err != nil {
+		t.Fatalf("build bad-result registry: %v", err)
+	}
+	registeredPrincipal, _ = badRegistry.PrincipalAdapter("user")
+	if _, err := registeredPrincipal.DeriveCandidates(context.Background(), "org:test", struct{}{}); err == nil {
+		t.Fatal("unregistered candidate kind accepted")
+	}
+}
+
+func TestRegisteredResourceAdapterDerivationContract(t *testing.T) {
+	t.Parallel()
+
+	infrastructureErr := errors.New("resource store unavailable")
+	tests := []struct {
+		name          string
+		derive        func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error)
+		wantKey       ResourceKey
+		wantSupported bool
+		wantError     error
+	}{
+		{name: "supported", derive: func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error) {
+			return NewCanonicalizationResult(ResourceKey("tool:search"))
+		}, wantKey: "tool:search", wantSupported: true},
+		{name: "unsupported", derive: func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error) {
+			return UnsupportedCanonicalizationResult[ResourceKey](), nil
+		}},
+		{name: "infrastructure error", derive: func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error) {
+			return CanonicalizationResult[ResourceKey]{}, infrastructureErr
+		}, wantError: infrastructureErr},
+		{name: "invalid zero result", derive: func(context.Context, OrganizationID, any) (CanonicalizationResult[ResourceKey], error) {
+			return CanonicalizationResult[ResourceKey]{}, nil
+		}, wantError: errors.New("contract error")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := validRegistration()
+			resource, ok := input.ResourceAdapters[0].Adapter.(*fakeResourceAdapter)
+			if !ok {
+				t.Fatal("resource adapter has unexpected type")
+			}
+			resource.derive = tt.derive
+			registry, err := BuildRegistry(input)
+			if err != nil {
+				t.Fatalf("build registry: %v", err)
+			}
+			adapter, _ := registry.ResourceAdapter("tool")
+			result, err := adapter.Derive(context.Background(), "org:test", struct{}{})
+			if tt.wantError != nil {
+				if err == nil {
+					t.Fatal("expected derivation error")
+				}
+				if errors.Is(tt.wantError, infrastructureErr) && !errors.Is(err, infrastructureErr) {
+					t.Fatalf("derivation error got %v", err)
+				}
+				return
+			}
+			key, supported, err := result.Key()
+			if err != nil || key != tt.wantKey || supported != tt.wantSupported {
+				t.Fatalf("derived key=%q supported=%v err=%v", key, supported, err)
+			}
+		})
+	}
+}
+
+func TestRegisteredTransportAdapterResolvesNeutralBehaviorMatrix(t *testing.T) {
+	t.Parallel()
+
+	registry, err := BuildRegistry(validRegistration())
+	if err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+	adapter, ok := registry.TransportAdapter("jsonrpc")
+	if !ok {
+		t.Fatal("transport adapter not found")
+	}
+	match, _ := NewMatchResult(testPrescriptionID, "Access paused.")
+	noMatch, _ := NewNoMatchResult(NoMatchReasonNoPrescription)
+	failure, _ := NewInfrastructureFailureResult(errors.New("evaluation unavailable"))
+	tests := []struct {
+		name        string
+		result      EvaluationResult
+		policy      FailurePolicy
+		wantKind    TransportDispositionKind
+		wantNote    string
+		wantHasNote bool
+	}{
+		{name: "match fail open", result: match, policy: FailurePolicyFailOpen, wantKind: TransportDispositionMatchedDenial, wantNote: "Access paused.", wantHasNote: true},
+		{name: "match fail closed", result: match, policy: FailurePolicyFailClosed, wantKind: TransportDispositionMatchedDenial, wantNote: "Access paused.", wantHasNote: true},
+		{name: "no match fail open", result: noMatch, policy: FailurePolicyFailOpen, wantKind: TransportDispositionContinue},
+		{name: "no match fail closed", result: noMatch, policy: FailurePolicyFailClosed, wantKind: TransportDispositionContinue},
+		{name: "failure fail open", result: failure, policy: FailurePolicyFailOpen, wantKind: TransportDispositionContinue},
+		{name: "failure fail closed", result: failure, policy: FailurePolicyFailClosed, wantKind: TransportDispositionInfrastructureRejection},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			disposition, err := adapter(tt.result, tt.policy)
+			if err != nil {
+				t.Fatalf("adapt: %v", err)
+			}
+			if disposition.Kind() != tt.wantKind {
+				t.Fatalf("kind got %q, want %q", disposition.Kind(), tt.wantKind)
+			}
+			note, hasNote := disposition.ExternalNote()
+			if note != tt.wantNote || hasNote != tt.wantHasNote {
+				t.Fatalf("note got %q,%t want %q,%t", note, hasNote, tt.wantNote, tt.wantHasNote)
+			}
+		})
+	}
+	if _, err := adapter(EvaluationResult{}, FailurePolicyFailOpen); err == nil {
+		t.Fatal("zero evaluation result accepted")
+	}
+	if _, err := adapter(noMatch, FailurePolicy("other")); err == nil {
+		t.Fatal("invalid failure policy accepted")
+	}
+}
+
+func TestRegisteredTransportAdapterRejectsOffMatrixDispositions(t *testing.T) {
+	t.Parallel()
+
+	match, _ := NewMatchResult(testPrescriptionID, "Access paused.")
+	noMatch, _ := NewNoMatchResult(NoMatchReasonNoPrescription)
+	failure, _ := NewInfrastructureFailureResult(errors.New("evaluation unavailable"))
+	otherMatchedDenial, _ := NewMatchedDenialDisposition("Different note.")
+	tests := []struct {
+		name        string
+		result      EvaluationResult
+		policy      FailurePolicy
+		disposition TransportDisposition
+	}{
+		{name: "invalid shape", result: noMatch, policy: FailurePolicyFailOpen, disposition: TransportDisposition{}},
+		{name: "match continues", result: match, policy: FailurePolicyFailOpen, disposition: NewContinueDisposition()},
+		{name: "match note replaced", result: match, policy: FailurePolicyFailClosed, disposition: otherMatchedDenial},
+		{name: "no match denied", result: noMatch, policy: FailurePolicyFailClosed, disposition: NewInfrastructureRejectionDisposition()},
+		{name: "fail open rejected", result: failure, policy: FailurePolicyFailOpen, disposition: NewInfrastructureRejectionDisposition()},
+		{name: "fail closed continues", result: failure, policy: FailurePolicyFailClosed, disposition: NewContinueDisposition()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := validRegistration()
+			input.TransportAdapters[0].Adapter = func(EvaluationResult, FailurePolicy) (TransportDisposition, error) {
+				return tt.disposition, nil
+			}
+			registry, err := BuildRegistry(input)
+			if err != nil {
+				t.Fatalf("build registry: %v", err)
+			}
+			adapter, _ := registry.TransportAdapter("jsonrpc")
+			if _, err := adapter(tt.result, tt.policy); err == nil {
+				t.Fatal("off-matrix transport disposition accepted")
+			}
+		})
+	}
+}
+
+func TestEvaluationResultsHaveNeutralValidShapes(t *testing.T) {
+	t.Parallel()
+
+	match, err := NewMatchResult(PrescriptionID(strings.ToUpper(string(testPrescriptionID))), "  Access paused. ")
+	if err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if match.Kind() != EvaluationResultMatch {
+		t.Fatalf("match kind: %q", match.Kind())
+	}
+	if id, ok := match.PrescriptionID(); !ok || id != testPrescriptionID {
+		t.Fatalf("match prescription ID: %q, %v", id, ok)
+	}
+	if note, ok := match.ExternalNote(); !ok || note != "Access paused." {
+		t.Fatalf("match external note: %q, %v", note, ok)
+	}
+	if _, ok := match.NoMatchReason(); ok || match.InfrastructureError() != nil {
+		t.Fatal("match exposed non-match metadata")
+	}
+	if _, err := NewMatchResult("not-a-uuid", "note"); err == nil {
+		t.Fatal("match with invalid prescription UUID accepted")
+	}
+	if _, err := NewMatchResult(testPrescriptionID, " "); err == nil {
+		t.Fatal("match without note accepted")
+	}
+
+	for _, reason := range []NoMatchReason{NoMatchReasonNoPrescription, NoMatchReasonUnsupportedIdentity, NoMatchReasonUnsupportedResource} {
+		noMatch, err := NewNoMatchResult(reason)
+		if err != nil {
+			t.Fatalf("no match: %v", err)
+		}
+		if noMatch.Kind() != EvaluationResultNoMatch {
+			t.Fatalf("no-match kind: %q", noMatch.Kind())
+		}
+		if got, ok := noMatch.NoMatchReason(); !ok || got != reason {
+			t.Fatalf("no-match reason: %q, %v", got, ok)
+		}
+		if _, ok := noMatch.ExternalNote(); ok || noMatch.InfrastructureError() != nil {
+			t.Fatal("no-match exposed denial or infrastructure metadata")
+		}
+	}
+	if _, err := NewNoMatchResult("other"); err == nil {
+		t.Fatal("unknown no-match reason accepted")
+	}
+
+	cause := errors.New("database unavailable")
+	failure, err := NewInfrastructureFailureResult(cause)
+	if err != nil {
+		t.Fatalf("infrastructure failure: %v", err)
+	}
+	if failure.Kind() != EvaluationResultInfrastructureFailure || !errors.Is(failure.InfrastructureError(), cause) {
+		t.Fatalf("infrastructure result mismatch: %+v", failure)
+	}
+	if _, ok := failure.ExternalNote(); ok {
+		t.Fatal("infrastructure failure exposed denial language")
+	}
+	if _, err := NewInfrastructureFailureResult(nil); err == nil {
+		t.Fatal("nil infrastructure cause accepted")
+	}
+	var typedNil *testError
+	if _, err := NewInfrastructureFailureResult(typedNil); err == nil {
+		t.Fatal("typed-nil infrastructure cause accepted")
+	}
+}
+
+type testError struct{}
+
+func (*testError) Error() string { return "test error" }
+
+func registeredFakePrincipal(registration PrincipalAdapterRegistration) *fakePrincipalAdapter {
+	switch adapter := registration.Adapter.(type) {
+	case *fakePrincipalAdapter:
+		return adapter
+	default:
+		panic("principal adapter has unexpected type")
+	}
+}
+
+func registeredFakeResource(registration ResourceAdapterRegistration) *fakeResourceAdapter {
+	switch adapter := registration.Adapter.(type) {
+	case *fakeResourceAdapter:
+		return adapter
+	default:
+		panic("resource adapter has unexpected type")
+	}
+}
+
+func validRegistration() Registration {
+	principalUser := &fakePrincipalAdapter{kind: "user"}
+	principalService := &fakePrincipalAdapter{kind: "service"}
+	resource := &fakeResourceAdapter{kind: "tool"}
+	userKey, _ := NewCanonicalizationResult(PrincipalKey("user:alpha"))
+	serviceKey, _ := NewCanonicalizationResult(PrincipalKey("service:alpha"))
+	resourceKey, _ := NewCanonicalizationResult(ResourceKey("org:test:tool:alpha"))
+	return Registration{
+		PrincipalAdapters: []PrincipalAdapterRegistration{
+			{Adapter: principalUser, Fixtures: []PrincipalCanonicalizationFixture{
+				{OrganizationID: "org:test", Input: " User:Alpha ", Expected: userKey},
+			}},
+			{Adapter: principalService, Fixtures: []PrincipalCanonicalizationFixture{
+				{OrganizationID: "org:test", Input: " Service:Alpha ", Expected: serviceKey},
+			}},
+		},
+		ResourceAdapters: []ResourceAdapterRegistration{
+			{Adapter: resource, Fixtures: []ResourceCanonicalizationFixture{
+				{OrganizationID: "org:test", Input: " Tool:Alpha ", Expected: resourceKey},
+			}},
+		},
+		Surfaces: []Surface{"mcp", "api"},
+		TransportAdapters: []TransportAdapterRegistration{
+			{Key: "jsonrpc", Adapter: ResolveTransportDisposition},
+			{Key: "http", Adapter: ResolveTransportDisposition},
+		},
+		IdentityContracts: []IdentityContract{{
+			Key: "actor-tool", PrincipalKinds: []PrincipalKind{"user", "service"}, ResourceKinds: []ResourceKind{"tool"},
+		}},
+		Definitions: []Definition{{
+			Key: "block-tools", PrincipalKinds: []PrincipalKind{"user", "service"}, ResourceKinds: []ResourceKind{"tool"},
+			FailurePolicy: FailurePolicyFailOpen, DefaultExternalNote: "  Access paused. ", EnforcementOwner: " security ",
+			IdentityContract: "actor-tool", Surfaces: []Surface{"mcp", "api"}, TransportAdapters: []TransportAdapterKey{"jsonrpc", "http"},
+		}},
+		Coverage: []CoverageContract{
+			{
+				Definition: "block-tools", Surface: "mcp", PrincipalSource: " authenticated actor ", ResourceSource: " tool request ",
+				Checkpoint: " before dispatch ", ProtectedWork: " tool execution ", FailurePolicy: FailurePolicyFailOpen,
+				TransportAdapter: "jsonrpc", EnforcementOwner: "security", IdentityContract: "actor-tool",
+			},
+			{
+				Definition: "block-tools", Surface: "api", PrincipalSource: " authenticated actor ", ResourceSource: " route resource ",
+				Checkpoint: " before handler ", ProtectedWork: " handler execution ", FailurePolicy: FailurePolicyFailOpen,
+				TransportAdapter: "http", EnforcementOwner: "security", IdentityContract: "actor-tool",
+			},
+		},
+	}
+}

--- a/server/internal/killswitches/registry_test.go
+++ b/server/internal/killswitches/registry_test.go
@@ -166,6 +166,7 @@ func TestBuildRegistryRejectsInvalidRegistration(t *testing.T) {
 		name   string
 		mutate func(*Registration)
 	}{
+		{name: "no definitions", mutate: func(r *Registration) { r.Definitions, r.Coverage = nil, nil }},
 		{name: "duplicate definition", mutate: func(r *Registration) { r.Definitions = append(r.Definitions, r.Definitions[0]) }},
 		{name: "duplicate identity contract", mutate: func(r *Registration) { r.IdentityContracts = append(r.IdentityContracts, r.IdentityContracts[0]) }},
 		{name: "duplicate principal adapter", mutate: func(r *Registration) { r.PrincipalAdapters = append(r.PrincipalAdapters, r.PrincipalAdapters[0]) }},

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -140,6 +140,15 @@ func TestKillswitchSchemaRejectsInvalidRows(t *testing.T) {
 		requireConstraint(t, err, tc.constraint)
 	}
 
+	// PostgreSQL text cannot represent NUL. Application normalization rejects it first, and this
+	// assertion documents the persistence boundary in case unnormalized input reaches the driver.
+	_, err = conn.Exec(ctx, `
+		INSERT INTO killswitch_prescription_versions (
+			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', 'selected', $3, $4, 'external')
+	`, orgID, prescriptionID, startsAt, "internal\x00note")
+	require.Error(t, err)
+
 	_, err = conn.Exec(ctx, `
 		INSERT INTO killswitch_prescription_versions (
 			organization_id, prescription_id, version, state, resource_scope, starts_at, internal_note, external_note


### PR DESCRIPTION
## Summary

Defines the code-owned killswitch framework contracts for capability definitions, principal and resource adapters, coverage, failure policy, and transport-neutral enforcement outcomes. Adds an immutable validated registry plus versioned canonical mutation encoding with fixed SHA-256 vectors.

## Technical details

### Startup validation

Registry construction rejects incomplete or duplicate registrations, invalid cross-references, and unstable canonicalization fixtures before consumers can access the registry.

### Replay compatibility

The V1 encoder fixes field ordering, UUID and timestamp normalization, note handling, optional-value representation, and selected-resource ordering so equivalent requests hash identically across releases.

Closes [DNO-977](https://linear.app/speakeasy/issue/DNO-977/feat-define-killswitch-registries-and-coverage-contracts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the killswitch framework contracts: code-owned registries and adapters for definitions, principal and resource kinds, failure policy, covered surfaces, and transport behavior. Adds transport-neutral match/no-match/infrastructure-failure results with a fixed disposition matrix, plus versioned V1 canonical mutation encoding with fixed SHA-256 vectors so equivalent requests hash identically across releases. Tenant-authored definitions are not supported.

**Startup validation**
- Registry construction rejects empty, duplicate, or incomplete registrations, invalid cross-references, unstable canonicalization fixtures, and transport dispositions outside the allowed matrix before consumers can read from it.

**Replay compatibility**
- V1 encoding fixes field ordering, UUID and timestamp normalization, note trimming, optional-value representation, and selected-resource ordering.
- Schema tests document that NUL bytes in internal notes are rejected at the persistence boundary.

Closes [DNO-977](https://linear.app/speakeasy/issue/DNO-977/feat-define-killswitch-registries-and-coverage-contracts).

<sup>Written for commit bb3738bc356abbf5683a45f6e4395f29858c7e97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

