### PR TITLE
chore: stop batching the gofix pre-commit step

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -35,7 +35,12 @@ local linters = new Mapping<String, Step> {
     fix = "gofmt -s -w {{files}}"
   }
   ["gofix"] {
-    batch = true
+    // Not batched, unlike the formatters above. `batch = true` splits the file
+    // list across parallel invocations, which pays off for per-file tools. This
+    // step is package-scoped: `go:fix` maps each file to its enclosing package
+    // and runs `go fix` on that package, type-checking it and its full
+    // dependency graph. Batching therefore turns N files in one package into N
+    // concurrent cold builds of the same graph, each forking its own compilers.
     glob = "**/*.go"
     exclude = "**/testdata/**"
     fix = "mise run -q go:fix {{files}}"


### PR DESCRIPTION
## Summary

Removes `batch = true` from the `gofix` step in `hk.pkl`, so the step runs as a single invocation over the full file list instead of being split across parallel ones.

Measured by temporarily swapping the step's command for a stub that reports its argument count, then running it over all 5170 Go files in the repo: 25 invocations before, 1 after.

## Motivation

hk's `batch` option splits a step's file list across parallel invocations to get concurrency out of single-threaded per-file tools. That is the right call for `gofmt`, `oxfmt`, and `ruff`, which are the other batched steps here, and all of which do genuinely per-file work.

`gofix` is not per-file. The `go:fix` task maps each file it receives to the enclosing directory and runs `go fix` on that **package**, which type-checks the package and its full dependency graph. Batching therefore does not divide the work, it multiplies it: N changed files in one package become N cold builds of the same graph, started concurrently, sharing no cache work, each forking its own set of compilers.

The practical effect is that one ordinary commit can saturate the machine. A commit touching 12 files in `server/internal/mcp` fanned out into 25 concurrent `go fix` invocations and nearly 300 `compile` processes, with two such commits in flight from different worktrees driving load average past 600 and leaving the hook unable to finish.

`.mise-tasks/go/fix.mts` needs no change. It already deduplicates directories before invoking `go fix`, which is fully effective once hk stops splitting its input; the redundant builds were a symptom of the batching rather than a separate bug.

A comment on the step records why it is deliberately unbatched, since `batch = true` reads like a straightforward speedup next to the formatters above it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `batch = true` from the `gofix` pre-commit step so it runs as a single invocation over the full file list instead of fanning out into parallel package builds, eliminating machine saturation from redundant cold `go fix` builds.

- `batch = true` helps per-file tools like `gofmt` and `oxfmt`, but `go:fix` maps each file to its enclosing package and type-checks the full dependency graph, so N files in one package became N concurrent rebuilds of the same graph.
- Measured over all 5170 Go files: 25 invocations before, 1 after.
- A commit touching 12 files in `server/internal/mcp` previously spawned 25 concurrent `go fix` invocations and nearly 300 compile processes.
- `.mise-tasks/go/fix.mts` needs no change; it already deduplicates directories before invoking `go fix`.

<sup>Written for commit 31fad85e31af60a3feecd04ef7d7a9c3a88f0983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

