### PR TITLE
feat: emit ttlMs and cacheScope on cacheable MCP results

### DIFF
--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -257,6 +257,7 @@ func handleSearchToolsCall(
 			IsError:           false,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize find_tools response").LogError(ctx, logger)
@@ -373,6 +374,7 @@ func handleDescribeToolsCall(
 			IsError:           false,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize describe_tools response").LogError(ctx, logger)

--- a/server/internal/mcp/rpc.go
+++ b/server/internal/mcp/rpc.go
@@ -24,6 +24,66 @@ const (
 	resultTypeComplete = "complete"
 )
 
+// cacheScope is MCP 2026-07-28's disclosure boundary for a cacheable result.
+// The specification reads an absent value as public, so every hint emitted
+// here names one of these explicitly rather than relying on that default.
+type cacheScope string
+
+const (
+	// cacheScopePublic permits any client, shared gateway, or caching proxy to
+	// store the result and serve it to any user.
+	cacheScopePublic cacheScope = "public"
+
+	// cacheScopePrivate confines caching to the requesting user's own client.
+	cacheScopePrivate cacheScope = "private"
+)
+
+// cacheHints carries the two members MCP 2026-07-28 requires on the results of
+// server/discover, tools/list, prompts/list, resources/list,
+// resources/templates/list, and resources/read.
+type cacheHints struct {
+	// TTLMs is how long a client may treat the result as fresh. Zero means
+	// immediately stale, and is the only value emitted today, on every
+	// operation. Raising it is deferred until there is evidence to set it
+	// from; a caller-uniform result is no more ready for a non-zero TTL than
+	// a caller-varying one, because nothing here advertises a listChanged
+	// capability, so a client has no channel to learn a list went stale
+	// before the TTL expires.
+	TTLMs int `json:"ttlMs"`
+
+	// CacheScope is the disclosure boundary for the result.
+	CacheScope cacheScope `json:"cacheScope"`
+}
+
+// The caching stances the cacheable operations resolve to. Both carry a zero
+// TTL; they differ only in who may be served the retained copy, which is the
+// value a future non-zero TTL would rely on being right.
+var (
+	// cacheHintsCallerVarying marks a result whose content depends on who
+	// asked, so no shared cache may serve it to a second caller.
+	cacheHintsCallerVarying = &cacheHints{TTLMs: 0, CacheScope: cacheScopePrivate}
+
+	// cacheHintsCallerUniform marks a result every caller receives identically.
+	cacheHintsCallerUniform = &cacheHints{TTLMs: 0, CacheScope: cacheScopePublic}
+)
+
+// hostedListCacheHints resolves the caching stance of a hosted list result
+// whose entries are not filtered per caller. Such a result is byte-identical
+// for everyone allowed to see it, so what remains is whether seeing it
+// required authorization at all: "public" licenses an intermediary to serve
+// the retained body to any caller, including one that never presented
+// credentials, which on a private server discloses the inventory the
+// visibility setting exists to withhold. An authenticated request is treated
+// as caller-varying on either kind of server, so a session-bound response is
+// never handed to an anonymous one.
+func hostedListCacheHints(mcpIsPublic, authenticated bool) *cacheHints {
+	if mcpIsPublic && !authenticated {
+		return cacheHintsCallerUniform
+	}
+
+	return cacheHintsCallerVarying
+}
+
 // Server identities injected into every result's _meta and answered from the
 // two initialize handlers. serverInfo is display/debug only per the MCP spec,
 // so the static version carries no compatibility meaning; keeping it constant
@@ -52,6 +112,12 @@ type result[T any] struct {
 	// identity. A zero value falls back to the hosted-toolset identity at
 	// marshal time.
 	serverIdentity serverInfo
+
+	// cacheHints are the caching members MCP 2026-07-28 requires on the six
+	// cacheable operations. Nil for every other method, which the
+	// specification leaves without caching hints, and which therefore emits
+	// neither member.
+	cacheHints *cacheHints
 }
 
 func (m result[T]) MarshalJSON() ([]byte, error) {
@@ -65,7 +131,7 @@ func (m result[T]) MarshalJSON() ([]byte, error) {
 		identity = serverInfoHostedToolset
 	}
 
-	spliced, err := spliceResultProtocolFields(resultBytes, identity)
+	spliced, err := spliceResultProtocolFields(resultBytes, identity, m.cacheHints)
 	if err != nil {
 		return nil, fmt.Errorf("splice result protocol fields: %w", err)
 	}
@@ -88,6 +154,12 @@ func (m result[T]) MarshalJSON() ([]byte, error) {
 // unconditionally. Both are fill-if-missing so a result relayed from an
 // upstream MCP server keeps whatever the upstream already supplied.
 //
+// Non-nil hints add the caching members the same revision requires on the six
+// cacheable operations, which callers serving any other method leave nil.
+// Those two overwrite rather than fill: an upstream's own caching stance
+// cannot account for the visibility rules and per-caller configuration
+// layered in front of it here.
+//
 // A result that is not a JSON object — possible only when an MCP-passthrough
 // tool returns spec-violating output — is returned unchanged: the malformed
 // shape stays the upstream's problem rather than becoming a Gram
@@ -96,7 +168,7 @@ func (m result[T]) MarshalJSON() ([]byte, error) {
 // re-marshaled in sorted order, and insignificant whitespace and HTML
 // escaping inside values may change, exactly as the pre-splice envelope
 // already did to passthrough bodies.
-func spliceResultProtocolFields(resultBytes []byte, identity serverInfo) (json.RawMessage, error) {
+func spliceResultProtocolFields(resultBytes []byte, identity serverInfo, hints *cacheHints) (json.RawMessage, error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(resultBytes, &fields); err != nil || fields == nil {
 		return resultBytes, nil
@@ -104,6 +176,18 @@ func spliceResultProtocolFields(resultBytes []byte, identity serverInfo) (json.R
 
 	if _, ok := fields["resultType"]; !ok {
 		fields["resultType"] = json.RawMessage(strconv.Quote(resultTypeComplete))
+	}
+
+	// The caching hints, unlike the fields above, overwrite rather than fill.
+	// On the resources/read passthrough path the relayed body carries an
+	// upstream MCP server's own hints, and an upstream declaring its result
+	// public is describing its own caller-uniformity: it cannot account for
+	// the visibility rules and per-caller header configuration layered in
+	// front of it here, either of which can make the same upstream body
+	// caller-specific by the time it reaches the client.
+	if hints != nil {
+		fields["ttlMs"] = json.RawMessage(strconv.Itoa(hints.TTLMs))
+		fields["cacheScope"] = json.RawMessage(strconv.Quote(string(hints.CacheScope)))
 	}
 
 	meta := map[string]json.RawMessage{}
@@ -154,6 +238,7 @@ func (m *result[T]) UnmarshalJSON(data []byte) error {
 	m.ID = envelope.ID
 	m.Result = envelope.Result
 	m.serverIdentity = serverInfo{Name: "", Version: ""}
+	m.cacheHints = nil
 
 	return nil
 }

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -110,6 +110,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpme
 	result := &result[initializeResult]{
 		ID:             req.ID,
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     nil,
 		Result: initializeResult{
 			ProtocolVersion: negotiated,
 			Capabilities: map[string]json.RawMessage{

--- a/server/internal/mcp/rpc_internal_test.go
+++ b/server/internal/mcp/rpc_internal_test.go
@@ -12,7 +12,7 @@ import (
 func TestSpliceResultProtocolFields_ObjectGainsBothFields(t *testing.T) {
 	t.Parallel()
 
-	out, err := spliceResultProtocolFields([]byte(`{}`), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(`{}`), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"resultType": "complete",
@@ -23,7 +23,7 @@ func TestSpliceResultProtocolFields_ObjectGainsBothFields(t *testing.T) {
 func TestSpliceResultProtocolFields_PreservesExistingResultType(t *testing.T) {
 	t.Parallel()
 
-	out, err := spliceResultProtocolFields([]byte(`{"resultType":"input_required"}`), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(`{"resultType":"input_required"}`), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 
 	// The upstream resultType survives while serverInfo is still injected;
@@ -37,7 +37,7 @@ func TestSpliceResultProtocolFields_PreservesExistingResultType(t *testing.T) {
 func TestSpliceResultProtocolFields_NullMetaTreatedAsAbsent(t *testing.T) {
 	t.Parallel()
 
-	out, err := spliceResultProtocolFields([]byte(`{"_meta":null}`), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(`{"_meta":null}`), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"resultType": "complete",
@@ -49,7 +49,7 @@ func TestSpliceResultProtocolFields_PreservesUpstreamServerInfo(t *testing.T) {
 	t.Parallel()
 
 	in := `{"_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Upstream","version":"1.2.3"}}}`
-	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"resultType": "complete",
@@ -61,7 +61,7 @@ func TestSpliceResultProtocolFields_MergesIntoExistingMeta(t *testing.T) {
 	t.Parallel()
 
 	in := `{"_meta":{"com.example/key":"kept"},"content":[]}`
-	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"resultType": "complete",
@@ -76,7 +76,7 @@ func TestSpliceResultProtocolFields_MergesIntoExistingMeta(t *testing.T) {
 func TestSpliceResultProtocolFields_NonObjectMetaLeftAlone(t *testing.T) {
 	t.Parallel()
 
-	out, err := spliceResultProtocolFields([]byte(`{"_meta":"not-an-object"}`), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(`{"_meta":"not-an-object"}`), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"resultType":"complete","_meta":"not-an-object"}`, string(out))
 }
@@ -85,7 +85,7 @@ func TestSpliceResultProtocolFields_NonObjectResultUnchanged(t *testing.T) {
 	t.Parallel()
 
 	for _, in := range []string{`"a string"`, `[1,2,3]`, `null`, `42`} {
-		out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+		out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, nil)
 		require.NoError(t, err)
 		require.Equal(t, in, string(out))
 	}
@@ -97,10 +97,120 @@ func TestSpliceResultProtocolFields_PreservesValueContent(t *testing.T) {
 	// Values are re-emitted as raw bytes, so content that float64 decoding
 	// would corrupt — like big numbers — survives the splice intact.
 	in := `{"content":[{"text":"a","n":123456789012345678901234567890}]}`
-	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset)
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, nil)
 	require.NoError(t, err)
 	require.Contains(t, string(out), `123456789012345678901234567890`)
 	require.Contains(t, string(out), `[{"text":"a","n":123456789012345678901234567890}]`)
+}
+
+func TestSpliceCacheHints_ObjectGainsBothMembers(t *testing.T) {
+	t.Parallel()
+
+	out, err := spliceResultProtocolFields([]byte(`{"tools":[]}`), serverInfoHostedToolset, cacheHintsCallerVarying)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Gram","version":"0.0.0"}},"tools":[],"ttlMs":0,"cacheScope":"private"}`, string(out))
+}
+
+func TestSpliceCacheHints_OverwritesUpstreamValues(t *testing.T) {
+	t.Parallel()
+
+	// Unlike the protocol fields, the caching hints are not fill-if-missing:
+	// an upstream's own stance cannot account for the layers in front of it,
+	// so a public upstream declaration is replaced rather than preserved.
+	in := `{"contents":[],"ttlMs":60000,"cacheScope":"public"}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, cacheHintsCallerVarying)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Gram","version":"0.0.0"}},"contents":[],"ttlMs":0,"cacheScope":"private"}`, string(out))
+}
+
+func TestSpliceCacheHints_OverwritesOffSpecUpstreamValues(t *testing.T) {
+	t.Parallel()
+
+	// A negative TTL and a scope that is neither spec value are replaced
+	// wholesale, so nothing off-spec reaches the client through the relay.
+	in := `{"ttlMs":-5000,"cacheScope":"whatever"}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, cacheHintsCallerVarying)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"resultType":"complete","_meta":{"io.modelcontextprotocol/serverInfo":{"name":"Gram","version":"0.0.0"}},"ttlMs":0,"cacheScope":"private"}`, string(out))
+}
+
+func TestSpliceCacheHints_NonObjectResultUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// A spec-violating upstream body stays the upstream's problem rather than
+	// becoming a serialization failure, matching the protocol fields. Such a
+	// result carries no caching hints at all.
+	for _, in := range []string{`"a string"`, `[1,2,3]`, `null`, `42`} {
+		out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, cacheHintsCallerUniform)
+		require.NoError(t, err)
+		require.Equal(t, in, string(out))
+	}
+}
+
+func TestSpliceCacheHints_PreservesValueContent(t *testing.T) {
+	t.Parallel()
+
+	in := `{"contents":[{"text":"a","n":123456789012345678901234567890}]}`
+	out, err := spliceResultProtocolFields([]byte(in), serverInfoHostedToolset, cacheHintsCallerUniform)
+	require.NoError(t, err)
+	require.Contains(t, string(out), `123456789012345678901234567890`)
+	require.Contains(t, string(out), `"cacheScope":"public"`)
+}
+
+func TestHostedListCacheHints_PublicOnlyWhenUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		mcpIsPublic   bool
+		authenticated bool
+		want          cacheScope
+	}{
+		{mcpIsPublic: true, authenticated: false, want: cacheScopePublic},
+		{mcpIsPublic: true, authenticated: true, want: cacheScopePrivate},
+		{mcpIsPublic: false, authenticated: false, want: cacheScopePrivate},
+		{mcpIsPublic: false, authenticated: true, want: cacheScopePrivate},
+	}
+
+	for _, tc := range cases {
+		got := hostedListCacheHints(tc.mcpIsPublic, tc.authenticated)
+		require.Equal(t, tc.want, got.CacheScope, "public=%t authenticated=%t", tc.mcpIsPublic, tc.authenticated)
+		require.Zero(t, got.TTLMs, "public=%t authenticated=%t", tc.mcpIsPublic, tc.authenticated)
+	}
+}
+
+func TestResultMarshal_EmitsCacheHintsWhenSet(t *testing.T) {
+	t.Parallel()
+
+	bs, err := json.Marshal(result[struct{}]{
+		ID:         mcpjsonrpc.NumberID(7),
+		Result:     struct{}{},
+		cacheHints: cacheHintsCallerVarying,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"id": 7,
+		"result": {
+			"resultType": "complete",
+			"ttlMs": 0,
+			"cacheScope": "private",
+			"_meta": {"io.modelcontextprotocol/serverInfo": {"name": "Gram", "version": "0.0.0"}}
+		}
+	}`, string(bs))
+}
+
+func TestResultMarshal_OmitsCacheHintsWhenNil(t *testing.T) {
+	t.Parallel()
+
+	// The caching MUST covers six operations; every other method emits
+	// neither member rather than a zero-valued one.
+	bs, err := json.Marshal(result[struct{}]{
+		ID:     mcpjsonrpc.NumberID(7),
+		Result: struct{}{},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(bs), "ttlMs")
+	require.NotContains(t, string(bs), "cacheScope")
 }
 
 func TestResultMarshal_DefaultsToHostedIdentity(t *testing.T) {

--- a/server/internal/mcp/rpc_ping.go
+++ b/server/internal/mcp/rpc_ping.go
@@ -14,6 +14,7 @@ func handlePing(ctx context.Context, logger *slog.Logger, id mcpjsonrpc.ID, iden
 		ID:             id,
 		Result:         struct{}{},
 		serverIdentity: identity,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize ping response").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_prompt_get.go
+++ b/server/internal/mcp/rpc_prompt_get.go
@@ -73,6 +73,7 @@ func handlePromptsGet(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool
 			Messages:    []promptMessage{{Role: "user", Content: content}},
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize prompts/get result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_prompts_list.go
+++ b/server/internal/mcp/rpc_prompts_list.go
@@ -100,6 +100,7 @@ func handlePromptsList(ctx context.Context, logger *slog.Logger, db *pgxpool.Poo
 			Prompts: prompts,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     hostedListCacheHints(conv.PtrValOr(toolset.McpIsPublic, false), payload.authenticated),
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_resources_list.go
+++ b/server/internal/mcp/rpc_resources_list.go
@@ -55,6 +55,7 @@ func handleResourcesList(ctx context.Context, logger *slog.Logger, db *pgxpool.P
 			Resources: resources,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     hostedListCacheHints(conv.PtrValOr(toolset.McpIsPublic, false), payload.authenticated),
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -241,6 +241,7 @@ func handleResourcesRead(
 			ID:             req.ID,
 			Result:         json.RawMessage(rw.body.Bytes()),
 			serverIdentity: serverInfoHostedToolset,
+			cacheHints:     cacheHintsCallerVarying,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP passthrough result").LogError(ctx, logger)
@@ -277,6 +278,11 @@ func handleResourcesRead(
 			Contents: []resourceContent{content},
 		},
 		serverIdentity: serverInfoHostedToolset,
+		// The body is produced by invoking the resource with the caller's own
+		// configuration, and MCP-* request headers reach that configuration on
+		// every server regardless of visibility or authentication. Two callers
+		// reading the same URI can therefore receive different content.
+		cacheHints: cacheHintsCallerVarying,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize resources/read result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_resources_templates_list.go
+++ b/server/internal/mcp/rpc_resources_templates_list.go
@@ -30,6 +30,9 @@ func handleResourcesTemplatesList(ctx context.Context, logger *slog.Logger, req 
 			ResourceTemplates: make([]*resourceTemplateListEntry, 0),
 		},
 		serverIdentity: serverInfoHostedToolset,
+		// The empty list is a constant, so every caller receives it
+		// identically regardless of server visibility or authentication.
+		cacheHints: cacheHintsCallerUniform,
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_resources_templates_list_test.go
+++ b/server/internal/mcp/rpc_resources_templates_list_test.go
@@ -31,6 +31,8 @@ func TestHandleResourcesTemplatesList_ReturnsEmptyList(t *testing.T) {
 	require.JSONEq(t, `{
 		"resourceTemplates": [],
 		"resultType": "complete",
+		"ttlMs": 0,
+		"cacheScope": "public",
 		"_meta": {
 			"io.modelcontextprotocol/serverInfo": {
 				"name": "Gram",

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -458,6 +458,7 @@ func handleToolsCall(
 			ID:             req.ID,
 			Result:         json.RawMessage(rw.body.Bytes()),
 			serverIdentity: serverInfoHostedToolset,
+			cacheHints:     nil,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize MCP result").LogError(ctx, logger)
@@ -479,6 +480,7 @@ func handleToolsCall(
 			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -192,6 +192,15 @@ func handleToolsList(
 			Tools: tools,
 		},
 		serverIdentity: serverInfoHostedToolset,
+		// Caller-varying unconditionally, on five independent axes: the
+		// per-tool authorization filter above, the Gram-Mode header selecting
+		// static or dynamic tools, the session's consent-screen tool
+		// selection, the ?tags= filter, and — for toolsets holding external
+		// MCP proxy tools — the upstream listing buildToolListEntries makes
+		// with the caller's own MCP-* header configuration and OAuth token.
+		// Only the first is gated on server visibility, so a public server is
+		// no more shareable than a private one.
+		cacheHints: cacheHintsCallerVarying,
 	}
 
 	bs, err := json.Marshal(result)

--- a/server/internal/mcp/rpc_tools_list_test.go
+++ b/server/internal/mcp/rpc_tools_list_test.go
@@ -264,6 +264,14 @@ func TestServePublic_RBAC_ToolsList_PublicMCPSkipsFiltering(t *testing.T) {
 	require.Len(t, names, 2)
 	require.Contains(t, names, "pub_tool_a")
 	require.Contains(t, names, "pub_tool_b")
+
+	// Skipping the authorization filter does not make the catalog shareable.
+	// A hosted tools/list still turns on the Gram-Mode header, the session's
+	// tool selection, the ?tags= filter, and any upstream listing made with
+	// the caller's own credentials, none of which a public MCP rules out.
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	requireCacheHints(t, envelope["result"], "private")
 }
 
 // ---------------------------------------------------------------------------

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -347,6 +347,7 @@ func (s *Service) handleMetaInitialize(
 			Instructions: metamcp.Instructions,
 		},
 		serverIdentity: serverInfoMetaServer,
+		cacheHints:     nil,
 	}
 	bs, err := json.Marshal(result)
 	if err != nil {
@@ -371,6 +372,9 @@ func (s *Service) handleMetaServerDiscover(
 			Instructions: metamcp.Instructions,
 		},
 		serverIdentity: serverInfoMetaServer,
+		// The self-description is assembled from constants, so every caller of
+		// this endpoint receives the same payload.
+		cacheHints: cacheHintsCallerUniform,
 	}
 	bs, err := json.Marshal(result)
 	if err != nil {
@@ -396,6 +400,9 @@ func (s *Service) listMetaServerTools(ctx context.Context, logger *slog.Logger, 
 		ID:             req.ID,
 		Result:         toolsListResultTools{Tools: tools},
 		serverIdentity: serverInfoMetaServer,
+		// The gateway tool contract is fixed and consults neither the endpoint
+		// nor the meta server, so every caller receives the same four tools.
+		cacheHints: cacheHintsCallerUniform,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").LogError(ctx, logger)

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -535,6 +535,7 @@ func (s *Service) executeProxiedMemberTool(
 		Result: upstreamResult,
 		// The result's _meta identity stays the member's, as on hosted.
 		serverIdentity: serverInfo{Name: member.slug, Version: "0.0.0"},
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "serialize member tool result").LogError(ctx, logger)

--- a/server/internal/mcp/serve_meta_test.go
+++ b/server/internal/mcp/serve_meta_test.go
@@ -204,6 +204,9 @@ func TestServePublic_MetaEndpoint_ServerDiscover(t *testing.T) {
 	require.NoError(t, json.Unmarshal(envelope["result"], &result))
 	require.Equal(t, []string{mcpversions.ServedMetaServer}, result.ProtocolVersions)
 	require.Equal(t, "Gram Gateway", result.ServerInfo.Name)
+
+	// The self-description is assembled from constants, so it is shareable.
+	requireCacheHints(t, envelope["result"], "public")
 }
 
 func TestServePublic_MetaEndpoint_ToolsList_FixedContract(t *testing.T) {
@@ -234,6 +237,10 @@ func TestServePublic_MetaEndpoint_ToolsList_FixedContract(t *testing.T) {
 		names = append(names, tool.Name)
 	}
 	require.Equal(t, []string{"list_servers", "describe_server", "describe_tools", "execute_tool"}, names)
+
+	// The contract consults neither the endpoint nor the meta server, so every
+	// caller receives these same four tools.
+	requireCacheHints(t, envelope["result"], "public")
 }
 
 func TestServePublic_MetaEndpoint_ListServers_ReturnsOrderedMembers(t *testing.T) {

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -519,6 +519,7 @@ func marshalMetaToolCallResult(ctx context.Context, logger *slog.Logger, id mcpj
 			IsError:           false,
 		},
 		serverIdentity: serverInfoMetaServer,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call response").LogError(ctx, logger)
@@ -547,6 +548,7 @@ func marshalMetaToolError(ctx context.Context, logger *slog.Logger, id mcpjsonrp
 			IsError:           true,
 		},
 		serverIdentity: serverInfoMetaServer,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call response").LogError(ctx, logger)

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -276,6 +276,7 @@ func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, telemetr
 			Instructions: "",
 		},
 		serverIdentity: serverInfoPlatformToolset,
+		cacheHints:     nil,
 	}
 	bs, err := json.Marshal(result)
 	if err != nil {
@@ -316,6 +317,9 @@ func (s *Service) listPlatformToolsetTools(
 		ID:             req.ID,
 		Result:         toolsListResultTools{Tools: tools},
 		serverIdentity: serverInfoPlatformToolset,
+		// The catalog is filtered by the active organization's product
+		// features, so two organizations receive different tool lists.
+		cacheHints: cacheHintsCallerVarying,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/list response").LogError(ctx, s.logger)
@@ -509,6 +513,7 @@ func (s *Service) callPlatformToolsetTool(
 			IsError:           rw.statusCode < 200 || rw.statusCode >= 300,
 		},
 		serverIdentity: serverInfoPlatformToolset,
+		cacheHints:     nil,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger, attr.SlogToolName(params.Name))

--- a/server/internal/mcp/serve_platform_test.go
+++ b/server/internal/mcp/serve_platform_test.go
@@ -352,6 +352,13 @@ func TestServePlatformToolset_PlatformMCPReadVariantListsTools(t *testing.T) {
 	// The assistant only ever acts in its own project, so the project the
 	// policy supplies is not advertised as an argument for a model to choose.
 	require.NotContains(t, body, `"project_id"`, "project arguments are injected, not requested")
+
+	// The catalogue is narrowed by the active organization's product features
+	// and embeds that organization's project in each tool, so it is never
+	// shareable with another caller.
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	requireCacheHints(t, envelope["result"], "private")
 }
 
 func TestServePlatformToolset_PlatformMCPReadLegacyVariantRejected(t *testing.T) {

--- a/server/internal/mcp/servepublic_resources_templates_list_test.go
+++ b/server/internal/mcp/servepublic_resources_templates_list_test.go
@@ -46,4 +46,70 @@ func TestServePublic_ResourcesTemplatesList_ReturnsEmptyList(t *testing.T) {
 	templates, ok := result["resourceTemplates"].([]any)
 	require.True(t, ok, "resourceTemplates should be an array: %v", result)
 	require.Empty(t, templates)
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	requireCacheHints(t, envelope["result"], "public")
+}
+
+// The hosted list operations that are not filtered per caller resolve their
+// cache scope from server visibility and whether the caller authenticated.
+// These two exercise the public branch end to end, which needs a request
+// carrying no auth context at all: a caller inside the owning organization is
+// treated as authenticated whether or not it presents a token, so passing the
+// fixture context here would exercise the private branch instead. It is also
+// the one combination whose two operands differ, so a transposed derivation
+// surfaces here as "private" rather than passing silently.
+func TestServePublic_PromptsList_PublicUnauthenticatedIsCacheablePublicly(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "prompts-scope-"+uuid.NewString()[:8])
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      5,
+		"method":  "prompts/list",
+	})
+	require.NoError(t, err)
+
+	w, err := servePublicHTTP(t, t.Context(), ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	requireCacheHints(t, envelope["result"], "public")
+}
+
+func TestServePublic_ResourcesList_PublicUnauthenticatedIsCacheablePublicly(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "resources-scope-"+uuid.NewString()[:8])
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      6,
+		"method":  "resources/list",
+	})
+	require.NoError(t, err)
+
+	w, err := servePublicHTTP(t, t.Context(), ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+	requireCacheHints(t, envelope["result"], "public")
 }

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -465,6 +465,23 @@ func TestServePublic_BatchRequestRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "batch requests are not supported")
 }
 
+// requireCacheHints asserts the caching members MCP 2026-07-28 requires on a
+// cacheable result. The members are read as pointers so an absent member fails
+// rather than decoding to a zero that happens to match the expected TTL.
+func requireCacheHints(t *testing.T, rawResult json.RawMessage, wantScope string) {
+	t.Helper()
+
+	var hints struct {
+		TTLMs      *int    `json:"ttlMs"`
+		CacheScope *string `json:"cacheScope"`
+	}
+	require.NoError(t, json.Unmarshal(rawResult, &hints))
+	require.NotNil(t, hints.TTLMs, "result carries no ttlMs")
+	require.NotNil(t, hints.CacheScope, "result carries no cacheScope")
+	require.Zero(t, *hints.TTLMs)
+	require.Equal(t, wantScope, *hints.CacheScope)
+}
+
 // servePublicToolsRequest issues a POST to /mcp/{slug} with an optional raw
 // query string (e.g. "tags=alpha,beta") and returns the recorder. Unlike
 // servePublicHTTP it threads a query string onto the URL so ?tags= filtering


### PR DESCRIPTION
[AIM-44](https://linear.app/speakeasy/issue/AIM-44/feat-emit-ttlms-and-cachescope-on-cacheable-mcp-results)

## Motivation

MCP `2026-07-28` requires `ttlMs` and `cacheScope` on the results of `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, and `resources/read`. Neither member was emitted anywhere.

`cacheScope` is a disclosure decision rather than a performance one. The specification is explicit that a `"public"` result may be served to any caller by a shared gateway or caching proxy, **even when it came from an authenticated endpoint**, so marking a caller-varying result public would license an intermediary to hand one principal's response to another.

## Summary

The hints ride the shared `result[T]` envelope as a nullable `cacheHints` field and are spliced in alongside `resultType` and the server identity, so one implementation covers all nine emission sites. Two of those sites can be reached no other way: the `resources/read` passthrough branch relays an upstream body as `result[json.RawMessage]` and has no typed payload struct, and `metamcp.DiscoverResult` sits in a package that deliberately avoids importing back into `mcp`. Every `result[T]` literal in the package now declares a caching stance, `nil` on the eleven methods the requirement does not cover, so a new result type cannot silently skip the decision.

`ttlMs` is `0` at every site. Raising it is deferred: nothing advertises a `listChanged` capability, so a client has no channel to learn a list went stale before the TTL expires.

`cacheScope` is derived, and more results vary by caller than the original triage assumed:

| Operation                                 | Scope     | Why                                                                                                                                                                                                                                                                                                                                                                                                   |
| ----------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| hosted `tools/list`                       | `private` | Unconditionally. The catalog turns on the `Gram-Mode` header, the session's consent-screen tool selection, the `?tags=` filter, and (for toolsets holding external MCP proxy tools) an upstream listing made with the caller's own `MCP-*` headers and OAuth token. Only the per-tool authorization filter is gated on server visibility, so a public server is no more shareable than a private one. |
| hosted `resources/read` (both branches)   | `private` | Unconditionally. `MCP-*` request headers reach the resource's configuration on every server regardless of visibility or authentication, so two callers reading one URI can receive different bodies.                                                                                                                                                                                                  |
| platform `tools/list`                     | `private` | Narrowed by the active organization's product features, and each tool embeds that organization's project.                                                                                                                                                                                                                                                                                             |
| hosted `prompts/list`, `resources/list`   | derived   | Not filtered per item, so `"public"` only when the server is public and the caller did not authenticate.                                                                                                                                                                                                                                                                                              |
| hosted `resources/templates/list`         | `public`  | A constant empty list.                                                                                                                                                                                                                                                                                                                                                                                |
| meta `tools/list`, meta `server/discover` | `public`  | Fixed contracts assembled from constants.                                                                                                                                                                                                                                                                                                                                                             |

At the passthrough site the hints overwrite the upstream's rather than merging most restrictive wins. An upstream declaring its own result public is describing its own caller uniformity and cannot account for the visibility rules and per-caller configuration layered in front of it here. Given `resources/read` is unconditionally private at `ttlMs: 0`, a merge would be equivalent to an overwrite today and strictly worse for a negative upstream `ttlMs`, which the overwrite corrects.

Emission is unconditional rather than gated on the negotiated revision, matching the precedent set for `resultType` and the server identity. The hosted and platform surfaces serve up to `2025-11-25` today; only the meta surface serves `2026-07-28`.

`spliceResultProtocolFields` gained the hints as an optional parameter rather than running as a second splice, so a cacheable result is parsed and re-serialized once rather than twice. On a large `tools/list` that avoids a full extra round trip over the whole document per request.

## Follow-ups filed

Both were found while investigating this change and are deliberately out of scope here.

- [AIM-139](https://linear.app/speakeasy/issue/AIM-139/feat-mark-rbac-filtered-remote-mcp-proxy-toolslist-results-as): the remote MCP proxy's `mcp:connect` RBAC filter relays a per-principal filtered `tools/list` without marking it private. The proxy relays upstream results rather than originating them, and the fix trades against a byte-for-byte relay property that deserves its own decision.
- [AIM-142](https://linear.app/speakeasy/issue/AIM-142/fix-the-consent-mcp-transport-echoes-an-unvalidated-protocol-version): the consent MCP transport echoes an unvalidated protocol version back as the negotiated one and emits no protocol result fields. It is a fourth Gram-served MCP surface that participates in none of the `mcpversions` machinery, and its responses already carry `Cache-Control: no-store`, so the missing members are a conformance gap rather than a live exposure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements [AIM-44](https://linear.app/speakeasy/issue/AIM-44/feat-emit-ttlms-and-cachescope-on-cacheable-mcp-results): emits the MCP 2026-07-28 `ttlMs` and `cacheScope` members on all cacheable results — `server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, and `resources/read` — which Gram previously emitted nowhere. `ttlMs` is `0` everywhere; `cacheScope` is `private` anywhere the result varies by caller, so no shared cache can serve one caller's response to another.

**Cache scope**
- Unconditionally `private` on hosted `tools/list`, hosted `resources/read` (both branches), and platform `tools/list` (per-organization feature filtering).
- `public` for the constant outputs — meta `server/discover`, meta `tools/list`, hosted `resources/templates/list` — and for hosted `prompts/list` and `resources/list` only when the server is public and the caller is unauthenticated.

**Implementation**
- The hints ride the shared `result[T]` envelope as a nullable `cacheHints` field spliced alongside `resultType` and server identity, covering all nine emission sites including the `resources/read` passthrough.
- Passthrough hints overwrite the upstream's rather than merging, since an upstream can't account for the visibility and per-caller configuration layered in front of it.
- Every result literal now declares a stance, `nil` on the eleven non-cacheable methods.
- A non-zero `ttlMs` is deferred until Gram advertises `listChanged` and the header/query cache-key inputs move into request parameters.

<sup>Written for commit ca5528ef08076650742bd97bbf88fed65775b552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

