### PR TITLE
feat: default CIMD client admission to open for unconfigured issuers

### DIFF
--- a/.changeset/cimd-open-admission-default.md
+++ b/.changeset/cimd-open-admission-default.md
@@ -1,0 +1,10 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Default CIMD client admission to `open` for issuers that were never configured, instead of the internal `reporting` mode. No client that authenticates today stops authenticating: both modes admit every spec-valid client ID metadata document. What changes is that the resting policy is now a real, readable, operator-changeable value: new issuers are created as `open`, the settings page shows Open selected with its warning rather than nothing selected, and `presets` enforcement becomes something an operator opts into rather than a default anyone lands on.
+
+Catalog-gap measurement survives the change. An open-mode admission still computes what `presets` would have decided and records it on `cimd.admission.decisions`, under the new `admitted_open_not_listed` outcome for a client no rule covers.
+
+The custom client URL list now follows the unsaved selection in the admission mode field, so the URLs that `presets` enforces can be added before switching to it rather than after.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -84584,7 +84584,7 @@ components:
             - interactive
         client_id_metadata_admission_mode:
           type: string
-          description: Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.
+          description: Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.
           enum:
             - disabled
             - presets
@@ -85262,7 +85262,7 @@ components:
           description: chain | interactive.
         client_id_metadata_admission_mode:
           type: string
-          description: 'The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note ''reporting'' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what ''presets'' would have refused. It exists so the platform can measure before switching the default to ''presets''. Set an explicit mode to opt out of it.'
+          description: 'The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. ''open'' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and ''presets'' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note ''reporting'' can be READ but not written: it is a legacy value that admits exactly what ''open'' admits, and no issuer is created with it.'
           enum:
             - disabled
             - presets

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -90,7 +90,21 @@ vi.mock("./UserSessionDurationField", () => ({
 }));
 
 vi.mock("./CimdAdmissionModeField", () => ({
-  CimdAdmissionModeField: () => <div>cimd-admission-mode</div>,
+  CimdAdmissionModeField: ({
+    onDraftModeChange,
+  }: {
+    onDraftModeChange?: (mode: string) => void;
+  }) => (
+    <div>
+      cimd-admission-mode
+      <button type="button" onClick={() => onDraftModeChange?.("presets")}>
+        draft-presets
+      </button>
+      <button type="button" onClick={() => onDraftModeChange?.("open")}>
+        draft-open
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("./CimdCustomClientsField", () => ({
@@ -250,6 +264,58 @@ describe("AuthenticationSectionBody", () => {
       expect(screen.getByText("cimd-custom-clients")).toBeDefined();
     },
   );
+
+  it("reveals the custom CIMD client list for an unsaved Known clients selection", () => {
+    useUserSessionIssuer.mockReturnValue({
+      data: {
+        id: "user-session-issuer",
+        clientIdMetadataAdmissionMode: "open",
+      },
+      isLoading: false,
+      isError: false,
+    });
+    useAllRemoteSessionClients.mockReturnValue({ items: [], isLoading: false });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "idle",
+      metadata: null,
+    });
+
+    render(
+      <AuthenticationSectionBody target={remoteTargetWithSessionIssuer} />,
+    );
+
+    // Staging the URLs that "Known clients" enforces has to be possible
+    // BEFORE the mode is saved, or an operator switches into enforcement
+    // with an empty list and races to fill it while clients are being
+    // turned away.
+    expect(screen.queryByText("cimd-custom-clients")).toBeNull();
+    fireEvent.click(screen.getByText("draft-presets"));
+    expect(screen.getByText("cimd-custom-clients")).toBeDefined();
+  });
+
+  it("hides the custom CIMD client list again when the selection moves off Known clients", () => {
+    useUserSessionIssuer.mockReturnValue({
+      data: {
+        id: "user-session-issuer",
+        clientIdMetadataAdmissionMode: "presets",
+      },
+      isLoading: false,
+      isError: false,
+    });
+    useAllRemoteSessionClients.mockReturnValue({ items: [], isLoading: false });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "idle",
+      metadata: null,
+    });
+
+    render(
+      <AuthenticationSectionBody target={remoteTargetWithSessionIssuer} />,
+    );
+
+    expect(screen.getByText("cimd-custom-clients")).toBeDefined();
+    fireEvent.click(screen.getByText("draft-open"));
+    expect(screen.queryByText("cimd-custom-clients")).toBeNull();
+  });
 
   it.each(["open", "disabled"])(
     "hides the custom CIMD client list in %s mode",

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -9,9 +9,10 @@ import {
 import { Text } from "@/components/ui/Text";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
+import { UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode as WritableMode } from "@gram/client/models/components/updateusersessionissuerform.js";
 import { useRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { useUserSessionIssuer } from "@gram/client/react-query/userSessionIssuer.js";
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { SettingsInlineEmptyState } from "../../SettingsInlineEmptyState";
 import { SettingsSection } from "@/components/detail/settings-section";
 import { AttachRemoteIdentityProviderSheet } from "./AttachRemoteIdentityProviderSheet";
@@ -164,6 +165,28 @@ export function AuthenticationSectionBody({
     [allIssuers, associatedIssuerIds],
   );
 
+  // Mirrors the unsaved selection in the admission mode field so the
+  // custom-URL list can render against it. The field owns the draft; this is
+  // a copy, so it has to be reset on every trigger the field resets its own
+  // on: a change to the saved mode, a different issuer, and the field going
+  // away. That last one is not hypothetical — the field lives in one branch
+  // below and this state does not, so a failed background refetch swaps the
+  // branch for an error, unmounts the field, and remounts it later with a
+  // fresh draft. Without it in the deps, this copy would keep a selection
+  // the field no longer holds, and the list would render for a mode nothing
+  // is showing as chosen.
+  const [cimdDraftMode, setCimdDraftMode] = useState<WritableMode | null>(null);
+  const savedCimdMode = userSessionIssuer?.clientIdMetadataAdmissionMode;
+  const loadedIssuerId = userSessionIssuer?.id;
+  const cimdFieldMounted =
+    issuerConfigured &&
+    !isLoadingUserSessionIssuer &&
+    !isUserSessionIssuerError &&
+    !!userSessionIssuer;
+  useEffect(() => {
+    setCimdDraftMode(null);
+  }, [savedCimdMode, loadedIssuerId, cimdFieldMounted]);
+
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetInitialUrl, setSheetInitialUrl] = useState<string | undefined>();
   const [sheetInitialScopes, setSheetInitialScopes] = useState<string[]>();
@@ -213,17 +236,23 @@ export function AuthenticationSectionBody({
   } else if (isUserSessionIssuerError || !userSessionIssuer) {
     authenticationFields = <AuthenticationLoadErrorField />;
   } else {
-    // The custom-URL list only means anything in the modes that consult it.
-    // Keyed on the SAVED effective mode, not an unsaved draft in the mode
-    // field, so the list never claims to apply before the policy does.
+    // The custom-URL list only means anything in the modes that consult it,
+    // so it follows the selection rather than the saved value: an operator
+    // moving onto "Known clients" can add the URLs that mode enforces before
+    // saving it, instead of switching first and racing to fill the list
+    // while enforcement is already live with nothing in it.
+    const shownMode =
+      cimdDraftMode ?? userSessionIssuer.clientIdMetadataAdmissionMode;
     const admitsCustomUrls =
-      userSessionIssuer.clientIdMetadataAdmissionMode === "presets" ||
-      userSessionIssuer.clientIdMetadataAdmissionMode === "reporting";
+      shownMode === "presets" || shownMode === "reporting";
 
     authenticationFields = (
       <>
         <UserSessionDurationField userSessionIssuer={userSessionIssuer} />
-        <CimdAdmissionModeField userSessionIssuer={userSessionIssuer} />
+        <CimdAdmissionModeField
+          userSessionIssuer={userSessionIssuer}
+          onDraftModeChange={setCimdDraftMode}
+        />
         {admitsCustomUrls && (
           <CimdCustomClientsField userSessionIssuer={userSessionIssuer} />
         )}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
@@ -31,13 +31,12 @@ import { Loader2 } from "lucide-react";
 import { useEffect, useId, useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 
-// The three modes an operator can actually choose. The read side of the API
-// can also return "reporting" — the default for an issuer that has never
-// been configured — but it is not writable and is deliberately not shown as
-// a fourth option: it is as permissive as "open" while it is on, so naming
-// it as a choice would put a reassuring label on the least restrictive
-// state. An unconfigured issuer therefore renders with nothing selected. See
-// server/internal/usersessions/cimd/admission/mode.go.
+// The three modes an operator can actually choose, and between them every
+// mode an issuer can be in: "open" is what an issuer carries unless someone
+// changes it. The read side of the API can also return "reporting", a legacy
+// value that admits exactly what "open" admits. It is not writable and is
+// deliberately not offered as a fourth option, so an issuer still storing it
+// renders with nothing selected.
 const MODE_OPTIONS: {
   value: WritableMode;
   title: string;
@@ -68,18 +67,25 @@ const MODE_OPTIONS: {
 
 export function CimdAdmissionModeField({
   userSessionIssuer,
+  onDraftModeChange,
 }: {
   userSessionIssuer: UserSessionIssuer;
+  /**
+   * Publishes each unsaved selection so a sibling field can render against
+   * it. The custom-URL list belongs to the modes that consult it, and an
+   * operator moving an issuer onto "Known clients" needs to stage those URLs
+   * before the switch takes effect, not after.
+   */
+  onDraftModeChange?: (mode: WritableMode) => void;
 }): JSX.Element {
   const queryClient = useQueryClient();
   const fieldId = useId();
   const effectiveMode = userSessionIssuer.clientIdMetadataAdmissionMode;
 
-  // "reporting" is only ever returned for an issuer whose mode was never
-  // set, and it cannot be written back, so there is no option to select for
-  // it. Saving any mode leaves that state permanently, but it is a
-  // short-lived migration default rather than something an operator chose,
-  // so it is not worth a confirmation step in front of every first save.
+  // "reporting" cannot be written back, so there is no option to select for
+  // it and the group renders with nothing chosen. Only a row stored before
+  // "open" became the written default can still read back as it, and saving
+  // any mode leaves that state for good.
   const unconfigured = effectiveMode === "reporting";
 
   const [draftMode, setDraftMode] = useState<WritableMode | null>(null);
@@ -138,7 +144,10 @@ export function CimdAdmissionModeField({
       <RadioGroup
         aria-labelledby={`${fieldId}-label`}
         value={selectedMode ?? ""}
-        onValueChange={(next) => setDraftMode(next as WritableMode)}
+        onValueChange={(next) => {
+          setDraftMode(next as WritableMode);
+          onDraftModeChange?.(next as WritableMode);
+        }}
         className="space-y-2.5"
       >
         {MODE_OPTIONS.map((option) => (

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdAdmissionModeField.tsx
@@ -31,12 +31,12 @@ import { Loader2 } from "lucide-react";
 import { useEffect, useId, useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 
-// The three modes an operator can actually choose, and between them every
-// mode an issuer can be in: "open" is what an issuer carries unless someone
-// changes it. The read side of the API can also return "reporting", a legacy
-// value that admits exactly what "open" admits. It is not writable and is
-// deliberately not offered as a fourth option, so an issuer still storing it
-// renders with nothing selected.
+// The three WRITABLE modes. "open" is what an issuer carries unless someone
+// changes it, so it is what a newly created or never-configured issuer shows
+// as selected. The read side of the API can also return "reporting", a
+// legacy value that admits exactly what "open" admits. It is not writable
+// and is deliberately not offered as a fourth option, so an issuer still
+// storing it renders with nothing selected.
 const MODE_OPTIONS: {
   value: WritableMode;
   title: string;

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdCustomClientsField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/CimdCustomClientsField.tsx
@@ -291,8 +291,8 @@ function CustomClientList({
   }
 
   // No enforcement claim in the empty state: what an empty list means
-  // depends on the admission mode, and in the unconfigured "reporting" state
-  // nothing is refused at all.
+  // depends on the admission mode, and this panel also renders against an
+  // unsaved selection, before that mode applies to anything.
   if (clients.length === 0) {
     return (
       <Text muted small className="block p-3">

--- a/client/dashboard/src/sdk/src/models/components/updateusersessionissuerform.ts
+++ b/client/dashboard/src/sdk/src/models/components/updateusersessionissuerform.ts
@@ -21,7 +21,7 @@ export type UpdateUserSessionIssuerFormAuthnChallengeMode = ClosedEnum<
 >;
 
 /**
- * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.
+ * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.
  */
 export const UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode = {
   Disabled: "disabled",
@@ -29,7 +29,7 @@ export const UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode = {
   Open: "open",
 } as const;
 /**
- * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.
+ * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.
  */
 export type UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode =
   ClosedEnum<typeof UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode>;
@@ -45,7 +45,7 @@ export type UpdateUserSessionIssuerForm = {
     | UpdateUserSessionIssuerFormAuthnChallengeMode
     | undefined;
   /**
-   * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.
+   * Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.
    */
   clientIdMetadataAdmissionMode?:
     | UpdateUserSessionIssuerFormClientIdMetadataAdmissionMode

--- a/client/dashboard/src/sdk/src/models/components/usersessionissuer.ts
+++ b/client/dashboard/src/sdk/src/models/components/usersessionissuer.ts
@@ -10,7 +10,7 @@ import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 /**
- * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note 'reporting' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what 'presets' would have refused. It exists so the platform can measure before switching the default to 'presets'. Set an explicit mode to opt out of it.
+ * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. 'open' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and 'presets' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note 'reporting' can be READ but not written: it is a legacy value that admits exactly what 'open' admits, and no issuer is created with it.
  */
 export const ClientIdMetadataAdmissionMode = {
   Disabled: "disabled",
@@ -19,7 +19,7 @@ export const ClientIdMetadataAdmissionMode = {
   Open: "open",
 } as const;
 /**
- * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note 'reporting' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what 'presets' would have refused. It exists so the platform can measure before switching the default to 'presets'. Set an explicit mode to opt out of it.
+ * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. 'open' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and 'presets' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note 'reporting' can be READ but not written: it is a legacy value that admits exactly what 'open' admits, and no issuer is created with it.
  */
 export type ClientIdMetadataAdmissionMode = ClosedEnum<
   typeof ClientIdMetadataAdmissionMode
@@ -34,7 +34,7 @@ export type UserSessionIssuer = {
    */
   authnChallengeMode: string;
   /**
-   * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note 'reporting' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what 'presets' would have refused. It exists so the platform can measure before switching the default to 'presets'. Set an explicit mode to opt out of it.
+   * The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. 'open' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and 'presets' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note 'reporting' can be READ but not written: it is a legacy value that admits exactly what 'open' admits, and no issuer is created with it.
    */
   clientIdMetadataAdmissionMode: ClientIdMetadataAdmissionMode;
   createdAt: Date;

--- a/server/design/usersessionissuers/design.go
+++ b/server/design/usersessionissuers/design.go
@@ -177,7 +177,7 @@ var UpdateUserSessionIssuerForm = Type("UpdateUserSessionIssuerForm", func() {
 		Enum("chain", "interactive")
 	})
 	Attribute("session_duration_hours", Int, "Maximum issued user session lifetime, in hours.")
-	Attribute("client_id_metadata_admission_mode", String, "Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.", func() {
+	Attribute("client_id_metadata_admission_mode", String, "Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.", func() {
 		Enum("disabled", "presets", "open")
 	})
 
@@ -198,7 +198,7 @@ var UserSessionIssuer = Type("UserSessionIssuer", func() {
 	Attribute("slug", String, "Project-unique slug.")
 	Attribute("authn_challenge_mode", String, "chain | interactive.")
 	Attribute("session_duration_hours", Int, "Maximum issued user session lifetime, in hours.")
-	Attribute("client_id_metadata_admission_mode", String, "The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note 'reporting' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what 'presets' would have refused. It exists so the platform can measure before switching the default to 'presets'. Set an explicit mode to opt out of it.", func() {
+	Attribute("client_id_metadata_admission_mode", String, "The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. 'open' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and 'presets' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note 'reporting' can be READ but not written: it is a legacy value that admits exactly what 'open' admits, and no issuer is created with it.", func() {
 		Enum("disabled", "presets", "reporting", "open")
 	})
 	Attribute("created_at", String, func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -85963,7 +85963,7 @@ components:
                         - interactive
                 client_id_metadata_admission_mode:
                     type: string
-                    description: Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged. Once set, the issuer can never return to the unset state — it can only be moved between explicit modes.
+                    description: Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits. 'presets' admits Gram's curated catalog plus this issuer's custom URLs; 'open' admits any spec-valid document; 'disabled' admits none and stops advertising CIMD support. Omit to leave unchanged.
                     enum:
                         - disabled
                         - presets
@@ -86641,7 +86641,7 @@ components:
                     description: chain | interactive.
                 client_id_metadata_admission_mode:
                     type: string
-                    description: 'The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. Note ''reporting'' can be READ but not written: it is the current default for an issuer whose mode has never been configured, and it admits every spec-valid client while recording what ''presets'' would have refused. It exists so the platform can measure before switching the default to ''presets''. Set an explicit mode to opt out of it.'
+                    description: 'The EFFECTIVE CIMD admission policy in force for this issuer: disabled | presets | reporting | open. Always populated, so clients never have to reason about an unset state. ''open'' is the resting policy an issuer carries unless an operator chooses otherwise: it admits any spec-valid document, and ''presets'' enforcement is opt-in because a denial under it is unrecoverable for the end user. Note ''reporting'' can be READ but not written: it is a legacy value that admits exactly what ''open'' admits, and no issuer is created with it.'
                     enum:
                         - disabled
                         - presets

--- a/server/gen/http/user_session_issuers/client/types.go
+++ b/server/gen/http/user_session_issuers/client/types.go
@@ -38,9 +38,7 @@ type UpdateUserSessionIssuerRequestBody struct {
 	// Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits.
 	// 'presets' admits Gram's curated catalog plus this issuer's custom URLs;
 	// 'open' admits any spec-valid document; 'disabled' admits none and stops
-	// advertising CIMD support. Omit to leave unchanged. Once set, the issuer can
-	// never return to the unset state — it can only be moved between explicit
-	// modes.
+	// advertising CIMD support. Omit to leave unchanged.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 }
 
@@ -59,11 +57,12 @@ type CreateUserSessionIssuerResponseBody struct {
 	SessionDurationHours *int `form:"session_duration_hours,omitempty" json:"session_duration_hours,omitempty" xml:"session_duration_hours,omitempty"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 	CreatedAt                     *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	UpdatedAt                     *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
@@ -84,11 +83,12 @@ type UpdateUserSessionIssuerResponseBody struct {
 	SessionDurationHours *int `form:"session_duration_hours,omitempty" json:"session_duration_hours,omitempty" xml:"session_duration_hours,omitempty"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 	CreatedAt                     *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	UpdatedAt                     *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
@@ -117,11 +117,12 @@ type GetUserSessionIssuerResponseBody struct {
 	SessionDurationHours *int `form:"session_duration_hours,omitempty" json:"session_duration_hours,omitempty" xml:"session_duration_hours,omitempty"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 	CreatedAt                     *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	UpdatedAt                     *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
@@ -1092,11 +1093,12 @@ type UserSessionIssuerResponseBody struct {
 	SessionDurationHours *int `form:"session_duration_hours,omitempty" json:"session_duration_hours,omitempty" xml:"session_duration_hours,omitempty"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 	CreatedAt                     *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	UpdatedAt                     *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`

--- a/server/gen/http/user_session_issuers/server/types.go
+++ b/server/gen/http/user_session_issuers/server/types.go
@@ -38,9 +38,7 @@ type UpdateUserSessionIssuerRequestBody struct {
 	// Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits.
 	// 'presets' admits Gram's curated catalog plus this issuer's custom URLs;
 	// 'open' admits any spec-valid document; 'disabled' admits none and stops
-	// advertising CIMD support. Omit to leave unchanged. Once set, the issuer can
-	// never return to the unset state — it can only be moved between explicit
-	// modes.
+	// advertising CIMD support. Omit to leave unchanged.
 	ClientIDMetadataAdmissionMode *string `form:"client_id_metadata_admission_mode,omitempty" json:"client_id_metadata_admission_mode,omitempty" xml:"client_id_metadata_admission_mode,omitempty"`
 }
 
@@ -59,11 +57,12 @@ type CreateUserSessionIssuerResponseBody struct {
 	SessionDurationHours int `form:"session_duration_hours" json:"session_duration_hours" xml:"session_duration_hours"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode string `form:"client_id_metadata_admission_mode" json:"client_id_metadata_admission_mode" xml:"client_id_metadata_admission_mode"`
 	CreatedAt                     string `form:"created_at" json:"created_at" xml:"created_at"`
 	UpdatedAt                     string `form:"updated_at" json:"updated_at" xml:"updated_at"`
@@ -84,11 +83,12 @@ type UpdateUserSessionIssuerResponseBody struct {
 	SessionDurationHours int `form:"session_duration_hours" json:"session_duration_hours" xml:"session_duration_hours"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode string `form:"client_id_metadata_admission_mode" json:"client_id_metadata_admission_mode" xml:"client_id_metadata_admission_mode"`
 	CreatedAt                     string `form:"created_at" json:"created_at" xml:"created_at"`
 	UpdatedAt                     string `form:"updated_at" json:"updated_at" xml:"updated_at"`
@@ -117,11 +117,12 @@ type GetUserSessionIssuerResponseBody struct {
 	SessionDurationHours int `form:"session_duration_hours" json:"session_duration_hours" xml:"session_duration_hours"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode string `form:"client_id_metadata_admission_mode" json:"client_id_metadata_admission_mode" xml:"client_id_metadata_admission_mode"`
 	CreatedAt                     string `form:"created_at" json:"created_at" xml:"created_at"`
 	UpdatedAt                     string `form:"updated_at" json:"updated_at" xml:"updated_at"`
@@ -1092,11 +1093,12 @@ type UserSessionIssuerResponseBody struct {
 	SessionDurationHours int `form:"session_duration_hours" json:"session_duration_hours" xml:"session_duration_hours"`
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode string `form:"client_id_metadata_admission_mode" json:"client_id_metadata_admission_mode" xml:"client_id_metadata_admission_mode"`
 	CreatedAt                     string `form:"created_at" json:"created_at" xml:"created_at"`
 	UpdatedAt                     string `form:"updated_at" json:"updated_at" xml:"updated_at"`

--- a/server/gen/types/user_session_issuer.go
+++ b/server/gen/types/user_session_issuer.go
@@ -22,11 +22,12 @@ type UserSessionIssuer struct {
 	SessionDurationHours int
 	// The EFFECTIVE CIMD admission policy in force for this issuer: disabled |
 	// presets | reporting | open. Always populated, so clients never have to
-	// reason about an unset state. Note 'reporting' can be READ but not written:
-	// it is the current default for an issuer whose mode has never been
-	// configured, and it admits every spec-valid client while recording what
-	// 'presets' would have refused. It exists so the platform can measure before
-	// switching the default to 'presets'. Set an explicit mode to opt out of it.
+	// reason about an unset state. 'open' is the resting policy an issuer carries
+	// unless an operator chooses otherwise: it admits any spec-valid document, and
+	// 'presets' enforcement is opt-in because a denial under it is unrecoverable
+	// for the end user. Note 'reporting' can be READ but not written: it is a
+	// legacy value that admits exactly what 'open' admits, and no issuer is
+	// created with it.
 	ClientIDMetadataAdmissionMode string
 	CreatedAt                     string
 	UpdatedAt                     string

--- a/server/gen/user_session_issuers/service.go
+++ b/server/gen/user_session_issuers/service.go
@@ -126,9 +126,7 @@ type UpdateUserSessionIssuerPayload struct {
 	// Which CIMD (OAuth Client ID Metadata Document) clients this issuer admits.
 	// 'presets' admits Gram's curated catalog plus this issuer's custom URLs;
 	// 'open' admits any spec-valid document; 'disabled' admits none and stops
-	// advertising CIMD support. Omit to leave unchanged. Once set, the issuer can
-	// never return to the unset state — it can only be moved between explicit
-	// modes.
+	// advertising CIMD support. Omit to leave unchanged.
 	ClientIDMetadataAdmissionMode *string
 }
 

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -193,17 +193,24 @@ const (
 	CIMDCrossOriginRedirectOriginsKey = attribute.Key("gram.cimd.cross_origin_redirect_origins")
 
 	// CIMDAdmissionModeKey is the effective per-issuer CIMD admission policy
-	// ("disabled", "presets", "open") — the low-cardinality dimension on
+	// ("disabled", "presets", "open", and "reporting" on rows that predate
+	// the open default) — the low-cardinality dimension on
 	// cimd.admission.decisions. Operator-chosen, never attacker-influenced.
 	CIMDAdmissionModeKey = attribute.Key("gram.cimd.admission_mode")
 
 	// CIMDAdmissionOutcomeKey is the machine-readable admission decision on
 	// cimd.admission.decisions. Admissions carry the reason they were
 	// admitted rather than a bare "admitted", so the values are
-	// "admitted_open", "admitted_catalog_exact", "admitted_catalog_pattern",
-	// "admitted_custom", "denied_disabled", "denied_not_listed",
-	// "denied_oversized", and "denied_unknown_mode". Chart the admitted_*
-	// values as a group; there is no single value meaning "admitted".
+	// "admitted_open", "admitted_open_not_listed",
+	// "admitted_open_oversized", "admitted_catalog_exact",
+	// "admitted_catalog_pattern", "admitted_custom", "denied_disabled",
+	// "denied_not_listed", "denied_oversized", and "denied_unknown_mode".
+	// Chart the admitted_* values as a group; there is no single value
+	// meaning "admitted".
+	//
+	// "admitted_open_not_listed" is the catalog-gap signal on an issuer that
+	// refuses nobody: the client got in, and no rule anywhere covered it.
+	// Alert on it alongside "denied_not_listed".
 	CIMDAdmissionOutcomeKey = attribute.Key("gram.cimd.admission_outcome")
 
 	// JWKSOriginKey is the host of a remote JWK Set URL — the per-key-host

--- a/server/internal/mcp/authnchallenge_cimd_admission_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_admission_test.go
@@ -22,8 +22,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -49,12 +54,12 @@ func setIssuerAdmissionMode(t *testing.T, ctx context.Context, ti *testInstance,
 	require.NoError(t, err)
 }
 
-// seedFreshIssuerToolset seeds a brand-new public issuer-gated toolset whose
-// admission mode has NEVER been set, i.e. the column is NULL. There is no
-// way back to NULL through the update path once a mode is written — that is
-// the intended one-way behavior — so tests covering the never-configured
-// default must start from a fresh issuer rather than clearing an existing
-// one.
+// seedFreshIssuerToolset seeds a brand-new public issuer-gated toolset and
+// pins what a create writes: the admission mode is stored as 'open', not
+// left NULL, so the resting policy is a real value on the row rather than an
+// absence the application has to interpret. Tests covering an unconfigured
+// issuer start here; clearIssuerAdmissionMode covers the older rows that
+// predate the create default.
 func seedFreshIssuerToolset(t *testing.T, ctx context.Context, ti *testInstance) toolsets_repo.Toolset {
 	t.Helper()
 
@@ -76,9 +81,49 @@ func seedFreshIssuerToolset(t *testing.T, ctx context.Context, ti *testInstance)
 		ProjectID: toolset.ProjectID,
 	})
 	require.NoError(t, err)
-	require.False(t, issuer.ClientIDMetadataAdmissionMode.Valid, "a freshly seeded issuer must have no stored admission mode")
+	require.True(t, issuer.ClientIDMetadataAdmissionMode.Valid, "a created issuer must carry an explicit admission mode")
+	require.Equal(t, string(admission.ModeOpen), issuer.ClientIDMetadataAdmissionMode.String)
 
 	return toolset
+}
+
+// clearIssuerAdmissionMode writes the column back to NULL, the state of
+// every row created before the create query wrote a mode explicitly. It has
+// no management API equivalent on purpose: this reproduces stored history,
+// not something an operator can do.
+func clearIssuerAdmissionMode(t *testing.T, ctx context.Context, ti *testInstance, toolset toolsets_repo.Toolset) {
+	t.Helper()
+
+	err := testrepo.New(ti.conn).SetUserSessionIssuerCIMDAdmissionMode(ctx, testrepo.SetUserSessionIssuerCIMDAdmissionModeParams{
+		ClientIDMetadataAdmissionMode: pgtype.Text{String: "", Valid: false},
+		ID:                            toolset.UserSessionIssuerID.UUID,
+		ProjectID:                     toolset.ProjectID,
+	})
+	require.NoError(t, err)
+}
+
+// admissionDecisionPoints reads the cimd.admission.decisions counter back as
+// an attribute-set keyed map.
+func admissionDecisionPoints(t *testing.T, reader *sdkmetric.ManualReader) map[attribute.Set]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	points := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "cimd.admission.decisions" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "the admission instrument must be an int64 counter")
+			for _, dp := range sum.DataPoints {
+				points[dp.Attributes] = dp.Value
+			}
+		}
+	}
+	return points
 }
 
 // allowCustomCimdURL adds an issuer-specific allowed CIMD document URL,
@@ -133,33 +178,121 @@ func requireAuthorizeErrorDescription(t *testing.T, w *httptest.ResponseRecorder
 	require.Contains(t, body["error_description"], wantSubstring)
 }
 
-// TestCIMDAdmission_DefaultReportsWithoutEnforcing pins the shipped
-// default. A fresh issuer has never had a mode set, which resolves to
-// reporting: it evaluates exactly what presets would decide, records it,
-// and admits anyway.
+// TestCIMDAdmission_DefaultAdmitsWithoutEnforcing pins the resting policy.
+// An issuer nobody configured admits every spec-valid client, because a
+// presets denial is unrecoverable for the end user and enforcement is
+// something an operator chooses rather than something a default imposes.
 //
-// This is what lets admission control ship without changing anyone's
-// behaviour. The URL below is not in the catalog, so presets would refuse
-// it — and the request still succeeds, right through to the document fetch.
-func TestCIMDAdmission_DefaultReportsWithoutEnforcing(t *testing.T) {
+// The URL below is not in the catalog, so presets would refuse it — and the
+// request still succeeds, right through to the document fetch.
+func TestCIMDAdmission_DefaultAdmitsWithoutEnforcing(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti, ds, _ := newTestCIMDService(t)
-	// A separate, never-configured issuer: the harness toolset is put in
-	// open mode, and there is no path back to NULL once a mode is written.
 	fresh := seedFreshIssuerToolset(t, ctx, ti)
 
 	verifier := pkceVerifier(t)
 	w := doCIMDAuthorize(t, ti, fresh.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
 
-	require.Equal(t, http.StatusFound, w.Code, "the default must not enforce yet")
-	require.Positive(t, ds.requests.Load(), "a reported client_id is still admitted, so the document is fetched")
+	require.Equal(t, http.StatusFound, w.Code, "the default must refuse nobody")
+	require.Positive(t, ds.requests.Load(), "an admitted client_id reaches the document fetch")
+}
+
+// TestCIMDAdmission_UnsetModeAdmits covers the rows that predate the create
+// default. They stay NULL until the backfill reaches them, and they must
+// behave exactly like the 'open' the backfill will write, or the deploy and
+// the backfill would be two different changes rather than one.
+func TestCIMDAdmission_UnsetModeAdmits(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, _ := newTestCIMDService(t)
+	legacy := seedFreshIssuerToolset(t, ctx, ti)
+	clearIssuerAdmissionMode(t, ctx, ti, legacy)
+
+	verifier := pkceVerifier(t)
+	w := doCIMDAuthorize(t, ti, legacy.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+
+	require.Equal(t, http.StatusFound, w.Code, "an unset mode must resolve to open, not fail closed")
+	require.Positive(t, ds.requests.Load(), "an admitted client_id reaches the document fetch")
+}
+
+// TestCIMDAdmission_OpenRecordsShadowDecision is the measurement the open
+// default rests on. Open refuses nobody, so without the shadow a catalog gap
+// would stop being discoverable the moment open became the resting state —
+// and the catalog is still learning from production traffic.
+//
+// The recorded outcome is admit-shaped because the request WAS admitted. It
+// still names what presets would have said, which is the signal an operator
+// acts on.
+func TestCIMDAdmission_OpenRecordsShadowDecision(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	_, ti, ds, toolset := newTestCIMDServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	verifier := pkceVerifier(t)
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+	require.Equal(t, http.StatusFound, w.Code, "open admits a client the catalog does not list")
+
+	points := admissionDecisionPoints(t, reader)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModeOpen),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitOpenNotListed)),
+	)], "an admitted client no rule covers must still name the gap")
+	require.Len(t, points, 1, "one request must produce exactly one decision")
+}
+
+// TestCIMDAdmission_OpenShadowRecordsOversized: an oversized client_id is
+// never handed to the database, so the shadow reaches no verdict about
+// whether the catalog covers it. That is the shadow working, not failing, so
+// it records its own outcome rather than borrowing the one that means the
+// measurement broke — on an unauthenticated endpoint a run of these is a
+// probing campaign, and it has to be visible as one.
+func TestCIMDAdmission_OpenShadowRecordsOversized(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	_, ti, ds, toolset := newTestCIMDServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	oversized := "https://oversized.example.test/" + strings.Repeat("a", admission.MaxClientIDLength)
+	require.Greater(t, len(oversized), admission.MaxClientIDLength)
+
+	verifier := pkceVerifier(t)
+	doCIMDAuthorize(t, ti, toolset.McpSlug.String, oversized, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+
+	points := admissionDecisionPoints(t, reader)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModeOpen),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitOpenOversized)),
+	)], "an oversized client_id must be distinguishable from a broken lookup")
+	require.Zero(t, ds.requests.Load(), "an oversized client_id must not reach a document fetch")
+}
+
+// TestCIMDAdmission_OpenShadowConsultsCustomURLs: the shadow performs the
+// same custom-URL lookup enforcement would, so "no rule anywhere covers this
+// client" keeps meaning that rather than the weaker "not in the catalog". An
+// issuer that already allowed a URL must not be reported as a catalog gap.
+func TestCIMDAdmission_OpenShadowConsultsCustomURLs(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti, ds, toolset := newTestCIMDServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
+
+	verifier := pkceVerifier(t)
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	points := admissionDecisionPoints(t, reader)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModeOpen),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitCustom)),
+	)], "a URL the issuer already allows is not a catalog gap")
 }
 
 // TestCIMDAdmission_PresetsDeniesUnknownURLWithoutFetching is the core
 // guarantee, exercised on an issuer that has explicitly opted in to
-// enforcement (and on the default once ResolveMode's NULL branch moves to
-// presets).
+// enforcement — the only way an issuer enforces.
 //
 // The no-request assertion is what makes this admission control rather than
 // post-fetch filtering.
@@ -176,43 +309,43 @@ func TestCIMDAdmission_PresetsDeniesUnknownURLWithoutFetching(t *testing.T) {
 	require.Zero(t, ds.requests.Load(), "a denied client_id must not cost an outbound document fetch")
 }
 
-// TestCIMDAdmission_ReportingMatchesPresetsExceptForEnforcement holds the
-// configuration constant and varies ONLY the mode, which is the whole claim:
-// reporting and presets reach the same decision and differ only in whether
-// it is applied.
+// TestCIMDAdmission_DefaultAdmitsWhatPresetsRefuses holds the configuration
+// constant and varies ONLY the mode, which is the whole claim: the default
+// and presets see the same client and differ entirely in what they do about
+// it.
 //
 // An earlier version gave the custom URL to one issuer and not the other, so
 // it compared two different configurations and demonstrated nothing about
 // mode equivalence. Decision-level equivalence is pinned exhaustively in
-// admission.TestEvaluate_ReportingDecidesExactlyAsPresets; this covers the
+// admission.TestEvaluateShadow_DecidesExactlyAsPresets; this covers the
 // wiring end to end.
-func TestCIMDAdmission_ReportingMatchesPresetsExceptForEnforcement(t *testing.T) {
+func TestCIMDAdmission_DefaultAdmitsWhatPresetsRefuses(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti, ds, toolset := newTestCIMDService(t)
 
 	// Two issuers, neither listing the URL, differing only in mode.
-	reporting := seedFreshIssuerToolset(t, ctx, ti)
+	unconfigured := seedFreshIssuerToolset(t, ctx, ti)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModePresets)
 
 	verifier := pkceVerifier(t)
 
-	w := doCIMDAuthorize(t, ti, reporting.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
-	require.Equal(t, http.StatusFound, w.Code, "reporting must admit what presets would refuse")
+	w := doCIMDAuthorize(t, ti, unconfigured.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+	require.Equal(t, http.StatusFound, w.Code, "the default must admit what presets would refuse")
 	require.Positive(t, ds.requests.Load(), "an admitted client_id reaches the document fetch")
 
 	w = doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
 	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
 
-	// The agreement runs the other way too: a URL the issuer does list is
-	// admitted under both, so reporting is not simply admitting blindly.
+	// A URL the issuer does list is admitted under both, so the difference
+	// above is the mode and not the configuration.
 	allowCustomCimdURL(t, ctx, ti, toolset, ds.clientID)
 	w = doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
 	require.Equal(t, http.StatusFound, w.Code, "presets admits a listed URL")
 
-	allowCustomCimdURL(t, ctx, ti, reporting, ds.clientID)
-	w = doCIMDAuthorize(t, ti, reporting.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
-	require.Equal(t, http.StatusFound, w.Code, "reporting admits a listed URL")
+	allowCustomCimdURL(t, ctx, ti, unconfigured, ds.clientID)
+	w = doCIMDAuthorize(t, ti, unconfigured.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(verifier))
+	require.Equal(t, http.StatusFound, w.Code, "the default admits a listed URL")
 }
 
 // TestCIMDAdmission_PresetsDenialIsActionable: the description is the end
@@ -350,8 +483,8 @@ func TestCIMDAdmission_PresetsAdvertisesSupport(t *testing.T) {
 	require.Equal(t, true, metadata["client_id_metadata_document_supported"])
 }
 
-// TestCIMDAdmission_DefaultAdvertisesSupport: an issuer that never had a
-// mode set resolves to presets, which advertises.
+// TestCIMDAdmission_DefaultAdvertisesSupport: an issuer nobody configured
+// resolves to open, and every mode but disabled advertises.
 func TestCIMDAdmission_DefaultAdvertisesSupport(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
@@ -186,8 +188,16 @@ func (ds *cimdDocServer) certPool() *x509.CertPool {
 func newTestCIMDService(t *testing.T) (context.Context, *testInstance, *cimdDocServer, toolsets_repo.Toolset) {
 	t.Helper()
 
+	return newTestCIMDServiceWithMeterProvider(t, testenv.NewMeterProvider(t))
+}
+
+// newTestCIMDServiceWithMeterProvider is newTestCIMDService over a caller's
+// meter provider, for tests that read the admission counter back.
+func newTestCIMDServiceWithMeterProvider(t *testing.T, meterProvider metric.MeterProvider) (context.Context, *testInstance, *cimdDocServer, toolsets_repo.Toolset) {
+	t.Helper()
+
 	ds := startCIMDDocServer(t)
-	ctx, ti := newTestMCPServiceWithGuardianOptions(t, guardian.WithTLSRootCAs(ds.certPool()))
+	ctx, ti := newTestMCPServiceWithMeterProviderAndGuardianOptions(t, meterProvider, guardian.WithTLSRootCAs(ds.certPool()))
 
 	toolset, _, _ := seedPrivateToolsetWithIssuer(t, ctx, ti)
 	setIssuerAdmissionMode(t, ctx, ti, toolset, admission.ModeOpen)

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -212,7 +212,9 @@ func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Log
 // admitCIMDClient enforces the issuer's CIMD admission policy against a
 // presented URL-shaped client_id, before any document is fetched. Returns
 // nil when the client is admitted, a *admission.DenialError when policy
-// denies it, and a wrapped error when the custom-URL lookup itself fails.
+// denies it, and a wrapped error when a custom-URL lookup the decision
+// depends on fails. An open-mode issuer refuses nobody, so its lookup feeds
+// telemetry only and a failure there is swallowed rather than returned.
 //
 // The catalog is consulted first and in memory, so the common case — a
 // preset client on a presets-mode issuer — never touches the database. Only
@@ -227,6 +229,15 @@ func (s *Service) admitCIMDClient(ctx context.Context, logger *slog.Logger, endp
 		logger.ErrorContext(ctx, "unrecognized cimd admission mode stored on issuer, failing closed",
 			attr.SlogCIMDAdmissionMode(endpoint.CIMDAdmissionModeRaw.String),
 		)
+	}
+
+	if mode == admission.ModeOpen {
+		// Open admits every spec-valid client, so Evaluate has nothing left
+		// to decide here. The shadow takes its place: the client is let
+		// through regardless, and what presets would have said about it is
+		// what lands on the counter.
+		s.cimdAdmissionMetrics.RecordAdmitted(ctx, mode, s.shadowCIMDAdmitReason(ctx, logger, endpoint, clientID))
+		return nil
 	}
 
 	decision := admission.Evaluate(mode, clientID)
@@ -276,6 +287,76 @@ func (s *Service) admitCIMDClient(ctx context.Context, logger *slog.Logger, endp
 
 	logger.InfoContext(ctx, "cimd admission denied", logAttrs...)
 	return &admission.DenialError{Mode: mode, Reason: decision.Denial}
+}
+
+// shadowCIMDAdmitReason computes what ModePresets WOULD have decided about
+// a client_id an open-mode issuer is admitting anyway, and returns it as the
+// outcome to record. It never refuses anything: every return value is an
+// AdmitReason, and a failure to reach a verdict is recorded as one too.
+//
+// The custom-URL lookup is the same one enforcement performs, so
+// AdmitOpenNotListed keeps meaning "no rule anywhere covers this client"
+// rather than the weaker "not in the catalog". It is not a new cost: every
+// catalog miss on an unconfigured issuer already paid for that query before
+// open became the resting state.
+func (s *Service) shadowCIMDAdmitReason(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint, clientID string) admission.AdmitReason {
+	shadow := admission.EvaluateShadow(clientID)
+
+	switch shadow.Outcome {
+	case admission.OutcomeAdmit:
+		return shadow.Admit
+	case admission.OutcomeDeny:
+		// Reachable only for a client_id too long to hand to the database.
+		// Nothing was refused, since the request was admitted before the
+		// shadow ran, but it is still named on both surfaces rather than
+		// dropped: on an unauthenticated endpoint a run of these is a
+		// probing campaign, and that is worth being able to see.
+		logger.InfoContext(ctx, "cimd admission would deny",
+			attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+			attr.SlogCIMDAdmissionMode(admission.ModeOpen),
+			attr.SlogCIMDAdmissionOutcome(shadow.Denial),
+		)
+		return admission.AdmitOpenOversized
+	case admission.OutcomeCheckCustom:
+		admitted, err := usersessions_repo.New(s.db).IssuerAdmitsCimdClientURI(ctx, usersessions_repo.IssuerAdmitsCimdClientURIParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			ClientIDMetadataUri: clientID,
+		})
+		if err != nil {
+			// Telemetry, never the flow. The client is already admitted, so a
+			// failed lookup costs the measurement and nothing else.
+			//
+			// A cancelled context is the client hanging up mid-authorize,
+			// which is ordinary on this surface and says nothing about the
+			// database. Logging those at error level would bury the failures
+			// that do mean something.
+			if !errors.Is(err, context.Canceled) {
+				logger.ErrorContext(ctx, "cimd admission shadow lookup failed",
+					attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+					attr.SlogError(err),
+				)
+			}
+			return admission.AdmitOpen
+		}
+		if admitted {
+			return admission.AdmitCustom
+		}
+		// The presented client_id goes in the log and never in a metric
+		// dimension. This is the line an operator triaging a catalog gap
+		// aggregates by client_id: the message keeps "denied" honest when
+		// nothing was, and the outcome attribute carries the shadow's own
+		// verdict so the line reads as the refusal that did not happen.
+		logger.InfoContext(ctx, "cimd admission would deny",
+			attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+			attr.SlogCIMDAdmissionMode(admission.ModeOpen),
+			attr.SlogCIMDAdmissionOutcome(admission.DenialNotListed),
+		)
+		return admission.AdmitOpenNotListed
+	default:
+		// Unreachable: Decision carries exactly the three outcomes above.
+		// Recorded as a missing verdict rather than invented as one.
+		return admission.AdmitOpen
+	}
 }
 
 // truncateClientIDForLog bounds a presented client_id for logging. The value

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -175,19 +175,20 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	})
 }
 
-// newTestMCPServiceWithGuardianOptions wires the permissive identity
-// resolver plus extra guardian policy options — e.g. guardian.WithTLSRootCAs
-// so CIMD document fetches trust an httptest.NewTLSServer certificate.
-func newTestMCPServiceWithGuardianOptions(t *testing.T, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
+// newTestMCPServiceWithMeterProviderAndGuardianOptions wires the permissive
+// identity resolver over the caller's meter provider plus extra guardian
+// policy options — e.g. guardian.WithTLSRootCAs so CIMD document fetches
+// trust an httptest.NewTLSServer certificate.
+func newTestMCPServiceWithMeterProviderAndGuardianOptions(t *testing.T, meterProvider metric.MeterProvider, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestMCPServiceWithTunnelPublicConfig(t, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		MaxRequestLifetime: 0,
-	}, guardianOpts...)
+	}, nil, guardianOpts...)
 }
 
 func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.IdentityResolver, tunnelPublicConfig mcp.TunnelPublicConfig, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {

--- a/server/internal/platformmcp/client_admission_integration_test.go
+++ b/server/internal/platformmcp/client_admission_integration_test.go
@@ -47,7 +47,7 @@ func TestClientAdmissionRoundTripsWithoutAConnection(t *testing.T) {
 
 	current, err := service.Get(ctx, assistant, project, registrationID)
 	require.NoError(t, err)
-	require.Equal(t, "reporting", current.Mode, "a freshly registered MCP reports the unconfigured default")
+	require.Equal(t, "open", current.Mode, "a freshly registered MCP reports the default written at create")
 	require.Equal(t, []string{"disabled", "presets", "open"}, current.AllowedModes)
 	require.Empty(t, current.CustomClientURLs)
 

--- a/server/internal/platformmcp/oauth_client_resolver.go
+++ b/server/internal/platformmcp/oauth_client_resolver.go
@@ -197,7 +197,15 @@ func (s *OAuthHTTP) admitCIMDClient(ctx context.Context, clientID string) error 
 	}
 
 	if decision.Outcome == admission.OutcomeAdmit {
-		s.cimdAdmission.RecordAdmitted(ctx, platformCIMDAdmissionMode, decision.Admit)
+		reason := decision.Admit
+		if reason == admission.AdmitOpen {
+			// Open admitted without consulting anything, so there is no
+			// verdict in that value. The shadow supplies one: the client is
+			// let through either way, and what a catalog-enforcing policy
+			// would have said about it is what lands on the counter.
+			reason = s.shadowCIMDAdmitReason(ctx, clientID)
+		}
+		s.cimdAdmission.RecordAdmitted(ctx, platformCIMDAdmissionMode, reason)
 		return nil
 	}
 
@@ -218,6 +226,48 @@ func (s *OAuthHTTP) admitCIMDClient(ctx context.Context, clientID string) error 
 	}
 	s.logger.InfoContext(ctx, "cimd admission denied", logAttrs...)
 	return &admission.DenialError{Mode: platformCIMDAdmissionMode, Reason: decision.Denial}
+}
+
+// shadowCIMDAdmitReason computes what a catalog-enforcing policy WOULD have
+// decided about a client_id this server is admitting anyway, and returns it
+// as the outcome to record. Every return value is an AdmitReason: the shadow
+// is telemetry, and nothing it produces may become a refusal.
+//
+// It is catalog-only, unlike the hosted authorization server's shadow. There
+// is no per-issuer custom URL table here to consult, so a catalog miss is
+// already the whole verdict.
+func (s *OAuthHTTP) shadowCIMDAdmitReason(ctx context.Context, clientID string) admission.AdmitReason {
+	shadow := admission.EvaluateShadow(clientID)
+
+	switch shadow.Outcome {
+	case admission.OutcomeAdmit:
+		return shadow.Admit
+	case admission.OutcomeCheckCustom:
+		// The branch that asks for a custom-URL lookup this server cannot
+		// perform. It reaches the counter as an admission, never the
+		// OutcomeCheckCustom to DenialNotListed mapping above: that one is a
+		// real refusal, and this is a measurement of a request that
+		// succeeded.
+		//
+		// The presented client_id goes in the log and never in a metric
+		// dimension. The message keeps "denied" honest when nothing was.
+		s.logger.InfoContext(ctx, "cimd admission would deny",
+			attr.SlogOAuthClientID(truncateClientIDForLog(clientID)),
+			attr.SlogCIMDAdmissionMode(platformCIMDAdmissionMode),
+			attr.SlogCIMDAdmissionOutcome(admission.DenialNotListed),
+		)
+		return admission.AdmitOpenNotListed
+	case admission.OutcomeDeny:
+		// Unreachable: an oversized client_id was already refused for real
+		// above, before the shadow could run. Named anyway rather than
+		// folded into AdmitOpen, so the two do not blur together if that
+		// ordering ever changes.
+		return admission.AdmitOpenOversized
+	default:
+		// Unreachable: Decision carries exactly the three outcomes above.
+		// Recorded as a missing verdict rather than invented as one.
+		return admission.AdmitOpen
+	}
 }
 
 // truncateClientIDForLog bounds a presented client_id for logging. The value

--- a/server/internal/platformmcp/oauth_client_resolver.go
+++ b/server/internal/platformmcp/oauth_client_resolver.go
@@ -257,15 +257,12 @@ func (s *OAuthHTTP) shadowCIMDAdmitReason(ctx context.Context, clientID string) 
 			attr.SlogCIMDAdmissionOutcome(admission.DenialNotListed),
 		)
 		return admission.AdmitOpenNotListed
-	case admission.OutcomeDeny:
-		// Unreachable: an oversized client_id was already refused for real
-		// above, before the shadow could run. Named anyway rather than
-		// folded into AdmitOpen, so the two do not blur together if that
-		// ordering ever changes.
-		return admission.AdmitOpenOversized
 	default:
-		// Unreachable: Decision carries exactly the three outcomes above.
-		// Recorded as a missing verdict rather than invented as one.
+		// OutcomeDeny is unreachable here: an oversized client_id is refused
+		// for real before the shadow runs, so this server never records
+		// AdmitOpenOversized the way the hosted one does. Anything reaching
+		// this arm has no verdict behind it and is recorded as such rather
+		// than invented.
 		return admission.AdmitOpen
 	}
 }

--- a/server/internal/platformmcp/tool_client_admission.go
+++ b/server/internal/platformmcp/tool_client_admission.go
@@ -47,8 +47,9 @@ func modeGuidance(mode string) string {
 	case admission.ModeDisabled:
 		return "Off: client ID metadata documents are not accepted at all, and the server stops advertising them, so apps use dynamic client registration instead."
 	case admission.ModeReporting:
-		// Not writable, and nothing resolves to it any more, but a row
-		// written while it was the default still reads back as it.
+		// Not writable, and no default resolves to it any more. Nothing in
+		// the application ever stored it either, so only a row carrying the
+		// legacy value from a direct database write still reads back as it.
 		return "Watching only: every app can sign in, while we record which ones \"known apps only\" would have turned away."
 	default:
 		return ""

--- a/server/internal/platformmcp/tool_client_admission.go
+++ b/server/internal/platformmcp/tool_client_admission.go
@@ -47,8 +47,8 @@ func modeGuidance(mode string) string {
 	case admission.ModeDisabled:
 		return "Off: client ID metadata documents are not accepted at all, and the server stops advertising them, so apps use dynamic client registration instead."
 	case admission.ModeReporting:
-		// Not writable, but an unconfigured issuer resolves to it, so a read
-		// can legitimately return it.
+		// Not writable, and nothing resolves to it any more, but a row
+		// written while it was the default still reads back as it.
 		return "Watching only: every app can sign in, while we record which ones \"known apps only\" would have turned away."
 	default:
 		return ""

--- a/server/internal/usersessions/cimd/admission/admission.go
+++ b/server/internal/usersessions/cimd/admission/admission.go
@@ -22,10 +22,10 @@ const MaxClientIDLength = 2048
 // URL rows, which is a database lookup only the caller can perform, and is
 // what OutcomeCheckCustom asks for.
 //
-// ModeReporting returns the identical decision to ModePresets. That is the
-// entire point: the recorded outcome must be comparable to what ModePresets
-// will produce after the switch. The caller consults Mode.Enforces to learn
-// that a denial should be recorded and then discarded.
+// ModeReporting returns the identical decision to ModePresets, so the
+// outcome it records is directly comparable to what ModePresets produces.
+// The caller consults Mode.Enforces to learn that a denial should be
+// recorded and then discarded.
 func Evaluate(mode Mode, clientID string) Decision {
 	switch mode {
 	case ModeOpen:
@@ -49,4 +49,26 @@ func Evaluate(mode Mode, clientID string) Decision {
 		// backstop for a mode built any other way.
 		return denyDecision(DenialUnknownMode)
 	}
+}
+
+// EvaluateShadow computes the decision ModePresets WOULD make for a
+// presented client_id, for a caller that is admitting it regardless. It is
+// how an open-mode issuer keeps producing the catalog-gap signal that
+// enforcement would otherwise be needed to discover: the client is let
+// through, and what a curated allowlist would have said about it is
+// recorded anyway.
+//
+// It is deliberately NOT reachable through Evaluate, and that separation is
+// load-bearing rather than stylistic. Evaluate is the enforcement path: what
+// it returns decides whether a client is refused. This function's result
+// decides nothing, so the two must not share a return value that a caller
+// could act on by mistake.
+//
+// The result is telemetry. Callers translate it into an AdmitReason — a
+// metric label — and must never surface it as a refusal. OutcomeCheckCustom
+// still asks for the custom-URL lookup, and an OutcomeDeny here means only
+// that no shadow verdict is available, never that the client should be
+// turned away.
+func EvaluateShadow(clientID string) Decision {
+	return Evaluate(ModePresets, clientID)
 }

--- a/server/internal/usersessions/cimd/admission/admission.go
+++ b/server/internal/usersessions/cimd/admission/admission.go
@@ -66,9 +66,10 @@ func Evaluate(mode Mode, clientID string) Decision {
 //
 // The result is telemetry. Callers translate it into an AdmitReason — a
 // metric label — and must never surface it as a refusal. OutcomeCheckCustom
-// still asks for the custom-URL lookup, and an OutcomeDeny here means only
-// that no shadow verdict is available, never that the client should be
-// turned away.
+// still asks for the custom-URL lookup. OutcomeDeny carries one case, an
+// oversized client_id refused before it could become a query parameter, and
+// it is a verdict about the measurement rather than about the client: even
+// then, the client is not to be turned away.
 func EvaluateShadow(clientID string) Decision {
 	return Evaluate(ModePresets, clientID)
 }

--- a/server/internal/usersessions/cimd/admission/admission_test.go
+++ b/server/internal/usersessions/cimd/admission/admission_test.go
@@ -97,18 +97,12 @@ func TestEvaluate_NeverReturnsAdmitCustom(t *testing.T) {
 	}
 }
 
-// TestEvaluate_ReportingDecidesExactlyAsPresets is the property the rollout
-// rests on. Reporting exists to predict what presets will do, so any
-// divergence would make the measurement worthless — an operator would see a
-// clean reporting signal and then break clients on the switch.
-//
-// The unset default resolves to reporting, so this also covers "whatever
-// presets does, an unconfigured issuer evaluates identically".
+// TestEvaluate_ReportingDecidesExactlyAsPresets: reporting exists to predict
+// what presets will do, so any divergence would make its recorded signal
+// worthless. Nothing resolves to reporting any more, but rows written while
+// it was the default still do, and they must keep behaving as they did.
 func TestEvaluate_ReportingDecidesExactlyAsPresets(t *testing.T) {
 	t.Parallel()
-
-	unsetMode, _ := ResolveMode("", false)
-	require.Equal(t, ModeReporting, unsetMode)
 
 	inputs := []string{
 		claudeCodeURL,
@@ -168,4 +162,63 @@ func TestEvaluate_ZeroValueModeFailsClosed(t *testing.T) {
 	decision := Evaluate(zero, claudeCodeURL)
 	require.Equal(t, OutcomeDeny, decision.Outcome)
 	require.Equal(t, DenialUnknownMode, decision.Denial)
+}
+
+// TestEvaluateShadow_DecidesExactlyAsPresets is the property the open-mode
+// measurement rests on. The shadow exists to say what presets WOULD have
+// decided, so a divergence would report catalog gaps that are not there, or
+// hide ones that are.
+func TestEvaluateShadow_DecidesExactlyAsPresets(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		claudeCodeURL,
+		chatGPTConnectorURL,
+		customURL,
+		unknownURL,
+		strings.Repeat("x", MaxClientIDLength+1),
+		"",
+	}
+	for _, clientID := range inputs {
+		require.Equalf(t, Evaluate(ModePresets, clientID), EvaluateShadow(clientID),
+			"the shadow and presets must agree on %q", clientID)
+	}
+}
+
+// TestEvaluate_OpenAdmitsWhateverTheShadowSays is the hazard this design
+// exists to avoid. A caller may run ModeOpen as a fixed policy and map
+// OutcomeCheckCustom onto a final denial because it has no custom-URL table
+// of its own; if Evaluate ever fell through to the catalog arm under open,
+// that caller would start refusing every client outside the catalog.
+//
+// The shadow is a separate call for exactly this reason, so the two must be
+// pinned apart rather than left to inspection.
+func TestEvaluate_OpenAdmitsWhateverTheShadowSays(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		claudeCodeURL,
+		chatGPTConnectorURL,
+		customURL,
+		unknownURL,
+		strings.Repeat("x", MaxClientIDLength+1),
+		"",
+	}
+	for _, clientID := range inputs {
+		require.Equalf(t, admitDecision(AdmitOpen), Evaluate(ModeOpen, clientID),
+			"open must admit %q whatever the shadow decides about it", clientID)
+	}
+}
+
+// TestEvaluateShadow_SurvivesTheOpenDefault: the reason the default can be
+// open at all is that moving to it costs no measurement. What the resolution
+// itself yields is pinned in mode_test.go; this covers the half that would
+// otherwise go quiet.
+func TestEvaluateShadow_SurvivesTheOpenDefault(t *testing.T) {
+	t.Parallel()
+
+	mode, _ := ResolveMode("", false)
+	require.Equal(t, ModeOpen, mode)
+	require.Equal(t, OutcomeCheckCustom, EvaluateShadow(unknownURL).Outcome,
+		"an unconfigured issuer must still ask what presets would decide")
 }

--- a/server/internal/usersessions/cimd/admission/admit_reason.go
+++ b/server/internal/usersessions/cimd/admission/admit_reason.go
@@ -18,8 +18,12 @@ package admission
 type AdmitReason string
 
 const (
-	// AdmitOpen: the issuer skips admission entirely. Document validation
-	// still ran, but no policy was consulted.
+	// AdmitOpen: open mode admitted the client and the shadow could not
+	// reach a verdict, because the lookup it needed failed. Every other
+	// open-mode admission records what the shadow decided, so this value
+	// means "admitted, verdict unavailable" rather than "admitted, nothing
+	// consulted". A sustained rise in it is a broken measurement, not a
+	// policy signal, and it is paired with an error log naming the cause.
 	AdmitOpen AdmitReason = "admitted_open"
 
 	// AdmitCatalogExact: an exact entry in Gram's curated catalog.
@@ -35,4 +39,20 @@ const (
 	// URL lookup is a database query the caller performs — so the caller
 	// supplies it.
 	AdmitCustom AdmitReason = "admitted_custom"
+
+	// AdmitOpenNotListed: open mode admitted the client, and the shadow
+	// evaluation found no rule anywhere that covers it — not an enabled
+	// catalog entry, not one of the issuer's own URLs. This is the same
+	// signal DenialNotListed carries, from a request that succeeded, and it
+	// is the value worth alerting on now that the resting state refuses
+	// nobody. A rise means the catalog is missing a client customers use.
+	AdmitOpenNotListed AdmitReason = "admitted_open_not_listed"
+
+	// AdmitOpenOversized: open mode admitted the client, and the shadow
+	// refused to evaluate a client_id longer than MaxClientIDLength rather
+	// than hand it to the database. Kept apart from AdmitOpen so that value
+	// keeps meaning "the measurement broke": this one is working exactly as
+	// intended, and on an unauthenticated endpoint a rise in it is a
+	// probing campaign rather than a fault.
+	AdmitOpenOversized AdmitReason = "admitted_open_oversized"
 )

--- a/server/internal/usersessions/cimd/admission/admit_reason.go
+++ b/server/internal/usersessions/cimd/admission/admit_reason.go
@@ -45,7 +45,12 @@ const (
 	// catalog entry, not one of the issuer's own URLs. This is the same
 	// signal DenialNotListed carries, from a request that succeeded, and it
 	// is the value worth alerting on now that the resting state refuses
-	// nobody. A rise means the catalog is missing a client customers use.
+	// nobody.
+	//
+	// A rise is a POSSIBLE catalog gap, not a confirmed one. Admission runs
+	// before any authentication, so an attacker-chosen or malformed URL
+	// reaches this outcome exactly as a real client does. The client_id on
+	// the paired log line is what tells the two apart.
 	AdmitOpenNotListed AdmitReason = "admitted_open_not_listed"
 
 	// AdmitOpenOversized: open mode admitted the client, and the shadow

--- a/server/internal/usersessions/cimd/admission/decision.go
+++ b/server/internal/usersessions/cimd/admission/decision.go
@@ -23,8 +23,9 @@ func denyDecision(reason DenialReason) Decision {
 }
 
 // checkCustomDecision defers the decision to the caller's database lookup.
-// It carries no reason: a custom-URL hit becomes AdmitCustom and a miss
-// becomes DenialNotListed, and only the caller can tell which.
+// It carries no reason: only the caller can tell a custom-URL hit from a
+// miss, and only the caller knows whether a miss refuses the client or
+// merely records that nothing covered it.
 func checkCustomDecision() Decision {
 	return Decision{Outcome: OutcomeCheckCustom, Admit: "", Denial: ""}
 }

--- a/server/internal/usersessions/cimd/admission/denial_reason.go
+++ b/server/internal/usersessions/cimd/admission/denial_reason.go
@@ -12,8 +12,9 @@ const (
 
 	// DenialNotListed: presets mode, and the client_id is neither an
 	// enabled catalog entry nor one of the issuer's custom URLs. This is
-	// the reason an operator sees when the catalog is missing a real
-	// client, so it is the one worth alerting on.
+	// what a missing catalog entry looks like on an issuer that enforces.
+	// Alerting wants AdmitOpenNotListed too: it carries the same gap from
+	// the issuers that admit rather than refuse, which is most of them.
 	DenialNotListed DenialReason = "denied_not_listed"
 
 	// DenialOversized: presets mode, and the client_id exceeds

--- a/server/internal/usersessions/cimd/admission/doc.go
+++ b/server/internal/usersessions/cimd/admission/doc.go
@@ -16,9 +16,15 @@
 // resolution rules. The second half — an issuer's own custom URL rows — is a
 // database lookup the caller performs, and only when Evaluate asks for it.
 //
+// The resting policy admits everything, so the catalog would go unexercised
+// were it consulted only to refuse. EvaluateShadow is how it stays
+// exercised: a mode that admits unconditionally still asks what the curated
+// allowlist would have decided, and records the answer.
+//
 // Layout is one type per file:
 //
-//   - admission.go: Evaluate, the entry point combining the rest
+//   - admission.go: Evaluate, the entry point combining the rest, plus
+//     EvaluateShadow, the measurement an admitting mode records instead
 //   - mode.go: Mode and the rules resolving a stored column value onto one
 //   - decision.go: Decision, what Evaluate returns
 //   - outcome.go: Outcome, whether a client was admitted, denied, or needs

--- a/server/internal/usersessions/cimd/admission/metrics_test.go
+++ b/server/internal/usersessions/cimd/admission/metrics_test.go
@@ -1,0 +1,110 @@
+// External test package on purpose: the instrument name below is asserted as
+// a literal rather than read from the unexported constant, because it is a
+// wire contract. Every dashboard and monitor over CIMD admission is written
+// against that string, so a rename has to fail here.
+package admission_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
+)
+
+const instrumentAdmissionDecisions = "cimd.admission.decisions"
+
+func newObservedMetrics(t *testing.T) (*admission.Metrics, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return admission.NewMetrics(provider, testenv.NewLogger(t)), reader
+}
+
+func decisionPoints(t *testing.T, reader *sdkmetric.ManualReader) map[attribute.Set]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	points := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != instrumentAdmissionDecisions {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "the admission instrument must be an int64 counter")
+			for _, dp := range sum.DataPoints {
+				points[dp.Attributes] = dp.Value
+			}
+		}
+	}
+	return points
+}
+
+// TestMetrics_RecordsOneShadowOutcome covers the recording surface only: a
+// shadow verdict reaches the counter as an ordinary admission, under both
+// dimensions and under no others. That one request yields one point is a
+// property of the callers, and is pinned end to end against a real authorize
+// in the mcp package.
+func TestMetrics_RecordsOneShadowOutcome(t *testing.T) {
+	t.Parallel()
+
+	metrics, reader := newObservedMetrics(t)
+	metrics.RecordAdmitted(t.Context(), admission.ModeOpen, admission.AdmitOpenNotListed)
+
+	points := decisionPoints(t, reader)
+	require.Len(t, points, 1)
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModeOpen),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitOpenNotListed)),
+	)])
+}
+
+// TestMetrics_SeparatesModesAndOutcomes: both dimensions have to survive onto
+// the point, or the counter cannot answer either question it exists for —
+// which policy was in force, and what it decided.
+func TestMetrics_SeparatesModesAndOutcomes(t *testing.T) {
+	t.Parallel()
+
+	metrics, reader := newObservedMetrics(t)
+	metrics.RecordAdmitted(t.Context(), admission.ModeOpen, admission.AdmitCatalogExact)
+	metrics.RecordAdmitted(t.Context(), admission.ModeOpen, admission.AdmitCatalogExact)
+	metrics.RecordAdmitted(t.Context(), admission.ModePresets, admission.AdmitCatalogExact)
+	metrics.RecordDenied(t.Context(), admission.ModePresets, admission.DenialNotListed)
+
+	points := decisionPoints(t, reader)
+	require.Len(t, points, 3)
+	require.Equal(t, int64(2), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModeOpen),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitCatalogExact)),
+	)])
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModePresets),
+		attr.CIMDAdmissionOutcome(string(admission.AdmitCatalogExact)),
+	)])
+	require.Equal(t, int64(1), points[attribute.NewSet(
+		attr.CIMDAdmissionMode(admission.ModePresets),
+		attr.CIMDAdmissionOutcome(string(admission.DenialNotListed)),
+	)])
+}
+
+// TestMetrics_NilIsInert: admission runs on an unauthenticated endpoint, so
+// a metrics value that failed to build must degrade to silence rather than
+// panic mid-flow.
+func TestMetrics_NilIsInert(t *testing.T) {
+	t.Parallel()
+
+	var metrics *admission.Metrics
+	require.NotPanics(t, func() {
+		metrics.RecordAdmitted(t.Context(), admission.ModeOpen, admission.AdmitOpen)
+		metrics.RecordDenied(t.Context(), admission.ModePresets, admission.DenialNotListed)
+	})
+}

--- a/server/internal/usersessions/cimd/admission/mode.go
+++ b/server/internal/usersessions/cimd/admission/mode.go
@@ -26,10 +26,15 @@ const (
 	ModeReporting Mode = "reporting"
 
 	// ModeOpen admits every spec-valid client. Document validation rules
-	// all still apply — open means "any spec-valid client", not "any
-	// client" — and the decision ModePresets would have made is computed
-	// and recorded alongside the admission, so a catalog gap stays visible
-	// on an issuer that refuses nobody.
+	// all still apply: open means "any spec-valid client", not "any
+	// client".
+	//
+	// The mode itself records nothing beyond the admission. Evaluate
+	// returns AdmitOpen immediately and consults no catalog, so a caller
+	// running this mode MUST call EvaluateShadow separately and record what
+	// it decided. Skipping that is silent: the client is admitted either
+	// way, and the only thing lost is every catalog gap this issuer would
+	// have revealed.
 	ModeOpen Mode = "open"
 )
 

--- a/server/internal/usersessions/cimd/admission/mode.go
+++ b/server/internal/usersessions/cimd/admission/mode.go
@@ -12,29 +12,24 @@ const (
 	ModeDisabled Mode = "disabled"
 
 	// ModePresets admits the enabled catalog entries plus the issuer's own
-	// custom URLs. This is the default for an issuer whose mode was never
-	// explicitly set.
+	// custom URLs, and refuses everything else. It is opt-in: an operator
+	// chooses it deliberately, because a denial under it is unrecoverable
+	// for the end user.
 	ModePresets Mode = "presets"
 
-	// ModeReporting evaluates exactly what ModePresets would decide, records
-	// it, and then admits regardless. It is the migration step onto
-	// ModePresets: an operator turns it on, waits, and reads
-	// cimd.admission.decisions to learn which client_ids WOULD have been
-	// refused, adding catalog entries or custom URLs until that number is
-	// zero. Only then is switching to ModePresets safe.
-	//
-	// It exists because a presets denial is unrecoverable for the end user
-	// (MCP clients do not fall back to dynamic registration after an
-	// authorize rejection), so the cost of discovering a missing entry the
-	// hard way is a support ticket. This mode makes that discovery free.
-	//
-	// Because it admits everything, it is exactly as permissive as ModeOpen
-	// while it is on. It is a temporary measurement state, not a resting
-	// place.
+	// ModeReporting evaluates exactly what ModePresets would decide,
+	// records it, and then admits regardless. It is no longer reachable:
+	// nothing writes it, and the unconfigured default is ModeOpen, which
+	// carries the same measurement. ResolveMode still recognizes it so a
+	// row written while it was the default resolves rather than failing
+	// closed.
 	ModeReporting Mode = "reporting"
 
-	// ModeOpen skips admission entirely. Every document validation rule
-	// still applies — open means "any spec-valid client", not "any client".
+	// ModeOpen admits every spec-valid client. Document validation rules
+	// all still apply — open means "any spec-valid client", not "any
+	// client" — and the decision ModePresets would have made is computed
+	// and recorded alongside the admission, so a catalog gap stays visible
+	// on an issuer that refuses nobody.
 	ModeOpen Mode = "open"
 )
 
@@ -42,45 +37,38 @@ const (
 // client. False only for ModeReporting, where the decision is recorded and
 // then discarded.
 //
-// Callers MUST consult this before acting on OutcomeDeny. Evaluate returns
-// the same decision for ModeReporting as for ModePresets on purpose: the
-// whole point is that the recorded outcome is directly comparable to what
-// ModePresets will produce after the switch, so the same query answers
-// "what would happen" before and "what is happening" after.
+// Callers MUST consult this before acting on OutcomeDeny.
+//
+// ModeOpen enforces, and that is not a contradiction to relax: Evaluate
+// never denies in open mode, so the only OutcomeDeny a caller can hold
+// under it is one that caller built itself, deliberately, as a real
+// refusal. The shadow measurement never produces one — EvaluateShadow's
+// result is translated into an AdmitReason and recorded, never returned as
+// a decision.
 func (m Mode) Enforces() bool {
 	return m != ModeReporting
 }
 
 // ResolveMode maps a stored user_session_issuers.client_id_metadata_admission_mode
-// value onto the effective policy. This is the ONLY place either resolution
-// rule lives, so the default can move without a migration or a backfill.
+// value onto the effective policy. This is the ONLY place the resolution
+// rules live.
 //
-// The column is nullable with no database default precisely so the two
-// states stay distinguishable: an operator who explicitly chose a mode, and
-// an issuer that never had one.
+// NULL resolves to ModeOpen. Open is the resting state rather than a
+// waypoint toward enforcement: MCP clients pick CIMD over dynamic client
+// registration once, at metadata-discovery time, and do not fall back when
+// /authorize refuses the client_id, so a presets denial is a dead end with
+// no client-side recovery. Applying a curated allowlist to an issuer whose
+// operator never chose one would impose that dead end on customers who
+// never asked for it, so ModePresets is opt-in.
 //
-// THE NULL BRANCH IS THE ROLLOUT LEVER, and it currently resolves to
-// ModeReporting, not ModePresets. Because no issuer has the default written
-// to its row, changing the line below changes the behaviour of every
-// unconfigured issuer with no migration and no backfill.
+// Nothing is given up by defaulting open. The measurement that would gate
+// an enforcement decision rides along with it: an open-mode admission also
+// computes what ModePresets would have decided (EvaluateShadow) and records
+// that, so catalog gaps stay discoverable from cimd.admission.decisions
+// without anyone being refused to find them.
 //
-// Shipping ModeReporting first is deliberate. An unconfigured issuer today
-// behaves exactly as it did before admission control existed (it admits
-// every spec-valid document), so nothing regresses, while every decision
-// ModePresets would have made is recorded. The exit condition is:
-//
-//  1. CIMD is exposed to the whole customer base (the gram-user-session-cimd
-//     rollout flag reached 100% and was then removed, AIS-210), so
-//     cimd.admission.decisions carries a meaningful sample.
-//  2. Watch cimd.admission.decisions for outcome denied_not_listed with
-//     mode reporting. Each one names a client the catalog is missing; add a
-//     catalog entry, or have the operator add a custom URL.
-//  3. Change this branch to ModePresets once that count is zero and stable.
-//     Enforcement then begins with evidence rather than a guess.
-//
-// The default moves in one direction, once. Operators who want enforcement
-// before then set ModePresets explicitly through the management API; only
-// the default is deferred, not the capability.
+// New rows are written 'open' explicitly, so this branch covers only rows
+// created before that and any row left unset by a direct database write.
 //
 // stored/valid mirror a nullable text column (pgtype.Text's String/Valid)
 // without dragging a pgx dependency into a policy package. The returned
@@ -95,7 +83,7 @@ func (m Mode) Enforces() bool {
 // unrecognized value.
 func ResolveMode(stored string, valid bool) (Mode, bool) {
 	if !valid {
-		return ModeReporting, true
+		return ModeOpen, true
 	}
 	switch mode := Mode(stored); mode {
 	case ModeDisabled, ModePresets, ModeReporting, ModeOpen:
@@ -110,11 +98,11 @@ func ResolveMode(stored string, valid bool) (Mode, bool) {
 // carries no CHECK constraint, by convention.
 //
 // ModeReporting is deliberately excluded. It is as permissive as ModeOpen
-// for as long as it is on, so exposing it as a per-issuer choice would put
-// a reassuringly-named permissive state in front of operators, with nothing
-// to stop it being left there. It is a deployment-time default (see
-// ResolveMode), not a setting. ResolveMode still recognizes it, so a value
-// written by that lever resolves correctly.
+// while it is on, so exposing it as a per-issuer choice would put a
+// reassuringly-named permissive state in front of operators with nothing to
+// stop it being left there. ModeOpen is the honest name for that behaviour
+// and is writable. ResolveMode still recognizes ModeReporting so rows
+// written while it was the default keep resolving.
 func IsValidMode(value string) bool {
 	switch Mode(value) {
 	case ModeDisabled, ModePresets, ModeOpen:

--- a/server/internal/usersessions/cimd/admission/mode_test.go
+++ b/server/internal/usersessions/cimd/admission/mode_test.go
@@ -6,17 +6,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestResolveMode_NullResolvesToReporting pins the rollout lever. An issuer
-// whose mode was never configured measures rather than enforces, so
-// admission control ships without changing anyone's behaviour. Flipping
-// this to ModePresets is the deliberate, evidence-gated final step.
-func TestResolveMode_NullResolvesToReporting(t *testing.T) {
+// TestResolveMode_NullResolvesToOpen pins the resting policy. An issuer
+// whose mode was never configured admits every spec-valid client: a presets
+// denial is unrecoverable for the end user, so enforcement is something an
+// operator opts into rather than something a default does to them.
+//
+// New rows are written 'open' explicitly, so this branch covers rows created
+// before that and any row a direct database write leaves unset.
+func TestResolveMode_NullResolvesToOpen(t *testing.T) {
 	t.Parallel()
 
 	mode, recognized := ResolveMode("", false)
-	require.Equal(t, ModeReporting, mode)
+	require.Equal(t, ModeOpen, mode)
 	require.True(t, recognized, "an absent mode is a valid state, not a data error")
-	require.False(t, mode.Enforces(), "the default must not enforce yet")
+	require.Equal(t, OutcomeAdmit, Evaluate(mode, "https://unknown.example.com/client.json").Outcome,
+		"the default must refuse nobody")
 }
 
 // TestResolveMode_EmptyStringFailsClosed: a non-NULL empty string is a data
@@ -66,18 +70,17 @@ func TestIsValidMode(t *testing.T) {
 	require.False(t, IsValidMode("allow-everything"))
 }
 
-// TestReportingIsNotWritable: reporting is as permissive as open for as
-// long as it is on, so it must never be selectable through the management
-// API. It is a deployment-time default, not a setting an operator can leave
-// switched on.
+// TestReportingIsNotWritable: reporting admits exactly what open admits, so
+// offering it through the management API would put a second, vaguer name on
+// a mode that already has an honest one.
 func TestReportingIsNotWritable(t *testing.T) {
 	t.Parallel()
 
 	require.False(t, IsValidMode(string(ModeReporting)))
 	require.NotContains(t, Modes(), ModeReporting)
 
-	// ResolveMode must still recognize it, or the rollout lever could not
-	// resolve its own value.
+	// ResolveMode must still recognize it, or a row written while it was
+	// the default would fail closed.
 	mode, recognized := ResolveMode(string(ModeReporting), true)
 	require.Equal(t, ModeReporting, mode)
 	require.True(t, recognized)
@@ -85,6 +88,10 @@ func TestReportingIsNotWritable(t *testing.T) {
 
 // TestEnforces covers the one property that separates reporting from every
 // other mode.
+//
+// ModeOpen enforces, which is not a contradiction to relax: Evaluate never
+// denies under it, so a caller can only hold an OutcomeDeny it built itself
+// as a real refusal. The shadow measurement never produces one.
 func TestEnforces(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/cimd/admission/outcome.go
+++ b/server/internal/usersessions/cimd/admission/outcome.go
@@ -10,8 +10,10 @@ const (
 	OutcomeAdmit Outcome = "admitted"
 
 	// OutcomeCheckCustom means the catalog did not match. The caller must
-	// query the issuer's custom URLs; a miss there is a final denial with
-	// reason DenialNotListed.
+	// query the issuer's custom URLs. What a miss there means depends on
+	// why the evaluation ran: under enforcement it is a final denial with
+	// reason DenialNotListed, and under a shadow evaluation it is a
+	// recorded gap on a request that was admitted anyway.
 	OutcomeCheckCustom Outcome = "check_custom"
 
 	// OutcomeDeny is a final denial. Pair it with a DenialReason.

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -4,14 +4,21 @@ INSERT INTO user_session_issuers (
     organization_id,
     slug,
     authn_challenge_mode,
-    session_duration
+    session_duration,
+    client_id_metadata_admission_mode
 )
 VALUES (
     @project_id::uuid,
     @organization_id,
     @slug,
     @authn_challenge_mode,
-    @session_duration
+    @session_duration,
+    -- Written explicitly rather than left NULL so the resting policy is a
+    -- real, readable, operator-changeable value on the row instead of an
+    -- absence the application has to interpret. A literal, not a parameter:
+    -- the create form carries no admission field, and an operator changes
+    -- the mode afterwards through the update endpoint.
+    'open'
 )
 RETURNING *;
 
@@ -40,9 +47,9 @@ SET
     slug = COALESCE(sqlc.narg('slug')::text, slug),
     authn_challenge_mode = COALESCE(sqlc.narg('authn_challenge_mode')::text, authn_challenge_mode),
     session_duration = COALESCE(sqlc.narg('session_duration')::interval, session_duration),
-    -- Omitting the mode keeps the stored value, including NULL. Once a
-    -- concrete mode is written the column can never return to NULL through
-    -- this endpoint: "never configured" is a one-way state, and the API
+    -- Omitting the mode keeps the stored value, NULL included. Rows created
+    -- before the insert above wrote a mode explicitly stay NULL until a
+    -- backfill converges them, and nothing here needs to care: the API
     -- reports the resolved effective mode either way.
     client_id_metadata_admission_mode = COALESCE(sqlc.narg('client_id_metadata_admission_mode')::text, client_id_metadata_admission_mode),
     updated_at = clock_timestamp()

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -311,14 +311,21 @@ INSERT INTO user_session_issuers (
     organization_id,
     slug,
     authn_challenge_mode,
-    session_duration
+    session_duration,
+    client_id_metadata_admission_mode
 )
 VALUES (
     $1::uuid,
     $2,
     $3,
     $4,
-    $5
+    $5,
+    -- Written explicitly rather than left NULL so the resting policy is a
+    -- real, readable, operator-changeable value on the row instead of an
+    -- absence the application has to interpret. A literal, not a parameter:
+    -- the create form carries no admission field, and an operator changes
+    -- the mode afterwards through the update endpoint.
+    'open'
 )
 RETURNING id, project_id, organization_id, slug, authn_challenge_mode, session_duration, classification, client_id_metadata_admission_mode, created_at, updated_at, deleted_at, deleted
 `
@@ -2266,9 +2273,9 @@ SET
     slug = COALESCE($1::text, slug),
     authn_challenge_mode = COALESCE($2::text, authn_challenge_mode),
     session_duration = COALESCE($3::interval, session_duration),
-    -- Omitting the mode keeps the stored value, including NULL. Once a
-    -- concrete mode is written the column can never return to NULL through
-    -- this endpoint: "never configured" is a one-way state, and the API
+    -- Omitting the mode keeps the stored value, NULL included. Rows created
+    -- before the insert above wrote a mode explicitly stay NULL until a
+    -- backfill converges them, and nothing here needs to care: the API
     -- reports the resolved effective mode either way.
     client_id_metadata_admission_mode = COALESCE($4::text, client_id_metadata_admission_mode),
     updated_at = clock_timestamp()


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-93/flip-the-cimd-admission-default-for-unconfigured-issuers-from

## Summary

- Resolve an unset `client_id_metadata_admission_mode` to `open` instead of the internal `reporting` mode, making `presets` enforcement something an operator opts into rather than a default anyone lands on.
- Add `admission.EvaluateShadow`, deliberately separate from `Evaluate`, so an open-mode issuer still records what `presets` would have decided. Two new outcome values on `cimd.admission.decisions`: `admitted_open_not_listed` when no rule anywhere covers the client, and `admitted_open_oversized` when the `client_id` is too long to evaluate safely. `admitted_open` now means only that the lookup failed.
- Write `'open'` explicitly in `CreateUserSessionIssuer`, as a SQL literal rather than a new form field. Rows created earlier stay NULL and resolve to `open` until a manual backfill converges them, which must run **after** the deploy.
- Reword the Goa doc strings that described `reporting` as the current default and the unset state as one an issuer can never leave. No enum or wire-shape change, so no breaking SDK change.
- In the dashboard, render the custom client URL list against the unsaved selection in the admission mode field rather than the saved value.
- The Datadog monitor over that counter was repointed to `gram.cimd.admission_outcome:*not_listed` ahead of this change, so it catches shadow-recorded gaps as well as real denials.

## Motivation

`reporting` was built as a staging post on the way to enforcement: measure, confirm the catalog is complete, then move the default to `presets`. That destination has changed.

A `presets` denial is unrecoverable for the end user. MCP clients pick CIMD over dynamic client registration once, at metadata discovery time, and do not fall back when `/authorize` rejects the `client_id`, so a catalog gap is a dead end with no client-side recovery. Making that the silent default would impose a curated allowlist on every issuer whose operator never chose one. The catalog is also still learning from production traffic, which is not a list to start enforcing quietly.

No admission outcome changes anywhere: `reporting` and `open` admit identically, so no client that authenticates today stops authenticating. What changes is that the resting state becomes a real, writable, operator-visible mode instead of an internal one the dashboard cannot render.

The measurement has to survive that, because `reporting` was the only mode recording what `presets` would refuse, and that signal is what surfaced the last two vendors added to the catalog. `Evaluate(ModeOpen)` must keep returning an admission: Platform MCP runs open as a compile-time policy and maps `OutcomeCheckCustom` onto a final denial, having no per-issuer custom URL table, so widening `Evaluate` would turn its authorization server into an enforcing one overnight. The shadow is therefore a separate call whose result becomes a metric label and never a decision, keeping one point per request on the counter.

The dashboard change follows from the flip. With the custom URL list gated on the saved mode, an operator moving an issuer onto `presets` would have had to switch first and fill the list afterwards, with enforcement already live and nothing in it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults CIMD client admission to `open` for issuers whose admission mode was never set, instead of the internal `reporting` default. Both modes admit every spec-valid client, so no client that authenticates today stops authenticating; `presets` enforcement becomes something an operator opts into.

**Measurement**
- Adds `admission.EvaluateShadow`, separate from `Evaluate`, so open-mode issuers still record what `presets` would have decided; `Evaluate(ModeOpen)` is unchanged because Platform MCP maps `OutcomeCheckCustom` onto a denial.
- Records `admitted_open_not_listed` for clients no rule covers and `admitted_open_oversized` when the client_id is too long to evaluate; `admitted_open` now means only the lookup failed.
- Dashboard custom client URL list follows the unsaved admission mode selection so URLs can be staged before switching to `presets`.

**Migration**
- New issuers are created as `open`, but existing NULL rows need a backfill after the deploy: `UPDATE user_session_issuers SET client_id_metadata_admission_mode = 'open' WHERE client_id_metadata_admission_mode IS NULL;`
- Rows still NULL resolve to `open` in the meantime and the read API returns `open` for them.
- `gram.cimd.admission_mode` stops reporting `reporting`; series continue under `open`, so repoint saved queries and dashboards filtering on `mode:reporting`.

<sup>Written for commit 39d2015874a70226a960d3b715e1c4cd295cb684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

