### PR TITLE
chore: unbatch gofix onto stdin and bump hk to 1.56.1

### DIFF
--- a/.mise-tasks/go/fix.mts
+++ b/.mise-tasks/go/fix.mts
@@ -3,14 +3,39 @@
 //MISE description="Run go fix on the specified files"
 //MISE dir="{{ config_root }}"
 
-//USAGE arg "<files>..." help="Go files to fix"
+//USAGE arg "[files]..." help="Go files to fix; read from stdin, one per line, when omitted"
 
 import path from "node:path";
 import { $ } from "zx";
 
-function run() {
+// hk hands the file list over stdin rather than argv: the repo-wide list is
+// large enough to exceed Linux's per-argument size cap once hk renders it into
+// a single shell command. Arguments still work for direct invocation.
+async function inputFiles(): Promise<string[]> {
+  const args = process.argv.slice(2);
+  if (args.length > 0) {
+    return args;
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+
+  return Buffer.concat(chunks)
+    .toString("utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+}
+
+async function run() {
   const cwd = process.cwd();
-  const files = process.argv.slice(2);
+  const files = await inputFiles();
+  if (files.length === 0) {
+    return;
+  }
+
   let dirs = files.map((f) => {
     const relpath = path.relative(cwd, path.dirname(path.resolve(f)));
     return relpath.startsWith("..") ? relpath : `./${relpath}`;
@@ -20,4 +45,4 @@ function run() {
   $.sync`go fix ${dirs}`;
 }
 
-run();
+await run();

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,18 +1,8 @@
-amends "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.38.0/hk@1.38.0#/Builtins.pkl"
-import "pkl:json"
+import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
 // Runtime data and local service configuration are outside source checks.
 exclude = List("local")
-
-// Source the oxfmt step's exclude list from `.oxfmtrc.json` so the two stay in sync.
-// Strip the leading `/` that .oxfmtrc.json uses for repo-root anchoring; hk globs are root-relative.
-local oxfmtIgnorePatterns: List<String> =
-  new json.Parser {}
-    .parse(read(".oxfmtrc.json"))
-    .getProperty("ignorePatterns")
-    .toList()
-    .map((p) -> let (s = p as String) if (s.startsWith("/")) s.substring(1, s.length) else s)
 
 local linters = new Mapping<String, Step> {
   ["pkleval"] = Builtins.pkl
@@ -69,15 +59,15 @@ local linters = new Mapping<String, Step> {
         "**/*.markdown.mdx",
         "**/*.md",
       )
-    exclude = oxfmtIgnorePatterns
-    // `--no-error-on-unmatched-pattern` keeps oxfmt from failing when every file
-    // it is handed is excluded by `.oxfmtrc.json`'s own ignorePatterns. This can
-    // happen when a commit only touches oxfmt-ignored files (e.g. the generated
-    // `docs/pubsub-topology.md`): hk caches the compiled config keyed on hk.pkl
-    // and does not track the `read(".oxfmtrc.json")` above, so a stale cache can
-    // pass an ignored file through `exclude`. Without the flag oxfmt would exit
-    // non-zero on "all files excluded" and break the hook; with it, oxfmt simply
-    // formats nothing and leaves the file untouched.
+    // `.oxfmtrc.json`'s own `ignorePatterns` decide what oxfmt formats, and this
+    // step deliberately does not mirror them: hk keys its compiled-config cache
+    // on imports, so a `read()` of that file would not invalidate the cache when
+    // it changed, and the copy here could silently drift.
+    //
+    // The cost is that oxfmt gets handed files it will skip, including whole
+    // generated trees. `--no-error-on-unmatched-pattern` covers the case where
+    // it is handed nothing but ignored files, which would otherwise exit
+    // non-zero on "all files excluded" and break the hook.
     check = "aube exec oxfmt -- --check --no-error-on-unmatched-pattern {{files}}"
     fix = "aube exec oxfmt -- --write --no-error-on-unmatched-pattern {{files}}"
   }

--- a/hk.pkl
+++ b/hk.pkl
@@ -31,9 +31,15 @@ local linters = new Mapping<String, Step> {
     // and runs `go fix` on that package, type-checking it and its full
     // dependency graph. Batching therefore turns N files in one package into N
     // concurrent cold builds of the same graph, each forking its own compilers.
+    //
+    // The list goes over stdin rather than argv so that hk cannot split it
+    // either. Repo-wide it is ~230KB, which exceeds Linux's 128KiB
+    // per-argument cap once hk renders it into a single `sh -c` string; hk
+    // skips its own ARG_MAX batching for steps that use stdin.
     glob = "**/*.go"
     exclude = "**/testdata/**"
-    fix = "mise run -q go:fix {{files}}"
+    stdin = "{{ files_list | join(sep='\n') }}"
+    fix = "mise run -q go:fix"
   }
   ["oxfmt"] {
     batch = true

--- a/mise.lock
+++ b/mise.lock
@@ -699,38 +699,38 @@ url = "https://github.com/charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0
 url_api = "https://api.github.com/repos/charmbracelet/gum/releases/assets/290080922"
 
 [[tools.hk]]
-version = "1.46.0"
+version = "1.56.1"
 backend = "aqua:jdx/hk"
 
 [tools.hk."platforms.linux-arm64"]
-checksum = "sha256:bad1b4e52cce2147646d943baa06a7bdb3d182ae0876853897a72225626411ae"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420599"
+checksum = "sha256:cd671706a273dac35b012fd585a0fba1b0c0f340558dccfd4c9a4b976a794597"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632120"
 
 [tools.hk."platforms.linux-arm64-musl"]
-checksum = "sha256:ad11b69485096ec5b1822f5bad298d2a44664b85d10d0308c812473b17b1321a"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420602"
+checksum = "sha256:5feac3cfcdae33227197d0104832b91a5d293733320632c3c19f864866a6c8ce"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632119"
 
 [tools.hk."platforms.linux-x64"]
-checksum = "sha256:85b2cc167443cd27b49e323ef9b9d1a946d4bc18196eccb66112842d30fb90cb"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420608"
+checksum = "sha256:67157431e36bb523213d8361a9f59b6eb718f80ae8534827849552b3c6c92a04"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632131"
 
 [tools.hk."platforms.linux-x64-musl"]
-checksum = "sha256:4ff45e1bfc9672b1b00572b4a50fac3b57e4add622ed56e9e2587745299932eb"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420609"
+checksum = "sha256:e7435c1aec98f60d98712da3231541987ac67c017c001f767c0f37bd517cfe43"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632133"
 
 [tools.hk."platforms.macos-arm64"]
-checksum = "sha256:9db3fac25754cfb929dc3f92b294fffdb966d4e838b8e0adeaf5b9b7eccc4f6c"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420600"
+checksum = "sha256:f8400a1427e66f1b968e58568115a2138b5d0fe88e0561b97d3822648b7e35ea"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632123"
 
 [tools.hk."platforms.windows-x64"]
-checksum = "sha256:5af7e769acb7f70d8630ed53ae1fb2cc4b205117f29df5d83619fa0ff72a3bf1"
-url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/hk/releases/assets/431420604"
+checksum = "sha256:4ccf353e484997dd4975361b6433f3b2661f5db614f2b382cddcac7eaa74a604"
+url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.jq]]
 version = "1.8.2"

--- a/mise.toml
+++ b/mise.toml
@@ -46,9 +46,7 @@ aube = "1.38.1"
 watchexec = "2.5.1"
 uv = "0.12.1"
 yq = "4.53.3"
-# hk ≥1.47 fails to evaluate the json.Parser usage in hk.pkl
-# ("unknown method 'parse'"); keep 1.46.0 until hk.pkl is ported.
-hk = "1.46.0"
+hk = "1.56.1"
 pkl = "0.32.1"
 "github:temporalio/cli" = "1.8.2"
 "github:pb33f/openapi-changes" = "0.2.10"


### PR DESCRIPTION
## Summary

Two related changes to the pre-commit tooling, one commit each.

**Hand the `gofix` file list to `go:fix` over stdin.** The step keeps the `batch = true` removal from #5805 and additionally sets `stdin`, so `.mise-tasks/go/fix.mts` receives the list on stdin instead of argv. The task reads stdin when it gets no arguments and still accepts arguments for direct invocation.

**Bump hk 1.46.0 to 1.56.1 and delete the derived oxfmt exclude list.** `hk.pkl` drops `import "pkl:json"`, the `oxfmtIgnorePatterns` block, and `exclude = oxfmtIgnorePatterns`. `mise.toml` loses the version-pin comment that recorded why the bump was blocked. No new configuration is introduced.

## Motivation

### The unbatched list does not fit on a command line

Unbatching `gofix` in #5805 was correct, but it left the whole repo-wide list on one command line, and that is what `batch = true` had been masking. hk renders a step's command into a single string and runs it as `sh -o errexit -c "<that string>"`, so the entire list occupies **one** argv entry. Linux caps each individual argument at `MAX_ARG_STRLEN`, 32 pages or 128KiB, independently of the aggregate `ARG_MAX`.

Measured on this repo, the rendered list is **236,780 bytes across 5170 files**. That fits comfortably on macOS, where the only limit is the 512KiB aggregate margin, and fails on Linux with `E2BIG`. Same shape as [jdx/hk#1061](https://github.com/jdx/hk/discussions/1061), where a large monorepo worked on macOS and died in Linux CI.

hk 1.56.1 would now split the list on its own, since [jdx/hk#1066](https://github.com/jdx/hk/pull/1066) taught its automatic `ARG_MAX` batching about the Linux cap. That is the wrong outcome here for the same reason `batch = true` was: any split multiplies package builds. hk skips automatic batching entirely for steps that set `stdin`, so passing the list that way pins the run to exactly one invocation on every platform and lets `go:fix` dedupe 5170 files down to 830 directories before invoking `go fix` once.

One implementation note: the task reads stdin as a stream rather than with `readFileSync(0)`, which throws `EAGAIN` on the non-blocking pipe hk provides.

### The version pin was guarding a redundant workaround

hk 1.47 and later default to `pklr`, a built-in Rust pkl evaluator whose stdlib is a stub: every `pkl:` module resolves to an empty object except `pkl:base`, which carries only `Regex`. `import "pkl:json"` bound nothing, `new json.Parser {}` built a plain `Object`, and evaluation failed with `unknown method 'parse' on Object`. Hence the pin.

That `json.Parser` usage derived the oxfmt step's exclude list from `.oxfmtrc.json` (#2957), to stop oxfmt exiting non-zero with `Expected at least one target file` when every staged file was ignored. It never reliably did that. hk keys its compiled-config cache on pkl **imports**, and `.oxfmtrc.json` is pulled in with `read()` rather than imported, so editing it does not invalidate the cache and the derived copy can go stale. #3828 hit exactly that and reached for oxfmt's `--no-error-on-unmatched-pattern`, which handles the original failure on its own and left the parsing redundant. The flag had been available since [oxc#13671](https://github.com/oxc-project/oxc/pull/13671) in September 2025, eight months before #2957.

So the mirror is gone and `.oxfmtrc.json` is the single source of truth, read only by oxfmt itself. The tradeoff is that hk hands oxfmt 5613 files instead of 2626 and oxfmt skips the ones it ignores; `hk check --all` measures the same either way, and ignored files stay untouched on the fix path as well as check.

With `pkl:json` out of the config, `pklr` evaluates it and the pin can go. Keeping hk current also removes the same latent Linux hazard from `gofmt`, `oxfmt`, and `ruff`, whose safety today rests on their batch count happening to divide the list far enough.

The alternative was setting `HK_PKL_BACKEND=pkl` to keep hk on the real pkl CLI. That works, but it trades a version pin for an environment variable and preserves a mirror that was already documented as unreliable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `gofix` failing on Linux with E2BIG by passing the file list over stdin, and bumps hk to 1.56.1 to drop the derived oxfmt exclude list.

- The repo-wide list is ~237KB from 5170 files, which exceeds Linux's 128KiB per-argument cap, and stdin also stops hk from splitting it into multiple `go fix` calls.
- `pkl:json` parsing is removed, lifting the pin that kept hk at 1.46.0.
- `.oxfmtrc.json` is now oxfmt's single source of truth instead of a stale config-cache mirror.

<sup>Written for commit b5dad52b574a8086405d351593bfb72b3d4feb0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

