### PR TITLE
feat: manage OpenRouter admin locks by cause (AGE-3219)

### DIFF
--- a/docs/superpowers/plans/2026-08-26-age-3219-openrouter-disable-causes.md
+++ b/docs/superpowers/plans/2026-08-26-age-3219-openrouter-disable-causes.md
@@ -1,0 +1,742 @@
+# AGE-3219 OpenRouter Disable Causes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve independent admin, trial, and billing reasons that disable a platform OpenRouter key, and expose those reasons only to platform administrators.
+
+**Architecture:** Replace the mutable `disabled` column with a set-like `disable_causes text[]` and a stored generated `disabled` compatibility column. Put cause-aware, upstream-first transitions in the production OpenRouter provisioner, then make admin, trial, and billing callers add or remove only their own cause while they retain the existing per-key billing locks.
+
+**Tech Stack:** PostgreSQL 16, Atlas migrations, SQLc, Go, Goa, React 19, TanStack Query, Vitest, generated TypeScript SDK.
+
+**Spec:** [AGE-3219 approved Linear design](https://linear.app/speakeasy/issue/AGE-3219/re-arming-a-trial-silently-re-enables-a-key-a-platform-admin-locked)
+
+## Global Constraints
+
+- Causes are exactly `admin_lock`, `trial_demotion`, and `billing_inactive`.
+- Treat `disable_causes` as a set. Never store duplicate values.
+- Keep `disabled` as a stored generated value of whether `disable_causes` is non-empty.
+- Backfill old `disabled = true` rows to `['admin_lock']`; backfill false rows to an empty array in the single Atlas migration.
+- Each recovery path removes only its own cause. A key is enabled only when no causes remain.
+- Preserve the existing per-key session lock, upstream-first order, and repeat-safe retries.
+- Send an upstream disabled-state patch only when the effective enabled/disabled state changes. Limit patches remain allowed when policy requires a limit change.
+- Admin lock changes write a key audit event even when another cause keeps the key disabled. Trial lifecycle changes use one organization event, not one event per key.
+- Platform-admin API and key UI expose causes. Customer APIs do not expose causes.
+- UI actions are **Disable key** and **Remove admin lock**. The UI cannot remove automatic causes.
+- Local development provisioner methods remain no-ops.
+- Do not edit files under `server/gen/`, `server/internal/**/repo/*.go`, or `client/dashboard/src/sdk/` by hand; regenerate them.
+- Work and test locally before any PR-stack update. Never bypass review or safeguards.
+
+---
+
+### Task 1: Add the database cause set and cause mutation queries
+
+**Files:**
+
+- Modify: `server/database/schema.sql:2307-2335`
+- Modify: `server/internal/thirdparty/openrouter/queries.sql:1-80`
+- Create: the dated `server/migrations/*_openrouter-disable-causes.sql` file produced by Atlas
+- Regenerate: `server/migrations/atlas.sum`
+- Regenerate: `server/internal/thirdparty/openrouter/repo/models.go`
+- Regenerate: `server/internal/thirdparty/openrouter/repo/queries.sql.go`
+- Test: `server/internal/thirdparty/openrouter/disable_test.go`
+
+**Interfaces:**
+
+- Produces: `OpenrouterAPIKey.DisableCauses []string` while retaining read-only `OpenrouterAPIKey.Disabled bool`.
+- Produces SQLc methods `AddOpenRouterAPIKeyDisableCause` and `RemoveOpenRouterAPIKeyDisableCause`, each scoped by organization ID and key type and returning the updated row.
+- Preserves `UpdateOpenRouterKey` as a limit/hash update only; it must not clear disable causes.
+
+- [ ] **Step 1: Add a failing repository-level test for set behavior**
+
+Add table-driven cases to `disable_test.go` that seed a key, call the wished-for SQLc cause queries, and assert this sequence:
+
+```go
+added, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+    OrganizationID: orgID,
+    KeyType:        string(KeyTypeChat),
+    DisableCause:   string(DisableCauseAdminLock),
+})
+require.NoError(t, err)
+require.Equal(t, []string{"admin_lock"}, added.DisableCauses)
+require.True(t, added.Disabled)
+
+addedAgain, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+    OrganizationID: orgID,
+    KeyType:        string(KeyTypeChat),
+    DisableCause:   string(DisableCauseAdminLock),
+})
+require.NoError(t, err)
+require.Equal(t, []string{"admin_lock"}, addedAgain.DisableCauses)
+
+withTrial, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+    OrganizationID: orgID,
+    KeyType:        string(KeyTypeChat),
+    DisableCause:   string(DisableCauseTrialDemotion),
+})
+require.NoError(t, err)
+require.ElementsMatch(t, []string{"admin_lock", "trial_demotion"}, withTrial.DisableCauses)
+
+withoutTrial, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
+    OrganizationID: orgID,
+    KeyType:        string(KeyTypeChat),
+    DisableCause:   string(DisableCauseTrialDemotion),
+})
+require.NoError(t, err)
+require.Equal(t, []string{"admin_lock"}, withoutTrial.DisableCauses)
+require.True(t, withoutTrial.Disabled)
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run:
+
+```bash
+mise run test:server ./internal/thirdparty/openrouter/ -run TestOpenRouterDisableCausesAreASet
+```
+
+Expected: compile failure because the cause constants, model field, and SQLc methods do not exist.
+
+- [ ] **Step 3: Edit the desired schema**
+
+Replace the writable Boolean with:
+
+```sql
+disable_causes TEXT[] NOT NULL DEFAULT '{}'::text[],
+disabled BOOLEAN NOT NULL GENERATED ALWAYS AS (cardinality(disable_causes) > 0) stored,
+```
+
+Do not add an enum `CHECK`; allowed values are application validation.
+
+- [ ] **Step 4: Add set-like SQL mutations and stop generic refresh from reinstating**
+
+Use `@disable_cause = ANY(disable_causes)` to prevent duplicates and `array_remove` for removal:
+
+```sql
+-- name: AddOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) THEN disable_causes
+      ELSE array_append(disable_causes, @disable_cause::text)
+    END,
+    updated_at = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) THEN updated_at
+      ELSE GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+    END
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE
+RETURNING *;
+
+-- name: RemoveOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = array_remove(disable_causes, @disable_cause::text),
+    updated_at = CASE
+      WHEN @disable_cause::text = ANY(disable_causes)
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE
+RETURNING *;
+```
+
+Remove `disabled = disabled AND NOT @reinstate` from `UpdateOpenRouterKey` and remove its `reinstate` parameter. Only explicit cause mutations can change disabled state.
+
+- [ ] **Step 5: Generate and then repair the single Atlas migration**
+
+Run:
+
+```bash
+mise run db:diff openrouter-disable-causes
+```
+
+Edit only the generated migration so the old Boolean remains available for the backfill. The migration body must have this order:
+
+```sql
+ALTER TABLE "openrouter_api_keys"
+  ADD COLUMN "disable_causes" text[] NOT NULL DEFAULT '{}'::text[];
+
+UPDATE "openrouter_api_keys"
+SET "disable_causes" = ARRAY['admin_lock']::text[]
+WHERE "disabled" IS TRUE;
+
+ALTER TABLE "openrouter_api_keys"
+  DROP COLUMN "disabled",
+  ADD COLUMN "disabled" boolean NOT NULL
+    GENERATED ALWAYS AS (cardinality(disable_causes) > 0) STORED;
+```
+
+Keep the exact Atlas quoting and header that `db:diff` generates. Do not create a second migration or a script.
+
+- [ ] **Step 6: Rehash and regenerate SQLc**
+
+Run:
+
+```bash
+mise run db:hash
+mise run gen:sqlc-server
+```
+
+- [ ] **Step 7: Complete the cause constants needed by the test**
+
+Create `server/internal/thirdparty/openrouter/disable_causes.go` with:
+
+```go
+package openrouter
+
+type DisableCause string
+
+const (
+    DisableCauseAdminLock      DisableCause = "admin_lock"
+    DisableCauseTrialDemotion  DisableCause = "trial_demotion"
+    DisableCauseBillingInactive DisableCause = "billing_inactive"
+)
+
+func (c DisableCause) Validate() error {
+    switch c {
+    case DisableCauseAdminLock, DisableCauseTrialDemotion, DisableCauseBillingInactive:
+        return nil
+    default:
+        return fmt.Errorf("unknown OpenRouter disable cause %q", c)
+    }
+}
+```
+
+Add the `fmt` import and a helper that converts `[]string` to validated `[]DisableCause` only if production code needs typed output.
+
+- [ ] **Step 8: Run database and package checks**
+
+Run:
+
+```bash
+mise run lint:migrations
+mise run test:server ./internal/thirdparty/openrouter/ -run TestOpenRouterDisableCausesAreASet
+```
+
+Expected: migration lint passes and the set test passes.
+
+- [ ] **Step 9: Commit the database slice**
+
+```bash
+git add server/database/schema.sql server/migrations server/internal/thirdparty/openrouter/queries.sql server/internal/thirdparty/openrouter/repo server/internal/thirdparty/openrouter/disable_causes.go server/internal/thirdparty/openrouter/disable_test.go
+git commit -m "feat: store OpenRouter disable causes"
+```
+
+---
+
+### Task 2: Make the production provisioner cause-aware
+
+**Files:**
+
+- Modify: `server/internal/thirdparty/openrouter/openrouter.go:310-340,540-735`
+- Modify: `server/internal/thirdparty/openrouter/local.go:20-55`
+- Modify: `server/internal/thirdparty/openrouter/disable_test.go`
+- Modify: `server/internal/thirdparty/openrouter/unified_client_test.go`
+
+**Interfaces:**
+
+- Produces: `DisableCauseChange{CauseChanged bool, KeyAccessChanged bool}`.
+- Produces provisioner methods:
+
+```go
+AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error)
+AddAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error)
+RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
+RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
+```
+
+- `RefreshAPIKeyLimit` and `RefreshAPIKeyLimitWithDB` preserve every cause and never enable a key.
+- Keep the legacy `DisableAPIKey*` and `ReinstateAPIKeyLimit*` methods temporarily in Task 2 so the repository compiles while callers migrate. Remove them only in Task 4.
+- Add temporary no-op implementations of the new methods to every test mock that asserts `openrouter.Provisioner`; Task 4 replaces those stubs with cause-specific expectations.
+
+- [ ] **Step 1: Write failing upstream-call matrix tests**
+
+Add cases to `disable_test.go` that use the existing HTTP test server and assert:
+
+```text
+add admin_lock to enabled key             -> PATCH disabled=true once; CauseChanged=true; KeyAccessChanged=true
+add trial_demotion to admin-locked key    -> no PATCH; CauseChanged=true; KeyAccessChanged=false
+add existing cause                         -> no PATCH; CauseChanged=false; KeyAccessChanged=false
+remove trial_demotion while admin remains -> no disabled PATCH; CauseChanged=true; KeyAccessChanged=false
+remove final cause                          -> PATCH disabled=false once; CauseChanged=true; KeyAccessChanged=true
+remove absent cause                         -> no disabled PATCH; CauseChanged=false; KeyAccessChanged=false
+upstream failure                            -> local causes remain unchanged
+retry after success                         -> no duplicate cause and no duplicate state PATCH
+```
+
+Also add a regression test that `RefreshAPIKeyLimit` on a disabled key updates the limit without sending `disabled=false` and without changing `disable_causes`.
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run:
+
+```bash
+mise run test:server ./internal/thirdparty/openrouter/ -run 'Test(Add|Remove)APIKeyDisableCause|TestRefreshAPIKeyLimit_PreservesDisableCauses'
+```
+
+Expected: compile failure because the new provisioner API and result type do not exist.
+
+- [ ] **Step 3: Add the result type and provisioner interface methods**
+
+Add to `openrouter.go`:
+
+```go
+type DisableCauseChange struct {
+    CauseChanged    bool
+    KeyAccessChanged bool
+}
+```
+
+Validate both key type and cause at every public entry point. The `WithDB` forms must use the supplied locked connection for every local read and write.
+
+- [ ] **Step 4: Implement upstream-first add behavior**
+
+The internal add helper must:
+
+1. Return a no-op for a missing key, matching current lifecycle behavior.
+2. Read `DisableCauses` under the caller’s existing key lock.
+3. Return a no-op when the cause already exists.
+4. PATCH `{disabled:true}` only when the pre-change array is empty.
+5. Add the cause locally only after the upstream PATCH succeeds.
+6. Return `CauseChanged=true` and `KeyAccessChanged=(len(before)==0)`.
+
+Do not send a limit in the disable PATCH.
+
+- [ ] **Step 5: Implement upstream-first removal behavior**
+
+The internal removal helper must:
+
+1. Return a no-op when the cause is absent.
+2. Resolve `limit` with the same explicit-limit and policy-default rules used today.
+3. Set `Disabled` to `false` in the upstream request only when this removal empties the cause array.
+4. Keep `Disabled=nil` when another cause remains.
+5. Include a limit only when the caller supplied one or current policy repair requires it.
+6. Remove the local cause only after the upstream request succeeds.
+7. Return `KeyAccessChanged=true` only when the removed cause was the final cause.
+
+If no disabled-state or limit change is needed, skip OpenRouter and perform only the local cause removal.
+
+- [ ] **Step 6: Make generic limit refresh cause-neutral**
+
+Delete the branch that uses a disabled row to set `patch.Disabled = new(false)`. A generic refresh can update `Limit` and `LimitReset`, but `Disabled` must remain nil. Replace every `UpdateOpenRouterKeyParams.Reinstate` use with the cause-neutral query shape from Task 1.
+
+- [ ] **Step 7: Keep local development no-op behavior**
+
+Implement all four new methods on `Development` without local or upstream writes:
+
+```go
+func (*Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
+    return DisableCauseChange{}, nil
+}
+
+func (*Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+    return 0, DisableCauseChange{}, nil
+}
+```
+
+The `WithDB` variants delegate to the matching no-op.
+
+- [ ] **Step 8: Keep the repository compiling during the API transition**
+
+Find every test double with `var _ openrouter.Provisioner` or a constructor parameter of that type. Add temporary no-op implementations of the four new methods while keeping the old methods. Run a compile-only server pass:
+
+```bash
+mise run test:server ./... -run '^$'
+```
+
+Expected: every server package compiles without running tests.
+
+- [ ] **Step 9: Run the core package suite**
+
+```bash
+mise run test:server ./internal/thirdparty/openrouter/
+```
+
+Expected: all OpenRouter tests pass, including upstream request-body assertions.
+
+- [ ] **Step 10: Commit the provisioner slice**
+
+```bash
+git add server/internal/thirdparty/openrouter server/internal/admin server/internal/background server/internal/modelkeys server/internal/openrouterkeys server/internal/usage
+git commit -m "feat: apply OpenRouter disable causes independently"
+```
+
+---
+
+### Task 3: Expose causes and admin-lock semantics in the platform-admin API
+
+**Files:**
+
+- Modify: `server/design/platformadmin/openrouterkeys/design.go:15-145`
+- Modify: `server/internal/openrouterkeys/queries.sql`
+- Modify: `server/internal/openrouterkeys/impl.go:120-390`
+- Modify: `server/internal/openrouterkeys/keys_test.go`
+- Modify: `server/internal/openrouterkeys/setup_test.go`
+- Modify: `server/internal/audit/openrouterkeys.go`
+- Regenerate: `server/internal/openrouterkeys/repo/*`
+- Regenerate: `server/gen/admin_open_router_keys/**` and `server/gen/http/admin_open_router_keys/**`
+
+**Interfaces:**
+
+- `AdminOpenRouterKey` adds required `disable_causes: array<string>` while retaining `disabled`.
+- Existing `disableKey` adds `admin_lock`. Existing `enableKey` removes only `admin_lock`; its HTTP operation stays compatible, while descriptions and UI use “remove admin lock.”
+- Key audit snapshots contain `disabled` and `disable_causes` before and after.
+
+- [ ] **Step 1: Write failing admin service tests**
+
+Extend `keys_test.go` with these cases:
+
+```text
+disable enabled key                 -> adds admin_lock, disables upstream, writes one audit row
+disable trial-demoted key           -> adds admin_lock, skips upstream state patch, still writes audit row
+disable key already admin-locked    -> repeat-safe, no new audit row
+remove admin lock only cause         -> removes cause, enables upstream, writes one audit row
+remove admin lock with trial cause   -> removes only admin_lock, skips enable patch, still writes audit row
+remove when no admin lock            -> repeat-safe, automatic causes remain, no audit row
+list/get response                     -> includes every active cause and generated disabled
+```
+
+Assert audit before/after snapshots show cause changes and contain no key material.
+
+- [ ] **Step 2: Run admin tests and confirm RED**
+
+```bash
+mise run test:server ./internal/openrouterkeys/ -run 'Test(Disable|Enable|List)Key'
+```
+
+Expected: tests fail because the API model and handlers still use one Boolean.
+
+- [ ] **Step 3: Add causes to the Goa design and admin SQL**
+
+In `AdminKey`, add a required array field with element enum values:
+
+```go
+Attribute("disable_causes", ArrayOf(String, func() {
+    Enum("admin_lock", "trial_demotion", "billing_inactive")
+}), "Independent reasons that keep the key disabled.")
+```
+
+Change the `enableKey` description to say that it removes only the platform-admin lock. Select `k.disable_causes` in both admin queries.
+
+- [ ] **Step 4: Regenerate SQLc and Goa server files**
+
+```bash
+mise run gen:sqlc-server
+mise run gen:goa-server
+```
+
+Do not hand-edit generated files.
+
+- [ ] **Step 5: Implement admin cause transitions**
+
+Map `DisableCauses` into every `AdminOpenRouterKey` response. In both handlers, retain `keybillinglock.WithAcquireTimeout`.
+
+- `DisableKey` calls `AddAPIKeyDisableCause(..., DisableCauseAdminLock)`.
+- `EnableKey` calls `RemoveAPIKeyDisableCause(..., DisableCauseAdminLock, recordedLimit)`.
+- Write an audit event when `CauseChanged` is true, regardless of `KeyAccessChanged`.
+- Do not write an audit event on an idempotent retry.
+- Never remove `trial_demotion` or `billing_inactive` in this service.
+
+Use the locked `*pgxpool.Conn` through the provisioner `WithDB` methods; do not reacquire from the pool inside the callback.
+
+- [ ] **Step 6: Add cause snapshots to admin key audit entries**
+
+Use one snapshot type for lock add/remove:
+
+```go
+type OpenRouterAPIKeyDisableSnapshot struct {
+    Disabled      bool     `json:"disabled"`
+    DisableCauses []string `json:"disable_causes"`
+}
+```
+
+Pass explicit before and after snapshots from the handler. Keep action names compatible unless an existing consumer requires a new name; the UI copy, not the audit action, says **Remove admin lock**.
+
+- [ ] **Step 7: Run the admin service suite**
+
+```bash
+mise run test:server ./internal/openrouterkeys/
+```
+
+Expected: all service, locking, authorization, and audit tests pass.
+
+- [ ] **Step 8: Commit the admin API slice**
+
+```bash
+git add server/design/platformadmin/openrouterkeys server/internal/openrouterkeys server/internal/audit/openrouterkeys.go server/gen/admin_open_router_keys server/gen/http/admin_open_router_keys
+git commit -m "feat: manage OpenRouter admin locks by cause"
+```
+
+---
+
+### Task 4: Update trial and billing lifecycle callers
+
+**Files:**
+
+- Modify: `server/internal/background/activities/trial_demotion.go`
+- Modify: `server/internal/background/activities/trial_demotion_test.go`
+- Modify: `server/internal/admin/impl.go:89-140,1260-1345`
+- Modify: `server/internal/admin/rearmtrial_test.go`
+- Modify: `server/internal/background/activities/reconcile_payg_openrouter_chat_key.go`
+- Modify: `server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go`
+- Modify: `server/internal/background/activities/queries.sql` if the PAYG projection needs trial conversion state
+- Regenerate: `server/internal/background/activities/repo/*` when its SQL changes
+- Modify: mocks that implement `openrouter.Provisioner`, including `server/internal/thirdparty/openrouter/unified_client_test.go` and relevant usage integration tests
+
+**Interfaces:**
+
+- Trial demotion adds `trial_demotion` to both key types.
+- Trial re-arm removes `trial_demotion` from both key types and returns whether any effective access changed for later AGE-3150 audit work.
+- Billing loss adds `billing_inactive` to the chat key only. Billing recovery removes only `billing_inactive`.
+- A Stripe checkout that has converted a previously demoted trial also removes `trial_demotion` from both keys based on authoritative trial state; ordinary billing recovery does not.
+
+- [ ] **Step 1: Write failing trial tests for independent causes**
+
+In `trial_demotion_test.go`, seed an admin-locked key and verify demotion appends `trial_demotion` without an upstream disabled patch. In `rearmtrial_test.go`, cover:
+
+```text
+{trial_demotion}                  -> re-arm removes it and enables the key
+{admin_lock, trial_demotion}      -> re-arm removes only trial_demotion and key stays disabled
+{billing_inactive, trial_demotion}-> re-arm removes only trial_demotion and key stays disabled
+missing key                        -> remains a no-op
+repeated re-arm                    -> no repeated state patch
+```
+
+Keep the existing guarantee that required key work happens before organization restoration commits.
+
+- [ ] **Step 2: Write failing billing tests for independent causes**
+
+In `reconcile_payg_openrouter_chat_key_test.go`, cover:
+
+```text
+billing loss on enabled chat key                 -> add billing_inactive and disable upstream
+billing loss on admin-locked chat key             -> add billing_inactive, no upstream state patch
+billing recovery with billing_inactive only       -> remove it and enable upstream
+billing recovery with admin_lock also present     -> remove billing_inactive only, remain disabled
+ordinary billing recovery                          -> never removes trial_demotion
+Stripe conversion of demoted trial                -> remove trial_demotion from chat and internal
+retries                                             -> preserve set semantics and avoid repeated state patches
+```
+
+- [ ] **Step 3: Run lifecycle tests and confirm RED**
+
+```bash
+mise run test:server ./internal/background/activities/ ./internal/admin/ -run 'Test(DemoteExpiredTrials|RearmTrial|ReconcilePaygOpenRouter)'
+```
+
+Expected: compile or assertion failures because lifecycle callers still use global disable/reinstate methods.
+
+- [ ] **Step 4: Change trial demotion to add its cause**
+
+Update the locked call for each key type to:
+
+```go
+change, err := dbProvisioner.AddAPIKeyDisableCauseWithDB(
+    ctx, conn, args.OrganizationID, keyType, openrouter.DisableCauseTrialDemotion,
+)
+```
+
+Keep missing keys as no-ops. Aggregate `change.KeyAccessChanged` at organization scope for the later audit contract, but do not write per-key trial events.
+
+- [ ] **Step 5: Change re-arm to remove only trial demotion**
+
+Replace “revive every disabled key” checks with “remove `trial_demotion` when present.” Pass the existing recorded ceiling before commit and preserve the post-commit recap for legacy zero ceilings. Do not skip a row merely because generated `Disabled` is false; inspect causes. An admin or billing cause must survive the transaction.
+
+Update `TrialKeyReviver` and `TrialKeysUnavailable` to the new cause-aware interface.
+
+- [ ] **Step 6: Change PAYG reconciliation to own only billing cause**
+
+- Base tier without subscription: add `billing_inactive` to chat.
+- PAYG with subscription: remove `billing_inactive` from chat and apply PAYG limit policy.
+- Delete the old binary-disabled shortcut that re-enabled Security inference merely because checkout occurred.
+- If the authoritative trial row shows that Stripe converted a demoted trial, remove `trial_demotion` from both chat and internal keys as a separate conversion reconciliation step. This is the trial-conversion owner; it must not be conflated with removing `billing_inactive`.
+- Keep both key-type billing locks and preserve newer explicit spend-cap choices.
+
+- [ ] **Step 7: Update all mocks and compile-time interface assertions**
+
+Replace mock expectations on `DisableAPIKey` and `ReinstateAPIKeyLimit` with the cause-aware methods and explicit causes. Keep `RefreshAPIKeyLimit` mocks only for cause-neutral limit changes.
+
+Remove the legacy `DisableAPIKey*` and `ReinstateAPIKeyLimit*` methods from `Provisioner`, `OpenRouter`, `Development`, and all test doubles only after every production caller uses the cause-aware methods.
+
+- [ ] **Step 8: Run focused and package suites**
+
+```bash
+mise run test:server ./internal/background/activities/ ./internal/admin/ ./internal/usage/
+```
+
+Expected: lifecycle, locking, retry, Stripe integration, and audit tests pass.
+
+- [ ] **Step 9: Commit the lifecycle slice**
+
+```bash
+git add server/internal/background server/internal/admin server/internal/usage server/internal/thirdparty/openrouter/unified_client_test.go
+git commit -m "fix: preserve OpenRouter causes across trial and billing changes"
+```
+
+---
+
+### Task 5: Show causes and admin-lock actions in the platform-admin key UI
+
+**Files:**
+
+- Regenerate: `client/dashboard/src/sdk/**`
+- Modify: `client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx`
+- Create: `client/dashboard/src/pages/platform-admin/openRouterKeyState.ts`
+- Create: `client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts`
+- Create or modify: `client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx` if the existing dashboard harness supports a focused component test without excessive fixtures
+
+**Interfaces:**
+
+- `AdminOpenRouterKey.disableCauses: string[]` comes from the generated SDK.
+- `openRouterKeyState.ts` exports cause labels and pure action eligibility helpers so combined causes are covered without coupling every test to the table harness.
+
+- [ ] **Step 1: Write failing UI state tests**
+
+Create pure helper tests for:
+
+```ts
+expect(causeLabels(["admin_lock", "trial_demotion"])).toEqual([
+  "Admin lock",
+  "Trial demotion",
+]);
+expect(keyAction([])).toBe("disable");
+expect(keyAction(["trial_demotion"])).toBe("disable");
+expect(keyAction(["admin_lock"])).toBe("remove-admin-lock");
+expect(keyAction(["admin_lock", "billing_inactive"])).toBe("remove-admin-lock");
+```
+
+Add a component assertion that automatic causes have no remove action and that combined causes are visible.
+
+- [ ] **Step 2: Run the focused UI tests and confirm RED**
+
+```bash
+aube run -F dashboard test -- src/pages/platform-admin/openRouterKeyState.test.ts src/pages/platform-admin/OpenRouterKeys.test.tsx
+```
+
+Expected: failure because the helper, generated field, and revised labels do not exist.
+
+- [ ] **Step 3: Regenerate the TypeScript SDK**
+
+```bash
+mise run gen:sdk
+```
+
+If this command requires `SPEAKEASY_API_KEY`, stop and report the credential blocker. Do not hand-edit generated SDK files.
+
+- [ ] **Step 4: Implement cause labels and action eligibility**
+
+Use this fixed label map:
+
+```ts
+export const DISABLE_CAUSE_LABELS = {
+  admin_lock: "Admin lock",
+  trial_demotion: "Trial demotion",
+  billing_inactive: "Billing inactive",
+} as const;
+```
+
+Unknown future values must render as their raw value instead of disappearing. Return `remove-admin-lock` only when `admin_lock` is present; otherwise return `disable`.
+
+- [ ] **Step 5: Update the key table**
+
+- Keep the generated `disabled` field for usage polling and the Enabled/Disabled badge.
+- Add active causes under the status or in a dedicated Causes column; all active causes must be readable without opening raw JSON.
+- Label the add action **Disable key**.
+- Label the remove action **Remove admin lock**.
+- When only automatic causes exist, offer **Disable key** so the admin can add an independent lock.
+- Never offer controls that remove `trial_demotion` or `billing_inactive`.
+- Keep the existing mutation invalidation and Sonner feedback, but make success copy say “Admin lock added” or “Admin lock removed.”
+
+- [ ] **Step 6: Run UI tests and type checking**
+
+```bash
+aube run -F dashboard test -- src/pages/platform-admin/openRouterKeyState.test.ts src/pages/platform-admin/OpenRouterKeys.test.tsx
+aube run -F dashboard type-check
+```
+
+Expected: focused tests and TypeScript compilation pass.
+
+- [ ] **Step 7: Commit the UI and generated SDK slice**
+
+```bash
+git add client/dashboard/src/sdk client/dashboard/src/pages/platform-admin
+git commit -m "feat: show OpenRouter disable causes to admins"
+```
+
+---
+
+### Task 6: Verify migration, server, UI, and scope
+
+**Files:**
+
+- Review only: all files changed by Tasks 1-5
+
+**Interfaces:**
+
+- Consumes the complete AGE-3219 implementation.
+- Produces local verification evidence for user approval before any PR update.
+
+- [ ] **Step 1: Verify generated artifacts and formatting**
+
+```bash
+hk fix
+git diff --check
+mise run db:hash
+mise run lint:migrations
+```
+
+Confirm `git diff server/migrations/atlas.sum` contains only the new migration hash and that no generated file was hand-edited.
+
+- [ ] **Step 2: Run focused server tests**
+
+```bash
+mise run test:server ./internal/thirdparty/openrouter/ ./internal/openrouterkeys/ ./internal/background/activities/ ./internal/admin/ ./internal/usage/
+```
+
+Expected: all focused server packages pass.
+
+- [ ] **Step 3: Run server lint on the changed backend**
+
+```bash
+mise lint:server
+```
+
+Expected: no lint errors.
+
+- [ ] **Step 4: Run dashboard checks**
+
+```bash
+aube run -F dashboard test -- src/pages/platform-admin/openRouterKeyState.test.ts src/pages/platform-admin/OpenRouterKeys.test.tsx
+aube run -F dashboard type-check
+```
+
+Expected: tests and type check pass.
+
+- [ ] **Step 5: Inspect migration and public-surface privacy**
+
+Verify manually from the diff:
+
+```text
+true rows backfill to exactly {admin_lock}
+false rows backfill to {}
+disabled is generated from cardinality(disable_causes) > 0
+no customer API or customer SDK contains disable_causes
+platform-admin API and dashboard SDK contain disable_causes
+no automatic lifecycle path removes admin_lock
+no admin path removes trial_demotion or billing_inactive
+```
+
+- [ ] **Step 6: Review branch scope**
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git log --oneline --decorate origin/main..HEAD
+```
+
+Confirm the original worktree’s untracked files are absent and untouched. Do not push or update a PR yet.
+
+- [ ] **Step 7: Present local evidence to the user**
+
+Report the migration shape, focused test counts, lint/type-check results, and any `gen:sdk` credential blocker. Ask for approval before updating the PR stack.

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -732,6 +732,22 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
 	return fmt.Errorf("not implemented in bench")
 }

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -285,6 +285,22 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
 	return fmt.Errorf("not implemented in bench")
 }

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2326,7 +2326,8 @@ CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   key_encrypted TEXT,
   key_hash TEXT NOT NULL,
   monthly_credits BIGINT NOT NULL DEFAULT 0,
-  disabled BOOLEAN NOT NULL DEFAULT FALSE,
+  disable_causes TEXT[] NOT NULL DEFAULT '{}'::text[],
+  disabled BOOLEAN NOT NULL GENERATED ALWAYS AS (cardinality(disable_causes) > 0) stored,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/design/platformadmin/openrouterkeys/design.go
+++ b/server/design/platformadmin/openrouterkeys/design.go
@@ -15,14 +15,17 @@ import (
 
 var AdminKey = Type("AdminOpenRouterKey", func() {
 	Description("One organization's platform OpenRouter key of a given type, without its key material.")
-	Required("organization_id", "organization_name", "organization_slug", "gram_account_type", "key_type", "monthly_credits", "disabled", "created_at", "updated_at")
+	Required("organization_id", "organization_name", "organization_slug", "gram_account_type", "key_type", "monthly_credits", "disabled", "disable_causes", "created_at", "updated_at")
 	Attribute("organization_id", String, "Organization that owns the key.")
 	Attribute("organization_name", String, "Display name of the owning organization.")
 	Attribute("organization_slug", String, "Slug of the owning organization.")
 	Attribute("gram_account_type", String, "The organization's Gram account type (e.g. free, pro, enterprise).")
 	Attribute("key_type", String, "Which upstream key this row provisions: 'chat' pays for customer-facing completions, 'internal' pays for platform-initiated LLM usage.")
 	Attribute("monthly_credits", Int64, "Monthly credit ceiling last mirrored from OpenRouter.")
-	Attribute("disabled", Boolean, "Whether the key is locked down (refused locally and disabled upstream).")
+	Attribute("disabled", Boolean, "Whether one or more active causes keep the key disabled.")
+	Attribute("disable_causes", ArrayOf(String, func() {
+		Enum("admin_lock", "trial_demotion", "billing_inactive")
+	}), "Independent reasons that keep the key disabled.")
 	Attribute("created_at", String, "When the key row was created.", func() { Format(FormatDateTime) })
 	Attribute("updated_at", String, "When the key row was last updated.", func() { Format(FormatDateTime) })
 })
@@ -114,12 +117,12 @@ var _ = Service("adminOpenRouterKeys", func() {
 	})
 
 	Method("enableKey", func() {
-		Description("Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.")
+		Description("Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.")
 
 		Payload(func() {
 			security.SessionPayload()
 			Attribute("organization_id", String, "Organization that owns the key.")
-			Attribute("key_type", String, "Key type to enable.", func() { Enum("chat", "internal") })
+			Attribute("key_type", String, "Key type from which to remove the platform-admin lock.", func() { Enum("chat", "internal") })
 			Required("organization_id", "key_type")
 			// Named explicitly: the disable and enable payloads are
 			// structurally identical and Goa deduplicates request bodies by

--- a/server/gen/admin_open_router_keys/service.go
+++ b/server/gen/admin_open_router_keys/service.go
@@ -25,8 +25,9 @@ type Service interface {
 	// Lock down an organization's platform OpenRouter key, upstream and locally.
 	// Requires platform admin.
 	DisableKey(context.Context, *DisableKeyPayload) (res *AdminOpenRouterKey, err error)
-	// Reinstate a disabled platform OpenRouter key, upstream and locally, keeping
-	// its recorded credit ceiling. Requires platform admin.
+	// Remove the platform-admin lock from an OpenRouter key, preserving any
+	// automatic disable causes and its recorded credit ceiling. Requires platform
+	// admin.
 	EnableKey(context.Context, *EnableKeyPayload) (res *AdminOpenRouterKey, err error)
 }
 
@@ -68,8 +69,10 @@ type AdminOpenRouterKey struct {
 	KeyType string
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits int64
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled bool
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string
 	// When the key row was created.
 	CreatedAt string
 	// When the key row was last updated.
@@ -92,7 +95,7 @@ type EnableKeyPayload struct {
 	SessionToken *string
 	// Organization that owns the key.
 	OrganizationID string
-	// Key type to enable.
+	// Key type from which to remove the platform-admin lock.
 	KeyType string
 }
 

--- a/server/gen/http/admin_open_router_keys/client/encode_decode.go
+++ b/server/gen/http/admin_open_router_keys/client/encode_decode.go
@@ -965,6 +965,10 @@ func unmarshalAdminOpenRouterKeyResponseBodyToAdminopenrouterkeysAdminOpenRouter
 		CreatedAt:        *v.CreatedAt,
 		UpdatedAt:        *v.UpdatedAt,
 	}
+	res.DisableCauses = make([]string, len(v.DisableCauses))
+	for i, val := range v.DisableCauses {
+		res.DisableCauses[i] = val
+	}
 
 	return res
 }

--- a/server/gen/http/admin_open_router_keys/client/types.go
+++ b/server/gen/http/admin_open_router_keys/client/types.go
@@ -26,7 +26,7 @@ type DisableKeyRequestBody struct {
 type EnableKeyRequestBody struct {
 	// Organization that owns the key.
 	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
-	// Key type to enable.
+	// Key type from which to remove the platform-admin lock.
 	KeyType string `form:"key_type" json:"key_type" xml:"key_type"`
 }
 
@@ -66,8 +66,10 @@ type DisableKeyResponseBody struct {
 	KeyType *string `form:"key_type,omitempty" json:"key_type,omitempty" xml:"key_type,omitempty"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits *int64 `form:"monthly_credits,omitempty" json:"monthly_credits,omitempty" xml:"monthly_credits,omitempty"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled *bool `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes,omitempty" json:"disable_causes,omitempty" xml:"disable_causes,omitempty"`
 	// When the key row was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the key row was last updated.
@@ -90,8 +92,10 @@ type EnableKeyResponseBody struct {
 	KeyType *string `form:"key_type,omitempty" json:"key_type,omitempty" xml:"key_type,omitempty"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits *int64 `form:"monthly_credits,omitempty" json:"monthly_credits,omitempty" xml:"monthly_credits,omitempty"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled *bool `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes,omitempty" json:"disable_causes,omitempty" xml:"disable_causes,omitempty"`
 	// When the key row was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the key row was last updated.
@@ -848,8 +852,10 @@ type AdminOpenRouterKeyResponseBody struct {
 	KeyType *string `form:"key_type,omitempty" json:"key_type,omitempty" xml:"key_type,omitempty"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits *int64 `form:"monthly_credits,omitempty" json:"monthly_credits,omitempty" xml:"monthly_credits,omitempty"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled *bool `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes,omitempty" json:"disable_causes,omitempty" xml:"disable_causes,omitempty"`
 	// When the key row was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the key row was last updated.
@@ -1218,6 +1224,10 @@ func NewDisableKeyAdminOpenRouterKeyOK(body *DisableKeyResponseBody) *adminopenr
 		CreatedAt:        *body.CreatedAt,
 		UpdatedAt:        *body.UpdatedAt,
 	}
+	v.DisableCauses = make([]string, len(body.DisableCauses))
+	for i, val := range body.DisableCauses {
+		v.DisableCauses[i] = val
+	}
 
 	return v
 }
@@ -1385,6 +1395,10 @@ func NewEnableKeyAdminOpenRouterKeyOK(body *EnableKeyResponseBody) *adminopenrou
 		Disabled:         *body.Disabled,
 		CreatedAt:        *body.CreatedAt,
 		UpdatedAt:        *body.UpdatedAt,
+	}
+	v.DisableCauses = make([]string, len(body.DisableCauses))
+	for i, val := range body.DisableCauses {
+		v.DisableCauses[i] = val
 	}
 
 	return v
@@ -1592,11 +1606,19 @@ func ValidateDisableKeyResponseBody(body *DisableKeyResponseBody) (err error) {
 	if body.Disabled == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
 	}
+	if body.DisableCauses == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disable_causes", "body"))
+	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	for _, e := range body.DisableCauses {
+		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
+		}
 	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
@@ -1631,11 +1653,19 @@ func ValidateEnableKeyResponseBody(body *EnableKeyResponseBody) (err error) {
 	if body.Disabled == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
 	}
+	if body.DisableCauses == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disable_causes", "body"))
+	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	for _, e := range body.DisableCauses {
+		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
+		}
 	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
@@ -2630,11 +2660,19 @@ func ValidateAdminOpenRouterKeyResponseBody(body *AdminOpenRouterKeyResponseBody
 	if body.Disabled == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
 	}
+	if body.DisableCauses == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disable_causes", "body"))
+	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	for _, e := range body.DisableCauses {
+		if !(e == "admin_lock" || e == "trial_demotion" || e == "billing_inactive") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disable_causes[*]", e, []any{"admin_lock", "trial_demotion", "billing_inactive"}))
+		}
 	}
 	if body.CreatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))

--- a/server/gen/http/admin_open_router_keys/server/encode_decode.go
+++ b/server/gen/http/admin_open_router_keys/server/encode_decode.go
@@ -864,6 +864,14 @@ func marshalAdminopenrouterkeysAdminOpenRouterKeyToAdminOpenRouterKeyResponseBod
 		CreatedAt:        v.CreatedAt,
 		UpdatedAt:        v.UpdatedAt,
 	}
+	if v.DisableCauses != nil {
+		res.DisableCauses = make([]string, len(v.DisableCauses))
+		for i, val := range v.DisableCauses {
+			res.DisableCauses[i] = val
+		}
+	} else {
+		res.DisableCauses = []string{}
+	}
 
 	return res
 }

--- a/server/gen/http/admin_open_router_keys/server/types.go
+++ b/server/gen/http/admin_open_router_keys/server/types.go
@@ -26,7 +26,7 @@ type DisableKeyRequestBody struct {
 type EnableKeyRequestBody struct {
 	// Organization that owns the key.
 	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
-	// Key type to enable.
+	// Key type from which to remove the platform-admin lock.
 	KeyType *string `form:"key_type,omitempty" json:"key_type,omitempty" xml:"key_type,omitempty"`
 }
 
@@ -66,8 +66,10 @@ type DisableKeyResponseBody struct {
 	KeyType string `form:"key_type" json:"key_type" xml:"key_type"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits int64 `form:"monthly_credits" json:"monthly_credits" xml:"monthly_credits"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled bool `form:"disabled" json:"disabled" xml:"disabled"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes" json:"disable_causes" xml:"disable_causes"`
 	// When the key row was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the key row was last updated.
@@ -90,8 +92,10 @@ type EnableKeyResponseBody struct {
 	KeyType string `form:"key_type" json:"key_type" xml:"key_type"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits int64 `form:"monthly_credits" json:"monthly_credits" xml:"monthly_credits"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled bool `form:"disabled" json:"disabled" xml:"disabled"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes" json:"disable_causes" xml:"disable_causes"`
 	// When the key row was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the key row was last updated.
@@ -848,8 +852,10 @@ type AdminOpenRouterKeyResponseBody struct {
 	KeyType string `form:"key_type" json:"key_type" xml:"key_type"`
 	// Monthly credit ceiling last mirrored from OpenRouter.
 	MonthlyCredits int64 `form:"monthly_credits" json:"monthly_credits" xml:"monthly_credits"`
-	// Whether the key is locked down (refused locally and disabled upstream).
+	// Whether one or more active causes keep the key disabled.
 	Disabled bool `form:"disabled" json:"disabled" xml:"disabled"`
+	// Independent reasons that keep the key disabled.
+	DisableCauses []string `form:"disable_causes" json:"disable_causes" xml:"disable_causes"`
 	// When the key row was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the key row was last updated.
@@ -900,6 +906,14 @@ func NewDisableKeyResponseBody(res *adminopenrouterkeys.AdminOpenRouterKey) *Dis
 		CreatedAt:        res.CreatedAt,
 		UpdatedAt:        res.UpdatedAt,
 	}
+	if res.DisableCauses != nil {
+		body.DisableCauses = make([]string, len(res.DisableCauses))
+		for i, val := range res.DisableCauses {
+			body.DisableCauses[i] = val
+		}
+	} else {
+		body.DisableCauses = []string{}
+	}
 	return body
 }
 
@@ -916,6 +930,14 @@ func NewEnableKeyResponseBody(res *adminopenrouterkeys.AdminOpenRouterKey) *Enab
 		Disabled:         res.Disabled,
 		CreatedAt:        res.CreatedAt,
 		UpdatedAt:        res.UpdatedAt,
+	}
+	if res.DisableCauses != nil {
+		body.DisableCauses = make([]string, len(res.DisableCauses))
+		for i, val := range res.DisableCauses {
+			body.DisableCauses[i] = val
+		}
+	} else {
+		body.DisableCauses = []string{}
 	}
 	return body
 }

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -16635,7 +16635,7 @@ func adminOpenRouterKeysUsage() {
 	fmt.Fprintln(os.Stderr, `    list-keys: List every organization's platform OpenRouter keys. Requires platform admin.`)
 	fmt.Fprintln(os.Stderr, `    get-key-usage: Fetch an organization's live credit usage from OpenRouter for one key. Requires platform admin.`)
 	fmt.Fprintln(os.Stderr, `    disable-key: Lock down an organization's platform OpenRouter key, upstream and locally. Requires platform admin.`)
-	fmt.Fprintln(os.Stderr, `    enable-key: Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.`)
+	fmt.Fprintln(os.Stderr, `    enable-key: Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin-open-router-keys COMMAND --help\n", os.Args[0])
@@ -16709,7 +16709,7 @@ func adminOpenRouterKeysEnableKeyUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.`)
+	fmt.Fprintln(os.Stderr, `Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -5261,7 +5261,7 @@ paths:
                 name: DisableAdminOpenRouterKey
     /rpc/adminOpenRouterKeys.enableKey:
         post:
-            description: Reinstate a disabled platform OpenRouter key, upstream and locally, keeping its recorded credit ceiling. Requires platform admin.
+            description: Remove the platform-admin lock from an OpenRouter key, preserving any automatic disable causes and its recorded credit ceiling. Requires platform admin.
             operationId: enableAdminOpenRouterKey
             parameters:
                 - allowEmptyValue: true
@@ -62538,9 +62538,18 @@ components:
                     type: string
                     description: When the key row was created.
                     format: date-time
+                disable_causes:
+                    type: array
+                    items:
+                        type: string
+                        enum:
+                            - admin_lock
+                            - trial_demotion
+                            - billing_inactive
+                    description: Independent reasons that keep the key disabled.
                 disabled:
                     type: boolean
-                    description: Whether the key is locked down (refused locally and disabled upstream).
+                    description: Whether one or more active causes keep the key disabled.
                 gram_account_type:
                     type: string
                     description: The organization's Gram account type (e.g. free, pro, enterprise).
@@ -62573,6 +62582,7 @@ components:
                 - key_type
                 - monthly_credits
                 - disabled
+                - disable_causes
                 - created_at
                 - updated_at
         AdminOrganization:
@@ -67715,7 +67725,7 @@ components:
             properties:
                 key_type:
                     type: string
-                    description: Key type to enable.
+                    description: Key type from which to remove the platform-admin lock.
                     enum:
                         - chat
                         - internal

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -98,7 +98,6 @@ func (p *rearmProvisioner) refreshAPIKeyLimit(ctx context.Context, orgID string,
 			KeyType:        string(keyType),
 			MonthlyCredits: int64(conv.PtrValOr(limit, 0)),
 			KeyHash:        "hash-" + orgID + "-" + string(keyType),
-			Reinstate:      true,
 		}); err != nil {
 			return 0, fmt.Errorf("reinstate %s key: %w", keyType, err)
 		}

--- a/server/internal/audit/openrouterkeys.go
+++ b/server/internal/audit/openrouterkeys.go
@@ -36,6 +36,13 @@ type OpenRouterAPIKeySpendCapSnapshot struct {
 	MonthlyCredits int64 `json:"monthly_credits"`
 }
 
+// OpenRouterAPIKeyDisableSnapshot captures only effective access and its
+// independent causes. Key material is deliberately excluded.
+type OpenRouterAPIKeyDisableSnapshot struct {
+	Disabled      bool     `json:"disabled"`
+	DisableCauses []string `json:"disable_causes"`
+}
+
 type LogOpenRouterAPIKeyDisableEvent struct {
 	OrganizationID string
 
@@ -46,6 +53,9 @@ type LogOpenRouterAPIKeyDisableEvent struct {
 	OpenRouterAPIKeyURN urn.OpenRouterAPIKey
 
 	KeyType string
+
+	OpenRouterAPIKeySnapshotBefore *OpenRouterAPIKeyDisableSnapshot
+	OpenRouterAPIKeySnapshotAfter  *OpenRouterAPIKeyDisableSnapshot
 }
 
 // LogOpenRouterAPIKeyDisable records the platform-admin lockdown of the key,
@@ -64,6 +74,9 @@ type LogOpenRouterAPIKeyEnableEvent struct {
 	OpenRouterAPIKeyURN urn.OpenRouterAPIKey
 
 	KeyType string
+
+	OpenRouterAPIKeySnapshotBefore *OpenRouterAPIKeyDisableSnapshot
+	OpenRouterAPIKeySnapshotAfter  *OpenRouterAPIKeyDisableSnapshot
 }
 
 // LogOpenRouterAPIKeyEnable records the platform-admin reinstatement of a
@@ -148,12 +161,23 @@ type openRouterAPIKeyEventFields struct {
 	ActorSlug           *string
 	OpenRouterAPIKeyURN urn.OpenRouterAPIKey
 	KeyType             string
+
+	OpenRouterAPIKeySnapshotBefore *OpenRouterAPIKeyDisableSnapshot
+	OpenRouterAPIKeySnapshotAfter  *OpenRouterAPIKeyDisableSnapshot
 }
 
 func (l *Logger) logOpenRouterAPIKeyEvent(ctx context.Context, dbtx repo.DBTX, action Action, fields openRouterAPIKeyEventFields) error {
 	metadata, err := json.Marshal(openRouterAPIKeyMetadata{KeyType: fields.KeyType, OperationID: ""})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+	beforeSnapshot, err := marshalAuditPayload(fields.OpenRouterAPIKeySnapshotBefore)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+	afterSnapshot, err := marshalAuditPayload(fields.OpenRouterAPIKeySnapshotAfter)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
 	}
 
 	entry := repo.InsertAuditLogParams{
@@ -172,8 +196,8 @@ func (l *Logger) logOpenRouterAPIKeyEvent(ctx context.Context, dbtx repo.DBTX, a
 		SubjectDisplayName: conv.ToPGTextEmpty(""),
 		SubjectSlug:        conv.ToPGTextEmpty(""),
 
-		BeforeSnapshot: nil,
-		AfterSnapshot:  nil,
+		BeforeSnapshot: beforeSnapshot,
+		AfterSnapshot:  afterSnapshot,
 		Metadata:       metadata,
 	}
 

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -45,6 +45,22 @@ func (m *mockPaygChatKeyProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Cont
 	return m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 }
 
+func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (m *mockPaygChatKeyProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
 	return m.Called(ctx, organizationID, keyType).Error(0)
 }

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1392,6 +1392,7 @@ type OpenrouterApiKey struct {
 	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
+	DisableCauses  []string
 	Disabled       bool
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -67,6 +67,22 @@ func (p *stubProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return 0, nil
 }
 
+func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (p *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
 	return nil
 }

--- a/server/internal/openrouterkeys/impl.go
+++ b/server/internal/openrouterkeys/impl.go
@@ -129,6 +129,7 @@ func (s *Service) ListKeys(ctx context.Context, _ *gen.ListKeysPayload) (*gen.Li
 			KeyType:          row.KeyType,
 			MonthlyCredits:   row.MonthlyCredits,
 			Disabled:         row.Disabled,
+			DisableCauses:    append([]string{}, row.DisableCauses...),
 			CreatedAt:        row.CreatedAt.Time.Format(time.RFC3339),
 			UpdatedAt:        row.UpdatedAt.Time.Format(time.RFC3339),
 		})
@@ -183,10 +184,8 @@ func (s *Service) DisableKey(ctx context.Context, payload *gen.DisableKeyPayload
 	}
 	logger = logger.With(attr.SlogOrganizationID(payload.OrganizationID), attr.SlogOpenRouterKeyType(payload.KeyType))
 
-	changed := false
+	var beforeSnapshot, afterSnapshot *audit.OpenRouterAPIKeyDisableSnapshot
 	err = keybillinglock.WithAcquireTimeout(ctx, logger, s.db, payload.OrganizationID, openrouter.KeyType(payload.KeyType), keyBillingLockWaitTimeout, func(conn *pgxpool.Conn) error {
-		// DisableAPIKey treats a missing key as a no-op, but the admin surface
-		// should 404 instead of pretending success.
 		row, err := repo.New(conn).GetOpenRouterAPIKeyForAdmin(ctx, repo.GetOpenRouterAPIKeyForAdminParams{
 			OrganizationID: payload.OrganizationID,
 			KeyType:        payload.KeyType,
@@ -196,14 +195,25 @@ func (s *Service) DisableKey(ctx context.Context, payload *gen.DisableKeyPayload
 			return oops.E(oops.CodeNotFound, err, "no openrouter key of this type for the organization")
 		case err != nil:
 			return oops.E(oops.CodeUnexpected, err, "read openrouter key").LogError(ctx, logger)
-		case row.Disabled:
+		}
+
+		change, err := s.provisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, payload.OrganizationID, openrouter.KeyType(payload.KeyType), openrouter.DisableCauseAdminLock)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "add openrouter key admin lock").LogError(ctx, logger)
+		}
+		if !change.CauseChanged {
 			return nil
 		}
 
-		if err := s.provisioner.DisableAPIKey(ctx, payload.OrganizationID, openrouter.KeyType(payload.KeyType)); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "disable openrouter key").LogError(ctx, logger)
+		updated, err := repo.New(conn).GetOpenRouterAPIKeyForAdmin(ctx, repo.GetOpenRouterAPIKeyForAdminParams{
+			OrganizationID: payload.OrganizationID,
+			KeyType:        payload.KeyType,
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "reload openrouter key after adding admin lock").LogError(ctx, logger)
 		}
-		changed = true
+		beforeSnapshot = newDisableSnapshot(row.Disabled, row.DisableCauses)
+		afterSnapshot = newDisableSnapshot(updated.Disabled, updated.DisableCauses)
 		return nil
 	})
 	if err != nil {
@@ -216,11 +226,11 @@ func (s *Service) DisableKey(ctx context.Context, payload *gen.DisableKeyPayload
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter key for disable").LogError(ctx, logger)
 	}
-	if !changed {
+	if beforeSnapshot == nil {
 		return s.adminKeyView(ctx, logger, payload.OrganizationID, payload.KeyType)
 	}
 
-	if err := s.logKeyAction(ctx, authCtx, payload.OrganizationID, payload.KeyType, audit.ActionOpenRouterAPIKeyDisable); err != nil {
+	if err := s.logKeyAction(ctx, authCtx, payload.OrganizationID, payload.KeyType, audit.ActionOpenRouterAPIKeyDisable, beforeSnapshot, afterSnapshot); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log openrouter key disable").LogError(ctx, logger)
 	}
 
@@ -234,7 +244,7 @@ func (s *Service) EnableKey(ctx context.Context, payload *gen.EnableKeyPayload) 
 	}
 	logger = logger.With(attr.SlogOrganizationID(payload.OrganizationID), attr.SlogOpenRouterKeyType(payload.KeyType))
 
-	changed := false
+	var beforeSnapshot, afterSnapshot *audit.OpenRouterAPIKeyDisableSnapshot
 	err = keybillinglock.WithAcquireTimeout(ctx, logger, s.db, payload.OrganizationID, openrouter.KeyType(payload.KeyType), keyBillingLockWaitTimeout, func(conn *pgxpool.Conn) error {
 		row, err := repo.New(conn).GetOpenRouterAPIKeyForAdmin(ctx, repo.GetOpenRouterAPIKeyForAdminParams{
 			OrganizationID: payload.OrganizationID,
@@ -259,10 +269,21 @@ func (s *Service) EnableKey(ctx context.Context, payload *gen.EnableKeyPayload) 
 				return oops.E(oops.CodeUnexpected, fmt.Errorf("no OpenRouter credit policy for account type %q", row.GramAccountType), "enable openrouter key").LogError(ctx, logger)
 			}
 		}
-		if _, err := s.provisioner.RefreshAPIKeyLimit(ctx, payload.OrganizationID, openrouter.KeyType(payload.KeyType), &limit); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "enable openrouter key").LogError(ctx, logger)
+		if _, change, err := s.provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, payload.OrganizationID, openrouter.KeyType(payload.KeyType), openrouter.DisableCauseAdminLock, &limit); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "remove openrouter key admin lock").LogError(ctx, logger)
+		} else if !change.CauseChanged {
+			return nil
 		}
-		changed = true
+
+		updated, err := repo.New(conn).GetOpenRouterAPIKeyForAdmin(ctx, repo.GetOpenRouterAPIKeyForAdminParams{
+			OrganizationID: payload.OrganizationID,
+			KeyType:        payload.KeyType,
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "reload openrouter key after removing admin lock").LogError(ctx, logger)
+		}
+		beforeSnapshot = newDisableSnapshot(row.Disabled, row.DisableCauses)
+		afterSnapshot = newDisableSnapshot(updated.Disabled, updated.DisableCauses)
 		return nil
 	})
 	if err != nil {
@@ -275,11 +296,11 @@ func (s *Service) EnableKey(ctx context.Context, payload *gen.EnableKeyPayload) 
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter key for enable").LogError(ctx, logger)
 	}
-	if !changed {
+	if beforeSnapshot == nil {
 		return s.adminKeyView(ctx, logger, payload.OrganizationID, payload.KeyType)
 	}
 
-	if err := s.logKeyAction(ctx, authCtx, payload.OrganizationID, payload.KeyType, audit.ActionOpenRouterAPIKeyEnable); err != nil {
+	if err := s.logKeyAction(ctx, authCtx, payload.OrganizationID, payload.KeyType, audit.ActionOpenRouterAPIKeyEnable, beforeSnapshot, afterSnapshot); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log openrouter key enable").LogError(ctx, logger)
 	}
 
@@ -304,7 +325,7 @@ func (s *Service) keyMaterial(row orrepo.OpenrouterApiKey) (string, error) {
 // logKeyAction writes the audit entry for the upstream enable/disable
 // actions. Those PATCH OpenRouter outside any local transaction, so the entry
 // commits in its own transaction once the action has already succeeded.
-func (s *Service) logKeyAction(ctx context.Context, authCtx *contextvalues.AuthContext, organizationID string, keyType string, action audit.Action) error {
+func (s *Service) logKeyAction(ctx context.Context, authCtx *contextvalues.AuthContext, organizationID string, keyType string, action audit.Action, beforeSnapshot, afterSnapshot *audit.OpenRouterAPIKeyDisableSnapshot) error {
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin audit transaction: %w", err)
@@ -317,21 +338,25 @@ func (s *Service) logKeyAction(ctx context.Context, authCtx *contextvalues.AuthC
 	switch action {
 	case audit.ActionOpenRouterAPIKeyDisable:
 		err = s.audit.LogOpenRouterAPIKeyDisable(ctx, dbtx, audit.LogOpenRouterAPIKeyDisableEvent{
-			OrganizationID:      organizationID,
-			Actor:               actor,
-			ActorDisplayName:    authCtx.Email,
-			ActorSlug:           nil,
-			OpenRouterAPIKeyURN: keyURN,
-			KeyType:             keyType,
+			OrganizationID:                 organizationID,
+			Actor:                          actor,
+			ActorDisplayName:               authCtx.Email,
+			ActorSlug:                      nil,
+			OpenRouterAPIKeyURN:            keyURN,
+			KeyType:                        keyType,
+			OpenRouterAPIKeySnapshotBefore: beforeSnapshot,
+			OpenRouterAPIKeySnapshotAfter:  afterSnapshot,
 		})
 	case audit.ActionOpenRouterAPIKeyEnable:
 		err = s.audit.LogOpenRouterAPIKeyEnable(ctx, dbtx, audit.LogOpenRouterAPIKeyEnableEvent{
-			OrganizationID:      organizationID,
-			Actor:               actor,
-			ActorDisplayName:    authCtx.Email,
-			ActorSlug:           nil,
-			OpenRouterAPIKeyURN: keyURN,
-			KeyType:             keyType,
+			OrganizationID:                 organizationID,
+			Actor:                          actor,
+			ActorDisplayName:               authCtx.Email,
+			ActorSlug:                      nil,
+			OpenRouterAPIKeyURN:            keyURN,
+			KeyType:                        keyType,
+			OpenRouterAPIKeySnapshotBefore: beforeSnapshot,
+			OpenRouterAPIKeySnapshotAfter:  afterSnapshot,
 		})
 	default:
 		return fmt.Errorf("unsupported openrouter key audit action %q", action)
@@ -344,6 +369,12 @@ func (s *Service) logKeyAction(ctx context.Context, authCtx *contextvalues.AuthC
 		return fmt.Errorf("commit audit transaction: %w", err)
 	}
 	return nil
+}
+
+func newDisableSnapshot(disabled bool, causes []string) *audit.OpenRouterAPIKeyDisableSnapshot {
+	copyOfCauses := make([]string, len(causes))
+	copy(copyOfCauses, causes)
+	return &audit.OpenRouterAPIKeyDisableSnapshot{Disabled: disabled, DisableCauses: copyOfCauses}
 }
 
 func (s *Service) adminKeyView(ctx context.Context, logger *slog.Logger, organizationID string, keyType string) (*gen.AdminOpenRouterKey, error) {
@@ -363,6 +394,7 @@ func (s *Service) adminKeyView(ctx context.Context, logger *slog.Logger, organiz
 		KeyType:          row.KeyType,
 		MonthlyCredits:   row.MonthlyCredits,
 		Disabled:         row.Disabled,
+		DisableCauses:    append([]string{}, row.DisableCauses...),
 		CreatedAt:        row.CreatedAt.Time.Format(time.RFC3339),
 		UpdatedAt:        row.UpdatedAt.Time.Format(time.RFC3339),
 	}, nil

--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -41,6 +41,18 @@ func TestListKeys_ReturnsSeededKeys(t *testing.T) {
 	adminCtx := withAdmin(t, ctx)
 
 	orgID := seedKey(t, ctx, ti, "list", "chat", "sk-or-list")
+	for _, cause := range []openrouter.DisableCause{
+		openrouter.DisableCauseAdminLock,
+		openrouter.DisableCauseTrialDemotion,
+		openrouter.DisableCauseBillingInactive,
+	} {
+		_, err := orgrepo.New(ti.conn).AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{
+			DisableCause:   string(cause),
+			OrganizationID: orgID,
+			KeyType:        "chat",
+		})
+		require.NoError(t, err)
+	}
 
 	res, err := ti.service.ListKeys(adminCtx, &gen.ListKeysPayload{SessionToken: nil})
 	require.NoError(t, err)
@@ -54,7 +66,8 @@ func TestListKeys_ReturnsSeededKeys(t *testing.T) {
 	require.NotNil(t, found)
 	require.Equal(t, "chat", found.KeyType)
 	require.Equal(t, int64(5), found.MonthlyCredits)
-	require.False(t, found.Disabled)
+	require.True(t, found.Disabled)
+	require.ElementsMatch(t, []string{"admin_lock", "trial_demotion", "billing_inactive"}, found.DisableCauses)
 }
 
 func TestGetKeyUsage_DecryptsStoredCiphertext(t *testing.T) {
@@ -140,10 +153,62 @@ func TestDisableKey_MarksDisabledAndAudits(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, view.Disabled)
+	require.Equal(t, []string{string(openrouter.DisableCauseAdminLock)}, view.DisableCauses)
+	require.Len(t, ti.provisioner.disableAccessCalls, 1)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
 	require.NoError(t, err)
 	require.Equal(t, before+1, after)
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"disabled":false,"disable_causes":[]}`, string(record.BeforeSnapshot))
+	require.JSONEq(t, `{"disabled":true,"disable_causes":["admin_lock"]}`, string(record.AfterSnapshot))
+	require.NotContains(t, string(record.BeforeSnapshot), "sk-or-disable")
+	require.NotContains(t, string(record.AfterSnapshot), "sk-or-disable")
+}
+
+func TestDisableKey_AddsAdminLockWhenAutomaticCauseAlreadyDisablesKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	adminCtx := withAdmin(t, ctx)
+	orgID := seedKey(t, ctx, ti, "disable-layered", "chat", "sk-or-disable-layered")
+	_, err := orgrepo.New(ti.conn).AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		DisableCause: string(openrouter.DisableCauseTrialDemotion), OrganizationID: orgID, KeyType: "chat",
+	})
+	require.NoError(t, err)
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
+	require.NoError(t, err)
+
+	view, err := ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
+	require.NoError(t, err)
+	require.True(t, view.Disabled)
+	require.ElementsMatch(t, []string{"trial_demotion", "admin_lock"}, view.DisableCauses)
+	require.Empty(t, ti.provisioner.disableAccessCalls, "effective access was already disabled")
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after, "cause changes must be audited even without access changes")
+}
+
+func TestDisableKey_AdminLockRetryIsIdempotentAndNotAudited(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	adminCtx := withAdmin(t, ctx)
+	orgID := seedKey(t, ctx, ti, "disable-retry", "chat", "sk-or-disable-retry")
+	payload := &gen.DisableKeyPayload{OrganizationID: orgID, KeyType: "chat"}
+	_, err := ti.service.DisableKey(adminCtx, payload)
+	require.NoError(t, err)
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
+	require.NoError(t, err)
+
+	view, err := ti.service.DisableKey(adminCtx, payload)
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock"}, view.DisableCauses)
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyDisable)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	require.Len(t, ti.provisioner.disableAccessCalls, 1)
 }
 
 func TestEnableKey_ReinstatesWithRecordedLimit(t *testing.T) {
@@ -174,11 +239,67 @@ func TestEnableKey_ReinstatesWithRecordedLimit(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, view.Disabled)
+	require.NotNil(t, view.DisableCauses, "required array must serialize as [] rather than null")
+	require.Empty(t, view.DisableCauses)
 	require.EqualValues(t, recordedLimit, view.MonthlyCredits, "recorded ceiling must be kept on reinstatement")
+	require.Len(t, ti.provisioner.enableAccessCalls, 1)
 
 	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
 	require.NoError(t, err)
 	require.Equal(t, before+1, after)
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"disabled":true,"disable_causes":["admin_lock"]}`, string(record.BeforeSnapshot))
+	require.JSONEq(t, `{"disabled":false,"disable_causes":[]}`, string(record.AfterSnapshot))
+	require.NotContains(t, string(record.BeforeSnapshot), "sk-or-enable")
+	require.NotContains(t, string(record.AfterSnapshot), "sk-or-enable")
+}
+
+func TestEnableKey_RemovesOnlyAdminLockWhenAutomaticCauseRemains(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	adminCtx := withAdmin(t, ctx)
+	orgID := seedKey(t, ctx, ti, "enable-layered", "chat", "sk-or-enable-layered")
+	queries := orgrepo.New(ti.conn)
+	for _, cause := range []openrouter.DisableCause{openrouter.DisableCauseAdminLock, openrouter.DisableCauseTrialDemotion} {
+		_, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{DisableCause: string(cause), OrganizationID: orgID, KeyType: "chat"})
+		require.NoError(t, err)
+	}
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
+	require.NoError(t, err)
+
+	view, err := ti.service.EnableKey(adminCtx, &gen.EnableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
+	require.NoError(t, err)
+	require.True(t, view.Disabled)
+	require.Equal(t, []string{"trial_demotion"}, view.DisableCauses)
+	require.Empty(t, ti.provisioner.enableAccessCalls, "automatic cause keeps effective access disabled")
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after, "cause removal must be audited even without access changes")
+}
+
+func TestEnableKey_WithoutAdminLockIsIdempotentAndPreservesAutomaticCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	adminCtx := withAdmin(t, ctx)
+	orgID := seedKey(t, ctx, ti, "enable-no-lock", "chat", "sk-or-enable-no-lock")
+	_, err := orgrepo.New(ti.conn).AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		DisableCause: string(openrouter.DisableCauseBillingInactive), OrganizationID: orgID, KeyType: "chat",
+	})
+	require.NoError(t, err)
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
+	require.NoError(t, err)
+
+	view, err := ti.service.EnableKey(adminCtx, &gen.EnableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
+	require.NoError(t, err)
+	require.True(t, view.Disabled)
+	require.Equal(t, []string{"billing_inactive"}, view.DisableCauses)
+	require.Empty(t, ti.provisioner.enableAccessCalls)
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOpenRouterAPIKeyEnable)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
 }
 
 func TestEnableKey_ReinstatesLegacyZeroSecurityKeyAtPaygPolicy(t *testing.T) {
@@ -212,7 +333,8 @@ func TestEnableKey_ReinstatesLegacyZeroSecurityKeyAtPaygPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, view.Disabled)
 	require.EqualValues(t, expected, view.MonthlyCredits)
-	require.Equal(t, []string{orgID + "/" + string(openrouter.KeyTypeInternal)}, ti.provisioner.refreshCalls)
+	require.Equal(t, []string{orgID + "/" + string(openrouter.KeyTypeInternal) + "/" + string(openrouter.DisableCauseAdminLock)}, ti.provisioner.removeCauseCalls)
+	require.Empty(t, ti.provisioner.refreshCalls)
 }
 
 func TestEnableKey_ReinstatesLegacyZeroTrialKeyAtTrialPolicy(t *testing.T) {

--- a/server/internal/openrouterkeys/queries.sql
+++ b/server/internal/openrouterkeys/queries.sql
@@ -9,6 +9,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    k.disable_causes,
     k.disabled,
     k.created_at,
     k.updated_at
@@ -25,6 +26,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    k.disable_causes,
     k.disabled,
     k.created_at,
     k.updated_at

--- a/server/internal/openrouterkeys/repo/queries.sql.go
+++ b/server/internal/openrouterkeys/repo/queries.sql.go
@@ -19,6 +19,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    k.disable_causes,
     k.disabled,
     k.created_at,
     k.updated_at
@@ -41,6 +42,7 @@ type GetOpenRouterAPIKeyForAdminRow struct {
 	GramAccountType  string
 	KeyType          string
 	MonthlyCredits   int64
+	DisableCauses    []string
 	Disabled         bool
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz
@@ -56,6 +58,7 @@ func (q *Queries) GetOpenRouterAPIKeyForAdmin(ctx context.Context, arg GetOpenRo
 		&i.GramAccountType,
 		&i.KeyType,
 		&i.MonthlyCredits,
+		&i.DisableCauses,
 		&i.Disabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -71,6 +74,7 @@ SELECT
     om.gram_account_type,
     k.key_type,
     k.monthly_credits,
+    k.disable_causes,
     k.disabled,
     k.created_at,
     k.updated_at
@@ -87,6 +91,7 @@ type ListOpenRouterAPIKeysForAdminRow struct {
 	GramAccountType  string
 	KeyType          string
 	MonthlyCredits   int64
+	DisableCauses    []string
 	Disabled         bool
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz
@@ -111,6 +116,7 @@ func (q *Queries) ListOpenRouterAPIKeysForAdmin(ctx context.Context) ([]ListOpen
 			&i.GramAccountType,
 			&i.KeyType,
 			&i.MonthlyCredits,
+			&i.DisableCauses,
 			&i.Disabled,
 			&i.CreatedAt,
 			&i.UpdatedAt,

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -96,11 +96,26 @@ func (s *stubProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 		KeyType:        string(keyType),
 		MonthlyCredits: int64(keyLimit),
 		KeyHash:        key.KeyHash,
-		Reinstate:      key.Disabled,
 	}); err != nil {
 		return 0, fmt.Errorf("stub refresh write: %w", err)
 	}
 	return keyLimit, nil
+}
+
+func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
 }
 
 func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 
@@ -64,9 +65,13 @@ type stubProvisioner struct {
 	usage      float64
 	usageLimit *int64
 
-	usageCalls   []string
-	disableCalls []string
-	refreshCalls []string
+	usageCalls         []string
+	disableCalls       []string
+	refreshCalls       []string
+	addCauseCalls      []string
+	removeCauseCalls   []string
+	disableAccessCalls []string
+	enableAccessCalls  []string
 }
 
 var _ openrouter.Provisioner = (*stubProvisioner)(nil)
@@ -102,20 +107,77 @@ func (s *stubProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return keyLimit, nil
 }
 
-func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return s.AddAPIKeyDisableCauseWithDB(ctx, s.conn, orgID, keyType, cause)
 }
 
-func (*stubProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	queries := orgrepo.New(db)
+	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if err != nil {
+		return openrouter.DisableCauseChange{}, err
+	}
+	call := orgID + "/" + string(keyType) + "/" + string(cause)
+	s.mu.Lock()
+	s.addCauseCalls = append(s.addCauseCalls, call)
+	s.mu.Unlock()
+	if slices.Contains(key.DisableCauses, string(cause)) {
+		return openrouter.DisableCauseChange{}, nil
+	}
+	if _, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{DisableCause: string(cause), OrganizationID: orgID, KeyType: string(keyType)}); err != nil {
+		return openrouter.DisableCauseChange{}, err
+	}
+	change := openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: !key.Disabled}
+	if change.KeyAccessChanged {
+		s.mu.Lock()
+		s.disableAccessCalls = append(s.disableAccessCalls, call)
+		s.mu.Unlock()
+	}
+	return change, nil
 }
 
-func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	return s.RemoveAPIKeyDisableCauseWithDB(ctx, s.conn, orgID, keyType, cause, limit)
 }
 
-func (*stubProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	queries := orgrepo.New(db)
+	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	call := orgID + "/" + string(keyType) + "/" + string(cause)
+	s.mu.Lock()
+	s.removeCauseCalls = append(s.removeCauseCalls, call)
+	s.mu.Unlock()
+	resultLimit := int(key.MonthlyCredits)
+	if limit != nil {
+		resultLimit = *limit
+	}
+	if !slices.Contains(key.DisableCauses, string(cause)) {
+		return resultLimit, openrouter.DisableCauseChange{}, nil
+	}
+	if int64(resultLimit) != key.MonthlyCredits {
+		if _, err := queries.UpdateOpenRouterKey(ctx, orgrepo.UpdateOpenRouterKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(keyType),
+			MonthlyCredits: int64(resultLimit),
+			KeyHash:        key.KeyHash,
+		}); err != nil {
+			return 0, openrouter.DisableCauseChange{}, err
+		}
+	}
+	updated, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, orgrepo.RemoveOpenRouterAPIKeyDisableCauseParams{DisableCause: string(cause), OrganizationID: orgID, KeyType: string(keyType)})
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	change := openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: !updated.Disabled}
+	if change.KeyAccessChanged {
+		s.mu.Lock()
+		s.enableAccessCalls = append(s.enableAccessCalls, call)
+		s.mu.Unlock()
+	}
+	return resultLimit, change, nil
 }
 
 func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -4,6 +4,11 @@ import "fmt"
 
 type DisableCause string
 
+type DisableCauseChange struct {
+	CauseChanged     bool
+	KeyAccessChanged bool
+}
+
 const (
 	DisableCauseAdminLock       DisableCause = "admin_lock"
 	DisableCauseTrialDemotion   DisableCause = "trial_demotion"

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -1,0 +1,20 @@
+package openrouter
+
+import "fmt"
+
+type DisableCause string
+
+const (
+	DisableCauseAdminLock       DisableCause = "admin_lock"
+	DisableCauseTrialDemotion   DisableCause = "trial_demotion"
+	DisableCauseBillingInactive DisableCause = "billing_inactive"
+)
+
+func (c DisableCause) Validate() error {
+	switch c {
+	case DisableCauseAdminLock, DisableCauseTrialDemotion, DisableCauseBillingInactive:
+		return nil
+	default:
+		return fmt.Errorf("unknown OpenRouter disable cause %q", c)
+	}
+}

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -105,6 +105,51 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 	return provisioner, upstream, repo.New(conn)
 }
 
+func TestOpenRouterDisableCausesAreASet(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+
+	added, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		DisableCause:   string(DisableCauseAdminLock),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock"}, added.DisableCauses)
+	require.True(t, added.Disabled)
+
+	addedAgain, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		DisableCause:   string(DisableCauseAdminLock),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock"}, addedAgain.DisableCauses)
+
+	withTrial, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		DisableCause:   string(DisableCauseTrialDemotion),
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"admin_lock", "trial_demotion"}, withTrial.DisableCauses)
+
+	withoutTrial, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		DisableCause:   string(DisableCauseTrialDemotion),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock"}, withoutTrial.DisableCauses)
+	require.True(t, withoutTrial.Disabled)
+}
+
 func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
 	t.Parallel()
 
@@ -295,7 +340,6 @@ func TestRefreshAPIKeyLimit_RejectsChangedUpstreamIdentity(t *testing.T) {
 		KeyType:        string(KeyTypeChat),
 		MonthlyCredits: 100,
 		KeyHash:        "hash-stored",
-		Reinstate:      false,
 	})
 	require.NoError(t, err)
 

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -288,6 +288,55 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
 }
 
+func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	_, err = queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+		DisableCause:   string(DisableCauseTrialDemotion),
+	})
+	require.NoError(t, err)
+
+	limit := 42
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+
+	// A retry sees that admin_lock is already gone, preserves the remaining
+	// cause, and repeats only the limit patch.
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+
+	patches := upstream.recorded()
+	require.Len(t, patches, 3)
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[1])
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
+
+	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+}
+
 // A refresh reads the key row, patches upstream, then writes the row back. A
 // lockdown that commits inside that window has to survive the write: the
 // refresh never sent disabled=false, so clearing the local flag would hand out

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 type disableTestUpstream struct {
-	server  *httptest.Server
-	mu      sync.Mutex
-	patches []string
-	onPatch func()
+	server      *httptest.Server
+	mu          sync.Mutex
+	patches     []string
+	onPatch     func()
+	patchStatus int
 }
 
 // recorded returns the raw patch bodies. They stay raw because the field a
@@ -44,6 +45,13 @@ func (u *disableTestUpstream) interceptPatch(fn func()) {
 	u.onPatch = fn
 }
 
+func (u *disableTestUpstream) respondToPatchesWith(status int) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.patchStatus = status
+}
+
 func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disableTestUpstream, *repo.Queries) {
 	t.Helper()
 
@@ -61,7 +69,7 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 	})
 	require.NoError(t, err)
 
-	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil, onPatch: nil}
+	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil, onPatch: nil, patchStatus: 0}
 	upstream.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -81,10 +89,15 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 			upstream.mu.Lock()
 			upstream.patches = append(upstream.patches, string(raw))
 			onPatch := upstream.onPatch
+			patchStatus := upstream.patchStatus
 			upstream.mu.Unlock()
 
 			if onPatch != nil {
 				onPatch()
+			}
+			if patchStatus != 0 {
+				w.WriteHeader(patchStatus)
+				return
 			}
 
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -150,6 +163,190 @@ func TestOpenRouterDisableCausesAreASet(t *testing.T) {
 	require.True(t, withoutTrial.Disabled)
 }
 
+func TestAddAPIKeyDisableCause(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+
+	change, err := provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	require.Equal(t, []string{`{"disabled":true}`}, upstream.recorded())
+
+	change, err = provisioner.AddAPIKeyDisableCauseWithDB(ctx, provisioner.db, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true}, change)
+	require.Len(t, upstream.recorded(), 1)
+
+	change, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{}, change)
+	require.Len(t, upstream.recorded(), 1)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"admin_lock", "trial_demotion"}, row.DisableCauses)
+}
+
+func TestAddAPIKeyDisableCause_UpstreamFailureAndRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+
+	upstream.respondToPatchesWith(http.StatusBadGateway)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeInternal, DisableCauseAdminLock)
+	require.Error(t, err)
+	row, readErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeInternal)})
+	require.NoError(t, readErr)
+	require.Empty(t, row.DisableCauses)
+
+	failedAttempts := len(upstream.recorded())
+	upstream.respondToPatchesWith(0)
+	change, err := provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeInternal, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	require.Len(t, upstream.recorded(), failedAttempts+1)
+	change, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeInternal, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{}, change)
+	require.Len(t, upstream.recorded(), failedAttempts+1, "the successful retry must not patch again")
+}
+
+func TestAddAPIKeyDisableCause_ValidatesAndMissingKeyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
+	change, err := provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{}, change)
+	require.Empty(t, upstream.recorded())
+
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyType("invalid"), DisableCauseAdminLock)
+	require.Error(t, err)
+	_, err = provisioner.AddAPIKeyDisableCauseWithDB(ctx, provisioner.db, orgID, KeyTypeChat, DisableCause("invalid"))
+	require.Error(t, err)
+}
+
+func TestRemoveAPIKeyDisableCause(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+
+	limit := int(before.MonthlyCredits)
+	gotLimit, change, err := provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, provisioner.db, orgID, KeyTypeChat, DisableCauseTrialDemotion, &limit)
+	require.NoError(t, err)
+	require.Equal(t, limit, gotLimit)
+	require.Equal(t, DisableCauseChange{CauseChanged: true}, change)
+	require.Len(t, upstream.recorded(), 1)
+
+	gotLimit, change, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion, &limit)
+	require.NoError(t, err)
+	require.Zero(t, gotLimit)
+	require.Equal(t, DisableCauseChange{}, change)
+	require.Len(t, upstream.recorded(), 1)
+
+	gotLimit, change, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, &limit)
+	require.NoError(t, err)
+	require.Equal(t, limit, gotLimit)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	require.Equal(t, []string{`{"disabled":true}`, `{"disabled":false}`}, upstream.recorded())
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Empty(t, row.DisableCauses)
+
+	_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyType("invalid"), DisableCauseAdminLock, nil)
+	require.Error(t, err)
+	_, _, err = provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, provisioner.db, orgID, KeyTypeChat, DisableCause("invalid"), nil)
+	require.Error(t, err)
+}
+
+func TestRemoveAPIKeyDisableCause_UpstreamFailurePreservesCause(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeInternal, DisableCauseBillingInactive)
+	require.NoError(t, err)
+
+	upstream.respondToPatchesWith(http.StatusBadGateway)
+	_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeInternal, DisableCauseBillingInactive, nil)
+	require.Error(t, err)
+	row, readErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeInternal)})
+	require.NoError(t, readErr)
+	require.Equal(t, []string{"billing_inactive"}, row.DisableCauses)
+}
+
+func TestRefreshAPIKeyLimit_PreservesDisableCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	_, err = queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(KeyTypeInternal), DisableCause: string(DisableCauseTrialDemotion)})
+	require.NoError(t, err)
+
+	limit := 42
+	got, err := provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+	require.Equal(t, 42, got)
+	patches := upstream.recorded()
+	require.Len(t, patches, 1)
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[0])
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeInternal)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+}
+
+func TestDevelopmentDisableCauseMethodsAreNoops(t *testing.T) {
+	t.Parallel()
+
+	dev := NewDevelopment("dev-key")
+	change, err := dev.AddAPIKeyDisableCause(t.Context(), "org", KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{}, change)
+
+	change, err = dev.AddAPIKeyDisableCauseWithDB(t.Context(), nil, "org", KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{}, change)
+
+	limit, change, err := dev.RemoveAPIKeyDisableCause(t.Context(), "org", KeyTypeChat, DisableCauseAdminLock, new(42))
+	require.NoError(t, err)
+	require.Zero(t, limit)
+	require.Equal(t, DisableCauseChange{}, change)
+
+	limit, change, err = dev.RemoveAPIKeyDisableCauseWithDB(t.Context(), nil, "org", KeyTypeChat, DisableCauseAdminLock, new(42))
+	require.NoError(t, err)
+	require.Zero(t, limit)
+	require.Equal(t, DisableCauseChange{}, change)
+}
+
 func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
 	t.Parallel()
 
@@ -200,7 +397,7 @@ func TestProvisionAPIKey_RefusesDisabledKey(t *testing.T) {
 
 	// Reinstatement makes resolution work again without minting a new key.
 	limit := 42
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	key, err = provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
@@ -248,7 +445,7 @@ func TestDisableAPIKey_NoKeyIsNoop(t *testing.T) {
 
 // Sales reinstate a demoted organization by raising its limit, so the refresh
 // path has to clear the flag on both sides.
-func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
+func TestReinstateAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -260,7 +457,7 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
 
 	limit := 42
-	refreshed, err := provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	refreshed, err := provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 	require.Equal(t, 42, refreshed)
 
@@ -280,7 +477,7 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	// Refreshing an enabled key must send the body it sent before the disabled
 	// field existed. Carrying disabled=false on every refresh would revive a
 	// key an operator turned off on the OpenRouter dashboard.
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	patches = upstream.recorded()
@@ -288,7 +485,7 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
 }
 
-func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
+func TestReinstateAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -307,7 +504,7 @@ func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 	require.NoError(t, err)
 
 	limit := 42
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
@@ -320,7 +517,7 @@ func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 
 	// A retry sees that admin_lock is already gone, preserves the remaining
 	// cause, and reasserts the disabled upstream state.
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	patches := upstream.recorded()
@@ -337,7 +534,7 @@ func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 	require.True(t, row.Disabled)
 }
 
-func TestRefreshAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
+func TestReinstateAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -362,7 +559,7 @@ func TestRefreshAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
 	})
 
 	limit := 42
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 	require.NoError(t, <-injected)
 
@@ -374,7 +571,7 @@ func TestRefreshAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
 	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
 	require.True(t, row.Disabled)
 
-	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	patches := upstream.recorded()

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -319,14 +319,14 @@ func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 	require.True(t, row.Disabled)
 
 	// A retry sees that admin_lock is already gone, preserves the remaining
-	// cause, and repeats only the limit patch.
+	// cause, and reasserts the disabled upstream state.
 	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	patches := upstream.recorded()
 	require.Len(t, patches, 3)
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[1])
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[1])
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[2])
 
 	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -335,6 +335,52 @@ func TestRefreshAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
 	require.True(t, row.Disabled)
+}
+
+func TestRefreshAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	injected := make(chan error, 1)
+	var injectOnce sync.Once
+	upstream.interceptPatch(func() {
+		injectOnce.Do(func() {
+			_, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+				OrganizationID: orgID,
+				KeyType:        string(KeyTypeInternal),
+				DisableCause:   string(DisableCauseTrialDemotion),
+			})
+			injected <- err
+		})
+	})
+
+	limit := 42
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+	require.NoError(t, <-injected)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+
+	patches := upstream.recorded()
+	require.Len(t, patches, 3)
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":false}`, patches[1])
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[2])
 }
 
 // A refresh reads the key row, patches upstream, then writes the row back. A

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -38,6 +38,22 @@ func (o *Development) ReinstateAPIKeyLimitWithDB(ctx context.Context, db DBTX, o
 	return o.ReinstateAPIKeyLimit(ctx, orgID, keyType, limit)
 }
 
+func (*Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
+	return DisableCauseChange{}, nil
+}
+
+func (o *Development) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	return o.AddAPIKeyDisableCause(ctx, orgID, keyType, cause)
+}
+
+func (*Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+	return 0, DisableCauseChange{}, nil
+}
+
+func (o *Development) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	return o.RemoveAPIKeyDisableCause(ctx, orgID, keyType, cause, limit)
+}
+
 func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	return nil
 }

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -632,10 +632,13 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 		keyLimit = o.defaultLimitForOrg(ctx, db, org)
 	}
 
+	removeLegacyAdminLock := (reinstate || limit != nil) && slices.Contains(key.DisableCauses, string(DisableCauseAdminLock))
+
 	creditLimit := float64(keyLimit)
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
-	if key.Disabled {
-		// Setting a limit on a disabled key does not bring it back upstream.
+	if removeLegacyAdminLock && len(key.DisableCauses) == 1 {
+		// The legacy reinstate paths enable upstream only when removing the admin
+		// lock makes the key locally enabled. Other causes keep it disabled.
 		patch.Disabled = new(false)
 	}
 
@@ -667,6 +670,17 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
+	}
+
+	if removeLegacyAdminLock {
+		_, err = keyRepo.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
+			OrganizationID: orgID,
+			KeyType:        string(keyType),
+			DisableCause:   string(DisableCauseAdminLock),
+		})
+		if err != nil {
+			return 0, oops.E(oops.CodeUnexpected, err, "failed to remove legacy OpenRouter admin lock").LogError(ctx, o.logger)
+		}
 	}
 
 	return keyLimit, nil

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -321,16 +321,19 @@ func IsSpecialLimitOrg(orgID string) bool {
 type Provisioner interface {
 	ProvisionAPIKey(ctx context.Context, orgID string, keyType KeyType) (string, error)
 
-	// RefreshAPIKeyLimit mutates the upstream OpenRouter key limit (PATCH
-	// /v1/keys/:hash) and mirrors the new value into the local DB. It is also
-	// the reinstatement path: a key that DisableAPIKey turned off comes back
-	// enabled, upstream and locally.
+	// RefreshAPIKeyLimit mutates only the upstream OpenRouter key limit and
+	// mirrors it locally. It never changes disable causes or effective access.
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error)
 
-	// DisableAPIKey turns the org's key off upstream and records that locally,
-	// after which ProvisionAPIKey refuses it with ErrPlatformKeyDisabled. The
-	// key survives, so RefreshAPIKeyLimit can reinstate it. An org with no key
-	// of that type is a no-op.
+	// Cause mutations are upstream-first and assume the caller serializes work
+	// for this organization and key type. WithDB variants keep all local access
+	// on the caller's locked connection.
+	AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error)
+	AddAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error)
+	RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
+	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
+
+	// DisableAPIKey is retained temporarily while callers migrate to causes.
 	DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error
 
 	GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error)
@@ -632,11 +635,11 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 		keyLimit = o.defaultLimitForOrg(ctx, db, org)
 	}
 
-	removeLegacyAdminLock := (reinstate || limit != nil) && slices.Contains(key.DisableCauses, string(DisableCauseAdminLock))
+	removeLegacyAdminLock := reinstate && slices.Contains(key.DisableCauses, string(DisableCauseAdminLock))
 
 	creditLimit := float64(keyLimit)
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
-	if key.Disabled {
+	if reinstate && key.Disabled {
 		// Reassert the local effective state so a retry repairs an upstream enable
 		// that raced with another cause landing during the prior PATCH.
 		patch.Disabled = new(true)
@@ -687,6 +690,130 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 	}
 
 	return keyLimit, nil
+}
+
+func (o *OpenRouter) AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	return o.addAPIKeyDisableCause(ctx, o.db, orgID, keyType, cause)
+}
+
+func (o *OpenRouter) AddAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	return o.addAPIKeyDisableCause(ctx, db, orgID, keyType, cause)
+}
+
+func (o *OpenRouter) addAPIKeyDisableCause(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return DisableCauseChange{}, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+	if err := cause.Validate(); err != nil {
+		return DisableCauseChange{}, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+
+	keyRepo := repo.New(db)
+	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return DisableCauseChange{}, nil
+	case err != nil:
+		return DisableCauseChange{}, fmt.Errorf("get OpenRouter API key to add disable cause: %w", err)
+	}
+	if slices.Contains(key.DisableCauses, string(cause)) {
+		return DisableCauseChange{}, nil
+	}
+
+	accessChanged := len(key.DisableCauses) == 0
+	if accessChanged {
+		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+		defer cancel()
+		if _, err := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Disabled: new(true)}); err != nil {
+			return DisableCauseChange{}, fmt.Errorf("disable upstream OpenRouter API key: %w", err)
+		}
+	}
+
+	if _, err := keyRepo.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(keyType), DisableCause: string(cause)}); err != nil {
+		return DisableCauseChange{}, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+
+	return DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
+}
+
+func (o *OpenRouter) RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	return o.removeAPIKeyDisableCause(ctx, o.db, orgID, keyType, cause, limit)
+}
+
+func (o *OpenRouter) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	return o.removeAPIKeyDisableCause(ctx, db, orgID, keyType, cause, limit)
+}
+
+func (o *OpenRouter) removeAPIKeyDisableCause(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if err := cause.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if limit != nil && *limit <= 0 {
+		return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+	}
+
+	keyRepo := repo.New(db)
+	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return 0, DisableCauseChange{}, nil
+	case err != nil:
+		return 0, DisableCauseChange{}, fmt.Errorf("get OpenRouter API key to remove disable cause: %w", err)
+	}
+	if !slices.Contains(key.DisableCauses, string(cause)) {
+		return 0, DisableCauseChange{}, nil
+	}
+
+	keyLimit := int(key.MonthlyCredits)
+	if limit != nil {
+		keyLimit = *limit
+	} else {
+		org, err := orgRepo.New(db).GetOrganizationMetadata(ctx, orgID)
+		if err != nil {
+			return 0, DisableCauseChange{}, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
+		}
+		keyLimit = o.defaultLimitForOrg(ctx, db, org)
+	}
+
+	accessChanged := len(key.DisableCauses) == 1
+	limitChanged := int64(keyLimit) != key.MonthlyCredits
+	patch := updateKeyRequest{}
+	if limitChanged {
+		creditLimit := float64(keyLimit)
+		patch.Limit = &creditLimit
+		patch.LimitReset = "monthly"
+	}
+	if accessChanged {
+		patch.Disabled = new(false)
+	}
+
+	if patch.Limit != nil || patch.Disabled != nil {
+		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+		defer cancel()
+		keyResponse, err := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, patch)
+		if err != nil {
+			return 0, DisableCauseChange{}, fmt.Errorf("patch upstream OpenRouter API key while removing disable cause: %w", err)
+		}
+		if keyResponse.Data.Hash != key.KeyHash {
+			return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: upstream key identity changed")
+		}
+		if limitChanged {
+			if _, err := keyRepo.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{OrganizationID: orgID, KeyType: string(keyType), MonthlyCredits: int64(keyLimit), KeyHash: keyResponse.Data.Hash}); err != nil {
+				return 0, DisableCauseChange{}, oops.E(oops.CodeUnexpected, err, "failed to update OpenRouter key limit").LogError(ctx, o.logger)
+			}
+		}
+	}
+
+	if _, err := keyRepo.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(keyType), DisableCause: string(cause)}); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+
+	return keyLimit, DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
 }
 
 // DisableAPIKey stops an organization from spending on its platform key. Gram

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -664,10 +664,6 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 		KeyType:        string(keyType),
 		MonthlyCredits: int64(keyLimit),
 		KeyHash:        keyResponse.Data.Hash,
-		// This matches the upstream PATCH above. A lockdown committed after the
-		// read is preserved because key.Disabled was false at the read and this
-		// value therefore remains false.
-		Reinstate: key.Disabled,
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -636,10 +636,13 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 
 	creditLimit := float64(keyLimit)
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
-	if removeLegacyAdminLock && len(key.DisableCauses) == 1 {
-		// The legacy reinstate paths enable upstream only when removing the admin
-		// lock makes the key locally enabled. Other causes keep it disabled.
-		patch.Disabled = new(false)
+	if key.Disabled {
+		// Reassert the local effective state so a retry repairs an upstream enable
+		// that raced with another cause landing during the prior PATCH.
+		patch.Disabled = new(true)
+		if removeLegacyAdminLock && len(key.DisableCauses) == 1 {
+			patch.Disabled = new(false)
+		}
 	}
 
 	patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -29,8 +29,35 @@ WHERE organization_id = @organization_id
 -- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
 SET monthly_credits = @monthly_credits, key_hash = @key_hash,
-    disabled = disabled AND NOT @reinstate::boolean,
     updated_at = GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE
+RETURNING *;
+
+-- name: AddOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) THEN disable_causes
+      ELSE array_append(disable_causes, @disable_cause::text)
+    END,
+    updated_at = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) THEN updated_at
+      ELSE GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+    END
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE
+RETURNING *;
+
+-- name: RemoveOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = array_remove(disable_causes, @disable_cause::text),
+    updated_at = CASE
+      WHEN @disable_cause::text = ANY(disable_causes)
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
 WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE
@@ -41,7 +68,10 @@ RETURNING *;
 -- the same upstream key and its ceiling. ProvisionAPIKey reads this flag and
 -- refuses to hand the key to a completion.
 UPDATE openrouter_api_keys
-SET disabled = TRUE,
+SET disable_causes = CASE
+      WHEN 'admin_lock' = ANY(disable_causes) THEN disable_causes
+      ELSE array_append(disable_causes, 'admin_lock')
+    END,
     updated_at = clock_timestamp()
 WHERE organization_id = @organization_id
   AND key_type = @key_type

--- a/server/internal/thirdparty/openrouter/repo/models.go
+++ b/server/internal/thirdparty/openrouter/repo/models.go
@@ -15,6 +15,7 @@ type OpenrouterApiKey struct {
 	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
+	DisableCauses  []string
 	Disabled       bool
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -11,6 +11,48 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const addOpenRouterAPIKeyDisableCause = `-- name: AddOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = CASE
+      WHEN $1::text = ANY(disable_causes) THEN disable_causes
+      ELSE array_append(disable_causes, $1::text)
+    END,
+    updated_at = CASE
+      WHEN $1::text = ANY(disable_causes) THEN updated_at
+      ELSE GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+    END
+WHERE organization_id = $2
+  AND key_type = $3
+  AND deleted IS FALSE
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disable_causes, disabled, created_at, updated_at, deleted_at, deleted
+`
+
+type AddOpenRouterAPIKeyDisableCauseParams struct {
+	DisableCause   string
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) AddOpenRouterAPIKeyDisableCause(ctx context.Context, arg AddOpenRouterAPIKeyDisableCauseParams) (OpenrouterApiKey, error) {
+	row := q.db.QueryRow(ctx, addOpenRouterAPIKeyDisableCause, arg.DisableCause, arg.OrganizationID, arg.KeyType)
+	var i OpenrouterApiKey
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.KeyType,
+		&i.Key,
+		&i.KeyEncrypted,
+		&i.KeyHash,
+		&i.MonthlyCredits,
+		&i.DisableCauses,
+		&i.Disabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const compareAndSetOpenRouterKeyMonthlyCredits = `-- name: CompareAndSetOpenRouterKeyMonthlyCredits :execrows
 UPDATE openrouter_api_keys
 SET monthly_credits = $1,
@@ -60,7 +102,7 @@ INSERT INTO openrouter_api_keys (
   , $4
   , $5
 )
-RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disable_causes, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateOpenRouterAPIKeyParams struct {
@@ -87,6 +129,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
+		&i.DisableCauses,
 		&i.Disabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -98,7 +141,10 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 
 const disableOpenRouterAPIKey = `-- name: DisableOpenRouterAPIKey :exec
 UPDATE openrouter_api_keys
-SET disabled = TRUE,
+SET disable_causes = CASE
+      WHEN 'admin_lock' = ANY(disable_causes) THEN disable_causes
+      ELSE array_append(disable_causes, 'admin_lock')
+    END,
     updated_at = clock_timestamp()
 WHERE organization_id = $1
   AND key_type = $2
@@ -119,7 +165,7 @@ func (q *Queries) DisableOpenRouterAPIKey(ctx context.Context, arg DisableOpenRo
 }
 
 const getOpenRouterAPIKey = `-- name: GetOpenRouterAPIKey :one
-SELECT organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+SELECT organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disable_causes, disabled, created_at, updated_at, deleted_at, deleted
 FROM openrouter_api_keys
 WHERE organization_id = $1
   AND key_type = $2
@@ -141,6 +187,7 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, arg GetOpenRouterAPIK
 		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
+		&i.DisableCauses,
 		&i.Disabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -166,21 +213,59 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 	return err
 }
 
+const removeOpenRouterAPIKeyDisableCause = `-- name: RemoveOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = array_remove(disable_causes, $1::text),
+    updated_at = CASE
+      WHEN $1::text = ANY(disable_causes)
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = $2
+  AND key_type = $3
+  AND deleted IS FALSE
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disable_causes, disabled, created_at, updated_at, deleted_at, deleted
+`
+
+type RemoveOpenRouterAPIKeyDisableCauseParams struct {
+	DisableCause   string
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) RemoveOpenRouterAPIKeyDisableCause(ctx context.Context, arg RemoveOpenRouterAPIKeyDisableCauseParams) (OpenrouterApiKey, error) {
+	row := q.db.QueryRow(ctx, removeOpenRouterAPIKeyDisableCause, arg.DisableCause, arg.OrganizationID, arg.KeyType)
+	var i OpenrouterApiKey
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.KeyType,
+		&i.Key,
+		&i.KeyEncrypted,
+		&i.KeyHash,
+		&i.MonthlyCredits,
+		&i.DisableCauses,
+		&i.Disabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
 SET monthly_credits = $1, key_hash = $2,
-    disabled = disabled AND NOT $3::boolean,
     updated_at = GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
-WHERE organization_id = $4
-  AND key_type = $5
+WHERE organization_id = $3
+  AND key_type = $4
   AND deleted IS FALSE
-RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disable_causes, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateOpenRouterKeyParams struct {
 	MonthlyCredits int64
 	KeyHash        string
-	Reinstate      bool
 	OrganizationID string
 	KeyType        string
 }
@@ -189,7 +274,6 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 	row := q.db.QueryRow(ctx, updateOpenRouterKey,
 		arg.MonthlyCredits,
 		arg.KeyHash,
-		arg.Reinstate,
 		arg.OrganizationID,
 		arg.KeyType,
 	)
@@ -201,6 +285,7 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
+		&i.DisableCauses,
 		&i.Disabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -65,6 +65,22 @@ func (m *mockProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return 0, nil
 }
 
+func (*mockProvisioner) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
+	return DisableCauseChange{}, nil
+}
+
+func (m *mockProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	return m.AddAPIKeyDisableCause(ctx, orgID, keyType, cause)
+}
+
+func (*mockProvisioner) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+	return 0, DisableCauseChange{}, nil
+}
+
+func (m *mockProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	return m.RemoveAPIKeyDisableCause(ctx, orgID, keyType, cause, limit)
+}
+
 func (m *mockProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	return nil
 }

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -164,6 +164,22 @@ func (p *recordingOpenRouterProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Co
 	return p.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 }
 
+func (*recordingOpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*recordingOpenRouterProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*recordingOpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*recordingOpenRouterProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (*recordingOpenRouterProvisioner) DisableAPIKey(context.Context, string, openrouter.KeyType) error {
 	return fmt.Errorf("not implemented")
 }

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -132,7 +132,6 @@ func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db o
 	refreshed, err := openrouterrepo.New(db).UpdateOpenRouterKey(ctx, openrouterrepo.UpdateOpenRouterKeyParams{
 		MonthlyCredits: int64(*limit),
 		KeyHash:        key.KeyHash,
-		Reinstate:      key.Disabled,
 		OrganizationID: organizationID,
 		KeyType:        string(keyType),
 	})
@@ -141,6 +140,22 @@ func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db o
 	}
 	p.refreshCalls = append(p.refreshCalls, keyType)
 	return int(refreshed.MonthlyCredits), nil
+}
+
+func (*m3OpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*m3OpenRouterProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
 }
 
 func (p *m3OpenRouterProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {

--- a/server/migrations/20260827023219_openrouter-disable-causes.sql
+++ b/server/migrations/20260827023219_openrouter-disable-causes.sql
@@ -1,0 +1,8 @@
+-- Modify "openrouter_api_keys" table
+ALTER TABLE "openrouter_api_keys" ADD COLUMN "disable_causes" text[] NOT NULL DEFAULT '{}';
+
+UPDATE "openrouter_api_keys"
+SET "disable_causes" = ARRAY['admin_lock']::text[]
+WHERE "disabled" IS TRUE;
+
+ALTER TABLE "openrouter_api_keys" DROP COLUMN "disabled", ADD COLUMN "disabled" boolean NOT NULL GENERATED ALWAYS AS (cardinality(disable_causes) > 0) STORED;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:aI7RQxqZLKGE6m9dNCGeMozWy5tE4uNZyMHZgM/Fj7Q=
+h1:xinBOq+eW3kSdsSeGYMwSS/0LSywsKPmmEMSjMWGDOw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -369,3 +369,4 @@ h1:aI7RQxqZLKGE6m9dNCGeMozWy5tE4uNZyMHZgM/Fj7Q=
 20260825221933_gcp-iam-credentials-add-skip-project-verification.sql h1:DZOWCldTGLdSq4DlHGhu2wnFhLiqVffCgOKC8LoGzkE=
 20260826163849_drop-mcp-server-authorization-exclusivity.sql h1:kTyvUQ+UXxaRY6PirpiwKX23Uq1VvLn5j5LxOHUXu3g=
 20260826174212_add-mcp-servers-user-session-issuer-index.sql h1:bV8x2GJNJerKXp7s1VyyO0GBQygI7ZPXwSdDbhrIftE=
+20260827023219_openrouter-disable-causes.sql h1:PoWmvvFTmKpFT4l5T5BVpfHMUnr/AVDaQjeWPg2oOiA=


### PR DESCRIPTION
## Rationale

AGE-3219 requires platform-admin actions to own only the `admin_lock` cause rather than overriding automatic trial or billing causes.

## Scope

- expose cause-aware admin lock operations in the platform-admin API
- update admin service, audit behavior, queries, generated API artifacts, and focused tests
- preserve all non-admin disable causes when an admin lock is added or removed

## Testing

No commits were rewritten for this split. Evidence inherited from the reviewed full stack at `29be69240`: focused server gate (1,063 tests), aggregate server gate (12,996 tests), `mise lint:server`, and repository compile-only check.

## Stack order

1. [Core #5812](https://github.com/speakeasy-api/gram/pull/5812)
2. [**Admin API #5813 (this PR)**](https://github.com/speakeasy-api/gram/pull/5813) — depends on Core
3. [Lifecycle #5814](https://github.com/speakeasy-api/gram/pull/5814) — depends on this PR
4. [UI / forward compatibility / final lint #5789](https://github.com/speakeasy-api/gram/pull/5789) — depends on Lifecycle

Linear: AGE-3219
