### PR TITLE
fix: preserve OpenRouter causes across lifecycle changes (AGE-3219)

### DIFF
--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -748,9 +748,6 @@ func (*devProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openroute
 	return 0, openrouter.DisableCauseChange{}, nil
 }
 
-func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
-	return fmt.Errorf("not implemented in bench")
-}
 func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openrouter.KeyType) (float64, int, error) {
 	return 0, 0, fmt.Errorf("not implemented in bench")
 }

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -301,9 +301,6 @@ func (*devProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openroute
 	return 0, openrouter.DisableCauseChange{}, nil
 }
 
-func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
-	return fmt.Errorf("not implemented in bench")
-}
 func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openrouter.KeyType) (float64, int, error) {
 	return 0, 0, fmt.Errorf("not implemented in bench")
 }

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -1146,11 +1146,34 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	}
 
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin trial re-arm transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	trials := trialsRepo.New(tx)
+	rearmed, err := trials.RearmTrial(ctx, trialsRepo.RearmTrialParams{
+		OrganizationID: payload.ID,
+		RearmForDays:   conv.SafeInt32(payload.Days),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// rejectTrialChange reads on the pool, so this connection goes back
+		// before it asks for a second one. The deferred rollback is idempotent.
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
+			"look up organization after unrearmed trial",
+			"organization has no demoted enterprise trial to re-arm")
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
+	}
+
 	lockedKeys := make(map[openrouter.KeyType]*pgxpool.Conn, len(openrouter.AllKeyTypes))
 	var result *gen.AdminOrganization
-	err := s.withTrialKeyBillingLocks(ctx, logger, payload.ID, openrouter.AllKeyTypes, lockedKeys, func() error {
+	err = s.withTrialKeyBillingLocks(ctx, logger, payload.ID, openrouter.AllKeyTypes, lockedKeys, func() error {
 		var lockedErr error
-		result, lockedErr = s.rearmTrialLocked(ctx, logger, payload, lockedKeys)
+		result, lockedErr = s.rearmTrialLocked(ctx, logger, payload, lockedKeys, tx, trials, rearmed)
 		return lockedErr
 	})
 	if err == nil {
@@ -1196,32 +1219,10 @@ func (s *Service) rearmTrialLocked(
 	logger *slog.Logger,
 	payload *gen.RearmTrialPayload,
 	lockedKeys map[openrouter.KeyType]*pgxpool.Conn,
+	tx pgx.Tx,
+	trials *trialsRepo.Queries,
+	rearmed trialsRepo.RearmTrialRow,
 ) (*gen.AdminOrganization, error) {
-
-	tx, err := s.db.Begin(ctx)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "begin trial re-arm transaction").LogError(ctx, logger)
-	}
-	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
-
-	trials := trialsRepo.New(tx)
-
-	rearmed, err := trials.RearmTrial(ctx, trialsRepo.RearmTrialParams{
-		OrganizationID: payload.ID,
-		RearmForDays:   conv.SafeInt32(payload.Days),
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		// rejectTrialChange reads on the pool, so this connection goes back
-		// before it asks for a second one. The deferred rollback is idempotent.
-		_ = tx.Rollback(ctx)
-		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
-			"look up organization after unrearmed trial",
-			"organization has no demoted enterprise trial to re-arm")
-	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
-	}
-
 	uncapped, keyAccessChanged, err := s.reviveTrialKeys(ctx, logger, lockedKeys, payload.ID)
 	if err != nil {
 		return nil, err
@@ -1280,7 +1281,8 @@ func (s *Service) rearmTrialLocked(
 // Shaped like openrouterkeys.EnableKey rather than the demotion's blind loop:
 // Cause removal no-ops on a missing key row, RefreshAPIKeyLimit errors on one.
 //
-// The caller holds both per-key session locks through commit. Key revival uses
+// The caller holds the trial row lock before both per-key session locks and
+// retains all three through commit. Key revival uses
 // those locked sessions but stays outside the organization transaction, so a
 // later rollback leaves the org demoted with live keys instead of exposing an
 // admitted trial whose keys are still disabled.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,8 +90,8 @@ type BillingOperations interface {
 // TrialKeyReviver is the OpenRouter surface a trial re-arm needs.
 type TrialKeyReviver interface {
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
-	ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
-	ReinstateAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
+	RefreshAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
+	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error)
 }
 
 type OpenRouterSpendCapScheduler interface {
@@ -128,12 +129,12 @@ func (TrialKeysUnavailable) RefreshAPIKeyLimit(context.Context, string, openrout
 	return 0, ErrOpenRouterUnavailable
 }
 
-func (TrialKeysUnavailable) ReinstateAPIKeyLimit(context.Context, string, openrouter.KeyType, *int) (int, error) {
+func (TrialKeysUnavailable) RefreshAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error) {
 	return 0, ErrOpenRouterUnavailable
 }
 
-func (TrialKeysUnavailable) ReinstateAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error) {
-	return 0, ErrOpenRouterUnavailable
+func (TrialKeysUnavailable) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, ErrOpenRouterUnavailable
 }
 
 func (TrialKeysUnavailable) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
@@ -1221,9 +1222,12 @@ func (s *Service) rearmTrialLocked(
 		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
 	}
 
-	uncapped, err := s.reviveTrialKeys(ctx, logger, lockedKeys, payload.ID)
+	uncapped, keyAccessChanged, err := s.reviveTrialKeys(ctx, logger, lockedKeys, payload.ID)
 	if err != nil {
 		return nil, err
+	}
+	if keyAccessChanged {
+		logger.DebugContext(ctx, "trial re-arm changed platform key access")
 	}
 
 	organization, err := trials.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{
@@ -1270,22 +1274,24 @@ func (s *Service) rearmTrialLocked(
 }
 
 // reviveTrialKeys brings every platform key the organization holds back up, and
-// returns the types revived at a pre-commit ceiling, for recapRevivedKeys.
+// returns the types revived at a pre-commit ceiling for recapRevivedKeys and
+// whether any key's effective access changed.
 //
 // Shaped like openrouterkeys.EnableKey rather than the demotion's blind loop:
-// DisableAPIKey no-ops on a missing key row, RefreshAPIKeyLimit errors on one.
+// Cause removal no-ops on a missing key row, RefreshAPIKeyLimit errors on one.
 //
 // The caller holds both per-key session locks through commit. Key revival uses
 // those locked sessions but stays outside the organization transaction, so a
 // later rollback leaves the org demoted with live keys instead of exposing an
 // admitted trial whose keys are still disabled.
-func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, lockedKeys map[openrouter.KeyType]*pgxpool.Conn, organizationID string) ([]openrouter.KeyType, error) {
+func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, lockedKeys map[openrouter.KeyType]*pgxpool.Conn, organizationID string) ([]openrouter.KeyType, bool, error) {
 	var uncapped []openrouter.KeyType
+	keyAccessChanged := false
 
 	for _, keyType := range openrouter.AllKeyTypes {
 		conn := lockedKeys[keyType]
 		if conn == nil {
-			return nil, oops.E(oops.CodeUnexpected, nil, "missing openrouter %s key lock", keyType).LogError(ctx, logger)
+			return nil, false, oops.E(oops.CodeUnexpected, nil, "missing openrouter %s key lock", keyType).LogError(ctx, logger)
 		}
 		row, err := orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{
 			OrganizationID: organizationID,
@@ -1295,8 +1301,8 @@ func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, lock
 		case errors.Is(err, pgx.ErrNoRows):
 			continue
 		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "read openrouter %s key", keyType).LogError(ctx, logger)
-		case !row.Disabled:
+			return nil, false, oops.E(oops.CodeUnexpected, err, "read openrouter %s key", keyType).LogError(ctx, logger)
+		case !slices.Contains(row.DisableCauses, string(openrouter.DisableCauseTrialDemotion)):
 			continue
 		}
 
@@ -1307,16 +1313,17 @@ func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, lock
 			uncapped = append(uncapped, keyType)
 		}
 		limit := conv.PtrEmpty(int(row.MonthlyCredits))
-		_, err = s.openRouter.ReinstateAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, limit)
+		_, change, err := s.openRouter.RemoveAPIKeyDisableCauseWithDB(ctx, conn, organizationID, keyType, openrouter.DisableCauseTrialDemotion, limit)
+		keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
 		switch {
 		case errors.Is(err, ErrOpenRouterUnavailable):
-			return nil, oops.E(oops.CodeInvalid, err, "this server cannot revive model provider keys: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
+			return nil, false, oops.E(oops.CodeInvalid, err, "this server cannot revive model provider keys: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
 		case err != nil:
-			return nil, oops.E(oops.CodeGatewayError, err, "revive openrouter %s key", keyType).LogError(ctx, logger)
+			return nil, false, oops.E(oops.CodeGatewayError, err, "revive openrouter %s key", keyType).LogError(ctx, logger)
 		}
 	}
 
-	return uncapped, nil
+	return uncapped, keyAccessChanged, nil
 }
 
 // recapRevivedKeys puts the trial's own ceiling on the keys reviveTrialKeys
@@ -1334,7 +1341,7 @@ func (s *Service) recapRevivedKeys(ctx context.Context, logger *slog.Logger, loc
 			)
 			continue
 		}
-		if _, err := s.openRouter.ReinstateAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, nil); err != nil {
+		if _, err := s.openRouter.RefreshAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, nil); err != nil {
 			logger.ErrorContext(ctx, "re-armed trial key kept the free-tier allowance: refresh it from the platform admin key page",
 				attr.SlogError(err),
 				attr.SlogOpenRouterKeyType(string(keyType)),

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -62,12 +65,28 @@ func (p *rearmProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string,
 	return p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
 }
 
-func (p *rearmProvisioner) ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
+func (p *rearmProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
 	return p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
 }
 
-func (p *rearmProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
+func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	row, err := orrepo.New(db).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, openrouter.DisableCauseChange{}, nil
+	}
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	hadCause := slices.Contains(row.DisableCauses, string(cause))
+	refreshed, err := p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
+	if err != nil || !hadCause {
+		return refreshed, openrouter.DisableCauseChange{}, err
+	}
+	updated, err := orrepo.New(db).RemoveOpenRouterAPIKeyDisableCause(ctx, orrepo.RemoveOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(keyType), DisableCause: string(cause)})
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	return refreshed, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: row.Disabled && !updated.Disabled}, nil
 }
 
 func (p *rearmProvisioner) refreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
@@ -158,6 +177,7 @@ type keyFixture struct {
 	keyType        openrouter.KeyType
 	monthlyCredits int64
 	disabled       bool
+	disableCauses  []openrouter.DisableCause
 }
 
 func seedOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, f keyFixture) {
@@ -177,11 +197,17 @@ func seedOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, or
 	})
 	require.NoError(t, err)
 
-	if f.disabled {
-		require.NoError(t, keys.DisableOpenRouterAPIKey(ctx, orrepo.DisableOpenRouterAPIKeyParams{
+	causes := f.disableCauses
+	if f.disabled && len(causes) == 0 {
+		causes = []openrouter.DisableCause{openrouter.DisableCauseTrialDemotion}
+	}
+	for _, cause := range causes {
+		_, err := keys.AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{
 			OrganizationID: orgID,
 			KeyType:        string(f.keyType),
-		}))
+			DisableCause:   string(cause),
+		})
+		require.NoError(t, err)
 	}
 }
 
@@ -282,6 +308,65 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.Equal(t, "running", *detail.TrialState)
 	require.Equal(t, *res.TrialEndsAt, *detail.TrialEndsAt)
 	require.Equal(t, "enterprise", detail.AccountType)
+}
+
+func TestRearmTrial_RemovesOnlyTrialDemotionCause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		extraCause openrouter.DisableCause
+	}{
+		{name: "trial demotion only"},
+		{name: "admin lock remains", extraCause: openrouter.DisableCauseAdminLock},
+		{name: "billing inactive remains", extraCause: openrouter.DisableCauseBillingInactive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, svc, conn, _ := newRearmService(t)
+			orgID := "org_rearm_" + strings.ReplaceAll(tt.name, " ", "_")
+			seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+			if tt.extraCause != "" {
+				for _, keyType := range openrouter.AllKeyTypes {
+					_, err := orrepo.New(conn).AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(keyType), DisableCause: string(tt.extraCause)})
+					require.NoError(t, err)
+				}
+			}
+
+			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+			require.NoError(t, err)
+			for _, keyType := range openrouter.AllKeyTypes {
+				key := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+				require.NotContains(t, key.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+				if tt.extraCause == "" {
+					require.False(t, key.Disabled)
+				} else {
+					require.True(t, key.Disabled)
+					require.Equal(t, []string{string(tt.extraCause)}, key.DisableCauses)
+				}
+			}
+		})
+	}
+}
+
+func TestReviveTrialKeysReportsEffectiveAccessChange(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, pool, _ := newRearmService(t)
+	const orgID = "org_rearm_access_change"
+	seedDemotedTrial(t, ctx, pool, orgID, "enterprise")
+	locked := make(map[openrouter.KeyType]*pgxpool.Conn, len(openrouter.AllKeyTypes))
+	for _, keyType := range openrouter.AllKeyTypes {
+		conn, err := pool.Acquire(ctx)
+		require.NoError(t, err)
+		t.Cleanup(conn.Release)
+		locked[keyType] = conn
+	}
+
+	_, accessChanged, err := svc.reviveTrialKeys(ctx, testenv.NewLogger(t), locked, orgID)
+	require.NoError(t, err)
+	require.True(t, accessChanged)
 }
 
 func TestRearmTrial_DoesNotRestartLoopsSequence(t *testing.T) {
@@ -599,7 +684,7 @@ func TestRearmTrial_ReleasesRejectedTransactionBeforeClassificationLookup(t *tes
 	requireOopsCode(t, err, oops.CodeConflict)
 }
 
-// DisableAPIKey no-ops on a missing key row but RefreshAPIKeyLimit errors on
+// Cause removal no-ops on a missing key row but RefreshAPIKeyLimit errors on
 // one, so the demotion's unconditional loop would fail this re-arm outright.
 func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	t.Parallel()
@@ -991,7 +1076,7 @@ func TestRearmTrial_TouchesOnlyTheTargetRow(t *testing.T) {
 func TestRearmTrial_IsIdempotentAcrossARetry(t *testing.T) {
 	t.Parallel()
 
-	ctx, svc, conn, _ := newRearmService(t)
+	ctx, svc, conn, provisioner := newRearmService(t)
 	seedDemotedTrial(t, ctx, conn, "org_rearm_twice", "enterprise")
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_twice", Days: 14})
@@ -1005,6 +1090,7 @@ func TestRearmTrial_IsIdempotentAcrossARetry(t *testing.T) {
 	require.Equal(t, first.EndsAt.Time, second.EndsAt.Time,
 		"a second re-arm must not move a trial that is already running")
 	require.Equal(t, first.UpdatedAt.Time, second.UpdatedAt.Time)
+	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes), "a repeated re-arm must not patch key state again")
 }
 
 func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *testing.T) {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -435,6 +436,94 @@ func TestRearmTrial_RevivesKeysBeforeTheRestoreCommits(t *testing.T) {
 }
 
 // The failure lands on the second key type, so the first is already back up.
+func TestRearmTrial_TrialRowLockPrecedesKeyLocks(t *testing.T) { //nolint:paralleltest // Coordinates two writers against one cloned database.
+	ctx, svc, pool, provisioner := newRearmService(t)
+	const orgID = "org_rearm_lock_order"
+	seedDemotedTrial(t, ctx, pool, orgID, "enterprise")
+
+	trialOwnerTx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = trialOwnerTx.Rollback(context.WithoutCancel(ctx)) })
+	var lockedOrgID string
+	require.NoError(t, trialOwnerTx.QueryRow(ctx, `SELECT organization_id FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID).Scan(&lockedOrgID))
+	require.Equal(t, orgID, lockedOrgID)
+
+	type rearmResult struct {
+		err error
+	}
+	rearmed := make(chan rearmResult, 1)
+	go func() {
+		_, rearmErr := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+		rearmed <- rearmResult{err: rearmErr}
+	}()
+
+	blockedPID := waitForBlockedTrialRearm(t, ctx, pool)
+	var advisoryLocks int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM pg_locks WHERE pid = $1 AND locktype = 'advisory' AND granted`, blockedPID).Scan(&advisoryLocks))
+
+	logger := testenv.NewLogger(t)
+	trialOwnerErr := keybillinglock.WithAcquireTimeout(ctx, logger, pool, orgID, openrouter.KeyTypeChat, time.Second, func(_ *pgxpool.Conn) error {
+		return keybillinglock.WithAcquireTimeout(ctx, logger, pool, orgID, openrouter.KeyTypeInternal, time.Second, func(_ *pgxpool.Conn) error {
+			return trialOwnerTx.Commit(ctx)
+		})
+	})
+	if trialOwnerErr != nil {
+		require.NoError(t, trialOwnerTx.Rollback(ctx))
+	}
+
+	var result rearmResult
+	select {
+	case result = <-rearmed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent trial demotion and re-arm did not complete")
+	}
+	require.Zero(t, advisoryLocks, "re-arm must not hold key locks while waiting for the trial row")
+	require.NoError(t, trialOwnerErr)
+	require.NoError(t, result.err)
+	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
+	for _, revival := range provisioner.revivals {
+		require.Equal(t, "free", revival.accountTypeSeen, "key work must finish before organization restoration commits")
+		require.True(t, revival.demotedSeen, "key work must observe the demoted trial before re-arm commits")
+	}
+}
+
+func waitForBlockedTrialRearm(t *testing.T, ctx context.Context, pool *pgxpool.Pool) int32 {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var pid int32
+		err := pool.QueryRow(ctx, `
+			SELECT pid
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND pid <> pg_backend_pid()
+			  AND query LIKE '%SET demoted_at = NULL%'
+			  AND wait_event_type = 'Lock'
+			LIMIT 1
+		`).Scan(&pid)
+		if err == nil {
+			return pid
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			require.NoError(t, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	rows, err := pool.Query(ctx, `SELECT pid, state, coalesce(wait_event_type, ''), left(query, 160) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid()`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var activity []string
+	for rows.Next() {
+		var pid int32
+		var state, waitType, query string
+		require.NoError(t, rows.Scan(&pid, &state, &waitType, &query))
+		activity = append(activity, fmt.Sprintf("pid=%d state=%s wait=%s query=%q", pid, state, waitType, query))
+	}
+	t.Fatalf("re-arm never blocked on the trial row lock: %v", activity)
+	return 0
+}
+
 func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/activities/openrouter_key_billing_lock.go
+++ b/server/internal/background/activities/openrouter_key_billing_lock.go
@@ -17,7 +17,8 @@ import (
 
 type openRouterKeyBillingDBProvisioner interface {
 	RefreshAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error)
-	DisableAPIKeyWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType) error
+	AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error)
+	RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error)
 	ReconcileMonthlyCreditsWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, int64, int64, *int64) (int64, error)
 }
 

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -64,6 +64,8 @@ SELECT
     organization_metadata.gram_account_type
   , billing_metadata.stripe_subscription_id
   , chat_key.disabled AS chat_key_disabled
+  , trials.demoted_at AS trial_demoted_at
+  , trials.converted_at AS trial_converted_at
 FROM organization_metadata
 LEFT JOIN billing_metadata
   ON billing_metadata.organization_id = organization_metadata.id
@@ -71,6 +73,8 @@ LEFT JOIN openrouter_api_keys chat_key
   ON chat_key.organization_id = organization_metadata.id
  AND chat_key.key_type = 'chat'
  AND chat_key.deleted IS FALSE
+LEFT JOIN trials
+  ON trials.organization_id = organization_metadata.id
 WHERE organization_metadata.id = @organization_id;
 
 -- name: GetOpenRouterInferenceKeyLimit :one

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key.go
@@ -13,7 +13,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -24,11 +23,7 @@ type ReconcilePaygOpenRouterChatKey struct {
 }
 
 func NewReconcilePaygOpenRouterChatKey(logger *slog.Logger, db *pgxpool.Pool, openRouter openrouter.Provisioner) *ReconcilePaygOpenRouterChatKey {
-	return &ReconcilePaygOpenRouterChatKey{
-		logger:     logger,
-		db:         db,
-		openRouter: openRouter,
-	}
+	return &ReconcilePaygOpenRouterChatKey{logger: logger, db: db, openRouter: openRouter}
 }
 
 type ReconcilePaygOpenRouterChatKeyArgs struct {
@@ -45,7 +40,7 @@ func (r *ReconcilePaygOpenRouterChatKey) Do(ctx context.Context, args ReconcileP
 	}
 
 	if err := withOpenRouterKeyBillingConnectionLock(ctx, r.logger, r.db, args.OrganizationID, openrouter.KeyTypeChat, func(conn *pgxpool.Conn, queries *repo.Queries) error {
-		return r.reconcileLocked(ctx, conn, queries, args)
+		return r.reconcileChatLocked(ctx, conn, queries, args)
 	}); err != nil {
 		return err
 	}
@@ -53,99 +48,60 @@ func (r *ReconcilePaygOpenRouterChatKey) Do(ctx context.Context, args ReconcileP
 		return nil
 	}
 
-	// Trial demotion disables both platform keys, while subscription loss only
-	// disables Other inference. Re-enable Security inference only when it is
-	// actually disabled; an ordinary recheckout therefore leaves its independent
-	// cap and enabled state untouched.
 	return withOpenRouterKeyBillingConnectionLock(ctx, r.logger, r.db, args.OrganizationID, openrouter.KeyTypeInternal, func(conn *pgxpool.Conn, queries *repo.Queries) error {
-		return r.reenableSecurityLocked(ctx, conn, queries, args.OrganizationID)
+		return r.reconcileConvertedTrialInternalLocked(ctx, conn, queries, args.OrganizationID)
 	})
 }
 
-func (r *ReconcilePaygOpenRouterChatKey) reconcileLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, args ReconcilePaygOpenRouterChatKeyArgs) error {
+func (r *ReconcilePaygOpenRouterChatKey) reconcileChatLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, args ReconcilePaygOpenRouterChatKeyArgs) error {
 	projection, err := queries.GetPaygOpenRouterChatKeyProjection(ctx, args.OrganizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// Organization deletion also removes its platform keys. An old outbox
-		// delivery has no remaining desired state to apply.
 		return nil
 	case err != nil:
 		return fmt.Errorf("read PAYG Other inference key billing projection: %w", err)
 	}
 
 	hasSubscription := projection.StripeSubscriptionID.Valid && projection.StripeSubscriptionID.String != ""
+	dbProvisioner, ok := r.openRouter.(openRouterKeyBillingDBProvisioner)
+	if !ok {
+		return errors.New("OpenRouter key provisioner cannot use the locked database session")
+	}
+
 	switch {
 	case projection.GramAccountType == string(billing.TierPayg) && hasSubscription:
 		if args.DesiredState != openrouter.KeyDesiredStateEnabled {
 			return nil
 		}
-		limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
-		if !ok {
-			return errors.New("PAYG OpenRouter credit policy is unavailable")
-		}
-		key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
-			OrganizationID: args.OrganizationID,
-			KeyType:        string(openrouter.KeyTypeChat),
-		})
-		if errors.Is(err, pgx.ErrNoRows) {
-			// Keys are provisioned lazily. Billing activation must not create one.
-			return nil
-		}
+		limit, err := paygKeyLimitLocked(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat)
 		if err != nil {
-			return fmt.Errorf("read PAYG Other inference key: %w", err)
+			return err
 		}
-		if !key.Disabled {
-			if key.MonthlyCredits == int64(limit) {
-				return nil
-			}
-			chosen, err := auditrepo.New(conn).GetLatestOpenRouterSpendCapAuditOperation(ctx, auditrepo.GetLatestOpenRouterSpendCapAuditOperationParams{
-				OrganizationID: args.OrganizationID,
-				SubjectID:      urn.NewOpenRouterAPIKey(args.OrganizationID, string(openrouter.KeyTypeChat)).ID,
-			})
-			if err != nil {
-				return fmt.Errorf("read latest Other inference cap selection: %w", err)
-			}
-			if chosen.OperationID != "" {
-				// A customer cap completed after this activation wake-up began. Do
-				// not let a retry overwrite that newer intent with the default.
-				return nil
-			}
+		if _, _, err := dbProvisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive, &limit); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("restore PAYG Other inference key billing access: %w", err)
 		}
-		dbProvisioner, ok := r.openRouter.(openRouterSpendCapDBProvisioner)
-		if !ok {
-			return errors.New("OpenRouter key provisioner cannot use the locked database session")
-		}
-		if _, err := dbProvisioner.ReinstateAPIKeyLimitWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat, &limit); errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		} else if err != nil {
-			return fmt.Errorf("enable PAYG Other inference key: %w", err)
+		if projection.TrialDemotedAt.Valid && projection.TrialConvertedAt.Valid {
+			if _, _, err := dbProvisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat, openrouter.DisableCauseTrialDemotion, &limit); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("restore converted trial Other inference key: %w", err)
+			}
 		}
 	case projection.GramAccountType == string(billing.TierBase) && !hasSubscription:
 		if args.DesiredState != openrouter.KeyDesiredStateDisabled {
 			return nil
 		}
-		dbProvisioner, ok := r.openRouter.(openRouterKeyBillingDBProvisioner)
-		if !ok {
-			return errors.New("OpenRouter key provisioner cannot use the locked database session")
-		}
-		if err := dbProvisioner.DisableAPIKeyWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat); err != nil {
-			return fmt.Errorf("disable PAYG Other inference key: %w", err)
+		if _, err := dbProvisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive); err != nil {
+			return fmt.Errorf("disable PAYG Other inference key for inactive billing: %w", err)
 		}
 	case projection.GramAccountType != string(billing.TierPayg) && projection.GramAccountType != string(billing.TierBase):
-		// Enterprise and Polar-managed tiers are outside self-serve Stripe
-		// billing. Old PAYG events must not mutate their keys.
 		return nil
 	default:
-		// The billing transition writes both halves in one transaction. A mixed
-		// projection means another writer did not honor that invariant; retrying
-		// is safer than granting or revoking access from partial state.
 		return fmt.Errorf("inconsistent PAYG Other inference key billing projection: account_type=%q has_subscription=%t", projection.GramAccountType, hasSubscription)
 	}
 
 	return nil
 }
 
-func (r *ReconcilePaygOpenRouterChatKey) reenableSecurityLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, organizationID string) error {
+func (r *ReconcilePaygOpenRouterChatKey) reconcileConvertedTrialInternalLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, organizationID string) error {
 	projection, err := queries.GetPaygOpenRouterChatKeyProjection(ctx, organizationID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
@@ -153,44 +109,39 @@ func (r *ReconcilePaygOpenRouterChatKey) reenableSecurityLocked(ctx context.Cont
 	if err != nil {
 		return fmt.Errorf("read PAYG Security inference key billing projection: %w", err)
 	}
-	if projection.GramAccountType != string(billing.TierPayg) || !projection.StripeSubscriptionID.Valid || projection.StripeSubscriptionID.String == "" {
+	hasSubscription := projection.StripeSubscriptionID.Valid && projection.StripeSubscriptionID.String != ""
+	if projection.GramAccountType != string(billing.TierPayg) || !hasSubscription || !projection.TrialDemotedAt.Valid || !projection.TrialConvertedAt.Valid {
 		return nil
 	}
 
-	key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
-		OrganizationID: organizationID,
-		KeyType:        string(openrouter.KeyTypeInternal),
-	})
-	if errors.Is(err, pgx.ErrNoRows) || (err == nil && !key.Disabled) {
-		return nil
-	}
+	limit, err := paygKeyLimitLocked(ctx, conn, organizationID, openrouter.KeyTypeInternal)
 	if err != nil {
-		return fmt.Errorf("read PAYG Security inference key: %w", err)
+		return err
 	}
+	dbProvisioner, ok := r.openRouter.(openRouterKeyBillingDBProvisioner)
+	if !ok {
+		return errors.New("OpenRouter key provisioner cannot use the locked database session")
+	}
+	if _, _, err := dbProvisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, organizationID, openrouter.KeyTypeInternal, openrouter.DisableCauseTrialDemotion, &limit); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("restore converted trial Security inference key: %w", err)
+	}
+	return nil
+}
 
+func paygKeyLimitLocked(ctx context.Context, conn *pgxpool.Conn, organizationID string, keyType openrouter.KeyType) (int, error) {
 	limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
 	if !ok {
-		return errors.New("PAYG OpenRouter credit policy is unavailable")
+		return 0, errors.New("PAYG OpenRouter credit policy is unavailable")
 	}
 	chosen, err := auditrepo.New(conn).GetLatestOpenRouterSpendCapAuditOperation(ctx, auditrepo.GetLatestOpenRouterSpendCapAuditOperationParams{
 		OrganizationID: organizationID,
-		SubjectID:      urn.NewOpenRouterAPIKey(organizationID, string(openrouter.KeyTypeInternal)).ID,
+		SubjectID:      urn.NewOpenRouterAPIKey(organizationID, string(keyType)).ID,
 	})
 	if err != nil {
-		return fmt.Errorf("read latest Security inference cap selection: %w", err)
+		return 0, fmt.Errorf("read latest %s inference cap selection: %w", keyType, err)
 	}
 	if chosen.OperationID != "" && chosen.MonthlyCredits > 0 {
 		limit = int(chosen.MonthlyCredits)
 	}
-	dbProvisioner, ok := r.openRouter.(openRouterSpendCapDBProvisioner)
-	if !ok {
-		return errors.New("OpenRouter key provisioner cannot use the locked database session")
-	}
-	if _, err := dbProvisioner.ReinstateAPIKeyLimitWithDB(ctx, conn, organizationID, openrouter.KeyTypeInternal, &limit); errors.Is(err, pgx.ErrNoRows) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("enable PAYG Security inference key: %w", err)
-	}
-
-	return nil
+	return limit, nil
 }

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -3,11 +3,13 @@ package activities_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/mock"
@@ -23,8 +25,17 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+type paygCauseCall struct {
+	organizationID string
+	keyType        openrouter.KeyType
+	cause          openrouter.DisableCause
+}
+
 type mockPaygChatKeyProvisioner struct {
 	mock.Mock
+	addedCauses   []paygCauseCall
+	removedCauses []paygCauseCall
+	layeredAdd    bool
 }
 
 func (m *mockPaygChatKeyProvisioner) ProvisionAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) (string, error) {
@@ -41,32 +52,43 @@ func (m *mockPaygChatKeyProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Contex
 	return m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 }
 
-func (m *mockPaygChatKeyProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
-}
-
 func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
 	return openrouter.DisableCauseChange{}, nil
 }
 
-func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (m *mockPaygChatKeyProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	m.addedCauses = append(m.addedCauses, paygCauseCall{organizationID: organizationID, keyType: keyType, cause: cause})
+	if m.layeredAdd {
+		return openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: false}, nil
+	}
+	err := m.Called(ctx, organizationID, keyType).Error(0)
+	return openrouter.DisableCauseChange{CauseChanged: err == nil, KeyAccessChanged: err == nil}, err
 }
 
 func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
 	return 0, openrouter.DisableCauseChange{}, nil
 }
 
-func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
-}
-
-func (m *mockPaygChatKeyProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
-	return m.Called(ctx, organizationID, keyType).Error(0)
-}
-
-func (m *mockPaygChatKeyProvisioner) DisableAPIKeyWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType) error {
-	return m.DisableAPIKey(ctx, organizationID, keyType)
+func (m *mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	m.removedCauses = append(m.removedCauses, paygCauseCall{organizationID: organizationID, keyType: keyType, cause: cause})
+	key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{OrganizationID: organizationID, KeyType: string(keyType)})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, openrouter.DisableCauseChange{}, nil
+	}
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	if limit != nil && key.MonthlyCredits == int64(*limit) && !slices.Contains(key.DisableCauses, string(cause)) {
+		return *limit, openrouter.DisableCauseChange{}, nil
+	}
+	if cause == openrouter.DisableCauseTrialDemotion {
+		if limit == nil {
+			return 0, openrouter.DisableCauseChange{CauseChanged: true}, nil
+		}
+		return *limit, openrouter.DisableCauseChange{CauseChanged: true}, nil
+	}
+	refreshed, err := m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
+	return refreshed, openrouter.DisableCauseChange{CauseChanged: err == nil, KeyAccessChanged: err == nil}, err
 }
 
 func (m *mockPaygChatKeyProvisioner) GetCreditsUsed(ctx context.Context, organizationID string, keyType openrouter.KeyType) (float64, int, error) {
@@ -155,7 +177,7 @@ func TestReconcilePaygOpenRouterChatKeyCurrentPaidStateEnablesOtherInferenceWhen
 	})).Return(100, nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 	provisioner.AssertExpectations(t)
 }
 
@@ -211,7 +233,7 @@ func TestReconcilePaygOpenRouterChatKeyActivationRetryPreservesSelectedOtherCap(
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestReconcilePaygOpenRouterChatKeyReenablesDisabledSecurityAtRecordedCap(t *testing.T) {
+func TestReconcilePaygOpenRouterChatKeyOrdinaryRecoveryPreservesAdminLockedSecurityAtRecordedCap(t *testing.T) {
 	t.Parallel()
 
 	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
@@ -244,15 +266,12 @@ func TestReconcilePaygOpenRouterChatKeyReenablesDisabledSecurityAtRecordedCap(t 
 		},
 	}))
 	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.AnythingOfType("*int")).Return(100, nil).Once()
-	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeInternal, mock.MatchedBy(func(limit *int) bool {
-		return limit != nil && *limit == 37
-	})).Return(37, nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
 	provisioner.AssertExpectations(t)
 }
 
-func TestReconcilePaygOpenRouterChatKeyReenablesDisabledTrialSecurityAtPaygDefault(t *testing.T) {
+func TestReconcilePaygOpenRouterChatKeyOrdinaryRecoveryPreservesUnconvertedTrialSecurity(t *testing.T) {
 	t.Parallel()
 
 	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
@@ -270,11 +289,32 @@ func TestReconcilePaygOpenRouterChatKeyReenablesDisabledTrialSecurityAtPaygDefau
 		KeyType:        string(openrouter.KeyTypeInternal),
 	}))
 	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.AnythingOfType("*int")).Return(100, nil).Once()
-	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeInternal, mock.MatchedBy(func(limit *int) bool {
-		return limit != nil && *limit == 100
-	})).Return(100, nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
+	provisioner.AssertExpectations(t)
+}
+
+func TestReconcilePaygOpenRouterChatKeyStripeConversionRemovesTrialDemotionFromBothKeys(t *testing.T) {
+	t.Parallel()
+
+	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeInternal, 37)
+	_, err := db.Exec(t.Context(), `INSERT INTO trials (organization_id, tier, ends_at, demoted_at, converted_at) VALUES ($1, 'enterprise', clock_timestamp() - interval '2 days', clock_timestamp() - interval '1 day', clock_timestamp())`, organizationID)
+	require.NoError(t, err)
+	for _, keyType := range openrouter.AllKeyTypes {
+		_, err = openrouterrepo.New(db).AddOpenRouterAPIKeyDisableCause(t.Context(), openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(openrouter.DisableCauseTrialDemotion)})
+		require.NoError(t, err)
+	}
+	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 100 })).Return(100, nil).Once()
+	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeInternal, mock.Anything).Return(100, nil).Maybe()
+
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
+	require.ElementsMatch(t, []paygCauseCall{
+		{organizationID: organizationID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseBillingInactive},
+		{organizationID: organizationID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseTrialDemotion},
+		{organizationID: organizationID, keyType: openrouter.KeyTypeInternal, cause: openrouter.DisableCauseTrialDemotion},
+	}, provisioner.removedCauses)
 	provisioner.AssertExpectations(t)
 }
 
@@ -284,7 +324,7 @@ func TestReconcilePaygOpenRouterChatKeyCurrentPaidStateWithoutKeyIsNoop(t *testi
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 	provisioner.AssertExpectations(t)
 }
 
@@ -292,10 +332,47 @@ func TestReconcilePaygOpenRouterChatKeyCurrentFreeStateDisablesOtherOnly(t *test
 	t.Parallel()
 
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
-	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
+	provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertExpectations(t)
+}
+
+func TestReconcilePaygOpenRouterChatKeyBillingLossOwnsOnlyBillingInactive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enabled chat key changes effective access", func(t *testing.T) {
+		reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+		provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
+
+		require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
+		require.Equal(t, []paygCauseCall{{organizationID: organizationID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseBillingInactive}}, provisioner.addedCauses)
+		provisioner.AssertExpectations(t)
+	})
+
+	t.Run("admin locked chat key stays disabled without another state patch", func(t *testing.T) {
+		reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+		provisioner.layeredAdd = true
+
+		require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
+		require.Equal(t, []paygCauseCall{{organizationID: organizationID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseBillingInactive}}, provisioner.addedCauses)
+		provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestReconcilePaygOpenRouterChatKeyBillingRecoveryRemovesOnlyBillingInactive(t *testing.T) {
+	t.Parallel()
+
+	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
+	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 100 })).Return(100, nil).Once()
+
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
+	require.Equal(t, []paygCauseCall{{organizationID: organizationID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseBillingInactive}}, provisioner.removedCauses)
+	for _, call := range provisioner.removedCauses {
+		require.NotEqual(t, openrouter.DisableCauseTrialDemotion, call.cause, "ordinary billing recovery must preserve trial demotion")
+	}
 	provisioner.AssertExpectations(t)
 }
 
@@ -303,7 +380,7 @@ func TestReconcilePaygOpenRouterChatKeyStaleActivationWakeupCannotOverrideCurren
 	t.Parallel()
 
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
-	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
+	provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}), "newer deactivation wake-up")
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}), "stale activation delivered last")
@@ -322,7 +399,7 @@ func TestReconcilePaygOpenRouterChatKeyStaleDeactivationWakeupCannotOverrideCurr
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}), "newer activation wake-up")
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}), "stale deactivation delivered last")
 
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 	provisioner.AssertExpectations(t)
 }
 
@@ -330,8 +407,8 @@ func TestReconcilePaygOpenRouterChatKeyExternalFailureIsRetryableAndIdempotent(t
 	t.Parallel()
 
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
-	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(errors.New("upstream unavailable")).Once()
-	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
+	provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(errors.New("upstream unavailable")).Once()
+	provisioner.On("AddAPIKeyDisableCauseWithDB", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	args := activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}
 	require.ErrorContains(t, reconciler.Do(t.Context(), args), "disable PAYG Other inference key")
@@ -347,7 +424,7 @@ func TestReconcilePaygOpenRouterChatKeyRejectsMixedProjection(t *testing.T) {
 	err := reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled})
 	require.ErrorContains(t, err, "inconsistent PAYG Other inference key billing projection")
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestReconcilePaygOpenRouterChatKeyIgnoresEnterpriseOrganization(t *testing.T) {
@@ -356,7 +433,7 @@ func TestReconcilePaygOpenRouterChatKeyIgnoresEnterpriseOrganization(t *testing.
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "enterprise", pgtype.Text{})
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestReconcilePaygOpenRouterChatKeyIgnoresPolarOrganization(t *testing.T) {
@@ -365,7 +442,7 @@ func TestReconcilePaygOpenRouterChatKeyIgnoresPolarOrganization(t *testing.T) {
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "pro", pgtype.Text{})
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertNotCalled(t, "AddAPIKeyDisableCauseWithDB", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestRefreshOpenRouterChatKeyDoesNotReinstateCommittedSubscriptionLoss(t *testing.T) {

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1124,6 +1124,8 @@ SELECT
     organization_metadata.gram_account_type
   , billing_metadata.stripe_subscription_id
   , chat_key.disabled AS chat_key_disabled
+  , trials.demoted_at AS trial_demoted_at
+  , trials.converted_at AS trial_converted_at
 FROM organization_metadata
 LEFT JOIN billing_metadata
   ON billing_metadata.organization_id = organization_metadata.id
@@ -1131,6 +1133,8 @@ LEFT JOIN openrouter_api_keys chat_key
   ON chat_key.organization_id = organization_metadata.id
  AND chat_key.key_type = 'chat'
  AND chat_key.deleted IS FALSE
+LEFT JOIN trials
+  ON trials.organization_id = organization_metadata.id
 WHERE organization_metadata.id = $1
 `
 
@@ -1138,12 +1142,20 @@ type GetPaygOpenRouterChatKeyProjectionRow struct {
 	GramAccountType      string
 	StripeSubscriptionID pgtype.Text
 	ChatKeyDisabled      pgtype.Bool
+	TrialDemotedAt       pgtype.Timestamptz
+	TrialConvertedAt     pgtype.Timestamptz
 }
 
 func (q *Queries) GetPaygOpenRouterChatKeyProjection(ctx context.Context, organizationID string) (GetPaygOpenRouterChatKeyProjectionRow, error) {
 	row := q.db.QueryRow(ctx, getPaygOpenRouterChatKeyProjection, organizationID)
 	var i GetPaygOpenRouterChatKeyProjectionRow
-	err := row.Scan(&i.GramAccountType, &i.StripeSubscriptionID, &i.ChatKeyDisabled)
+	err := row.Scan(
+		&i.GramAccountType,
+		&i.StripeSubscriptionID,
+		&i.ChatKeyDisabled,
+		&i.TrialDemotedAt,
+		&i.TrialConvertedAt,
+	)
 	return i, err
 }
 

--- a/server/internal/background/activities/set_openrouter_spend_cap.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap.go
@@ -32,7 +32,7 @@ type openRouterSpendCapAuditLogger interface {
 }
 
 type openRouterSpendCapDBProvisioner interface {
-	ReinstateAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error)
+	RefreshAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error)
 }
 
 const spendCapKeyBillingLockWaitTimeout = 10 * time.Second
@@ -274,7 +274,7 @@ func (s *SetOpenRouterSpendCap) setLocked(ctx context.Context, conn *pgxpool.Con
 		if !ok {
 			return temporal.NewNonRetryableApplicationError("OpenRouter spend-cap provisioner cannot use the locked database session", "invalid-spend-cap-provisioner", nil)
 		}
-		refreshed, err = dbProvisioner.ReinstateAPIKeyLimitWithDB(ctx, conn, args.OrganizationID, keyType, &args.Limit)
+		refreshed, err = dbProvisioner.RefreshAPIKeyLimitWithDB(ctx, conn, args.OrganizationID, keyType, &args.Limit)
 		if err != nil {
 			return fmt.Errorf("refresh OpenRouter %s inference cap: %w", keyType, err)
 		}

--- a/server/internal/background/activities/set_openrouter_spend_cap_test.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap_test.go
@@ -29,7 +29,6 @@ import (
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
-	usagerepo "github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
 type failFirstSpendCapAuditLogger struct {
@@ -950,7 +949,8 @@ func TestSetOpenRouterSpendCapRecordedRetryNoopsWhenKeyIsDisabled(t *testing.T) 
 	}
 
 	require.ErrorContains(t, run(), "re-arm OpenRouter chat credits alerts")
-	require.NoError(t, usagerepo.New(db).DisablePaygOpenRouterChatKey(t.Context(), organizationID))
+	_, err := openrouterrepo.New(db).AddOpenRouterAPIKeyDisableCause(t.Context(), openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(openrouter.KeyTypeChat), DisableCause: string(openrouter.DisableCauseBillingInactive)})
+	require.NoError(t, err)
 	require.NoError(t, run())
 	provisioner.AssertExpectations(t)
 

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -88,20 +88,27 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	// stamp back and leaves the trial armed for the next sweep, which a lockdown
 	// after the commit would not get: a stamped row drops out of the sweep.
 	//
-	// DisableAPIKeyWithDB writes its disabled flag on the locked key session,
+	// AddAPIKeyDisableCauseWithDB writes its cause on the locked key session,
 	// outside dbtx, so a key already taken down stays down through an
 	// organization-transaction rollback. The organization reads as enterprise
 	// with a dead key until the next sweep completes the demotion.
+	keyAccessChanged := false
 	for _, keyType := range openrouter.AllKeyTypes {
 		if err := keybillinglock.With(ctx, d.logger, d.db, args.OrganizationID, keyType, func(conn *pgxpool.Conn) error {
 			dbProvisioner, ok := d.openRouter.(openRouterKeyBillingDBProvisioner)
 			if !ok {
 				return errors.New("OpenRouter key provisioner cannot use the locked database session")
 			}
-			return dbProvisioner.DisableAPIKeyWithDB(ctx, conn, args.OrganizationID, keyType)
+			change, err := dbProvisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, args.OrganizationID, keyType, openrouter.DisableCauseTrialDemotion)
+			keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
+			return err
 		}); err != nil {
 			return fmt.Errorf("disable openrouter %s key: %w", keyType, err)
 		}
+	}
+
+	if keyAccessChanged {
+		d.logger.DebugContext(ctx, "trial demotion changed platform key access", attr.SlogOrganizationID(args.OrganizationID))
 	}
 
 	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, dbtx, args.OrganizationID, false); err != nil {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -29,8 +29,16 @@ import (
 type trialProvisioner struct {
 	*openrouter.Development
 
-	disabled []string
-	failWith error
+	causeAdds            []trialCauseAdd
+	adminLocked          bool
+	upstreamStatePatches int
+	failWith             error
+}
+
+type trialCauseAdd struct {
+	orgID   string
+	keyType openrouter.KeyType
+	cause   openrouter.DisableCause
 }
 
 type recordingTrialNotifier struct {
@@ -52,17 +60,16 @@ func (n *recordingTrialNotifier) TrialInactive(_ context.Context, organizationID
 
 var _ openrouter.Provisioner = (*trialProvisioner)(nil)
 
-func (p *trialProvisioner) DisableAPIKey(_ context.Context, orgID string, keyType openrouter.KeyType) error {
+func (p *trialProvisioner) AddAPIKeyDisableCauseWithDB(_ context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
 	if p.failWith != nil {
-		return p.failWith
+		return openrouter.DisableCauseChange{}, p.failWith
 	}
-	p.disabled = append(p.disabled, orgID+":"+string(keyType))
-
-	return nil
-}
-
-func (p *trialProvisioner) DisableAPIKeyWithDB(ctx context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType) error {
-	return p.DisableAPIKey(ctx, orgID, keyType)
+	p.causeAdds = append(p.causeAdds, trialCauseAdd{orgID: orgID, keyType: keyType, cause: cause})
+	if p.adminLocked {
+		return openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: false}, nil
+	}
+	p.upstreamStatePatches++
+	return openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, nil
 }
 
 type trialTestInstance struct {
@@ -83,7 +90,7 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	conn, err := infra.CloneTestDatabase(t, "trialdemotion")
 	require.NoError(t, err)
 
-	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
+	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), causeAdds: nil, failWith: nil}
 	notifier := &recordingTrialNotifier{inactive: nil}
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
@@ -138,6 +145,21 @@ func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsA
 	return orgID
 }
 
+func TestDemoteExpiredTrials_AddsTrialDemotionToAdminLockedKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	ti.provisioner.adminLocked = true
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	require.ElementsMatch(t, []trialCauseAdd{
+		{orgID: orgID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseTrialDemotion},
+		{orgID: orgID, keyType: openrouter.KeyTypeInternal, cause: openrouter.DisableCauseTrialDemotion},
+	}, ti.provisioner.causeAdds)
+	require.Zero(t, ti.provisioner.upstreamStatePatches, "an admin-locked key must not receive another disabled-state patch")
+}
+
 func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	t.Parallel()
 
@@ -182,7 +204,10 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, trial.DemotedAt.Valid)
 
-	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
+	require.ElementsMatch(t, []trialCauseAdd{
+		{orgID: orgID, keyType: openrouter.KeyTypeChat, cause: openrouter.DisableCauseTrialDemotion},
+		{orgID: orgID, keyType: openrouter.KeyTypeInternal, cause: openrouter.DisableCauseTrialDemotion},
+	}, ti.provisioner.causeAdds)
 	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 	for _, feature := range productfeatures.TrialRuntimeFeatures {
 		enabled, err := ti.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
@@ -262,7 +287,7 @@ func TestDemoteExpiredTrials_DemoteSkipsTrialConvertedAfterListing(t *testing.T)
 	require.NoError(t, err)
 	require.False(t, trial.DemotedAt.Valid)
 
-	require.Empty(t, ti.provisioner.disabled, "a trial that converted keeps its keys")
+	require.Empty(t, ti.provisioner.causeAdds, "a trial that converted keeps its keys")
 	require.Empty(t, ti.notifier.inactive, "a no-op demotion must not publish trial inactivity")
 }
 

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -83,10 +83,6 @@ func (*stubProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrout
 	return 0, openrouter.DisableCauseChange{}, nil
 }
 
-func (p *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
-	return nil
-}
-
 func (p *stubProvisioner) GetCreditsUsed(ctx context.Context, orgID string, keyType openrouter.KeyType) (float64, int, error) {
 	return 0, 0, nil
 }

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -180,20 +180,6 @@ func (s *stubProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db
 	return resultLimit, change, nil
 }
 
-func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
-	s.mu.Lock()
-	s.disableCalls = append(s.disableCalls, orgID+"/"+string(keyType))
-	s.mu.Unlock()
-
-	if err := orgrepo.New(s.conn).DisableOpenRouterAPIKey(ctx, orgrepo.DisableOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(keyType),
-	}); err != nil {
-		return fmt.Errorf("stub disable write: %w", err)
-	}
-	return nil
-}
-
 func (s *stubProvisioner) GetCreditsUsed(ctx context.Context, orgID string, keyType openrouter.KeyType) (float64, int, error) {
 	return 0, 0, nil
 }

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -1,6 +1,7 @@
 package openrouter
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -18,6 +19,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 )
+
+func addAdminLockForTest(provisioner *OpenRouter, ctx context.Context, orgID string, keyType KeyType) error {
+	_, err := provisioner.AddAPIKeyDisableCause(ctx, orgID, keyType, DisableCauseAdminLock)
+	return err
+}
+
+func removeAdminLockForTest(provisioner *OpenRouter, ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error) {
+	refreshed, _, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, keyType, DisableCauseAdminLock, limit)
+	return refreshed, err
+}
 
 type disableTestUpstream struct {
 	server      *httptest.Server
@@ -347,7 +358,7 @@ func TestDevelopmentDisableCauseMethodsAreNoops(t *testing.T) {
 	require.Equal(t, DisableCauseChange{}, change)
 }
 
-func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
+func TestAddAdminLock_DisablesKeyUpstream(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -363,7 +374,7 @@ func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeInternal))
 
 	// The patch carries the off switch and nothing else. Touching the ceiling
 	// would lose the value a reinstatement restores.
@@ -389,7 +400,7 @@ func TestProvisionAPIKey_RefusesDisabledKey(t *testing.T) {
 
 	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
 	require.NoError(t, err)
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeInternal))
 
 	key, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
 	require.ErrorIs(t, err, ErrPlatformKeyDisabled)
@@ -397,7 +408,7 @@ func TestProvisionAPIKey_RefusesDisabledKey(t *testing.T) {
 
 	// Reinstatement makes resolution work again without minting a new key.
 	limit := 42
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	_, err = removeAdminLockForTest(provisioner, ctx, orgID, KeyTypeInternal, &limit)
 	require.NoError(t, err)
 
 	key, err = provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
@@ -407,7 +418,7 @@ func TestProvisionAPIKey_RefusesDisabledKey(t *testing.T) {
 
 // A retried demotion must not fail on a key it already turned off, so
 // disabling twice has to stay safe.
-func TestDisableAPIKey_IsIdempotent(t *testing.T) {
+func TestAddAdminLock_IsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -417,10 +428,10 @@ func TestDisableAPIKey_IsIdempotent(t *testing.T) {
 	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
 	require.NoError(t, err)
 
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeInternal))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeInternal))
 
-	require.Len(t, upstream.recorded(), 2)
+	require.Len(t, upstream.recorded(), 1)
 
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -432,152 +443,15 @@ func TestDisableAPIKey_IsIdempotent(t *testing.T) {
 
 // An organization that never provisioned a key of this type has nothing to
 // lock down, and the sweeper must not fail on it.
-func TestDisableAPIKey_NoKeyIsNoop(t *testing.T) {
+func TestAddAdminLock_NoKeyIsNoop(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	orgID := "org-" + uuid.NewString()[:8]
 	provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
 
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeChat))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeChat))
 	require.Empty(t, upstream.recorded())
-}
-
-// Sales reinstate a demoted organization by raising its limit, so the refresh
-// path has to clear the flag on both sides.
-func TestReinstateAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-	require.NoError(t, err)
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
-
-	limit := 42
-	refreshed, err := provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-	require.Equal(t, 42, refreshed)
-
-	patches := upstream.recorded()
-	require.Len(t, patches, 2)
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":false}`, patches[1],
-		"a limit alone does not bring a disabled key back")
-
-	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.False(t, row.Disabled, "a stale flag keeps key resolution failing after reinstatement")
-	require.Equal(t, int64(42), row.MonthlyCredits)
-
-	// Refreshing an enabled key must send the body it sent before the disabled
-	// field existed. Carrying disabled=false on every refresh would revive a
-	// key an operator turned off on the OpenRouter dashboard.
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-
-	patches = upstream.recorded()
-	require.Len(t, patches, 3)
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
-}
-
-func TestReinstateAPIKeyLimit_RemovesOnlyLegacyAdminLock(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-	require.NoError(t, err)
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
-
-	_, err = queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeInternal),
-		DisableCause:   string(DisableCauseTrialDemotion),
-	})
-	require.NoError(t, err)
-
-	limit := 42
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-
-	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
-	require.True(t, row.Disabled)
-
-	// A retry sees that admin_lock is already gone, preserves the remaining
-	// cause, and reasserts the disabled upstream state.
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-
-	patches := upstream.recorded()
-	require.Len(t, patches, 3)
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[1])
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[2])
-
-	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
-	require.True(t, row.Disabled)
-}
-
-func TestReinstateAPIKeyLimit_RetryDisablesAfterConcurrentCause(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-	require.NoError(t, err)
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
-
-	injected := make(chan error, 1)
-	var injectOnce sync.Once
-	upstream.interceptPatch(func() {
-		injectOnce.Do(func() {
-			_, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
-				OrganizationID: orgID,
-				KeyType:        string(KeyTypeInternal),
-				DisableCause:   string(DisableCauseTrialDemotion),
-			})
-			injected <- err
-		})
-	})
-
-	limit := 42
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-	require.NoError(t, <-injected)
-
-	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
-	require.True(t, row.Disabled)
-
-	_, err = provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.NoError(t, err)
-
-	patches := upstream.recorded()
-	require.Len(t, patches, 3)
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":false}`, patches[1])
-	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":true}`, patches[2])
 }
 
 // A refresh reads the key row, patches upstream, then writes the row back. A
@@ -802,7 +676,7 @@ func TestRefreshAPIKeyLimit_NilPreservesDisabledKeyAfterTierTransition(t *testin
 			raisedCap := 321
 			_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, keyType, &raisedCap)
 			require.NoError(t, err)
-			require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, keyType))
+			require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, keyType))
 			require.NoError(t, provisioner.orgRepo.SetAccountType(ctx, orgRepo.SetAccountTypeParams{
 				ID:              orgID,
 				GramAccountType: string(billing.TierBase),
@@ -895,7 +769,7 @@ func TestRefreshAPIKeyLimit_NilPreservesPaygZeroSpendCap(t *testing.T) {
 	}
 }
 
-func TestReinstateAPIKeyLimit_NilRevivesLegacyZeroChatKey(t *testing.T) {
+func TestRemoveAdminLock_NilRevivesLegacyZeroChatKey(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -909,9 +783,9 @@ func TestReinstateAPIKeyLimit_NilRevivesLegacyZeroChatKey(t *testing.T) {
 		KeyType:        string(KeyTypeChat),
 		MonthlyCredits: 0,
 	}))
-	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeChat))
+	require.NoError(t, addAdminLockForTest(provisioner, ctx, orgID, KeyTypeChat))
 
-	refreshed, err := provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeChat, nil)
+	refreshed, err := removeAdminLockForTest(provisioner, ctx, orgID, KeyTypeChat, nil)
 	require.NoError(t, err)
 	require.Positive(t, refreshed)
 	patches := upstream.recorded()

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -24,7 +24,7 @@ func IsInsufficientCredits(err error) bool {
 }
 
 // ErrPlatformKeyDisabled is returned when an organization's provisioned
-// platform key is locked down (see DisableAPIKey). Key resolution fails on it
+// platform key has one or more disable causes. Key resolution fails on it
 // before the request reaches OpenRouter, so the caller has a reason it can
 // state to the user rather than an ambiguous upstream status.
 var ErrPlatformKeyDisabled = errors.New("openrouter: platform key disabled")

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -30,14 +30,6 @@ func (o *Development) RefreshAPIKeyLimitWithDB(ctx context.Context, db DBTX, org
 	return o.RefreshAPIKeyLimit(ctx, orgID, keyType, limit)
 }
 
-func (o *Development) ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error) {
-	return 0, nil
-}
-
-func (o *Development) ReinstateAPIKeyLimitWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, limit *int) (int, error) {
-	return o.ReinstateAPIKeyLimit(ctx, orgID, keyType, limit)
-}
-
 func (*Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
 	return DisableCauseChange{}, nil
 }
@@ -52,14 +44,6 @@ func (*Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, D
 
 func (o *Development) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
 	return o.RemoveAPIKeyDisableCause(ctx, orgID, keyType, cause, limit)
-}
-
-func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
-	return nil
-}
-
-func (o *Development) DisableAPIKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType) error {
-	return o.DisableAPIKey(ctx, orgID, keyType)
 }
 
 func (o *Development) GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error) {

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -333,9 +333,6 @@ type Provisioner interface {
 	RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
 	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
 
-	// DisableAPIKey is retained temporarily while callers migrate to causes.
-	DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error
-
 	GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error)
 
 	// GetKeyUsage issues GET /v1/key for the given API key and returns the
@@ -567,30 +564,17 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 }
 
 func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error) {
-	return o.refreshAPIKeyLimit(ctx, o.db, orgID, keyType, limit, false)
+	return o.refreshAPIKeyLimit(ctx, o.db, orgID, keyType, limit)
 }
 
 // RefreshAPIKeyLimitWithDB is RefreshAPIKeyLimit using db for every local read
 // and write. Callers holding a session advisory lock must use the same
 // connection rather than acquiring a second pool connection while locked.
 func (o *OpenRouter) RefreshAPIKeyLimitWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, limit *int) (int, error) {
-	return o.refreshAPIKeyLimit(ctx, db, orgID, keyType, limit, false)
+	return o.refreshAPIKeyLimit(ctx, db, orgID, keyType, limit)
 }
 
-// ReinstateAPIKeyLimit refreshes a key while explicitly allowing a disabled
-// key to come back when its caller needs the policy default resolved from nil.
-func (o *OpenRouter) ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error) {
-	return o.refreshAPIKeyLimit(ctx, o.db, orgID, keyType, limit, true)
-}
-
-// ReinstateAPIKeyLimitWithDB is ReinstateAPIKeyLimit using db for every local
-// read and write. Callers holding a session advisory lock must pass that same
-// connection instead of making the pool acquire a second connection.
-func (o *OpenRouter) ReinstateAPIKeyLimitWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, limit *int) (int, error) {
-	return o.refreshAPIKeyLimit(ctx, db, orgID, keyType, limit, true)
-}
-
-func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID string, keyType KeyType, limit *int, reinstate bool) (int, error) {
+func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID string, keyType KeyType, limit *int) (int, error) {
 	keyType = keyType.OrDefault()
 	if err := keyType.Validate(); err != nil {
 		return 0, fmt.Errorf("refresh openrouter key limit: %w", err)
@@ -607,7 +591,7 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 		return 0, fmt.Errorf("failed to get OpenRouter API key: %w", err)
 	}
 
-	if limit == nil && key.Disabled && !reinstate {
+	if limit == nil && key.Disabled {
 		// Generic refreshes must never undo a billing lockdown. An explicit
 		// activation, re-subscription, or platform-admin enable is the only path
 		// allowed to reinstate either platform key.
@@ -618,7 +602,7 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
-	if limit == nil && org.GramAccountType == string(billing.TierPayg) && !reinstate {
+	if limit == nil && org.GramAccountType == string(billing.TierPayg) {
 		// OpenRouter is the authority for a PAYG customer's chosen inference cap
 		// on each materialized platform key. Generic tier refreshes preserve both
 		// the mirrored value and the key's
@@ -635,18 +619,8 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 		keyLimit = o.defaultLimitForOrg(ctx, db, org)
 	}
 
-	removeLegacyAdminLock := reinstate && slices.Contains(key.DisableCauses, string(DisableCauseAdminLock))
-
 	creditLimit := float64(keyLimit)
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
-	if reinstate && key.Disabled {
-		// Reassert the local effective state so a retry repairs an upstream enable
-		// that raced with another cause landing during the prior PATCH.
-		patch.Disabled = new(true)
-		if removeLegacyAdminLock && len(key.DisableCauses) == 1 {
-			patch.Disabled = new(false)
-		}
-	}
 
 	patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
 	defer cancel()
@@ -676,17 +650,6 @@ func (o *OpenRouter) refreshAPIKeyLimit(ctx context.Context, db DBTX, orgID stri
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
-	}
-
-	if removeLegacyAdminLock {
-		_, err = keyRepo.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
-			OrganizationID: orgID,
-			KeyType:        string(keyType),
-			DisableCause:   string(DisableCauseAdminLock),
-		})
-		if err != nil {
-			return 0, oops.E(oops.CodeUnexpected, err, "failed to remove legacy OpenRouter admin lock").LogError(ctx, o.logger)
-		}
 	}
 
 	return keyLimit, nil
@@ -814,60 +777,6 @@ func (o *OpenRouter) removeAPIKeyDisableCause(ctx context.Context, db DBTX, orgI
 	}
 
 	return keyLimit, DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
-}
-
-// DisableAPIKey stops an organization from spending on its platform key. Gram
-// enforces the lockdown itself: ProvisionAPIKey refuses a disabled key and
-// returns ErrPlatformKeyDisabled. The upstream flag covers any spend that never
-// passes through key resolution, such as a key that leaked.
-//
-// The upstream PATCH runs before the local write. The reverse order would
-// record a lockdown that a permanently failing PATCH never made.
-func (o *OpenRouter) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
-	return o.disableAPIKey(ctx, o.db, orgID, keyType)
-}
-
-// DisableAPIKeyWithDB is DisableAPIKey using db for every local read and
-// write. It is used while a caller owns the key's session advisory lock.
-func (o *OpenRouter) DisableAPIKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType) error {
-	return o.disableAPIKey(ctx, db, orgID, keyType)
-}
-
-func (o *OpenRouter) disableAPIKey(ctx context.Context, db DBTX, orgID string, keyType KeyType) error {
-	keyType = keyType.OrDefault()
-	if err := keyType.Validate(); err != nil {
-		return fmt.Errorf("disable openrouter key: %w", err)
-	}
-
-	keyRepo := repo.New(db)
-	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(keyType),
-	})
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		// An organization that never ran a completion has no key of this type.
-		return nil
-	case err != nil:
-		return fmt.Errorf("get openrouter key to disable: %w", err)
-	}
-
-	if _, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, updateKeyRequest{
-		Limit:      nil,
-		LimitReset: "",
-		Disabled:   new(true),
-	}); err != nil {
-		return fmt.Errorf("disable upstream openrouter key: %w", err)
-	}
-
-	if err := keyRepo.DisableOpenRouterAPIKey(ctx, repo.DisableOpenRouterAPIKeyParams{
-		OrganizationID: orgID,
-		KeyType:        string(keyType),
-	}); err != nil {
-		return fmt.Errorf("mark openrouter key disabled: %w", err)
-	}
-
-	return nil
 }
 
 type keyUsageResponse struct {

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -81,10 +81,6 @@ func (m *mockProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ 
 	return m.RemoveAPIKeyDisableCause(ctx, orgID, keyType, cause, limit)
 }
 
-func (m *mockProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
-	return nil
-}
-
 func (m *mockProvisioner) GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error) {
 	return 0, 0, nil
 }

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -180,10 +180,6 @@ func (*recordingOpenRouterProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Co
 	return 0, openrouter.DisableCauseChange{}, nil
 }
 
-func (*recordingOpenRouterProvisioner) DisableAPIKey(context.Context, string, openrouter.KeyType) error {
-	return fmt.Errorf("not implemented")
-}
-
 func (*recordingOpenRouterProvisioner) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
 	return 0, 0, fmt.Errorf("not implemented")
 }

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -110,18 +110,14 @@ func (*m3OpenRouterProvisioner) ProvisionAPIKey(context.Context, string, openrou
 }
 
 func (p *m3OpenRouterProvisioner) RefreshAPIKeyLimit(ctx context.Context, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, p.db, organizationID, keyType, limit)
+	return p.refreshAPIKeyLimit(ctx, p.db, organizationID, keyType, limit)
 }
 
 func (p *m3OpenRouterProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, db, organizationID, keyType, limit)
+	return p.refreshAPIKeyLimit(ctx, db, organizationID, keyType, limit)
 }
 
-func (p *m3OpenRouterProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, db, organizationID, keyType, limit)
-}
-
-func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
+func (p *m3OpenRouterProvisioner) refreshAPIKeyLimit(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
 	key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
 		OrganizationID: organizationID,
 		KeyType:        string(keyType),
@@ -142,39 +138,35 @@ func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db o
 	return int(refreshed.MonthlyCredits), nil
 }
 
-func (*m3OpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (p *m3OpenRouterProvisioner) AddAPIKeyDisableCause(ctx context.Context, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return p.addAPIKeyDisableCause(ctx, p.db, organizationID, keyType, cause)
 }
 
-func (*m3OpenRouterProvisioner) AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (p *m3OpenRouterProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return p.addAPIKeyDisableCause(ctx, db, organizationID, keyType, cause)
 }
 
-func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
-}
-
-func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
-}
-
-func (p *m3OpenRouterProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
-	return p.disableAPIKey(ctx, p.db, organizationID, keyType)
-}
-
-func (p *m3OpenRouterProvisioner) DisableAPIKeyWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType) error {
-	return p.disableAPIKey(ctx, db, organizationID, keyType)
-}
-
-func (p *m3OpenRouterProvisioner) disableAPIKey(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType) error {
+func (p *m3OpenRouterProvisioner) addAPIKeyDisableCause(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
 	p.disableCalls = append(p.disableCalls, keyType)
-	if err := openrouterrepo.New(db).DisableOpenRouterAPIKey(ctx, openrouterrepo.DisableOpenRouterAPIKeyParams{
-		OrganizationID: organizationID,
-		KeyType:        string(keyType),
-	}); err != nil {
-		return fmt.Errorf("disable OpenRouter API key: %w", err)
+	_, err := openrouterrepo.New(db).AddOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(cause)})
+	return openrouter.DisableCauseChange{CauseChanged: err == nil}, err
+}
+
+func (p *m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(ctx context.Context, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	return p.removeAPIKeyDisableCause(ctx, p.db, organizationID, keyType, cause, limit)
+}
+
+func (p *m3OpenRouterProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	return p.removeAPIKeyDisableCause(ctx, db, organizationID, keyType, cause, limit)
+}
+
+func (p *m3OpenRouterProvisioner) removeAPIKeyDisableCause(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	refreshed, err := p.refreshAPIKeyLimit(ctx, db, organizationID, keyType, limit)
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
 	}
-	return nil
+	_, err = openrouterrepo.New(db).RemoveOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.RemoveOpenRouterAPIKeyDisableCauseParams{OrganizationID: organizationID, KeyType: string(keyType), DisableCause: string(cause)})
+	return refreshed, openrouter.DisableCauseChange{CauseChanged: err == nil}, err
 }
 
 func (*m3OpenRouterProvisioner) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
@@ -283,7 +275,7 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	checkout("event_initial_checkout", "subscription_initial", firstAnchor)
 	deleted("event_subscription_loss", "subscription_initial")
 	require.EqualValues(t, 1, metrics.SubscriptionLosses())
-	require.True(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.False(t, keyState(openrouter.KeyTypeChat).Disabled, "billing metadata commits before the durable key wake-up is consumed")
 	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
 
 	reconciler := activities.NewReconcilePaygOpenRouterChatKey(logger, db, provisioner)

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -377,14 +377,6 @@ SET gram_account_type = 'free',
 WHERE id = @organization_id
   AND gram_account_type = 'payg';
 
--- name: DisablePaygOpenRouterChatKey :exec
-UPDATE openrouter_api_keys
-SET disabled = TRUE,
-    updated_at = clock_timestamp()
-WHERE organization_id = @organization_id
-  AND key_type = 'chat'
-  AND deleted IS FALSE;
-
 -- name: CreateStripeBillingMetadataFixture :exec
 -- Test-only fixture for webhook tests that need a Stripe customer association.
 INSERT INTO billing_metadata (organization_id, stripe_customer_id)

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -510,20 +510,6 @@ func (q *Queries) DeactivatePaygOrganization(ctx context.Context, organizationID
 	return result.RowsAffected(), nil
 }
 
-const disablePaygOpenRouterChatKey = `-- name: DisablePaygOpenRouterChatKey :exec
-UPDATE openrouter_api_keys
-SET disabled = TRUE,
-    updated_at = clock_timestamp()
-WHERE organization_id = $1
-  AND key_type = 'chat'
-  AND deleted IS FALSE
-`
-
-func (q *Queries) DisablePaygOpenRouterChatKey(ctx context.Context, organizationID string) error {
-	_, err := q.db.Exec(ctx, disablePaygOpenRouterChatKey, organizationID)
-	return err
-}
-
 const finalizeStripeCheckoutIntent = `-- name: FinalizeStripeCheckoutIntent :one
 WITH locked AS (
   SELECT

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -330,10 +330,6 @@ func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, org
 	if organizationRows != 1 {
 		return stripeWebhookResult{}, fmt.Errorf("deactivate PAYG organization: expected one row, updated %d", organizationRows)
 	}
-	if err := q.DisablePaygOpenRouterChatKey(ctx, organizationID); err != nil {
-		return stripeWebhookResult{}, fmt.Errorf("disable PAYG OpenRouter chat key: %w", err)
-	}
-
 	if s.auditLogger == nil {
 		return stripeWebhookResult{}, errors.New("audit logger is unavailable")
 	}

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1323,7 +1323,7 @@ func TestStripeSubscriptionDeletionDeactivatesCurrentPaygBillingAtomically(t *te
 		KeyType:        string(openrouter.KeyTypeChat),
 	})
 	require.NoError(t, err)
-	require.True(t, chatKey.Disabled)
+	require.False(t, chatKey.Disabled, "the durable reconciliation activity owns billing_inactive")
 	require.EqualValues(t, 321, chatKey.MonthlyCredits)
 	internalKey, err := openrouterrepo.New(db).GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
 		OrganizationID: stripeWebhookOrganizationID,
@@ -1393,7 +1393,7 @@ func TestStripeSubscriptionDeletionDeactivatesUnwhitelistedPaygBilling(t *testin
 		KeyType:        string(openrouter.KeyTypeChat),
 	})
 	require.NoError(t, err)
-	require.True(t, chatKey.Disabled)
+	require.False(t, chatKey.Disabled, "the durable reconciliation activity owns billing_inactive")
 
 	record, err := audittest.LatestAuditLogByAction(t.Context(), db, audit.ActionOrganizationPaygDeactivated)
 	require.NoError(t, err)


### PR DESCRIPTION
## Rationale

AGE-3219 requires trial and billing transitions to manage only their own OpenRouter disable causes, so lifecycle automation cannot clear an independent admin lock or another active cause.

## Scope

- make trial demotion/re-arm and billing reconciliation own only their corresponding causes
- keep upstream-first, retry-safe behavior and consistent lifecycle lock ordering
- update lifecycle queries, activities, webhook handling, and focused regression/integration tests

## Testing

No commits were rewritten for this split. Evidence inherited from the reviewed full stack at `29be69240`: focused server gate (1,063 tests), aggregate server gate (12,996 tests), `mise lint:server`, and repository compile-only check.

## Stack order

1. [Core #5812](https://github.com/speakeasy-api/gram/pull/5812)
2. [Admin API #5813](https://github.com/speakeasy-api/gram/pull/5813)
3. [**Lifecycle #5814 (this PR)**](https://github.com/speakeasy-api/gram/pull/5814) — depends on Admin API
4. [UI / forward compatibility / final lint #5789](https://github.com/speakeasy-api/gram/pull/5789) — depends on this PR

Linear: AGE-3219

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenRouter key lifecycle so trial demotion/re-arm and billing reconciliation only manage their own disable cause, and an admin lock is never silently cleared (AGE-3219). Keys now track `disable_causes` instead of a single boolean; the key is enabled only when the last cause is removed.

**Lifecycle behavior**
- Trial demotion adds `trial_demotion`; re-arm and conversion remove only that cause.
- Billing loss adds `billing_inactive`; recovery removes only that cause.
- Admin lock is preserved across both, and key access changes only when the last cause is removed.
- Trial re-arm now acquires the trial row lock before per-key locks to keep consistent ordering.

<sup>Written for commit f7cfd49a918609c70cb9e253e970634b6d3adc60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


