### PR TITLE
chore: bump Speakeasy CLI to 1.796.1

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.791.1
+speakeasyVersion: 1.796.1
 sources: {}
 targets:
     gram-internal:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -7,7 +7,7 @@ targets:
         source: Hooks-Ingest
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.791.1
+    speakeasyVersion: 1.796.1
     sources:
         Gram-Internal:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.791.1
+speakeasyVersion: 1.796.1
 sources:
     Gram-Internal:
         inputs:

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -2,14 +2,14 @@ lockVersion: 2.0.0
 id: f77ef720-de44-40b6-8dc1-f16f936ef992
 management:
   docVersion: 0.0.1
-  speakeasyVersion: 1.791.1
-  generationVersion: 2.926.2
+  speakeasyVersion: 1.796.1
+  generationVersion: 2.933.0
   releaseVersion: 0.33.8
 features:
   typescript:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.1.14
-    core: 3.31.4
+    core: 3.31.6
     defaultEnabledRetries: 0.1.0
     devContainers: 2.90.1
     downloadStreams: 0.1.1

--- a/client/dashboard/src/sdk/src/lib/config.ts
+++ b/client/dashboard/src/sdk/src/lib/config.ts
@@ -57,6 +57,6 @@ export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "0.0.1",
   sdkVersion: "0.33.8",
-  genVersion: "2.926.2",
-  userAgent: "speakeasy-sdk/typescript 0.33.8 2.926.2 0.0.1 @gram/client",
+  genVersion: "2.933.0",
+  userAgent: "speakeasy-sdk/typescript 0.33.8 2.933.0 0.0.1 @gram/client",
 } as const;

--- a/client/dashboard/src/sdk/src/lib/encodings.ts
+++ b/client/dashboard/src/sdk/src/lib/encodings.ts
@@ -12,10 +12,41 @@ export class EncodingError extends Error {
   }
 }
 
+export type CharEncoding = "percent" | "percentExceptReserved" | "none";
+
+const reservedEscapes = /%(2[346bcf]|3[abdf]|40|5[bd])/gi;
+
+function encodeKeyChars(
+  v: string,
+  charEncoding: CharEncoding | undefined,
+): string {
+  return encodeChars(
+    v,
+    charEncoding === "percentExceptReserved" ? "percent" : charEncoding,
+  );
+}
+
+function encodeChars(
+  v: string,
+  charEncoding: CharEncoding | undefined,
+): string {
+  switch (charEncoding) {
+    case "percent":
+      return encodeURIComponent(v);
+    case "percentExceptReserved":
+      return encodeURIComponent(v).replace(
+        reservedEscapes,
+        (m) => decodeURIComponent(m),
+      );
+    default:
+      return v;
+  }
+}
+
 export function encodeMatrix(
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ): string | undefined {
   let out = "";
   const pairs: [string, unknown][] = options?.explode
@@ -27,7 +58,7 @@ export function encodeMatrix(
   }
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
   const encodeValue = (v: unknown) => encodeString(serializeValue(v));
 
@@ -52,7 +83,7 @@ export function encodeMatrix(
       return;
     }
 
-    const keyPrefix = encodeString(pk);
+    const keyPrefix = encodeKeyChars(pk, options?.charEncoding);
     tmp = `${keyPrefix}=${encValue}`;
     // trim trailing '=' if value was empty
     if (tmp === `${keyPrefix}=`) {
@@ -73,7 +104,7 @@ export function encodeMatrix(
 export function encodeLabel(
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ): string | undefined {
   let out = "";
   const pairs: [string, unknown][] = options?.explode
@@ -85,7 +116,7 @@ export function encodeLabel(
   }
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
   const encodeValue = (v: unknown) => encodeString(serializeValue(v));
 
@@ -103,7 +134,7 @@ export function encodeLabel(
       encValue = mapped?.join("").slice(1);
     } else {
       const k = options?.explode && isPlainObject(value)
-        ? `${encodeString(pk)}=`
+        ? `${encodeKeyChars(pk, options?.charEncoding)}=`
         : "";
       encValue = `${k}${encodeValue(pv)}`;
     }
@@ -117,14 +148,14 @@ export function encodeLabel(
 type FormEncoder = (
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ) => string | undefined;
 
 function formEncoder(sep: string): FormEncoder {
   return (
     key: string,
     value: unknown,
-    options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+    options?: { explode?: boolean; charEncoding?: CharEncoding },
   ) => {
     let out = "";
     const pairs: [string, unknown][] = options?.explode
@@ -136,7 +167,7 @@ function formEncoder(sep: string): FormEncoder {
     }
 
     const encodeString = (v: string) => {
-      return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+      return encodeChars(v, options?.charEncoding);
     };
 
     const encodeValue = (v: unknown) => encodeString(serializeValue(v));
@@ -163,7 +194,7 @@ function formEncoder(sep: string): FormEncoder {
         return;
       }
 
-      tmp = `${encodeString(pk)}=${encValue}`;
+      tmp = `${encodeKeyChars(pk, options?.charEncoding)}=${encValue}`;
 
       // If we end up with the nothing then skip forward
       if (!tmp || tmp === "=") {
@@ -184,7 +215,7 @@ export const encodePipeDelimited = formEncoder("|");
 export function encodeBodyForm(
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ): string {
   let out = "";
   const pairs: [string, unknown][] = options?.explode
@@ -192,7 +223,7 @@ export function encodeBodyForm(
     : [[key, value]];
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
 
   const encodeValue = (v: unknown) => encodeString(serializeValue(v));
@@ -211,7 +242,7 @@ export function encodeBodyForm(
       encValue = `${encodeValue(pv)}`;
     }
 
-    tmp = `${encodeString(pk)}=${encValue}`;
+    tmp = `${encodeKeyChars(pk, options?.charEncoding)}=${encValue}`;
 
     // If we end up with the nothing then skip forward
     if (!tmp || tmp === "=") {
@@ -227,7 +258,7 @@ export function encodeBodyForm(
 export function encodeDeepObject(
   key: string,
   value: unknown,
-  options?: { charEncoding?: "percent" | "none" },
+  options?: { charEncoding?: CharEncoding },
 ): string | undefined {
   if (value == null) {
     return;
@@ -245,7 +276,7 @@ export function encodeDeepObject(
 export function encodeDeepObjectObject(
   key: string,
   value: unknown,
-  options?: { charEncoding?: "percent" | "none" },
+  options?: { charEncoding?: CharEncoding },
 ): string | undefined {
   if (value == null) {
     return;
@@ -254,7 +285,7 @@ export function encodeDeepObjectObject(
   let out = "";
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
 
   if (!isPlainObject(value)) {
@@ -278,7 +309,9 @@ export function encodeDeepObjectObject(
 
     const pairs: unknown[] = Array.isArray(cv) ? cv : [cv];
     const encoded = mapDefined(pairs, (v) => {
-      return `${encodeString(pk)}=${encodeString(serializeValue(v))}`;
+      return `${encodeKeyChars(pk, options?.charEncoding)}=${
+        encodeString(serializeValue(v))
+      }`;
     })?.join("&");
 
     out += encoded == null ? "" : `&${encoded}`;
@@ -290,25 +323,27 @@ export function encodeDeepObjectObject(
 export function encodeJSON(
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ): string | undefined {
   if (typeof value === "undefined") {
     return;
   }
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
 
   const encVal = encodeString(JSON.stringify(value, jsonReplacer));
 
-  return options?.explode ? encVal : `${encodeString(key)}=${encVal}`;
+  return options?.explode
+    ? encVal
+    : `${encodeKeyChars(key, options?.charEncoding)}=${encVal}`;
 }
 
 export const encodeSimple = (
   key: string,
   value: unknown,
-  options?: { explode?: boolean; charEncoding?: "percent" | "none" },
+  options?: { explode?: boolean; charEncoding?: CharEncoding },
 ): string | undefined => {
   let out = "";
   const pairs: [string, unknown][] = options?.explode
@@ -320,7 +355,7 @@ export const encodeSimple = (
   }
 
   const encodeString = (v: string) => {
-    return options?.charEncoding === "percent" ? encodeURIComponent(v) : v;
+    return encodeChars(v, options?.charEncoding);
   };
   const encodeValue = (v: unknown) => encodeString(serializeValue(v));
 
@@ -426,7 +461,7 @@ export function queryJoin(...args: (string | undefined)[]): string {
 
 type QueryEncoderOptions = {
   explode?: boolean;
-  charEncoding?: "percent" | "none";
+  charEncoding?: CharEncoding;
   allowEmptyValue?: string[];
 };
 

--- a/hooks/sdk/.speakeasy/gen.lock
+++ b/hooks/sdk/.speakeasy/gen.lock
@@ -2,17 +2,17 @@ lockVersion: 2.0.0
 id: 89c6b3db-5ce7-4976-841a-59e4c12e08b8
 management:
   docVersion: 0.0.1
-  speakeasyVersion: 1.791.1
-  generationVersion: 2.926.2
+  speakeasyVersion: 1.796.1
+  generationVersion: 2.933.0
   releaseVersion: 0.1.0
 persistentEdits:
-  generation_id: 24194af0-4224-4f48-8d18-b0dd5ff74af0
-  pristine_commit_hash: b4715fcefeb2733ca10c7af186a20f69a01d06be
-  pristine_tree_hash: 5af3c193222af5acdec37bf69b6cc16b4552f551
+  generation_id: 3f1be4df-b7e1-4adf-a5ec-af0a067bddeb
+  pristine_commit_hash: 9f7c01c09a261774fe4936aa36ea8fb300bd7d5b
+  pristine_tree_hash: ec5925ed7ad78ba544c60817fedf566c8f3169b9
 features:
   go:
     additionalDependencies: 0.1.0
-    core: 3.13.47
+    core: 3.13.51
     defaultEnabledRetries: 0.2.0
     envVarSecurityUsage: 0.3.2
     globalSecurity: 2.82.15
@@ -339,8 +339,8 @@ trackedFiles:
     pristine_git_object: 767002c7898128324d8741ce9c534bd466492169
   speakeasyhooks.go:
     id: "362480178789"
-    last_write_checksum: sha1:aefa6147d5fe1b2d6a0d0c9c1b788207e0db1605
-    pristine_git_object: a453a526673062d74f7e84995efc0668b2dae98d
+    last_write_checksum: sha1:ea5aea339360c52fdac398ad32c9fbfdc68666ab
+    pristine_git_object: a099b75031df3bd42ffa47acb9c0534e52641b0d
   types/bigint.go:
     id: 6f911e1a03c3
     last_write_checksum: sha1:49b004005d0461fb04b846eca062b070b0360b31

--- a/hooks/sdk/speakeasyhooks.go
+++ b/hooks/sdk/speakeasyhooks.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 0.0.1 and generator version 2.926.2
+// Generated from OpenAPI doc version 0.0.1 and generator version 2.933.0
 
 import (
 	"context"
@@ -129,7 +129,7 @@ func New(opts ...SDKOption) *SpeakeasyHooks {
 	sdk := &SpeakeasyHooks{
 		SDKVersion: "0.1.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/go 0.1.0 2.926.2 0.0.1 github.com/speakeasy-api/gram/hooks/sdk",
+			UserAgent:  "speakeasy-sdk/go 0.1.0 2.933.0 0.0.1 github.com/speakeasy-api/gram/hooks/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/mise.lock
+++ b/mise.lock
@@ -349,6 +349,7 @@ checksum = "sha256:1b1630c3ae133448a9445911499ab2d59bd77f860abbd595dbc89da4eb82c
 url = "https://github.com/pnpm/pnpm/releases/download/v11.19.0/pnpm-linux-arm64.tar.gz"
 url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/496485122"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:pnpm/pnpm"."platforms.linux-arm64-musl"]
 checksum = "sha256:89309036b565a41e28f970a95c45ae2c448f80cc54c77a309f140e11706dd858"
@@ -426,43 +427,43 @@ url = "https://github.com/speakeasy-api/openapi/releases/download/v1.24.0/openap
 url_api = "https://api.github.com/repos/speakeasy-api/openapi/releases/assets/454075702"
 
 [[tools."github:speakeasy-api/speakeasy"]]
-version = "1.791.1"
+version = "1.796.1"
 backend = "github:speakeasy-api/speakeasy"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-arm64"]
-checksum = "sha256:7ea91ff8e1b4be9d6e28a549b50f68260c39e342a76d63ddc7b7123033ac7915"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_linux_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964320"
+checksum = "sha256:35255f34b8c5566b84ad401db660a1f5a6528258fcf4ff68b7a6fe49fdaa7845"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_linux_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553189"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-arm64-musl"]
-checksum = "sha256:7ea91ff8e1b4be9d6e28a549b50f68260c39e342a76d63ddc7b7123033ac7915"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_linux_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964320"
+checksum = "sha256:35255f34b8c5566b84ad401db660a1f5a6528258fcf4ff68b7a6fe49fdaa7845"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_linux_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553189"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-x64"]
-checksum = "sha256:486274fde3a058fdab9eb3d73dee7322f10b80ad6cd25d8aba91cb30da507f72"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_linux_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964319"
+checksum = "sha256:9e96748587b119ec53e7f8bf5b8efb4155477e1462e935e5236c974d34d5ffc9"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_linux_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553191"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.linux-x64-musl"]
-checksum = "sha256:486274fde3a058fdab9eb3d73dee7322f10b80ad6cd25d8aba91cb30da507f72"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_linux_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964319"
+checksum = "sha256:9e96748587b119ec53e7f8bf5b8efb4155477e1462e935e5236c974d34d5ffc9"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_linux_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553191"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.macos-arm64"]
-checksum = "sha256:9a4eae23e2461923be661a1755de32f576c311a6fd28696e807fe8f5ec198267"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_darwin_arm64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964316"
+checksum = "sha256:77194aa6803c83fb8da6a45f5197cd3f05927a9817d9edcb1c6490a176f3e2f4"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_darwin_arm64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553185"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.macos-x64"]
-checksum = "sha256:e9924b866a4bb375ea006d41e2a77cdefd2c989a5ca44d63aea134e6feca1106"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_darwin_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964321"
+checksum = "sha256:0ac8d33aff5a410122cfcd2032ea2daefac732528b05c37af886bb1a5f7653d1"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_darwin_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553194"
 
 [tools."github:speakeasy-api/speakeasy"."platforms.windows-x64"]
-checksum = "sha256:beb7227ca3218ce43d2b2f7a833ca26144bccb65a27f1951c9d156db8076e0cf"
-url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.791.1/speakeasy_windows_amd64.zip"
-url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/499964323"
+checksum = "sha256:ad5d94f98bc8d87b1ace175a663bf146aebdcd9721e775d8fbf860f9b94a5675"
+url = "https://github.com/speakeasy-api/speakeasy/releases/download/v1.796.1/speakeasy_windows_amd64.zip"
+url_api = "https://api.github.com/repos/speakeasy-api/speakeasy/releases/assets/532553193"
 
 [[tools."github:sqlc-dev/sqlc"]]
 version = "1.31.1"

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ pin = true
 "github:speakeasy-api/openapi" = "1.24.0"
 # Keep in sync with speakeasyVersion in .speakeasy/workflow.yaml, otherwise the
 # installed version and the version generation runs on can mismatch.
-"github:speakeasy-api/speakeasy" = "1.791.1"
+"github:speakeasy-api/speakeasy" = "1.796.1"
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.2.31"
 flyctl = "0.4.77"


### PR DESCRIPTION
## Summary

- Bump the pinned Speakeasy CLI from 1.791.1 to 1.796.1 and refresh the mise and generation locks.
- Regenerate the TypeScript and Go SDK metadata and output, including the updated TypeScript character-encoding behavior.

## Motivation

Keep local and CI generation on the same current CLI version, with committed generated output and lock metadata preventing generator drift.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the pinned Speakeasy CLI from 1.791.1 to 1.796.1 and regenerates the TypeScript and Go SDKs so local and CI generation stay in sync. The TypeScript SDK gains a new `percentExceptReserved` character-encoding mode and now encodes keys separately from values.

- Updates `mise.toml`, `mise.lock`, and both `.speakeasy` lock files.
- Regenerates the TypeScript `encodings.ts` logic and the Go/TypeScript generation metadata.

<sup>Written for commit b54a7d47dddc54d82d567151ba013033b7b28096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

