### PR TITLE
feat: support manual enterprise trial conversion (AGE-3131)

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -72323,6 +72323,15 @@ components:
         - coverage_bucket
         - first_seen_at
         - last_seen_at
+    MarkEnterpriseTrialConvertedRequestBody:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
     MarkRiskResultsFalsePositiveRequestBody:
       type: object
       properties:

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -98,6 +98,7 @@ export const AUDIT_ACTIONS = [
   "openrouter-key:set_spend_cap",
   "organization:device_agent_configuration_updated",
   "organization:enterprise_trial_armed",
+  "organization:enterprise_trial_converted",
   "organization:enterprise_trial_demoted",
   "organization:enterprise_trial_extended",
   "organization:enterprise_trial_rearmed",
@@ -445,6 +446,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "updated device agent configuration";
     case "organization:enterprise_trial_armed":
       return "started enterprise trial";
+    case "organization:enterprise_trial_converted":
+      return "converted enterprise trial";
     case "organization:enterprise_trial_demoted":
       return "ended enterprise trial";
     case "organization:enterprise_trial_extended":

--- a/docs/superpowers/plans/2026-08-27-age-3131-manual-enterprise-trial-conversion.md
+++ b/docs/superpowers/plans/2026-08-27-age-3131-manual-enterprise-trial-conversion.md
@@ -1,0 +1,56 @@
+# AGE-3131 Manual Enterprise Trial Conversion Plan
+
+**Goal:** Add a dedicated admin transition that records an enterprise contract conversion, safely restores trial-demoted access, and remains retry-safe.
+
+**Constraints:** Strict TDD. Dedicated endpoint; organization ID only; authenticated admin actor. Eligible running, ending-soon, expired, demoted. Preserve `ends_at`, historical `demoted_at`, and organization `disabled_at`. Server assigns `converted_at`. No trial/PAYG return 409; missing org 404. Upstream key work precedes conversion/admission commit and removes only `trial_demotion`. Already converted succeeds without duplicate audit but always retries post-commit `TrialInactive`. Audit action `organization:enterprise_trial_converted`; source `admin`, while Stripe uses `stripe_checkout`.
+
+## Task 1: Shared conversion audit and Stripe attribution
+
+**Files:** `server/internal/audit/organizations.go`, `server/internal/outbox/events/audit_log.go`, `server/internal/usage/stripe_webhook.go`, focused usage tests.
+
+- Add failing tests proving first Stripe conversion writes one enterprise-trial-converted audit/outbox event with `conversion_source=stripe_checkout`; replay writes none; audit failure rolls back conversion/PAYG activation.
+- Add the shared action/logger and make Stripe use `MarkTrialConverted` row count to gate the event in its existing transaction.
+- Run focused then full usage/audit tests.
+- Commit `feat: audit enterprise trial conversions`.
+
+## Task 2: Dedicated admin conversion endpoint and transaction
+
+**Files:** `server/design/admin/design.go`, `server/internal/trials/queries.sql`, generated Goa/SQLc, `server/internal/admin/impl.go`, setup/tests, new `server/internal/admin/converttrial_test.go`.
+
+- Add failing endpoint/service tests for running, ending-soon, expired, demoted, already converted, missing org, no trial, PAYG, disabled organization, and updateOrganization non-conversion.
+- Add `markEnterpriseTrialConverted`: admin auth, required organization `id`, `POST /admin/trial.convert`, `AdminOrganization` result.
+- Add SQL that locks the trial first, assigns `converted_at` with `clock_timestamp()`, preserves `ends_at`/`demoted_at`, and distinguishes eligibility/idempotency/conflicts.
+- Generate with `mise run gen:sqlc-server` and `mise run gen:goa-server`; never hand-edit generated files.
+- Implement global order: trial row lock → deterministic chat/internal billing locks → required OpenRouter work → organization/features/audit writes → commit.
+- Apply enterprise limits to every `openrouter.AllKeyTypes` key and remove only `DisableCauseTrialDemotion`; preserve other causes and missing-key no-ops.
+- Restore demoted account/admission/features without clearing `disabled_at`. Active/expired enterprise conversions avoid unnecessary restoration.
+- Write one admin-actor audit/outbox event with `conversion_source=admin` in the transaction.
+- After commit, recap legacy zero-limit keys, refresh caches, and call `TrialInactive`. Already-converted retries skip mutation/audit but still call `TrialInactive`; notifier failures do not undo success.
+- Run focused and full admin/trials/OpenRouter tests.
+- Commit `feat: convert enterprise trials manually`.
+
+## Task 3: Concurrency, retry, and lifecycle regressions
+
+**Files:** admin conversion tests plus relevant demotion, trial-email, audit, and OpenRouter tests.
+
+- Add deterministic bounded tests proving conversion serializes against demotion using trial-row-before-key-lock ordering.
+- Prove upstream failure commits no converted/admitted state; retries converge after partial upstream work.
+- Prove composed causes preserve admin/billing locks and effective disable state.
+- Prove repeated converted calls re-enqueue `TrialInactive` but never duplicate conversion audit.
+- Prove converted trials cannot be demoted or re-armed.
+- Run full admin, usage, background activities, background, trialemails, audit, trials, and OpenRouter suites.
+- Commit `test: cover enterprise trial conversion races` if separate changes are required.
+
+## Task 4: Verification and PR stack
+
+- Run `mise lint:server` and repository compile-only check.
+- Run generated checks and confirm no schema migration is introduced.
+- Run focused/aggregate server tests and inspect audit payloads for key/customer-data leakage.
+- Rebase the remaining stack branches, run post-rebase checks, request final branch review, then push/update stacked PRs without bypassing safeguards.
+
+## Routine rulings
+
+- Already-converted success applies only to non-PAYG trial conversions; PAYG remains a conflict for this endpoint.
+- Audit/outbox is transactional; `TrialInactive` is strictly post-commit and repeatable.
+- Explicit enterprise limits are supplied during pre-commit key work; any legacy zero-limit policy recap happens after commit.
+- No conversion reversal, no inference from account-type edits, and no customer-facing API change.

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -356,6 +356,28 @@ var _ = Service("admin", func() {
 		Meta("openapi:operationId", "adminUpdateOrganization")
 	})
 
+	Method("markEnterpriseTrialConverted", func() {
+		Description("Records that an organization's enterprise trial converted to a signed contract.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id")
+
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/trial.convert")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminMarkEnterpriseTrialConverted")
+	})
+
 	Method("bulkUpdateAccountType", func() {
 		Description("Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.")
 

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -15,59 +15,61 @@ import (
 
 // Client is the "admin" service client.
 type Client struct {
-	LoginEndpoint                       goa.Endpoint
-	CallbackEndpoint                    goa.Endpoint
-	LogoutEndpoint                      goa.Endpoint
-	GetProjectEndpoint                  goa.Endpoint
-	UpdateOrganizationEndpoint          goa.Endpoint
-	BulkUpdateAccountTypeEndpoint       goa.Endpoint
-	DisableOrganizationEndpoint         goa.Endpoint
-	EnableOrganizationEndpoint          goa.Endpoint
-	GetOrganizationEndpoint             goa.Endpoint
-	ListOrganizationMembersEndpoint     goa.Endpoint
-	ListOrganizationProjectsEndpoint    goa.Endpoint
-	ListOrganizationActivityEndpoint    goa.Endpoint
-	ListOrganizationsEndpoint           goa.Endpoint
-	ExtendTrialEndpoint                 goa.Endpoint
-	CreateOrganizationEndpoint          goa.Endpoint
-	RearmTrialEndpoint                  goa.Endpoint
-	GetOrganizationStatsEndpoint        goa.Endpoint
-	GetInferenceKeysEndpoint            goa.Endpoint
-	SetInferenceKeyMonthlyLimitEndpoint goa.Endpoint
-	GetInferenceSpendHistoryEndpoint    goa.Endpoint
-	GetPaygBillingSummaryEndpoint       goa.Endpoint
-	GetStripeSubscriptionEndpoint       goa.Endpoint
-	CancelStripeSubscriptionEndpoint    goa.Endpoint
-	ResumeStripeSubscriptionEndpoint    goa.Endpoint
+	LoginEndpoint                        goa.Endpoint
+	CallbackEndpoint                     goa.Endpoint
+	LogoutEndpoint                       goa.Endpoint
+	GetProjectEndpoint                   goa.Endpoint
+	UpdateOrganizationEndpoint           goa.Endpoint
+	MarkEnterpriseTrialConvertedEndpoint goa.Endpoint
+	BulkUpdateAccountTypeEndpoint        goa.Endpoint
+	DisableOrganizationEndpoint          goa.Endpoint
+	EnableOrganizationEndpoint           goa.Endpoint
+	GetOrganizationEndpoint              goa.Endpoint
+	ListOrganizationMembersEndpoint      goa.Endpoint
+	ListOrganizationProjectsEndpoint     goa.Endpoint
+	ListOrganizationActivityEndpoint     goa.Endpoint
+	ListOrganizationsEndpoint            goa.Endpoint
+	ExtendTrialEndpoint                  goa.Endpoint
+	CreateOrganizationEndpoint           goa.Endpoint
+	RearmTrialEndpoint                   goa.Endpoint
+	GetOrganizationStatsEndpoint         goa.Endpoint
+	GetInferenceKeysEndpoint             goa.Endpoint
+	SetInferenceKeyMonthlyLimitEndpoint  goa.Endpoint
+	GetInferenceSpendHistoryEndpoint     goa.Endpoint
+	GetPaygBillingSummaryEndpoint        goa.Endpoint
+	GetStripeSubscriptionEndpoint        goa.Endpoint
+	CancelStripeSubscriptionEndpoint     goa.Endpoint
+	ResumeStripeSubscriptionEndpoint     goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizationActivity, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, setInferenceKeyMonthlyLimit, getInferenceSpendHistory, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, markEnterpriseTrialConverted, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizationActivity, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, setInferenceKeyMonthlyLimit, getInferenceSpendHistory, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
 	return &Client{
-		LoginEndpoint:                       login,
-		CallbackEndpoint:                    callback,
-		LogoutEndpoint:                      logout,
-		GetProjectEndpoint:                  getProject,
-		UpdateOrganizationEndpoint:          updateOrganization,
-		BulkUpdateAccountTypeEndpoint:       bulkUpdateAccountType,
-		DisableOrganizationEndpoint:         disableOrganization,
-		EnableOrganizationEndpoint:          enableOrganization,
-		GetOrganizationEndpoint:             getOrganization,
-		ListOrganizationMembersEndpoint:     listOrganizationMembers,
-		ListOrganizationProjectsEndpoint:    listOrganizationProjects,
-		ListOrganizationActivityEndpoint:    listOrganizationActivity,
-		ListOrganizationsEndpoint:           listOrganizations,
-		ExtendTrialEndpoint:                 extendTrial,
-		CreateOrganizationEndpoint:          createOrganization,
-		RearmTrialEndpoint:                  rearmTrial,
-		GetOrganizationStatsEndpoint:        getOrganizationStats,
-		GetInferenceKeysEndpoint:            getInferenceKeys,
-		SetInferenceKeyMonthlyLimitEndpoint: setInferenceKeyMonthlyLimit,
-		GetInferenceSpendHistoryEndpoint:    getInferenceSpendHistory,
-		GetPaygBillingSummaryEndpoint:       getPaygBillingSummary,
-		GetStripeSubscriptionEndpoint:       getStripeSubscription,
-		CancelStripeSubscriptionEndpoint:    cancelStripeSubscription,
-		ResumeStripeSubscriptionEndpoint:    resumeStripeSubscription,
+		LoginEndpoint:                        login,
+		CallbackEndpoint:                     callback,
+		LogoutEndpoint:                       logout,
+		GetProjectEndpoint:                   getProject,
+		UpdateOrganizationEndpoint:           updateOrganization,
+		MarkEnterpriseTrialConvertedEndpoint: markEnterpriseTrialConverted,
+		BulkUpdateAccountTypeEndpoint:        bulkUpdateAccountType,
+		DisableOrganizationEndpoint:          disableOrganization,
+		EnableOrganizationEndpoint:           enableOrganization,
+		GetOrganizationEndpoint:              getOrganization,
+		ListOrganizationMembersEndpoint:      listOrganizationMembers,
+		ListOrganizationProjectsEndpoint:     listOrganizationProjects,
+		ListOrganizationActivityEndpoint:     listOrganizationActivity,
+		ListOrganizationsEndpoint:            listOrganizations,
+		ExtendTrialEndpoint:                  extendTrial,
+		CreateOrganizationEndpoint:           createOrganization,
+		RearmTrialEndpoint:                   rearmTrial,
+		GetOrganizationStatsEndpoint:         getOrganizationStats,
+		GetInferenceKeysEndpoint:             getInferenceKeys,
+		SetInferenceKeyMonthlyLimitEndpoint:  setInferenceKeyMonthlyLimit,
+		GetInferenceSpendHistoryEndpoint:     getInferenceSpendHistory,
+		GetPaygBillingSummaryEndpoint:        getPaygBillingSummary,
+		GetStripeSubscriptionEndpoint:        getStripeSubscription,
+		CancelStripeSubscriptionEndpoint:     cancelStripeSubscription,
+		ResumeStripeSubscriptionEndpoint:     resumeStripeSubscription,
 	}
 }
 
@@ -172,6 +174,29 @@ func (c *Client) GetProject(ctx context.Context, p *GetProjectPayload) (res *Adm
 func (c *Client) UpdateOrganization(ctx context.Context, p *UpdateOrganizationPayload) (res *AdminOrganization, err error) {
 	var ires any
 	ires, err = c.UpdateOrganizationEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
+}
+
+// MarkEnterpriseTrialConverted calls the "markEnterpriseTrialConverted"
+// endpoint of the "admin" service.
+// MarkEnterpriseTrialConverted may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) MarkEnterpriseTrialConverted(ctx context.Context, p *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.MarkEnterpriseTrialConvertedEndpoint(ctx, p)
 	if err != nil {
 		return
 	}

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -16,30 +16,31 @@ import (
 
 // Endpoints wraps the "admin" service endpoints.
 type Endpoints struct {
-	Login                       goa.Endpoint
-	Callback                    goa.Endpoint
-	Logout                      goa.Endpoint
-	GetProject                  goa.Endpoint
-	UpdateOrganization          goa.Endpoint
-	BulkUpdateAccountType       goa.Endpoint
-	DisableOrganization         goa.Endpoint
-	EnableOrganization          goa.Endpoint
-	GetOrganization             goa.Endpoint
-	ListOrganizationMembers     goa.Endpoint
-	ListOrganizationProjects    goa.Endpoint
-	ListOrganizationActivity    goa.Endpoint
-	ListOrganizations           goa.Endpoint
-	ExtendTrial                 goa.Endpoint
-	CreateOrganization          goa.Endpoint
-	RearmTrial                  goa.Endpoint
-	GetOrganizationStats        goa.Endpoint
-	GetInferenceKeys            goa.Endpoint
-	SetInferenceKeyMonthlyLimit goa.Endpoint
-	GetInferenceSpendHistory    goa.Endpoint
-	GetPaygBillingSummary       goa.Endpoint
-	GetStripeSubscription       goa.Endpoint
-	CancelStripeSubscription    goa.Endpoint
-	ResumeStripeSubscription    goa.Endpoint
+	Login                        goa.Endpoint
+	Callback                     goa.Endpoint
+	Logout                       goa.Endpoint
+	GetProject                   goa.Endpoint
+	UpdateOrganization           goa.Endpoint
+	MarkEnterpriseTrialConverted goa.Endpoint
+	BulkUpdateAccountType        goa.Endpoint
+	DisableOrganization          goa.Endpoint
+	EnableOrganization           goa.Endpoint
+	GetOrganization              goa.Endpoint
+	ListOrganizationMembers      goa.Endpoint
+	ListOrganizationProjects     goa.Endpoint
+	ListOrganizationActivity     goa.Endpoint
+	ListOrganizations            goa.Endpoint
+	ExtendTrial                  goa.Endpoint
+	CreateOrganization           goa.Endpoint
+	RearmTrial                   goa.Endpoint
+	GetOrganizationStats         goa.Endpoint
+	GetInferenceKeys             goa.Endpoint
+	SetInferenceKeyMonthlyLimit  goa.Endpoint
+	GetInferenceSpendHistory     goa.Endpoint
+	GetPaygBillingSummary        goa.Endpoint
+	GetStripeSubscription        goa.Endpoint
+	CancelStripeSubscription     goa.Endpoint
+	ResumeStripeSubscription     goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -47,30 +48,31 @@ func NewEndpoints(s Service) *Endpoints {
 	// Casting service to Auther interface
 	a := s.(Auther)
 	return &Endpoints{
-		Login:                       NewLoginEndpoint(s),
-		Callback:                    NewCallbackEndpoint(s),
-		Logout:                      NewLogoutEndpoint(s),
-		GetProject:                  NewGetProjectEndpoint(s, a.APIKeyAuth),
-		UpdateOrganization:          NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
-		BulkUpdateAccountType:       NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
-		DisableOrganization:         NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
-		EnableOrganization:          NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
-		GetOrganization:             NewGetOrganizationEndpoint(s, a.APIKeyAuth),
-		ListOrganizationMembers:     NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
-		ListOrganizationProjects:    NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
-		ListOrganizationActivity:    NewListOrganizationActivityEndpoint(s, a.APIKeyAuth),
-		ListOrganizations:           NewListOrganizationsEndpoint(s, a.APIKeyAuth),
-		ExtendTrial:                 NewExtendTrialEndpoint(s, a.APIKeyAuth),
-		CreateOrganization:          NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
-		RearmTrial:                  NewRearmTrialEndpoint(s, a.APIKeyAuth),
-		GetOrganizationStats:        NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
-		GetInferenceKeys:            NewGetInferenceKeysEndpoint(s, a.APIKeyAuth),
-		SetInferenceKeyMonthlyLimit: NewSetInferenceKeyMonthlyLimitEndpoint(s, a.APIKeyAuth),
-		GetInferenceSpendHistory:    NewGetInferenceSpendHistoryEndpoint(s, a.APIKeyAuth),
-		GetPaygBillingSummary:       NewGetPaygBillingSummaryEndpoint(s, a.APIKeyAuth),
-		GetStripeSubscription:       NewGetStripeSubscriptionEndpoint(s, a.APIKeyAuth),
-		CancelStripeSubscription:    NewCancelStripeSubscriptionEndpoint(s, a.APIKeyAuth),
-		ResumeStripeSubscription:    NewResumeStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		Login:                        NewLoginEndpoint(s),
+		Callback:                     NewCallbackEndpoint(s),
+		Logout:                       NewLogoutEndpoint(s),
+		GetProject:                   NewGetProjectEndpoint(s, a.APIKeyAuth),
+		UpdateOrganization:           NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
+		MarkEnterpriseTrialConverted: NewMarkEnterpriseTrialConvertedEndpoint(s, a.APIKeyAuth),
+		BulkUpdateAccountType:        NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
+		DisableOrganization:          NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
+		EnableOrganization:           NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
+		GetOrganization:              NewGetOrganizationEndpoint(s, a.APIKeyAuth),
+		ListOrganizationMembers:      NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
+		ListOrganizationProjects:     NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
+		ListOrganizationActivity:     NewListOrganizationActivityEndpoint(s, a.APIKeyAuth),
+		ListOrganizations:            NewListOrganizationsEndpoint(s, a.APIKeyAuth),
+		ExtendTrial:                  NewExtendTrialEndpoint(s, a.APIKeyAuth),
+		CreateOrganization:           NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
+		RearmTrial:                   NewRearmTrialEndpoint(s, a.APIKeyAuth),
+		GetOrganizationStats:         NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
+		GetInferenceKeys:             NewGetInferenceKeysEndpoint(s, a.APIKeyAuth),
+		SetInferenceKeyMonthlyLimit:  NewSetInferenceKeyMonthlyLimitEndpoint(s, a.APIKeyAuth),
+		GetInferenceSpendHistory:     NewGetInferenceSpendHistoryEndpoint(s, a.APIKeyAuth),
+		GetPaygBillingSummary:        NewGetPaygBillingSummaryEndpoint(s, a.APIKeyAuth),
+		GetStripeSubscription:        NewGetStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		CancelStripeSubscription:     NewCancelStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		ResumeStripeSubscription:     NewResumeStripeSubscriptionEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -81,6 +83,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.Logout = m(e.Logout)
 	e.GetProject = m(e.GetProject)
 	e.UpdateOrganization = m(e.UpdateOrganization)
+	e.MarkEnterpriseTrialConverted = m(e.MarkEnterpriseTrialConverted)
 	e.BulkUpdateAccountType = m(e.BulkUpdateAccountType)
 	e.DisableOrganization = m(e.DisableOrganization)
 	e.EnableOrganization = m(e.EnableOrganization)
@@ -172,6 +175,29 @@ func NewUpdateOrganizationEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFu
 			return nil, err
 		}
 		return s.UpdateOrganization(ctx, p)
+	}
+}
+
+// NewMarkEnterpriseTrialConvertedEndpoint returns an endpoint function that
+// calls the method "markEnterpriseTrialConverted" of service "admin".
+func NewMarkEnterpriseTrialConvertedEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*MarkEnterpriseTrialConvertedPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.MarkEnterpriseTrialConverted(ctx, p)
 	}
 }
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -29,6 +29,9 @@ type Service interface {
 	// Updates admin-managed fields on an organization. At least one of
 	// account_type or whitelisted must be supplied.
 	UpdateOrganization(context.Context, *UpdateOrganizationPayload) (res *AdminOrganization, err error)
+	// Records that an organization's enterprise trial converted to a signed
+	// contract.
+	MarkEnterpriseTrialConverted(context.Context, *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error)
 	// Sets one account type on many organizations in a single statement. An ID
 	// that matches no organization is reported back rather than failing the batch,
 	// so a stale ID costs the operator that row and not the whole call.
@@ -109,7 +112,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [24]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizationActivity", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "setInferenceKeyMonthlyLimit", "getInferenceSpendHistory", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
+var MethodNames = [25]string{"login", "callback", "logout", "getProject", "updateOrganization", "markEnterpriseTrialConverted", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizationActivity", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "setInferenceKeyMonthlyLimit", "getInferenceSpendHistory", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
 
 // AdminBulkUpdateAccountTypeResult is the result type of the admin service
 // bulkUpdateAccountType method.
@@ -575,6 +578,14 @@ type LoginResult struct {
 type LogoutPayload struct {
 	// The session cookie value to clear for logging out
 	SessionID *string
+}
+
+// MarkEnterpriseTrialConvertedPayload is the payload type of the admin service
+// markEnterpriseTrialConverted method.
+type MarkEnterpriseTrialConvertedPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
 }
 
 // RearmTrialPayload is the payload type of the admin service rearmTrial method.

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -157,6 +157,37 @@ func BuildUpdateOrganizationPayload(adminUpdateOrganizationBody string, adminUpd
 	return v, nil
 }
 
+// BuildMarkEnterpriseTrialConvertedPayload builds the payload for the admin
+// markEnterpriseTrialConverted endpoint from CLI flags.
+func BuildMarkEnterpriseTrialConvertedPayload(adminMarkEnterpriseTrialConvertedBody string, adminMarkEnterpriseTrialConvertedAdminSessionToken string) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+	var err error
+	var body MarkEnterpriseTrialConvertedRequestBody
+	{
+		err = json.Unmarshal([]byte(adminMarkEnterpriseTrialConvertedBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminMarkEnterpriseTrialConvertedAdminSessionToken != "" {
+			adminSessionToken = &adminMarkEnterpriseTrialConvertedAdminSessionToken
+		}
+	}
+	v := &admin.MarkEnterpriseTrialConvertedPayload{
+		ID: body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}
+
 // BuildBulkUpdateAccountTypePayload builds the payload for the admin
 // bulkUpdateAccountType endpoint from CLI flags.
 func BuildBulkUpdateAccountTypePayload(adminBulkUpdateAccountTypeBody string, adminBulkUpdateAccountTypeAdminSessionToken string) (*admin.BulkUpdateAccountTypePayload, error) {

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -35,6 +35,10 @@ type Client struct {
 	// updateOrganization endpoint.
 	UpdateOrganizationDoer goahttp.Doer
 
+	// MarkEnterpriseTrialConverted Doer is the HTTP client used to make requests
+	// to the markEnterpriseTrialConverted endpoint.
+	MarkEnterpriseTrialConvertedDoer goahttp.Doer
+
 	// BulkUpdateAccountType Doer is the HTTP client used to make requests to the
 	// bulkUpdateAccountType endpoint.
 	BulkUpdateAccountTypeDoer goahttp.Doer
@@ -131,35 +135,36 @@ func NewClient(
 	restoreBody bool,
 ) *Client {
 	return &Client{
-		LoginDoer:                       doer,
-		CallbackDoer:                    doer,
-		LogoutDoer:                      doer,
-		GetProjectDoer:                  doer,
-		UpdateOrganizationDoer:          doer,
-		BulkUpdateAccountTypeDoer:       doer,
-		DisableOrganizationDoer:         doer,
-		EnableOrganizationDoer:          doer,
-		GetOrganizationDoer:             doer,
-		ListOrganizationMembersDoer:     doer,
-		ListOrganizationProjectsDoer:    doer,
-		ListOrganizationActivityDoer:    doer,
-		ListOrganizationsDoer:           doer,
-		ExtendTrialDoer:                 doer,
-		CreateOrganizationDoer:          doer,
-		RearmTrialDoer:                  doer,
-		GetOrganizationStatsDoer:        doer,
-		GetInferenceKeysDoer:            doer,
-		SetInferenceKeyMonthlyLimitDoer: doer,
-		GetInferenceSpendHistoryDoer:    doer,
-		GetPaygBillingSummaryDoer:       doer,
-		GetStripeSubscriptionDoer:       doer,
-		CancelStripeSubscriptionDoer:    doer,
-		ResumeStripeSubscriptionDoer:    doer,
-		RestoreResponseBody:             restoreBody,
-		scheme:                          scheme,
-		host:                            host,
-		decoder:                         dec,
-		encoder:                         enc,
+		LoginDoer:                        doer,
+		CallbackDoer:                     doer,
+		LogoutDoer:                       doer,
+		GetProjectDoer:                   doer,
+		UpdateOrganizationDoer:           doer,
+		MarkEnterpriseTrialConvertedDoer: doer,
+		BulkUpdateAccountTypeDoer:        doer,
+		DisableOrganizationDoer:          doer,
+		EnableOrganizationDoer:           doer,
+		GetOrganizationDoer:              doer,
+		ListOrganizationMembersDoer:      doer,
+		ListOrganizationProjectsDoer:     doer,
+		ListOrganizationActivityDoer:     doer,
+		ListOrganizationsDoer:            doer,
+		ExtendTrialDoer:                  doer,
+		CreateOrganizationDoer:           doer,
+		RearmTrialDoer:                   doer,
+		GetOrganizationStatsDoer:         doer,
+		GetInferenceKeysDoer:             doer,
+		SetInferenceKeyMonthlyLimitDoer:  doer,
+		GetInferenceSpendHistoryDoer:     doer,
+		GetPaygBillingSummaryDoer:        doer,
+		GetStripeSubscriptionDoer:        doer,
+		CancelStripeSubscriptionDoer:     doer,
+		ResumeStripeSubscriptionDoer:     doer,
+		RestoreResponseBody:              restoreBody,
+		scheme:                           scheme,
+		host:                             host,
+		decoder:                          dec,
+		encoder:                          enc,
 	}
 }
 
@@ -278,6 +283,30 @@ func (c *Client) UpdateOrganization() goa.Endpoint {
 		resp, err := c.UpdateOrganizationDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "updateOrganization", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// MarkEnterpriseTrialConverted returns an endpoint that makes HTTP requests to
+// the admin service markEnterpriseTrialConverted server.
+func (c *Client) MarkEnterpriseTrialConverted() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeMarkEnterpriseTrialConvertedRequest(c.encoder)
+		decodeResponse = DecodeMarkEnterpriseTrialConvertedResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildMarkEnterpriseTrialConvertedRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.MarkEnterpriseTrialConvertedDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "markEnterpriseTrialConverted", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -1221,6 +1221,241 @@ func DecodeUpdateOrganizationResponse(decoder func(*http.Response) goahttp.Decod
 	}
 }
 
+// BuildMarkEnterpriseTrialConvertedRequest instantiates a HTTP request object
+// with method and path set to call the "admin" service
+// "markEnterpriseTrialConverted" endpoint
+func (c *Client) BuildMarkEnterpriseTrialConvertedRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: MarkEnterpriseTrialConvertedAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "markEnterpriseTrialConverted", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeMarkEnterpriseTrialConvertedRequest returns an encoder for requests
+// sent to the admin markEnterpriseTrialConverted server.
+func EncodeMarkEnterpriseTrialConvertedRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.MarkEnterpriseTrialConvertedPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "markEnterpriseTrialConverted", "*admin.MarkEnterpriseTrialConvertedPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewMarkEnterpriseTrialConvertedRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "markEnterpriseTrialConverted", err)
+		}
+		return nil
+	}
+}
+
+// DecodeMarkEnterpriseTrialConvertedResponse returns a decoder for responses
+// returned by the admin markEnterpriseTrialConverted endpoint. restoreBody
+// controls whether the response body should be restored after having been read.
+// DecodeMarkEnterpriseTrialConvertedResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeMarkEnterpriseTrialConvertedResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body MarkEnterpriseTrialConvertedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			res := NewMarkEnterpriseTrialConvertedAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body MarkEnterpriseTrialConvertedUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body MarkEnterpriseTrialConvertedForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body MarkEnterpriseTrialConvertedBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body MarkEnterpriseTrialConvertedNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body MarkEnterpriseTrialConvertedConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body MarkEnterpriseTrialConvertedInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body MarkEnterpriseTrialConvertedInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+				}
+				err = ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+				}
+				return nil, NewMarkEnterpriseTrialConvertedInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body MarkEnterpriseTrialConvertedUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+				}
+				err = ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+				}
+				return nil, NewMarkEnterpriseTrialConvertedUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "markEnterpriseTrialConverted", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body MarkEnterpriseTrialConvertedGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "markEnterpriseTrialConverted", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // BuildBulkUpdateAccountTypeRequest instantiates a HTTP request object with
 // method and path set to call the "admin" service "bulkUpdateAccountType"
 // endpoint

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -32,6 +32,11 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// MarkEnterpriseTrialConvertedAdminPath returns the URL path to the admin service markEnterpriseTrialConverted HTTP endpoint.
+func MarkEnterpriseTrialConvertedAdminPath() string {
+	return "/admin/trial.convert"
+}
+
 // BulkUpdateAccountTypeAdminPath returns the URL path to the admin service bulkUpdateAccountType HTTP endpoint.
 func BulkUpdateAccountTypeAdminPath() string {
 	return "/admin/organizations.bulkUpdateAccountType"

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -25,6 +25,13 @@ type UpdateOrganizationRequestBody struct {
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
 }
 
+// MarkEnterpriseTrialConvertedRequestBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP request body.
+type MarkEnterpriseTrialConvertedRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+}
+
 // BulkUpdateAccountTypeRequestBody is the type of the "admin" service
 // "bulkUpdateAccountType" endpoint HTTP request body.
 type BulkUpdateAccountTypeRequestBody struct {
@@ -127,6 +134,42 @@ type GetProjectResponseBody struct {
 // UpdateOrganizationResponseBody is the type of the "admin" service
 // "updateOrganization" endpoint HTTP response body.
 type UpdateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, payg, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The trial tier. Absent when the organization never trialled.
+	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// The time at which the trial converted to a paid plan, if any.
+	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
+	// The time at which the organization was demoted after its trial, if any.
+	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP response body.
+type MarkEnterpriseTrialConvertedResponseBody struct {
 	// The ID of the organization
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	// The name of the organization
@@ -1392,6 +1435,196 @@ type UpdateOrganizationUnexpectedResponseBody struct {
 // service "updateOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type UpdateOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedUnauthorizedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unauthorized" error.
+type MarkEnterpriseTrialConvertedUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedForbiddenResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "forbidden" error.
+type MarkEnterpriseTrialConvertedForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedBadRequestResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "bad_request" error.
+type MarkEnterpriseTrialConvertedBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedNotFoundResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "not_found" error.
+type MarkEnterpriseTrialConvertedNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedConflictResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "conflict" error.
+type MarkEnterpriseTrialConvertedConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unsupported_media" error.
+type MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedInvalidResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "invalid" error.
+type MarkEnterpriseTrialConvertedInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedInvariantViolationResponseBody is the type of
+// the "admin" service "markEnterpriseTrialConverted" endpoint HTTP response
+// body for the "invariant_violation" error.
+type MarkEnterpriseTrialConvertedInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedUnexpectedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unexpected" error.
+type MarkEnterpriseTrialConvertedUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedGatewayErrorResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "gateway_error" error.
+type MarkEnterpriseTrialConvertedGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -5073,6 +5306,16 @@ func NewUpdateOrganizationRequestBody(p *admin.UpdateOrganizationPayload) *Updat
 	return body
 }
 
+// NewMarkEnterpriseTrialConvertedRequestBody builds the HTTP request body from
+// the payload of the "markEnterpriseTrialConverted" endpoint of the "admin"
+// service.
+func NewMarkEnterpriseTrialConvertedRequestBody(p *admin.MarkEnterpriseTrialConvertedPayload) *MarkEnterpriseTrialConvertedRequestBody {
+	body := &MarkEnterpriseTrialConvertedRequestBody{
+		ID: p.ID,
+	}
+	return body
+}
+
 // NewBulkUpdateAccountTypeRequestBody builds the HTTP request body from the
 // payload of the "bulkUpdateAccountType" endpoint of the "admin" service.
 func NewBulkUpdateAccountTypeRequestBody(p *admin.BulkUpdateAccountTypePayload) *BulkUpdateAccountTypeRequestBody {
@@ -5957,6 +6200,180 @@ func NewUpdateOrganizationUnexpected(body *UpdateOrganizationUnexpectedResponseB
 // NewUpdateOrganizationGatewayError builds a admin service updateOrganization
 // endpoint gateway_error error.
 func NewUpdateOrganizationGatewayError(body *UpdateOrganizationGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedAdminOrganizationOK builds a "admin" service
+// "markEnterpriseTrialConverted" endpoint result from a HTTP "OK" response.
+func NewMarkEnterpriseTrialConvertedAdminOrganizationOK(body *MarkEnterpriseTrialConvertedResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:               *body.ID,
+		Name:             *body.Name,
+		Slug:             *body.Slug,
+		AccountType:      *body.AccountType,
+		WorkosID:         body.WorkosID,
+		Whitelisted:      *body.Whitelisted,
+		DisabledAt:       body.DisabledAt,
+		TrialState:       body.TrialState,
+		TrialTier:        body.TrialTier,
+		TrialEndsAt:      body.TrialEndsAt,
+		TrialConvertedAt: body.TrialConvertedAt,
+		TrialDemotedAt:   body.TrialDemotedAt,
+		MemberCount:      *body.MemberCount,
+		CreatedAt:        *body.CreatedAt,
+		UpdatedAt:        *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnauthorized builds a admin service
+// markEnterpriseTrialConverted endpoint unauthorized error.
+func NewMarkEnterpriseTrialConvertedUnauthorized(body *MarkEnterpriseTrialConvertedUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedForbidden builds a admin service
+// markEnterpriseTrialConverted endpoint forbidden error.
+func NewMarkEnterpriseTrialConvertedForbidden(body *MarkEnterpriseTrialConvertedForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedBadRequest builds a admin service
+// markEnterpriseTrialConverted endpoint bad_request error.
+func NewMarkEnterpriseTrialConvertedBadRequest(body *MarkEnterpriseTrialConvertedBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedNotFound builds a admin service
+// markEnterpriseTrialConverted endpoint not_found error.
+func NewMarkEnterpriseTrialConvertedNotFound(body *MarkEnterpriseTrialConvertedNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedConflict builds a admin service
+// markEnterpriseTrialConverted endpoint conflict error.
+func NewMarkEnterpriseTrialConvertedConflict(body *MarkEnterpriseTrialConvertedConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnsupportedMedia builds a admin service
+// markEnterpriseTrialConverted endpoint unsupported_media error.
+func NewMarkEnterpriseTrialConvertedUnsupportedMedia(body *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedInvalid builds a admin service
+// markEnterpriseTrialConverted endpoint invalid error.
+func NewMarkEnterpriseTrialConvertedInvalid(body *MarkEnterpriseTrialConvertedInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedInvariantViolation builds a admin service
+// markEnterpriseTrialConverted endpoint invariant_violation error.
+func NewMarkEnterpriseTrialConvertedInvariantViolation(body *MarkEnterpriseTrialConvertedInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnexpected builds a admin service
+// markEnterpriseTrialConverted endpoint unexpected error.
+func NewMarkEnterpriseTrialConvertedUnexpected(body *MarkEnterpriseTrialConvertedUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedGatewayError builds a admin service
+// markEnterpriseTrialConverted endpoint gateway_error error.
+func NewMarkEnterpriseTrialConvertedGatewayError(body *MarkEnterpriseTrialConvertedGatewayErrorResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -9281,6 +9698,59 @@ func ValidateUpdateOrganizationResponseBody(body *UpdateOrganizationResponseBody
 	return
 }
 
+// ValidateMarkEnterpriseTrialConvertedResponseBody runs the validations
+// defined on MarkEnterpriseTrialConvertedResponseBody
+func ValidateMarkEnterpriseTrialConvertedResponseBody(body *MarkEnterpriseTrialConvertedResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialConvertedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_converted_at", *body.TrialConvertedAt, goa.FormatDateTime))
+	}
+	if body.TrialDemotedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_demoted_at", *body.TrialDemotedAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
 // ValidateBulkUpdateAccountTypeResponseBody runs the validations defined on
 // BulkUpdateAccountTypeResponseBody
 func ValidateBulkUpdateAccountTypeResponseBody(body *BulkUpdateAccountTypeResponseBody) (err error) {
@@ -11064,6 +11534,250 @@ func ValidateUpdateOrganizationUnexpectedResponseBody(body *UpdateOrganizationUn
 // ValidateUpdateOrganizationGatewayErrorResponseBody runs the validations
 // defined on updateOrganization_gateway_error_response_body
 func ValidateUpdateOrganizationGatewayErrorResponseBody(body *UpdateOrganizationGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_unauthorized_response_body
+func ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody(body *MarkEnterpriseTrialConvertedUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_forbidden_response_body
+func ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody(body *MarkEnterpriseTrialConvertedForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_bad_request_response_body
+func ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody(body *MarkEnterpriseTrialConvertedBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_not_found_response_body
+func ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody(body *MarkEnterpriseTrialConvertedNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedConflictResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_conflict_response_body
+func ValidateMarkEnterpriseTrialConvertedConflictResponseBody(body *MarkEnterpriseTrialConvertedConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_unsupported_media_response_body
+func ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(body *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedInvalidResponseBody runs the validations
+// defined on markEnterpriseTrialConverted_invalid_response_body
+func ValidateMarkEnterpriseTrialConvertedInvalidResponseBody(body *MarkEnterpriseTrialConvertedInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_invariant_violation_response_body
+func ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody(body *MarkEnterpriseTrialConvertedInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_unexpected_response_body
+func ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody(body *MarkEnterpriseTrialConvertedUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_gateway_error_response_body
+func ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody(body *MarkEnterpriseTrialConvertedGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1052,6 +1052,219 @@ func EncodeUpdateOrganizationError(encoder func(context.Context, http.ResponseWr
 	}
 }
 
+// EncodeMarkEnterpriseTrialConvertedResponse returns an encoder for responses
+// returned by the admin markEnterpriseTrialConverted endpoint.
+func EncodeMarkEnterpriseTrialConvertedResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewMarkEnterpriseTrialConvertedResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeMarkEnterpriseTrialConvertedRequest returns a decoder for requests
+// sent to the admin markEnterpriseTrialConverted endpoint.
+func DecodeMarkEnterpriseTrialConvertedRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+	return func(r *http.Request) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+		var payload *admin.MarkEnterpriseTrialConvertedPayload
+		var (
+			body MarkEnterpriseTrialConvertedRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateMarkEnterpriseTrialConvertedRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewMarkEnterpriseTrialConvertedPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeMarkEnterpriseTrialConvertedError returns an encoder for errors
+// returned by the markEnterpriseTrialConverted admin endpoint.
+func EncodeMarkEnterpriseTrialConvertedError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // EncodeBulkUpdateAccountTypeResponse returns an encoder for responses
 // returned by the admin bulkUpdateAccountType endpoint.
 func EncodeBulkUpdateAccountTypeResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -32,6 +32,11 @@ func UpdateOrganizationAdminPath() string {
 	return "/admin/organization.update"
 }
 
+// MarkEnterpriseTrialConvertedAdminPath returns the URL path to the admin service markEnterpriseTrialConverted HTTP endpoint.
+func MarkEnterpriseTrialConvertedAdminPath() string {
+	return "/admin/trial.convert"
+}
+
 // BulkUpdateAccountTypeAdminPath returns the URL path to the admin service bulkUpdateAccountType HTTP endpoint.
 func BulkUpdateAccountTypeAdminPath() string {
 	return "/admin/organizations.bulkUpdateAccountType"

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -18,31 +18,32 @@ import (
 
 // Server lists the admin service endpoint HTTP handlers.
 type Server struct {
-	Mounts                      []*MountPoint
-	Login                       http.Handler
-	Callback                    http.Handler
-	Logout                      http.Handler
-	GetProject                  http.Handler
-	UpdateOrganization          http.Handler
-	BulkUpdateAccountType       http.Handler
-	DisableOrganization         http.Handler
-	EnableOrganization          http.Handler
-	GetOrganization             http.Handler
-	ListOrganizationMembers     http.Handler
-	ListOrganizationProjects    http.Handler
-	ListOrganizationActivity    http.Handler
-	ListOrganizations           http.Handler
-	ExtendTrial                 http.Handler
-	CreateOrganization          http.Handler
-	RearmTrial                  http.Handler
-	GetOrganizationStats        http.Handler
-	GetInferenceKeys            http.Handler
-	SetInferenceKeyMonthlyLimit http.Handler
-	GetInferenceSpendHistory    http.Handler
-	GetPaygBillingSummary       http.Handler
-	GetStripeSubscription       http.Handler
-	CancelStripeSubscription    http.Handler
-	ResumeStripeSubscription    http.Handler
+	Mounts                       []*MountPoint
+	Login                        http.Handler
+	Callback                     http.Handler
+	Logout                       http.Handler
+	GetProject                   http.Handler
+	UpdateOrganization           http.Handler
+	MarkEnterpriseTrialConverted http.Handler
+	BulkUpdateAccountType        http.Handler
+	DisableOrganization          http.Handler
+	EnableOrganization           http.Handler
+	GetOrganization              http.Handler
+	ListOrganizationMembers      http.Handler
+	ListOrganizationProjects     http.Handler
+	ListOrganizationActivity     http.Handler
+	ListOrganizations            http.Handler
+	ExtendTrial                  http.Handler
+	CreateOrganization           http.Handler
+	RearmTrial                   http.Handler
+	GetOrganizationStats         http.Handler
+	GetInferenceKeys             http.Handler
+	SetInferenceKeyMonthlyLimit  http.Handler
+	GetInferenceSpendHistory     http.Handler
+	GetPaygBillingSummary        http.Handler
+	GetStripeSubscription        http.Handler
+	CancelStripeSubscription     http.Handler
+	ResumeStripeSubscription     http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -77,6 +78,7 @@ func New(
 			{"Logout", "POST", "/admin/auth.logout"},
 			{"GetProject", "GET", "/admin/project.get"},
 			{"UpdateOrganization", "POST", "/admin/organization.update"},
+			{"MarkEnterpriseTrialConverted", "POST", "/admin/trial.convert"},
 			{"BulkUpdateAccountType", "POST", "/admin/organizations.bulkUpdateAccountType"},
 			{"DisableOrganization", "POST", "/admin/organization.disable"},
 			{"EnableOrganization", "POST", "/admin/organization.enable"},
@@ -97,30 +99,31 @@ func New(
 			{"CancelStripeSubscription", "POST", "/admin/organization.cancelStripeSubscription"},
 			{"ResumeStripeSubscription", "POST", "/admin/organization.resumeStripeSubscription"},
 		},
-		Login:                       NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
-		Callback:                    NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
-		Logout:                      NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
-		GetProject:                  NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
-		UpdateOrganization:          NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
-		BulkUpdateAccountType:       NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
-		DisableOrganization:         NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
-		EnableOrganization:          NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
-		GetOrganization:             NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationMembers:     NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationProjects:    NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationActivity:    NewListOrganizationActivityHandler(e.ListOrganizationActivity, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizations:           NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
-		ExtendTrial:                 NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
-		CreateOrganization:          NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
-		RearmTrial:                  NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
-		GetOrganizationStats:        NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
-		GetInferenceKeys:            NewGetInferenceKeysHandler(e.GetInferenceKeys, mux, decoder, encoder, errhandler, formatter),
-		SetInferenceKeyMonthlyLimit: NewSetInferenceKeyMonthlyLimitHandler(e.SetInferenceKeyMonthlyLimit, mux, decoder, encoder, errhandler, formatter),
-		GetInferenceSpendHistory:    NewGetInferenceSpendHistoryHandler(e.GetInferenceSpendHistory, mux, decoder, encoder, errhandler, formatter),
-		GetPaygBillingSummary:       NewGetPaygBillingSummaryHandler(e.GetPaygBillingSummary, mux, decoder, encoder, errhandler, formatter),
-		GetStripeSubscription:       NewGetStripeSubscriptionHandler(e.GetStripeSubscription, mux, decoder, encoder, errhandler, formatter),
-		CancelStripeSubscription:    NewCancelStripeSubscriptionHandler(e.CancelStripeSubscription, mux, decoder, encoder, errhandler, formatter),
-		ResumeStripeSubscription:    NewResumeStripeSubscriptionHandler(e.ResumeStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		Login:                        NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
+		Callback:                     NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
+		Logout:                       NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
+		GetProject:                   NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
+		UpdateOrganization:           NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
+		MarkEnterpriseTrialConverted: NewMarkEnterpriseTrialConvertedHandler(e.MarkEnterpriseTrialConverted, mux, decoder, encoder, errhandler, formatter),
+		BulkUpdateAccountType:        NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
+		DisableOrganization:          NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
+		EnableOrganization:           NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
+		GetOrganization:              NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationMembers:      NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationProjects:     NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationActivity:     NewListOrganizationActivityHandler(e.ListOrganizationActivity, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizations:            NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
+		ExtendTrial:                  NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
+		CreateOrganization:           NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
+		RearmTrial:                   NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
+		GetOrganizationStats:         NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
+		GetInferenceKeys:             NewGetInferenceKeysHandler(e.GetInferenceKeys, mux, decoder, encoder, errhandler, formatter),
+		SetInferenceKeyMonthlyLimit:  NewSetInferenceKeyMonthlyLimitHandler(e.SetInferenceKeyMonthlyLimit, mux, decoder, encoder, errhandler, formatter),
+		GetInferenceSpendHistory:     NewGetInferenceSpendHistoryHandler(e.GetInferenceSpendHistory, mux, decoder, encoder, errhandler, formatter),
+		GetPaygBillingSummary:        NewGetPaygBillingSummaryHandler(e.GetPaygBillingSummary, mux, decoder, encoder, errhandler, formatter),
+		GetStripeSubscription:        NewGetStripeSubscriptionHandler(e.GetStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		CancelStripeSubscription:     NewCancelStripeSubscriptionHandler(e.CancelStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		ResumeStripeSubscription:     NewResumeStripeSubscriptionHandler(e.ResumeStripeSubscription, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -134,6 +137,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.Logout = m(s.Logout)
 	s.GetProject = m(s.GetProject)
 	s.UpdateOrganization = m(s.UpdateOrganization)
+	s.MarkEnterpriseTrialConverted = m(s.MarkEnterpriseTrialConverted)
 	s.BulkUpdateAccountType = m(s.BulkUpdateAccountType)
 	s.DisableOrganization = m(s.DisableOrganization)
 	s.EnableOrganization = m(s.EnableOrganization)
@@ -165,6 +169,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountLogoutHandler(mux, h.Logout)
 	MountGetProjectHandler(mux, h.GetProject)
 	MountUpdateOrganizationHandler(mux, h.UpdateOrganization)
+	MountMarkEnterpriseTrialConvertedHandler(mux, h.MarkEnterpriseTrialConverted)
 	MountBulkUpdateAccountTypeHandler(mux, h.BulkUpdateAccountType)
 	MountDisableOrganizationHandler(mux, h.DisableOrganization)
 	MountEnableOrganizationHandler(mux, h.EnableOrganization)
@@ -433,6 +438,60 @@ func NewUpdateOrganizationHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "updateOrganization")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountMarkEnterpriseTrialConvertedHandler configures the mux to serve the
+// "admin" service "markEnterpriseTrialConverted" endpoint.
+func MountMarkEnterpriseTrialConvertedHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/trial.convert", f)
+}
+
+// NewMarkEnterpriseTrialConvertedHandler creates a HTTP handler which loads
+// the HTTP request and calls the "admin" service
+// "markEnterpriseTrialConverted" endpoint.
+func NewMarkEnterpriseTrialConvertedHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeMarkEnterpriseTrialConvertedRequest(mux, decoder)
+		encodeResponse = EncodeMarkEnterpriseTrialConvertedResponse(encoder)
+		encodeError    = EncodeMarkEnterpriseTrialConvertedError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "markEnterpriseTrialConverted")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -26,6 +26,13 @@ type UpdateOrganizationRequestBody struct {
 	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
 }
 
+// MarkEnterpriseTrialConvertedRequestBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP request body.
+type MarkEnterpriseTrialConvertedRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+}
+
 // BulkUpdateAccountTypeRequestBody is the type of the "admin" service
 // "bulkUpdateAccountType" endpoint HTTP request body.
 type BulkUpdateAccountTypeRequestBody struct {
@@ -128,6 +135,42 @@ type GetProjectResponseBody struct {
 // UpdateOrganizationResponseBody is the type of the "admin" service
 // "updateOrganization" endpoint HTTP response body.
 type UpdateOrganizationResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, payg, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The trial tier. Absent when the organization never trialled.
+	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// The time at which the trial converted to a paid plan, if any.
+	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
+	// The time at which the organization was demoted after its trial, if any.
+	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP response body.
+type MarkEnterpriseTrialConvertedResponseBody struct {
 	// The ID of the organization
 	ID string `form:"id" json:"id" xml:"id"`
 	// The name of the organization
@@ -1401,6 +1444,196 @@ type UpdateOrganizationUnexpectedResponseBody struct {
 // service "updateOrganization" endpoint HTTP response body for the
 // "gateway_error" error.
 type UpdateOrganizationGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedUnauthorizedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unauthorized" error.
+type MarkEnterpriseTrialConvertedUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedForbiddenResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "forbidden" error.
+type MarkEnterpriseTrialConvertedForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedBadRequestResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "bad_request" error.
+type MarkEnterpriseTrialConvertedBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedNotFoundResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "not_found" error.
+type MarkEnterpriseTrialConvertedNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedConflictResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "conflict" error.
+type MarkEnterpriseTrialConvertedConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unsupported_media" error.
+type MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedInvalidResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "invalid" error.
+type MarkEnterpriseTrialConvertedInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedInvariantViolationResponseBody is the type of
+// the "admin" service "markEnterpriseTrialConverted" endpoint HTTP response
+// body for the "invariant_violation" error.
+type MarkEnterpriseTrialConvertedInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedUnexpectedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unexpected" error.
+type MarkEnterpriseTrialConvertedUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedGatewayErrorResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "gateway_error" error.
+type MarkEnterpriseTrialConvertedGatewayErrorResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -5116,6 +5349,30 @@ func NewUpdateOrganizationResponseBody(res *admin.AdminOrganization) *UpdateOrga
 	return body
 }
 
+// NewMarkEnterpriseTrialConvertedResponseBody builds the HTTP response body
+// from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedResponseBody(res *admin.AdminOrganization) *MarkEnterpriseTrialConvertedResponseBody {
+	body := &MarkEnterpriseTrialConvertedResponseBody{
+		ID:               res.ID,
+		Name:             res.Name,
+		Slug:             res.Slug,
+		AccountType:      res.AccountType,
+		WorkosID:         res.WorkosID,
+		Whitelisted:      res.Whitelisted,
+		DisabledAt:       res.DisabledAt,
+		TrialState:       res.TrialState,
+		TrialTier:        res.TrialTier,
+		TrialEndsAt:      res.TrialEndsAt,
+		TrialConvertedAt: res.TrialConvertedAt,
+		TrialDemotedAt:   res.TrialDemotedAt,
+		MemberCount:      res.MemberCount,
+		CreatedAt:        res.CreatedAt,
+		UpdatedAt:        res.UpdatedAt,
+	}
+	return body
+}
+
 // NewBulkUpdateAccountTypeResponseBody builds the HTTP response body from the
 // result of the "bulkUpdateAccountType" endpoint of the "admin" service.
 func NewBulkUpdateAccountTypeResponseBody(res *admin.AdminBulkUpdateAccountTypeResult) *BulkUpdateAccountTypeResponseBody {
@@ -6171,6 +6428,156 @@ func NewUpdateOrganizationUnexpectedResponseBody(res *goa.ServiceError) *UpdateO
 // from the result of the "updateOrganization" endpoint of the "admin" service.
 func NewUpdateOrganizationGatewayErrorResponseBody(res *goa.ServiceError) *UpdateOrganizationGatewayErrorResponseBody {
 	body := &UpdateOrganizationGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnauthorizedResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedForbiddenResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedForbiddenResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedForbiddenResponseBody {
+	body := &MarkEnterpriseTrialConvertedForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedBadRequestResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedBadRequestResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedBadRequestResponseBody {
+	body := &MarkEnterpriseTrialConvertedBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedNotFoundResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedNotFoundResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedNotFoundResponseBody {
+	body := &MarkEnterpriseTrialConvertedNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedConflictResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedConflictResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedConflictResponseBody {
+	body := &MarkEnterpriseTrialConvertedConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedInvalidResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedInvalidResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedInvalidResponseBody {
+	body := &MarkEnterpriseTrialConvertedInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody builds the
+// HTTP response body from the result of the "markEnterpriseTrialConverted"
+// endpoint of the "admin" service.
+func NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedInvariantViolationResponseBody {
+	body := &MarkEnterpriseTrialConvertedInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedUnexpectedResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnexpectedResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnexpectedResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedGatewayErrorResponseBody {
+	body := &MarkEnterpriseTrialConvertedGatewayErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -9014,6 +9421,17 @@ func NewUpdateOrganizationPayload(body *UpdateOrganizationRequestBody, adminSess
 	return v
 }
 
+// NewMarkEnterpriseTrialConvertedPayload builds a admin service
+// markEnterpriseTrialConverted endpoint payload.
+func NewMarkEnterpriseTrialConvertedPayload(body *MarkEnterpriseTrialConvertedRequestBody, adminSessionToken *string) *admin.MarkEnterpriseTrialConvertedPayload {
+	v := &admin.MarkEnterpriseTrialConvertedPayload{
+		ID: *body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // NewBulkUpdateAccountTypePayload builds a admin service bulkUpdateAccountType
 // endpoint payload.
 func NewBulkUpdateAccountTypePayload(body *BulkUpdateAccountTypeRequestBody, adminSessionToken *string) *admin.BulkUpdateAccountTypePayload {
@@ -9238,6 +9656,20 @@ func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) 
 	if body.AccountType != nil {
 		if !(*body.AccountType == "free" || *body.AccountType == "pro" || *body.AccountType == "payg" || *body.AccountType == "enterprise") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.account_type", *body.AccountType, []any{"free", "pro", "payg", "enterprise"}))
+		}
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedRequestBody runs the validations defined
+// on MarkEnterpriseTrialConvertedRequestBody
+func ValidateMarkEnterpriseTrialConvertedRequestBody(body *MarkEnterpriseTrialConvertedRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
 		}
 	}
 	return

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -110,7 +110,7 @@ func UsageCommands() []string {
 		"assistant-memories (list-assistant-memories|get-assistant-memory|delete-assistant-memory)",
 		"assistants (list-assistants|get-assistant|create-assistant|update-assistant|delete-assistant|send-message|interrupt-turn|get-managed-assistant|ensure-managed-assistant)",
 		"auditlogs (list|list-facets)",
-		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organization-activity|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|set-inference-key-monthly-limit|get-inference-spend-history|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
+		"admin (login|callback|logout|get-project|update-organization|mark-enterprise-trial-converted|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organization-activity|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|set-inference-key-monthly-limit|get-inference-spend-history|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
 		"auth (callback|login|switch-scopes|enter-demo|logout|register|info)",
 		"business-memories (list-business-memories|list-business-memory-content-scopes|search-business-memories)",
 		"chat (list-chats|get-assistant-session-summary|get-work-units-trend|load-chat|generate-title|credit-usage|delete-chat|set-pinned|summarize|summarize-tool-call|submit-feedback|list-sources|list-session-links)",
@@ -586,6 +586,10 @@ func ParseEndpoint(
 		adminUpdateOrganizationFlags                 = flag.NewFlagSet("update-organization", flag.ExitOnError)
 		adminUpdateOrganizationBodyFlag              = adminUpdateOrganizationFlags.String("body", "REQUIRED", "")
 		adminUpdateOrganizationAdminSessionTokenFlag = adminUpdateOrganizationFlags.String("admin-session-token", "", "")
+
+		adminMarkEnterpriseTrialConvertedFlags                 = flag.NewFlagSet("mark-enterprise-trial-converted", flag.ExitOnError)
+		adminMarkEnterpriseTrialConvertedBodyFlag              = adminMarkEnterpriseTrialConvertedFlags.String("body", "REQUIRED", "")
+		adminMarkEnterpriseTrialConvertedAdminSessionTokenFlag = adminMarkEnterpriseTrialConvertedFlags.String("admin-session-token", "", "")
 
 		adminBulkUpdateAccountTypeFlags                 = flag.NewFlagSet("bulk-update-account-type", flag.ExitOnError)
 		adminBulkUpdateAccountTypeBodyFlag              = adminBulkUpdateAccountTypeFlags.String("body", "REQUIRED", "")
@@ -3807,6 +3811,7 @@ func ParseEndpoint(
 	adminLogoutFlags.Usage = adminLogoutUsage
 	adminGetProjectFlags.Usage = adminGetProjectUsage
 	adminUpdateOrganizationFlags.Usage = adminUpdateOrganizationUsage
+	adminMarkEnterpriseTrialConvertedFlags.Usage = adminMarkEnterpriseTrialConvertedUsage
 	adminBulkUpdateAccountTypeFlags.Usage = adminBulkUpdateAccountTypeUsage
 	adminDisableOrganizationFlags.Usage = adminDisableOrganizationUsage
 	adminEnableOrganizationFlags.Usage = adminEnableOrganizationUsage
@@ -4929,6 +4934,9 @@ func ParseEndpoint(
 
 			case "update-organization":
 				epf = adminUpdateOrganizationFlags
+
+			case "mark-enterprise-trial-converted":
+				epf = adminMarkEnterpriseTrialConvertedFlags
 
 			case "bulk-update-account-type":
 				epf = adminBulkUpdateAccountTypeFlags
@@ -7158,6 +7166,9 @@ func ParseEndpoint(
 			case "update-organization":
 				endpoint = c.UpdateOrganization()
 				data, err = adminc.BuildUpdateOrganizationPayload(*adminUpdateOrganizationBodyFlag, *adminUpdateOrganizationAdminSessionTokenFlag)
+			case "mark-enterprise-trial-converted":
+				endpoint = c.MarkEnterpriseTrialConverted()
+				data, err = adminc.BuildMarkEnterpriseTrialConvertedPayload(*adminMarkEnterpriseTrialConvertedBodyFlag, *adminMarkEnterpriseTrialConvertedAdminSessionTokenFlag)
 			case "bulk-update-account-type":
 				endpoint = c.BulkUpdateAccountType()
 				data, err = adminc.BuildBulkUpdateAccountTypePayload(*adminBulkUpdateAccountTypeBodyFlag, *adminBulkUpdateAccountTypeAdminSessionTokenFlag)
@@ -10717,6 +10728,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    logout: Logout implements logout.`)
 	fmt.Fprintln(os.Stderr, `    get-project: Returns full admin details for a project by id or slug, including aggregated counts of child resources.`)
 	fmt.Fprintln(os.Stderr, `    update-organization: Updates admin-managed fields on an organization. At least one of account_type or whitelisted must be supplied.`)
+	fmt.Fprintln(os.Stderr, `    mark-enterprise-trial-converted: Records that an organization's enterprise trial converted to a signed contract.`)
 	fmt.Fprintln(os.Stderr, `    bulk-update-account-type: Sets one account type on many organizations in a single statement. An ID that matches no organization is reported back rather than failing the batch, so a stale ID costs the operator that row and not the whole call.`)
 	fmt.Fprintln(os.Stderr, `    disable-organization: Disables an organization, recording the moment of the action in disabled_at. Idempotent: disabling an already-disabled organization keeps the original timestamp.`)
 	fmt.Fprintln(os.Stderr, `    enable-organization: Re-enables a disabled organization by clearing disabled_at. Idempotent: an organization that is already active is unaffected.`)
@@ -10844,6 +10856,26 @@ func adminUpdateOrganizationUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin update-organization --body '{\n      \"account_type\": \"pro\",\n      \"id\": \"abc123\",\n      \"whitelisted\": false\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminMarkEnterpriseTrialConvertedUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin mark-enterprise-trial-converted", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Records that an organization's enterprise trial converted to a signed contract.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin mark-enterprise-trial-converted --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 func adminBulkUpdateAccountTypeUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1848,6 +1848,82 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/trial.convert:
+        post:
+            tags:
+                - admin
+            summary: markEnterpriseTrialConverted admin
+            description: Records that an organization's enterprise trial converted to a signed contract.
+            operationId: adminMarkEnterpriseTrialConverted
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/MarkEnterpriseTrialConvertedRequestBody'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/trial.extend:
         post:
             tags:
@@ -73702,6 +73778,15 @@ components:
                 - coverage_bucket
                 - first_seen_at
                 - last_seen_at
+        MarkEnterpriseTrialConvertedRequestBody:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
         MarkRiskResultsFalsePositiveRequestBody:
             type: object
             properties:

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -1,0 +1,188 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/admin/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.AdminOrganization, error) {
+	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin enterprise trial conversion transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	trials := trialsRepo.New(tx)
+	trial, err := trials.LockEnterpriseTrialForConversion(ctx, payload.ID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
+			"look up organization after missing enterprise trial",
+			"organization has no enterprise trial to convert")
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "lock enterprise trial for conversion").LogError(ctx, logger)
+	}
+
+	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "read organization for enterprise trial conversion").LogError(ctx, logger)
+	}
+	if organization.AccountType == string(billing.TierPayg) {
+		return nil, oops.E(oops.CodeConflict, nil, "PAYG organizations cannot be converted through the enterprise trial endpoint")
+	}
+
+	if trial.ConvertedAt.Valid {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "commit idempotent enterprise trial conversion").LogError(ctx, logger)
+		}
+		s.notifyTrialInactive(ctx, logger, payload.ID)
+		return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion")
+	}
+
+	lockedKeys := make(map[openrouter.KeyType]*pgxpool.Conn, len(openrouter.AllKeyTypes))
+	var result *gen.AdminOrganization
+	err = s.withTrialKeyBillingLocks(ctx, logger, payload.ID, openrouter.AllKeyTypes, lockedKeys, func() error {
+		var lockedErr error
+		result, lockedErr = s.convertEnterpriseTrialLocked(ctx, logger, payload.ID, lockedKeys, tx, trials, trial.DemotedAt.Valid, organization)
+		return lockedErr
+	})
+	if err == nil {
+		return result, nil
+	}
+
+	var shareable *oops.ShareableError
+	if errors.As(err, &shareable) {
+		return nil, shareable
+	}
+	if errors.Is(err, keybillinglock.ErrAcquireTimeout) {
+		return nil, oops.E(oops.CodeUnavailable, err, "another billing operation is in progress; retry shortly").LogWarn(ctx, logger)
+	}
+	return nil, oops.E(oops.CodeUnexpected, err, "lock inference keys for enterprise trial conversion").LogError(ctx, logger)
+}
+
+func (s *Service) convertEnterpriseTrialLocked(
+	ctx context.Context,
+	logger *slog.Logger,
+	organizationID string,
+	lockedKeys map[openrouter.KeyType]*pgxpool.Conn,
+	tx pgx.Tx,
+	trials *trialsRepo.Queries,
+	wasDemoted bool,
+	organization repo.AdminGetOrganizationRow,
+) (*gen.AdminOrganization, error) {
+	legacyZeroLimitKeys, err := s.convertEnterpriseTrialKeys(ctx, logger, lockedKeys, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	if wasDemoted {
+		restored, err := trials.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{
+			OrganizationID: organizationID,
+			AccountType:    string(billing.TierEnterprise),
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "restore organization from converted enterprise trial").LogError(ctx, logger)
+		}
+		organization.Name = restored.Name
+		organization.Slug = restored.Slug
+		if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, organizationID, true); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "restore converted enterprise trial runtime features").LogError(ctx, logger)
+		}
+	}
+
+	if _, err := trials.MarkEnterpriseTrialConverted(ctx, organizationID); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "mark enterprise trial converted").LogError(ctx, logger)
+	}
+
+	actor, actorDisplayName, _ := adminActor(ctx)
+	if err := s.audit.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
+		OrganizationID:   organizationID,
+		Actor:            actor,
+		ActorDisplayName: actorDisplayName,
+		ActorSlug:        nil,
+		OrganizationName: organization.Name,
+		OrganizationSlug: organization.Slug,
+		ConversionSource: "admin",
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log enterprise trial conversion").LogError(ctx, logger)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit enterprise trial conversion").LogError(ctx, logger)
+	}
+
+	s.recapRevivedKeys(ctx, logger, lockedKeys, organizationID, legacyZeroLimitKeys)
+	if wasDemoted {
+		for _, feature := range productfeatures.TrialRuntimeFeatures {
+			s.productFeatures.UpdateFeatureCache(ctx, organizationID, feature, true)
+		}
+	}
+	s.notifyTrialInactive(ctx, logger, organizationID)
+
+	return s.readOrganizationAfterWrite(ctx, organizationID, "fetch organization after enterprise trial conversion")
+}
+
+func (s *Service) convertEnterpriseTrialKeys(ctx context.Context, logger *slog.Logger, lockedKeys map[openrouter.KeyType]*pgxpool.Conn, organizationID string) ([]openrouter.KeyType, error) {
+	enterpriseLimit, ok := openrouter.AccountTypeCreditLimit(billing.TierEnterprise)
+	if !ok {
+		return nil, oops.E(oops.CodeUnexpected, nil, "enterprise openrouter credit policy is missing").LogError(ctx, logger)
+	}
+
+	var legacyZeroLimitKeys []openrouter.KeyType
+	for _, keyType := range openrouter.AllKeyTypes {
+		conn := lockedKeys[keyType]
+		if conn == nil {
+			return nil, oops.E(oops.CodeUnexpected, nil, "missing openrouter %s key lock", keyType).LogError(ctx, logger)
+		}
+		row, err := orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: organizationID, KeyType: string(keyType)})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			continue
+		case err != nil:
+			return nil, oops.E(oops.CodeUnexpected, err, "read openrouter %s key", keyType).LogError(ctx, logger)
+		}
+
+		if row.MonthlyCredits == 0 {
+			legacyZeroLimitKeys = append(legacyZeroLimitKeys, keyType)
+		}
+		if slices.Contains(row.DisableCauses, string(openrouter.DisableCauseTrialDemotion)) {
+			_, _, err = s.openRouter.RemoveAPIKeyDisableCauseWithDB(ctx, conn, organizationID, keyType, openrouter.DisableCauseTrialDemotion, &enterpriseLimit)
+		} else {
+			_, err = s.openRouter.RefreshAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, &enterpriseLimit)
+		}
+		switch {
+		case errors.Is(err, ErrOpenRouterUnavailable):
+			return nil, oops.E(oops.CodeInvalid, err, "this server cannot convert enterprise trials: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
+		case err != nil:
+			return nil, oops.E(oops.CodeGatewayError, err, "apply enterprise limit to openrouter %s key", keyType).LogError(ctx, logger)
+		}
+	}
+
+	return legacyZeroLimitKeys, nil
+}
+
+func (s *Service) notifyTrialInactive(ctx context.Context, logger *slog.Logger, organizationID string) {
+	if err := s.trial.TrialInactive(ctx, organizationID); err != nil {
+		logger.ErrorContext(ctx, "failed to notify trial inactive", attr.SlogError(err))
+	}
+}

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -42,7 +42,7 @@ func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *t
 func TestMarkEnterpriseTrialConverted_AcceptsEveryEligibleStateAndPreservesHistory(t *testing.T) {
 	t.Parallel()
 
-	now := time.Now().UTC()
+	now := time.Now().UTC().Truncate(time.Microsecond).Add(time.Nanosecond)
 	demotedAt := now.Add(-9 * 24 * time.Hour)
 	disabledAt := now.Add(-8 * 24 * time.Hour)
 	cases := []struct {
@@ -92,7 +92,7 @@ func TestMarkEnterpriseTrialConverted_AcceptsEveryEligibleStateAndPreservesHisto
 			require.True(t, state.Whitelisted)
 			if tc.disabledAt != nil {
 				require.True(t, state.DisabledAt.Valid)
-				require.WithinDuration(t, *tc.disabledAt, state.DisabledAt.Time, 0)
+				require.WithinDuration(t, *tc.disabledAt, state.DisabledAt.Time, time.Microsecond)
 			}
 		})
 	}
@@ -181,7 +181,7 @@ func TestMarkEnterpriseTrialConverted_RejectsMissingNoTrialAndPayg(t *testing.T)
 	ctx, svc, conn, _ := newRearmService(t)
 	seedOrg(t, ctx, conn, orgFixture{id: "org_convert_no_trial", name: "No Trial", slug: "no-trial", accountType: "enterprise", whitelisted: true})
 	seedOrg(t, ctx, conn, orgFixture{id: "org_convert_payg", name: "PAYG", slug: "payg", accountType: "payg", whitelisted: true})
-	convertedAt := time.Now().UTC().Add(-time.Hour)
+	convertedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond).Add(time.Nanosecond)
 	seedTrial(t, ctx, conn, trialFixture{orgID: "org_convert_payg", endsAt: time.Now().UTC().Add(10 * 24 * time.Hour), convertedAt: &convertedAt})
 
 	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: "org_convert_missing"})
@@ -190,7 +190,7 @@ func TestMarkEnterpriseTrialConverted_RejectsMissingNoTrialAndPayg(t *testing.T)
 	requireOopsCode(t, err, oops.CodeConflict)
 	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: "org_convert_payg"})
 	requireOopsCode(t, err, oops.CodeConflict)
-	require.True(t, convertedAt.Equal(readTrial(t, ctx, conn, "org_convert_payg").ConvertedAt.Time))
+	require.WithinDuration(t, convertedAt, readTrial(t, ctx, conn, "org_convert_payg").ConvertedAt.Time, time.Microsecond)
 }
 
 type assertiveNotifierError struct{}

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -71,16 +71,19 @@ func TestMarkEnterpriseTrialConverted_AcceptsEveryEligibleStateAndPreservesHisto
 			seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: tc.endsAt, demotedAt: tc.demotedAt})
 
 			before := readTrial(t, ctx, conn, orgID)
-			started := time.Now().UTC()
+			trialQueries := trialsRepo.New(conn)
+			started, err := trialQueries.GetTrialClockFixture(ctx)
+			require.NoError(t, err)
 			res, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
-			finished := time.Now().UTC()
+			require.NoError(t, err)
+			finished, err := trialQueries.GetTrialClockFixture(ctx)
 			require.NoError(t, err)
 			require.Equal(t, orgID, res.ID)
 
 			after := readTrial(t, ctx, conn, orgID)
 			require.True(t, after.ConvertedAt.Valid)
-			require.False(t, after.ConvertedAt.Time.Before(started))
-			require.False(t, after.ConvertedAt.Time.After(finished))
+			require.False(t, after.ConvertedAt.Time.Before(started.Time))
+			require.False(t, after.ConvertedAt.Time.After(finished.Time))
 			require.Equal(t, before.EndsAt.Time, after.EndsAt.Time)
 			require.Equal(t, before.DemotedAt, after.DemotedAt)
 

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -214,12 +214,28 @@ func (n *concurrentTrialNotifier) inactiveCount() int {
 	return len(n.inactive)
 }
 
+func waitForBlockedBackendCount(t *testing.T, ctx context.Context, conn *pgxpool.Pool, want int64) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		var blocked int64
+		err := conn.QueryRow(ctx, `
+			SELECT count(*)
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND wait_event_type = 'Lock'
+		`).Scan(&blocked)
+		return err == nil && blocked >= want
+	}, 5*time.Second, 10*time.Millisecond, "expected at least %d blocked backends", want)
+}
+
 func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestoration(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn, _ := newRearmService(t)
-	orgID := "org_convert_audit_atomic"
+	orgID := "org_convert_audit_atomic_" + uuid.NewString()
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, orgID)
 	before := readTrial(t, ctx, conn, orgID)
 	outboxBefore, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
 	require.NoError(t, err)
@@ -240,10 +256,23 @@ func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestorat
 	require.NoError(t, err)
 	require.Equal(t, outboxBefore, outboxAfter)
 	require.Empty(t, notifier.inactive)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, featureErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, featureErr)
+		require.False(t, enabled, "%s restoration must roll back with the rejected audit", feature)
+	}
+	for _, keyType := range openrouter.AllKeyTypes {
+		key := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.EqualValues(t, 100, key.MonthlyCredits, "pre-commit upstream limit work is intentionally durable")
+		require.NotContains(t, key.DisableCauses, string(openrouter.DisableCauseTrialDemotion), "pre-commit key-cause work is intentionally durable")
+		require.False(t, key.Disabled)
+	}
 }
 
 func TestMarkEnterpriseTrialConverted_ConcurrentAndReplayedCallsCommitOneConversion(t *testing.T) { //nolint:paralleltest // Coordinates writers against one trial row.
-	ctx, svc, conn, _ := newRearmService(t)
+	baseCtx, svc, conn, _ := newRearmService(t)
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+	defer cancel()
 	const orgID = "org_convert_concurrent"
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Concurrent Conversion", slug: "concurrent-conversion", accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(24 * time.Hour)})
@@ -252,30 +281,39 @@ func TestMarkEnterpriseTrialConverted_ConcurrentAndReplayedCallsCommitOneConvers
 
 	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
+	first := make(chan error, 1)
+	second := make(chan error, 1)
 
-	const calls = 2
-	start := make(chan struct{})
-	results := make(chan error, calls)
-	var wg sync.WaitGroup
-	for range calls {
-		wg.Go(func() {
-			<-start
+	err = keybillinglock.WithAcquireTimeout(ctx, testenv.NewLogger(t), conn, orgID, openrouter.KeyTypeChat, time.Second, func(_ *pgxpool.Conn) error {
+		go func() {
 			_, callErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
-			results <- callErr
-		})
-	}
-	close(start)
-	wg.Wait()
-	close(results)
+			first <- callErr
+		}()
+		waitForBlockedBackendCount(t, ctx, conn, 1) // first owns the trial row and waits for chat
 
-	for callErr := range results {
-		require.NoError(t, callErr)
+		go func() {
+			_, callErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+			second <- callErr
+		}()
+		waitForBlockedBackendCount(t, ctx, conn, 2) // second waits for the first writer's trial row
+		return nil
+	})
+	require.NoError(t, err)
+
+	for index, result := range []<-chan error{first, second} {
+		select {
+		case callErr := <-result:
+			require.NoError(t, callErr, "conversion call %d", index+1)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("conversion call %d did not complete", index+1)
+		}
 	}
-	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	trial := readTrial(t, ctx, conn, orgID)
+	require.True(t, trial.ConvertedAt.Valid)
 	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
 	require.Equal(t, before+1, after)
-	require.Equal(t, calls, notifier.inactiveCount(), "every successful conversion replay must enqueue TrialInactive")
+	require.Equal(t, 2, notifier.inactiveCount(), "every successful conversion replay must enqueue TrialInactive")
 }
 
 func TestMarkEnterpriseTrialConverted_UpstreamFailureRollsBackAndRetryConverges(t *testing.T) {
@@ -304,6 +342,19 @@ func TestMarkEnterpriseTrialConverted_UpstreamFailureRollsBackAndRetryConverges(
 	require.Equal(t, "free", state.GramAccountType)
 	require.False(t, state.Whitelisted)
 	require.Empty(t, notifier.inactive)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, featureErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, featureErr)
+		require.False(t, enabled, "%s admission must remain disabled after upstream failure", feature)
+	}
+	chatAfterFailure := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	require.EqualValues(t, 100, chatAfterFailure.MonthlyCredits)
+	require.NotContains(t, chatAfterFailure.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+	require.False(t, chatAfterFailure.Disabled)
+	internalAfterFailure := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal)
+	require.EqualValues(t, 37, internalAfterFailure.MonthlyCredits)
+	require.Contains(t, internalAfterFailure.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+	require.True(t, internalAfterFailure.Disabled)
 
 	auditAfterFailure, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
@@ -320,6 +371,17 @@ func TestMarkEnterpriseTrialConverted_UpstreamFailureRollsBackAndRetryConverges(
 	require.Equal(t, "enterprise", state.GramAccountType)
 	require.True(t, state.Whitelisted)
 	require.Equal(t, []string{orgID}, notifier.inactive)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, featureErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, featureErr)
+		require.True(t, enabled, "%s admission must converge after retry", feature)
+	}
+	for _, keyType := range openrouter.AllKeyTypes {
+		key := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.EqualValues(t, 100, key.MonthlyCredits)
+		require.NotContains(t, key.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+		require.False(t, key.Disabled)
+	}
 
 	auditAfterRetry, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
@@ -330,32 +392,41 @@ func TestMarkEnterpriseTrialConverted_UpstreamFailureRollsBackAndRetryConverges(
 }
 
 func TestMarkEnterpriseTrialConverted_TrialRowPrecedesChatAndInternalKeyLocks(t *testing.T) { //nolint:paralleltest // Deliberately coordinates lock owners.
-	ctx, svc, conn, _ := newRearmService(t)
+	baseCtx, svc, conn, _ := newRearmService(t)
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+	defer cancel()
 	const orgID = "org_convert_lock_order"
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Lock Order", slug: "lock-order", accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(24 * time.Hour)})
 
 	trialOwner := testenv.BeginTx(t, ctx, conn)
+	defer func() { _ = trialOwner.Rollback(baseCtx) }()
 	lockedID, err := repo.New(trialOwner).LockTrialForUpdate(ctx, orgID)
 	require.NoError(t, err)
 	require.Equal(t, orgID, lockedID)
 
 	converted := make(chan error, 1)
-	go func() {
-		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
-		converted <- conversionErr
-	}()
-	testenv.WaitForBlockedBackend(t, ctx, conn)
-
 	logger := testenv.NewLogger(t)
-	err = keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeChat, time.Second, func(_ *pgxpool.Conn) error {
-		return keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeInternal, time.Second, func(_ *pgxpool.Conn) error {
-			return trialOwner.Commit(ctx)
-		})
+	err = keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeInternal, time.Second, func(_ *pgxpool.Conn) error {
+		go func() {
+			_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+			converted <- conversionErr
+		}()
+		waitForBlockedBackendCount(t, ctx, conn, 1)
+
+		// While conversion waits for the trial row, neither key lock may be held.
+		chatErr := keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeChat, 250*time.Millisecond, func(_ *pgxpool.Conn) error { return nil })
+		require.NoError(t, chatErr)
+		require.NoError(t, trialOwner.Commit(ctx))
+
+		// The internal lock remains ours. A correct conversion therefore takes chat
+		// and waits here; an internal-before-chat implementation leaves chat free.
+		require.Eventually(t, func() bool {
+			chatErr = keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeChat, 100*time.Millisecond, func(_ *pgxpool.Conn) error { return nil })
+			return errors.Is(chatErr, keybillinglock.ErrAcquireTimeout)
+		}, 3*time.Second, 10*time.Millisecond, "conversion must hold chat before waiting for internal")
+		return nil
 	})
-	if err != nil {
-		require.NoError(t, trialOwner.Rollback(ctx))
-	}
 	require.NoError(t, err)
 
 	select {
@@ -367,12 +438,15 @@ func TestMarkEnterpriseTrialConverted_TrialRowPrecedesChatAndInternalKeyLocks(t 
 }
 
 func TestMarkEnterpriseTrialConverted_SerializesBehindTrialDemotion(t *testing.T) { //nolint:paralleltest // Coordinates two lifecycle writers.
-	ctx, svc, conn, _ := newRearmService(t)
+	baseCtx, svc, conn, _ := newRearmService(t)
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+	defer cancel()
 	const orgID = "org_convert_after_demotion"
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Demotion Race", slug: "demotion-race", accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(-24 * time.Hour)})
 
 	demotionTx := testenv.BeginTx(t, ctx, conn)
+	defer func() { _ = demotionTx.Rollback(baseCtx) }()
 	demotionQueries := trialsRepo.New(demotionTx)
 	_, err := demotionQueries.MarkTrialDemoted(ctx, orgID)
 	require.NoError(t, err)
@@ -384,7 +458,7 @@ func TestMarkEnterpriseTrialConverted_SerializesBehindTrialDemotion(t *testing.T
 		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 		converted <- conversionErr
 	}()
-	testenv.WaitForBlockedBackend(t, ctx, conn)
+	waitForBlockedBackendCount(t, ctx, conn, 1)
 	require.NoError(t, demotionTx.Commit(ctx))
 
 	select {
@@ -402,11 +476,14 @@ func TestMarkEnterpriseTrialConverted_SerializesBehindTrialDemotion(t *testing.T
 }
 
 func TestMarkEnterpriseTrialConverted_SerializesBehindTrialRearm(t *testing.T) { //nolint:paralleltest // Coordinates two lifecycle writers.
-	ctx, svc, conn, _ := newRearmService(t)
+	baseCtx, svc, conn, _ := newRearmService(t)
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+	defer cancel()
 	const orgID = "org_convert_after_rearm"
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
 
 	rearmTx := testenv.BeginTx(t, ctx, conn)
+	defer func() { _ = rearmTx.Rollback(baseCtx) }()
 	rearmQueries := trialsRepo.New(rearmTx)
 	_, err := rearmQueries.RearmTrial(ctx, trialsRepo.RearmTrialParams{OrganizationID: orgID, RearmForDays: 14})
 	require.NoError(t, err)
@@ -418,7 +495,7 @@ func TestMarkEnterpriseTrialConverted_SerializesBehindTrialRearm(t *testing.T) {
 		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 		converted <- conversionErr
 	}()
-	testenv.WaitForBlockedBackend(t, ctx, conn)
+	waitForBlockedBackendCount(t, ctx, conn, 1)
 	require.NoError(t, rearmTx.Commit(ctx))
 
 	select {
@@ -433,13 +510,18 @@ func TestMarkEnterpriseTrialConverted_SerializesBehindTrialRearm(t *testing.T) {
 }
 
 func TestMarkEnterpriseTrialConverted_SerializesWithBillingCauseMutation(t *testing.T) { //nolint:paralleltest // Coordinates the chat-key lock holder and conversion.
-	ctx, svc, conn, _ := newRearmService(t)
+	baseCtx, svc, conn, _ := newRearmService(t)
+	ctx, cancel := context.WithTimeout(baseCtx, 10*time.Second)
+	defer cancel()
 	const orgID = "org_convert_cause_race"
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
 
 	mutationStarted := make(chan struct{})
 	releaseMutation := make(chan struct{})
 	mutationDone := make(chan error, 1)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseMutation) }) }
+	defer release()
 	go func() {
 		mutationDone <- keybillinglock.WithAcquireTimeout(ctx, testenv.NewLogger(t), conn, orgID, openrouter.KeyTypeChat, time.Second, func(keyConn *pgxpool.Conn) error {
 			for _, cause := range []openrouter.DisableCause{openrouter.DisableCauseAdminLock, openrouter.DisableCauseBillingInactive} {
@@ -449,20 +531,36 @@ func TestMarkEnterpriseTrialConverted_SerializesWithBillingCauseMutation(t *test
 				}
 			}
 			close(mutationStarted)
-			<-releaseMutation
-			return nil
+			select {
+			case <-releaseMutation:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		})
 	}()
-	<-mutationStarted
+	select {
+	case <-mutationStarted:
+	case mutationErr := <-mutationDone:
+		require.NoError(t, mutationErr)
+		t.Fatal("billing mutation exited before acquiring the chat lock")
+	case <-time.After(3 * time.Second):
+		t.Fatal("billing mutation did not acquire the chat lock")
+	}
 
 	converted := make(chan error, 1)
 	go func() {
 		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 		converted <- conversionErr
 	}()
-	testenv.WaitForBlockedBackend(t, ctx, conn)
-	close(releaseMutation)
-	require.NoError(t, <-mutationDone)
+	waitForBlockedBackendCount(t, ctx, conn, 1)
+	release()
+	select {
+	case mutationErr := <-mutationDone:
+		require.NoError(t, mutationErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("billing mutation did not release the chat lock")
+	}
 
 	select {
 	case err := <-converted:

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -219,6 +220,7 @@ func waitForBlockedBackendCount(t *testing.T, ctx context.Context, conn *pgxpool
 
 	require.Eventually(t, func() bool {
 		var blocked int64
+		//nolint:glint // notestingrawsql: PostgreSQL system view is absent from SQLc's schema snapshot.
 		err := conn.QueryRow(ctx, `
 			SELECT count(*)
 			FROM pg_stat_activity
@@ -527,7 +529,7 @@ func TestMarkEnterpriseTrialConverted_SerializesWithBillingCauseMutation(t *test
 			for _, cause := range []openrouter.DisableCause{openrouter.DisableCauseAdminLock, openrouter.DisableCauseBillingInactive} {
 				_, mutationErr := orrepo.New(keyConn).AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), DisableCause: string(cause)})
 				if mutationErr != nil {
-					return mutationErr
+					return fmt.Errorf("add %s disable cause: %w", cause, mutationErr)
 				}
 			}
 			close(mutationStarted)

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -1,21 +1,32 @@
 package admin
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	testrepo "github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *testing.T) {
@@ -182,6 +193,27 @@ type assertiveNotifierError struct{}
 
 func (assertiveNotifierError) Error() string { return "notifier unavailable" }
 
+type concurrentTrialNotifier struct {
+	mu       sync.Mutex
+	inactive []string
+}
+
+func (*concurrentTrialNotifier) TrialStarted(context.Context, string) error       { return nil }
+func (*concurrentTrialNotifier) AdminAdded(context.Context, string, string) error { return nil }
+
+func (n *concurrentTrialNotifier) TrialInactive(_ context.Context, organizationID string) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.inactive = append(n.inactive, organizationID)
+	return nil
+}
+
+func (n *concurrentTrialNotifier) inactiveCount() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.inactive)
+}
+
 func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestoration(t *testing.T) {
 	t.Parallel()
 
@@ -189,9 +221,13 @@ func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestorat
 	orgID := "org_convert_audit_atomic"
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
 	before := readTrial(t, ctx, conn, orgID)
+	outboxBefore, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
+	require.NoError(t, err)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
 	require.NoError(t, audittest.RejectAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted))
 
-	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 	requireOopsCode(t, err, oops.CodeUnexpected)
 
 	after := readTrial(t, ctx, conn, orgID)
@@ -200,6 +236,264 @@ func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestorat
 	state := readOrgState(t, ctx, conn, orgID)
 	require.Equal(t, "free", state.GramAccountType)
 	require.False(t, state.Whitelisted)
+	outboxAfter, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
+	require.NoError(t, err)
+	require.Equal(t, outboxBefore, outboxAfter)
+	require.Empty(t, notifier.inactive)
+}
+
+func TestMarkEnterpriseTrialConverted_ConcurrentAndReplayedCallsCommitOneConversion(t *testing.T) { //nolint:paralleltest // Coordinates writers against one trial row.
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_concurrent"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Concurrent Conversion", slug: "concurrent-conversion", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(24 * time.Hour)})
+	notifier := &concurrentTrialNotifier{}
+	svc.trial = notifier
+
+	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+
+	const calls = 2
+	start := make(chan struct{})
+	results := make(chan error, calls)
+	var wg sync.WaitGroup
+	for range calls {
+		wg.Go(func() {
+			<-start
+			_, callErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+			results <- callErr
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for callErr := range results {
+		require.NoError(t, callErr)
+	}
+	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+	require.Equal(t, calls, notifier.inactiveCount(), "every successful conversion replay must enqueue TrialInactive")
+}
+
+func TestMarkEnterpriseTrialConverted_UpstreamFailureRollsBackAndRetryConverges(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_upstream_retry_" + uuid.NewString()
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, orgID)
+	notifier := &fakeTrialNotifier{}
+	svc.trial = notifier
+	provisioner.failOn = openrouter.KeyTypeInternal
+	provisioner.failWith = errors.New("upstream unavailable")
+
+	auditBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	outboxBefore, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
+	require.NoError(t, err)
+
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	trial := readTrial(t, ctx, conn, orgID)
+	require.False(t, trial.ConvertedAt.Valid)
+	require.True(t, trial.DemotedAt.Valid)
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "free", state.GramAccountType)
+	require.False(t, state.Whitelisted)
+	require.Empty(t, notifier.inactive)
+
+	auditAfterFailure, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Equal(t, auditBefore, auditAfterFailure)
+	outboxAfterFailure, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
+	require.NoError(t, err)
+	require.Equal(t, outboxBefore, outboxAfterFailure)
+
+	provisioner.failWith = nil
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	state = readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted)
+	require.Equal(t, []string{orgID}, notifier.inactive)
+
+	auditAfterRetry, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Equal(t, auditBefore+1, auditAfterRetry)
+	outboxAfterRetry, err := testrepo.New(conn).CountOutboxEntriesByEventType(ctx, string(events.OrganizationEnterpriseTrialV1.EventType()))
+	require.NoError(t, err)
+	require.Equal(t, outboxBefore+1, outboxAfterRetry)
+}
+
+func TestMarkEnterpriseTrialConverted_TrialRowPrecedesChatAndInternalKeyLocks(t *testing.T) { //nolint:paralleltest // Deliberately coordinates lock owners.
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_lock_order"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Lock Order", slug: "lock-order", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(24 * time.Hour)})
+
+	trialOwner := testenv.BeginTx(t, ctx, conn)
+	lockedID, err := repo.New(trialOwner).LockTrialForUpdate(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, orgID, lockedID)
+
+	converted := make(chan error, 1)
+	go func() {
+		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- conversionErr
+	}()
+	testenv.WaitForBlockedBackend(t, ctx, conn)
+
+	logger := testenv.NewLogger(t)
+	err = keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeChat, time.Second, func(_ *pgxpool.Conn) error {
+		return keybillinglock.WithAcquireTimeout(ctx, logger, conn, orgID, openrouter.KeyTypeInternal, time.Second, func(_ *pgxpool.Conn) error {
+			return trialOwner.Commit(ctx)
+		})
+	})
+	if err != nil {
+		require.NoError(t, trialOwner.Rollback(ctx))
+	}
+	require.NoError(t, err)
+
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("conversion deadlocked while acquiring chat then internal billing locks")
+	}
+}
+
+func TestMarkEnterpriseTrialConverted_SerializesBehindTrialDemotion(t *testing.T) { //nolint:paralleltest // Coordinates two lifecycle writers.
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_after_demotion"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Demotion Race", slug: "demotion-race", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(-24 * time.Hour)})
+
+	demotionTx := testenv.BeginTx(t, ctx, conn)
+	demotionQueries := trialsRepo.New(demotionTx)
+	_, err := demotionQueries.MarkTrialDemoted(ctx, orgID)
+	require.NoError(t, err)
+	_, err = demotionQueries.DemoteOrganizationToFree(ctx, orgID)
+	require.NoError(t, err)
+
+	converted := make(chan error, 1)
+	go func() {
+		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- conversionErr
+	}()
+	testenv.WaitForBlockedBackend(t, ctx, conn)
+	require.NoError(t, demotionTx.Commit(ctx))
+
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("conversion deadlocked behind trial demotion")
+	}
+	trial := readTrial(t, ctx, conn, orgID)
+	require.True(t, trial.ConvertedAt.Valid)
+	require.True(t, trial.DemotedAt.Valid, "conversion preserves demotion history")
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "enterprise", state.GramAccountType)
+	require.True(t, state.Whitelisted)
+}
+
+func TestMarkEnterpriseTrialConverted_SerializesBehindTrialRearm(t *testing.T) { //nolint:paralleltest // Coordinates two lifecycle writers.
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_after_rearm"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+
+	rearmTx := testenv.BeginTx(t, ctx, conn)
+	rearmQueries := trialsRepo.New(rearmTx)
+	_, err := rearmQueries.RearmTrial(ctx, trialsRepo.RearmTrialParams{OrganizationID: orgID, RearmForDays: 14})
+	require.NoError(t, err)
+	_, err = rearmQueries.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{OrganizationID: orgID, AccountType: "enterprise"})
+	require.NoError(t, err)
+
+	converted := make(chan error, 1)
+	go func() {
+		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- conversionErr
+	}()
+	testenv.WaitForBlockedBackend(t, ctx, conn)
+	require.NoError(t, rearmTx.Commit(ctx))
+
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("conversion deadlocked behind trial re-arm")
+	}
+	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+}
+
+func TestMarkEnterpriseTrialConverted_SerializesWithBillingCauseMutation(t *testing.T) { //nolint:paralleltest // Coordinates the chat-key lock holder and conversion.
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_cause_race"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+
+	mutationStarted := make(chan struct{})
+	releaseMutation := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		mutationDone <- keybillinglock.WithAcquireTimeout(ctx, testenv.NewLogger(t), conn, orgID, openrouter.KeyTypeChat, time.Second, func(keyConn *pgxpool.Conn) error {
+			for _, cause := range []openrouter.DisableCause{openrouter.DisableCauseAdminLock, openrouter.DisableCauseBillingInactive} {
+				_, mutationErr := orrepo.New(keyConn).AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), DisableCause: string(cause)})
+				if mutationErr != nil {
+					return mutationErr
+				}
+			}
+			close(mutationStarted)
+			<-releaseMutation
+			return nil
+		})
+	}()
+	<-mutationStarted
+
+	converted := make(chan error, 1)
+	go func() {
+		_, conversionErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- conversionErr
+	}()
+	testenv.WaitForBlockedBackend(t, ctx, conn)
+	close(releaseMutation)
+	require.NoError(t, <-mutationDone)
+
+	select {
+	case err := <-converted:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("conversion deadlocked behind billing cause mutation")
+	}
+	key := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	require.NotContains(t, key.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+	require.Contains(t, key.DisableCauses, string(openrouter.DisableCauseAdminLock))
+	require.Contains(t, key.DisableCauses, string(openrouter.DisableCauseBillingInactive))
+	require.True(t, key.Disabled, "remaining causes must keep effective access disabled")
+}
+
+func TestMarkEnterpriseTrialConverted_CannotBeDemotedOrRearmed(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	const orgID = "org_convert_terminal"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	converted := readTrial(t, ctx, conn, orgID)
+
+	_, err = trialsRepo.New(conn).MarkTrialDemoted(ctx, orgID)
+	require.Error(t, err)
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+	after := readTrial(t, ctx, conn, orgID)
+	require.Equal(t, converted.ConvertedAt, after.ConvertedAt)
+	require.Equal(t, converted.EndsAt, after.EndsAt)
 }
 
 func TestUpdateOrganization_DoesNotInferEnterpriseTrialConversion(t *testing.T) {

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -1,0 +1,217 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+)
+
+func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *testing.T) {
+	t.Parallel()
+
+	id := "org_convert_validate"
+	require.NoError(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: &id}))
+	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{}))
+	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: new(string)}))
+}
+
+func TestMarkEnterpriseTrialConverted_AcceptsEveryEligibleStateAndPreservesHistory(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	demotedAt := now.Add(-9 * 24 * time.Hour)
+	disabledAt := now.Add(-8 * 24 * time.Hour)
+	cases := []struct {
+		name       string
+		endsAt     time.Time
+		demotedAt  *time.Time
+		disabledAt *time.Time
+	}{
+		{name: "running", endsAt: now.Add(14 * 24 * time.Hour)},
+		{name: "ending soon", endsAt: now.Add(2 * 24 * time.Hour)},
+		{name: "expired", endsAt: now.Add(-2 * 24 * time.Hour)},
+		{name: "demoted and disabled", endsAt: now.Add(-10 * 24 * time.Hour), demotedAt: &demotedAt, disabledAt: &disabledAt},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, svc, conn, _ := newRearmService(t)
+			orgID := "org_convert_" + tc.name
+			accountType, whitelisted := "enterprise", true
+			if tc.demotedAt != nil {
+				accountType, whitelisted = "free", false
+			}
+			seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: accountType, whitelisted: whitelisted, disabledAt: tc.disabledAt})
+			seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: tc.endsAt, demotedAt: tc.demotedAt})
+
+			before := readTrial(t, ctx, conn, orgID)
+			started := time.Now().UTC()
+			res, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+			finished := time.Now().UTC()
+			require.NoError(t, err)
+			require.Equal(t, orgID, res.ID)
+
+			after := readTrial(t, ctx, conn, orgID)
+			require.True(t, after.ConvertedAt.Valid)
+			require.False(t, after.ConvertedAt.Time.Before(started))
+			require.False(t, after.ConvertedAt.Time.After(finished))
+			require.Equal(t, before.EndsAt.Time, after.EndsAt.Time)
+			require.Equal(t, before.DemotedAt, after.DemotedAt)
+
+			state := readOrgState(t, ctx, conn, orgID)
+			require.Equal(t, "enterprise", state.GramAccountType)
+			require.True(t, state.Whitelisted)
+			if tc.disabledAt != nil {
+				require.True(t, state.DisabledAt.Valid)
+				require.WithinDuration(t, *tc.disabledAt, state.DisabledAt.Time, 0)
+			}
+		})
+	}
+}
+
+func TestMarkEnterpriseTrialConverted_RestoresDemotedFeaturesAndKeysWithoutClearingOtherCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_demoted_resources"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, orgID)
+
+	// Add independent causes to the trial cause seeded by seedDemotedTrial.
+	for _, keyType := range openrouter.AllKeyTypes {
+		for _, cause := range []openrouter.DisableCause{openrouter.DisableCauseAdminLock, openrouter.DisableCauseBillingInactive} {
+			_, err := orrepo.New(conn).AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{
+				OrganizationID: orgID,
+				KeyType:        string(keyType),
+				DisableCause:   string(cause),
+			})
+			require.NoError(t, err)
+		}
+	}
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+
+	for _, keyType := range openrouter.AllKeyTypes {
+		key := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.EqualValues(t, 100, key.MonthlyCredits)
+		require.NotContains(t, key.DisableCauses, string(openrouter.DisableCauseTrialDemotion))
+		require.Contains(t, key.DisableCauses, string(openrouter.DisableCauseAdminLock))
+		require.Contains(t, key.DisableCauses, string(openrouter.DisableCauseBillingInactive))
+	}
+	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
+	for _, call := range provisioner.revivals {
+		require.NotNil(t, call.limit)
+		require.Equal(t, 100, *call.limit, "conversion must send the explicit enterprise ceiling upstream before commit")
+		require.Equal(t, "free", call.accountTypeSeen, "upstream work must precede admission commit")
+		require.True(t, call.demotedSeen, "upstream work must precede trial conversion commit")
+	}
+
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, err)
+		require.True(t, enabled, "%s must be restored for a converted demoted trial", feature)
+	}
+}
+
+func TestMarkEnterpriseTrialConverted_IsIdempotentAndAlwaysNotifiesInactive(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	orgID := "org_convert_idempotent"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Idempotent Co", slug: "idempotent-co", accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(10 * 24 * time.Hour)})
+	notifier := &fakeTrialNotifier{inactiveErr: assertiveNotifierError{}}
+	svc.trial = notifier
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{OIDCSubject: "operator-placeholder", Name: "Test Operator", Email: "operator@example.test"})
+
+	before, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	first := readTrial(t, ctx, conn, orgID).ConvertedAt.Time
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	require.Equal(t, first, readTrial(t, ctx, conn, orgID).ConvertedAt.Time)
+	require.Equal(t, []string{orgID, orgID}, notifier.inactive)
+
+	after, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	var metadata map[string]string
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, "admin", metadata["conversion_source"])
+	require.Equal(t, "Test Operator", *entry.ActorDisplayName)
+}
+
+func TestMarkEnterpriseTrialConverted_RejectsMissingNoTrialAndPayg(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	seedOrg(t, ctx, conn, orgFixture{id: "org_convert_no_trial", name: "No Trial", slug: "no-trial", accountType: "enterprise", whitelisted: true})
+	seedOrg(t, ctx, conn, orgFixture{id: "org_convert_payg", name: "PAYG", slug: "payg", accountType: "payg", whitelisted: true})
+	convertedAt := time.Now().UTC().Add(-time.Hour)
+	seedTrial(t, ctx, conn, trialFixture{orgID: "org_convert_payg", endsAt: time.Now().UTC().Add(10 * 24 * time.Hour), convertedAt: &convertedAt})
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: "org_convert_missing"})
+	requireOopsCode(t, err, oops.CodeNotFound)
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: "org_convert_no_trial"})
+	requireOopsCode(t, err, oops.CodeConflict)
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: "org_convert_payg"})
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.True(t, convertedAt.Equal(readTrial(t, ctx, conn, "org_convert_payg").ConvertedAt.Time))
+}
+
+type assertiveNotifierError struct{}
+
+func (assertiveNotifierError) Error() string { return "notifier unavailable" }
+
+func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackConversionAndRestoration(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newRearmService(t)
+	orgID := "org_convert_audit_atomic"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	before := readTrial(t, ctx, conn, orgID)
+	require.NoError(t, audittest.RejectAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted))
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+
+	after := readTrial(t, ctx, conn, orgID)
+	require.False(t, after.ConvertedAt.Valid)
+	require.Equal(t, before.DemotedAt, after.DemotedAt)
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "free", state.GramAccountType)
+	require.False(t, state.Whitelisted)
+}
+
+func TestUpdateOrganization_DoesNotInferEnterpriseTrialConversion(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	orgID := "org_update_not_conversion"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Update Only", slug: "update-only", accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: time.Now().UTC().Add(10 * 24 * time.Hour)})
+	enterprise := "enterprise"
+
+	_, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &enterprise})
+	require.NoError(t, err)
+	require.False(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+}

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -27,9 +27,10 @@ const (
 
 	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
 
-	ActionOrganizationEnterpriseTrialDemoted  Action = "organization:enterprise_trial_demoted"
-	ActionOrganizationEnterpriseTrialRearmed  Action = "organization:enterprise_trial_rearmed"
-	ActionOrganizationEnterpriseTrialExtended Action = "organization:enterprise_trial_extended"
+	ActionOrganizationEnterpriseTrialConverted Action = "organization:enterprise_trial_converted"
+	ActionOrganizationEnterpriseTrialDemoted   Action = "organization:enterprise_trial_demoted"
+	ActionOrganizationEnterpriseTrialRearmed   Action = "organization:enterprise_trial_rearmed"
+	ActionOrganizationEnterpriseTrialExtended  Action = "organization:enterprise_trial_extended"
 
 	ActionOrganizationPaygActivated   Action = "organization:payg_activated"
 	ActionOrganizationPaygDeactivated Action = "organization:payg_deactivated"
@@ -518,6 +519,53 @@ func (l *Logger) LogOrganizationEnterpriseTrialDemoted(ctx context.Context, dbtx
 	metadata, err := marshalAuditPayload(map[string]any{
 		"previous_account_type": event.PreviousAccountType,
 		"trial_ends_at":         event.TrialEndsAt,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
+}
+
+type LogOrganizationEnterpriseTrialConvertedEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	ConversionSource string
+}
+
+func (l *Logger) LogOrganizationEnterpriseTrialConverted(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialConvertedEvent) error {
+	action := ActionOrganizationEnterpriseTrialConverted
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"conversion_source": event.ConversionSource,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -49,7 +49,7 @@ var (
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
 	OrganizationBillingV1                  = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_billing_event_v1", "Emitted when the organization's billing state changes")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
-	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed")
+	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, converted, demoted, or re-armed")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1978,7 +1978,7 @@ webhooks:
                 required: true
     audit_log.organization_enterprise_trial_event_v1:
         post:
-            description: Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed
+            description: Emitted when the organization's enterprise trial is armed, extended, converted, demoted, or re-armed
             operationId: audit_log.organization_enterprise_trial_event_v1
             requestBody:
                 content:

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -1,3 +1,7 @@
+-- name: GetTrialClockFixture :one
+-- Test-only clock bound for timestamps assigned by PostgreSQL.
+SELECT clock_timestamp()::timestamptz;
+
 -- name: CreateTrial :exec
 -- One row per organization forever: extend a trial by moving ends_at forward,
 -- never by inserting a second row.

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -56,6 +56,26 @@ SET converted_at = clock_timestamp(),
 WHERE organization_id = @organization_id
   AND converted_at IS NULL;
 
+-- name: LockEnterpriseTrialForConversion :one
+-- This row lock is the first lock in the manual conversion transition. It is
+-- retained while deterministic per-key billing locks are acquired, so the
+-- demotion and conversion paths cannot invert their lock order.
+SELECT tier, ends_at, converted_at, demoted_at
+FROM trials
+WHERE organization_id = @organization_id
+FOR UPDATE;
+
+-- name: MarkEnterpriseTrialConverted :one
+-- The server owns the conversion timestamp. Historical lifecycle timestamps
+-- remain untouched. The converted_at predicate is replay protection after the
+-- caller's locking read.
+UPDATE trials
+SET converted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND converted_at IS NULL
+RETURNING converted_at;
+
 -- name: MarkTrialDemoted :one
 -- No rows means the trial no longer meets the sweep conditions.
 UPDATE trials

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -221,6 +221,18 @@ func (q *Queries) GetTrial(ctx context.Context, organizationID string) (Trial, e
 	return i, err
 }
 
+const getTrialClockFixture = `-- name: GetTrialClockFixture :one
+SELECT clock_timestamp()::timestamptz
+`
+
+// Test-only clock bound for timestamps assigned by PostgreSQL.
+func (q *Queries) GetTrialClockFixture(ctx context.Context) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getTrialClockFixture)
+	var column_1 pgtype.Timestamptz
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const insertTrialFixture = `-- name: InsertTrialFixture :exec
 INSERT INTO trials (organization_id, tier, created_at, ends_at, converted_at, demoted_at)
 VALUES (

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -284,6 +284,54 @@ func (q *Queries) ListExpiredTrials(ctx context.Context) ([]string, error) {
 	return items, nil
 }
 
+const lockEnterpriseTrialForConversion = `-- name: LockEnterpriseTrialForConversion :one
+SELECT tier, ends_at, converted_at, demoted_at
+FROM trials
+WHERE organization_id = $1
+FOR UPDATE
+`
+
+type LockEnterpriseTrialForConversionRow struct {
+	Tier        string
+	EndsAt      pgtype.Timestamptz
+	ConvertedAt pgtype.Timestamptz
+	DemotedAt   pgtype.Timestamptz
+}
+
+// This row lock is the first lock in the manual conversion transition. It is
+// retained while deterministic per-key billing locks are acquired, so the
+// demotion and conversion paths cannot invert their lock order.
+func (q *Queries) LockEnterpriseTrialForConversion(ctx context.Context, organizationID string) (LockEnterpriseTrialForConversionRow, error) {
+	row := q.db.QueryRow(ctx, lockEnterpriseTrialForConversion, organizationID)
+	var i LockEnterpriseTrialForConversionRow
+	err := row.Scan(
+		&i.Tier,
+		&i.EndsAt,
+		&i.ConvertedAt,
+		&i.DemotedAt,
+	)
+	return i, err
+}
+
+const markEnterpriseTrialConverted = `-- name: MarkEnterpriseTrialConverted :one
+UPDATE trials
+SET converted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+WHERE organization_id = $1
+  AND converted_at IS NULL
+RETURNING converted_at
+`
+
+// The server owns the conversion timestamp. Historical lifecycle timestamps
+// remain untouched. The converted_at predicate is replay protection after the
+// caller's locking read.
+func (q *Queries) MarkEnterpriseTrialConverted(ctx context.Context, organizationID string) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, markEnterpriseTrialConverted, organizationID)
+	var converted_at pgtype.Timestamptz
+	err := row.Scan(&converted_at)
+	return converted_at, err
+}
+
 const markTrialConverted = `-- name: MarkTrialConverted :execrows
 UPDATE trials
 SET converted_at = clock_timestamp(),

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -830,3 +830,19 @@ WHERE organization_id = @organization_id
 UPDATE openrouter_api_keys
 SET created_at = @created_at
 WHERE organization_id = @organization_id;
+
+-- name: CreateEnterpriseTrialConversionAuditFailureFunctionFixture :exec
+-- Test-only trigger function for proving conversion audit failures roll back checkout changes.
+CREATE OR REPLACE FUNCTION fail_enterprise_trial_conversion_audit() RETURNS trigger AS $$
+BEGIN
+  IF NEW.action = 'organization:enterprise_trial_converted' THEN
+    RAISE EXCEPTION 'forced enterprise trial conversion audit failure';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- name: CreateEnterpriseTrialConversionAuditFailureTriggerFixture :exec
+CREATE TRIGGER fail_enterprise_trial_conversion_audit
+BEFORE INSERT ON audit_logs
+FOR EACH ROW EXECUTE FUNCTION fail_enterprise_trial_conversion_audit();

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -230,6 +230,34 @@ func (q *Queries) CountStripeWebhookReceiptsFixture(ctx context.Context, organiz
 	return count, err
 }
 
+const createEnterpriseTrialConversionAuditFailureFunctionFixture = `-- name: CreateEnterpriseTrialConversionAuditFailureFunctionFixture :exec
+CREATE OR REPLACE FUNCTION fail_enterprise_trial_conversion_audit() RETURNS trigger AS $$
+BEGIN
+  IF NEW.action = 'organization:enterprise_trial_converted' THEN
+    RAISE EXCEPTION 'forced enterprise trial conversion audit failure';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+`
+
+// Test-only trigger function for proving conversion audit failures roll back checkout changes.
+func (q *Queries) CreateEnterpriseTrialConversionAuditFailureFunctionFixture(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, createEnterpriseTrialConversionAuditFailureFunctionFixture)
+	return err
+}
+
+const createEnterpriseTrialConversionAuditFailureTriggerFixture = `-- name: CreateEnterpriseTrialConversionAuditFailureTriggerFixture :exec
+CREATE TRIGGER fail_enterprise_trial_conversion_audit
+BEFORE INSERT ON audit_logs
+FOR EACH ROW EXECUTE FUNCTION fail_enterprise_trial_conversion_audit()
+`
+
+func (q *Queries) CreateEnterpriseTrialConversionAuditFailureTriggerFixture(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, createEnterpriseTrialConversionAuditFailureTriggerFixture)
+	return err
+}
+
 const createLegacyTUMMeterReportFixture = `-- name: CreateLegacyTUMMeterReportFixture :one
 INSERT INTO stripe_meter_reports (
     organization_id

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -40,7 +40,7 @@ type stripeWebhookResult struct {
 	subscriptionLost     bool
 }
 
-type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error)
+type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error)
 
 func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
@@ -154,10 +154,13 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 			return oops.E(oops.CodeUnexpected, err, "failed to lock billing metadata organization").LogError(ctx, logger)
 		}
 	}
+	trialConverted := false
 	if event.Type == "checkout.session.completed" && checkoutEligible {
-		if _, err := trialsrepo.New(tx).MarkTrialConverted(ctx, organizationID); err != nil {
+		convertedRows, err := trialsrepo.New(tx).MarkTrialConverted(ctx, organizationID)
+		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to mark enterprise trial converted").LogError(ctx, logger)
 		}
+		trialConverted = convertedRows > 0
 	}
 
 	// Trial demotion locks the trial row before it takes the platform-key
@@ -188,7 +191,7 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return nil
 	}
 
-	result, err := s.stripeHandler(ctx, logger, tx, organizationID, event, checkoutState, invoiceState)
+	result, err := s.stripeHandler(ctx, logger, tx, organizationID, trialConverted, event, checkoutState, invoiceState)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to handle Stripe webhook event").LogError(ctx, logger)
 	}
@@ -275,10 +278,10 @@ func (s *Service) currentCheckoutSession(ctx context.Context, event *stripeclien
 	}
 }
 
-func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState, invoice *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, trialConverted bool, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState, invoice *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 	switch event.Type {
 	case "checkout.session.completed":
-		return s.activatePaygCheckout(ctx, tx, organizationID, event, checkout)
+		return s.activatePaygCheckout(ctx, tx, organizationID, trialConverted, event, checkout)
 	case "invoice.created":
 		recorded, err := s.recordStripeInvoice(ctx, tx, organizationID, event, invoice)
 		if err != nil {
@@ -415,7 +418,7 @@ func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizati
 	return true, nil
 }
 
-func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
+func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizationID string, trialConverted bool, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState) (stripeWebhookResult, error) {
 	if checkout == nil {
 		return stripeWebhookResult{}, errors.New("missing current Stripe Checkout state")
 	}
@@ -467,6 +470,11 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		state.BillingCycleAnchorDay == anchorDay &&
 		state.GramAccountType == "payg" && state.Whitelisted
 	if alreadyActivated {
+		if trialConverted {
+			if err := s.logStripeEnterpriseTrialConversion(ctx, tx, organizationID, state.OrganizationName, state.OrganizationSlug); err != nil {
+				return stripeWebhookResult{}, err
+			}
+		}
 		return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled, invoicePaymentFailed: false, subscriptionLost: false}, nil
 	}
 
@@ -505,5 +513,29 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		return stripeWebhookResult{}, fmt.Errorf("log PAYG organization activation: %w", err)
 	}
 
+	if trialConverted {
+		if err := s.logStripeEnterpriseTrialConversion(ctx, tx, organizationID, state.OrganizationName, state.OrganizationSlug); err != nil {
+			return stripeWebhookResult{}, err
+		}
+	}
+
 	return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled, invoicePaymentFailed: false, subscriptionLost: false}, nil
+}
+
+func (s *Service) logStripeEnterpriseTrialConversion(ctx context.Context, tx pgx.Tx, organizationID, organizationName, organizationSlug string) error {
+	if s.auditLogger == nil {
+		return errors.New("audit logger is unavailable")
+	}
+	if err := s.auditLogger.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
+		OrganizationID:   organizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, "system"),
+		ActorDisplayName: nil,
+		ActorSlug:        nil,
+		OrganizationName: organizationName,
+		OrganizationSlug: organizationSlug,
+		ConversionSource: "stripe_checkout",
+	}); err != nil {
+		return fmt.Errorf("log enterprise trial conversion: %w", err)
+	}
+	return nil
 }

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1263,20 +1263,9 @@ func TestStripeCheckoutConversionAuditFailureRollsBackTrialAndPaygActivation(t *
 		Tier:           "enterprise",
 		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(7 * 24 * time.Hour), Valid: true},
 	}))
-	_, err := db.Exec(ctx, `
-		CREATE FUNCTION fail_enterprise_trial_conversion_audit() RETURNS trigger AS $$
-		BEGIN
-			IF NEW.action = 'organization:enterprise_trial_converted' THEN
-				RAISE EXCEPTION 'forced enterprise trial conversion audit failure';
-			END IF;
-			RETURN NEW;
-		END;
-		$$ LANGUAGE plpgsql;
-		CREATE TRIGGER fail_enterprise_trial_conversion_audit
-		BEFORE INSERT ON audit_logs
-		FOR EACH ROW EXECUTE FUNCTION fail_enterprise_trial_conversion_audit();
-	`)
-	require.NoError(t, err)
+	queries := repo.New(db)
+	require.NoError(t, queries.CreateEnterpriseTrialConversionAuditFailureFunctionFixture(ctx))
+	require.NoError(t, queries.CreateEnterpriseTrialConversionAuditFailureTriggerFixture(ctx))
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
 

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -48,7 +48,11 @@ type fakeStripeWebhookClient struct {
 	verifyCalls   atomic.Int32
 }
 
-const stripeWebhookOrganizationID = "org_placeholder"
+const (
+	stripeWebhookOrganizationID    = "org_placeholder"
+	enterpriseTrialConvertedAction = audit.Action("organization:enterprise_trial_converted")
+	stripeCheckoutConversionSource = "stripe_checkout"
+)
 
 func (f *fakeStripeWebhookClient) CreateCustomer(context.Context, stripeclient.CreateCustomerInput) (*stripeclient.Customer, error) {
 	return nil, errors.New("not implemented")
@@ -145,7 +149,7 @@ func (f *fakeStripeWebhookClient) Catalog() stripeclient.Catalog {
 	return stripeclient.Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: "", PortalConfigurationID: ""}
 }
 
-func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+func testStripeWebhookHandler(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 	return stripeWebhookResult{newlyEnabledFeatures: nil, invoicePaymentFailed: false, subscriptionLost: false}, nil
 }
 
@@ -284,6 +288,16 @@ func paygSchedulingIntentCount(t *testing.T, db *pgxpool.Pool) int {
 
 func organizationBillingActionIntentCount(t *testing.T, db *pgxpool.Pool, action audit.Action) int {
 	t.Helper()
+	return organizationActionIntentCount(t, db, string(events.OrganizationBillingV1.EventType()), action)
+}
+
+func organizationEnterpriseTrialActionIntentCount(t *testing.T, db *pgxpool.Pool, action audit.Action) int {
+	t.Helper()
+	return organizationActionIntentCount(t, db, string(events.OrganizationEnterpriseTrialV1.EventType()), action)
+}
+
+func organizationActionIntentCount(t *testing.T, db *pgxpool.Pool, eventType string, action audit.Action) int {
+	t.Helper()
 
 	rows, err := testrepo.New(db).ListPublishOutboxRows(t.Context())
 	require.NoError(t, err)
@@ -292,7 +306,7 @@ func organizationBillingActionIntentCount(t *testing.T, db *pgxpool.Pool, action
 	for _, row := range rows {
 		var event webhooksv1.Event
 		require.NoError(t, proto.Unmarshal(row.Message, &event))
-		if event.GetEventType() != string(events.OrganizationBillingV1.EventType()) {
+		if event.GetEventType() != eventType {
 			continue
 		}
 
@@ -496,7 +510,7 @@ func TestStripeWebhookAcknowledgesEventsWithoutDispatch(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+			service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 				t.Fatal("handler must not run")
 				return stripeWebhookResult{}, nil
 			})
@@ -532,7 +546,7 @@ func TestStripeWebhookSequentialDuplicateDispatchesOnce(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		return stripeWebhookResult{}, nil
 	})
@@ -550,7 +564,7 @@ func TestStripeWebhookConcurrentDuplicateDispatchesOnce(t *testing.T) {
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	var enterOnce sync.Once
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		enterOnce.Do(func() { close(entered) })
 		<-release
@@ -580,7 +594,7 @@ func TestStripeWebhookConcurrentDistinctEventsForSameCustomerDoNotSerialize(t *t
 			close(release)
 		}
 	}()
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		calls.Add(1)
 		<-release
 		return stripeWebhookResult{}, nil
@@ -614,7 +628,7 @@ func TestStripeWebhookHandlerFailureRollsBackForRetry(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
-	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+	service, db := newStripeWebhookService(t, "customer_placeholder", func(context.Context, *slog.Logger, pgx.Tx, string, bool, *stripeclient.WebhookEvent, *stripeclient.CheckoutSessionState, *stripeclient.InvoiceState) (stripeWebhookResult, error) {
 		if calls.Add(1) == 1 {
 			return stripeWebhookResult{}, errors.New("transient handler failure")
 		}
@@ -1057,6 +1071,51 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NotContains(t, string(record.AfterSnapshot), "subscription_activation")
 }
 
+func TestStripeCheckoutEnterpriseTrialConversionAuditIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_trial_conversion", "subscription_trial_conversion", "active")
+	ctx := t.Context()
+	require.NoError(t, trialsrepo.New(db).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(7 * 24 * time.Hour), Valid: true},
+	}))
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+
+	count, err := audittest.AuditLogCountByAction(ctx, db, enterpriseTrialConvertedAction)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+	record, err := audittest.LatestAuditLogByAction(ctx, db, enterpriseTrialConvertedAction)
+	require.NoError(t, err)
+	require.Equal(t, "system", record.ActorID)
+	metadata, err := audittest.DecodeAuditData(record.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, stripeCheckoutConversionSource, metadata["conversion_source"])
+	require.Equal(t, 1, organizationEnterpriseTrialActionIntentCount(t, db, enterpriseTrialConvertedAction))
+
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	client.verify = func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+		return &stripeclient.WebhookEvent{
+			ID:             "event_trial_conversion_replay",
+			Type:           "checkout.session.completed",
+			Created:        time.Now().UTC(),
+			ObjectID:       "checkout_placeholder",
+			CustomerID:     "customer_placeholder",
+			SubscriptionID: "subscription_trial_conversion",
+		}, nil
+	}
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "replay").Code)
+
+	count, err = audittest.AuditLogCountByAction(ctx, db, enterpriseTrialConvertedAction)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+	require.Equal(t, 1, organizationEnterpriseTrialActionIntentCount(t, db, enterpriseTrialConvertedAction))
+}
+
 func TestStripeCheckoutCompletionRestoresDemotedTrialRuntimeFeatures(t *testing.T) {
 	t.Parallel()
 
@@ -1193,27 +1252,53 @@ func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
 	require.Equal(t, 1, paygSchedulingIntentCount(t, service.db))
 }
 
-func TestStripeCheckoutAuditFailureRollsBackActivationAndSchedulingIntent(t *testing.T) {
+func TestStripeCheckoutConversionAuditFailureRollsBackTrialAndPaygActivation(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
 	featureCache := configurePaygCheckout(t, service, "event_audit_failure", "subscription_audit_failure", "active")
-	service.auditLogger = nil
+	ctx := t.Context()
+	require.NoError(t, trialsrepo.New(db).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(7 * 24 * time.Hour), Valid: true},
+	}))
+	_, err := db.Exec(ctx, `
+		CREATE FUNCTION fail_enterprise_trial_conversion_audit() RETURNS trigger AS $$
+		BEGIN
+			IF NEW.action = 'organization:enterprise_trial_converted' THEN
+				RAISE EXCEPTION 'forced enterprise trial conversion audit failure';
+			END IF;
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER fail_enterprise_trial_conversion_audit
+		BEFORE INSERT ON audit_logs
+		FOR EACH ROW EXECUTE FUNCTION fail_enterprise_trial_conversion_audit();
+	`)
+	require.NoError(t, err)
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
 
-	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	metadata, err := repo.New(db).GetBillingMetadata(ctx, stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.False(t, metadata.StripeSubscriptionID.Valid)
-	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(ctx, stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.NotEqual(t, "payg", organization.GramAccountType)
+	trial, err := trialsrepo.New(db).GetTrial(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, trial.ConvertedAt.Valid)
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
 	require.Zero(t, paygSchedulingIntentCount(t, db))
 	require.Empty(t, featureCache.snapshot())
-	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	paygCount, err := audittest.AuditLogCountByAction(ctx, db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
-	require.Zero(t, count)
+	require.Zero(t, paygCount)
+	conversionCount, err := audittest.AuditLogCountByAction(ctx, db, enterpriseTrialConvertedAction)
+	require.NoError(t, err)
+	require.Zero(t, conversionCount)
+	require.Zero(t, organizationEnterpriseTrialActionIntentCount(t, db, enterpriseTrialConvertedAction))
 }
 
 func TestStripeCheckoutSubscriptionConflictRollsBackTrialConversion(t *testing.T) {


### PR DESCRIPTION
## Rationale

AGE-3131 needs a dedicated, retry-safe admin transition for recording an enterprise trial conversion. Account-type edits cannot represent this lifecycle event, and a converted organization must not later be demoted or have an independent provider-key lock removed.

## Scope

- add a dedicated admin conversion endpoint and transactional trial transition
- preserve trial history and independent organization disablement while restoring demoted enterprise access
- apply enterprise limits to all OpenRouter key types and remove only the `trial_demotion` cause
- stop pending trial emails, emit one actor-attributed conversion audit event, and keep retries idempotent
- share conversion auditing with Stripe checkout while preserving transactional rollback behavior
- add race, replay, partial-failure, lifecycle, and generated API coverage

## Safety invariants

- the trial row is locked before deterministic provider-key/billing locks
- required upstream key work completes before converted/admitted state commits
- admin and billing disable causes are preserved; only `trial_demotion` is removed
- `ends_at`, historical `demoted_at`, and organization `disabled_at` are preserved
- the server assigns `converted_at`; replay does not duplicate audit events
- post-commit `TrialInactive` notification is retried without undoing a committed conversion
- no-trial/PAYG conversions conflict; missing organizations remain not found

## Verification and review

Reviewed and approved at exact head `1014f1fb14e93090dcfdfe02a0cef288cb31a3cc`; final review found no blocking findings.

Fresh publication gate at that head:

- `mise run test:server` — **13,101 tests passed** in 360.591s
- `git diff --check origin/age-3219-openrouter-disable-causes...HEAD` — clean
- exact-head and clean-worktree checks — passed

## Dependency stack

AGE-3131 is stacked on the completed AGE-3219 four-PR branch:

1. [Core #5812](https://github.com/speakeasy-api/gram/pull/5812)
2. [Admin API #5813](https://github.com/speakeasy-api/gram/pull/5813)
3. [Lifecycle #5814](https://github.com/speakeasy-api/gram/pull/5814)
4. [UI / forward compatibility / final lint #5789](https://github.com/speakeasy-api/gram/pull/5789)

Linear: AGE-3131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated admin endpoint for recording manual enterprise trial conversions so a signed contract can't be demoted by the trial sweeper.

- Accepts only the organization ID; the server assigns `converted_at` and restores enterprise access for running, ending-soon, expired, and demoted trials.
- Preserves `ends_at`, historical `demoted_at`, and organization `disabled_at`; converted trials cannot be demoted or re-armed.
- Reconciles every OpenRouter key type to enterprise limits and removes only the `trial_demotion` cause, so admin-locked or billing-inactive keys stay disabled.
- If an upstream key update fails, the organization remains unconverted; retries converge and emit only one audit event.
- Stops pending trial emails after commit and repairs a missed enqueue on retry.
- Stripe checkout now shares the conversion audit event using `conversion_source = stripe_checkout`.
- Returns 409 for PAYG organizations or organizations without an enterprise trial, 404 for missing ones.

<sup>Written for commit 824e305d24a5eef104b7a5a34dbf6cf58279b285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

