### PR TITLE
feat: hide OpenClaw's inbound envelope in transcripts, titles, and summaries

### DIFF
--- a/.changeset/openclaw-envelope-strip.md
+++ b/.changeset/openclaw-envelope-strip.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Strip OpenClaw's inbound-metadata envelope (conversation info, reply targets, chat history, delivery hints, timestamp prefix) from turn text before generating session titles and summaries, matching the harness framing already stripped for Claude Code.

--- a/.changeset/openclaw-envelope-strip.md
+++ b/.changeset/openclaw-envelope-strip.md
@@ -1,5 +1,6 @@
 ---
 "server": patch
+"dashboard": patch
 ---
 
-Strip OpenClaw's inbound-metadata envelope (conversation info, reply targets, chat history, delivery hints, timestamp prefix) from turn text before generating session titles and summaries, matching the harness framing already stripped for Claude Code.
+Hide OpenClaw's inbound-metadata envelope (conversation info, reply targets, chat history, delivery hints, timestamp prefix) when rendering session transcripts and when generating session titles and summaries, matching the treatment of the assistant runtime's `<message-context>` framing. Stored messages are unchanged.

--- a/client/dashboard/src/lib/harnessEnvelopes.test.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { stripLeadingEnvelopes } from "./harnessEnvelopes";
+
+const conversationInfo =
+  'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "channel:42",\n  "sender": {\n    "name": "Example User"\n  },\n  "was_mentioned": true\n}\n```';
+
+describe("stripLeadingEnvelopes", () => {
+  it("strips the assistant runtime's message-context framing", () => {
+    expect(
+      stripLeadingEnvelopes(
+        "<message-context>\nEventID: abc\n</message-context>\n\nHow do I reduce token usage?",
+      ),
+    ).toBe("How do I reduce token usage?");
+  });
+
+  it("strips OpenClaw's conversation info block", () => {
+    expect(
+      stripLeadingEnvelopes(
+        `${conversationInfo}\n\n@Bot what does this command do`,
+      ),
+    ).toBe("@Bot what does this command do");
+  });
+
+  it("strips the timestamp and delivery hint only when an envelope follows", () => {
+    expect(
+      stripLeadingEnvelopes(
+        `[Thu 2026-08-27 13:51 EDT] Delivery: to send a message, use the \`message\` tool.\n\n${conversationInfo}\n\nping`,
+      ),
+    ).toBe("ping");
+    expect(
+      stripLeadingEnvelopes("[Mon 2024-05-01 09:30] could we move the sync?"),
+    ).toBe("[Mon 2024-05-01 09:30] could we move the sync?");
+  });
+
+  it("strips stacked blocks including history rows", () => {
+    expect(
+      stripLeadingEnvelopes(
+        `${conversationInfo}\n\nReply target of current user message (untrusted, for context):\n\`\`\`json\n{"body": "earlier"}\n\`\`\`\n\nChat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n#2 2026-08-27 13:52:10 EDT ->#1 bob: yo\n\nRecent messages (untrusted, chronological, oldest first):\n#3 2026-08-27 13:53:00 EDT carol: hey\n\nsummarize the thread`,
+      ),
+    ).toBe("summarize the thread");
+  });
+
+  it("keeps a human line right after a history block", () => {
+    expect(
+      stripLeadingEnvelopes(
+        "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\nNote: can you continue",
+      ),
+    ).toBe("Note: can you continue");
+  });
+
+  it("leaves mid-message sentinels and unterminated fences alone", () => {
+    const mid = "why does the prompt say (untrusted metadata): here";
+    expect(stripLeadingEnvelopes(mid)).toBe(mid);
+    const open =
+      'Conversation info (untrusted metadata):\n```json\n{"chat_id": "x"\n\nping';
+    expect(stripLeadingEnvelopes(open)).toBe(open);
+  });
+
+  it("returns text without an envelope untouched", () => {
+    expect(stripLeadingEnvelopes("  indented paste\n")).toBe(
+      "  indented paste\n",
+    );
+  });
+});

--- a/client/dashboard/src/lib/harnessEnvelopes.test.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { stripLeadingEnvelopes } from "./harnessEnvelopes";
+import {
+  splitLeadingEnvelopes,
+  stripLeadingEnvelopes,
+} from "./harnessEnvelopes";
 
 const conversationInfo =
   'Conversation info (untrusted metadata):\n```json\n{\n  "chat_id": "channel:42",\n  "sender": {\n    "name": "Example User"\n  },\n  "was_mentioned": true\n}\n```';
@@ -72,5 +75,17 @@ describe("stripLeadingEnvelopes", () => {
     expect(stripLeadingEnvelopes("  indented paste\n")).toBe(
       "  indented paste\n",
     );
+  });
+
+  it("splits the envelope off so the transcript can fold it", () => {
+    const { envelope, body } = splitLeadingEnvelopes(
+      `${conversationInfo}\n\nping`,
+    );
+    expect(envelope.trim()).toBe(conversationInfo);
+    expect(body).toBe("ping");
+    expect(splitLeadingEnvelopes("plain")).toEqual({
+      envelope: "",
+      body: "plain",
+    });
   });
 });

--- a/client/dashboard/src/lib/harnessEnvelopes.test.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.test.ts
@@ -55,6 +55,14 @@ describe("stripLeadingEnvelopes", () => {
     ).toBe("summarize the thread");
   });
 
+  it("does not treat a hash-tagged human line as a history row", () => {
+    expect(
+      stripLeadingEnvelopes(
+        "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n#note can: continue",
+      ),
+    ).toBe("#note can: continue");
+  });
+
   it("keeps a human line right after a history block", () => {
     expect(
       stripLeadingEnvelopes(

--- a/client/dashboard/src/lib/harnessEnvelopes.test.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.test.ts
@@ -21,7 +21,19 @@ describe("stripLeadingEnvelopes", () => {
     ).toBe("@Bot what does this command do");
   });
 
-  it("strips the timestamp and delivery hint only when an envelope follows", () => {
+  it("strips OpenClaw's zone-bearing stamp on a plain turn but not a human bracket", () => {
+    expect(stripLeadingEnvelopes("[Thu 2026-08-27 13:51 EDT] hello")).toBe(
+      "hello",
+    );
+    expect(
+      stripLeadingEnvelopes("[Thu 2026-08-27 13:51:33 GMT+5:30] hello"),
+    ).toBe("hello");
+    expect(
+      stripLeadingEnvelopes("[Mon 2024-05-01 09:30] could we move the sync?"),
+    ).toBe("[Mon 2024-05-01 09:30] could we move the sync?");
+  });
+
+  it("strips the timestamp and delivery hint ahead of an envelope", () => {
     expect(
       stripLeadingEnvelopes(
         `[Thu 2026-08-27 13:51 EDT] Delivery: to send a message, use the \`message\` tool.\n\n${conversationInfo}\n\nping`,

--- a/client/dashboard/src/lib/harnessEnvelopes.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.ts
@@ -12,20 +12,22 @@
 //   Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):" headers over a
 //   ```json fence (Conversation info, Sender, Reply target, …), and
 //   chat-history / chat-window paragraphs whose rows are
-//   "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text". An optional
-//   "[Thu 2026-08-27 13:51 EDT]" timestamp stamps the head of the whole text and
-//   is removed only when an envelope element follows it.
-const STAMP = String.raw`\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *`;
+//   "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text". OpenClaw
+//   also stamps every turn with a leading "[Thu 2026-08-27 13:51 EDT] " that
+//   always carries a short zone name; a human date-time bracket without a
+//   zone is not the stamp and is left alone.
+const STAMP = String.raw`\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [A-Z]{1,5}(?:[+-]\d{1,2}(?::\d{2})?)?\] *`;
 const ROW_TIME = String.raw`\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? `;
 const HISTORY_ROW = String.raw`(?:#\S+ (?:${ROW_TIME})?|${ROW_TIME})(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$)`;
 const ENVELOPE = [
+  STAMP,
   String.raw`\s*<message-context>[\s\S]*?<\/message-context>\s*`,
   String.raw`\s*<notification>[\s\S]*?<\/notification>\s*`,
   String.raw`\s*Delivery: (?:to send a message, use the \x60message\x60 tool\.|Final assistant text is not automatically delivered in this run\.[^\n]*|No visible reply is delivered automatically in this run[^\n]*)\s*`,
   String.raw`\s*[^\n]* \(untrusted[^)\n]*\):\n\x60\x60\x60json\n[\s\S]*?\n\x60\x60\x60\s*`,
   String.raw`\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:${HISTORY_ROW})*\s*`,
 ].join("|");
-const LEADING_ENVELOPE_RE = new RegExp(`^(?:${STAMP})?(?:${ENVELOPE})+`, "i");
+const LEADING_ENVELOPE_RE = new RegExp(`^(?:${ENVELOPE})+`, "i");
 
 /** Removes leading harness envelopes from a persisted user turn for display.
  * Text with no envelope is returned unchanged. */

--- a/client/dashboard/src/lib/harnessEnvelopes.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.ts
@@ -12,13 +12,14 @@
 //   Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):" headers over a
 //   ```json fence (Conversation info, Sender, Reply target, …), and
 //   chat-history / chat-window paragraphs whose rows are
-//   "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text". OpenClaw
+//   "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text" — a row
+//   always carries the timestamp, so "#note can: continue" is not one. OpenClaw
 //   also stamps every turn with a leading "[Thu 2026-08-27 13:51 EDT] " that
 //   always carries a short zone name; a human date-time bracket without a
 //   zone is not the stamp and is left alone.
 const STAMP = String.raw`\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [A-Z]{1,5}(?:[+-]\d{1,2}(?::\d{2})?)?\] *`;
 const ROW_TIME = String.raw`\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? `;
-const HISTORY_ROW = String.raw`(?:#\S+ (?:${ROW_TIME})?|${ROW_TIME})(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$)`;
+const HISTORY_ROW = String.raw`(?:#\S+ ${ROW_TIME}|${ROW_TIME})(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$)`;
 const ENVELOPE = [
   STAMP,
   String.raw`\s*<message-context>[\s\S]*?<\/message-context>\s*`,

--- a/client/dashboard/src/lib/harnessEnvelopes.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.ts
@@ -1,0 +1,34 @@
+// Display-time stripping of the machine framing agent harnesses prepend to a
+// user turn. The stored message keeps the framing — the model needed it and
+// risk findings may point into it — but it is plumbing, not conversation, so
+// transcripts render only the human-authored text. Mirrors the server's
+// `chat.StripLeadingEnvelopes`, which applies the same allowlist before title
+// and summary generation.
+//
+// Envelopes recognized, all anchored to the start of the text:
+// - `<message-context>…</message-context>` (Gram assistant runtime) and
+//   `<notification>…</notification>` (Claude Code background tasks).
+// - OpenClaw's inbound metadata on channel-originated turns (Discord / Slack /
+//   Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):" headers over a
+//   ```json fence (Conversation info, Sender, Reply target, …), and
+//   chat-history / chat-window paragraphs whose rows are
+//   "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text". An optional
+//   "[Thu 2026-08-27 13:51 EDT]" timestamp stamps the head of the whole text and
+//   is removed only when an envelope element follows it.
+const STAMP = String.raw`\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *`;
+const ROW_TIME = String.raw`\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? `;
+const HISTORY_ROW = String.raw`(?:#\S+ (?:${ROW_TIME})?|${ROW_TIME})(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$)`;
+const ENVELOPE = [
+  String.raw`\s*<message-context>[\s\S]*?<\/message-context>\s*`,
+  String.raw`\s*<notification>[\s\S]*?<\/notification>\s*`,
+  String.raw`\s*Delivery: (?:to send a message, use the \x60message\x60 tool\.|Final assistant text is not automatically delivered in this run\.[^\n]*|No visible reply is delivered automatically in this run[^\n]*)\s*`,
+  String.raw`\s*[^\n]* \(untrusted[^)\n]*\):\n\x60\x60\x60json\n[\s\S]*?\n\x60\x60\x60\s*`,
+  String.raw`\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:${HISTORY_ROW})*\s*`,
+].join("|");
+const LEADING_ENVELOPE_RE = new RegExp(`^(?:${STAMP})?(?:${ENVELOPE})+`, "i");
+
+/** Removes leading harness envelopes from a persisted user turn for display.
+ * Text with no envelope is returned unchanged. */
+export function stripLeadingEnvelopes(text: string): string {
+  return text.replace(LEADING_ENVELOPE_RE, "");
+}

--- a/client/dashboard/src/lib/harnessEnvelopes.ts
+++ b/client/dashboard/src/lib/harnessEnvelopes.ts
@@ -29,8 +29,22 @@ const ENVELOPE = [
 ].join("|");
 const LEADING_ENVELOPE_RE = new RegExp(`^(?:${ENVELOPE})+`, "i");
 
+/** Splits a persisted user turn into the leading harness envelope and the
+ * human-authored body. `envelope` is "" when there is none, and `body` is then
+ * the input unchanged. */
+export function splitLeadingEnvelopes(text: string): {
+  envelope: string;
+  body: string;
+} {
+  const match = LEADING_ENVELOPE_RE.exec(text);
+  if (!match) return { envelope: "", body: text };
+  return { envelope: match[0], body: text.slice(match[0].length) };
+}
+
 /** Removes leading harness envelopes from a persisted user turn for display.
- * Text with no envelope is returned unchanged. */
+ * Text with no envelope is returned unchanged. The envelope is not lost — the
+ * transcript folds it into a collapsed disclosure via `splitLeadingEnvelopes`,
+ * so a spoofed envelope inside a prompt stays inspectable. */
 export function stripLeadingEnvelopes(text: string): string {
-  return text.replace(LEADING_ENVELOPE_RE, "");
+  return splitLeadingEnvelopes(text).body;
 }

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -41,6 +41,11 @@ import {
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback } from "@/components/ui/Avatar";
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/Collapsible";
+import {
   type ClaudeUsageMatch,
   formatDurationFromNanos,
   formatUsageCost,
@@ -55,6 +60,7 @@ import {
   displayItemContainsMessage,
   type DisplayItem,
   findQueryRanges,
+  messageEnvelope,
   messageText,
   type MessageRow,
   type PromptAttachment,
@@ -339,6 +345,46 @@ function TurnHeader({
   );
 }
 
+// The harness framing a user turn opened with (`<message-context>`, OpenClaw's
+// "Conversation info (untrusted metadata)" block, …). Stored verbatim and
+// folded into a disclosure that is collapsed by default: it is plumbing, not
+// conversation, but a reviewer must still be able to inspect it — a prompt
+// that spoofs an envelope is exactly the kind of thing they are looking for.
+function HarnessContextDisclosure({
+  envelope,
+  results,
+  revealed,
+}: {
+  envelope: string;
+  results: RiskResult[] | undefined;
+  revealed?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mb-1.5">
+      <CollapsibleTrigger className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs">
+        {open ? (
+          <ChevronUp className="size-3" />
+        ) : (
+          <ChevronDown className="size-3" />
+        )}
+        Harness context
+      </CollapsibleTrigger>
+      <CollapsibleContent className="text-muted-foreground mt-1 border-l-2 pl-2 font-mono text-xs whitespace-pre-wrap">
+        {results && results.length > 0 ? (
+          <HighlightedMessageText
+            text={envelope}
+            results={results}
+            revealed={revealed}
+          />
+        ) : (
+          envelope
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
 // Outgoing turn — left-aligned to match the assistant, but kept in a bg-muted
 // bubble. The avatar/name + risk badge sit in the turn header above (the risk
 // badge's popover carries "Mark false positive" and "Setup exclusion rule"
@@ -368,6 +414,7 @@ function UserMessageRow({
   }
   const usage = ctx.claudeUsageByMessage.get(message.id);
   const text = messageText(message.content);
+  const envelope = messageEnvelope(message.content);
   const flagged =
     (!!results && results.length > 0) ||
     row.attachments.some((attachment) => attachment.isRisk);
@@ -389,6 +436,13 @@ function UserMessageRow({
           "bg-muted text-foreground mx-2 max-w-[80%] px-4 py-2 wrap-break-word",
         )}
       >
+        {envelope && (
+          <HarnessContextDisclosure
+            envelope={envelope}
+            results={messageResults}
+            revealed={messageSensitive ? revealed : undefined}
+          />
+        )}
         {messageResults && messageResults.length > 0 ? (
           <HighlightedMessageText
             text={text}

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -76,6 +76,7 @@ import {
   RiskBadge,
 } from "./chatRisk";
 import {
+  getMatchStrings,
   distinctRiskCount,
   resultsAreSensitive,
   useRowReveal,
@@ -360,6 +361,16 @@ function HarnessContextDisclosure({
   revealed?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  // Only findings whose match lives in the envelope belong here; a body match
+  // would otherwise be repeated as an out-of-text "Flagged value" — it is
+  // already highlighted in the message body below.
+  const envelopeResults = useMemo(
+    () =>
+      (results ?? []).filter((r) =>
+        getMatchStrings([r]).some((m) => envelope.includes(m)),
+      ),
+    [results, envelope],
+  );
   return (
     <Collapsible open={open} onOpenChange={setOpen} className="mb-1.5">
       <CollapsibleTrigger className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs">
@@ -371,10 +382,10 @@ function HarnessContextDisclosure({
         Harness context
       </CollapsibleTrigger>
       <CollapsibleContent className="text-muted-foreground mt-1 border-l-2 pl-2 font-mono text-xs whitespace-pre-wrap">
-        {results && results.length > 0 ? (
+        {envelopeResults.length > 0 ? (
           <HighlightedMessageText
             text={envelope}
-            results={results}
+            results={envelopeResults}
             revealed={revealed}
           />
         ) : (

--- a/client/dashboard/src/pages/chatLogs/transcript.test.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.test.ts
@@ -4,7 +4,9 @@ import {
   buildDisplayItems,
   displayItemContainsMessage,
   displayItemRows,
+  messageEnvelope,
   messageText,
+  buildTranscript,
   type DisplayItem,
   type ToolRow,
   type TranscriptRow,
@@ -15,6 +17,40 @@ describe("messageText", () => {
     const stored =
       'Conversation info (untrusted metadata):\n```json\n{"chat_id": "channel:42"}\n```\n\n@Bot what does this command do';
     expect(messageText(stored)).toBe("@Bot what does this command do");
+  });
+
+  it("exposes the envelope for the folded disclosure", () => {
+    const stored =
+      'Conversation info (untrusted metadata):\n```json\n{"chat_id": "channel:42"}\n```\n\n@Bot what does this command do';
+    expect(messageEnvelope(stored)).toBe(
+      'Conversation info (untrusted metadata):\n```json\n{"chat_id": "channel:42"}\n```',
+    );
+    expect(messageEnvelope("plain")).toBe("");
+    expect(messageEnvelope([{ type: "text", text: stored }])).toContain(
+      "Conversation info",
+    );
+  });
+
+  it("hides a text-part turn that is only envelope, but keeps media", () => {
+    const envelopeOnly = "<message-context>\nEventID: e1\n</message-context>";
+    const rows = buildTranscript([
+      {
+        id: "a",
+        seq: 1,
+        role: "user",
+        content: [{ type: "text", text: envelopeOnly }],
+      },
+      {
+        id: "b",
+        seq: 2,
+        role: "user",
+        content: [
+          { type: "text", text: envelopeOnly },
+          { type: "image", image: "x" },
+        ],
+      },
+    ] as never);
+    expect(rows.map((r) => r.id)).toEqual(["b"]);
   });
 
   it("still strips the assistant runtime's message-context envelope", () => {

--- a/client/dashboard/src/pages/chatLogs/transcript.test.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.test.ts
@@ -4,10 +4,27 @@ import {
   buildDisplayItems,
   displayItemContainsMessage,
   displayItemRows,
+  messageText,
   type DisplayItem,
   type ToolRow,
   type TranscriptRow,
 } from "./transcript";
+
+describe("messageText", () => {
+  it("renders only the human text of an OpenClaw channel turn", () => {
+    const stored =
+      'Conversation info (untrusted metadata):\n```json\n{"chat_id": "channel:42"}\n```\n\n@Bot what does this command do';
+    expect(messageText(stored)).toBe("@Bot what does this command do");
+  });
+
+  it("still strips the assistant runtime's message-context envelope", () => {
+    expect(
+      messageText(
+        "<message-context>\nEventID: e1\n</message-context>\nWhat changed?",
+      ),
+    ).toBe("What changed?");
+  });
+});
 
 describe("argsToString", () => {
   it("omits blank argument payloads instead of rendering an empty section", () => {

--- a/client/dashboard/src/pages/chatLogs/transcript.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.ts
@@ -6,7 +6,10 @@ import {
   type ToolCall,
   type TraceEntryType,
 } from "./traceEntries";
-import { stripLeadingEnvelopes } from "@/lib/harnessEnvelopes";
+import {
+  splitLeadingEnvelopes,
+  stripLeadingEnvelopes,
+} from "@/lib/harnessEnvelopes";
 
 type MessageEntryType = Extract<
   TraceEntryType,
@@ -20,6 +23,30 @@ function cleanMessageText(raw: string): string {
   return stripLeadingEnvelopes(raw)
     .replace(/[ \t]+$/gm, "")
     .trim();
+}
+
+/** Joined text of a message's text parts; "" for content with no text. */
+function joinedTextParts(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) =>
+      part &&
+      typeof part === "object" &&
+      "text" in part &&
+      typeof (part as { text: unknown }).text === "string"
+        ? (part as { text: string }).text
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** The harness envelope a user turn opened with (`<message-context>`,
+ * OpenClaw's inbound metadata, …), for the collapsed disclosure the transcript
+ * renders above the human text. "" when the turn has none. */
+export function messageEnvelope(content: unknown): string {
+  return splitLeadingEnvelopes(joinedTextParts(content)).envelope.trim();
 }
 
 /** Render-time plain text of a message's content (string, multimodal text
@@ -196,11 +223,22 @@ function hasTextContent(content: unknown): boolean {
 
 /** A message with nothing left once the leading harness envelope is stripped —
  * machine plumbing, so its row is hidden instead of rendered as an empty
- * bubble. Only applies to plain string content (arrays go through
- * hasTextContent). */
+ * bubble. A part array counts only when every part is text; a row carrying
+ * media (image, audio, …) is always shown. */
 function hasNoVisibleText(content: unknown): boolean {
-  if (typeof content !== "string") return false;
-  return stripLeadingEnvelopes(content).trim().length === 0;
+  if (typeof content === "string") {
+    return stripLeadingEnvelopes(content).trim().length === 0;
+  }
+  if (!Array.isArray(content) || content.length === 0) return false;
+  const allText = content.every(
+    (part) =>
+      !!part &&
+      typeof part === "object" &&
+      "text" in part &&
+      typeof (part as { text: unknown }).text === "string",
+  );
+  if (!allText) return false;
+  return stripLeadingEnvelopes(joinedTextParts(content)).trim().length === 0;
 }
 
 /**

--- a/client/dashboard/src/pages/chatLogs/transcript.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.ts
@@ -6,18 +6,18 @@ import {
   type ToolCall,
   type TraceEntryType,
 } from "./traceEntries";
+import { stripLeadingEnvelopes } from "@/lib/harnessEnvelopes";
 
 type MessageEntryType = Extract<
   TraceEntryType,
   "user" | "assistant" | "system"
 >;
 
-// Strip the injected `<message-context>…</message-context>` envelope (event id,
-// timestamp, user id) and trailing whitespace the harness prepends to prompts —
-// it's machine plumbing, not part of the conversation.
+// Strip the harness envelope (`<message-context>`, OpenClaw's inbound metadata,
+// …) and trailing whitespace prepended to prompts — it's machine plumbing, not
+// part of the conversation. The stored message keeps it; see harnessEnvelopes.
 function cleanMessageText(raw: string): string {
-  return raw
-    .replace(/^\s*<message-context>[\s\S]*?<\/message-context>/i, "")
+  return stripLeadingEnvelopes(raw)
     .replace(/[ \t]+$/gm, "")
     .trim();
 }
@@ -194,17 +194,13 @@ function hasTextContent(content: unknown): boolean {
   return false;
 }
 
-/** A message with nothing left once the leading <message-context> envelope is
- * stripped — machine plumbing, so its row is hidden instead of rendered as an
- * empty bubble. Only applies to plain string content (arrays go through
+/** A message with nothing left once the leading harness envelope is stripped —
+ * machine plumbing, so its row is hidden instead of rendered as an empty
+ * bubble. Only applies to plain string content (arrays go through
  * hasTextContent). */
 function hasNoVisibleText(content: unknown): boolean {
   if (typeof content !== "string") return false;
-  return (
-    content
-      .replace(/^\s*<message-context>[\s\S]*?<\/message-context>/i, "")
-      .trim().length === 0
-  );
+  return stripLeadingEnvelopes(content).trim().length === 0;
 }
 
 /**

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -28,16 +28,15 @@ import (
 // "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text"; a row
 // must open with the #id and/or timestamp marker (each followed by its
 // separator) and carry a "sender: " later, which bounds the paragraph so a
-// human line right after it survives. An optional "[Thu 2026-08-27 13:51 EDT]"
-// timestamp stamps the head of the whole text; it is only removed when an
-// envelope element follows, so a human message that opens with a
-// timestamp-shaped bracket is left alone. The hooks relay strips all of this
+// human line right after it survives. OpenClaw also stamps every turn with a
+// leading "[Thu 2026-08-27 13:51 EDT] " that always carries a short zone name;
+// a human line that opens with a date-time bracket but no zone is not the
+// stamp and is left alone. The hooks relay strips all of this
 // before ingest on current installs; this covers turns stored before it did
 // and any install still bootstrapping an older hooks binary.
-var leadingEnvelopeRE = regexp.MustCompile(`(?s)^` +
-	`(?:\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *)?` +
-	`(?:` +
-	`\s*<message-context>.*?</message-context>\s*` +
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:` +
+	`\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [A-Z]{1,5}(?:[+-]\d{1,2}(?::\d{2})?)?\] *` +
+	`|\s*<message-context>.*?</message-context>\s*` +
 	`|\s*<notification>.*?</notification>\s*` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -22,19 +22,24 @@ import (
 // a tag a user types mid-message is preserved; the non-greedy body stops at the
 // first close tag.
 // OpenClaw prepends its own envelope to channel-originated turns (Discord /
-// Slack / Telegram): an optional "[Thu 2026-08-27 13:51 EDT]" timestamp, a
-// "Delivery: …" hint line, "<Label> (untrusted…):" headers over a ```json
-// fence (Conversation info, Sender, Reply target, …), and blank-line-terminated
-// chat-history / chat-window paragraphs. The hooks relay strips these before
-// ingest on current installs; this covers turns stored before it did and any
-// install still bootstrapping an older hooks binary.
-var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:` +
+// Slack / Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):"
+// headers over a ```json fence (Conversation info, Sender, Reply target, …),
+// and chat-history / chat-window paragraphs whose every line is
+// "[#id ts] sender: text" (the entry shape bounds the paragraph so a human
+// line right after it survives). An optional "[Thu 2026-08-27 13:51 EDT]"
+// timestamp stamps the head of the whole text; it is only removed when an
+// envelope element follows, so a human message that opens with a
+// timestamp-shaped bracket is left alone. The hooks relay strips all of this
+// before ingest on current installs; this covers turns stored before it did
+// and any install still bootstrapping an older hooks binary.
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^` +
+	`(?:\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *)?` +
+	`(?:` +
 	`\s*<message-context>.*?</message-context>\s*` +
 	`|\s*<notification>.*?</notification>\s*` +
-	`|\s*\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
-	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:[^\n]+(?:\n|$))*\s*` +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:[^\n:]+: [^\n]*(?:\n|$))*\s*` +
 	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -40,7 +40,7 @@ var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:` +
 	`|\s*<notification>.*?</notification>\s*` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
-	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+ )?\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$))*\s*` +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+ )?\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? (?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$))*\s*` +
 	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -21,7 +21,21 @@ import (
 // `<message-context>…</notification>` is left alone. Anchored to the start, so
 // a tag a user types mid-message is preserved; the non-greedy body stops at the
 // first close tag.
-var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:\s*<message-context>.*?</message-context>\s*|\s*<notification>.*?</notification>\s*)+`)
+// OpenClaw prepends its own envelope to channel-originated turns (Discord /
+// Slack / Telegram): an optional "[Thu 2026-08-27 13:51 EDT]" timestamp, a
+// "Delivery: …" hint line, "<Label> (untrusted…):" headers over a ```json
+// fence (Conversation info, Sender, Reply target, …), and blank-line-terminated
+// chat-history / chat-window paragraphs. The hooks relay strips these before
+// ingest on current installs; this covers turns stored before it did and any
+// install still bootstrapping an older hooks binary.
+var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:` +
+	`\s*<message-context>.*?</message-context>\s*` +
+	`|\s*<notification>.*?</notification>\s*` +
+	`|\s*\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]\n]*\] *` +
+	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
+	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:[^\n]+(?:\n|$))*\s*` +
+	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM
 // prompts (titles, session summaries) see only the human-authored turn text.

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -26,9 +26,9 @@ import (
 // headers over a ```json fence (Conversation info, Sender, Reply target, …),
 // and chat-history / chat-window paragraphs whose rows are
 // "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text"; a row
-// must open with the #id and/or timestamp marker (each followed by its
-// separator) and carry a "sender: " later, which bounds the paragraph so a
-// human line right after it survives. OpenClaw also stamps every turn with a
+// must carry the timestamp (after an optional #id) and a "sender: " later,
+// which bounds the paragraph so a human line right after it — even
+// "#note can: continue" — survives. OpenClaw also stamps every turn with a
 // leading "[Thu 2026-08-27 13:51 EDT] " that always carries a short zone name;
 // a human line that opens with a date-time bracket but no zone is not the
 // stamp and is left alone. The hooks relay strips all of this
@@ -40,7 +40,7 @@ var leadingEnvelopeRE = regexp.MustCompile(`(?s)^(?:` +
 	`|\s*<notification>.*?</notification>\s*` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
-	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+ (?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )?|\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$))*\s*` +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+ )?\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$))*\s*` +
 	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -25,9 +25,10 @@ import (
 // Slack / Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):"
 // headers over a ```json fence (Conversation info, Sender, Reply target, …),
 // and chat-history / chat-window paragraphs whose rows are
-// "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text"; a row is
-// recognized by its leading #id or timestamp marker, which bounds the
-// paragraph so a human line right after it survives. An optional "[Thu 2026-08-27 13:51 EDT]"
+// "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text"; a row
+// must open with the #id and/or timestamp marker (each followed by its
+// separator) and carry a "sender: " later, which bounds the paragraph so a
+// human line right after it survives. An optional "[Thu 2026-08-27 13:51 EDT]"
 // timestamp stamps the head of the whole text; it is only removed when an
 // envelope element follows, so a human message that opens with a
 // timestamp-shaped bracket is left alone. The hooks relay strips all of this
@@ -40,7 +41,7 @@ var leadingEnvelopeRE = regexp.MustCompile(`(?s)^` +
 	`|\s*<notification>.*?</notification>\s*` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
-	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+|\d{4}-\d{2}-\d{2} \d{2}:\d{2})[^\n]*: [^\n]*(?:\n|$))*\s*` +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+ (?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )?|\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})?(?: [A-Z]{1,5})? )(?:\[reply target\] )?(?:->#\S+ )?[^\n]*: [^\n]*(?:\n|$))*\s*` +
 	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM

--- a/server/internal/chat/envelopes.go
+++ b/server/internal/chat/envelopes.go
@@ -24,9 +24,10 @@ import (
 // OpenClaw prepends its own envelope to channel-originated turns (Discord /
 // Slack / Telegram): a "Delivery: …" hint line, "<Label> (untrusted…):"
 // headers over a ```json fence (Conversation info, Sender, Reply target, …),
-// and chat-history / chat-window paragraphs whose every line is
-// "[#id ts] sender: text" (the entry shape bounds the paragraph so a human
-// line right after it survives). An optional "[Thu 2026-08-27 13:51 EDT]"
+// and chat-history / chat-window paragraphs whose rows are
+// "#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text"; a row is
+// recognized by its leading #id or timestamp marker, which bounds the
+// paragraph so a human line right after it survives. An optional "[Thu 2026-08-27 13:51 EDT]"
 // timestamp stamps the head of the whole text; it is only removed when an
 // envelope element follows, so a human message that opens with a
 // timestamp-shaped bracket is left alone. The hooks relay strips all of this
@@ -39,7 +40,7 @@ var leadingEnvelopeRE = regexp.MustCompile(`(?s)^` +
 	`|\s*<notification>.*?</notification>\s*` +
 	"|\\s*Delivery: (?:to send a message, use the `message` tool\\.|Final assistant text is not automatically delivered in this run\\.[^\\n]*|No visible reply is delivered automatically in this run[^\\n]*)\\s*" +
 	"|\\s*[^\\n]* \\(untrusted[^)\\n]*\\):\\n```json\\n.*?\\n```\\s*" +
-	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:[^\n:]+: [^\n]*(?:\n|$))*\s*` +
+	`|\s*[^\n]* \(untrusted(?:, chronological[^)\n]*|, for context)\):\n(?:(?:#\S+|\d{4}-\d{2}-\d{2} \d{2}:\d{2})[^\n]*: [^\n]*(?:\n|$))*\s*` +
 	`)+`)
 
 // StripLeadingEnvelopes removes any leading harness framing so downstream LLM

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -94,8 +94,8 @@ func TestStripLeadingEnvelopesRemovesOpenClawStackedBlocks(t *testing.T) {
 
 	input := openclawConversationInfo +
 		"\n\nReply target of current user message (untrusted, for context):\n```json\n{\"body\": \"earlier\"}\n```" +
-		"\n\nChat history since last reply (untrusted, for context):\n[1] alice: hi\n[2] bob: yo" +
-		"\n\nRecent messages (untrusted, chronological, oldest first):\n[3] carol: hey" +
+		"\n\nChat history since last reply (untrusted, for context):\n#1 alice: hi\n#2 bob: yo" +
+		"\n\nRecent messages (untrusted, chronological, oldest first):\n#3 carol: hey" +
 		"\n\nsummarize the thread"
 	require.Equal(t, "summarize the thread", chat.StripLeadingEnvelopes(input))
 }
@@ -111,5 +111,19 @@ func TestStripLeadingEnvelopesLeavesUnterminatedOpenClawFence(t *testing.T) {
 	t.Parallel()
 
 	input := "Conversation info (untrusted metadata):\n```json\n{\"chat_id\": \"x\"\n\nping"
+	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesKeepsTextRightAfterOpenClawHistory(t *testing.T) {
+	t.Parallel()
+
+	input := "Chat history since last reply (untrusted, for context):\n#1 alice: hi\n#2 bob: yo\ncan you continue"
+	require.Equal(t, "can you continue", chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesLeavesHumanTimestampWithoutEnvelope(t *testing.T) {
+	t.Parallel()
+
+	input := "[Mon 2024-05-01 09:30] could we move the sync?"
 	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
 }

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -148,3 +148,10 @@ func TestStripLeadingEnvelopesRemovesOpenClawStampOnPlainTurn(t *testing.T) {
 	require.Equal(t, "hello", chat.StripLeadingEnvelopes("[Thu 2026-08-27 13:51 EDT] hello"))
 	require.Equal(t, "hello", chat.StripLeadingEnvelopes("[Thu 2026-08-27 13:51:33 GMT+5:30] hello"))
 }
+
+func TestStripLeadingEnvelopesKeepsHashTaggedLineAfterOpenClawHistory(t *testing.T) {
+	t.Parallel()
+
+	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n#note can: continue"
+	require.Equal(t, "#note can: continue", chat.StripLeadingEnvelopes(input))
+}

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -94,8 +94,8 @@ func TestStripLeadingEnvelopesRemovesOpenClawStackedBlocks(t *testing.T) {
 
 	input := openclawConversationInfo +
 		"\n\nReply target of current user message (untrusted, for context):\n```json\n{\"body\": \"earlier\"}\n```" +
-		"\n\nChat history since last reply (untrusted, for context):\n#1 alice: hi\n#2 bob: yo" +
-		"\n\nRecent messages (untrusted, chronological, oldest first):\n#3 carol: hey" +
+		"\n\nChat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n#2 2026-08-27 13:52:10 EDT ->#1 bob: yo" +
+		"\n\nRecent messages (untrusted, chronological, oldest first):\n#3 2026-08-27 13:53:00 EDT carol: hey" +
 		"\n\nsummarize the thread"
 	require.Equal(t, "summarize the thread", chat.StripLeadingEnvelopes(input))
 }
@@ -117,7 +117,7 @@ func TestStripLeadingEnvelopesLeavesUnterminatedOpenClawFence(t *testing.T) {
 func TestStripLeadingEnvelopesKeepsTextRightAfterOpenClawHistory(t *testing.T) {
 	t.Parallel()
 
-	input := "Chat history since last reply (untrusted, for context):\n#1 alice: hi\n#2 bob: yo\ncan you continue"
+	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n#2 2026-08-27 13:52:10 EDT ->#1 bob: yo\ncan you continue"
 	require.Equal(t, "can you continue", chat.StripLeadingEnvelopes(input))
 }
 
@@ -126,4 +126,11 @@ func TestStripLeadingEnvelopesLeavesHumanTimestampWithoutEnvelope(t *testing.T) 
 
 	input := "[Mon 2024-05-01 09:30] could we move the sync?"
 	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesKeepsColonLineAfterOpenClawHistory(t *testing.T) {
+	t.Parallel()
+
+	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\nNote: can you continue"
+	require.Equal(t, "Note: can you continue", chat.StripLeadingEnvelopes(input))
 }

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -141,3 +141,10 @@ func TestStripLeadingEnvelopesKeepsTimestampPhraseAfterOpenClawHistory(t *testin
 	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n2026-08-27 standup: can you continue"
 	require.Equal(t, "2026-08-27 standup: can you continue", chat.StripLeadingEnvelopes(input))
 }
+
+func TestStripLeadingEnvelopesRemovesOpenClawStampOnPlainTurn(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "hello", chat.StripLeadingEnvelopes("[Thu 2026-08-27 13:51 EDT] hello"))
+	require.Equal(t, "hello", chat.StripLeadingEnvelopes("[Thu 2026-08-27 13:51:33 GMT+5:30] hello"))
+}

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -72,3 +72,44 @@ func TestStripLeadingEnvelopesOnlyStripsLeadingBlock(t *testing.T) {
 	input := "why does my agent emit <message-context>foo</message-context> in its output?"
 	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
 }
+
+const openclawConversationInfo = "Conversation info (untrusted metadata):\n```json\n{\n  \"chat_id\": \"channel:42\",\n  \"sender\": {\n    \"name\": \"Example User\"\n  },\n  \"was_mentioned\": true\n}\n```"
+
+func TestStripLeadingEnvelopesRemovesOpenClawConversationInfo(t *testing.T) {
+	t.Parallel()
+
+	input := openclawConversationInfo + "\n\n@Bot what does this command do"
+	require.Equal(t, "@Bot what does this command do", chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesRemovesOpenClawTimestampAndHint(t *testing.T) {
+	t.Parallel()
+
+	input := "[Thu 2026-08-27 13:51 EDT] Delivery: to send a message, use the `message` tool.\n\n" + openclawConversationInfo + "\n\nping"
+	require.Equal(t, "ping", chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesRemovesOpenClawStackedBlocks(t *testing.T) {
+	t.Parallel()
+
+	input := openclawConversationInfo +
+		"\n\nReply target of current user message (untrusted, for context):\n```json\n{\"body\": \"earlier\"}\n```" +
+		"\n\nChat history since last reply (untrusted, for context):\n[1] alice: hi\n[2] bob: yo" +
+		"\n\nRecent messages (untrusted, chronological, oldest first):\n[3] carol: hey" +
+		"\n\nsummarize the thread"
+	require.Equal(t, "summarize the thread", chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesLeavesOpenClawSentinelMidMessage(t *testing.T) {
+	t.Parallel()
+
+	input := "why does the prompt say (untrusted metadata): here"
+	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
+}
+
+func TestStripLeadingEnvelopesLeavesUnterminatedOpenClawFence(t *testing.T) {
+	t.Parallel()
+
+	input := "Conversation info (untrusted metadata):\n```json\n{\"chat_id\": \"x\"\n\nping"
+	require.Equal(t, input, chat.StripLeadingEnvelopes(input))
+}

--- a/server/internal/chat/envelopes_test.go
+++ b/server/internal/chat/envelopes_test.go
@@ -134,3 +134,10 @@ func TestStripLeadingEnvelopesKeepsColonLineAfterOpenClawHistory(t *testing.T) {
 	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\nNote: can you continue"
 	require.Equal(t, "Note: can you continue", chat.StripLeadingEnvelopes(input))
 }
+
+func TestStripLeadingEnvelopesKeepsTimestampPhraseAfterOpenClawHistory(t *testing.T) {
+	t.Parallel()
+
+	input := "Chat history since last reply (untrusted, for context):\n#1 2026-08-27 13:51:33 EDT alice: hi\n2026-08-27 standup: can you continue"
+	require.Equal(t, "2026-08-27 standup: can you continue", chat.StripLeadingEnvelopes(input))
+}


### PR DESCRIPTION
Linear: DNO-994 — Gram half; the agenthooks half (`PromptEvent.Inbound` + exported stripper, `Prompt` kept verbatim) is speakeasy-api/agenthooks#22.

## Problem

Channel-originated OpenClaw turns (Discord/Slack/Telegram) arrive with OpenClaw's AI-facing metadata envelope at the head of the prompt — `Conversation info (untrusted metadata):` + a ```json block, reply-target / chat-history blocks, `Delivery:` hints, a `[Thu 2026-08-27 13:51 EDT]` timestamp. It rendered as the session's first "You" message, and `buildTitleContext` / session summaries fed it to the model.

## Approach

**Store what the model saw; hide the envelope at render time** — the convention Assistants already uses for `<message-context>`. Nothing here rewrites stored messages.

- **Dashboard** — `lib/harnessEnvelopes.ts`: `splitLeadingEnvelopes` / `stripLeadingEnvelopes` covering `<message-context>`, `<notification>`, and the OpenClaw envelope, mirroring the server regex. `chatLogs/transcript.ts` renders `messageText` through it, and `UserMessageRow` **folds the envelope into a "Harness context" disclosure, collapsed by default** — it is plumbing, not conversation, but a reviewer can still open it (a prompt that spoofs an envelope is exactly what they're looking for), and a user-authored block that happens to match the shape is folded, never lost. Risk highlighting/masking applies inside the disclosure via `HighlightedMessageText`. A text-part turn that is *only* envelope is hidden as before; rows carrying media stay.
- **Server** — the same OpenClaw alternatives added to `chat.StripLeadingEnvelopes`, which runs only for title generation and `buildSummarizeTranscript`.

Envelope rules (both sides, start-anchored): OpenClaw's zone-bearing timestamp stamp (`[Thu 2026-08-27 13:51 EDT] `) — a human `[Mon 2024-05-01 09:30]` bracket is left alone; delivery-hint lines; `<Label> (untrusted…):` + fenced JSON; chat-history / chat-window paragraphs whose rows match `#id 2026-08-27 13:51:33 EDT [reply target] ->#id sender: text`. Mid-message occurrences, unterminated fences, and human lines right after a block are left alone; no-envelope input is returned byte-identical.

Tests: 8 dashboard helper cases + 4 transcript cases; 11 server cases. Changeset: server + dashboard patch.

Note: `server/internal/chat` tests need Docker for their TestMain; verified in an isolated copy locally and run for real in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xyc7vXYdhBwgnB5F8LXx1H
