### PR TITLE
feat: evaluate overlapping killswitches with database time

### DIFF
--- a/server/internal/killswitches/contracts.go
+++ b/server/internal/killswitches/contracts.go
@@ -165,6 +165,23 @@ type PrincipalCandidate struct {
 	Key  PrincipalKey
 }
 
+const (
+	// MaxEvaluationDefinitionCandidates bounds server-controlled definition precedence input.
+	MaxEvaluationDefinitionCandidates = 16
+	// MaxEvaluationPrincipalCandidates bounds server-controlled principal specificity input.
+	MaxEvaluationPrincipalCandidates = 16
+)
+
+// EvaluationRequest contains ordered, canonical, server-derived candidates for one protected resource.
+// Definition and principal order are the authoritative precedence used by the evaluator.
+type EvaluationRequest struct {
+	OrganizationID      OrganizationID
+	DefinitionKeys      []DefinitionKey
+	PrincipalCandidates []PrincipalCandidate
+	ResourceKind        ResourceKind
+	ResourceKey         ResourceKey
+}
+
 // PrincipalCandidateResultKind identifies a successful or deliberately unsupported derivation.
 type PrincipalCandidateResultKind string
 
@@ -301,12 +318,25 @@ const (
 // EvaluationResult is an immutable transport-neutral evaluation result. Its zero value is
 // invalid; use one of its constructors.
 type EvaluationResult struct {
-	kind              EvaluationResultKind
-	prescriptionID    PrescriptionID
-	externalNote      string
-	noMatchReason     NoMatchReason
-	infrastructureErr error
+	kind                      EvaluationResultKind
+	prescriptionID            PrescriptionID
+	externalNote              string
+	noMatchReason             NoMatchReason
+	infrastructureErr         error
+	failurePolicy             FailurePolicy
+	infrastructureFailureKind InfrastructureFailureKind
 }
+
+// InfrastructureFailureKind distinguishes bounded evaluator failure classes without exposing data.
+type InfrastructureFailureKind string
+
+const (
+	InfrastructureFailureInvalidRequest     InfrastructureFailureKind = "invalid_request"
+	InfrastructureFailureParentCancellation InfrastructureFailureKind = "parent_cancellation"
+	InfrastructureFailureTimeout            InfrastructureFailureKind = "timeout"
+	InfrastructureFailureDatabase           InfrastructureFailureKind = "database"
+	InfrastructureFailureDataIntegrity      InfrastructureFailureKind = "data_integrity"
+)
 
 // NewMatchResult constructs a matched result with customer-safe denial language.
 func NewMatchResult(prescriptionID PrescriptionID, externalNote string) (EvaluationResult, error) {
@@ -319,11 +349,13 @@ func NewMatchResult(prescriptionID PrescriptionID, externalNote string) (Evaluat
 		return EvaluationResult{}, fmt.Errorf("external note: %w", err)
 	}
 	return EvaluationResult{
-		kind:              EvaluationResultMatch,
-		prescriptionID:    *canonicalID,
-		externalNote:      note,
-		noMatchReason:     "",
-		infrastructureErr: nil,
+		kind:                      EvaluationResultMatch,
+		prescriptionID:            *canonicalID,
+		externalNote:              note,
+		noMatchReason:             "",
+		infrastructureErr:         nil,
+		failurePolicy:             "",
+		infrastructureFailureKind: "",
 	}, nil
 }
 
@@ -333,11 +365,13 @@ func NewNoMatchResult(reason NoMatchReason) (EvaluationResult, error) {
 		return EvaluationResult{}, fmt.Errorf("invalid no-match reason %q", reason)
 	}
 	return EvaluationResult{
-		kind:              EvaluationResultNoMatch,
-		prescriptionID:    "",
-		externalNote:      "",
-		noMatchReason:     reason,
-		infrastructureErr: nil,
+		kind:                      EvaluationResultNoMatch,
+		prescriptionID:            "",
+		externalNote:              "",
+		noMatchReason:             reason,
+		infrastructureErr:         nil,
+		failurePolicy:             "",
+		infrastructureFailureKind: "",
 	}, nil
 }
 
@@ -347,12 +381,32 @@ func NewInfrastructureFailureResult(cause error) (EvaluationResult, error) {
 		return EvaluationResult{}, errors.New("infrastructure failure cause is required")
 	}
 	return EvaluationResult{
-		kind:              EvaluationResultInfrastructureFailure,
-		prescriptionID:    "",
-		externalNote:      "",
-		noMatchReason:     "",
-		infrastructureErr: cause,
+		kind:                      EvaluationResultInfrastructureFailure,
+		prescriptionID:            "",
+		externalNote:              "",
+		noMatchReason:             "",
+		infrastructureErr:         cause,
+		failurePolicy:             "",
+		infrastructureFailureKind: "",
 	}, nil
+}
+
+// NewInfrastructureFailureResultWithPolicy constructs a classified infrastructure failure and
+// retains the effective policy for the complete ordered definition candidate set.
+func NewInfrastructureFailureResultWithPolicy(cause error, policy FailurePolicy, failureKind InfrastructureFailureKind) (EvaluationResult, error) {
+	result, err := NewInfrastructureFailureResult(cause)
+	if err != nil {
+		return EvaluationResult{}, err
+	}
+	if policy != FailurePolicyFailOpen && policy != FailurePolicyFailClosed {
+		return EvaluationResult{}, fmt.Errorf("invalid failure policy %q", policy)
+	}
+	if !validInfrastructureFailureKind(failureKind) {
+		return EvaluationResult{}, fmt.Errorf("invalid infrastructure failure kind %q", failureKind)
+	}
+	result.failurePolicy = policy
+	result.infrastructureFailureKind = failureKind
+	return result, nil
 }
 
 // Kind returns the result discriminator.
@@ -379,6 +433,25 @@ func (r EvaluationResult) InfrastructureError() error {
 		return nil
 	}
 	return r.infrastructureErr
+}
+
+// FailurePolicy returns evaluator-selected policy information for a match or infrastructure failure.
+func (r EvaluationResult) FailurePolicy() (FailurePolicy, bool) {
+	return r.failurePolicy, r.failurePolicy == FailurePolicyFailOpen || r.failurePolicy == FailurePolicyFailClosed
+}
+
+// InfrastructureFailureKind returns the bounded class only for a classified infrastructure failure.
+func (r EvaluationResult) InfrastructureFailureKind() (InfrastructureFailureKind, bool) {
+	return r.infrastructureFailureKind, r.kind == EvaluationResultInfrastructureFailure && validInfrastructureFailureKind(r.infrastructureFailureKind)
+}
+
+func validInfrastructureFailureKind(kind InfrastructureFailureKind) bool {
+	switch kind {
+	case InfrastructureFailureInvalidRequest, InfrastructureFailureParentCancellation, InfrastructureFailureTimeout, InfrastructureFailureDatabase, InfrastructureFailureDataIntegrity:
+		return true
+	default:
+		return false
+	}
 }
 
 // TransportDispositionKind identifies the neutral action selected before concrete transport mapping.
@@ -441,36 +514,54 @@ type TransportAdapterRegistration struct {
 
 // ResolveTransportDisposition applies the shared transport-neutral evaluation matrix.
 func ResolveTransportDisposition(result EvaluationResult, failurePolicy FailurePolicy) (TransportDisposition, error) {
+	disposition, _, err := resolveTransportDisposition(result, failurePolicy)
+	return disposition, err
+}
+
+func resolveTransportDisposition(result EvaluationResult, suppliedPolicy FailurePolicy) (TransportDisposition, FailurePolicy, error) {
 	if err := validateEvaluationResult(result); err != nil {
-		return TransportDisposition{}, err
+		return TransportDisposition{}, "", err
 	}
-	if failurePolicy != FailurePolicyFailOpen && failurePolicy != FailurePolicyFailClosed {
-		return TransportDisposition{}, fmt.Errorf("invalid failure policy %q", failurePolicy)
+	failurePolicy, err := effectiveFailurePolicy(result, suppliedPolicy)
+	if err != nil {
+		return TransportDisposition{}, "", err
 	}
 
 	switch result.kind {
 	case EvaluationResultMatch:
-		return NewMatchedDenialDisposition(result.externalNote)
+		disposition, err := NewMatchedDenialDisposition(result.externalNote)
+		return disposition, failurePolicy, err
 	case EvaluationResultNoMatch:
-		return NewContinueDisposition(), nil
+		return NewContinueDisposition(), failurePolicy, nil
 	case EvaluationResultInfrastructureFailure:
 		if failurePolicy == FailurePolicyFailOpen {
-			return NewContinueDisposition(), nil
+			return NewContinueDisposition(), failurePolicy, nil
 		}
-		return NewInfrastructureRejectionDisposition(), nil
+		return NewInfrastructureRejectionDisposition(), failurePolicy, nil
 	default:
-		return TransportDisposition{}, errors.New("invalid evaluation result")
+		return TransportDisposition{}, "", errors.New("invalid evaluation result")
 	}
+}
+
+func effectiveFailurePolicy(result EvaluationResult, suppliedPolicy FailurePolicy) (FailurePolicy, error) {
+	if suppliedPolicy != FailurePolicyFailOpen && suppliedPolicy != FailurePolicyFailClosed {
+		return "", fmt.Errorf("invalid failure policy %q", suppliedPolicy)
+	}
+	if authoritativePolicy, ok := result.FailurePolicy(); ok {
+		return authoritativePolicy, nil
+	}
+	return suppliedPolicy, nil
 }
 
 func validateEvaluationResult(result EvaluationResult) error {
 	switch result.kind {
 	case EvaluationResultMatch:
-		if result.prescriptionID == "" || result.externalNote == "" || result.noMatchReason != "" || result.infrastructureErr != nil {
+		hasPolicy := result.failurePolicy == FailurePolicyFailOpen || result.failurePolicy == FailurePolicyFailClosed
+		if result.prescriptionID == "" || result.externalNote == "" || result.noMatchReason != "" || result.infrastructureErr != nil || (result.failurePolicy != "" && !hasPolicy) || result.infrastructureFailureKind != "" {
 			return errors.New("invalid match evaluation result")
 		}
 	case EvaluationResultNoMatch:
-		if result.prescriptionID != "" || result.externalNote != "" || result.infrastructureErr != nil {
+		if result.prescriptionID != "" || result.externalNote != "" || result.infrastructureErr != nil || result.failurePolicy != "" || result.infrastructureFailureKind != "" {
 			return errors.New("invalid no-match evaluation result")
 		}
 		if result.noMatchReason != NoMatchReasonNoPrescription && result.noMatchReason != NoMatchReasonUnsupportedIdentity && result.noMatchReason != NoMatchReasonUnsupportedResource {
@@ -478,6 +569,10 @@ func validateEvaluationResult(result EvaluationResult) error {
 		}
 	case EvaluationResultInfrastructureFailure:
 		if result.prescriptionID != "" || result.externalNote != "" || result.noMatchReason != "" || isNilInterface(result.infrastructureErr) {
+			return errors.New("invalid infrastructure-failure evaluation result")
+		}
+		hasPolicy := result.failurePolicy == FailurePolicyFailOpen || result.failurePolicy == FailurePolicyFailClosed
+		if (result.failurePolicy != "" && !hasPolicy) || (result.infrastructureFailureKind != "" && !validInfrastructureFailureKind(result.infrastructureFailureKind)) || (hasPolicy != (result.infrastructureFailureKind != "")) {
 			return errors.New("invalid infrastructure-failure evaluation result")
 		}
 	default:

--- a/server/internal/killswitches/evaluator.go
+++ b/server/internal/killswitches/evaluator.go
@@ -1,0 +1,225 @@
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches/repo"
+)
+
+// ErrEvaluatorTimeout marks the evaluator-owned deadline rather than parent cancellation.
+var ErrEvaluatorTimeout = errors.New("kill-switch evaluator timeout")
+
+type evaluationQueries interface {
+	EvaluateCurrentPrescriptions(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error)
+}
+
+// Evaluator performs one authoritative PostgreSQL query for each supported evaluation request.
+type Evaluator struct {
+	queries  evaluationQueries
+	registry *Registry
+	timeout  time.Duration
+	metrics  *evaluationMetrics
+}
+
+type preparedEvaluation struct {
+	params          repo.EvaluateCurrentPrescriptionsParams
+	policies        map[DefinitionKey]FailurePolicy
+	effectivePolicy FailurePolicy
+	noMatchReason   NoMatchReason
+}
+
+// NewEvaluator constructs an evaluator over the authoritative PostgreSQL connection. A positive
+// evaluator-specific timeout is mandatory even when callers normally carry a deadline.
+func NewEvaluator(db repo.DBTX, registry *Registry, timeout time.Duration, meterProvider metric.MeterProvider, logger *slog.Logger) (*Evaluator, error) {
+	if isNilInterface(db) {
+		return nil, errors.New("kill-switch evaluator database is required")
+	}
+	return newEvaluator(repo.New(db), registry, timeout, newEvaluationMetrics(meterProvider, logger))
+}
+
+func newEvaluator(queries evaluationQueries, registry *Registry, timeout time.Duration, metrics *evaluationMetrics) (*Evaluator, error) {
+	if isNilInterface(queries) {
+		return nil, errors.New("kill-switch evaluator queries are required")
+	}
+	if registry == nil {
+		return nil, errors.New("kill-switch evaluator registry is required")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("kill-switch evaluator timeout must be positive")
+	}
+	return &Evaluator{queries: queries, registry: registry, timeout: timeout, metrics: metrics}, nil
+}
+
+// Evaluate returns a matched denial, an ordinary no-match, or a classified infrastructure failure.
+func (e *Evaluator) Evaluate(ctx context.Context, request EvaluationRequest) EvaluationResult {
+	outcome := killswitchEvaluationOutcomeEvaluatorFailure
+	if e.metrics.enabled(ctx) {
+		started := time.Now()
+		defer func() { e.metrics.record(ctx, outcome, time.Since(started)) }()
+	}
+
+	prepared, err := e.prepare(request)
+	if err != nil {
+		return infrastructureFailureResult(err, prepared.effectivePolicy, InfrastructureFailureInvalidRequest)
+	}
+	if err := ctx.Err(); err != nil {
+		return infrastructureFailureResult(err, prepared.effectivePolicy, InfrastructureFailureParentCancellation)
+	}
+	if prepared.noMatchReason != "" {
+		outcome = killswitchEvaluationOutcomeUnmatched
+		result, _ := NewNoMatchResult(prepared.noMatchReason)
+		return result
+	}
+
+	queryContext, cancel := context.WithTimeoutCause(ctx, e.timeout, ErrEvaluatorTimeout)
+	defer cancel()
+	row, err := e.queries.EvaluateCurrentPrescriptions(queryContext, prepared.params)
+	if errors.Is(err, pgx.ErrNoRows) {
+		outcome = killswitchEvaluationOutcomeUnmatched
+		result, _ := NewNoMatchResult(NoMatchReasonNoPrescription)
+		return result
+	}
+	if cause := context.Cause(queryContext); err != nil && cause != nil {
+		if errors.Is(cause, ErrEvaluatorTimeout) {
+			return infrastructureFailureResult(errors.Join(cause, queryContext.Err()), prepared.effectivePolicy, InfrastructureFailureTimeout)
+		}
+		return infrastructureFailureResult(cause, prepared.effectivePolicy, InfrastructureFailureParentCancellation)
+	}
+	if err != nil {
+		return infrastructureFailureResult(fmt.Errorf("evaluate current kill-switch prescriptions: %w", err), prepared.effectivePolicy, InfrastructureFailureDatabase)
+	}
+
+	policy, ok := prepared.policies[DefinitionKey(row.DefinitionKey)]
+	if !ok {
+		return infrastructureFailureResult(errors.New("evaluation returned an unexpected definition"), prepared.effectivePolicy, InfrastructureFailureDataIntegrity)
+	}
+	result, err := NewMatchResult(PrescriptionID(row.PrescriptionID.String()), row.ExternalNote)
+	if err != nil {
+		return infrastructureFailureResult(errors.New("evaluation returned invalid match data"), prepared.effectivePolicy, InfrastructureFailureDataIntegrity)
+	}
+	result.failurePolicy = policy
+	outcome = killswitchEvaluationOutcomeMatched
+	return result
+}
+
+func (e *Evaluator) prepare(request EvaluationRequest) (preparedEvaluation, error) {
+	prepared := preparedEvaluation{
+		params: repo.EvaluateCurrentPrescriptionsParams{
+			OrganizationID:           "",
+			ResourceKind:             "",
+			ResourceKey:              "",
+			DefinitionKeys:           nil,
+			PrincipalKinds:           nil,
+			PrincipalKeys:            nil,
+			CompatibleDefinitionKeys: nil,
+			CompatiblePrincipalKinds: nil,
+		},
+		policies:        nil,
+		effectivePolicy: FailurePolicyFailOpen,
+		noMatchReason:   "",
+	}
+	invalid := func(format string, args ...any) (preparedEvaluation, error) {
+		prepared.effectivePolicy = FailurePolicyFailClosed
+		return prepared, fmt.Errorf(format, args...)
+	}
+
+	if len(request.DefinitionKeys) == 0 || len(request.DefinitionKeys) > MaxEvaluationDefinitionCandidates {
+		return invalid("evaluation definition candidate count must be between 1 and %d", MaxEvaluationDefinitionCandidates)
+	}
+	if len(request.PrincipalCandidates) > MaxEvaluationPrincipalCandidates {
+		return invalid("evaluation principal candidate count must not exceed %d", MaxEvaluationPrincipalCandidates)
+	}
+	if err := validateIdentifier("evaluation organization ID", string(request.OrganizationID)); err != nil {
+		return invalid("%v", err)
+	}
+
+	prepared.policies = make(map[DefinitionKey]FailurePolicy, len(request.DefinitionKeys))
+	definitions := make([]Definition, 0, len(request.DefinitionKeys))
+	supportedPrincipalKinds := make(map[PrincipalKind]struct{})
+	prepared.params.DefinitionKeys = make([]string, 0, len(request.DefinitionKeys))
+	for _, key := range request.DefinitionKeys {
+		if _, duplicate := prepared.policies[key]; duplicate {
+			return invalid("duplicate evaluation definition candidate")
+		}
+		definition, ok := e.registry.Definition(key)
+		if !ok {
+			return invalid("unknown evaluation definition candidate")
+		}
+		definitions = append(definitions, definition)
+		for _, kind := range definition.PrincipalKinds {
+			supportedPrincipalKinds[kind] = struct{}{}
+		}
+		prepared.policies[key] = definition.FailurePolicy
+		if definition.FailurePolicy == FailurePolicyFailClosed {
+			prepared.effectivePolicy = FailurePolicyFailClosed
+		}
+		prepared.params.DefinitionKeys = append(prepared.params.DefinitionKeys, string(key))
+	}
+
+	if request.ResourceKind == "" && request.ResourceKey == "" {
+		prepared.noMatchReason = NoMatchReasonUnsupportedResource
+		return prepared, nil
+	}
+	if err := validateIdentifier("evaluation resource kind", string(request.ResourceKind)); err != nil {
+		return invalid("%v", err)
+	}
+	if err := validateIdentifier("evaluation resource key", string(request.ResourceKey)); err != nil {
+		return invalid("%v", err)
+	}
+	for _, definition := range definitions {
+		if !slices.Contains(definition.ResourceKinds, request.ResourceKind) {
+			return invalid("evaluation resource kind is not supported by every definition candidate")
+		}
+	}
+	prepared.params.OrganizationID = string(request.OrganizationID)
+	prepared.params.ResourceKind = string(request.ResourceKind)
+	prepared.params.ResourceKey = string(request.ResourceKey)
+
+	if len(request.PrincipalCandidates) == 0 {
+		prepared.noMatchReason = NoMatchReasonUnsupportedIdentity
+		return prepared, nil
+	}
+	seenPrincipals := make(map[PrincipalCandidate]struct{}, len(request.PrincipalCandidates))
+	prepared.params.PrincipalKinds = make([]string, 0, len(request.PrincipalCandidates))
+	prepared.params.PrincipalKeys = make([]string, 0, len(request.PrincipalCandidates))
+	compatibleCapacity := len(definitions) * len(request.PrincipalCandidates)
+	prepared.params.CompatibleDefinitionKeys = make([]string, 0, compatibleCapacity)
+	prepared.params.CompatiblePrincipalKinds = make([]string, 0, compatibleCapacity)
+	for _, candidate := range request.PrincipalCandidates {
+		if err := validateIdentifier("evaluation principal kind", string(candidate.Kind)); err != nil {
+			return invalid("%v", err)
+		}
+		if err := validateIdentifier("evaluation principal key", string(candidate.Key)); err != nil {
+			return invalid("%v", err)
+		}
+		if _, duplicate := seenPrincipals[candidate]; duplicate {
+			return invalid("duplicate evaluation principal candidate")
+		}
+		if _, supported := supportedPrincipalKinds[candidate.Kind]; !supported {
+			return invalid("evaluation principal kind is not supported by any definition candidate")
+		}
+		seenPrincipals[candidate] = struct{}{}
+		prepared.params.PrincipalKinds = append(prepared.params.PrincipalKinds, string(candidate.Kind))
+		prepared.params.PrincipalKeys = append(prepared.params.PrincipalKeys, string(candidate.Key))
+		for _, definition := range definitions {
+			if slices.Contains(definition.PrincipalKinds, candidate.Kind) {
+				prepared.params.CompatibleDefinitionKeys = append(prepared.params.CompatibleDefinitionKeys, string(definition.Key))
+				prepared.params.CompatiblePrincipalKinds = append(prepared.params.CompatiblePrincipalKinds, string(candidate.Kind))
+			}
+		}
+	}
+	return prepared, nil
+}
+
+func infrastructureFailureResult(cause error, policy FailurePolicy, kind InfrastructureFailureKind) EvaluationResult {
+	result, _ := NewInfrastructureFailureResultWithPolicy(cause, policy, kind)
+	return result
+}

--- a/server/internal/killswitches/evaluator_test.go
+++ b/server/internal/killswitches/evaluator_test.go
@@ -1,0 +1,455 @@
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/repo"
+)
+
+type evaluationQueryFunc func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error)
+
+func (f evaluationQueryFunc) EvaluateCurrentPrescriptions(ctx context.Context, params repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+	return f(ctx, params)
+}
+
+type disabledTrackingHistogram struct {
+	metricnoop.Float64Histogram
+	enabledCalls atomic.Int32
+	recordCalls  atomic.Int32
+}
+
+func (h *disabledTrackingHistogram) Enabled(context.Context) bool {
+	h.enabledCalls.Add(1)
+	return false
+}
+
+func (h *disabledTrackingHistogram) Record(context.Context, float64, ...metric.RecordOption) {
+	h.recordCalls.Add(1)
+}
+
+func TestEvaluatorRequiresBoundedTimeoutAndCandidates(t *testing.T) {
+	t.Parallel()
+	registry := evaluationRegistry(t)
+	var calls atomic.Int32
+	query := evaluationQueryFunc(func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		calls.Add(1)
+		return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+	})
+
+	_, err := newEvaluator(query, registry, 0, nil)
+	require.EqualError(t, err, "kill-switch evaluator timeout must be positive")
+
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+	request := evaluationRequest("block-tools")
+	request.DefinitionKeys = make([]DefinitionKey, MaxEvaluationDefinitionCandidates+1)
+	prepared, prepareErr := evaluator.prepare(request)
+	require.Error(t, prepareErr)
+	require.Nil(t, prepared.policies)
+	require.Nil(t, prepared.params.DefinitionKeys)
+	result := evaluator.Evaluate(t.Context(), request)
+	require.Equal(t, EvaluationResultInfrastructureFailure, result.Kind())
+	kind, ok := result.InfrastructureFailureKind()
+	require.True(t, ok)
+	require.Equal(t, InfrastructureFailureInvalidRequest, kind)
+	policy, ok := result.FailurePolicy()
+	require.True(t, ok)
+	require.Equal(t, FailurePolicyFailClosed, policy)
+
+	request = evaluationRequest("block-tools")
+	request.PrincipalCandidates = make([]PrincipalCandidate, MaxEvaluationPrincipalCandidates+1)
+	prepared, prepareErr = evaluator.prepare(request)
+	require.Error(t, prepareErr)
+	require.Nil(t, prepared.policies)
+	require.Nil(t, prepared.params.PrincipalKinds)
+	require.Nil(t, prepared.params.PrincipalKeys)
+	result = evaluator.Evaluate(t.Context(), request)
+	require.Equal(t, EvaluationResultInfrastructureFailure, result.Kind())
+	kind, ok = result.InfrastructureFailureKind()
+	require.True(t, ok)
+	require.Equal(t, InfrastructureFailureInvalidRequest, kind)
+	require.Zero(t, calls.Load())
+}
+
+func TestEvaluatorUsesOneQueryAndRetainsWinningPolicy(t *testing.T) {
+	t.Parallel()
+	registry := evaluationRegistry(t)
+	var calls atomic.Int32
+	prescriptionID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	query := evaluationQueryFunc(func(_ context.Context, params repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		calls.Add(1)
+		require.Equal(t, []string{"closed-tools", "block-tools"}, params.DefinitionKeys)
+		require.Equal(t, []string{"user"}, params.PrincipalKinds)
+		require.Equal(t, []string{"user:alpha"}, params.PrincipalKeys)
+		require.Equal(t, []string{"closed-tools", "block-tools"}, params.CompatibleDefinitionKeys)
+		require.Equal(t, []string{"user", "user"}, params.CompatiblePrincipalKinds)
+		return repo.EvaluateCurrentPrescriptionsRow{PrescriptionID: prescriptionID, DefinitionKey: "closed-tools", ExternalNote: "Exact public note."}, nil
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(t.Context(), evaluationRequest("closed-tools", "block-tools"))
+	require.Equal(t, int32(1), calls.Load())
+	require.Equal(t, EvaluationResultMatch, result.Kind())
+	note, ok := result.ExternalNote()
+	require.True(t, ok)
+	require.Equal(t, "Exact public note.", note)
+	policy, ok := result.FailurePolicy()
+	require.True(t, ok)
+	require.Equal(t, FailurePolicyFailClosed, policy)
+}
+
+func TestEvaluatorPreservesDefinitionPrincipalCompatibility(t *testing.T) {
+	t.Parallel()
+	registration := validRegistration()
+	registration.Definitions[0].PrincipalKinds = []PrincipalKind{"user"}
+	serviceOnly := registration.Definitions[0]
+	serviceOnly.Key = "service-only"
+	serviceOnly.PrincipalKinds = []PrincipalKind{"service"}
+	registration.Definitions = append(registration.Definitions, serviceOnly)
+	for _, coverage := range append([]CoverageContract(nil), registration.Coverage...) {
+		coverage.Definition = serviceOnly.Key
+		registration.Coverage = append(registration.Coverage, coverage)
+	}
+	registry, err := BuildRegistry(registration)
+	require.NoError(t, err)
+
+	query := evaluationQueryFunc(func(_ context.Context, params repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		require.Equal(t, []string{"service-only", "block-tools"}, params.DefinitionKeys)
+		require.Equal(t, []string{"service", "user"}, params.PrincipalKinds)
+		require.Equal(t, []string{"service:alpha", "user:alpha"}, params.PrincipalKeys)
+		require.Equal(t, []string{"service-only", "block-tools"}, params.CompatibleDefinitionKeys)
+		require.Equal(t, []string{"service", "user"}, params.CompatiblePrincipalKinds)
+		return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(t.Context(), EvaluationRequest{
+		OrganizationID: "org:test",
+		DefinitionKeys: []DefinitionKey{"service-only", "block-tools"},
+		PrincipalCandidates: []PrincipalCandidate{
+			{Kind: "service", Key: "service:alpha"},
+			{Kind: "user", Key: "user:alpha"},
+		},
+		ResourceKind: "tool", ResourceKey: "org:test:tool:alpha",
+	})
+	require.Equal(t, EvaluationResultNoMatch, result.Kind())
+}
+
+func TestResolveTransportDispositionUsesAuthoritativeEmbeddedPolicy(t *testing.T) {
+	t.Parallel()
+
+	classified, err := NewInfrastructureFailureResultWithPolicy(errors.New("evaluation unavailable"), FailurePolicyFailClosed, InfrastructureFailureDatabase)
+	require.NoError(t, err)
+	disposition, err := ResolveTransportDisposition(classified, FailurePolicyFailOpen)
+	require.NoError(t, err)
+	require.Equal(t, TransportDispositionInfrastructureRejection, disposition.Kind())
+	_, err = ResolveTransportDisposition(classified, FailurePolicy("invalid"))
+	require.EqualError(t, err, `invalid failure policy "invalid"`)
+
+	legacy, err := NewInfrastructureFailureResult(errors.New("evaluation unavailable"))
+	require.NoError(t, err)
+	disposition, err = ResolveTransportDisposition(legacy, FailurePolicyFailOpen)
+	require.NoError(t, err)
+	require.Equal(t, TransportDispositionContinue, disposition.Kind())
+}
+
+func TestEvaluatorDistinguishesFailuresAndAppliesCandidatePolicies(t *testing.T) {
+	t.Parallel()
+	registry := evaluationRegistry(t)
+	tests := []struct {
+		name        string
+		definitions []DefinitionKey
+		query       evaluationQueryFunc
+		wantKind    InfrastructureFailureKind
+		wantPolicy  FailurePolicy
+		wantError   error
+	}{
+		{
+			name: "fail open database failure", definitions: []DefinitionKey{"block-tools"},
+			query: func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+				return repo.EvaluateCurrentPrescriptionsRow{}, errors.New("database unavailable")
+			},
+			wantKind: InfrastructureFailureDatabase, wantPolicy: FailurePolicyFailOpen,
+		},
+		{
+			name: "any fail closed definition dominates database failure", definitions: []DefinitionKey{"block-tools", "closed-tools"},
+			query: func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+				return repo.EvaluateCurrentPrescriptionsRow{}, errors.New("database unavailable")
+			},
+			wantKind: InfrastructureFailureDatabase, wantPolicy: FailurePolicyFailClosed,
+		},
+		{
+			name: "evaluator timeout", definitions: []DefinitionKey{"block-tools"},
+			query: func(ctx context.Context, _ repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+				<-ctx.Done()
+				return repo.EvaluateCurrentPrescriptionsRow{}, ctx.Err()
+			},
+			wantKind: InfrastructureFailureTimeout, wantPolicy: FailurePolicyFailOpen, wantError: ErrEvaluatorTimeout,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			evaluator, err := newEvaluator(test.query, registry, time.Millisecond, nil)
+			require.NoError(t, err)
+			request := evaluationRequest(test.definitions...)
+			result := evaluator.Evaluate(t.Context(), request)
+			require.Equal(t, EvaluationResultInfrastructureFailure, result.Kind())
+			kind, ok := result.InfrastructureFailureKind()
+			require.True(t, ok)
+			require.Equal(t, test.wantKind, kind)
+			policy, ok := result.FailurePolicy()
+			require.True(t, ok)
+			require.Equal(t, test.wantPolicy, policy)
+			if test.wantError != nil {
+				require.ErrorIs(t, result.InfrastructureError(), test.wantError)
+			}
+			disposition, err := ResolveTransportDisposition(result, policy)
+			require.NoError(t, err)
+			if policy == FailurePolicyFailOpen {
+				require.Equal(t, TransportDispositionContinue, disposition.Kind())
+			} else {
+				require.Equal(t, TransportDispositionInfrastructureRejection, disposition.Kind())
+			}
+		})
+	}
+}
+
+func TestEvaluatorUsesSuccessfulDatabaseResultWhenParentCancellationRaces(t *testing.T) {
+	t.Parallel()
+
+	registry := evaluationRegistry(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	query := evaluationQueryFunc(func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		cancel()
+		return repo.EvaluateCurrentPrescriptionsRow{
+			PrescriptionID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			DefinitionKey:  "block-tools",
+			ExternalNote:   "Authoritative match.",
+		}, nil
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(ctx, evaluationRequest("block-tools"))
+	require.Equal(t, EvaluationResultMatch, result.Kind())
+	note, ok := result.ExternalNote()
+	require.True(t, ok)
+	require.Equal(t, "Authoritative match.", note)
+}
+
+func TestEvaluatorUsesSuccessfulNoMatchWhenParentCancellationRaces(t *testing.T) {
+	t.Parallel()
+
+	registry := evaluationRegistry(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	query := evaluationQueryFunc(func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		cancel()
+		return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(ctx, evaluationRequest("closed-tools"))
+	require.Equal(t, EvaluationResultNoMatch, result.Kind())
+	reason, ok := result.NoMatchReason()
+	require.True(t, ok)
+	require.Equal(t, NoMatchReasonNoPrescription, reason)
+}
+
+func TestEvaluatorDistinguishesInFlightParentDeadlineFromEvaluatorTimeout(t *testing.T) {
+	t.Parallel()
+
+	registry := evaluationRegistry(t)
+	var queryStarted atomic.Bool
+	query := evaluationQueryFunc(func(ctx context.Context, _ repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		queryStarted.Store(true)
+		<-ctx.Done()
+		return repo.EvaluateCurrentPrescriptionsRow{}, ctx.Err()
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+
+	result := evaluator.Evaluate(ctx, evaluationRequest("block-tools"))
+	require.True(t, queryStarted.Load())
+	kind, ok := result.InfrastructureFailureKind()
+	require.True(t, ok)
+	require.Equal(t, InfrastructureFailureParentCancellation, kind)
+	require.ErrorIs(t, result.InfrastructureError(), context.DeadlineExceeded)
+	require.NotErrorIs(t, result.InfrastructureError(), ErrEvaluatorTimeout)
+}
+
+func TestEvaluatorTimeoutCauseWinsWhenParentExpiresBeforeDelayedQueryReturn(t *testing.T) {
+	t.Parallel()
+
+	registry := evaluationRegistry(t)
+	parentContext, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	query := evaluationQueryFunc(func(queryContext context.Context, _ repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		<-queryContext.Done()
+		<-parentContext.Done()
+		return repo.EvaluateCurrentPrescriptionsRow{}, queryContext.Err()
+	})
+	evaluator, err := newEvaluator(query, registry, 5*time.Millisecond, nil)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(parentContext, evaluationRequest("block-tools"))
+	kind, ok := result.InfrastructureFailureKind()
+	require.True(t, ok)
+	require.Equal(t, InfrastructureFailureTimeout, kind)
+	require.ErrorIs(t, result.InfrastructureError(), ErrEvaluatorTimeout)
+}
+
+func TestEvaluatorPreservesParentCancellationAndSkipsUnsupportedCandidates(t *testing.T) {
+	t.Parallel()
+	registry := evaluationRegistry(t)
+	var calls atomic.Int32
+	query := evaluationQueryFunc(func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		calls.Add(1)
+		return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+	})
+	evaluator, err := newEvaluator(query, registry, time.Second, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	result := evaluator.Evaluate(ctx, evaluationRequest("block-tools"))
+	require.ErrorIs(t, result.InfrastructureError(), context.Canceled)
+	kind, ok := result.InfrastructureFailureKind()
+	require.True(t, ok)
+	require.Equal(t, InfrastructureFailureParentCancellation, kind)
+	require.Zero(t, calls.Load())
+
+	request := evaluationRequest("block-tools")
+	request.PrincipalCandidates = nil
+	result = evaluator.Evaluate(t.Context(), request)
+	require.Equal(t, EvaluationResultNoMatch, result.Kind())
+	reason, ok := result.NoMatchReason()
+	require.True(t, ok)
+	require.Equal(t, NoMatchReasonUnsupportedIdentity, reason)
+
+	request = evaluationRequest("block-tools")
+	request.PrincipalCandidates = []PrincipalCandidate{{Kind: "unknown", Key: "unknown:alpha"}}
+	result = evaluator.Evaluate(t.Context(), request)
+	require.Equal(t, EvaluationResultInfrastructureFailure, result.Kind())
+
+	request = evaluationRequest("block-tools")
+	request.ResourceKind = ""
+	request.ResourceKey = ""
+	result = evaluator.Evaluate(t.Context(), request)
+	require.Equal(t, EvaluationResultNoMatch, result.Kind())
+	reason, ok = result.NoMatchReason()
+	require.True(t, ok)
+	require.Equal(t, NoMatchReasonUnsupportedResource, reason)
+	require.Zero(t, calls.Load())
+}
+
+func TestEvaluatorSkipsRecordingWhenMetricInstrumentIsDisabled(t *testing.T) {
+	t.Parallel()
+
+	histogram := &disabledTrackingHistogram{}
+	metrics := &evaluationMetrics{
+		duration:               histogram,
+		matchedOption:          nil,
+		unmatchedOption:        nil,
+		evaluatorFailureOption: nil,
+	}
+	query := evaluationQueryFunc(func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+	})
+	evaluator, err := newEvaluator(query, evaluationRegistry(t), time.Second, metrics)
+	require.NoError(t, err)
+
+	result := evaluator.Evaluate(t.Context(), evaluationRequest("block-tools"))
+	require.Equal(t, EvaluationResultNoMatch, result.Kind())
+	require.Equal(t, int32(1), histogram.enabledCalls.Load())
+	require.Zero(t, histogram.recordCalls.Load())
+}
+
+func TestKillswitchEvaluationMetricsHaveClosedAttributes(t *testing.T) {
+	t.Parallel()
+	registry := evaluationRegistry(t)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics := newEvaluationMetrics(provider, nil)
+	prescriptionID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	queries := []evaluationQueryFunc{
+		func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+			return repo.EvaluateCurrentPrescriptionsRow{PrescriptionID: prescriptionID, DefinitionKey: "block-tools", ExternalNote: "Public note."}, nil
+		},
+		func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+			return repo.EvaluateCurrentPrescriptionsRow{}, pgx.ErrNoRows
+		},
+		func(context.Context, repo.EvaluateCurrentPrescriptionsParams) (repo.EvaluateCurrentPrescriptionsRow, error) {
+			return repo.EvaluateCurrentPrescriptionsRow{}, errors.New("database unavailable")
+		},
+	}
+	for _, query := range queries {
+		evaluator, err := newEvaluator(query, registry, time.Second, metrics)
+		require.NoError(t, err)
+		evaluator.Evaluate(t.Context(), evaluationRequest("block-tools"))
+	}
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+	var outcomes []string
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, collected := range scope.Metrics {
+			if collected.Name != meterKillswitchEvaluationDuration {
+				continue
+			}
+			histogram, ok := collected.Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			for _, point := range histogram.DataPoints {
+				require.Equal(t, 1, point.Attributes.Len())
+				value, ok := point.Attributes.Value(attr.OutcomeKey)
+				require.True(t, ok)
+				outcomes = append(outcomes, value.AsString())
+			}
+		}
+	}
+	require.ElementsMatch(t, []string{killswitchEvaluationOutcomeMatched, killswitchEvaluationOutcomeUnmatched, killswitchEvaluationOutcomeEvaluatorFailure}, outcomes)
+}
+
+func evaluationRequest(definitions ...DefinitionKey) EvaluationRequest {
+	return EvaluationRequest{
+		OrganizationID: "org:test", DefinitionKeys: definitions,
+		PrincipalCandidates: []PrincipalCandidate{{Kind: "user", Key: "user:alpha"}},
+		ResourceKind:        "tool", ResourceKey: "org:test:tool:alpha",
+	}
+}
+
+func evaluationRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registration := validRegistration()
+	closed := registration.Definitions[0]
+	closed.Key = "closed-tools"
+	closed.FailurePolicy = FailurePolicyFailClosed
+	registration.Definitions = append(registration.Definitions, closed)
+	for _, coverage := range append([]CoverageContract(nil), registration.Coverage...) {
+		coverage.Definition = closed.Key
+		coverage.FailurePolicy = closed.FailurePolicy
+		registration.Coverage = append(registration.Coverage, coverage)
+	}
+	registry, err := BuildRegistry(registration)
+	require.NoError(t, err)
+	return registry
+}

--- a/server/internal/killswitches/lifecycle.go
+++ b/server/internal/killswitches/lifecycle.go
@@ -49,6 +49,7 @@ type versionResourceSnapshot struct {
 }
 
 type operationReceipt struct {
+	actorUserID string
 	operation   string
 	requestHash string
 	status      string
@@ -313,7 +314,7 @@ func (s *LifecycleService) executeMutation(ctx context.Context, mutation Mutatio
 		return MutationResult{}, err
 	}
 	if !fresh {
-		return replayOperation(receipt, operation, requestHash)
+		return replayOperation(receipt, mutation.ActorUserID, operation, requestHash)
 	}
 
 	result, err := apply(mutationQueries{repo: queries, restricted: restricted})
@@ -354,7 +355,7 @@ func claimOperation(ctx context.Context, queries *repo.Queries, mutation Mutatio
 		}
 		locked, err := queries.LockKillswitchOperation(ctx, repo.LockKillswitchOperationParams{OrganizationID: string(mutation.OrganizationID), OperationID: mutation.OperationID})
 		if err == nil {
-			return operationReceipt{operation: locked.Operation, requestHash: locked.RequestHash, status: locked.Status, response: locked.Response}, false, nil
+			return operationReceipt{actorUserID: locked.ActorUserID, operation: locked.Operation, requestHash: locked.RequestHash, status: locked.Status, response: locked.Response}, false, nil
 		}
 		if !errors.Is(err, pgx.ErrNoRows) {
 			return operationReceipt{}, false, fmt.Errorf("lock killswitch operation: %w", err)
@@ -363,8 +364,8 @@ func claimOperation(ctx context.Context, queries *repo.Queries, mutation Mutatio
 	return operationReceipt{}, false, fmt.Errorf("%w: operation receipt changed during reclaim", ErrOperationUnavailable)
 }
 
-func replayOperation(receipt operationReceipt, operation MutationOperation, requestHash string) (MutationResult, error) {
-	if receipt.operation != string(operation) || receipt.requestHash != requestHash {
+func replayOperation(receipt operationReceipt, actorUserID string, operation MutationOperation, requestHash string) (MutationResult, error) {
+	if receipt.actorUserID != actorUserID || receipt.operation != string(operation) || receipt.requestHash != requestHash {
 		return MutationResult{}, ErrOperationConflict
 	}
 	if receipt.status != operationStatusCompleted || len(receipt.response) == 0 {

--- a/server/internal/killswitches/lifecycle_test.go
+++ b/server/internal/killswitches/lifecycle_test.go
@@ -160,6 +160,11 @@ func TestLifecycleReplayConflictAndBoundedReceipt(t *testing.T) {
 	require.True(t, replayed.Replayed)
 	require.Equal(t, result.PrescriptionID, replayed.PrescriptionID)
 
+	crossActor := retry
+	crossActor.ActorUserID = "user:other"
+	_, err = service.ActivatePrescription(t.Context(), crossActor)
+	require.ErrorIs(t, err, ErrOperationConflict, "operation replay is bound to the actor that claimed it")
+
 	conflict := retry
 	conflict.Desired.InternalNote = "different"
 	_, err = service.ActivatePrescription(t.Context(), conflict)

--- a/server/internal/killswitches/metrics.go
+++ b/server/internal/killswitches/metrics.go
@@ -1,0 +1,70 @@
+package killswitches
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const (
+	meterKillswitchEvaluationDuration = "killswitch.evaluation.duration"
+
+	killswitchEvaluationOutcomeMatched          = "matched"
+	killswitchEvaluationOutcomeUnmatched        = "unmatched"
+	killswitchEvaluationOutcomeEvaluatorFailure = "evaluator_failure"
+)
+
+type evaluationMetrics struct {
+	duration               metric.Float64Histogram
+	matchedOption          metric.RecordOption
+	unmatchedOption        metric.RecordOption
+	evaluatorFailureOption metric.RecordOption
+}
+
+func newEvaluationMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *evaluationMetrics {
+	if meterProvider == nil {
+		return nil
+	}
+
+	histogram, err := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/killswitches").Float64Histogram(
+		meterKillswitchEvaluationDuration,
+		metric.WithDescription("Duration of authoritative kill-switch evaluation in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1),
+	)
+	if err != nil {
+		if logger != nil {
+			logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(meterKillswitchEvaluationDuration), attr.SlogError(err))
+		}
+		return nil
+	}
+	return &evaluationMetrics{
+		duration:               histogram,
+		matchedOption:          metric.WithAttributes(attr.Outcome(killswitchEvaluationOutcomeMatched)),
+		unmatchedOption:        metric.WithAttributes(attr.Outcome(killswitchEvaluationOutcomeUnmatched)),
+		evaluatorFailureOption: metric.WithAttributes(attr.Outcome(killswitchEvaluationOutcomeEvaluatorFailure)),
+	}
+}
+
+func (m *evaluationMetrics) enabled(ctx context.Context) bool {
+	return m != nil && m.duration != nil && m.duration.Enabled(ctx)
+}
+
+func (m *evaluationMetrics) record(ctx context.Context, outcome string, duration time.Duration) {
+	var option metric.RecordOption
+	switch outcome {
+	case killswitchEvaluationOutcomeMatched:
+		option = m.matchedOption
+	case killswitchEvaluationOutcomeUnmatched:
+		option = m.unmatchedOption
+	case killswitchEvaluationOutcomeEvaluatorFailure:
+		option = m.evaluatorFailureOption
+	default:
+		return
+	}
+	m.duration.Record(ctx, duration.Seconds(), option)
+}

--- a/server/internal/killswitches/queries.sql
+++ b/server/internal/killswitches/queries.sql
@@ -139,7 +139,7 @@ WHERE killswitch_operations.expires_at <= EXCLUDED.created_at
 RETURNING operation_id;
 
 -- name: LockKillswitchOperation :one
-SELECT operation, request_hash, status, response
+SELECT actor_user_id, operation, request_hash, status, response
 FROM killswitch_operations
 WHERE organization_id = @organization_id
   AND operation_id = @operation_id

--- a/server/internal/killswitches/queries.sql
+++ b/server/internal/killswitches/queries.sql
@@ -1,3 +1,90 @@
+-- name: EvaluateCurrentPrescriptions :one
+WITH evaluation_clock AS MATERIALIZED (
+  SELECT clock_timestamp() AS database_now
+),
+definition_candidates AS (
+  SELECT definition_key, definition_rank
+  FROM unnest(@definition_keys::text[]) WITH ORDINALITY AS candidate(definition_key, definition_rank)
+),
+principal_candidates AS (
+  SELECT principal_kind, principal_key, principal_rank
+  FROM ROWS FROM (
+    unnest(@principal_kinds::text[]),
+    unnest(@principal_keys::text[])
+  ) WITH ORDINALITY AS candidate(principal_kind, principal_key, principal_rank)
+),
+compatible_definition_principals AS (
+  SELECT definition_key, principal_kind
+  FROM ROWS FROM (
+    unnest(@compatible_definition_keys::text[]),
+    unnest(@compatible_principal_kinds::text[])
+  ) AS candidate(definition_key, principal_kind)
+)
+SELECT
+  matched.prescription_id,
+  matched.definition_key,
+  matched.external_note
+FROM definition_candidates AS definition_candidate
+JOIN principal_candidates AS principal_candidate
+  ON EXISTS (
+    SELECT 1
+    FROM compatible_definition_principals AS compatible
+    WHERE compatible.definition_key = definition_candidate.definition_key
+      AND compatible.principal_kind = principal_candidate.principal_kind
+  )
+CROSS JOIN LATERAL (
+  SELECT
+    prescription.id AS prescription_id,
+    prescription.definition_key,
+    version.external_note,
+    CASE version.resource_scope WHEN 'selected' THEN 0 ELSE 1 END AS resource_scope_rank,
+    version.starts_at,
+    version.activated_at
+  FROM killswitch_prescriptions AS prescription
+  JOIN killswitch_prescription_versions AS version
+    ON version.organization_id = prescription.organization_id
+    AND version.prescription_id = prescription.id
+    AND version.version = prescription.current_version
+  CROSS JOIN evaluation_clock
+  WHERE prescription.organization_id = @organization_id
+    AND prescription.definition_key = definition_candidate.definition_key
+    AND prescription.principal_kind = principal_candidate.principal_kind
+    AND prescription.principal_key = principal_candidate.principal_key
+    AND prescription.resource_kind = @resource_kind
+    AND version.state = 'active'
+    AND version.starts_at <= evaluation_clock.database_now
+    AND (version.expires_at IS NULL OR version.expires_at > evaluation_clock.database_now)
+    AND (
+      version.resource_scope = 'all'
+      OR (
+        version.resource_scope = 'selected'
+        AND EXISTS (
+          SELECT 1
+          FROM killswitch_prescription_version_resources AS resource
+          WHERE resource.organization_id = @organization_id
+            AND resource.organization_id = version.organization_id
+            AND resource.prescription_id = version.prescription_id
+            AND resource.version = version.version
+            AND resource.resource_key = @resource_key
+        )
+      )
+    )
+  ORDER BY
+    resource_scope_rank,
+    version.starts_at DESC,
+    version.activated_at DESC NULLS LAST,
+    prescription.id ASC
+  LIMIT 1
+) AS matched
+ORDER BY
+  definition_candidate.definition_rank,
+  matched.resource_scope_rank,
+  principal_candidate.principal_rank,
+  matched.starts_at DESC,
+  matched.activated_at DESC NULLS LAST,
+  matched.prescription_id ASC
+LIMIT 1;
+
 -- name: GetKillswitchPrescriptionIdentity :one
 SELECT
   id,

--- a/server/internal/killswitches/queries_test.go
+++ b/server/internal/killswitches/queries_test.go
@@ -1,0 +1,334 @@
+//nolint:glint,paralleltest // Integration fixtures intentionally create private rows with raw SQL in one isolated database.
+package killswitches
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches/repo"
+)
+
+type capturingEvaluationDB struct {
+	repo.DBTX
+	query string
+	args  []any
+}
+
+func (db *capturingEvaluationDB) QueryRow(ctx context.Context, query string, args ...any) pgx.Row {
+	db.query = query
+	db.args = args
+	return db.DBTX.QueryRow(ctx, query, args...)
+}
+
+type evaluationFixture struct {
+	ID             uuid.UUID
+	OrganizationID string
+	DefinitionKey  string
+	PrincipalKind  string
+	PrincipalKey   string
+	ResourceKind   string
+	CurrentVersion int64
+	Version        int64
+	State          string
+	Scope          string
+	StartsAt       time.Time
+	ExpiresAt      *time.Time
+	ActivatedAt    *time.Time
+	ExternalNote   string
+	Resources      []string
+}
+
+func TestEvaluateCurrentPrescriptionsIntegration(t *testing.T) {
+	conn, organizationID := newLifecycleDatabase(t, "killswitch_evaluator")
+	queries := repo.New(conn)
+	var databaseNow time.Time
+	require.NoError(t, conn.QueryRow(t.Context(), "SELECT clock_timestamp()").Scan(&databaseNow))
+	past := databaseNow.Add(-time.Hour)
+	older := databaseNow.Add(-2 * time.Hour)
+	future := databaseNow.Add(time.Hour)
+	activeUntil := databaseNow.Add(time.Hour)
+	activated := databaseNow.Add(-30 * time.Minute)
+	newerActivation := databaseNow.Add(-10 * time.Minute)
+
+	insert := func(fixture evaluationFixture) {
+		fixture.OrganizationID = organizationID
+		fixture.ResourceKind = "tool"
+		if fixture.CurrentVersion == 0 {
+			fixture.CurrentVersion = fixture.Version
+		}
+		insertEvaluationFixture(t, conn, fixture)
+	}
+	evaluate := func(principalKinds, principalKeys, definitions []string, resource string) (repo.EvaluateCurrentPrescriptionsRow, error) {
+		compatibleDefinitions := make([]string, 0, len(definitions)*len(principalKinds))
+		compatiblePrincipalKinds := make([]string, 0, len(definitions)*len(principalKinds))
+		for _, definition := range definitions {
+			for _, principalKind := range principalKinds {
+				compatibleDefinitions = append(compatibleDefinitions, definition)
+				compatiblePrincipalKinds = append(compatiblePrincipalKinds, principalKind)
+			}
+		}
+		return queries.EvaluateCurrentPrescriptions(t.Context(), repo.EvaluateCurrentPrescriptionsParams{
+			OrganizationID: organizationID, ResourceKind: "tool", ResourceKey: resource,
+			DefinitionKeys: definitions, PrincipalKinds: principalKinds, PrincipalKeys: principalKeys,
+			CompatibleDefinitionKeys: compatibleDefinitions, CompatiblePrincipalKinds: compatiblePrincipalKinds,
+		})
+	}
+
+	insert(evaluationFixture{ID: evaluationUUID(1), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:interval", Version: 1, State: "active", Scope: "selected", StartsAt: future, ExpiresAt: nil, ActivatedAt: &activated, ExternalNote: "Scheduled.", Resources: []string{"tool:interval"}})
+	insert(evaluationFixture{ID: evaluationUUID(2), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:interval", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &databaseNow, ActivatedAt: &activated, ExternalNote: "Expired exactly.", Resources: []string{"tool:interval"}})
+	_, err := evaluate([]string{"user"}, []string{"user:interval"}, []string{"block-tools"}, "tool:interval")
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	insert(evaluationFixture{ID: evaluationUUID(3), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:dynamic", Version: 1, State: "active", Scope: "all", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Dynamic all."})
+	row, err := evaluate([]string{"user"}, []string{"user:dynamic"}, []string{"block-tools"}, "tool:created-after-activation")
+	require.NoError(t, err)
+	require.Equal(t, "Dynamic all.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(4), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:scope", Version: 1, State: "active", Scope: "all", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "All fallback."})
+	insert(evaluationFixture{ID: evaluationUUID(5), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:scope", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Exact selected note.", Resources: []string{"tool:scope"}})
+	row, err = evaluate([]string{"user"}, []string{"user:scope"}, []string{"block-tools"}, "tool:scope")
+	require.NoError(t, err)
+	require.Equal(t, "Exact selected note.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(6), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:fallback", Version: 1, State: "active", Scope: "all", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Still active all."})
+	insert(evaluationFixture{ID: evaluationUUID(7), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:fallback", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &databaseNow, ActivatedAt: &newerActivation, ExternalNote: "Expired selected.", Resources: []string{"tool:fallback"}})
+	row, err = evaluate([]string{"user"}, []string{"user:fallback"}, []string{"block-tools"}, "tool:fallback")
+	require.NoError(t, err)
+	require.Equal(t, "Still active all.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(8), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:definition", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "First definition.", Resources: []string{"tool:definition"}})
+	insert(evaluationFixture{ID: evaluationUUID(9), DefinitionKey: "broad-tools", PrincipalKind: "user", PrincipalKey: "user:definition", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Second definition.", Resources: []string{"tool:definition"}})
+	row, err = evaluate([]string{"user"}, []string{"user:definition"}, []string{"block-tools", "broad-tools"}, "tool:definition")
+	require.NoError(t, err)
+	require.Equal(t, "First definition.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(10), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:principal", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Exact principal.", Resources: []string{"tool:principal"}})
+	insert(evaluationFixture{ID: evaluationUUID(11), DefinitionKey: "block-tools", PrincipalKind: "service", PrincipalKey: "service:principal", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Broader principal.", Resources: []string{"tool:principal"}})
+	insert(evaluationFixture{ID: evaluationUUID(23), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "service:principal", Version: 1, State: "active", Scope: "selected", StartsAt: databaseNow.Add(-time.Minute), ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Crossed principal tuple.", Resources: []string{"tool:principal"}})
+	row, err = evaluate([]string{"user", "service"}, []string{"user:principal", "service:principal"}, []string{"block-tools"}, "tool:principal")
+	require.NoError(t, err)
+	require.Equal(t, "Exact principal.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(12), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:starts", Version: 1, State: "active", Scope: "selected", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Older start.", Resources: []string{"tool:starts"}})
+	insert(evaluationFixture{ID: evaluationUUID(13), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:starts", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Newer start.", Resources: []string{"tool:starts"}})
+	row, err = evaluate([]string{"user"}, []string{"user:starts"}, []string{"block-tools"}, "tool:starts")
+	require.NoError(t, err)
+	require.Equal(t, "Newer start.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(14), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:activation", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Older activation.", Resources: []string{"tool:activation"}})
+	insert(evaluationFixture{ID: evaluationUUID(15), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:activation", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Newer activation.", Resources: []string{"tool:activation"}})
+	row, err = evaluate([]string{"user"}, []string{"user:activation"}, []string{"block-tools"}, "tool:activation")
+	require.NoError(t, err)
+	require.Equal(t, "Newer activation.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(17), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:uuid", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Larger UUID.", Resources: []string{"tool:uuid"}})
+	insert(evaluationFixture{ID: evaluationUUID(16), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:uuid", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Smaller UUID.", Resources: []string{"tool:uuid"}})
+	row, err = evaluate([]string{"user"}, []string{"user:uuid"}, []string{"block-tools"}, "tool:uuid")
+	require.NoError(t, err)
+	require.Equal(t, "Smaller UUID.", row.ExternalNote)
+
+	currentID := evaluationUUID(18)
+	insert(evaluationFixture{ID: currentID, DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:current", CurrentVersion: 2, Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &newerActivation, ExternalNote: "Old noncurrent version.", Resources: []string{"tool:current"}})
+	insertEvaluationVersion(t, conn, evaluationFixture{ID: currentID, OrganizationID: organizationID, Version: 2, State: "active", Scope: "all", StartsAt: older, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Current version."})
+	row, err = evaluate([]string{"user"}, []string{"user:current"}, []string{"block-tools"}, "tool:current")
+	require.NoError(t, err)
+	require.Equal(t, "Current version.", row.ExternalNote)
+
+	insert(evaluationFixture{ID: evaluationUUID(20), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:members", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Selected members.", Resources: []string{"tool:member-a", "tool:member-b"}})
+	for _, resourceKey := range []string{"tool:member-a", "tool:member-b"} {
+		row, err = evaluate([]string{"user"}, []string{"user:members"}, []string{"block-tools"}, resourceKey)
+		require.NoError(t, err)
+		require.Equal(t, "Selected members.", row.ExternalNote)
+	}
+	_, err = evaluate([]string{"user"}, []string{"user:members"}, []string{"block-tools"}, "tool:unrelated")
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	_, err = queries.EvaluateCurrentPrescriptions(t.Context(), repo.EvaluateCurrentPrescriptionsParams{
+		OrganizationID: organizationID, ResourceKind: "other", ResourceKey: "tool:member-a",
+		DefinitionKeys: []string{"block-tools"}, PrincipalKinds: []string{"user"}, PrincipalKeys: []string{"user:members"},
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	inactiveID := evaluationUUID(21)
+	insert(evaluationFixture{ID: inactiveID, DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:inactive", CurrentVersion: 2, Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Old active version.", Resources: []string{"tool:inactive"}})
+	insertEvaluationVersion(t, conn, evaluationFixture{ID: inactiveID, OrganizationID: organizationID, Version: 2, State: "inactive", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Inactive current version.", Resources: []string{"tool:inactive"}})
+	_, err = evaluate([]string{"user"}, []string{"user:inactive"}, []string{"block-tools"}, "tool:inactive")
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	insert(evaluationFixture{ID: evaluationUUID(22), DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:unbounded", Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: nil, ActivatedAt: &activated, ExternalNote: "Active without expiry.", Resources: []string{"tool:unbounded"}})
+	row, err = evaluate([]string{"user"}, []string{"user:unbounded"}, []string{"block-tools"}, "tool:unbounded")
+	require.NoError(t, err)
+	require.Equal(t, "Active without expiry.", row.ExternalNote)
+
+	otherOrganization := "org_" + uuid.NewString()
+	insertOrganization(t, conn, otherOrganization)
+	insertEvaluationFixture(t, conn, evaluationFixture{ID: evaluationUUID(19), OrganizationID: otherOrganization, DefinitionKey: "block-tools", PrincipalKind: "user", PrincipalKey: "user:tenant", ResourceKind: "tool", CurrentVersion: 1, Version: 1, State: "active", Scope: "selected", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Other tenant.", Resources: []string{"tool:tenant"}})
+	_, err = evaluate([]string{"user"}, []string{"user:tenant"}, []string{"block-tools"}, "tool:tenant")
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	insert(evaluationFixture{ID: evaluationUUID(25), DefinitionKey: "service-only", PrincipalKind: "user", PrincipalKey: "user:compatible", Version: 1, State: "active", Scope: "all", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Incompatible higher-ranked definition."})
+	insert(evaluationFixture{ID: evaluationUUID(26), DefinitionKey: "user-only", PrincipalKind: "user", PrincipalKey: "user:compatible", Version: 1, State: "active", Scope: "all", StartsAt: past, ExpiresAt: &activeUntil, ActivatedAt: &activated, ExternalNote: "Compatible lower-ranked definition."})
+	row, err = queries.EvaluateCurrentPrescriptions(t.Context(), repo.EvaluateCurrentPrescriptionsParams{
+		OrganizationID: organizationID, ResourceKind: "tool", ResourceKey: "tool:compatible",
+		DefinitionKeys: []string{"service-only", "user-only"}, PrincipalKinds: []string{"user"}, PrincipalKeys: []string{"user:compatible"},
+		CompatibleDefinitionKeys: []string{"user-only"}, CompatiblePrincipalKinds: []string{"user"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Compatible lower-ranked definition.", row.ExternalNote)
+}
+
+func TestEvaluateCurrentPrescriptionsRepresentativePlan(t *testing.T) {
+	conn, organizationID := newLifecycleDatabase(t, "killswitch_evaluator_plan")
+	otherOrganizationID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, otherOrganizationID)
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		SELECT $1, 'block-tools', 'user', 'user:plan', 'tool', 1
+		FROM generate_series(1, 256)
+	`, organizationID)
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		SELECT $1, 'block-tools', 'user', 'user:noise', 'tool', 1
+		FROM generate_series(1, 4096)
+	`, otherOrganizationID)
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescription_versions (
+		  organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+		)
+		SELECT organization_id, id, 1, 'active', 'selected',
+		  clock_timestamp() - INTERVAL '1 hour', NULL, clock_timestamp() - INTERVAL '1 hour',
+		  'private plan fixture', 'Plan fixture.'
+		FROM killswitch_prescriptions
+		WHERE organization_id IN ($1, $2) AND principal_key IN ('user:plan', 'user:noise')
+	`, organizationID, otherOrganizationID)
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+		SELECT organization_id, id, 1,
+		  CASE principal_key WHEN 'user:plan' THEN 'tool:plan' ELSE 'tool:noise' END
+		FROM killswitch_prescriptions
+		WHERE organization_id IN ($1, $2) AND principal_key IN ('user:plan', 'user:noise')
+	`, organizationID, otherOrganizationID)
+	require.NoError(t, err)
+	_, err = conn.Exec(t.Context(), "ANALYZE killswitch_prescriptions, killswitch_prescription_versions, killswitch_prescription_version_resources")
+	require.NoError(t, err)
+
+	capture := &capturingEvaluationDB{DBTX: conn, query: "", args: nil}
+	queries := repo.New(capture)
+	_, err = queries.EvaluateCurrentPrescriptions(t.Context(), repo.EvaluateCurrentPrescriptionsParams{
+		OrganizationID: organizationID, ResourceKind: "tool", ResourceKey: "tool:plan",
+		DefinitionKeys: []string{"block-tools"}, PrincipalKinds: []string{"user"}, PrincipalKeys: []string{"user:plan"},
+		CompatibleDefinitionKeys: []string{"block-tools"}, CompatiblePrincipalKinds: []string{"user"},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, capture.query, "generate_subscripts")
+
+	query := capture.query
+	if newline := strings.IndexByte(query, '\n'); newline >= 0 && strings.HasPrefix(query, "--") {
+		query = query[newline+1:]
+	}
+	rows, err := conn.Query(t.Context(), "EXPLAIN (ANALYZE, BUFFERS) "+query, capture.args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var planLines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		planLines = append(planLines, line)
+	}
+	require.NoError(t, rows.Err())
+	plan := strings.Join(planLines, "\n")
+	t.Log("representative evaluator plan:\n" + plan)
+	var principalCandidatePlan string
+	for _, line := range planLines {
+		if strings.Contains(line, "Function Scan on candidate_1") {
+			principalCandidatePlan = line
+			break
+		}
+	}
+	require.NotEmpty(t, principalCandidatePlan)
+	estimateMatch := regexp.MustCompile(`(?:^|\s)rows=([0-9]+)(?:\s|$)`).FindStringSubmatch(principalCandidatePlan)
+	require.Len(t, estimateMatch, 2)
+	estimatedRows, err := strconv.Atoi(estimateMatch[1])
+	require.NoError(t, err)
+	require.Equal(t, 1, estimatedRows)
+	require.Contains(t, plan, "killswitch_prescriptions_evaluator_idx")
+	require.Contains(t, plan, "killswitch_prescription_version_resources_lookup_idx")
+}
+
+func TestKillswitchEvaluationIntervalUsesExactDatabaseTimeBoundaries(t *testing.T) {
+	conn, organizationID := newLifecycleDatabase(t, "killswitch_evaluator_interval_boundaries")
+	capture := &capturingEvaluationDB{DBTX: conn, query: "", args: nil}
+	_, err := repo.New(capture).EvaluateCurrentPrescriptions(t.Context(), repo.EvaluateCurrentPrescriptionsParams{
+		OrganizationID: organizationID, ResourceKind: "tool", ResourceKey: "tool:boundary",
+		DefinitionKeys: []string{"block-tools"}, PrincipalKinds: []string{"user"}, PrincipalKeys: []string{"user:boundary"},
+		CompatibleDefinitionKeys: []string{"block-tools"}, CompatiblePrincipalKinds: []string{"user"},
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	require.Contains(t, capture.query, "WITH evaluation_clock AS MATERIALIZED")
+	require.Equal(t, 1, strings.Count(capture.query, "clock_timestamp()"))
+	require.Contains(t, capture.query, "version.starts_at <= evaluation_clock.database_now")
+	require.Contains(t, capture.query, "version.expires_at > evaluation_clock.database_now")
+
+	var startsAtBoundaryMatches, expiresAtBoundaryMatches bool
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		WITH evaluation_clock AS MATERIALIZED (
+		  SELECT clock_timestamp() AS database_now
+		), boundaries AS (
+		  SELECT database_now AS starts_at, database_now AS expires_at
+		  FROM evaluation_clock
+		)
+		SELECT
+		  boundaries.starts_at <= evaluation_clock.database_now,
+		  boundaries.expires_at > evaluation_clock.database_now
+		FROM boundaries
+		CROSS JOIN evaluation_clock
+	`).Scan(&startsAtBoundaryMatches, &expiresAtBoundaryMatches))
+	require.True(t, startsAtBoundaryMatches)
+	require.False(t, expiresAtBoundaryMatches)
+}
+
+func insertEvaluationFixture(t *testing.T, conn repo.DBTX, fixture evaluationFixture) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescriptions (id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, fixture.ID, fixture.OrganizationID, fixture.DefinitionKey, fixture.PrincipalKind, fixture.PrincipalKey, fixture.ResourceKind, fixture.CurrentVersion)
+	require.NoError(t, err)
+	insertEvaluationVersion(t, conn, fixture)
+}
+
+func insertEvaluationVersion(t *testing.T, conn repo.DBTX, fixture evaluationFixture) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescription_versions (
+		  organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'private fixture note', $9)
+	`, fixture.OrganizationID, fixture.ID, fixture.Version, fixture.State, fixture.Scope, fixture.StartsAt, fixture.ExpiresAt, fixture.ActivatedAt, fixture.ExternalNote)
+	require.NoError(t, err)
+	for _, resource := range fixture.Resources {
+		_, err = conn.Exec(t.Context(), `
+			INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+			VALUES ($1, $2, $3, $4)
+		`, fixture.OrganizationID, fixture.ID, fixture.Version, resource)
+		require.NoError(t, err)
+	}
+}
+
+func evaluationUUID(value int) uuid.UUID {
+	return uuid.MustParse(fmtEvaluationUUID(value))
+}
+
+func fmtEvaluationUUID(value int) string {
+	const hexadecimal = "0123456789abcdef"
+	return "00000000-0000-0000-0000-0000000000" + string([]byte{hexadecimal[value/16], hexadecimal[value%16]})
+}

--- a/server/internal/killswitches/registry.go
+++ b/server/internal/killswitches/registry.go
@@ -12,6 +12,9 @@ import (
 	"unicode/utf8"
 )
 
+// All killswitch identifiers share a bounded storage contract; this also keeps composite B-tree tuples small.
+const maxIdentifierBytes = 255
+
 // Registration contains all code-owned contracts finalized into a Registry. Registered adapter
 // implementations are retained behind interfaces because they cannot be deep-copied. They must
 // therefore be immutable, return a stable Kind, and be safe for concurrent use after registration.
@@ -669,6 +672,9 @@ func validateUniqueIdentifiers[T comparable](label string, values []T, stringify
 func validateIdentifier(label, value string) error {
 	if !utf8.ValidString(value) {
 		return fmt.Errorf("%s must be valid UTF-8", label)
+	}
+	if len(value) > maxIdentifierBytes {
+		return fmt.Errorf("%s must not exceed %d bytes", label, maxIdentifierBytes)
 	}
 	if strings.TrimSpace(value) == "" {
 		return fmt.Errorf("%s is required", label)

--- a/server/internal/killswitches/registry.go
+++ b/server/internal/killswitches/registry.go
@@ -234,11 +234,11 @@ func validateCanonicalizationFixture[T ~string](
 
 func wrapTransportAdapter(key TransportAdapterKey, adapter TransportAdapter) TransportAdapter {
 	return func(result EvaluationResult, failurePolicy FailurePolicy) (TransportDisposition, error) {
-		expected, err := ResolveTransportDisposition(result, failurePolicy)
+		expected, effectivePolicy, err := resolveTransportDisposition(result, failurePolicy)
 		if err != nil {
 			return TransportDisposition{}, fmt.Errorf("transport adapter %q: %w", key, err)
 		}
-		disposition, err := adapter(result, failurePolicy)
+		disposition, err := adapter(result, effectivePolicy)
 		if err != nil {
 			return TransportDisposition{}, fmt.Errorf("transport adapter %q: %w", key, err)
 		}

--- a/server/internal/killswitches/registry_test.go
+++ b/server/internal/killswitches/registry_test.go
@@ -538,6 +538,58 @@ func TestRegisteredTransportAdapterResolvesNeutralBehaviorMatrix(t *testing.T) {
 	}
 }
 
+func TestRegisteredTransportAdapterReceivesEffectiveFailurePolicy(t *testing.T) {
+	t.Parallel()
+
+	classified, err := NewInfrastructureFailureResultWithPolicy(errors.New("evaluation unavailable"), FailurePolicyFailClosed, InfrastructureFailureDatabase)
+	if err != nil {
+		t.Fatalf("classified failure: %v", err)
+	}
+	legacy, err := NewInfrastructureFailureResult(errors.New("evaluation unavailable"))
+	if err != nil {
+		t.Fatalf("legacy failure: %v", err)
+	}
+	tests := []struct {
+		name           string
+		result         EvaluationResult
+		suppliedPolicy FailurePolicy
+		wantPolicy     FailurePolicy
+		wantKind       TransportDispositionKind
+	}{
+		{name: "classified uses authoritative policy", result: classified, suppliedPolicy: FailurePolicyFailOpen, wantPolicy: FailurePolicyFailClosed, wantKind: TransportDispositionInfrastructureRejection},
+		{name: "legacy uses supplied policy", result: legacy, suppliedPolicy: FailurePolicyFailOpen, wantPolicy: FailurePolicyFailOpen, wantKind: TransportDispositionContinue},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var receivedPolicy FailurePolicy
+			input := validRegistration()
+			input.TransportAdapters[0].Adapter = func(result EvaluationResult, policy FailurePolicy) (TransportDisposition, error) {
+				receivedPolicy = policy
+				return ResolveTransportDisposition(result, policy)
+			}
+			registry, err := BuildRegistry(input)
+			if err != nil {
+				t.Fatalf("build registry: %v", err)
+			}
+			adapter, ok := registry.TransportAdapter("jsonrpc")
+			if !ok {
+				t.Fatal("transport adapter not found")
+			}
+			disposition, err := adapter(test.result, test.suppliedPolicy)
+			if err != nil {
+				t.Fatalf("adapt: %v", err)
+			}
+			if receivedPolicy != test.wantPolicy {
+				t.Fatalf("adapter policy got %q, want %q", receivedPolicy, test.wantPolicy)
+			}
+			if disposition.Kind() != test.wantKind {
+				t.Fatalf("disposition got %q, want %q", disposition.Kind(), test.wantKind)
+			}
+		})
+	}
+}
+
 func TestRegisteredTransportAdapterRejectsOffMatrixDispositions(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/killswitches/registry_test.go
+++ b/server/internal/killswitches/registry_test.go
@@ -353,6 +353,9 @@ func TestAdapterResultContracts(t *testing.T) {
 	if _, err := NewCanonicalizationResult(PrincipalKey("")); err == nil {
 		t.Fatal("empty canonical principal key accepted")
 	}
+	if _, err := NewCanonicalizationResult(ResourceKey(strings.Repeat("é", maxIdentifierBytes/2+1))); err == nil {
+		t.Fatal("oversized canonical resource key accepted")
+	}
 	if _, supported, err := UnsupportedCanonicalizationResult[PrincipalKey]().Key(); err != nil || supported {
 		t.Fatalf("unsupported canonicalization supported=%v err=%v", supported, err)
 	}

--- a/server/internal/killswitches/repo/queries.sql.go
+++ b/server/internal/killswitches/repo/queries.sql.go
@@ -597,7 +597,7 @@ func (q *Queries) ListKillswitchPrescriptionVersionResources(ctx context.Context
 }
 
 const lockKillswitchOperation = `-- name: LockKillswitchOperation :one
-SELECT operation, request_hash, status, response
+SELECT actor_user_id, operation, request_hash, status, response
 FROM killswitch_operations
 WHERE organization_id = $1
   AND operation_id = $2
@@ -610,6 +610,7 @@ type LockKillswitchOperationParams struct {
 }
 
 type LockKillswitchOperationRow struct {
+	ActorUserID string
 	Operation   string
 	RequestHash string
 	Status      string
@@ -620,6 +621,7 @@ func (q *Queries) LockKillswitchOperation(ctx context.Context, arg LockKillswitc
 	row := q.db.QueryRow(ctx, lockKillswitchOperation, arg.OrganizationID, arg.OperationID)
 	var i LockKillswitchOperationRow
 	err := row.Scan(
+		&i.ActorUserID,
 		&i.Operation,
 		&i.RequestHash,
 		&i.Status,

--- a/server/internal/killswitches/repo/queries.sql.go
+++ b/server/internal/killswitches/repo/queries.sql.go
@@ -343,6 +343,127 @@ func (q *Queries) DeleteExpiredKillswitchOperations(ctx context.Context, arg Del
 	return result.RowsAffected(), nil
 }
 
+const evaluateCurrentPrescriptions = `-- name: EvaluateCurrentPrescriptions :one
+WITH evaluation_clock AS MATERIALIZED (
+  SELECT clock_timestamp() AS database_now
+),
+definition_candidates AS (
+  SELECT definition_key, definition_rank
+  FROM unnest($4::text[]) WITH ORDINALITY AS candidate(definition_key, definition_rank)
+),
+principal_candidates AS (
+  SELECT principal_kind, principal_key, principal_rank
+  FROM ROWS FROM (
+    unnest($5::text[]),
+    unnest($6::text[])
+  ) WITH ORDINALITY AS candidate(principal_kind, principal_key, principal_rank)
+),
+compatible_definition_principals AS (
+  SELECT definition_key, principal_kind
+  FROM ROWS FROM (
+    unnest($7::text[]),
+    unnest($8::text[])
+  ) AS candidate(definition_key, principal_kind)
+)
+SELECT
+  matched.prescription_id,
+  matched.definition_key,
+  matched.external_note
+FROM definition_candidates AS definition_candidate
+JOIN principal_candidates AS principal_candidate
+  ON EXISTS (
+    SELECT 1
+    FROM compatible_definition_principals AS compatible
+    WHERE compatible.definition_key = definition_candidate.definition_key
+      AND compatible.principal_kind = principal_candidate.principal_kind
+  )
+CROSS JOIN LATERAL (
+  SELECT
+    prescription.id AS prescription_id,
+    prescription.definition_key,
+    version.external_note,
+    CASE version.resource_scope WHEN 'selected' THEN 0 ELSE 1 END AS resource_scope_rank,
+    version.starts_at,
+    version.activated_at
+  FROM killswitch_prescriptions AS prescription
+  JOIN killswitch_prescription_versions AS version
+    ON version.organization_id = prescription.organization_id
+    AND version.prescription_id = prescription.id
+    AND version.version = prescription.current_version
+  CROSS JOIN evaluation_clock
+  WHERE prescription.organization_id = $1
+    AND prescription.definition_key = definition_candidate.definition_key
+    AND prescription.principal_kind = principal_candidate.principal_kind
+    AND prescription.principal_key = principal_candidate.principal_key
+    AND prescription.resource_kind = $2
+    AND version.state = 'active'
+    AND version.starts_at <= evaluation_clock.database_now
+    AND (version.expires_at IS NULL OR version.expires_at > evaluation_clock.database_now)
+    AND (
+      version.resource_scope = 'all'
+      OR (
+        version.resource_scope = 'selected'
+        AND EXISTS (
+          SELECT 1
+          FROM killswitch_prescription_version_resources AS resource
+          WHERE resource.organization_id = $1
+            AND resource.organization_id = version.organization_id
+            AND resource.prescription_id = version.prescription_id
+            AND resource.version = version.version
+            AND resource.resource_key = $3
+        )
+      )
+    )
+  ORDER BY
+    resource_scope_rank,
+    version.starts_at DESC,
+    version.activated_at DESC NULLS LAST,
+    prescription.id ASC
+  LIMIT 1
+) AS matched
+ORDER BY
+  definition_candidate.definition_rank,
+  matched.resource_scope_rank,
+  principal_candidate.principal_rank,
+  matched.starts_at DESC,
+  matched.activated_at DESC NULLS LAST,
+  matched.prescription_id ASC
+LIMIT 1
+`
+
+type EvaluateCurrentPrescriptionsParams struct {
+	OrganizationID           string
+	ResourceKind             string
+	ResourceKey              string
+	DefinitionKeys           []string
+	PrincipalKinds           []string
+	PrincipalKeys            []string
+	CompatibleDefinitionKeys []string
+	CompatiblePrincipalKinds []string
+}
+
+type EvaluateCurrentPrescriptionsRow struct {
+	PrescriptionID uuid.UUID
+	DefinitionKey  string
+	ExternalNote   string
+}
+
+func (q *Queries) EvaluateCurrentPrescriptions(ctx context.Context, arg EvaluateCurrentPrescriptionsParams) (EvaluateCurrentPrescriptionsRow, error) {
+	row := q.db.QueryRow(ctx, evaluateCurrentPrescriptions,
+		arg.OrganizationID,
+		arg.ResourceKind,
+		arg.ResourceKey,
+		arg.DefinitionKeys,
+		arg.PrincipalKinds,
+		arg.PrincipalKeys,
+		arg.CompatibleDefinitionKeys,
+		arg.CompatiblePrincipalKinds,
+	)
+	var i EvaluateCurrentPrescriptionsRow
+	err := row.Scan(&i.PrescriptionID, &i.DefinitionKey, &i.ExternalNote)
+	return i, err
+}
+
 const getKillswitchDatabaseTime = `-- name: GetKillswitchDatabaseTime :one
 SELECT clock_timestamp()::timestamptz
 `

--- a/server/internal/killswitches/transaction_queries.go
+++ b/server/internal/killswitches/transaction_queries.go
@@ -83,16 +83,18 @@ func validateLifecycleTransactionSQL(sql string) error {
 	}
 	first := keywords[0]
 	second := keywords[1]
-	third := keywords[2]
-	fourth := keywords[3]
-	fifth := keywords[4]
 	switch first {
 	case "ABORT", "BEGIN", "COMMIT", "END", "RELEASE", "ROLLBACK", "SAVEPOINT":
 		return fmt.Errorf("%w: transaction-control statement %s is not allowed", errLifecycleTransactionQueryRejected, first)
-	case "PREPARE", "SET":
-		if second == "TRANSACTION" ||
-			(first == "SET" && second == "SESSION" && third == "CHARACTERISTICS" && fourth == "AS" && fifth == "TRANSACTION") {
+	case "DISCARD", "RESET":
+		return fmt.Errorf("%w: session-state statement %s is not allowed", errLifecycleTransactionQueryRejected, first)
+	case "PREPARE":
+		if second == "TRANSACTION" {
 			return fmt.Errorf("%w: transaction-control statement %s is not allowed", errLifecycleTransactionQueryRejected, first)
+		}
+	case "SET":
+		if second != "LOCAL" && second != "CONSTRAINTS" {
+			return fmt.Errorf("%w: session-state statement %s is not allowed", errLifecycleTransactionQueryRejected, first)
 		}
 	case "START":
 		return fmt.Errorf("%w: transaction-control statement START is not allowed", errLifecycleTransactionQueryRejected)
@@ -100,8 +102,8 @@ func validateLifecycleTransactionSQL(sql string) error {
 	return nil
 }
 
-func lifecycleSQLKeywords(sql string) ([5]string, error) {
-	var keywords [5]string
+func lifecycleSQLKeywords(sql string) ([2]string, error) {
+	var keywords [2]string
 	keywordCount := 0
 	hasContent := false
 	terminated := false

--- a/server/internal/killswitches/transaction_queries_test.go
+++ b/server/internal/killswitches/transaction_queries_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLifecycleTransactionQueriesRejectTransactionControlAndMultipleStatements(t *testing.T) {
+func TestLifecycleTransactionQueriesRejectTransactionControlSessionStateAndMultipleStatements(t *testing.T) {
 	t.Parallel()
 
 	tests := []string{
@@ -24,6 +24,10 @@ func TestLifecycleTransactionQueriesRejectTransactionControlAndMultipleStatement
 		"PREPARE /* split keyword */ TRANSACTION 'prepared_change'",
 		"SET TRANSACTION ISOLATION LEVEL SERIALIZABLE",
 		"SET SESSION /* split phrase */ CHARACTERISTICS AS TRANSACTION READ ONLY",
+		"SET search_path = attacker",
+		"SET ROLE attacker",
+		"RESET statement_timeout",
+		"DISCARD ALL",
 		"SELECT 1; COMMIT",
 		"SELECT ';'; ROLLBACK",
 		"SELECT $body$; COMMIT$body$; SELECT 2",
@@ -76,6 +80,10 @@ func TestLifecycleTransactionQueriesAllowSingleDomainStatements(t *testing.T) {
 	queries := lifecycleTransactionQueries{db: delegate}
 	_, err := queries.Exec(t.Context(), "/* domain write */ INSERT INTO audit_events (payload) VALUES ('semi;colon');")
 	require.NoError(t, err)
+	_, err = queries.Exec(t.Context(), "SET LOCAL statement_timeout = '1s'")
+	require.NoError(t, err)
+	_, err = queries.Exec(t.Context(), "SET CONSTRAINTS ALL DEFERRED")
+	require.NoError(t, err)
 	rows, err := queries.Query(t.Context(), `SELECT E'escaped\'quote;still-string' -- trailing comment`)
 	require.NoError(t, err)
 	if rows != nil {
@@ -83,7 +91,7 @@ func TestLifecycleTransactionQueriesAllowSingleDomainStatements(t *testing.T) {
 	}
 	err = queries.QueryRow(t.Context(), "SELECT $body$BEGIN; COMMIT;$body$; /* trailing */").Scan()
 	require.NoError(t, err)
-	require.Equal(t, 3, delegate.calls)
+	require.Equal(t, 5, delegate.calls)
 }
 
 type rewritingLifecycleQuery struct {


### PR DESCRIPTION
## Summary

- Add the authoritative PostgreSQL evaluator for current killswitch prescriptions using database time and request-local canonical candidates.
- Union overlapping matches while selecting one deterministic external note by definition, scope, principal, interval, activation, and prescription precedence.
- Classify evaluator failures with their effective fail-open or fail-closed policy and emit privacy-safe, bounded outcome latency telemetry.

## Technical details

### Bounded indexed evaluation

Definition and principal inputs are validated and capped before one timed database query. Paired candidate tuples drive exact lateral index probes, each returning one local winner before the final deterministic selection.

### Failure behavior

Parent cancellation remains distinct from evaluator-owned timeout and database failure. Any fail-closed definition candidate dominates infrastructure failures, and transport resolution cannot override the evaluator-derived policy.

Closes [DNO-975](https://linear.app/speakeasy/issue/DNO-975/feat-evaluate-overlapping-killswitches-with-database-time)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared PostgreSQL evaluator that makes killswitch enforcement authoritative by using database time and unioning overlapping prescriptions, replacing cache-based evaluation with a single deterministic query per request.

- Bounds definition and principal candidate inputs before one indexed database query.
- Restricts matching to definition-principal pairs the registry supports so an incompatible higher-ranked definition cannot shadow a compatible one.
- Distinguishes invalid requests, parent cancellation, timeout, database, and data-integrity failures, applying each definition's fail-open or fail-closed policy.
- Carries the winning definition's policy into results so transport resolution and registered adapters cannot override enforcement.
- Honors a successful match or no-match when the parent deadline races but the database query still completes.
- Emits outcome and duration telemetry without tenant, principal, prescription, or note data.

**Lifecycle hardening**
- Binds operation replay to the actor that claimed it, so a different actor cannot reuse a receipt.
- Blocks session-state SQL statements in lifecycle transactions (`SET`, `RESET`, `DISCARD`) while still allowing `SET LOCAL` and `SET CONSTRAINTS`.

Closes [DNO-975](https://linear.app/speakeasy/issue/DNO-975/feat-evaluate-overlapping-killswitches-with-database-time).

<sup>Written for commit a46d4c3554852f2770fdb66a604b09531df791ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

