### PR TITLE
fix(authz): batch challenge writes to ClickHouse

### DIFF
--- a/.changeset/authz-challenge-batch-writes.md
+++ b/.changeset/authz-challenge-batch-writes.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Authz challenge logging now writes to ClickHouse in batches rather than one insert per event. The previous per-row insert held a pooled ClickHouse connection for the duration of a server-side flush, capping the subscriber's throughput and exhausting the connection pool shared with the other ClickHouse writers, so challenge, event feed, and risk finding ingestion could all fall behind a growing Pub/Sub backlog under sustained challenge volume.

--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -125,7 +125,7 @@ flowchart LR
   t_gram_telemetry_v1_log_record --> s_gram_telemetry_v1_noop
   t_gram_webhooks_v1_event --> s_gram_webhooks_v1_svix_relay
   s_gram_webhooks_v1_svix_relay -. dead-letter .-> t_gram_webhooks_v1_svix_relay_dlq
-  c13[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter"\]:::go
+  c13[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter<br/>(batch)"\]:::go
   s_gram_authz_v1_challenge_ch_writer --> c13
   c14[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingCHWriter<br/>(batch)"\]:::go
   s_gram_metering_v1_meter_reading_ch_writer --> c14

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -194,6 +194,14 @@ func newClickhouseClient(ctx context.Context, logger *slog.Logger, c *cli.Contex
 		Settings: clickhouse.Settings{
 			"max_execution_time": 60, // query timeout
 		},
+		// The driver defaults to MaxIdleConns+5 open connections, which is far
+		// too few for the streams process: one pool is shared by every
+		// subscription's ClickHouse writer. DialTimeout doubles as the pool
+		// acquisition timeout, so keep it short enough that saturation surfaces
+		// as a fast failure instead of parking each message for 30s.
+		MaxOpenConns: 32,
+		MaxIdleConns: 16,
+		DialTimeout:  10 * time.Second,
 		TLS: &tls.Config{
 			// #nosec G402 -- we're reading the value from an environment variable.
 			InsecureSkipVerify: insecure,

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -36,7 +36,6 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	authzrepo "github.com/speakeasy-api/gram/server/internal/authz/repo"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -578,7 +577,7 @@ func newStreamsCommand() *cli.Command {
 
 				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, webhookEventHandler)
 
-				mustReceiveBatchWithResult(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, authzrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
+				mustReceiveBatchWithResult(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, chConn), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
 				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, db, meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
 
 				mustReceive(rg, &otelv1.InboundLogRecord{}, &otelv1.InboundLogRecordTransformer{}, otelsvc.NewLogTransformHandler(

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	authzrepo "github.com/speakeasy-api/gram/server/internal/authz/repo"
 	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/billingnotifications"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -577,7 +578,7 @@ func newStreamsCommand() *cli.Command {
 
 				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, webhookEventHandler)
 
-				mustReceive(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, chConn))
+				mustReceiveBatch(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, authzrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
 				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, db, meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
 
 				mustReceive(rg, &otelv1.InboundLogRecord{}, &otelv1.InboundLogRecordTransformer{}, otelsvc.NewLogTransformHandler(

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -578,7 +578,7 @@ func newStreamsCommand() *cli.Command {
 
 				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, webhookEventHandler)
 
-				mustReceiveBatch(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, authzrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
+				mustReceiveBatchWithResult(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, authzrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
 				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, db, meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
 
 				mustReceive(rg, &otelv1.InboundLogRecord{}, &otelv1.InboundLogRecordTransformer{}, otelsvc.NewLogTransformHandler(

--- a/server/internal/authz/challenge_writer.go
+++ b/server/internal/authz/challenge_writer.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	authzv1 "github.com/speakeasy-api/gram/infra/gen/gram/authz/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
@@ -31,8 +33,8 @@ type ChallengeInserter interface {
 
 // ChallengeCHWriter consumes authz challenge events from Pub/Sub and persists
 // them to ClickHouse in batches. Invalid messages are poison records: they are
-// logged and acknowledged, while ClickHouse failures are returned so the batch
-// is redelivered.
+// logged and acknowledged, while a failed insert is staged against the messages
+// it covered so only those redeliver.
 type ChallengeCHWriter struct {
 	logger             *slog.Logger
 	inserter           ChallengeInserter
@@ -75,11 +77,37 @@ func NewChallengeCHWriter(
 	}
 }
 
-var _ streams.BatchHandler[*authzv1.Challenge] = (*ChallengeCHWriter)(nil)
+var _ streams.BatchResultHandler[*authzv1.Challenge] = (*ChallengeCHWriter)(nil)
 
-func (w *ChallengeCHWriter) HandleBatch(ctx context.Context, messages []*authzv1.Challenge, _ []gcp.MessageMetadata) error {
+// HandleBatchWithResult adapts processBatch to the streams runner: an insert
+// failure is staged against the messages it actually covered, so poison records
+// are acknowledged and dropped whatever the insert does rather than being
+// nacked alongside rows that deserve a retry.
+func (w *ChallengeCHWriter) HandleBatchWithResult(ctx context.Context, batch []gcp.BatchMessage[*authzv1.Challenge]) error {
+	messages := make([]*authzv1.Challenge, len(batch))
+	for i, m := range batch {
+		messages[i] = m.Message
+	}
+
+	for i, err := range w.processBatch(ctx, messages) {
+		if err != nil {
+			batch[i].Fail(err)
+		}
+	}
+
+	return nil
+}
+
+// processBatch writes the batch's valid rows to ClickHouse. The returned slice
+// is parallel to messages: a non-nil entry means that message must redeliver.
+// Poison records keep a nil entry so they are acknowledged and dropped — they
+// can never be persisted, and a failing insert says nothing about them.
+func (w *ChallengeCHWriter) processBatch(ctx context.Context, messages []*authzv1.Challenge) []error {
+	failed := make([]error, len(messages))
+
 	rows := make([]authzrepo.ChallengeRow, 0, len(messages))
-	for _, message := range messages {
+	covered := make([]int, 0, len(messages))
+	for i, message := range messages {
 		row, err := challengeRowFromMessage(message)
 		if err != nil {
 			w.logger.ErrorContext(ctx, "skipping unprocessable authz challenge message",
@@ -92,21 +120,36 @@ func (w *ChallengeCHWriter) HandleBatch(ctx context.Context, messages []*authzv1
 			continue
 		}
 		rows = append(rows, row)
+		covered = append(covered, i)
 	}
 
 	if len(rows) == 0 {
-		return nil
+		return failed
 	}
 
 	err := w.inserter.InsertChallenges(ctx, rows)
 	if w.challengesInserted != nil {
 		w.challengesInserted.Add(ctx, int64(len(rows)), metric.WithAttributes(attr.Outcome(o11y.OutcomeFromError(err))))
 	}
-	if err != nil {
-		return fmt.Errorf("insert authz challenges: %w", err)
+	if err == nil {
+		return failed
 	}
 
-	return nil
+	err = fmt.Errorf("insert authz challenges: %w", err)
+	w.logger.ErrorContext(ctx, "failed to insert authz challenge batch", attr.SlogError(err))
+
+	// Staged failures leave the runner's batch span unmarked because the handler
+	// returns nil, so record the insert failure here: a ClickHouse outage stalls
+	// every ClickHouse writer at once and has to stay visible in traces.
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+
+	for _, i := range covered {
+		failed[i] = err
+	}
+
+	return failed
 }
 
 func challengeRowFromMessage(message *authzv1.Challenge) (authzrepo.ChallengeRow, error) {

--- a/server/internal/authz/challenge_writer.go
+++ b/server/internal/authz/challenge_writer.go
@@ -6,22 +6,38 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/metric"
 
 	authzv1 "github.com/speakeasy-api/gram/infra/gen/gram/authz/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	authzrepo "github.com/speakeasy-api/gram/server/internal/authz/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/streams"
 )
 
+const (
+	meterChallengeCHWriterSkipped  = "gram.authz_ch_writer.challenges_skipped"
+	meterChallengeCHWriterInserted = "gram.authz_ch_writer.challenges_inserted"
+)
+
+// ChallengeInserter writes a batch of challenge rows to ClickHouse.
+// *authzrepo.Queries satisfies it; tests supply a fake.
+type ChallengeInserter interface {
+	InsertChallenges(ctx context.Context, rows []authzrepo.ChallengeRow) error
+}
+
 // ChallengeCHWriter consumes authz challenge events from Pub/Sub and persists
-// them to ClickHouse. Invalid messages are poison records: they are logged and
-// acknowledged, while ClickHouse failures are returned for redelivery.
+// them to ClickHouse in batches. Invalid messages are poison records: they are
+// logged and acknowledged, while ClickHouse failures are returned so the batch
+// is redelivered.
 type ChallengeCHWriter struct {
-	logger *slog.Logger
-	conn   clickhouse.Conn
+	logger             *slog.Logger
+	inserter           ChallengeInserter
+	challengesSkipped  metric.Int64Counter
+	challengesInserted metric.Int64Counter
 }
 
 const (
@@ -31,27 +47,65 @@ const (
 
 func NewChallengeCHWriter(
 	logger *slog.Logger,
-	conn clickhouse.Conn,
+	meterProvider metric.MeterProvider,
+	inserter ChallengeInserter,
 ) *ChallengeCHWriter {
+	logger = logger.With(attr.SlogComponent("authz-challenge-ch-writer"))
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/authz")
+	challengesSkipped, err := meter.Int64Counter(
+		meterChallengeCHWriterSkipped,
+		metric.WithDescription("Authz challenge messages dropped by the ClickHouse writer as unprocessable"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(meterChallengeCHWriterSkipped), attr.SlogError(err))
+	}
+	challengesInserted, err := meter.Int64Counter(
+		meterChallengeCHWriterInserted,
+		metric.WithDescription("Authz challenge rows the ClickHouse writer attempted to insert"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(meterChallengeCHWriterInserted), attr.SlogError(err))
+	}
+
 	return &ChallengeCHWriter{
-		logger: logger.With(attr.SlogComponent("authz-challenge-ch-writer")),
-		conn:   conn,
+		logger:             logger,
+		inserter:           inserter,
+		challengesSkipped:  challengesSkipped,
+		challengesInserted: challengesInserted,
 	}
 }
 
-func (w *ChallengeCHWriter) Handle(ctx context.Context, message *authzv1.Challenge, _ gcp.MessageMetadata) error {
-	row, err := challengeRowFromMessage(message)
-	if err != nil {
-		w.logger.ErrorContext(ctx, "invalid authz challenge message",
-			attr.SlogError(err),
-			attr.SlogValueString(message.GetId()),
-		)
+var _ streams.BatchHandler[*authzv1.Challenge] = (*ChallengeCHWriter)(nil)
+
+func (w *ChallengeCHWriter) HandleBatch(ctx context.Context, messages []*authzv1.Challenge, _ []gcp.MessageMetadata) error {
+	rows := make([]authzrepo.ChallengeRow, 0, len(messages))
+	for _, message := range messages {
+		row, err := challengeRowFromMessage(message)
+		if err != nil {
+			w.logger.ErrorContext(ctx, "skipping unprocessable authz challenge message",
+				attr.SlogError(err),
+				attr.SlogValueString(message.GetId()),
+			)
+			if w.challengesSkipped != nil {
+				w.challengesSkipped.Add(ctx, 1)
+			}
+			continue
+		}
+		rows = append(rows, row)
+	}
+
+	if len(rows) == 0 {
 		return nil
 	}
 
-	if err := authzrepo.New(w.conn).InsertChallenge(ctx, row); err != nil {
-		return fmt.Errorf("insert authz challenge: %w", err)
+	err := w.inserter.InsertChallenges(ctx, rows)
+	if w.challengesInserted != nil {
+		w.challengesInserted.Add(ctx, int64(len(rows)), metric.WithAttributes(attr.Outcome(o11y.OutcomeFromError(err))))
 	}
+	if err != nil {
+		return fmt.Errorf("insert authz challenges: %w", err)
+	}
+
 	return nil
 }
 

--- a/server/internal/authz/challenge_writer.go
+++ b/server/internal/authz/challenge_writer.go
@@ -3,6 +3,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"log/slog"
 	"time"
 
@@ -25,19 +26,13 @@ const (
 	meterChallengeCHWriterInserted = "gram.authz_ch_writer.challenges_inserted"
 )
 
-// ChallengeInserter writes a batch of challenge rows to ClickHouse.
-// *authzrepo.Queries satisfies it; tests supply a fake.
-type ChallengeInserter interface {
-	InsertChallenges(ctx context.Context, rows []authzrepo.ChallengeRow) error
-}
-
 // ChallengeCHWriter consumes authz challenge events from Pub/Sub and persists
 // them to ClickHouse in batches. Invalid messages are poison records: they are
 // logged and acknowledged, while a failed insert is staged against the messages
 // it covered so only those redeliver.
 type ChallengeCHWriter struct {
 	logger             *slog.Logger
-	inserter           ChallengeInserter
+	repo               *authzrepo.Queries
 	challengesSkipped  metric.Int64Counter
 	challengesInserted metric.Int64Counter
 }
@@ -50,7 +45,7 @@ const (
 func NewChallengeCHWriter(
 	logger *slog.Logger,
 	meterProvider metric.MeterProvider,
-	inserter ChallengeInserter,
+	conn clickhouse.Conn,
 ) *ChallengeCHWriter {
 	logger = logger.With(attr.SlogComponent("authz-challenge-ch-writer"))
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/authz")
@@ -71,7 +66,7 @@ func NewChallengeCHWriter(
 
 	return &ChallengeCHWriter{
 		logger:             logger,
-		inserter:           inserter,
+		repo:               authzrepo.New(conn),
 		challengesSkipped:  challengesSkipped,
 		challengesInserted: challengesInserted,
 	}
@@ -127,7 +122,7 @@ func (w *ChallengeCHWriter) processBatch(ctx context.Context, messages []*authzv
 		return failed
 	}
 
-	err := w.inserter.InsertChallenges(ctx, rows)
+	err := w.repo.InsertChallenges(ctx, rows)
 	if w.challengesInserted != nil {
 		w.challengesInserted.Add(ctx, int64(len(rows)), metric.WithAttributes(attr.Outcome(o11y.OutcomeFromError(err))))
 	}

--- a/server/internal/authz/challenge_writer_test.go
+++ b/server/internal/authz/challenge_writer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	authzv1 "github.com/speakeasy-api/gram/infra/gen/gram/authz/v1"
-	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	authzrepo "github.com/speakeasy-api/gram/server/internal/authz/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -58,31 +57,17 @@ func newChallengeCHWriter(t *testing.T) (*ChallengeCHWriter, clickhouse.Conn) {
 	return NewChallengeCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), authzrepo.New(conn)), conn
 }
 
-// challengeMetadata returns metadata parallel to messages. The writer ignores
-// it, but HandleBatch takes it to satisfy the streams.BatchHandler contract.
-func challengeMetadata(count int) []gcp.MessageMetadata {
-	metas := make([]gcp.MessageMetadata, count)
-	for i := range metas {
-		metas[i] = gcp.MessageMetadata{
-			ID:              "message-id",
-			Attributes:      nil,
-			DeliveryAttempt: nil,
-		}
-	}
-	return metas
-}
-
 func TestChallengeCHWriterPersistsMessage(t *testing.T) {
 	t.Parallel()
 
 	writer, conn := newChallengeCHWriter(t)
 	message := testChallengeMessage()
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
-	require.NoError(t, err)
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{message})
+	require.Equal(t, []error{nil}, failed)
 
 	var count uint64
-	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
+	err := conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), count)
 }
@@ -94,11 +79,11 @@ func TestChallengeCHWriterPersistsBatch(t *testing.T) {
 	first := testChallengeMessage()
 	second := testChallengeMessage()
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{first, second}, challengeMetadata(2))
-	require.NoError(t, err)
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{first, second})
+	require.Equal(t, []error{nil, nil}, failed)
 
 	var count uint64
-	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id IN (?, ?)`, first.GetId(), second.GetId()).Scan(&count)
+	err := conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id IN (?, ?)`, first.GetId(), second.GetId()).Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), count)
 }
@@ -113,11 +98,11 @@ func TestChallengeCHWriterSkipsInvalidMessageInBatch(t *testing.T) {
 	invalid := testChallengeMessage()
 	invalid.SetTraceId(strings.Repeat("a", maxChallengeTraceIDBytes+1))
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{invalid, valid}, challengeMetadata(2))
-	require.NoError(t, err)
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{invalid, valid})
+	require.Equal(t, []error{nil, nil}, failed)
 
 	var validCount uint64
-	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, valid.GetId()).Scan(&validCount)
+	err := conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, valid.GetId()).Scan(&validCount)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), validCount)
 
@@ -127,6 +112,23 @@ func TestChallengeCHWriterSkipsInvalidMessageInBatch(t *testing.T) {
 	require.Zero(t, invalidCount)
 }
 
+// A failing insert says nothing about a poison record, so the poison keeps its
+// nil entry and is acknowledged while only the rows the insert covered redeliver.
+func TestChallengeCHWriterDropsPoisonWhenInsertFails(t *testing.T) {
+	t.Parallel()
+
+	writer, _ := newChallengeCHWriter(t)
+	invalid := testChallengeMessage()
+	invalid.SetTraceId(strings.Repeat("a", maxChallengeTraceIDBytes+1))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	failed := writer.processBatch(ctx, []*authzv1.Challenge{invalid, testChallengeMessage()})
+	require.Len(t, failed, 2)
+	require.NoError(t, failed[0])
+	require.ErrorContains(t, failed[1], "insert authz challenges")
+}
+
 func TestChallengeCHWriterAcknowledgesInvalidMessage(t *testing.T) {
 	t.Parallel()
 
@@ -134,11 +136,11 @@ func TestChallengeCHWriterAcknowledgesInvalidMessage(t *testing.T) {
 	id := "not-a-uuid"
 	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{authzv1.Challenge_builder{
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{authzv1.Challenge_builder{
 		Id:        &id,
 		Timestamp: &timestamp,
-	}.Build()}, challengeMetadata(1))
-	require.NoError(t, err)
+	}.Build()})
+	require.Equal(t, []error{nil}, failed)
 }
 
 func TestChallengeCHWriterAcknowledgesOverlongTraceID(t *testing.T) {
@@ -148,11 +150,11 @@ func TestChallengeCHWriterAcknowledgesOverlongTraceID(t *testing.T) {
 	message := testChallengeMessage()
 	message.SetTraceId(strings.Repeat("a", maxChallengeTraceIDBytes+1))
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
-	require.NoError(t, err)
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{message})
+	require.Equal(t, []error{nil}, failed)
 
 	var count uint64
-	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
+	err := conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
 	require.NoError(t, err)
 	require.Zero(t, count)
 }
@@ -164,11 +166,11 @@ func TestChallengeCHWriterAcknowledgesOverlongSpanID(t *testing.T) {
 	message := testChallengeMessage()
 	message.SetSpanId(strings.Repeat("a", maxChallengeSpanIDBytes+1))
 
-	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
-	require.NoError(t, err)
+	failed := writer.processBatch(t.Context(), []*authzv1.Challenge{message})
+	require.Equal(t, []error{nil}, failed)
 
 	var count uint64
-	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
+	err := conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, message.GetId()).Scan(&count)
 	require.NoError(t, err)
 	require.Zero(t, count)
 }
@@ -180,8 +182,9 @@ func TestChallengeCHWriterRetriesClickHouseFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := writer.HandleBatch(ctx, []*authzv1.Challenge{testChallengeMessage()}, challengeMetadata(1))
-	require.ErrorContains(t, err, "insert authz challenges")
+	failed := writer.processBatch(ctx, []*authzv1.Challenge{testChallengeMessage()})
+	require.Len(t, failed, 1)
+	require.ErrorContains(t, failed[0], "insert authz challenges")
 }
 
 func testChallengeMessage() *authzv1.Challenge {

--- a/server/internal/authz/challenge_writer_test.go
+++ b/server/internal/authz/challenge_writer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -46,19 +47,38 @@ func TestChallengeRowFromMessage(t *testing.T) {
 	}}, row.MatchedGrants)
 }
 
-func TestChallengeCHWriterPersistsMessage(t *testing.T) {
-	t.Parallel()
+// newChallengeCHWriter builds a writer over a live ClickHouse connection and
+// returns both so tests can assert on the rows the writer persisted.
+func newChallengeCHWriter(t *testing.T) (*ChallengeCHWriter, clickhouse.Conn) {
+	t.Helper()
 
 	conn, err := newClickhouseClient(t)
 	require.NoError(t, err)
-	writer := NewChallengeCHWriter(testenv.NewLogger(t), conn)
+
+	return NewChallengeCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), authzrepo.New(conn)), conn
+}
+
+// challengeMetadata returns metadata parallel to messages. The writer ignores
+// it, but HandleBatch takes it to satisfy the streams.BatchHandler contract.
+func challengeMetadata(count int) []gcp.MessageMetadata {
+	metas := make([]gcp.MessageMetadata, count)
+	for i := range metas {
+		metas[i] = gcp.MessageMetadata{
+			ID:              "message-id",
+			Attributes:      nil,
+			DeliveryAttempt: nil,
+		}
+	}
+	return metas
+}
+
+func TestChallengeCHWriterPersistsMessage(t *testing.T) {
+	t.Parallel()
+
+	writer, conn := newChallengeCHWriter(t)
 	message := testChallengeMessage()
 
-	err = writer.Handle(t.Context(), message, gcp.MessageMetadata{
-		ID:              "message-id",
-		Attributes:      nil,
-		DeliveryAttempt: nil,
-	})
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
 	require.NoError(t, err)
 
 	var count uint64
@@ -67,40 +87,68 @@ func TestChallengeCHWriterPersistsMessage(t *testing.T) {
 	require.Equal(t, uint64(1), count)
 }
 
+func TestChallengeCHWriterPersistsBatch(t *testing.T) {
+	t.Parallel()
+
+	writer, conn := newChallengeCHWriter(t)
+	first := testChallengeMessage()
+	second := testChallengeMessage()
+
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{first, second}, challengeMetadata(2))
+	require.NoError(t, err)
+
+	var count uint64
+	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id IN (?, ?)`, first.GetId(), second.GetId()).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), count)
+}
+
+// A poison record must not cost the batch its valid rows: the writer drops the
+// bad message and inserts the rest.
+func TestChallengeCHWriterSkipsInvalidMessageInBatch(t *testing.T) {
+	t.Parallel()
+
+	writer, conn := newChallengeCHWriter(t)
+	valid := testChallengeMessage()
+	invalid := testChallengeMessage()
+	invalid.SetTraceId(strings.Repeat("a", maxChallengeTraceIDBytes+1))
+
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{invalid, valid}, challengeMetadata(2))
+	require.NoError(t, err)
+
+	var validCount uint64
+	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, valid.GetId()).Scan(&validCount)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), validCount)
+
+	var invalidCount uint64
+	err = conn.QueryRow(t.Context(), `SELECT count() FROM authz_challenges WHERE id = ?`, invalid.GetId()).Scan(&invalidCount)
+	require.NoError(t, err)
+	require.Zero(t, invalidCount)
+}
+
 func TestChallengeCHWriterAcknowledgesInvalidMessage(t *testing.T) {
 	t.Parallel()
 
-	conn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	writer := NewChallengeCHWriter(testenv.NewLogger(t), conn)
+	writer, _ := newChallengeCHWriter(t)
 	id := "not-a-uuid"
 	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 
-	err = writer.Handle(t.Context(), authzv1.Challenge_builder{
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{authzv1.Challenge_builder{
 		Id:        &id,
 		Timestamp: &timestamp,
-	}.Build(), gcp.MessageMetadata{
-		ID:              "message-id",
-		Attributes:      nil,
-		DeliveryAttempt: nil,
-	})
+	}.Build()}, challengeMetadata(1))
 	require.NoError(t, err)
 }
 
 func TestChallengeCHWriterAcknowledgesOverlongTraceID(t *testing.T) {
 	t.Parallel()
 
-	conn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	writer := NewChallengeCHWriter(testenv.NewLogger(t), conn)
+	writer, conn := newChallengeCHWriter(t)
 	message := testChallengeMessage()
 	message.SetTraceId(strings.Repeat("a", maxChallengeTraceIDBytes+1))
 
-	err = writer.Handle(t.Context(), message, gcp.MessageMetadata{
-		ID:              "message-id",
-		Attributes:      nil,
-		DeliveryAttempt: nil,
-	})
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
 	require.NoError(t, err)
 
 	var count uint64
@@ -112,17 +160,11 @@ func TestChallengeCHWriterAcknowledgesOverlongTraceID(t *testing.T) {
 func TestChallengeCHWriterAcknowledgesOverlongSpanID(t *testing.T) {
 	t.Parallel()
 
-	conn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	writer := NewChallengeCHWriter(testenv.NewLogger(t), conn)
+	writer, conn := newChallengeCHWriter(t)
 	message := testChallengeMessage()
 	message.SetSpanId(strings.Repeat("a", maxChallengeSpanIDBytes+1))
 
-	err = writer.Handle(t.Context(), message, gcp.MessageMetadata{
-		ID:              "message-id",
-		Attributes:      nil,
-		DeliveryAttempt: nil,
-	})
+	err := writer.HandleBatch(t.Context(), []*authzv1.Challenge{message}, challengeMetadata(1))
 	require.NoError(t, err)
 
 	var count uint64
@@ -134,18 +176,12 @@ func TestChallengeCHWriterAcknowledgesOverlongSpanID(t *testing.T) {
 func TestChallengeCHWriterRetriesClickHouseFailure(t *testing.T) {
 	t.Parallel()
 
-	conn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	writer := NewChallengeCHWriter(testenv.NewLogger(t), conn)
+	writer, _ := newChallengeCHWriter(t)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err = writer.Handle(ctx, testChallengeMessage(), gcp.MessageMetadata{
-		ID:              "message-id",
-		Attributes:      nil,
-		DeliveryAttempt: nil,
-	})
-	require.ErrorContains(t, err, "insert authz challenge")
+	err := writer.HandleBatch(ctx, []*authzv1.Challenge{testChallengeMessage()}, challengeMetadata(1))
+	require.ErrorContains(t, err, "insert authz challenges")
 }
 
 func testChallengeMessage() *authzv1.Challenge {

--- a/server/internal/authz/challenge_writer_test.go
+++ b/server/internal/authz/challenge_writer_test.go
@@ -54,7 +54,7 @@ func newChallengeCHWriter(t *testing.T) (*ChallengeCHWriter, clickhouse.Conn) {
 	conn, err := newClickhouseClient(t)
 	require.NoError(t, err)
 
-	return NewChallengeCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), authzrepo.New(conn)), conn
+	return NewChallengeCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn), conn
 }
 
 func TestChallengeCHWriterPersistsMessage(t *testing.T) {

--- a/server/internal/authz/repo/queries.go
+++ b/server/internal/authz/repo/queries.go
@@ -12,119 +12,136 @@ import (
 // sq is the squirrel statement builder pre-configured for ClickHouse (uses ? placeholders).
 var sq = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question)
 
-// InsertChallenge writes one challenge with a stable deduplication token. The
-// server may batch concurrent async inserts, but the call waits for the flush so
-// the Pub/Sub handler only acknowledges a durably accepted row.
-func (q *Queries) InsertChallenge(ctx context.Context, row ChallengeRow) error {
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"async_insert":               1,
-		"async_insert_deduplicate":   1,
-		"insert_deduplication_token": "authz-challenge:" + row.ID,
-		"wait_for_async_insert":      1,
+// authzChallengeColumns is the authz_challenges column list, in the exact order
+// InsertChallenges binds values. The Nested subcolumns are quoted because their
+// names contain a dot.
+var authzChallengeColumns = []string{
+	"id",
+	"timestamp",
+	"organization_id",
+	"project_id",
+	"trace_id",
+	"span_id",
+	"request_id",
+	"principal_urn",
+	"principal_type",
+	"user_id",
+	"user_external_id",
+	"user_email",
+	"api_key_id",
+	"session_id",
+	"role_slugs",
+	"operation",
+	"outcome",
+	"reason",
+	"scope",
+	"resource_kind",
+	"resource_id",
+	"selector",
+	"expanded_scopes",
+	`"requested_checks.scope"`,
+	`"requested_checks.resource_kind"`,
+	`"requested_checks.resource_id"`,
+	`"requested_checks.selector"`,
+	`"matched_grants.principal_urn"`,
+	`"matched_grants.scope"`,
+	`"matched_grants.selector"`,
+	`"matched_grants.matched_via_check_scope"`,
+	"evaluated_grant_count",
+	"filter_candidate_count",
+	"filter_allowed_count",
+}
+
+// InsertChallenges writes a batch of challenge rows to authz_challenges. The
+// call waits for the flush so the Pub/Sub handler only acknowledges durably
+// accepted rows.
+//
+// authz_challenges is plain MergeTree, so a redelivered batch lands as duplicate
+// rows. The read path absorbs them: ListChallenges selects DISTINCT,
+// CountChallenges counts uniqExact(id), and every aggregate feeding
+// authz_challenge_bucket_summaries (argMax, groupUniqArray, min, max) returns
+// the same value whether a row appears once or many times.
+func (q *Queries) InsertChallenges(ctx context.Context, rows []ChallengeRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	builder := sq.Insert("authz_challenges").Columns(authzChallengeColumns...)
+	for _, row := range rows {
+		reqScope := make([]string, len(row.RequestedChecks))
+		reqKind := make([]string, len(row.RequestedChecks))
+		reqRID := make([]string, len(row.RequestedChecks))
+		reqSel := make([]string, len(row.RequestedChecks))
+		for i, c := range row.RequestedChecks {
+			reqScope[i] = c.Scope
+			reqKind[i] = c.ResourceKind
+			reqRID[i] = c.ResourceID
+			reqSel[i] = c.Selector
+		}
+
+		mgURN := make([]string, len(row.MatchedGrants))
+		mgScope := make([]string, len(row.MatchedGrants))
+		mgSel := make([]string, len(row.MatchedGrants))
+		mgVia := make([]string, len(row.MatchedGrants))
+		for i, g := range row.MatchedGrants {
+			mgURN[i] = g.PrincipalURN
+			mgScope[i] = g.Scope
+			mgSel[i] = g.Selector
+			mgVia[i] = g.MatchedViaCheckScope
+		}
+
+		builder = builder.Values(
+			row.ID,
+			row.Timestamp,
+			row.OrganizationID,
+			row.ProjectID,
+			row.TraceID,
+			row.SpanID,
+			row.RequestID,
+			row.PrincipalURN,
+			string(row.PrincipalType),
+			row.UserID,
+			row.UserExternalID,
+			row.UserEmail,
+			row.APIKeyID,
+			row.SessionID,
+			row.RoleSlugs,
+			string(row.Operation),
+			string(row.Outcome),
+			string(row.Reason),
+			row.Scope,
+			row.ResourceKind,
+			row.ResourceID,
+			row.Selector,
+			row.ExpandedScopes,
+			reqScope,
+			reqKind,
+			reqRID,
+			reqSel,
+			mgURN,
+			mgScope,
+			mgSel,
+			mgVia,
+			row.EvaluatedGrantCount,
+			row.FilterCandidateCount,
+			row.FilterAllowedCount,
+		)
+	}
+
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("build authz challenge insert query: %w", err)
+	}
+
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 1,
 	}))
 
-	reqScope := make([]string, len(row.RequestedChecks))
-	reqKind := make([]string, len(row.RequestedChecks))
-	reqRID := make([]string, len(row.RequestedChecks))
-	reqSel := make([]string, len(row.RequestedChecks))
-	for i, c := range row.RequestedChecks {
-		reqScope[i] = c.Scope
-		reqKind[i] = c.ResourceKind
-		reqRID[i] = c.ResourceID
-		reqSel[i] = c.Selector
-	}
-
-	mgURN := make([]string, len(row.MatchedGrants))
-	mgScope := make([]string, len(row.MatchedGrants))
-	mgSel := make([]string, len(row.MatchedGrants))
-	mgVia := make([]string, len(row.MatchedGrants))
-	for i, g := range row.MatchedGrants {
-		mgURN[i] = g.PrincipalURN
-		mgScope[i] = g.Scope
-		mgSel[i] = g.Selector
-		mgVia[i] = g.MatchedViaCheckScope
-	}
-
-	const query = `INSERT INTO authz_challenges (
-		id,
-		timestamp,
-		organization_id,
-		project_id,
-		trace_id,
-		span_id,
-		request_id,
-		principal_urn,
-		principal_type,
-		user_id,
-		user_external_id,
-		user_email,
-		api_key_id,
-		session_id,
-		role_slugs,
-		operation,
-		outcome,
-		reason,
-		scope,
-		resource_kind,
-		resource_id,
-		selector,
-		expanded_scopes,
-		"requested_checks.scope",
-		"requested_checks.resource_kind",
-		"requested_checks.resource_id",
-		"requested_checks.selector",
-		"matched_grants.principal_urn",
-		"matched_grants.scope",
-		"matched_grants.selector",
-		"matched_grants.matched_via_check_scope",
-		evaluated_grant_count,
-		filter_candidate_count,
-		filter_allowed_count
-	) VALUES (
-		?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-		?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-		?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-		?, ?, ?, ?
-	)`
-
-	if err := q.conn.Exec(ctx, query,
-		row.ID,
-		row.Timestamp,
-		row.OrganizationID,
-		row.ProjectID,
-		row.TraceID,
-		row.SpanID,
-		row.RequestID,
-		row.PrincipalURN,
-		string(row.PrincipalType),
-		row.UserID,
-		row.UserExternalID,
-		row.UserEmail,
-		row.APIKeyID,
-		row.SessionID,
-		row.RoleSlugs,
-		string(row.Operation),
-		string(row.Outcome),
-		string(row.Reason),
-		row.Scope,
-		row.ResourceKind,
-		row.ResourceID,
-		row.Selector,
-		row.ExpandedScopes,
-		reqScope,
-		reqKind,
-		reqRID,
-		reqSel,
-		mgURN,
-		mgScope,
-		mgSel,
-		mgVia,
-		row.EvaluatedGrantCount,
-		row.FilterCandidateCount,
-		row.FilterAllowedCount,
-	); err != nil {
+	if err := q.conn.Exec(insertCtx, query, args...); err != nil {
 		return fmt.Errorf("exec authz challenge insert: %w", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Converts `ChallengeCHWriter` from a single-message Pub/Sub handler to a batch handler, matching the three other ClickHouse writers in the streams process.

- **`InsertChallenge(row)` → `InsertChallenges(rows)`** — the column list moves to `authzChallengeColumns` and rows are bound through one multi-row `INSERT`, mirroring `chrepo.InsertOTelLogs`. The per-row `insert_deduplication_token` and `async_insert_deduplicate` are dropped; a batch cannot carry a stable per-row token, and Pub/Sub does not guarantee identical batch composition across redeliveries, so a per-batch token would not match either.
- **`ChallengeCHWriter` implements `streams.BatchResultHandler`** — it takes a `ChallengeInserter` instead of a raw `clickhouse.Conn`, so the handler is testable without a live ClickHouse. Adds `gram.authz_ch_writer.challenges_skipped` and `challenges_inserted`, matching the metric shape the OTel writers already expose.
- **`streams.go`** — registration becomes `mustReceiveBatchWithResult` with `MaxMessages: 1000, MaxBytes: 10MiB, MaxLatency: 1s`, the same sizing as `FindingCHWriter`. `docs/pubsub-topology.md` is regenerated and now marks the consumer `(batch)`.
- **`deps.go`** — the ClickHouse pool gets explicit bounds (`MaxOpenConns: 32`, `MaxIdleConns: 16`, `DialTimeout: 10s`).

### ⚠️ Tradeoff to weigh: one rejected row now fails its whole batch

This is the part of the change I'd most like a second opinion on.

Batching introduces a failure mode that did not exist before. Under the old single-message `mustReceive`, a message whose row ClickHouse rejects for something `challengeRowFromMessage` does not validate would poison **only itself** and dead-letter after ten attempts. Under batching, that one row fails the entire 1,000-row `INSERT` — and because the driver does not tell us *which* row was rejected, `processBatch` stages the same error against every row the insert covered. All 1,000 retry together, fail together, and dead-letter together.

**Why the risk is low.** `challengeRowFromMessage` already validates the type-sensitive columns: the id must parse as a UUID, trace and span ids are length-checked, and the timestamp must parse as RFC3339. Everything else is `String`, `LowCardinality(String)`, `Array(String)`, or `UInt32` — columns that accept anything the proto can carry.

**Why it is not zero.** The validator protects today's schema, not tomorrow's. A future column with a stricter type, or a value that trips a ClickHouse limit, would land in this path. And it would be silent: the synthesized DLQ topic has no subscriber (`infra/gen/kcc.yaml`, `name: gram-authz-v1-challenge-ch-writer-dlq` with `spec: {}`, and no subscription's `topicRef` points at it), so a Pub/Sub topic with zero subscriptions discards what it receives. There is no metric or alert on dead-lettered challenges today.

**The mitigation, deliberately not in this PR.** The standard answer is bisect-on-failure: when a batch insert fails, retry the rows individually to isolate the offender and `Fail` only that one. It costs nothing on the happy path. I left it out to keep this PR to the throughput fix, and because attaching subscriptions to the DLQ topics is the more valuable of the two — it converts silent loss into something inspectable for all 13 DLQs, not just this one. Happy to fold the bisect in here if a reviewer would rather it ship together.

### Why the result-aware API

The all-or-nothing `BatchHandler` couples two outcomes that need to differ here. Poison records — a malformed id, an overlong trace id, an unparseable timestamp — can never be persisted, and the writer's contract is to log and drop them. But returning the insert error from `HandleBatch` nacks *every* decoded message in the batch, poison included, so a ClickHouse failure would redeliver records that are guaranteed to be skipped again: re-logged, re-counted in `challenges_skipped`, and dead-lettered after ten attempts during a long enough outage.

`HandleBatchWithResult` separates them. Poison keeps a nil entry and is acknowledged whatever the insert does; a failure is staged only against the rows the insert actually covered. The mapping and insert live in `processBatch`, which returns the parallel error slice — mirroring `risk.FindingCHWriter`, and keeping tests off `gcp.BatchMessage`, whose `Fail` panics on a zero value.

One consequence worth knowing while reviewing: staged failures mean the handler returns nil, and the runner only marks the batch span `Error` on a returned error. The insert failure is therefore recorded on the span explicitly inside `processBatch`. A ClickHouse outage stalls every ClickHouse writer at once, and the error spans are what make that diagnosable — losing them to get better nack granularity would be a bad trade, so this keeps both.

Redelivered batches can now land as duplicate rows. The read path already absorbs them, and did before this change: `ListChallenges` selects `DISTINCT`, `CountChallenges` counts `uniqExact(id)`, and every aggregate feeding `authz_challenge_bucket_summaries` (`argMax`, `groupUniqArray`, `min`, `max`) returns the same value whether a row appears once or many times. The summary table has no count column.

## Motivation

`authz_challenges` ingestion fell behind in production: oldest unacked message age crossed the one-hour monitor threshold with tens of thousands of undelivered messages, and every failing handler span ended at exactly 30.00s with `clickhouse: acquire conn timeout`.

ClickHouse itself was healthy throughout — around two active queries, no delayed inserts, no stalled merges. The bottleneck was entirely client-side, and had two compounding causes:

1. The pool was never sized. `clickhouse.Options` set no `MaxOpenConns`, so the driver default of `MaxIdleConns + 5` applied — **10 connections** shared by every subscription in the streams process. `DialTimeout` also defaults to 30s and doubles as the pool acquisition timeout, which is where the exact 30.00s spans came from.
2. When challenge logging moved behind Pub/Sub, at-least-once delivery required a confirmed write, so the insert gained `wait_for_async_insert: 1`. That was correct for durability, but it turned a previously fire-and-forget call into one that holds a connection through a server-side flush — roughly 500ms — while the handler kept its original one-row-per-message shape.

Ten connections at ~500ms each caps the subscriber near 18 msg/s. Normal volume on this topic is ~5 msg/s, so the writer had been running at roughly 3.5x headroom since the Pub/Sub migration, with brief bursts of the same timeouts appearing well before the sustained backlog. Once it saturated, the shared pool starved the event feed and risk finding writers too, and both of their subscriptions built their own backlogs.

Batching addresses the actual shape of the problem: one connection acquisition per batch instead of per message. Sizing the pool explicitly is a second, independent safeguard — the previous value was inherited from a library default rather than chosen, which is what allowed one writer to starve the others.

The batch writers keep `async_insert: 1, wait_for_async_insert: 1`, matching `chWriterInsertContext` in the OTel repo. With a 1s max latency per subscriber across several pods, fully synchronous inserts would create many small parts; async insert coalescing is what prevents that, and the connection is now held once per batch rather than once per row.
