### PR TITLE
fix: count directly attached MCP servers on assistant surfaces

### DIFF
--- a/.changeset/assistant-direct-mcp-servers.md
+++ b/.changeset/assistant-direct-mcp-servers.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Assistant surfaces now count MCP servers attached directly to the assistant, not only through a toolset. The composer @-picker explains empty tools instead of hiding the Tools section.
+Assistant surfaces now count MCP servers attached directly to the assistant, not only through a toolset. The composer @-picker stays visible and explains empty tools (no servers, list failed, or zero tools) instead of hiding the Tools section.

--- a/.changeset/assistant-direct-mcp-servers.md
+++ b/.changeset/assistant-direct-mcp-servers.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Assistant surfaces now count MCP servers attached directly to the assistant, not only through a toolset. The composer @-picker explains empty tools instead of hiding the Tools section.

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -1,4 +1,5 @@
 import { useNoToolsetsConfigured } from "@/hooks/useObservabilityMcpConfig";
+import { showProjectAssistantConnecting } from "@/hooks/projectAssistantAccess";
 import { useServerAssistantTransport } from "@/hooks/useServerAssistantTransport";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { useListChats } from "@gram/client/react-query/listChats.js";
@@ -1512,7 +1513,11 @@ export function InsightsProvider({
             {panelCloseButton}
           </div>
           {panelNotices}
-          {!assistantError && !assistantNeedsAdmin && (
+          {showProjectAssistantConnecting({
+            assistantError,
+            assistantNeedsAdmin,
+            noMcpAccessConfigured: noToolsetsConfigured,
+          }) && (
             <div className="text-muted-foreground flex flex-1 items-center justify-center gap-2 text-sm">
               <Loader2 className="size-4 animate-spin" />
               <span>Connecting to the Project Assistant…</span>

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -94,6 +94,7 @@ import { getApiUrl } from "@/elements/lib/api";
 import { dictationAdapter } from "@/elements/lib/dictation";
 import {
   composerContextToolsEmptyMessage,
+  composerMcpServersPresence,
   mcpToolsAvailability,
   mcpToolsListPending,
   mcpToolsSendBlocked,
@@ -1338,14 +1339,15 @@ const ComposerContextPicker: FC = () => {
       composerConfig.toolMentions.enabled !== false);
 
   const tools = useMemo(() => toolSetToMentionableTools(mcpTools), [mcpTools]);
-  const toolsQueryEnabled =
-    Boolean(config.mcp) || (config.mcps?.length ?? 0) > 0;
-  const toolsListPending = mcpToolsListPending(
-    mcpToolsLoading,
-    mcpTools,
-    mcpToolsError,
-    toolsQueryEnabled,
-  );
+  const serversPresence = composerMcpServersPresence(config.mcp, config.mcps);
+  const toolsListPending =
+    serversPresence === "unknown" ||
+    mcpToolsListPending(
+      mcpToolsLoading,
+      mcpTools,
+      mcpToolsError,
+      serversPresence === "some",
+    );
 
   const categories = useMemo<ToolCategory[]>(() => {
     const grouped = new Map<string, MentionableTool[]>();
@@ -1644,7 +1646,7 @@ const ComposerContextPicker: FC = () => {
                       mcpToolsLoading,
                       mcpTools,
                       mcpToolsError,
-                      toolsQueryEnabled,
+                      serversPresence,
                     )}
                     onSelect={insertMention}
                   />

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -93,6 +93,7 @@ import { useToolMentions } from "@/elements/hooks/useToolMentions";
 import { getApiUrl } from "@/elements/lib/api";
 import { dictationAdapter } from "@/elements/lib/dictation";
 import {
+  composerContextToolsEmptyMessage,
   mcpToolsAvailability,
   mcpToolsSendBlocked,
   mcpToolsSendTooltip,
@@ -1355,11 +1356,11 @@ const ComposerContextPicker: FC = () => {
 
   // Both halves stay visible while their source is still loading, so the
   // button appears immediately rather than popping in once the async list
-  // resolves — but a half that loaded empty is dropped, and a button with
-  // nothing behind it at all is not rendered.
+  // resolves. An empty tools/list stays visible too — hiding it would read
+  // as "this assistant has no tools" with no explanation.
   const hasSkills =
     !!skillContext && (skillContext.skills.length > 0 || skillContext.loading);
-  const hasTools = toolMentionsEnabled && (tools.length > 0 || mcpToolsLoading);
+  const hasTools = toolMentionsEnabled;
   if (!hasSkills && !hasTools) {
     return null;
   }
@@ -1630,7 +1631,9 @@ const ComposerContextPicker: FC = () => {
                   />
                   <ContextToolResults
                     tools={matchingTools}
-                    loading={mcpToolsLoading}
+                    emptyMessage={composerContextToolsEmptyMessage(
+                      mcpToolsLoading,
+                    )}
                     onSelect={insertMention}
                   />
                 </>
@@ -1644,17 +1647,17 @@ const ComposerContextPicker: FC = () => {
 
 function ContextToolResults({
   tools,
-  loading,
+  emptyMessage,
   onSelect,
 }: {
   tools: MentionableTool[];
-  loading: boolean;
+  emptyMessage: string;
   onSelect: (toolName: string) => void;
 }): React.ReactElement {
   if (tools.length === 0) {
     return (
       <div className="px-2 py-6 text-center text-xs text-muted-foreground">
-        {loading ? "Loading tools…" : "No tools found"}
+        {emptyMessage}
       </div>
     );
   }

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -95,6 +95,7 @@ import { dictationAdapter } from "@/elements/lib/dictation";
 import {
   composerContextToolsEmptyMessage,
   mcpToolsAvailability,
+  mcpToolsListPending,
   mcpToolsSendBlocked,
   mcpToolsSendTooltip,
 } from "@/elements/lib/mcpToolsAvailability";
@@ -1314,7 +1315,7 @@ const CONTEXT_ALL_TOOLS_SECTION = "__all_tools__";
  * `@mention` into the draft — but the user makes one trip to one list.
  */
 const ComposerContextPicker: FC = () => {
-  const { config, mcpTools, mcpToolsLoading } = useElements();
+  const { config, mcpTools, mcpToolsLoading, mcpToolsError } = useElements();
   const aui = useAui();
   const triggerRef = useRef<HTMLButtonElement>(null);
   // Read the composer text from the same reactive source the tool-mention
@@ -1337,6 +1338,14 @@ const ComposerContextPicker: FC = () => {
       composerConfig.toolMentions.enabled !== false);
 
   const tools = useMemo(() => toolSetToMentionableTools(mcpTools), [mcpTools]);
+  const toolsQueryEnabled =
+    Boolean(config.mcp) || (config.mcps?.length ?? 0) > 0;
+  const toolsListPending = mcpToolsListPending(
+    mcpToolsLoading,
+    mcpTools,
+    mcpToolsError,
+    toolsQueryEnabled,
+  );
 
   const categories = useMemo<ToolCategory[]>(() => {
     const grouped = new Map<string, MentionableTool[]>();
@@ -1595,7 +1604,7 @@ const ComposerContextPicker: FC = () => {
                 {/* A search that outruns the fetch has nothing to match yet;
                     saying "nothing found" there reports absence when the
                     answer is simply not back. */}
-                {skillContext?.loading || mcpToolsLoading
+                {skillContext?.loading || toolsListPending
                   ? "Loading…"
                   : "Nothing found"}
               </div>
@@ -1633,6 +1642,9 @@ const ComposerContextPicker: FC = () => {
                     tools={matchingTools}
                     emptyMessage={composerContextToolsEmptyMessage(
                       mcpToolsLoading,
+                      mcpTools,
+                      mcpToolsError,
+                      toolsQueryEnabled,
                     )}
                     onSelect={insertMention}
                   />

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  composerContextToolsEmptyMessage,
   mcpToolsAvailability,
   mcpToolsSendBlocked,
   mcpToolsSendTooltip,
   mcpToolsWelcomeSubtitle,
+  NO_CONTEXT_TOOLS_MESSAGE,
   NO_MCP_TOOLS_MESSAGE,
 } from "./mcpToolsAvailability";
 
@@ -57,6 +59,15 @@ describe("mcpToolsAvailability", () => {
     expect(mcpToolsSendBlocked(true, false, {}, new Error("401"))).toBe(true);
     expect(mcpToolsSendBlocked(true, false, { list_issues: {} }, null)).toBe(
       false,
+    );
+  });
+});
+
+describe("composerContextToolsEmptyMessage", () => {
+  it("explains a settled empty tools/list instead of vanishing", () => {
+    expect(composerContextToolsEmptyMessage(true)).toBe("Loading tools…");
+    expect(composerContextToolsEmptyMessage(false)).toBe(
+      NO_CONTEXT_TOOLS_MESSAGE,
     );
   });
 });

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   composerContextToolsEmptyMessage,
+  composerMcpServersPresence,
   CONTEXT_TOOLS_EMPTY_MESSAGE,
   CONTEXT_TOOLS_LOAD_FAILED_MESSAGE,
   mcpToolsAvailability,
@@ -66,18 +67,40 @@ describe("mcpToolsAvailability", () => {
   });
 });
 
+describe("composerMcpServersPresence", () => {
+  it("treats omitted mcp and mcps as unknown", () => {
+    expect(composerMcpServersPresence(undefined, undefined)).toBe("unknown");
+  });
+
+  it("treats an explicit empty mcps list as none", () => {
+    expect(composerMcpServersPresence(undefined, [])).toBe("none");
+  });
+
+  it("treats a url or non-empty list as some", () => {
+    expect(
+      composerMcpServersPresence("https://gram.test/mcp/a", undefined),
+    ).toBe("some");
+    expect(composerMcpServersPresence(undefined, [{ url: "/mcp/a" }])).toBe(
+      "some",
+    );
+  });
+});
+
 describe("composerContextToolsEmptyMessage", () => {
-  it("stays on loading while tools/list has not settled", () => {
-    expect(composerContextToolsEmptyMessage(true, undefined, null, true)).toBe(
-      "Loading tools…",
-    );
-    expect(composerContextToolsEmptyMessage(false, undefined, null, true)).toBe(
-      "Loading tools…",
-    );
+  it("stays on loading while host config or tools/list is unknown", () => {
+    expect(
+      composerContextToolsEmptyMessage(false, undefined, null, "unknown"),
+    ).toBe("Loading tools…");
+    expect(
+      composerContextToolsEmptyMessage(true, undefined, null, "some"),
+    ).toBe("Loading tools…");
+    expect(
+      composerContextToolsEmptyMessage(false, undefined, null, "some"),
+    ).toBe("Loading tools…");
   });
 
   it("explains a settled empty tools/list", () => {
-    expect(composerContextToolsEmptyMessage(false, {}, null, true)).toBe(
+    expect(composerContextToolsEmptyMessage(false, {}, null, "some")).toBe(
       CONTEXT_TOOLS_EMPTY_MESSAGE,
     );
   });
@@ -88,18 +111,15 @@ describe("composerContextToolsEmptyMessage", () => {
         false,
         undefined,
         new Error("401"),
-        true,
+        "some",
       ),
     ).toBe(CONTEXT_TOOLS_LOAD_FAILED_MESSAGE);
   });
 
   it("explains when no servers are attached", () => {
     expect(
-      composerContextToolsEmptyMessage(false, undefined, null, false),
+      composerContextToolsEmptyMessage(false, undefined, null, "none"),
     ).toBe(NO_CONTEXT_SERVERS_MESSAGE);
-    expect(composerContextToolsEmptyMessage(true, undefined, null, false)).toBe(
-      NO_CONTEXT_SERVERS_MESSAGE,
-    );
     expect(mcpToolsListPending(false, undefined, null, false)).toBe(false);
     expect(mcpToolsListPending(true, undefined, null, false)).toBe(false);
   });

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   composerContextToolsEmptyMessage,
+  CONTEXT_TOOLS_EMPTY_MESSAGE,
+  CONTEXT_TOOLS_LOAD_FAILED_MESSAGE,
   mcpToolsAvailability,
   mcpToolsListPending,
   mcpToolsSendBlocked,
   mcpToolsSendTooltip,
   mcpToolsWelcomeSubtitle,
-  NO_CONTEXT_TOOLS_MESSAGE,
+  NO_CONTEXT_SERVERS_MESSAGE,
   NO_MCP_TOOLS_MESSAGE,
 } from "./mcpToolsAvailability";
 
@@ -74,10 +76,13 @@ describe("composerContextToolsEmptyMessage", () => {
     );
   });
 
-  it("explains a settled empty or failed tools/list instead of vanishing", () => {
+  it("explains a settled empty tools/list", () => {
     expect(composerContextToolsEmptyMessage(false, {}, null, true)).toBe(
-      NO_CONTEXT_TOOLS_MESSAGE,
+      CONTEXT_TOOLS_EMPTY_MESSAGE,
     );
+  });
+
+  it("explains a failed tools/list", () => {
     expect(
       composerContextToolsEmptyMessage(
         false,
@@ -85,15 +90,18 @@ describe("composerContextToolsEmptyMessage", () => {
         new Error("401"),
         true,
       ),
-    ).toBe(NO_CONTEXT_TOOLS_MESSAGE);
+    ).toBe(CONTEXT_TOOLS_LOAD_FAILED_MESSAGE);
   });
 
-  it("does not spin forever when the tools query is disabled", () => {
+  it("explains when no servers are attached", () => {
     expect(
       composerContextToolsEmptyMessage(false, undefined, null, false),
-    ).toBe(NO_CONTEXT_TOOLS_MESSAGE);
+    ).toBe(NO_CONTEXT_SERVERS_MESSAGE);
+    expect(composerContextToolsEmptyMessage(true, undefined, null, false)).toBe(
+      NO_CONTEXT_SERVERS_MESSAGE,
+    );
     expect(mcpToolsListPending(false, undefined, null, false)).toBe(false);
-    expect(mcpToolsListPending(true, undefined, null, false)).toBe(true);
+    expect(mcpToolsListPending(true, undefined, null, false)).toBe(false);
   });
 });
 

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   composerContextToolsEmptyMessage,
   mcpToolsAvailability,
+  mcpToolsListPending,
   mcpToolsSendBlocked,
   mcpToolsSendTooltip,
   mcpToolsWelcomeSubtitle,
@@ -64,11 +65,35 @@ describe("mcpToolsAvailability", () => {
 });
 
 describe("composerContextToolsEmptyMessage", () => {
-  it("explains a settled empty tools/list instead of vanishing", () => {
-    expect(composerContextToolsEmptyMessage(true)).toBe("Loading tools…");
-    expect(composerContextToolsEmptyMessage(false)).toBe(
+  it("stays on loading while tools/list has not settled", () => {
+    expect(composerContextToolsEmptyMessage(true, undefined, null, true)).toBe(
+      "Loading tools…",
+    );
+    expect(composerContextToolsEmptyMessage(false, undefined, null, true)).toBe(
+      "Loading tools…",
+    );
+  });
+
+  it("explains a settled empty or failed tools/list instead of vanishing", () => {
+    expect(composerContextToolsEmptyMessage(false, {}, null, true)).toBe(
       NO_CONTEXT_TOOLS_MESSAGE,
     );
+    expect(
+      composerContextToolsEmptyMessage(
+        false,
+        undefined,
+        new Error("401"),
+        true,
+      ),
+    ).toBe(NO_CONTEXT_TOOLS_MESSAGE);
+  });
+
+  it("does not spin forever when the tools query is disabled", () => {
+    expect(
+      composerContextToolsEmptyMessage(false, undefined, null, false),
+    ).toBe(NO_CONTEXT_TOOLS_MESSAGE);
+    expect(mcpToolsListPending(false, undefined, null, false)).toBe(false);
+    expect(mcpToolsListPending(true, undefined, null, false)).toBe(true);
   });
 });
 

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -67,6 +67,28 @@ export function mcpToolsWelcomeSubtitle(
   }
 }
 
-export function composerContextToolsEmptyMessage(loading: boolean): string {
-  return loading ? "Loading tools…" : NO_CONTEXT_TOOLS_MESSAGE;
+/**
+ * True while tools/list has not settled. A disabled query (no servers yet)
+ * is not pending — that is a settled empty, not an in-flight list.
+ */
+export function mcpToolsListPending(
+  loading: boolean,
+  tools: Record<string, unknown> | undefined,
+  error: unknown,
+  toolsQueryEnabled: boolean,
+): boolean {
+  if (loading) return true;
+  if (!toolsQueryEnabled) return false;
+  return mcpToolsAvailability(loading, tools, error) === "loading";
+}
+
+export function composerContextToolsEmptyMessage(
+  loading: boolean,
+  tools: Record<string, unknown> | undefined,
+  error: unknown,
+  toolsQueryEnabled: boolean,
+): string {
+  return mcpToolsListPending(loading, tools, error, toolsQueryEnabled)
+    ? "Loading tools…"
+    : NO_CONTEXT_TOOLS_MESSAGE;
 }

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -4,9 +4,16 @@ export type McpToolsAvailability = "loading" | "ready" | "unavailable";
 export const NO_MCP_TOOLS_MESSAGE =
   "No tools loaded from this server — connect authentication to test it.";
 
-/** Shown in the composer @-picker when tools/list settled empty or failed. */
-export const NO_CONTEXT_TOOLS_MESSAGE =
-  "No tools loaded from attached servers.";
+/** Composer @-picker: no MCP servers on the assistant, so tools/list never ran. */
+export const NO_CONTEXT_SERVERS_MESSAGE = "No MCP servers attached.";
+
+/** Composer @-picker: tools/list failed after servers were attached. */
+export const CONTEXT_TOOLS_LOAD_FAILED_MESSAGE =
+  "Couldn't load tools from attached servers.";
+
+/** Composer @-picker: tools/list settled with zero tools. */
+export const CONTEXT_TOOLS_EMPTY_MESSAGE =
+  "Attached servers didn't return any tools.";
 
 /**
  * Distinguishes in-flight tools/list from a settled empty/error result so
@@ -77,8 +84,8 @@ export function mcpToolsListPending(
   error: unknown,
   toolsQueryEnabled: boolean,
 ): boolean {
-  if (loading) return true;
   if (!toolsQueryEnabled) return false;
+  if (loading) return true;
   return mcpToolsAvailability(loading, tools, error) === "loading";
 }
 
@@ -88,7 +95,10 @@ export function composerContextToolsEmptyMessage(
   error: unknown,
   toolsQueryEnabled: boolean,
 ): string {
-  return mcpToolsListPending(loading, tools, error, toolsQueryEnabled)
-    ? "Loading tools…"
-    : NO_CONTEXT_TOOLS_MESSAGE;
+  if (!toolsQueryEnabled) return NO_CONTEXT_SERVERS_MESSAGE;
+  if (mcpToolsListPending(loading, tools, error, toolsQueryEnabled)) {
+    return "Loading tools…";
+  }
+  if (error) return CONTEXT_TOOLS_LOAD_FAILED_MESSAGE;
+  return CONTEXT_TOOLS_EMPTY_MESSAGE;
 }

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -75,6 +75,21 @@ export function mcpToolsWelcomeSubtitle(
 }
 
 /**
+ * Host config for MCP servers: omitted (`mcp` and `mcps` both unset) is
+ * unknown, `mcps: []` is settled-empty, and a URL or non-empty list is some.
+ */
+export type ComposerMcpServersPresence = "unknown" | "none" | "some";
+
+export function composerMcpServersPresence(
+  mcp: string | undefined,
+  mcps: ReadonlyArray<unknown> | undefined,
+): ComposerMcpServersPresence {
+  if (Boolean(mcp) || (mcps !== undefined && mcps.length > 0)) return "some";
+  if (mcps !== undefined) return "none";
+  return "unknown";
+}
+
+/**
  * True while tools/list has not settled. A disabled query (no servers yet)
  * is not pending — that is a settled empty, not an in-flight list.
  */
@@ -93,10 +108,11 @@ export function composerContextToolsEmptyMessage(
   loading: boolean,
   tools: Record<string, unknown> | undefined,
   error: unknown,
-  toolsQueryEnabled: boolean,
+  servers: ComposerMcpServersPresence,
 ): string {
-  if (!toolsQueryEnabled) return NO_CONTEXT_SERVERS_MESSAGE;
-  if (mcpToolsListPending(loading, tools, error, toolsQueryEnabled)) {
+  if (servers === "unknown") return "Loading tools…";
+  if (servers === "none") return NO_CONTEXT_SERVERS_MESSAGE;
+  if (mcpToolsListPending(loading, tools, error, true)) {
     return "Loading tools…";
   }
   if (error) return CONTEXT_TOOLS_LOAD_FAILED_MESSAGE;

--- a/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
+++ b/client/dashboard/src/elements/lib/mcpToolsAvailability.ts
@@ -4,6 +4,10 @@ export type McpToolsAvailability = "loading" | "ready" | "unavailable";
 export const NO_MCP_TOOLS_MESSAGE =
   "No tools loaded from this server — connect authentication to test it.";
 
+/** Shown in the composer @-picker when tools/list settled empty or failed. */
+export const NO_CONTEXT_TOOLS_MESSAGE =
+  "No tools loaded from attached servers.";
+
 /**
  * Distinguishes in-flight tools/list from a settled empty/error result so
  * callers can avoid flashing the empty state during normal load.
@@ -61,4 +65,8 @@ export function mcpToolsWelcomeSubtitle(
     case "ready":
       return readySubtitle ?? "";
   }
+}
+
+export function composerContextToolsEmptyMessage(loading: boolean): string {
+  return loading ? "Loading tools…" : NO_CONTEXT_TOOLS_MESSAGE;
 }

--- a/client/dashboard/src/hooks/observabilityMcpEntries.test.ts
+++ b/client/dashboard/src/hooks/observabilityMcpEntries.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { observabilityMcpEntries } from "./observabilityMcpEntries";
+
+const base = {
+  projectSlug: "proj",
+  serverURL: "https://gram.test",
+  toolsetsLoading: false,
+  toolsets: [] as const,
+  mcpServersLoading: false,
+  mcpServers: [] as const,
+  endpointsLoading: false,
+  endpoints: [] as const,
+};
+
+describe("observabilityMcpEntries", () => {
+  it("is unknown while any listing is loading or missing", () => {
+    expect(
+      observabilityMcpEntries({ ...base, toolsetsLoading: true }),
+    ).toBeUndefined();
+    expect(
+      observabilityMcpEntries({ ...base, mcpServersLoading: true }),
+    ).toBeUndefined();
+    expect(
+      observabilityMcpEntries({ ...base, endpointsLoading: true }),
+    ).toBeUndefined();
+    expect(
+      observabilityMcpEntries({ ...base, toolsets: undefined }),
+    ).toBeUndefined();
+    expect(
+      observabilityMcpEntries({ ...base, mcpServers: undefined }),
+    ).toBeUndefined();
+    expect(
+      observabilityMcpEntries({ ...base, endpoints: undefined }),
+    ).toBeUndefined();
+  });
+
+  it("is an empty list when every listing settled empty", () => {
+    expect(observabilityMcpEntries(base)).toEqual([]);
+  });
+
+  it("includes toolset-backed URLs", () => {
+    expect(
+      observabilityMcpEntries({
+        ...base,
+        toolsets: [
+          {
+            slug: "github",
+            mcpSlug: "github-mcp",
+            defaultEnvironmentSlug: "default",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        url: "https://gram.test/mcp/github-mcp",
+        name: "github",
+        environment: "default",
+      },
+    ]);
+  });
+
+  it("includes directly hosted MCP servers that have an endpoint", () => {
+    expect(
+      observabilityMcpEntries({
+        ...base,
+        mcpServers: [
+          { id: "srv-1", slug: "remote-docs", visibility: "private" },
+        ],
+        endpoints: [{ slug: "acme-remote-docs", mcpServerId: "srv-1" }],
+      }),
+    ).toEqual([
+      {
+        url: "https://gram.test/mcp/acme-remote-docs",
+        name: "remote-docs",
+      },
+    ]);
+  });
+
+  it("skips disabled and unproxied servers and does not duplicate toolset URLs", () => {
+    expect(
+      observabilityMcpEntries({
+        ...base,
+        toolsets: [{ slug: "github", mcpSlug: "github-mcp" }],
+        mcpServers: [
+          { id: "toolset-srv", slug: "github", visibility: "private" },
+          { id: "off", slug: "off", visibility: "disabled" },
+          {
+            id: "unproxied",
+            slug: "vendor",
+            visibility: "private",
+            unproxiedMcpServerId: "up-1",
+          },
+        ],
+        endpoints: [
+          { slug: "github-mcp", mcpServerId: "toolset-srv" },
+          { slug: "off-ep", mcpServerId: "off" },
+          { slug: "vendor-ep", mcpServerId: "unproxied" },
+        ],
+      }),
+    ).toEqual([
+      {
+        url: "https://gram.test/mcp/github-mcp",
+        name: "github",
+        environment: undefined,
+      },
+    ]);
+  });
+});

--- a/client/dashboard/src/hooks/observabilityMcpEntries.test.ts
+++ b/client/dashboard/src/hooks/observabilityMcpEntries.test.ts
@@ -76,6 +76,31 @@ describe("observabilityMcpEntries", () => {
     ]);
   });
 
+  it("skips custom-domain-only endpoints", () => {
+    expect(
+      observabilityMcpEntries({
+        ...base,
+        mcpServers: [
+          { id: "custom-only", slug: "branded", visibility: "private" },
+          { id: "platform", slug: "docs", visibility: "private" },
+        ],
+        endpoints: [
+          {
+            slug: "branded",
+            mcpServerId: "custom-only",
+            customDomainId: "dom-1",
+          },
+          { slug: "acme-docs", mcpServerId: "platform" },
+        ],
+      }),
+    ).toEqual([
+      {
+        url: "https://gram.test/mcp/acme-docs",
+        name: "docs",
+      },
+    ]);
+  });
+
   it("skips disabled and unproxied servers and does not duplicate toolset URLs", () => {
     expect(
       observabilityMcpEntries({

--- a/client/dashboard/src/hooks/observabilityMcpEntries.ts
+++ b/client/dashboard/src/hooks/observabilityMcpEntries.ts
@@ -71,9 +71,10 @@ export function observabilityMcpEntries({
   const serverById = new Map(mcpServers.map((server) => [server.id, server]));
   const endpointByServer = new Map<string, EndpointUrlSource>();
   for (const endpoint of endpoints) {
-    if (!endpoint.mcpServerId) continue;
-    const existing = endpointByServer.get(endpoint.mcpServerId);
-    if (!existing || (existing.customDomainId && !endpoint.customDomainId)) {
+    // Custom-domain slugs are not registered on the Gram origin this config
+    // dials, so a Gram `/mcp/{slug}` tools/list would 404.
+    if (!endpoint.mcpServerId || endpoint.customDomainId) continue;
+    if (!endpointByServer.has(endpoint.mcpServerId)) {
       endpointByServer.set(endpoint.mcpServerId, endpoint);
     }
   }

--- a/client/dashboard/src/hooks/observabilityMcpEntries.ts
+++ b/client/dashboard/src/hooks/observabilityMcpEntries.ts
@@ -1,0 +1,114 @@
+import type { MCPServerEntry } from "@/elements";
+
+type ToolsetUrlSource = {
+  slug: string;
+  mcpSlug?: string;
+  defaultEnvironmentSlug?: string;
+};
+
+type McpServerUrlSource = {
+  id: string;
+  slug?: string;
+  unproxiedMcpServerId?: string;
+  visibility: string;
+};
+
+type EndpointUrlSource = {
+  slug: string;
+  mcpServerId?: string;
+  customDomainId?: string;
+};
+
+/**
+ * Client MCP entries for the insights dock tools/list. Undefined while any
+ * listing is still in flight or unknown so the picker stays on loading.
+ * Settled empty is `[]`.
+ */
+export function observabilityMcpEntries({
+  projectSlug,
+  serverURL,
+  toolsetsLoading,
+  toolsets,
+  mcpServersLoading,
+  mcpServers,
+  endpointsLoading,
+  endpoints,
+}: {
+  projectSlug: string;
+  serverURL: string;
+  toolsetsLoading: boolean;
+  toolsets: readonly ToolsetUrlSource[] | undefined;
+  mcpServersLoading: boolean;
+  mcpServers: readonly McpServerUrlSource[] | undefined;
+  endpointsLoading: boolean;
+  endpoints: readonly EndpointUrlSource[] | undefined;
+}): MCPServerEntry[] | undefined {
+  if (toolsetsLoading || mcpServersLoading || endpointsLoading) {
+    return undefined;
+  }
+  if (
+    toolsets === undefined ||
+    mcpServers === undefined ||
+    endpoints === undefined
+  ) {
+    return undefined;
+  }
+
+  const seen = new Set<string>();
+  const entries: MCPServerEntry[] = [];
+
+  for (const toolset of toolsets) {
+    const url = toolsetMcpUrl(serverURL, projectSlug, toolset);
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    entries.push({
+      url,
+      name: toolset.slug,
+      environment: toolset.defaultEnvironmentSlug,
+    });
+  }
+
+  const serverById = new Map(mcpServers.map((server) => [server.id, server]));
+  const endpointByServer = new Map<string, EndpointUrlSource>();
+  for (const endpoint of endpoints) {
+    if (!endpoint.mcpServerId) continue;
+    const existing = endpointByServer.get(endpoint.mcpServerId);
+    if (!existing || (existing.customDomainId && !endpoint.customDomainId)) {
+      endpointByServer.set(endpoint.mcpServerId, endpoint);
+    }
+  }
+
+  for (const [serverId, endpoint] of endpointByServer) {
+    const server = serverById.get(serverId);
+    if (
+      !server ||
+      server.visibility === "disabled" ||
+      server.unproxiedMcpServerId
+    ) {
+      continue;
+    }
+    const url = `${serverURL}/mcp/${endpoint.slug}`;
+    if (seen.has(url)) continue;
+    seen.add(url);
+    entries.push({
+      url,
+      name: server.slug ?? endpoint.slug,
+    });
+  }
+
+  return entries;
+}
+
+/** Same suffix rules as `internalMcpUrl`, with a caller-supplied origin. */
+function toolsetMcpUrl(
+  serverURL: string,
+  projectSlug: string,
+  toolset: ToolsetUrlSource,
+): string | undefined {
+  const suffix = toolset.mcpSlug
+    ? toolset.mcpSlug
+    : toolset.defaultEnvironmentSlug
+      ? [projectSlug, toolset.slug, toolset.defaultEnvironmentSlug].join("/")
+      : undefined;
+  return suffix ? `${serverURL}/mcp/${suffix}` : undefined;
+}

--- a/client/dashboard/src/hooks/projectAssistantAccess.test.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNoMcpAccessConfigured,
+  showProjectAssistantConnecting,
+} from "./projectAssistantAccess";
+
+describe("isNoMcpAccessConfigured", () => {
+  const settledEmpty = {
+    projectSlug: "proj",
+    toolsetsLoading: false,
+    toolsetCount: 0,
+    mcpServersLoading: false,
+    mcpServerCount: 0,
+  };
+
+  it("is false while the project slug is missing or either query is loading", () => {
+    expect(isNoMcpAccessConfigured({ ...settledEmpty, projectSlug: "" })).toBe(
+      false,
+    );
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, toolsetsLoading: true }),
+    ).toBe(false);
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, mcpServersLoading: true }),
+    ).toBe(false);
+  });
+
+  it("is true only when both toolsets and MCP servers settled empty", () => {
+    expect(isNoMcpAccessConfigured(settledEmpty)).toBe(true);
+  });
+
+  it("is false when the project has toolsets", () => {
+    expect(isNoMcpAccessConfigured({ ...settledEmpty, toolsetCount: 2 })).toBe(
+      false,
+    );
+  });
+
+  it("is false when the project has MCP servers but no toolsets", () => {
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, mcpServerCount: 1 }),
+    ).toBe(false);
+  });
+});
+
+describe("showProjectAssistantConnecting", () => {
+  it("shows the spinner only while connecting with servers available", () => {
+    expect(
+      showProjectAssistantConnecting({
+        assistantError: undefined,
+        assistantNeedsAdmin: false,
+        noMcpAccessConfigured: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not claim to be connecting when no servers are configured", () => {
+    expect(
+      showProjectAssistantConnecting({
+        assistantError: undefined,
+        assistantNeedsAdmin: false,
+        noMcpAccessConfigured: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the spinner when the assistant failed or needs an admin", () => {
+    expect(
+      showProjectAssistantConnecting({
+        assistantError: "failed",
+        assistantNeedsAdmin: false,
+        noMcpAccessConfigured: false,
+      }),
+    ).toBe(false);
+    expect(
+      showProjectAssistantConnecting({
+        assistantError: undefined,
+        assistantNeedsAdmin: true,
+        noMcpAccessConfigured: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/client/dashboard/src/hooks/projectAssistantAccess.test.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.test.ts
@@ -40,6 +40,21 @@ describe("isNoMcpAccessConfigured", () => {
       isNoMcpAccessConfigured({ ...settledEmpty, mcpServerCount: 1 }),
     ).toBe(false);
   });
+
+  it("is false when either listing failed or the count is still unknown", () => {
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, toolsetsFailed: true }),
+    ).toBe(false);
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, mcpServersFailed: true }),
+    ).toBe(false);
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, toolsetCount: undefined }),
+    ).toBe(false);
+    expect(
+      isNoMcpAccessConfigured({ ...settledEmpty, mcpServerCount: undefined }),
+    ).toBe(false);
+  });
 });
 
 describe("showProjectAssistantConnecting", () => {

--- a/client/dashboard/src/hooks/projectAssistantAccess.test.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.test.ts
@@ -1,8 +1,27 @@
 import { describe, expect, it } from "vitest";
 import {
   isNoMcpAccessConfigured,
+  settledListCount,
   showProjectAssistantConnecting,
 } from "./projectAssistantAccess";
+
+describe("settledListCount", () => {
+  it("stays unknown when the query has no data", () => {
+    expect(settledListCount(undefined, undefined)).toBeUndefined();
+    expect(settledListCount(undefined, [])).toBeUndefined();
+  });
+
+  it("does not treat a settled empty list as unknown", () => {
+    expect(settledListCount({ mcpServers: [] }, [])).toBe(0);
+    expect(settledListCount({ mcpServers: undefined }, undefined)).toBe(0);
+  });
+
+  it("counts a settled list", () => {
+    expect(settledListCount({ mcpServers: [{ id: "1" }] }, [{ id: "1" }])).toBe(
+      1,
+    );
+  });
+});
 
 describe("isNoMcpAccessConfigured", () => {
   const settledEmpty = {

--- a/client/dashboard/src/hooks/projectAssistantAccess.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.ts
@@ -1,4 +1,16 @@
 /**
+ * Length of a settled list. `undefined` data (loading, failed, or unknown)
+ * stays unknown — do not fall back to `?? 0`.
+ */
+export function settledListCount(
+  data: unknown,
+  items: readonly unknown[] | undefined,
+): number | undefined {
+  if (data === undefined) return undefined;
+  return items?.length ?? 0;
+}
+
+/**
  * True when the project has neither toolsets nor MCP servers. Either
  * attachment kind is enough for the Project Assistant to have tools.
  * Returns false while either list is still loading, failed, or unknown so

--- a/client/dashboard/src/hooks/projectAssistantAccess.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.ts
@@ -1,0 +1,38 @@
+/**
+ * True when the project has neither toolsets nor MCP servers. Either
+ * attachment kind is enough for the Project Assistant to have tools.
+ * Returns false while either list is still loading so the dock does not
+ * flash a "create a server" prompt during the first paint.
+ */
+export function isNoMcpAccessConfigured({
+  projectSlug,
+  toolsetsLoading,
+  toolsetCount,
+  mcpServersLoading,
+  mcpServerCount,
+}: {
+  projectSlug?: string;
+  toolsetsLoading: boolean;
+  toolsetCount: number;
+  mcpServersLoading: boolean;
+  mcpServerCount: number;
+}): boolean {
+  if (!projectSlug || toolsetsLoading || mcpServersLoading) return false;
+  return toolsetCount === 0 && mcpServerCount === 0;
+}
+
+/**
+ * The connecting spinner and the "no servers" notice must not show
+ * together — an empty project is a settled state, not an in-flight one.
+ */
+export function showProjectAssistantConnecting({
+  assistantError,
+  assistantNeedsAdmin,
+  noMcpAccessConfigured,
+}: {
+  assistantError: unknown;
+  assistantNeedsAdmin: boolean;
+  noMcpAccessConfigured: boolean;
+}): boolean {
+  return !assistantError && !assistantNeedsAdmin && !noMcpAccessConfigured;
+}

--- a/client/dashboard/src/hooks/projectAssistantAccess.ts
+++ b/client/dashboard/src/hooks/projectAssistantAccess.ts
@@ -1,8 +1,8 @@
 /**
  * True when the project has neither toolsets nor MCP servers. Either
  * attachment kind is enough for the Project Assistant to have tools.
- * Returns false while either list is still loading so the dock does not
- * flash a "create a server" prompt during the first paint.
+ * Returns false while either list is still loading, failed, or unknown so
+ * the dock does not treat a suppressed 403 / failed listing as "empty".
  */
 export function isNoMcpAccessConfigured({
   projectSlug,
@@ -10,14 +10,20 @@ export function isNoMcpAccessConfigured({
   toolsetCount,
   mcpServersLoading,
   mcpServerCount,
+  toolsetsFailed = false,
+  mcpServersFailed = false,
 }: {
   projectSlug?: string;
   toolsetsLoading: boolean;
-  toolsetCount: number;
+  toolsetCount: number | undefined;
   mcpServersLoading: boolean;
-  mcpServerCount: number;
+  mcpServerCount: number | undefined;
+  toolsetsFailed?: boolean;
+  mcpServersFailed?: boolean;
 }): boolean {
   if (!projectSlug || toolsetsLoading || mcpServersLoading) return false;
+  if (toolsetsFailed || mcpServersFailed) return false;
+  if (toolsetCount === undefined || mcpServerCount === undefined) return false;
   return toolsetCount === 0 && mcpServerCount === 0;
 }
 

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -1,14 +1,18 @@
-import { useProject, useSession } from "@/contexts/Auth";
+import { useSession } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
-import { internalMcpUrl } from "@/hooks/useToolsetUrl";
 import { getServerURL } from "@/lib/utils";
-import type { ElementsConfig, MCPServerEntry, ToolsFilter } from "@/elements";
+import type { ElementsConfig, ToolsFilter } from "@/elements";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useListToolsets } from "@gram/client/react-query/listToolsets.js";
+import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
 import { useMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { useCallback, useMemo } from "react";
-import { isNoMcpAccessConfigured } from "./projectAssistantAccess";
+import { observabilityMcpEntries } from "./observabilityMcpEntries";
+import {
+  isNoMcpAccessConfigured,
+  settledListCount,
+} from "./projectAssistantAccess";
 
 interface ObservabilityMcpConfigOptions {
   toolsToInclude: ToolsFilter;
@@ -16,8 +20,8 @@ interface ObservabilityMcpConfigOptions {
 
 /**
  * Hook to generate MCP configuration for AI Insights copilot features.
- * Connects to all toolsets in the current project and filters tools
- * based on the provided filter function.
+ * Connects to project toolsets and directly hosted MCP servers, then
+ * filters tools based on the provided filter function.
  */
 export function useObservabilityMcpConfig({
   toolsToInclude,
@@ -26,11 +30,25 @@ export function useObservabilityMcpConfig({
   "variant" | "welcome" | "theme"
 > {
   const { projectSlug } = useSlugs();
-  const project = useProject();
   const client = useGramContext();
   const { session } = useSession();
-  const { data: toolsetsData, isLoading: isLoadingToolsets } =
-    useListToolsets();
+  const enabled = Boolean(projectSlug);
+  const request = projectSlug ? { gramProject: projectSlug } : undefined;
+  const { data: toolsetsData, isLoading: toolsetsLoading } = useListToolsets(
+    request,
+    undefined,
+    { enabled },
+  );
+  const { data: mcpServersData, isLoading: mcpServersLoading } = useMcpServers(
+    request,
+    undefined,
+    { enabled },
+  );
+  const { data: endpointsData, isLoading: endpointsLoading } = useMcpEndpoints(
+    request,
+    undefined,
+    { enabled },
+  );
 
   const getSession = useCallback(async (): Promise<string> => {
     const res = await chatSessionsCreate(
@@ -50,24 +68,32 @@ export function useObservabilityMcpConfig({
     return res.value?.clientToken ?? "";
   }, [client, projectSlug]);
 
-  // Build MCP server entries for all project toolsets
-  const mcps = useMemo<MCPServerEntry[] | undefined>(() => {
-    if (isLoadingToolsets || !toolsetsData?.toolsets?.length) {
-      return undefined;
-    }
-
-    return toolsetsData.toolsets.flatMap((toolset) => {
-      const url = internalMcpUrl({ slug: project.slug }, toolset);
-      if (!url) return [];
-      return [
-        {
-          url,
-          name: toolset.slug,
-          environment: toolset.defaultEnvironmentSlug,
-        },
-      ];
-    });
-  }, [toolsetsData?.toolsets, project.slug, isLoadingToolsets]);
+  // Undefined while listings are in flight; `[]` when settled empty so the
+  // picker can tell "still loading" from "no servers attached".
+  const mcps = useMemo(
+    () =>
+      projectSlug
+        ? observabilityMcpEntries({
+            projectSlug,
+            serverURL: getServerURL(),
+            toolsetsLoading,
+            toolsets: toolsetsData?.toolsets,
+            mcpServersLoading,
+            mcpServers: mcpServersData?.mcpServers,
+            endpointsLoading,
+            endpoints: endpointsData?.mcpEndpoints,
+          })
+        : undefined,
+    [
+      projectSlug,
+      toolsetsLoading,
+      toolsetsData?.toolsets,
+      mcpServersLoading,
+      mcpServersData?.mcpServers,
+      endpointsLoading,
+      endpointsData?.mcpEndpoints,
+    ],
+  );
 
   return useMemo(() => {
     if (!projectSlug) {
@@ -94,7 +120,7 @@ export function useObservabilityMcpConfig({
         GRAM_APIKEY_HEADER_GRAM_KEY: "",
         GRAM_PROJECT_SLUG_HEADER_GRAM_PROJECT: projectSlug,
       },
-      ...(mcps && mcps.length > 0 && { mcps }),
+      ...(mcps !== undefined && { mcps }),
     };
   }, [toolsToInclude, getSession, session, projectSlug, mcps]);
 }
@@ -120,15 +146,12 @@ export function useNoToolsetsConfigured(projectSlug?: string): boolean {
   return isNoMcpAccessConfigured({
     projectSlug,
     toolsetsLoading,
-    toolsetCount:
-      toolsetsData === undefined
-        ? undefined
-        : (toolsetsData.toolsets?.length ?? 0),
+    toolsetCount: settledListCount(toolsetsData, toolsetsData?.toolsets),
     mcpServersLoading,
-    mcpServerCount:
-      mcpServersData === undefined
-        ? undefined
-        : (mcpServersData.mcpServers?.length ?? 0),
+    mcpServerCount: settledListCount(
+      mcpServersData,
+      mcpServersData?.mcpServers,
+    ),
     toolsetsFailed,
     mcpServersFailed,
   });

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -6,7 +6,9 @@ import type { ElementsConfig, MCPServerEntry, ToolsFilter } from "@/elements";
 import { chatSessionsCreate } from "@gram/client/funcs/chatSessionsCreate";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useListToolsets } from "@gram/client/react-query/listToolsets.js";
+import { useMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { useCallback, useMemo } from "react";
+import { isNoMcpAccessConfigured } from "./projectAssistantAccess";
 
 interface ObservabilityMcpConfigOptions {
   toolsToInclude: ToolsFilter;
@@ -98,16 +100,28 @@ export function useObservabilityMcpConfig({
 }
 
 /**
- * Whether the project has no toolsets configured yet.
+ * Whether the project has neither toolsets nor MCP servers.
  * Used to show a setup prompt in the AI Insights sidebar.
  */
 export function useNoToolsetsConfigured(projectSlug?: string): boolean {
-  const { data: toolsetsData, isLoading } = useListToolsets(
-    projectSlug ? { gramProject: projectSlug } : undefined,
+  const enabled = Boolean(projectSlug);
+  const request = projectSlug ? { gramProject: projectSlug } : undefined;
+  const { data: toolsetsData, isLoading: toolsetsLoading } = useListToolsets(
+    request,
     undefined,
-    { enabled: Boolean(projectSlug) },
+    { enabled },
+  );
+  const { data: mcpServersData, isLoading: mcpServersLoading } = useMcpServers(
+    request,
+    undefined,
+    { enabled },
   );
 
-  if (!projectSlug || isLoading) return false;
-  return !toolsetsData?.toolsets?.length;
+  return isNoMcpAccessConfigured({
+    projectSlug,
+    toolsetsLoading,
+    toolsetCount: toolsetsData?.toolsets?.length ?? 0,
+    mcpServersLoading,
+    mcpServerCount: mcpServersData?.mcpServers?.length ?? 0,
+  });
 }

--- a/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
+++ b/client/dashboard/src/hooks/useObservabilityMcpConfig.ts
@@ -106,22 +106,30 @@ export function useObservabilityMcpConfig({
 export function useNoToolsetsConfigured(projectSlug?: string): boolean {
   const enabled = Boolean(projectSlug);
   const request = projectSlug ? { gramProject: projectSlug } : undefined;
-  const { data: toolsetsData, isLoading: toolsetsLoading } = useListToolsets(
-    request,
-    undefined,
-    { enabled },
-  );
-  const { data: mcpServersData, isLoading: mcpServersLoading } = useMcpServers(
-    request,
-    undefined,
-    { enabled },
-  );
+  const {
+    data: toolsetsData,
+    isLoading: toolsetsLoading,
+    isError: toolsetsFailed,
+  } = useListToolsets(request, undefined, { enabled });
+  const {
+    data: mcpServersData,
+    isLoading: mcpServersLoading,
+    isError: mcpServersFailed,
+  } = useMcpServers(request, undefined, { enabled });
 
   return isNoMcpAccessConfigured({
     projectSlug,
     toolsetsLoading,
-    toolsetCount: toolsetsData?.toolsets?.length ?? 0,
+    toolsetCount:
+      toolsetsData === undefined
+        ? undefined
+        : (toolsetsData.toolsets?.length ?? 0),
     mcpServersLoading,
-    mcpServerCount: mcpServersData?.mcpServers?.length ?? 0,
+    mcpServerCount:
+      mcpServersData === undefined
+        ? undefined
+        : (mcpServersData.mcpServers?.length ?? 0),
+    toolsetsFailed,
+    mcpServersFailed,
   });
 }

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -32,6 +32,7 @@ import { MouseEvent, useMemo, useState } from "react";
 import { Outlet } from "react-router";
 
 import { AssistantsAuditLog } from "./AssistantAuditLog";
+import { assistantAttachedServerSlugs } from "./assistantServers";
 import { TriggersPanel } from "../triggers/Triggers";
 
 const TOP_LEVEL_TABS = ["assistants", "triggers", "audit"] as const;
@@ -225,7 +226,8 @@ function AssistantIcon() {
 const MAX_VISIBLE_TOOLSETS = 3;
 
 function AssistantToolsets({ assistant }: { assistant: Assistant }) {
-  if (assistant.toolsets.length === 0) {
+  const slugs = assistantAttachedServerSlugs(assistant);
+  if (slugs.length === 0) {
     return (
       <div className="flex items-center gap-1.5">
         <Boxes className="text-muted-foreground/70 size-3.5 shrink-0" />
@@ -236,21 +238,21 @@ function AssistantToolsets({ assistant }: { assistant: Assistant }) {
     );
   }
 
-  const visible = assistant.toolsets.slice(0, MAX_VISIBLE_TOOLSETS);
-  const overflow = assistant.toolsets.length - visible.length;
+  const visible = slugs.slice(0, MAX_VISIBLE_TOOLSETS);
+  const overflow = slugs.length - visible.length;
 
   return (
     <div className="flex min-w-0 items-center gap-1.5">
       <Boxes className="text-muted-foreground/70 size-3.5 shrink-0" />
       <div className="flex min-w-0 flex-wrap items-center gap-1">
-        {visible.map((toolset) => (
+        {visible.map((slug, index) => (
           <Badge
-            key={toolset.toolsetSlug}
+            key={`${index}:${slug}`}
             variant="neutral"
             className="max-w-[10rem]"
-            title={toolset.toolsetSlug}
+            title={slug}
           >
-            <span className="min-w-0 truncate">{toolset.toolsetSlug}</span>
+            <span className="min-w-0 truncate">{slug}</span>
           </Badge>
         ))}
         {overflow > 0 && <Badge variant="neutral">+{overflow}</Badge>}

--- a/client/dashboard/src/pages/assistants/assistantServers.test.ts
+++ b/client/dashboard/src/pages/assistants/assistantServers.test.ts
@@ -35,6 +35,15 @@ describe("assistantAttachedServerSlugs", () => {
     ).toEqual(["github", "remote-docs"]);
   });
 
+  it("dedupes overlapping toolset and MCP server slugs", () => {
+    expect(
+      assistantAttachedServerSlugs({
+        toolsets: [{ toolsetSlug: "github" }],
+        mcpServers: [{ mcpServerSlug: "github" }],
+      }),
+    ).toEqual(["github"]);
+  });
+
   it("treats a missing mcpServers array as empty", () => {
     expect(
       assistantAttachedServerSlugs({

--- a/client/dashboard/src/pages/assistants/assistantServers.test.ts
+++ b/client/dashboard/src/pages/assistants/assistantServers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { assistantAttachedServerSlugs } from "./assistantServers";
+
+describe("assistantAttachedServerSlugs", () => {
+  it("is empty when the assistant has neither toolsets nor direct MCP servers", () => {
+    expect(
+      assistantAttachedServerSlugs({ toolsets: [], mcpServers: [] }),
+    ).toEqual([]);
+  });
+
+  it("includes toolset slugs", () => {
+    expect(
+      assistantAttachedServerSlugs({
+        toolsets: [{ toolsetSlug: "github" }, { toolsetSlug: "linear" }],
+        mcpServers: [],
+      }),
+    ).toEqual(["github", "linear"]);
+  });
+
+  it("includes directly attached MCP servers when there are no toolsets", () => {
+    expect(
+      assistantAttachedServerSlugs({
+        toolsets: [],
+        mcpServers: [{ mcpServerSlug: "remote-docs" }],
+      }),
+    ).toEqual(["remote-docs"]);
+  });
+
+  it("lists toolsets and directly attached MCP servers together", () => {
+    expect(
+      assistantAttachedServerSlugs({
+        toolsets: [{ toolsetSlug: "github" }],
+        mcpServers: [{ mcpServerSlug: "remote-docs" }],
+      }),
+    ).toEqual(["github", "remote-docs"]);
+  });
+
+  it("treats a missing mcpServers array as empty", () => {
+    expect(
+      assistantAttachedServerSlugs({
+        toolsets: [{ toolsetSlug: "github" }],
+      }),
+    ).toEqual(["github"]);
+  });
+});

--- a/client/dashboard/src/pages/assistants/assistantServers.ts
+++ b/client/dashboard/src/pages/assistants/assistantServers.ts
@@ -7,7 +7,9 @@ export function assistantAttachedServerSlugs(assistant: {
   mcpServers?: ReadonlyArray<{ mcpServerSlug: string }>;
 }): string[] {
   return [
-    ...assistant.toolsets.map((toolset) => toolset.toolsetSlug),
-    ...(assistant.mcpServers ?? []).map((server) => server.mcpServerSlug),
+    ...new Set([
+      ...assistant.toolsets.map((toolset) => toolset.toolsetSlug),
+      ...(assistant.mcpServers ?? []).map((server) => server.mcpServerSlug),
+    ]),
   ];
 }

--- a/client/dashboard/src/pages/assistants/assistantServers.ts
+++ b/client/dashboard/src/pages/assistants/assistantServers.ts
@@ -1,0 +1,13 @@
+/**
+ * Slugs the assistants list treats as "MCP servers": toolset-backed
+ * attachments and servers joined through `assistant_mcp_servers`.
+ */
+export function assistantAttachedServerSlugs(assistant: {
+  toolsets: ReadonlyArray<{ toolsetSlug: string }>;
+  mcpServers?: ReadonlyArray<{ mcpServerSlug: string }>;
+}): string[] {
+  return [
+    ...assistant.toolsets.map((toolset) => toolset.toolsetSlug),
+    ...(assistant.mcpServers ?? []).map((server) => server.mcpServerSlug),
+  ];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

An assistant can reach an MCP server two ways: through a toolset, or directly through `assistant_mcp_servers`. Several surfaces only counted the first, so an assistant wired up the second way read as empty.

Fixes GRW-17.

## Changes

* **Assistants list.** Cards now render `assistant.mcpServers` alongside `assistant.toolsets`. Direct-only attachments no longer show "No MCP servers".
* **Dock gate.** `useNoToolsetsConfigured` queries MCP server state as well as toolsets, so a project with servers but no toolsets is not told to create one.
* **Dock tools/list.** Insights dock `mcps` now includes toolset URLs and Gram-hosted **platform-domain** endpoints for directly attached MCP servers. Custom-domain-only endpoints are skipped (those slugs are not registered on the Gram origin). An omitted `mcps` key means still loading; `mcps: []` means settled empty.
* **Contradictory dock states.** The "Connecting to the Project Assistant…" spinner is hidden when no servers are configured, so the dock does not claim tools are unavailable and that it is still connecting at the same time.
* **Tool mention picker.** The @-picker stays visible. Empty copy depends on the state:
  * Host config still loading (`mcp`/`mcps` omitted): "Loading tools…"
  * No servers attached (`mcps: []`): "No MCP servers attached."
  * `tools/list` failed: "Couldn't load tools from attached servers."
  * Servers listed with zero tools: "Attached servers didn't return any tools."
  * Still in flight: "Loading tools…"

## Tests

Unit tests cover combined slugs, the dock gate, failed/unknown listings, dock MCP entry building (including skipping custom-domain endpoints), and picker empty-state copy for each tools/list outcome.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-17](https://linear.app/speakeasy/issue/GRW-17/fix-assistant-surfaces-report-no-mcp-servers-when-servers-are-attached)

<div><a href="https://cursor.com/agents/bc-26fa2e3a-bf62-4109-883a-9406d7175670?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fa2e3a-bf62-4109-883a-9406d7175670&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GRW-17: assistants with MCP servers attached directly through `assistant_mcp_servers` were read as empty on surfaces that only counted toolsets. The assistants list, dock gate, and @-picker now count both attachment kinds.

- Assistant cards render direct MCP server slugs alongside toolset slugs, deduplicated.
- The dock gate treats a project with servers but no toolsets as configured; loading or failed listings stay unknown, not empty.
- The dock tools/list now includes directly hosted MCP endpoints along with toolset-backed URLs; custom-domain-only endpoints are skipped since Gram-origin `/mcp/{slug}` URLs would fail.
- The connecting spinner is hidden when no servers are configured, so it no longer contradicts the empty-state notice.
- The @-picker distinguishes omitted config, no attached servers, a failed `tools/list`, an empty list, and an in-flight list.
- Ships a `dashboard` patch changeset with unit tests for each surface.

<sup>Written for commit 9c38cf8ede3055e960c6292a0a4bfe5620d2bb29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

