### PR TITLE
mig: integrate killswitch audit, expiry, and receipt cleanup

### DIFF
--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -64,6 +64,10 @@ export const AUDIT_ACTIONS = [
   "json_web_key_set:create",
   "json_web_key_set:delete",
   "json_web_key_set:update",
+  "killswitch:activate",
+  "killswitch:change",
+  "killswitch:deactivate",
+  "killswitch:expire",
   "litellm_instance:create",
   "litellm_instance:revoke",
   "litellm_instance:rotate_key",
@@ -360,6 +364,15 @@ export function staticActionPhrase(action: AuditAction): string {
       return "updated environment";
     case "environment:delete":
       return "deleted environment";
+
+    case "killswitch:activate":
+      return "activated killswitch";
+    case "killswitch:change":
+      return "changed killswitch";
+    case "killswitch:deactivate":
+      return "deactivated killswitch";
+    case "killswitch:expire":
+      return "recorded killswitch expiry";
 
     case "litellm_instance:create":
       return "created LiteLLM instance";

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -7740,6 +7740,10 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   CONSTRAINT killswitch_prescription_versions_internal_note_check CHECK (char_length(internal_note) BETWEEN 1 AND 4000)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescription_versions_org_prescription_version_key ON killswitch_prescription_versions (organization_id, prescription_id, version);
+-- Privileged cross-organization expiry discovery: the maintenance sweep scans due
+-- versions globally ordered by expires_at, prescription_id, and version, so the index
+-- deliberately does not lead with organization_id.
+CREATE INDEX IF NOT EXISTS killswitch_prescription_versions_expiry_due_idx ON killswitch_prescription_versions (expires_at, prescription_id, version) WHERE state = 'active' AND expires_at IS NOT NULL AND (superseded_at IS NULL OR expires_at < superseded_at);
 
 CREATE TABLE IF NOT EXISTS killswitch_prescription_version_resources (
   organization_id TEXT NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -7727,7 +7727,6 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   expires_at timestamptz,
   activated_at timestamptz,
   superseded_at timestamptz,
-  expiry_event_recorded_at timestamptz,
   internal_note TEXT NOT NULL,
   external_note TEXT NOT NULL,
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -7741,10 +7740,10 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   CONSTRAINT killswitch_prescription_versions_internal_note_check CHECK (char_length(internal_note) BETWEEN 1 AND 4000)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescription_versions_org_prescription_version_key ON killswitch_prescription_versions (organization_id, prescription_id, version);
--- Privileged cross-organization expiry discovery: the maintenance sweep scans pending
--- due versions globally ordered by expires_at, prescription_id, and version, so the index
+-- Privileged cross-organization expiry discovery: the maintenance sweep scans due
+-- versions globally ordered by expires_at, prescription_id, and version, so the index
 -- deliberately does not lead with organization_id.
-CREATE INDEX IF NOT EXISTS killswitch_prescription_versions_expiry_due_idx ON killswitch_prescription_versions (expires_at, prescription_id, version) WHERE state = 'active' AND expires_at IS NOT NULL AND expiry_event_recorded_at IS NULL AND (superseded_at IS NULL OR expires_at < superseded_at);
+CREATE INDEX IF NOT EXISTS killswitch_prescription_versions_expiry_due_idx ON killswitch_prescription_versions (expires_at, prescription_id, version) WHERE state = 'active' AND expires_at IS NOT NULL AND (superseded_at IS NULL OR expires_at < superseded_at);
 
 CREATE TABLE IF NOT EXISTS killswitch_prescription_version_resources (
   organization_id TEXT NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -7727,6 +7727,7 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   expires_at timestamptz,
   activated_at timestamptz,
   superseded_at timestamptz,
+  expiry_event_recorded_at timestamptz,
   internal_note TEXT NOT NULL,
   external_note TEXT NOT NULL,
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -7740,10 +7741,10 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   CONSTRAINT killswitch_prescription_versions_internal_note_check CHECK (char_length(internal_note) BETWEEN 1 AND 4000)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescription_versions_org_prescription_version_key ON killswitch_prescription_versions (organization_id, prescription_id, version);
--- Privileged cross-organization expiry discovery: the maintenance sweep scans due
--- versions globally ordered by expires_at, prescription_id, and version, so the index
+-- Privileged cross-organization expiry discovery: the maintenance sweep scans pending
+-- due versions globally ordered by expires_at, prescription_id, and version, so the index
 -- deliberately does not lead with organization_id.
-CREATE INDEX IF NOT EXISTS killswitch_prescription_versions_expiry_due_idx ON killswitch_prescription_versions (expires_at, prescription_id, version) WHERE state = 'active' AND expires_at IS NOT NULL AND (superseded_at IS NULL OR expires_at < superseded_at);
+CREATE INDEX IF NOT EXISTS killswitch_prescription_versions_expiry_due_idx ON killswitch_prescription_versions (expires_at, prescription_id, version) WHERE state = 'active' AND expires_at IS NOT NULL AND expiry_event_recorded_at IS NULL AND (superseded_at IS NULL OR expires_at < superseded_at);
 
 CREATE TABLE IF NOT EXISTS killswitch_prescription_version_resources (
   organization_id TEXT NOT NULL,

--- a/server/internal/audit/events.go
+++ b/server/internal/audit/events.go
@@ -30,6 +30,7 @@ const (
 	subjectTypeGcpKmsKey                   subjectType = "gcp_kms_key"
 	subjectTypeJsonWebKey                  subjectType = "json_web_key"
 	subjectTypeJsonWebKeySet               subjectType = "json_web_key_set"
+	subjectTypeKillswitchPrescription      subjectType = "killswitch_prescription"
 	subjectTypeLiteLLMInstance             subjectType = "litellm_instance"
 	subjectTypeMcpApprovalRequest          subjectType = "mcp_approval_request"
 	subjectTypeMcpCollection               subjectType = "mcp_collection"

--- a/server/internal/audit/killswitches.go
+++ b/server/internal/audit/killswitches.go
@@ -1,0 +1,148 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/audit/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	ActionKillswitchActivate   Action = "killswitch:activate"
+	ActionKillswitchChange     Action = "killswitch:change"
+	ActionKillswitchDeactivate Action = "killswitch:deactivate"
+	ActionKillswitchExpire     Action = "killswitch:expire"
+)
+
+// KillswitchVersionSnapshot is the bounded audit projection of one committed
+// prescription version. Internal notes are admin-only and deliberately absent:
+// audit reads and their webhook copies are organization-visible, not
+// admin-only.
+type KillswitchVersionSnapshot struct {
+	Version int64  `json:"version"`
+	State   string `json:"state"`
+}
+
+type killswitchLifecycleMetadata struct {
+	Operation   string    `json:"operation"`
+	OperationID uuid.UUID `json:"operation_id"`
+}
+
+type LogKillswitchLifecycleEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+
+	// Action must be one of the killswitch lifecycle actions; reactivation is
+	// recorded as an activation.
+	Action Action
+
+	PrescriptionURN urn.KillswitchPrescription
+	Version         int64
+	State           string
+
+	// Operation is the raw lifecycle operation and OperationReceipt the durable
+	// operation receipt this transition committed under.
+	Operation        string
+	OperationReceipt uuid.UUID
+}
+
+func (l *Logger) LogKillswitchLifecycle(ctx context.Context, dbtx repo.DBTX, event LogKillswitchLifecycleEvent) error {
+	action := event.Action
+	switch action {
+	case ActionKillswitchActivate, ActionKillswitchChange, ActionKillswitchDeactivate:
+	default:
+		return fmt.Errorf("invalid killswitch lifecycle audit action %q", action)
+	}
+
+	afterSnapshot, err := marshalAuditPayload(KillswitchVersionSnapshot{Version: event.Version, State: event.State})
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+	metadata, err := marshalAuditPayload(killswitchLifecycleMetadata{Operation: event.Operation, OperationID: event.OperationReceipt})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.ToPGTextEmpty(""),
+
+		Action: string(action),
+
+		SubjectID:          event.PrescriptionURN.ID.String(),
+		SubjectType:        string(subjectTypeKillswitchPrescription),
+		SubjectDisplayName: conv.ToPGTextEmpty(""),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  afterSnapshot,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.KillswitchV1})
+}
+
+type killswitchExpireMetadata struct {
+	Version   int64     `json:"version"`
+	ExpiredAt time.Time `json:"expired_at"`
+}
+
+// LogKillswitchExpireEvent records that one specific prescription version
+// reached its expiry deadline while still current. Effective state is decided
+// at query time from database clock and expires_at; this entry is history
+// only.
+type LogKillswitchExpireEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+
+	PrescriptionURN urn.KillswitchPrescription
+	Version         int64
+	ExpiredAt       time.Time
+}
+
+func (l *Logger) LogKillswitchExpire(ctx context.Context, dbtx repo.DBTX, event LogKillswitchExpireEvent) error {
+	action := ActionKillswitchExpire
+
+	metadata, err := marshalAuditPayload(killswitchExpireMetadata{Version: event.Version, ExpiredAt: event.ExpiredAt})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.ToPGTextEmpty(""),
+
+		Action: string(action),
+
+		SubjectID:          event.PrescriptionURN.ID.String(),
+		SubjectType:        string(subjectTypeKillswitchPrescription),
+		SubjectDisplayName: conv.ToPGTextEmpty(""),
+		SubjectSlug:        conv.ToPGTextEmpty(""),
+
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+		Metadata:       metadata,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.KillswitchV1})
+}

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -48,6 +48,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	mcpapprovaladvisories "github.com/speakeasy-api/gram/server/internal/mcpapproval/advisories"
 	mcpapprovalcatalog "github.com/speakeasy-api/gram/server/internal/mcpapproval/catalog"
 	"github.com/speakeasy-api/gram/server/internal/mcpapproval/domainmeta"
@@ -163,6 +164,7 @@ type Activities struct {
 	cancelAssistantsSubscription    *activities.CancelAssistantsSubscription
 	outboxRelay                     *outbox_relay.Relay
 	outboxGC                        *outbox_relay.GC
+	killswitchMaintenance           *killswitches.MaintenanceService
 	publishOutbox                   *publish_outbox.Relay
 	pluginPublisher                 *activities.PluginPublisher
 	sessionQuarantineReassert       *activities.SessionQuarantineReassert
@@ -425,6 +427,7 @@ func NewActivities(
 		cancelAssistantsSubscription:    activities.NewCancelAssistantsSubscription(logger, billingRepo),
 		outboxRelay:                     outbox_relay.New(logger, tracerProvider, db, svixClient),
 		outboxGC:                        outbox_relay.NewGC(logger, meterProvider, db),
+		killswitchMaintenance:           killswitches.NewMaintenanceService(db, auditLogger),
 		publishOutbox:                   publish_outbox.New(logger, tracerProvider, meterProvider, db, publishers.Outbox),
 		pluginPublisher:                 activities.NewPluginPublisher(logger, db, pluginPublisher),
 		sessionQuarantineReassert:       activities.NewSessionQuarantineReassert(logger, db, cacheAdapter),
@@ -938,6 +941,26 @@ func (a *Activities) GCPublishOutboxDeadLetters(ctx context.Context, cutoff time
 	n, err := a.publishOutbox.DeleteDeadLetters(ctx, cutoff, batchSize)
 	if err != nil {
 		return 0, fmt.Errorf("gc publish outbox dead letters: %w", err)
+	}
+	return n, nil
+}
+
+// RecordDueKillswitchExpiries and CleanupExpiredKillswitchOperations take only
+// a batch size and return only aggregate counts: killswitch identifiers,
+// notes, and tenant data stay inside the database-backed maintenance
+// transactions and never enter Temporal history.
+func (a *Activities) RecordDueKillswitchExpiries(ctx context.Context, batchSize int32) (killswitches.ExpiryBatchResult, error) {
+	result, err := a.killswitchMaintenance.RecordDueExpiries(ctx, batchSize)
+	if err != nil {
+		return result, fmt.Errorf("record due killswitch expiries: %w", err)
+	}
+	return result, nil
+}
+
+func (a *Activities) CleanupExpiredKillswitchOperations(ctx context.Context, batchSize int32) (int64, error) {
+	n, err := a.killswitchMaintenance.CleanupExpiredOperationsGlobal(ctx, batchSize)
+	if err != nil {
+		return n, fmt.Errorf("cleanup expired killswitch operations: %w", err)
 	}
 	return n, nil
 }

--- a/server/internal/background/killswitch_maintenance.go
+++ b/server/internal/background/killswitch_maintenance.go
@@ -1,0 +1,119 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+// The killswitch maintenance sweep records history only: query-time database
+// state is authoritative for enforcement, so a delayed or absent sweep never
+// extends or shortens any prescription. Workflow inputs and results carry no
+// organization, prescription, operation, or note data — only batch sizes in
+// and aggregate counts out.
+const (
+	killswitchMaintenanceScheduleID       = "v1:killswitch-maintenance-schedule"
+	killswitchMaintenanceWorkflowID       = killswitchMaintenanceScheduleID + "/scheduled"
+	killswitchMaintenanceInterval         = 5 * time.Minute
+	killswitchExpiryBatchSize       int32 = 100
+	killswitchCleanupBatchSize      int32 = 500
+)
+
+func KillswitchMaintenanceWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    time.Minute,
+		},
+	})
+
+	var a *Activities
+
+	// Expiry recording and receipt cleanup run as separate activities with
+	// separate database transactions, so a cleanup failure cannot roll back or
+	// block recorded expiry history.
+	for {
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+			return workflow.NewContinueAsNewError(ctx, KillswitchMaintenanceWorkflow)
+		}
+
+		var batch killswitches.ExpiryBatchResult
+		if err := workflow.ExecuteActivity(ctx, a.RecordDueKillswitchExpiries, killswitchExpiryBatchSize).Get(ctx, &batch); err != nil {
+			return fmt.Errorf("record due killswitch expiries: %w", err)
+		}
+		workflow.GetLogger(ctx).Info("killswitch expiry batch completed", "candidates", batch.Candidates, "rows_recorded", batch.Recorded)
+		// Drain on the candidate count: a full candidate batch can still record
+		// fewer rows when candidates raced with a concurrent sweep, and more due
+		// work may remain behind it.
+		if batch.Candidates < int64(killswitchExpiryBatchSize) {
+			break
+		}
+	}
+
+	for {
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+			return workflow.NewContinueAsNewError(ctx, KillswitchMaintenanceWorkflow)
+		}
+
+		var deleted int64
+		if err := workflow.ExecuteActivity(ctx, a.CleanupExpiredKillswitchOperations, killswitchCleanupBatchSize).Get(ctx, &deleted); err != nil {
+			return fmt.Errorf("cleanup expired killswitch operations: %w", err)
+		}
+		workflow.GetLogger(ctx).Info("killswitch operation cleanup batch completed", "rows_deleted", deleted)
+		if deleted < int64(killswitchCleanupBatchSize) {
+			return nil
+		}
+	}
+}
+
+func AddKillswitchMaintenanceSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	sc := temporalEnv.Client().ScheduleClient()
+
+	spec := client.ScheduleSpec{
+		Intervals: []client.ScheduleIntervalSpec{{Every: killswitchMaintenanceInterval}},
+	}
+	action := &client.ScheduleWorkflowAction{
+		ID:                 killswitchMaintenanceWorkflowID,
+		Workflow:           KillswitchMaintenanceWorkflow,
+		TaskQueue:          string(temporalEnv.Queue()),
+		WorkflowRunTimeout: 5 * time.Minute,
+	}
+
+	_, err := sc.Create(ctx, client.ScheduleOptions{
+		ID:      killswitchMaintenanceScheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec:    spec,
+		Action:  action,
+	})
+	switch {
+	case errors.Is(err, temporal.ErrScheduleAlreadyRunning):
+		if err := sc.GetHandle(ctx, killswitchMaintenanceScheduleID).Update(ctx, client.ScheduleUpdateOptions{
+			DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+				input.Description.Schedule.Spec = &spec
+				input.Description.Schedule.Action = action
+				return &client.ScheduleUpdate{
+					Schedule:              &input.Description.Schedule,
+					TypedSearchAttributes: nil,
+				}, nil
+			},
+		}); err != nil {
+			return fmt.Errorf("update existing killswitch maintenance schedule: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("create killswitch maintenance schedule: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/background/killswitch_maintenance_test.go
+++ b/server/internal/background/killswitch_maintenance_test.go
@@ -1,0 +1,116 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+func registerKillswitchMaintenanceActivities(env *testsuite.TestWorkflowEnvironment, expiry func(int32) (killswitches.ExpiryBatchResult, error), cleanup func(int32) (int64, error)) {
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batchSize int32) (killswitches.ExpiryBatchResult, error) {
+			return expiry(batchSize)
+		},
+		activity.RegisterOptions{Name: "RecordDueKillswitchExpiries"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, batchSize int32) (int64, error) { return cleanup(batchSize) },
+		activity.RegisterOptions{Name: "CleanupExpiredKillswitchOperations"},
+	)
+}
+
+func TestKillswitchMaintenanceWorkflow_PartialBatches(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	expiryCalls, cleanupCalls := 0, 0
+	var gotExpiryBatch, gotCleanupBatch int32
+	registerKillswitchMaintenanceActivities(env,
+		func(batchSize int32) (killswitches.ExpiryBatchResult, error) {
+			expiryCalls++
+			gotExpiryBatch = batchSize
+			partial := int64(killswitchExpiryBatchSize) - 1
+			return killswitches.ExpiryBatchResult{Candidates: partial, Recorded: partial}, nil
+		},
+		func(batchSize int32) (int64, error) {
+			cleanupCalls++
+			gotCleanupBatch = batchSize
+			return 0, nil
+		},
+	)
+
+	env.ExecuteWorkflow(KillswitchMaintenanceWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, expiryCalls)
+	require.Equal(t, 1, cleanupCalls)
+	require.Equal(t, killswitchExpiryBatchSize, gotExpiryBatch)
+	require.Equal(t, killswitchCleanupBatchSize, gotCleanupBatch)
+}
+
+func TestKillswitchMaintenanceWorkflow_FullBatchesContinue(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	expiryCalls, cleanupCalls := 0, 0
+	registerKillswitchMaintenanceActivities(env,
+		func(int32) (killswitches.ExpiryBatchResult, error) {
+			expiryCalls++
+			if expiryCalls == 1 {
+				// A full candidate batch that recorded fewer rows (raced
+				// candidates) must still continue draining.
+				return killswitches.ExpiryBatchResult{Candidates: int64(killswitchExpiryBatchSize), Recorded: int64(killswitchExpiryBatchSize) - 3}, nil
+			}
+			return killswitches.ExpiryBatchResult{Candidates: 0, Recorded: 0}, nil
+		},
+		func(int32) (int64, error) {
+			cleanupCalls++
+			if cleanupCalls == 1 {
+				return int64(killswitchCleanupBatchSize), nil
+			}
+			return 0, nil
+		},
+	)
+
+	env.ExecuteWorkflow(KillswitchMaintenanceWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2, expiryCalls, "a full candidate batch continues draining")
+	require.Equal(t, 2, cleanupCalls, "a full cleanup batch continues draining")
+}
+
+func TestKillswitchMaintenanceWorkflow_CleanupFailureDoesNotAffectExpiry(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	expiryCalls := 0
+	registerKillswitchMaintenanceActivities(env,
+		func(int32) (killswitches.ExpiryBatchResult, error) {
+			expiryCalls++
+			return killswitches.ExpiryBatchResult{Candidates: 0, Recorded: 0}, nil
+		},
+		func(int32) (int64, error) {
+			return 0, errors.New("cleanup unavailable")
+		},
+	)
+
+	env.ExecuteWorkflow(KillswitchMaintenanceWorkflow)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError(), "cleanup failure surfaces for the schedule to retry")
+	require.Equal(t, 1, expiryCalls, "expiry recording ran in its own activity and transaction before cleanup failed")
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -486,6 +486,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.FilterNoopOutboxEvents)
 	temporalWorker.RegisterActivity(activities.RelayOutboxEvents)
 	temporalWorker.RegisterActivity(activities.GCOutboxProcessedRows)
+	// Killswitch maintenance activities
+	temporalWorker.RegisterActivity(activities.RecordDueKillswitchExpiries)
+	temporalWorker.RegisterActivity(activities.CleanupExpiredKillswitchOperations)
 	// Publish outbox relay activities
 	temporalWorker.RegisterActivity(activities.DrainPublishOutbox)
 	temporalWorker.RegisterActivity(activities.GCPublishOutboxDeadLetters)
@@ -609,6 +612,8 @@ func NewTemporalWorker(
 	// Outbox -> Relay workflow and GC
 	temporalWorker.RegisterWorkflow(ProcessOutboxWorkflow)
 	temporalWorker.RegisterWorkflow(OutboxGCWorkflow)
+	// Killswitch expiry history and receipt retention
+	temporalWorker.RegisterWorkflow(KillswitchMaintenanceWorkflow)
 	// Publish outbox -> Pub/Sub workflow and dead letter GC
 	temporalWorker.RegisterWorkflow(PublishOutboxWorkflow)
 	temporalWorker.RegisterWorkflow(PublishOutboxGCWorkflow)
@@ -727,6 +732,10 @@ func (w *Workers) registerSchedules(ctx context.Context) {
 
 	if err := AddOutboxGCSchedule(ctx, env); err != nil {
 		logger.ErrorContext(ctx, "failed to add outbox gc schedule", attr.SlogError(err))
+	}
+
+	if err := AddKillswitchMaintenanceSchedule(ctx, env); err != nil {
+		logger.ErrorContext(ctx, "failed to add killswitch maintenance schedule", attr.SlogError(err))
 	}
 
 	if err := AddPublishOutboxSchedule(ctx, env); err != nil {

--- a/server/internal/background/worker_test.go
+++ b/server/internal/background/worker_test.go
@@ -37,6 +37,7 @@ func TestWorkers_Run_RegistersSchedules(t *testing.T) {
 
 		assert.Subset(c, ids, []string{
 			outboxGCScheduleID,
+			killswitchMaintenanceScheduleID,
 			assistantReaperScheduleID,
 			chatAnalysisSweepScheduleID,
 			aiUsagePollerCoordinatorScheduleID,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1124,19 +1124,18 @@ type KillswitchPrescription struct {
 }
 
 type KillswitchPrescriptionVersion struct {
-	OrganizationID        string
-	PrescriptionID        uuid.UUID
-	Version               int64
-	State                 string
-	ResourceScope         string
-	StartsAt              pgtype.Timestamptz
-	ExpiresAt             pgtype.Timestamptz
-	ActivatedAt           pgtype.Timestamptz
-	SupersededAt          pgtype.Timestamptz
-	ExpiryEventRecordedAt pgtype.Timestamptz
-	InternalNote          string
-	ExternalNote          string
-	CreatedAt             pgtype.Timestamptz
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+	State          string
+	ResourceScope  string
+	StartsAt       pgtype.Timestamptz
+	ExpiresAt      pgtype.Timestamptz
+	ActivatedAt    pgtype.Timestamptz
+	SupersededAt   pgtype.Timestamptz
+	InternalNote   string
+	ExternalNote   string
+	CreatedAt      pgtype.Timestamptz
 }
 
 type KillswitchPrescriptionVersionResource struct {

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1124,18 +1124,19 @@ type KillswitchPrescription struct {
 }
 
 type KillswitchPrescriptionVersion struct {
-	OrganizationID string
-	PrescriptionID uuid.UUID
-	Version        int64
-	State          string
-	ResourceScope  string
-	StartsAt       pgtype.Timestamptz
-	ExpiresAt      pgtype.Timestamptz
-	ActivatedAt    pgtype.Timestamptz
-	SupersededAt   pgtype.Timestamptz
-	InternalNote   string
-	ExternalNote   string
-	CreatedAt      pgtype.Timestamptz
+	OrganizationID        string
+	PrescriptionID        uuid.UUID
+	Version               int64
+	State                 string
+	ResourceScope         string
+	StartsAt              pgtype.Timestamptz
+	ExpiresAt             pgtype.Timestamptz
+	ActivatedAt           pgtype.Timestamptz
+	SupersededAt          pgtype.Timestamptz
+	ExpiryEventRecordedAt pgtype.Timestamptz
+	InternalNote          string
+	ExternalNote          string
+	CreatedAt             pgtype.Timestamptz
 }
 
 type KillswitchPrescriptionVersionResource struct {

--- a/server/internal/killswitches/audit.go
+++ b/server/internal/killswitches/audit.go
@@ -1,0 +1,53 @@
+package killswitches
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// NewAuditBeforeCommitHook records the typed lifecycle audit entry and its
+// cataloged outbox event inside the lifecycle transaction, so a state change,
+// its completed operation receipt, its audit row, and its outbox row commit or
+// roll back together.
+func NewAuditBeforeCommitHook(auditLogger *audit.Logger) BeforeCommitHook {
+	return func(ctx context.Context, queries LifecycleTransactionQueries, event MutationEvent) error {
+		action, err := lifecycleAuditAction(event.Operation)
+		if err != nil {
+			return err
+		}
+		prescriptionID, err := parsePrescriptionID(event.Result.PrescriptionID)
+		if err != nil {
+			return err
+		}
+		if err := auditLogger.LogKillswitchLifecycle(ctx, queries, audit.LogKillswitchLifecycleEvent{
+			OrganizationID:   string(event.OrganizationID),
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, event.ActorUserID),
+			ActorDisplayName: &event.ActorDisplayName,
+			Action:           action,
+			PrescriptionURN:  urn.NewKillswitchPrescription(prescriptionID),
+			Version:          event.Result.Version,
+			State:            string(event.Result.State),
+			Operation:        string(event.Operation),
+			OperationReceipt: event.OperationID,
+		}); err != nil {
+			return fmt.Errorf("audit killswitch lifecycle transition: %w", err)
+		}
+		return nil
+	}
+}
+
+func lifecycleAuditAction(operation MutationOperation) (audit.Action, error) {
+	switch operation {
+	case MutationOperationActivate, MutationOperationReactivate:
+		return audit.ActionKillswitchActivate, nil
+	case MutationOperationChange:
+		return audit.ActionKillswitchChange, nil
+	case MutationOperationDeactivate:
+		return audit.ActionKillswitchDeactivate, nil
+	default:
+		return "", fmt.Errorf("no audit action for killswitch operation %q", operation)
+	}
+}

--- a/server/internal/killswitches/audit_test.go
+++ b/server/internal/killswitches/audit_test.go
@@ -1,0 +1,203 @@
+//nolint:glint // Integration tests inspect audit and outbox rows directly.
+package killswitches
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+)
+
+const sentinelInternalNote = "SENTINEL-INTERNAL-NOTE-d0f1"
+
+type auditRow struct {
+	Action           string
+	ActorID          string
+	ActorDisplayName string
+	SubjectID        string
+	SubjectType      string
+	AfterSnapshot    []byte
+	Metadata         []byte
+}
+
+func listAuditRows(t *testing.T, conn *pgxpool.Pool, orgID string) []auditRow {
+	t.Helper()
+	rows, err := conn.Query(t.Context(), `
+		SELECT action, actor_id, coalesce(actor_display_name, ''), subject_id, subject_type, coalesce(after_snapshot, 'null'::jsonb), coalesce(metadata, 'null'::jsonb)
+		FROM audit_logs
+		WHERE organization_id = $1
+		ORDER BY seq
+	`, orgID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var result []auditRow
+	for rows.Next() {
+		var row auditRow
+		require.NoError(t, rows.Scan(&row.Action, &row.ActorID, &row.ActorDisplayName, &row.SubjectID, &row.SubjectType, &row.AfterSnapshot, &row.Metadata))
+		result = append(result, row)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func listOutboxMessages(t *testing.T, conn *pgxpool.Pool, orgID string) [][]byte {
+	t.Helper()
+	rows, err := conn.Query(t.Context(), `SELECT message FROM publish_outbox WHERE organization_id = $1 ORDER BY id`, orgID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var messages [][]byte
+	for rows.Next() {
+		var message []byte
+		require.NoError(t, rows.Scan(&message))
+		messages = append(messages, message)
+	}
+	require.NoError(t, rows.Err())
+	return messages
+}
+
+func requireNoSentinelLeak(t *testing.T, conn *pgxpool.Pool, orgID string) {
+	t.Helper()
+	var leaked int
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT count(*) FROM audit_logs WHERE organization_id = $1 AND audit_logs::text LIKE '%' || $2 || '%'
+	`, orgID, sentinelInternalNote).Scan(&leaked))
+	require.Zero(t, leaked, "internal note must not appear in any audit column")
+	for _, message := range listOutboxMessages(t, conn, orgID) {
+		require.False(t, bytes.Contains(message, []byte(sentinelInternalNote)), "internal note must not appear in outbox payloads")
+	}
+}
+
+func TestLifecycleAuditAtomicityAndReplay(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_lifecycle_audit")
+	service := newLifecycleServiceForTest(t, conn, nil, nil, NewAuditBeforeCommitHook(audit.NewLogger()))
+
+	activate := testActivateRequest(orgID, uuid.New())
+	activate.Desired.InternalNote = sentinelInternalNote
+	activated, err := service.ActivatePrescription(t.Context(), activate)
+	require.NoError(t, err)
+
+	change := testChangeRequest(orgID, activated.PrescriptionID, 1, uuid.New(), []string{"tool:a", "tool:b"})
+	change.Desired.InternalNote = sentinelInternalNote
+	changed, err := service.ChangePrescription(t.Context(), change)
+	require.NoError(t, err)
+
+	deactivate := DeactivatePrescriptionRequest{MutationContext: testMutationContext(orgID, uuid.New()), PrescriptionID: activated.PrescriptionID, ExpectedVersion: changed.Version}
+	_, err = service.DeactivatePrescription(t.Context(), deactivate)
+	require.NoError(t, err)
+
+	reactivate := ReactivatePrescriptionRequest{MutationContext: testMutationContext(orgID, uuid.New()), PrescriptionID: activated.PrescriptionID, ExpectedVersion: 3, Desired: testDesired([]string{"tool:a"})}
+	reactivate.Desired.InternalNote = sentinelInternalNote
+	reactivated, err := service.ReactivatePrescription(t.Context(), reactivate)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), reactivated.Version)
+
+	auditRows := listAuditRows(t, conn, orgID)
+	require.Len(t, auditRows, 4, "each successful transition writes exactly one audit row")
+	actions := make([]string, len(auditRows))
+	for i, row := range auditRows {
+		actions[i] = row.Action
+		require.Equal(t, string(activated.PrescriptionID), row.SubjectID)
+		require.Equal(t, "killswitch_prescription", row.SubjectType)
+		require.Equal(t, "user:test", row.ActorID)
+		require.Equal(t, "Test User", row.ActorDisplayName)
+	}
+	require.Equal(t, []string{"killswitch:activate", "killswitch:change", "killswitch:deactivate", "killswitch:activate"}, actions, "reactivation is recorded as an activation")
+
+	var snapshot audit.KillswitchVersionSnapshot
+	require.NoError(t, json.Unmarshal(auditRows[3].AfterSnapshot, &snapshot))
+	require.Equal(t, audit.KillswitchVersionSnapshot{Version: 4, State: "active"}, snapshot)
+	var metadata struct {
+		Operation   string    `json:"operation"`
+		OperationID uuid.UUID `json:"operation_id"`
+	}
+	require.NoError(t, json.Unmarshal(auditRows[3].Metadata, &metadata))
+	require.Equal(t, "reactivate", metadata.Operation)
+	require.Equal(t, reactivate.OperationID, metadata.OperationID)
+
+	messages := listOutboxMessages(t, conn, orgID)
+	require.Len(t, messages, 4, "each successful transition enqueues exactly one outbox row")
+	for _, message := range messages {
+		require.True(t, bytes.Contains(message, []byte("audit_log.killswitch_event_v1")), "outbox rows carry the cataloged killswitch event type")
+		require.Contains(t, string(message), `"actor_display_name":"Test User"`)
+	}
+	requireNoSentinelLeak(t, conn, orgID)
+
+	replayed, err := service.ChangePrescription(t.Context(), change)
+	require.NoError(t, err)
+	require.True(t, replayed.Replayed)
+
+	conflicting := testChangeRequest(orgID, activated.PrescriptionID, 1, change.OperationID, []string{"tool:c"})
+	_, err = service.ChangePrescription(t.Context(), conflicting)
+	require.ErrorIs(t, err, ErrOperationConflict)
+
+	require.Len(t, listAuditRows(t, conn, orgID), 4, "replay and conflicting reuse must not duplicate audit history")
+	require.Len(t, listOutboxMessages(t, conn, orgID), 4, "replay and conflicting reuse must not duplicate outbox rows")
+}
+
+func TestLifecycleAuditRollback(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_lifecycle_audit_rollback")
+	auditHook := NewAuditBeforeCommitHook(audit.NewLogger())
+	failingService := newLifecycleServiceForTest(t, conn, nil, nil, func(ctx context.Context, queries LifecycleTransactionQueries, event MutationEvent) error {
+		if err := auditHook(ctx, queries, event); err != nil {
+			return err
+		}
+		return errors.New("forced post-audit failure")
+	})
+
+	activate := testActivateRequest(orgID, uuid.New())
+	_, err := failingService.ActivatePrescription(t.Context(), activate)
+	require.ErrorContains(t, err, "forced post-audit failure")
+
+	for _, table := range []string{"killswitch_prescriptions", "killswitch_prescription_versions", "killswitch_operations", "audit_logs", "publish_outbox"} {
+		var count int
+		require.NoError(t, conn.QueryRow(t.Context(), `SELECT count(*) FROM `+table+` WHERE organization_id = $1`, orgID).Scan(&count))
+		require.Zero(t, count, "a failed lifecycle transaction must roll back %s together with the mutation", table)
+	}
+
+	service := newLifecycleServiceForTest(t, conn, nil, nil, auditHook)
+	activated, err := service.ActivatePrescription(t.Context(), activate)
+	require.NoError(t, err, "a rolled-back attempt must not consume its operation ID")
+	require.False(t, activated.Replayed)
+	require.Len(t, listAuditRows(t, conn, orgID), 1)
+	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
+}
+
+func TestLifecycleAuditActionMapping(t *testing.T) {
+	t.Parallel()
+
+	for operation, want := range map[MutationOperation]audit.Action{
+		MutationOperationActivate:   audit.ActionKillswitchActivate,
+		MutationOperationReactivate: audit.ActionKillswitchActivate,
+		MutationOperationChange:     audit.ActionKillswitchChange,
+		MutationOperationDeactivate: audit.ActionKillswitchDeactivate,
+	} {
+		got, err := lifecycleAuditAction(operation)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+	_, err := lifecycleAuditAction(MutationOperation("unknown"))
+	require.Error(t, err)
+}
+
+// expiredAtOf reads the recorded expiry deadline back out of an audit metadata payload.
+func expiredAtOf(t *testing.T, metadata []byte) time.Time {
+	t.Helper()
+	var decoded struct {
+		Version   int64     `json:"version"`
+		ExpiredAt time.Time `json:"expired_at"`
+	}
+	require.NoError(t, json.Unmarshal(metadata, &decoded))
+	return decoded.ExpiredAt
+}

--- a/server/internal/killswitches/lifecycle.go
+++ b/server/internal/killswitches/lifecycle.go
@@ -327,7 +327,7 @@ func (s *LifecycleService) executeMutation(ctx context.Context, mutation Mutatio
 		return MutationResult{}, fmt.Errorf("encode killswitch operation response: %w", err)
 	}
 	if s.beforeCommit != nil {
-		event := MutationEvent{OrganizationID: mutation.OrganizationID, ActorUserID: mutation.ActorUserID, OperationID: mutation.OperationID, Operation: operation, Result: result}
+		event := MutationEvent{OrganizationID: mutation.OrganizationID, ActorUserID: mutation.ActorUserID, ActorDisplayName: mutation.ActorDisplayName, OperationID: mutation.OperationID, Operation: operation, Result: result}
 		if err := s.beforeCommit(ctx, restricted, event); err != nil {
 			return MutationResult{}, fmt.Errorf("before killswitch lifecycle commit: %w", err)
 		}
@@ -595,6 +595,9 @@ func validateMutationContext(mutation MutationContext) error {
 		return fmt.Errorf("%w: %w", ErrInvalidArgument, err)
 	}
 	if err := validateIdentifier("actor user ID", mutation.ActorUserID); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidArgument, err)
+	}
+	if err := validateIdentifier("actor display name", mutation.ActorDisplayName); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidArgument, err)
 	}
 	if mutation.OperationID == uuid.Nil {

--- a/server/internal/killswitches/lifecycle_test.go
+++ b/server/internal/killswitches/lifecycle_test.go
@@ -741,7 +741,7 @@ func newLifecycleServiceForTest(t *testing.T, conn *pgxpool.Pool, principalValid
 }
 
 func testMutationContext(orgID string, operationID uuid.UUID) MutationContext {
-	return MutationContext{OrganizationID: OrganizationID(orgID), ActorUserID: "user:test", OperationID: operationID}
+	return MutationContext{OrganizationID: OrganizationID(orgID), ActorUserID: "user:test", ActorDisplayName: "Test User", OperationID: operationID}
 }
 
 func testActivateRequest(orgID string, operationID uuid.UUID) ActivatePrescriptionRequest {

--- a/server/internal/killswitches/maintenance.go
+++ b/server/internal/killswitches/maintenance.go
@@ -22,9 +22,8 @@ const (
 
 // MaintenanceService owns the privileged cross-organization killswitch
 // maintenance transactions: version-specific expiry history and operation
-// receipt retention. It records history only; query-time database state stays
-// authoritative for enforcement, and no method here mutates prescription
-// headers or versions.
+// receipt retention. Query-time database state stays authoritative for
+// enforcement; the expiry transaction only marks its audit history as emitted.
 type MaintenanceService struct {
 	db          *pgxpool.Pool
 	auditLogger *audit.Logger
@@ -102,24 +101,22 @@ func (s *MaintenanceService) recordExpiry(ctx context.Context, candidate repo.Li
 		return 0, nil
 	}
 
-	rows, err := queries.RecordKillswitchExpiryEvent(ctx, repo.RecordKillswitchExpiryEventParams(candidate))
+	eventInserted, err := queries.CompleteKillswitchExpiryEvent(ctx, repo.CompleteKillswitchExpiryEventParams(candidate))
 	if err != nil {
-		return 0, fmt.Errorf("record killswitch expiry event: %w", err)
+		return 0, fmt.Errorf("complete killswitch expiry event: %w", err)
 	}
-	if rows != 1 {
-		return 0, nil
-	}
-
-	actorDisplayName := maintenanceActorDisplayName
-	if err := s.auditLogger.LogKillswitchExpire(ctx, tx, audit.LogKillswitchExpireEvent{
-		OrganizationID:   candidate.OrganizationID,
-		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, maintenanceActorUserID),
-		ActorDisplayName: &actorDisplayName,
-		PrescriptionURN:  urn.NewKillswitchPrescription(candidate.PrescriptionID),
-		Version:          candidate.Version,
-		ExpiredAt:        locked.ExpiresAt.Time.UTC(),
-	}); err != nil {
-		return 0, fmt.Errorf("audit killswitch expiry: %w", err)
+	if eventInserted {
+		actorDisplayName := maintenanceActorDisplayName
+		if err := s.auditLogger.LogKillswitchExpire(ctx, tx, audit.LogKillswitchExpireEvent{
+			OrganizationID:   candidate.OrganizationID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, maintenanceActorUserID),
+			ActorDisplayName: &actorDisplayName,
+			PrescriptionURN:  urn.NewKillswitchPrescription(candidate.PrescriptionID),
+			Version:          candidate.Version,
+			ExpiredAt:        locked.ExpiresAt.Time.UTC(),
+		}); err != nil {
+			return 0, fmt.Errorf("audit killswitch expiry: %w", err)
+		}
 	}
 
 	if s.beforeExpiryCommit != nil {
@@ -130,11 +127,14 @@ func (s *MaintenanceService) recordExpiry(ctx context.Context, candidate repo.Li
 	if err := tx.Commit(ctx); err != nil {
 		return 0, fmt.Errorf("commit killswitch expiry transaction: %w", err)
 	}
-	return 1, nil
+	if eventInserted {
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func expiryEligible(locked repo.LockKillswitchVersionForExpiryRow) bool {
-	if PrescriptionState(locked.State) != PrescriptionStateActive {
+	if PrescriptionState(locked.State) != PrescriptionStateActive || locked.ExpiryEventRecordedAt.Valid {
 		return false
 	}
 	if !locked.ExpiresAt.Valid || !locked.DatabaseNow.Valid || locked.ExpiresAt.Time.After(locked.DatabaseNow.Time) {

--- a/server/internal/killswitches/maintenance.go
+++ b/server/internal/killswitches/maintenance.go
@@ -1,0 +1,164 @@
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// maintenanceActorUserID is the synthetic actor recorded on background-emitted
+// audit entries, matching the fleet's existing system-job convention.
+const (
+	maintenanceActorUserID      = "system"
+	maintenanceActorDisplayName = "System"
+)
+
+// MaintenanceService owns the privileged cross-organization killswitch
+// maintenance transactions: version-specific expiry history and operation
+// receipt retention. It records history only; query-time database state stays
+// authoritative for enforcement, and no method here mutates prescription
+// headers or versions.
+type MaintenanceService struct {
+	db          *pgxpool.Pool
+	auditLogger *audit.Logger
+
+	// beforeExpiryCommit runs after the marker and audit writes but before the
+	// expiry transaction commits. Test seam for retry-recovery coverage.
+	beforeExpiryCommit func(context.Context) error
+}
+
+func NewMaintenanceService(db *pgxpool.Pool, auditLogger *audit.Logger) *MaintenanceService {
+	return &MaintenanceService{db: db, auditLogger: auditLogger, beforeExpiryCommit: nil}
+}
+
+// ExpiryBatchResult summarizes one bounded expiry batch as aggregate counts
+// only: how many due candidates discovery returned and how many of them were
+// recorded. Candidates that raced with a concurrent sweep or became ineligible
+// under the row lock are counted but not recorded, so drain decisions must
+// follow Candidates, not Recorded.
+type ExpiryBatchResult struct {
+	Candidates int64 `json:"candidates"`
+	Recorded   int64 `json:"recorded"`
+}
+
+// RecordDueExpiries records expiry history for one bounded batch of versions
+// that reached their deadline while still current: active state, a due
+// expires_at, and no supersession before the deadline. Each candidate commits
+// its idempotency marker, typed audit entry, and outbox row in one
+// transaction; only the transaction whose marker insert succeeds audits.
+func (s *MaintenanceService) RecordDueExpiries(ctx context.Context, batchSize int32) (ExpiryBatchResult, error) {
+	var result ExpiryBatchResult
+	if batchSize < 1 || batchSize > maxCleanupBatchSize {
+		return result, fmt.Errorf("%w: expiry batch size must be between 1 and %d", ErrInvalidArgument, maxCleanupBatchSize)
+	}
+
+	candidates, err := repo.New(s.db).ListDueKillswitchExpiries(ctx, batchSize)
+	if err != nil {
+		return result, fmt.Errorf("list due killswitch expiries: %w", err)
+	}
+	result.Candidates = int64(len(candidates))
+
+	for _, candidate := range candidates {
+		count, err := s.recordExpiry(ctx, candidate)
+		if err != nil {
+			return result, err
+		}
+		result.Recorded += count
+	}
+	return result, nil
+}
+
+func (s *MaintenanceService) recordExpiry(ctx context.Context, candidate repo.ListDueKillswitchExpiriesRow) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.ReadCommitted, AccessMode: "", DeferrableMode: "", BeginQuery: "", CommitQuery: ""})
+	if err != nil {
+		return 0, fmt.Errorf("begin killswitch expiry transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	queries := repo.New(tx)
+
+	_, err = queries.LockKillswitchPrescriptionCurrent(ctx, repo.LockKillswitchPrescriptionCurrentParams{OrganizationID: candidate.OrganizationID, PrescriptionID: candidate.PrescriptionID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("lock killswitch prescription for expiry: %w", err)
+	}
+
+	locked, err := queries.LockKillswitchVersionForExpiry(ctx, repo.LockKillswitchVersionForExpiryParams(candidate))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("lock killswitch version for expiry: %w", err)
+	}
+	if !expiryEligible(locked) {
+		return 0, nil
+	}
+
+	rows, err := queries.RecordKillswitchExpiryEvent(ctx, repo.RecordKillswitchExpiryEventParams(candidate))
+	if err != nil {
+		return 0, fmt.Errorf("record killswitch expiry event: %w", err)
+	}
+	if rows != 1 {
+		return 0, nil
+	}
+
+	actorDisplayName := maintenanceActorDisplayName
+	if err := s.auditLogger.LogKillswitchExpire(ctx, tx, audit.LogKillswitchExpireEvent{
+		OrganizationID:   candidate.OrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, maintenanceActorUserID),
+		ActorDisplayName: &actorDisplayName,
+		PrescriptionURN:  urn.NewKillswitchPrescription(candidate.PrescriptionID),
+		Version:          candidate.Version,
+		ExpiredAt:        locked.ExpiresAt.Time.UTC(),
+	}); err != nil {
+		return 0, fmt.Errorf("audit killswitch expiry: %w", err)
+	}
+
+	if s.beforeExpiryCommit != nil {
+		if err := s.beforeExpiryCommit(ctx); err != nil {
+			return 0, fmt.Errorf("before killswitch expiry commit: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit killswitch expiry transaction: %w", err)
+	}
+	return 1, nil
+}
+
+func expiryEligible(locked repo.LockKillswitchVersionForExpiryRow) bool {
+	if PrescriptionState(locked.State) != PrescriptionStateActive {
+		return false
+	}
+	if !locked.ExpiresAt.Valid || !locked.DatabaseNow.Valid || locked.ExpiresAt.Time.After(locked.DatabaseNow.Time) {
+		return false
+	}
+	// A version replaced at or before its deadline never expired; only expiry
+	// strictly before supersession is durable history.
+	if locked.SupersededAt.Valid && !locked.ExpiresAt.Time.Before(locked.SupersededAt.Time) {
+		return false
+	}
+	return true
+}
+
+// CleanupExpiredOperationsGlobal deletes one bounded, ordered batch of expired
+// operation receipts across all organizations. Cleanup is physical retention
+// only: replay eligibility ends at each receipt's expires_at regardless of
+// when cleanup runs. The returned value is a row count only.
+func (s *MaintenanceService) CleanupExpiredOperationsGlobal(ctx context.Context, batchSize int32) (int64, error) {
+	if batchSize < 1 || batchSize > maxCleanupBatchSize {
+		return 0, fmt.Errorf("%w: cleanup batch size must be between 1 and %d", ErrInvalidArgument, maxCleanupBatchSize)
+	}
+	rows, err := repo.New(s.db).DeleteExpiredKillswitchOperationsGlobal(ctx, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("delete expired killswitch operations: %w", err)
+	}
+	return rows, nil
+}

--- a/server/internal/killswitches/maintenance.go
+++ b/server/internal/killswitches/maintenance.go
@@ -22,8 +22,9 @@ const (
 
 // MaintenanceService owns the privileged cross-organization killswitch
 // maintenance transactions: version-specific expiry history and operation
-// receipt retention. Query-time database state stays authoritative for
-// enforcement; the expiry transaction only marks its audit history as emitted.
+// receipt retention. It records history only; query-time database state stays
+// authoritative for enforcement, and no method here mutates prescription
+// headers or versions.
 type MaintenanceService struct {
 	db          *pgxpool.Pool
 	auditLogger *audit.Logger
@@ -101,22 +102,24 @@ func (s *MaintenanceService) recordExpiry(ctx context.Context, candidate repo.Li
 		return 0, nil
 	}
 
-	eventInserted, err := queries.CompleteKillswitchExpiryEvent(ctx, repo.CompleteKillswitchExpiryEventParams(candidate))
+	rows, err := queries.RecordKillswitchExpiryEvent(ctx, repo.RecordKillswitchExpiryEventParams(candidate))
 	if err != nil {
-		return 0, fmt.Errorf("complete killswitch expiry event: %w", err)
+		return 0, fmt.Errorf("record killswitch expiry event: %w", err)
 	}
-	if eventInserted {
-		actorDisplayName := maintenanceActorDisplayName
-		if err := s.auditLogger.LogKillswitchExpire(ctx, tx, audit.LogKillswitchExpireEvent{
-			OrganizationID:   candidate.OrganizationID,
-			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, maintenanceActorUserID),
-			ActorDisplayName: &actorDisplayName,
-			PrescriptionURN:  urn.NewKillswitchPrescription(candidate.PrescriptionID),
-			Version:          candidate.Version,
-			ExpiredAt:        locked.ExpiresAt.Time.UTC(),
-		}); err != nil {
-			return 0, fmt.Errorf("audit killswitch expiry: %w", err)
-		}
+	if rows != 1 {
+		return 0, nil
+	}
+
+	actorDisplayName := maintenanceActorDisplayName
+	if err := s.auditLogger.LogKillswitchExpire(ctx, tx, audit.LogKillswitchExpireEvent{
+		OrganizationID:   candidate.OrganizationID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, maintenanceActorUserID),
+		ActorDisplayName: &actorDisplayName,
+		PrescriptionURN:  urn.NewKillswitchPrescription(candidate.PrescriptionID),
+		Version:          candidate.Version,
+		ExpiredAt:        locked.ExpiresAt.Time.UTC(),
+	}); err != nil {
+		return 0, fmt.Errorf("audit killswitch expiry: %w", err)
 	}
 
 	if s.beforeExpiryCommit != nil {
@@ -127,14 +130,11 @@ func (s *MaintenanceService) recordExpiry(ctx context.Context, candidate repo.Li
 	if err := tx.Commit(ctx); err != nil {
 		return 0, fmt.Errorf("commit killswitch expiry transaction: %w", err)
 	}
-	if eventInserted {
-		return 1, nil
-	}
-	return 0, nil
+	return 1, nil
 }
 
 func expiryEligible(locked repo.LockKillswitchVersionForExpiryRow) bool {
-	if PrescriptionState(locked.State) != PrescriptionStateActive || locked.ExpiryEventRecordedAt.Valid {
+	if PrescriptionState(locked.State) != PrescriptionStateActive {
 		return false
 	}
 	if !locked.ExpiresAt.Valid || !locked.DatabaseNow.Valid || locked.ExpiresAt.Time.After(locked.DatabaseNow.Time) {

--- a/server/internal/killswitches/maintenance_test.go
+++ b/server/internal/killswitches/maintenance_test.go
@@ -1,0 +1,340 @@
+//nolint:glint // Integration tests fabricate and inspect private rows directly.
+package killswitches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/repo"
+)
+
+// insertVersionRow fabricates one prescription header and version directly so
+// eligibility timestamps can be controlled exactly. Interval expressions are
+// evaluated by the database clock, which is authoritative for expiry.
+func insertVersionRow(t *testing.T, conn *pgxpool.Pool, orgID, state, expiresAtSQL, supersededAtSQL string) PrescriptionID {
+	t.Helper()
+	var id uuid.UUID
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		INSERT INTO killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		VALUES ($1, 'block-tools', 'user', 'user:fabricated', 'tool', 1)
+		RETURNING id
+	`, orgID).Scan(&id))
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO killswitch_prescription_versions (organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, superseded_at, internal_note, external_note)
+		VALUES ($1, $2, 1, $3, 'all', clock_timestamp() - interval '3 hours', %s, clock_timestamp() - interval '3 hours', %s, $4, 'Access paused.')
+	`, expiresAtSQL, supersededAtSQL), orgID, id, state, sentinelInternalNote)
+	require.NoError(t, err)
+	return PrescriptionID(id.String())
+}
+
+func countExpiryMarkers(t *testing.T, conn *pgxpool.Pool, orgID string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT count(*) FROM killswitch_expiry_events WHERE organization_id = $1`, orgID).Scan(&count))
+	return count
+}
+
+func markerExists(t *testing.T, conn *pgxpool.Pool, prescriptionID PrescriptionID) bool {
+	t.Helper()
+	var count int
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT count(*) FROM killswitch_expiry_events WHERE prescription_id = $1`, string(prescriptionID)).Scan(&count))
+	return count > 0
+}
+
+func TestExpirySweepRecordsOnlyGenuinelyExpiredVersions(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_matrix")
+	maintenance := NewMaintenanceService(conn, audit.NewLogger())
+
+	dueCurrent := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+	expiredThenSuperseded := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '2 hours'", "clock_timestamp() - interval '1 hour'")
+	supersededBeforeExpiry := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "clock_timestamp() - interval '2 hours'")
+	expiryEqualsSupersession := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "clock_timestamp() - interval '1 hour'")
+	notYetExpired := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() + interval '1 hour'", "NULL")
+	inactive := insertVersionRow(t, conn, orgID, "inactive", "clock_timestamp() - interval '1 hour'", "NULL")
+	unbounded := insertVersionRow(t, conn, orgID, "active", "NULL", "NULL")
+	// Force the equality boundary to exact identity: interval arithmetic above
+	// evaluates clock_timestamp() per call.
+	_, err := conn.Exec(t.Context(), `UPDATE killswitch_prescription_versions SET superseded_at = expires_at WHERE prescription_id = $1`, string(expiryEqualsSupersession))
+	require.NoError(t, err)
+
+	result, err := maintenance.RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, ExpiryBatchResult{Candidates: 2, Recorded: 2}, result, "only the due current version and the version that expired strictly before supersession are eligible")
+
+	require.True(t, markerExists(t, conn, dueCurrent))
+	require.True(t, markerExists(t, conn, expiredThenSuperseded), "a delayed sweep still records a version that expired before being superseded")
+	for name, prescription := range map[string]PrescriptionID{
+		"superseded before expiry":   supersededBeforeExpiry,
+		"expiry equals supersession": expiryEqualsSupersession,
+		"not yet expired":            notYetExpired,
+		"inactive":                   inactive,
+		"unbounded":                  unbounded,
+	} {
+		require.False(t, markerExists(t, conn, prescription), "%s must not be recorded", name)
+	}
+
+	auditRows := listAuditRows(t, conn, orgID)
+	require.Len(t, auditRows, 2)
+	for _, row := range auditRows {
+		require.Equal(t, "killswitch:expire", row.Action)
+		require.Equal(t, "system", row.ActorID)
+		require.Equal(t, "System", row.ActorDisplayName)
+		require.Equal(t, "killswitch_prescription", row.SubjectType)
+		require.False(t, expiredAtOf(t, row.Metadata).IsZero())
+	}
+	require.Len(t, listOutboxMessages(t, conn, orgID), 2)
+	requireNoSentinelLeak(t, conn, orgID)
+
+	result, err = maintenance.RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, ExpiryBatchResult{Candidates: 0, Recorded: 0}, result, "a repeated sweep is a no-op")
+	require.Equal(t, 2, countExpiryMarkers(t, conn, orgID))
+	require.Len(t, listAuditRows(t, conn, orgID), 2)
+	require.Len(t, listOutboxMessages(t, conn, orgID), 2)
+
+	_, err = maintenance.RecordDueExpiries(t.Context(), 0)
+	require.ErrorIs(t, err, ErrInvalidArgument)
+	_, err = maintenance.RecordDueExpiries(t.Context(), maxCleanupBatchSize+1)
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}
+
+func TestExpirySweepDoesNotAlterEffectiveState(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_state")
+	maintenance := NewMaintenanceService(conn, audit.NewLogger())
+	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+
+	result, err := maintenance.RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), result.Recorded)
+
+	var state string
+	var supersededAt *time.Time
+	var currentVersion int64
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT version.state, version.superseded_at, prescription.current_version
+		FROM killswitch_prescription_versions AS version
+		JOIN killswitch_prescriptions AS prescription ON prescription.id = version.prescription_id
+		WHERE version.prescription_id = $1
+	`, string(prescription)).Scan(&state, &supersededAt, &currentVersion))
+	require.Equal(t, "active", state, "expiry recording never rewrites version state; enforcement expires at query time")
+	require.Nil(t, supersededAt)
+	require.Equal(t, int64(1), currentVersion)
+}
+
+func TestExpiryConcurrentSweepsRecordExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_concurrency")
+	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+
+	const sweeps = 4
+	totals := make([]ExpiryBatchResult, sweeps)
+	sweepErrs := make([]error, sweeps)
+	var wg sync.WaitGroup
+	for i := range sweeps {
+		wg.Go(func() {
+			maintenance := NewMaintenanceService(conn, audit.NewLogger())
+			totals[i], sweepErrs[i] = maintenance.RecordDueExpiries(context.Background(), 100)
+		})
+	}
+	wg.Wait()
+
+	var total int64
+	for i, result := range totals {
+		require.NoError(t, sweepErrs[i])
+		total += result.Recorded
+	}
+	require.Equal(t, int64(1), total, "concurrent sweeps must record one expiry exactly once")
+	require.True(t, markerExists(t, conn, prescription))
+	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
+	require.Len(t, listAuditRows(t, conn, orgID), 1)
+	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
+}
+
+func TestExpirySweepSerializesWithLifecycleHeaderLock(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_lifecycle_lock")
+	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+	prescriptionID := uuid.MustParse(string(prescription))
+	maintenance := NewMaintenanceService(conn, audit.NewLogger())
+
+	tx, err := conn.Begin(t.Context())
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(t.Context()) }()
+	_, err = tx.Exec(t.Context(), `
+		SELECT id FROM killswitch_prescriptions
+		WHERE organization_id = $1 AND id = $2
+		FOR UPDATE
+	`, orgID, prescriptionID)
+	require.NoError(t, err)
+
+	type expiryResult struct {
+		recorded int64
+		err      error
+	}
+	resultCh := make(chan expiryResult, 1)
+	go func() {
+		recorded, recordErr := maintenance.recordExpiry(context.Background(), repo.ListDueKillswitchExpiriesRow{OrganizationID: orgID, PrescriptionID: prescriptionID, Version: 1})
+		resultCh <- expiryResult{recorded: recorded, err: recordErr}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.FailNow(t, "expiry recording bypassed the lifecycle header lock", "result: %+v", result)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	_, err = tx.Exec(t.Context(), `
+		UPDATE killswitch_prescription_versions
+		SET superseded_at = expires_at
+		WHERE organization_id = $1 AND prescription_id = $2 AND version = 1
+	`, orgID, prescriptionID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(t.Context()))
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		require.Zero(t, result.recorded, "expiry eligibility is rechecked after the lifecycle lock releases")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "expiry recording did not resume after the lifecycle transaction committed")
+	}
+	require.Zero(t, countExpiryMarkers(t, conn, orgID))
+	require.Empty(t, listAuditRows(t, conn, orgID))
+	require.Empty(t, listOutboxMessages(t, conn, orgID))
+}
+
+func TestExpiryRetryRecovery(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_retry")
+	insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+
+	maintenance := NewMaintenanceService(conn, audit.NewLogger())
+	maintenance.beforeExpiryCommit = func(context.Context) error { return errors.New("forced pre-commit failure") }
+
+	_, err := maintenance.RecordDueExpiries(t.Context(), 100)
+	require.ErrorContains(t, err, "forced pre-commit failure")
+	require.Zero(t, countExpiryMarkers(t, conn, orgID), "a failed attempt rolls back its marker")
+	require.Empty(t, listAuditRows(t, conn, orgID), "a failed attempt rolls back its audit row")
+	require.Empty(t, listOutboxMessages(t, conn, orgID), "a failed attempt rolls back its outbox row")
+
+	maintenance.beforeExpiryCommit = nil
+	result, err := maintenance.RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, ExpiryBatchResult{Candidates: 1, Recorded: 1}, result, "a retry after rollback records the expiry once")
+
+	result, err = maintenance.RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, ExpiryBatchResult{Candidates: 0, Recorded: 0}, result, "a retry after commit observes the marker and is a no-op")
+	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
+	require.Len(t, listAuditRows(t, conn, orgID), 1)
+	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
+}
+
+func insertOperationReceipt(t *testing.T, conn *pgxpool.Pool, orgID, expiresAtSQL string) uuid.UUID {
+	t.Helper()
+	operationID := uuid.New()
+	_, err := conn.Exec(t.Context(), fmt.Sprintf(`
+		INSERT INTO killswitch_operations (organization_id, operation_id, actor_user_id, operation, request_hash, expires_at)
+		VALUES ($1, $2, 'user:test', 'activate', 'hash', %s)
+	`, expiresAtSQL), orgID, operationID)
+	require.NoError(t, err)
+	return operationID
+}
+
+func countOperations(t *testing.T, conn *pgxpool.Pool, orgID string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT count(*) FROM killswitch_operations WHERE organization_id = $1`, orgID).Scan(&count))
+	return count
+}
+
+func TestOperationCleanupBoundaryAndBatching(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_cleanup_boundary")
+	otherOrgID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, otherOrgID)
+	maintenance := NewMaintenanceService(conn, audit.NewLogger())
+
+	insertOperationReceipt(t, conn, orgID, "clock_timestamp() - interval '1 hour'")
+	insertOperationReceipt(t, conn, orgID, "clock_timestamp()")
+	retained := insertOperationReceipt(t, conn, orgID, "clock_timestamp() + interval '1 hour'")
+	insertOperationReceipt(t, conn, otherOrgID, "clock_timestamp() - interval '1 minute'")
+
+	deleted, err := maintenance.CleanupExpiredOperationsGlobal(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), deleted, "a full batch deletes exactly the batch size")
+	deleted, err = maintenance.CleanupExpiredOperationsGlobal(t.Context(), 2)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), deleted, "the privileged sweep continues across organizations")
+	deleted, err = maintenance.CleanupExpiredOperationsGlobal(t.Context(), 2)
+	require.NoError(t, err)
+	require.Zero(t, deleted, "receipts strictly after their expiry boundary are retained")
+
+	require.Equal(t, 1, countOperations(t, conn, orgID))
+	require.Zero(t, countOperations(t, conn, otherOrgID))
+	var remaining uuid.UUID
+	require.NoError(t, conn.QueryRow(t.Context(), `SELECT operation_id FROM killswitch_operations WHERE organization_id = $1`, orgID).Scan(&remaining))
+	require.Equal(t, retained, remaining)
+
+	_, err = maintenance.CleanupExpiredOperationsGlobal(t.Context(), 0)
+	require.ErrorIs(t, err, ErrInvalidArgument)
+	_, err = maintenance.CleanupExpiredOperationsGlobal(t.Context(), maxCleanupBatchSize+1)
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}
+
+func TestOperationCleanupConcurrentCleanersDoNotDoubleCount(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_cleanup_concurrency")
+	const expired = 24
+	for range expired {
+		insertOperationReceipt(t, conn, orgID, "clock_timestamp() - interval '1 hour'")
+	}
+
+	const cleaners = 3
+	totals := make([]int64, cleaners)
+	cleanupErrs := make([]error, cleaners)
+	var wg sync.WaitGroup
+	for i := range cleaners {
+		wg.Go(func() {
+			maintenance := NewMaintenanceService(conn, audit.NewLogger())
+			for {
+				deleted, err := maintenance.CleanupExpiredOperationsGlobal(context.Background(), 5)
+				if err != nil {
+					cleanupErrs[i] = err
+					return
+				}
+				if deleted == 0 {
+					return
+				}
+				totals[i] += deleted
+			}
+		})
+	}
+	wg.Wait()
+
+	var total int64
+	for i, deleted := range totals {
+		require.NoError(t, cleanupErrs[i])
+		total += deleted
+	}
+	require.Equal(t, int64(expired), total, "concurrent cleaners must not double-count deletions")
+	require.Zero(t, countOperations(t, conn, orgID))
+}

--- a/server/internal/killswitches/maintenance_test.go
+++ b/server/internal/killswitches/maintenance_test.go
@@ -50,17 +50,6 @@ func markerExists(t *testing.T, conn *pgxpool.Pool, prescriptionID PrescriptionI
 	return count > 0
 }
 
-func expiryEventRecorded(t *testing.T, conn *pgxpool.Pool, orgID string, prescriptionID PrescriptionID, version int64) bool {
-	t.Helper()
-	var recordedAt *time.Time
-	require.NoError(t, conn.QueryRow(t.Context(), `
-		SELECT expiry_event_recorded_at
-		FROM killswitch_prescription_versions
-		WHERE organization_id = $1 AND prescription_id = $2 AND version = $3
-	`, orgID, string(prescriptionID), version).Scan(&recordedAt))
-	return recordedAt != nil
-}
-
 func TestExpirySweepRecordsOnlyGenuinelyExpiredVersions(t *testing.T) {
 	t.Parallel()
 
@@ -85,8 +74,6 @@ func TestExpirySweepRecordsOnlyGenuinelyExpiredVersions(t *testing.T) {
 
 	require.True(t, markerExists(t, conn, dueCurrent))
 	require.True(t, markerExists(t, conn, expiredThenSuperseded), "a delayed sweep still records a version that expired before being superseded")
-	require.True(t, expiryEventRecorded(t, conn, orgID, dueCurrent, 1))
-	require.True(t, expiryEventRecorded(t, conn, orgID, expiredThenSuperseded, 1))
 	for name, prescription := range map[string]PrescriptionID{
 		"superseded before expiry":   supersededBeforeExpiry,
 		"expiry equals supersession": expiryEqualsSupersession,
@@ -134,17 +121,16 @@ func TestExpirySweepDoesNotAlterEffectiveState(t *testing.T) {
 	require.Equal(t, int64(1), result.Recorded)
 
 	var state string
-	var supersededAt, expiryEventRecordedAt *time.Time
+	var supersededAt *time.Time
 	var currentVersion int64
 	require.NoError(t, conn.QueryRow(t.Context(), `
-		SELECT version.state, version.superseded_at, version.expiry_event_recorded_at, prescription.current_version
+		SELECT version.state, version.superseded_at, prescription.current_version
 		FROM killswitch_prescription_versions AS version
 		JOIN killswitch_prescriptions AS prescription ON prescription.id = version.prescription_id
 		WHERE version.prescription_id = $1
-	`, string(prescription)).Scan(&state, &supersededAt, &expiryEventRecordedAt, &currentVersion))
+	`, string(prescription)).Scan(&state, &supersededAt, &currentVersion))
 	require.Equal(t, "active", state, "expiry recording never rewrites version state; enforcement expires at query time")
 	require.Nil(t, supersededAt)
-	require.NotNil(t, expiryEventRecordedAt)
 	require.Equal(t, int64(1), currentVersion)
 }
 
@@ -173,7 +159,6 @@ func TestExpiryConcurrentSweepsRecordExactlyOnce(t *testing.T) {
 	}
 	require.Equal(t, int64(1), total, "concurrent sweeps must record one expiry exactly once")
 	require.True(t, markerExists(t, conn, prescription))
-	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
 	require.Len(t, listAuditRows(t, conn, orgID), 1)
 	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
@@ -229,7 +214,6 @@ func TestExpirySweepSerializesWithLifecycleHeaderLock(t *testing.T) {
 		require.FailNow(t, "expiry recording did not resume after the lifecycle transaction committed")
 	}
 	require.Zero(t, countExpiryMarkers(t, conn, orgID))
-	require.False(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 	require.Empty(t, listAuditRows(t, conn, orgID))
 	require.Empty(t, listOutboxMessages(t, conn, orgID))
 }
@@ -238,7 +222,7 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	t.Parallel()
 
 	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_retry")
-	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+	insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
 
 	maintenance := NewMaintenanceService(conn, audit.NewLogger())
 	maintenance.beforeExpiryCommit = func(context.Context) error { return errors.New("forced pre-commit failure") }
@@ -246,7 +230,6 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	_, err := maintenance.RecordDueExpiries(t.Context(), 100)
 	require.ErrorContains(t, err, "forced pre-commit failure")
 	require.Zero(t, countExpiryMarkers(t, conn, orgID), "a failed attempt rolls back its marker")
-	require.False(t, expiryEventRecorded(t, conn, orgID, prescription, 1), "a failed attempt rolls back its completion marker")
 	require.Empty(t, listAuditRows(t, conn, orgID), "a failed attempt rolls back its audit row")
 	require.Empty(t, listOutboxMessages(t, conn, orgID), "a failed attempt rolls back its outbox row")
 
@@ -254,7 +237,6 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	result, err := maintenance.RecordDueExpiries(t.Context(), 100)
 	require.NoError(t, err)
 	require.Equal(t, ExpiryBatchResult{Candidates: 1, Recorded: 1}, result, "a retry after rollback records the expiry once")
-	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 
 	result, err = maintenance.RecordDueExpiries(t.Context(), 100)
 	require.NoError(t, err)
@@ -262,25 +244,6 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
 	require.Len(t, listAuditRows(t, conn, orgID), 1)
 	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
-}
-
-func TestExpirySweepRepairsExistingEventCompletionMarker(t *testing.T) {
-	t.Parallel()
-
-	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_marker_repair")
-	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
-	_, err := conn.Exec(t.Context(), `
-		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
-		VALUES ($1, $2, 1)
-	`, orgID, string(prescription))
-	require.NoError(t, err)
-
-	result, err := NewMaintenanceService(conn, audit.NewLogger()).RecordDueExpiries(t.Context(), 100)
-	require.NoError(t, err)
-	require.Equal(t, ExpiryBatchResult{Candidates: 1, Recorded: 0}, result)
-	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
-	require.Empty(t, listAuditRows(t, conn, orgID))
-	require.Empty(t, listOutboxMessages(t, conn, orgID))
 }
 
 func insertOperationReceipt(t *testing.T, conn *pgxpool.Pool, orgID, expiresAtSQL string) uuid.UUID {

--- a/server/internal/killswitches/maintenance_test.go
+++ b/server/internal/killswitches/maintenance_test.go
@@ -50,6 +50,17 @@ func markerExists(t *testing.T, conn *pgxpool.Pool, prescriptionID PrescriptionI
 	return count > 0
 }
 
+func expiryEventRecorded(t *testing.T, conn *pgxpool.Pool, orgID string, prescriptionID PrescriptionID, version int64) bool {
+	t.Helper()
+	var recordedAt *time.Time
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT expiry_event_recorded_at
+		FROM killswitch_prescription_versions
+		WHERE organization_id = $1 AND prescription_id = $2 AND version = $3
+	`, orgID, string(prescriptionID), version).Scan(&recordedAt))
+	return recordedAt != nil
+}
+
 func TestExpirySweepRecordsOnlyGenuinelyExpiredVersions(t *testing.T) {
 	t.Parallel()
 
@@ -74,6 +85,8 @@ func TestExpirySweepRecordsOnlyGenuinelyExpiredVersions(t *testing.T) {
 
 	require.True(t, markerExists(t, conn, dueCurrent))
 	require.True(t, markerExists(t, conn, expiredThenSuperseded), "a delayed sweep still records a version that expired before being superseded")
+	require.True(t, expiryEventRecorded(t, conn, orgID, dueCurrent, 1))
+	require.True(t, expiryEventRecorded(t, conn, orgID, expiredThenSuperseded, 1))
 	for name, prescription := range map[string]PrescriptionID{
 		"superseded before expiry":   supersededBeforeExpiry,
 		"expiry equals supersession": expiryEqualsSupersession,
@@ -121,16 +134,17 @@ func TestExpirySweepDoesNotAlterEffectiveState(t *testing.T) {
 	require.Equal(t, int64(1), result.Recorded)
 
 	var state string
-	var supersededAt *time.Time
+	var supersededAt, expiryEventRecordedAt *time.Time
 	var currentVersion int64
 	require.NoError(t, conn.QueryRow(t.Context(), `
-		SELECT version.state, version.superseded_at, prescription.current_version
+		SELECT version.state, version.superseded_at, version.expiry_event_recorded_at, prescription.current_version
 		FROM killswitch_prescription_versions AS version
 		JOIN killswitch_prescriptions AS prescription ON prescription.id = version.prescription_id
 		WHERE version.prescription_id = $1
-	`, string(prescription)).Scan(&state, &supersededAt, &currentVersion))
+	`, string(prescription)).Scan(&state, &supersededAt, &expiryEventRecordedAt, &currentVersion))
 	require.Equal(t, "active", state, "expiry recording never rewrites version state; enforcement expires at query time")
 	require.Nil(t, supersededAt)
+	require.NotNil(t, expiryEventRecordedAt)
 	require.Equal(t, int64(1), currentVersion)
 }
 
@@ -159,6 +173,7 @@ func TestExpiryConcurrentSweepsRecordExactlyOnce(t *testing.T) {
 	}
 	require.Equal(t, int64(1), total, "concurrent sweeps must record one expiry exactly once")
 	require.True(t, markerExists(t, conn, prescription))
+	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
 	require.Len(t, listAuditRows(t, conn, orgID), 1)
 	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
@@ -214,6 +229,7 @@ func TestExpirySweepSerializesWithLifecycleHeaderLock(t *testing.T) {
 		require.FailNow(t, "expiry recording did not resume after the lifecycle transaction committed")
 	}
 	require.Zero(t, countExpiryMarkers(t, conn, orgID))
+	require.False(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 	require.Empty(t, listAuditRows(t, conn, orgID))
 	require.Empty(t, listOutboxMessages(t, conn, orgID))
 }
@@ -222,7 +238,7 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	t.Parallel()
 
 	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_retry")
-	insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
 
 	maintenance := NewMaintenanceService(conn, audit.NewLogger())
 	maintenance.beforeExpiryCommit = func(context.Context) error { return errors.New("forced pre-commit failure") }
@@ -230,6 +246,7 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	_, err := maintenance.RecordDueExpiries(t.Context(), 100)
 	require.ErrorContains(t, err, "forced pre-commit failure")
 	require.Zero(t, countExpiryMarkers(t, conn, orgID), "a failed attempt rolls back its marker")
+	require.False(t, expiryEventRecorded(t, conn, orgID, prescription, 1), "a failed attempt rolls back its completion marker")
 	require.Empty(t, listAuditRows(t, conn, orgID), "a failed attempt rolls back its audit row")
 	require.Empty(t, listOutboxMessages(t, conn, orgID), "a failed attempt rolls back its outbox row")
 
@@ -237,6 +254,7 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	result, err := maintenance.RecordDueExpiries(t.Context(), 100)
 	require.NoError(t, err)
 	require.Equal(t, ExpiryBatchResult{Candidates: 1, Recorded: 1}, result, "a retry after rollback records the expiry once")
+	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
 
 	result, err = maintenance.RecordDueExpiries(t.Context(), 100)
 	require.NoError(t, err)
@@ -244,6 +262,25 @@ func TestExpiryRetryRecovery(t *testing.T) {
 	require.Equal(t, 1, countExpiryMarkers(t, conn, orgID))
 	require.Len(t, listAuditRows(t, conn, orgID), 1)
 	require.Len(t, listOutboxMessages(t, conn, orgID), 1)
+}
+
+func TestExpirySweepRepairsExistingEventCompletionMarker(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newLifecycleDatabase(t, "killswitch_expiry_marker_repair")
+	prescription := insertVersionRow(t, conn, orgID, "active", "clock_timestamp() - interval '1 hour'", "NULL")
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO killswitch_expiry_events (organization_id, prescription_id, version)
+		VALUES ($1, $2, 1)
+	`, orgID, string(prescription))
+	require.NoError(t, err)
+
+	result, err := NewMaintenanceService(conn, audit.NewLogger()).RecordDueExpiries(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, ExpiryBatchResult{Candidates: 1, Recorded: 0}, result)
+	require.True(t, expiryEventRecorded(t, conn, orgID, prescription, 1))
+	require.Empty(t, listAuditRows(t, conn, orgID))
+	require.Empty(t, listOutboxMessages(t, conn, orgID))
 }
 
 func insertOperationReceipt(t *testing.T, conn *pgxpool.Pool, orgID, expiresAtSQL string) uuid.UUID {

--- a/server/internal/killswitches/queries.sql
+++ b/server/internal/killswitches/queries.sql
@@ -171,6 +171,66 @@ USING expired
 WHERE operation.organization_id = @organization_id
   AND operation.operation_id = expired.operation_id;
 
+-- name: ListDueKillswitchExpiries :many
+-- Privileged cross-organization discovery for the maintenance sweep. Killswitch
+-- maintenance deliberately spans tenants; every subsequent mutation is
+-- requalified by the candidate's organization_id under a row lock. The STABLE
+-- statement_timestamp() keeps the expires_at comparison plannable as an index
+-- bound; per-candidate eligibility is re-decided under the row lock.
+SELECT organization_id, prescription_id, version
+FROM killswitch_prescription_versions
+WHERE state = 'active'
+  AND expires_at IS NOT NULL
+  AND expires_at <= statement_timestamp()
+  AND (superseded_at IS NULL OR expires_at < superseded_at)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM killswitch_expiry_events AS marker
+    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
+      AND marker.version = killswitch_prescription_versions.version
+  )
+ORDER BY expires_at, prescription_id, version
+LIMIT @batch_size;
+
+-- name: LockKillswitchVersionForExpiry :one
+SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
+FROM killswitch_prescription_versions
+WHERE organization_id = @organization_id
+  AND prescription_id = @prescription_id
+  AND version = @version
+FOR UPDATE;
+
+-- name: RecordKillswitchExpiryEvent :execrows
+INSERT INTO killswitch_expiry_events (
+  organization_id,
+  prescription_id,
+  version
+) VALUES (
+  @organization_id,
+  @prescription_id,
+  @version
+)
+ON CONFLICT (prescription_id, version) DO NOTHING;
+
+-- name: DeleteExpiredKillswitchOperationsGlobal :execrows
+-- Privileged cross-organization retention cleanup for the maintenance sweep.
+-- Receipts are deleted strictly by their database-anchored expires_at; replay
+-- validity is decided by the claim query, never by cleanup timing. The STABLE
+-- statement_timestamp() keeps the expires_at comparison plannable as an index
+-- bound.
+WITH expired AS (
+  SELECT organization_id, operation_id
+  FROM killswitch_operations
+  WHERE expires_at <= statement_timestamp()
+  ORDER BY expires_at, organization_id, operation_id
+  FOR UPDATE SKIP LOCKED
+  LIMIT @batch_size
+)
+DELETE FROM killswitch_operations AS operation
+USING expired
+WHERE operation.organization_id = expired.organization_id
+  AND operation.operation_id = expired.operation_id;
+
 -- name: LockKillswitchPrescriptionCurrent :one
 SELECT id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version
 FROM killswitch_prescriptions

--- a/server/internal/killswitches/queries.sql
+++ b/server/internal/killswitches/queries.sql
@@ -182,35 +182,40 @@ FROM killswitch_prescription_versions
 WHERE state = 'active'
   AND expires_at IS NOT NULL
   AND expires_at <= statement_timestamp()
+  AND expiry_event_recorded_at IS NULL
   AND (superseded_at IS NULL OR expires_at < superseded_at)
-  AND NOT EXISTS (
-    SELECT 1
-    FROM killswitch_expiry_events AS marker
-    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
-      AND marker.version = killswitch_prescription_versions.version
-  )
 ORDER BY expires_at, prescription_id, version
 LIMIT @batch_size;
 
 -- name: LockKillswitchVersionForExpiry :one
-SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
+SELECT state, expires_at, superseded_at, expiry_event_recorded_at, clock_timestamp()::timestamptz AS database_now
 FROM killswitch_prescription_versions
 WHERE organization_id = @organization_id
   AND prescription_id = @prescription_id
   AND version = @version
 FOR UPDATE;
 
--- name: RecordKillswitchExpiryEvent :execrows
-INSERT INTO killswitch_expiry_events (
-  organization_id,
-  prescription_id,
-  version
-) VALUES (
-  @organization_id,
-  @prescription_id,
-  @version
+-- name: CompleteKillswitchExpiryEvent :one
+WITH inserted_event AS (
+  INSERT INTO killswitch_expiry_events (
+    organization_id,
+    prescription_id,
+    version
+  ) VALUES (
+    @organization_id,
+    @prescription_id,
+    @version
+  )
+  ON CONFLICT (prescription_id, version) DO NOTHING
+  RETURNING 1
 )
-ON CONFLICT (prescription_id, version) DO NOTHING;
+UPDATE killswitch_prescription_versions AS version_row
+SET expiry_event_recorded_at = clock_timestamp()
+WHERE version_row.organization_id = @organization_id
+  AND version_row.prescription_id = @prescription_id
+  AND version_row.version = @version
+  AND version_row.expiry_event_recorded_at IS NULL
+RETURNING EXISTS (SELECT 1 FROM inserted_event) AS event_inserted;
 
 -- name: DeleteExpiredKillswitchOperationsGlobal :execrows
 -- Privileged cross-organization retention cleanup for the maintenance sweep.

--- a/server/internal/killswitches/queries.sql
+++ b/server/internal/killswitches/queries.sql
@@ -182,40 +182,35 @@ FROM killswitch_prescription_versions
 WHERE state = 'active'
   AND expires_at IS NOT NULL
   AND expires_at <= statement_timestamp()
-  AND expiry_event_recorded_at IS NULL
   AND (superseded_at IS NULL OR expires_at < superseded_at)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM killswitch_expiry_events AS marker
+    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
+      AND marker.version = killswitch_prescription_versions.version
+  )
 ORDER BY expires_at, prescription_id, version
 LIMIT @batch_size;
 
 -- name: LockKillswitchVersionForExpiry :one
-SELECT state, expires_at, superseded_at, expiry_event_recorded_at, clock_timestamp()::timestamptz AS database_now
+SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
 FROM killswitch_prescription_versions
 WHERE organization_id = @organization_id
   AND prescription_id = @prescription_id
   AND version = @version
 FOR UPDATE;
 
--- name: CompleteKillswitchExpiryEvent :one
-WITH inserted_event AS (
-  INSERT INTO killswitch_expiry_events (
-    organization_id,
-    prescription_id,
-    version
-  ) VALUES (
-    @organization_id,
-    @prescription_id,
-    @version
-  )
-  ON CONFLICT (prescription_id, version) DO NOTHING
-  RETURNING 1
+-- name: RecordKillswitchExpiryEvent :execrows
+INSERT INTO killswitch_expiry_events (
+  organization_id,
+  prescription_id,
+  version
+) VALUES (
+  @organization_id,
+  @prescription_id,
+  @version
 )
-UPDATE killswitch_prescription_versions AS version_row
-SET expiry_event_recorded_at = clock_timestamp()
-WHERE version_row.organization_id = @organization_id
-  AND version_row.prescription_id = @prescription_id
-  AND version_row.version = @version
-  AND version_row.expiry_event_recorded_at IS NULL
-RETURNING EXISTS (SELECT 1 FROM inserted_event) AS event_inserted;
+ON CONFLICT (prescription_id, version) DO NOTHING;
 
 -- name: DeleteExpiredKillswitchOperationsGlobal :execrows
 -- Privileged cross-organization retention cleanup for the maintenance sweep.

--- a/server/internal/killswitches/repo/queries.sql.go
+++ b/server/internal/killswitches/repo/queries.sql.go
@@ -343,6 +343,34 @@ func (q *Queries) DeleteExpiredKillswitchOperations(ctx context.Context, arg Del
 	return result.RowsAffected(), nil
 }
 
+const deleteExpiredKillswitchOperationsGlobal = `-- name: DeleteExpiredKillswitchOperationsGlobal :execrows
+WITH expired AS (
+  SELECT organization_id, operation_id
+  FROM killswitch_operations
+  WHERE expires_at <= statement_timestamp()
+  ORDER BY expires_at, organization_id, operation_id
+  FOR UPDATE SKIP LOCKED
+  LIMIT $1
+)
+DELETE FROM killswitch_operations AS operation
+USING expired
+WHERE operation.organization_id = expired.organization_id
+  AND operation.operation_id = expired.operation_id
+`
+
+// Privileged cross-organization retention cleanup for the maintenance sweep.
+// Receipts are deleted strictly by their database-anchored expires_at; replay
+// validity is decided by the claim query, never by cleanup timing. The STABLE
+// statement_timestamp() keeps the expires_at comparison plannable as an index
+// bound.
+func (q *Queries) DeleteExpiredKillswitchOperationsGlobal(ctx context.Context, batchSize int32) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteExpiredKillswitchOperationsGlobal, batchSize)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const evaluateCurrentPrescriptions = `-- name: EvaluateCurrentPrescriptions :one
 WITH evaluation_clock AS MATERIALIZED (
   SELECT clock_timestamp() AS database_now
@@ -560,6 +588,54 @@ func (q *Queries) GetKillswitchPrescriptionVersion(ctx context.Context, arg GetK
 	return i, err
 }
 
+const listDueKillswitchExpiries = `-- name: ListDueKillswitchExpiries :many
+SELECT organization_id, prescription_id, version
+FROM killswitch_prescription_versions
+WHERE state = 'active'
+  AND expires_at IS NOT NULL
+  AND expires_at <= statement_timestamp()
+  AND (superseded_at IS NULL OR expires_at < superseded_at)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM killswitch_expiry_events AS marker
+    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
+      AND marker.version = killswitch_prescription_versions.version
+  )
+ORDER BY expires_at, prescription_id, version
+LIMIT $1
+`
+
+type ListDueKillswitchExpiriesRow struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+}
+
+// Privileged cross-organization discovery for the maintenance sweep. Killswitch
+// maintenance deliberately spans tenants; every subsequent mutation is
+// requalified by the candidate's organization_id under a row lock. The STABLE
+// statement_timestamp() keeps the expires_at comparison plannable as an index
+// bound; per-candidate eligibility is re-decided under the row lock.
+func (q *Queries) ListDueKillswitchExpiries(ctx context.Context, batchSize int32) ([]ListDueKillswitchExpiriesRow, error) {
+	rows, err := q.db.Query(ctx, listDueKillswitchExpiries, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDueKillswitchExpiriesRow
+	for rows.Next() {
+		var i ListDueKillswitchExpiriesRow
+		if err := rows.Scan(&i.OrganizationID, &i.PrescriptionID, &i.Version); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listKillswitchPrescriptionVersionResources = `-- name: ListKillswitchPrescriptionVersionResources :many
 SELECT resource_key
 FROM killswitch_prescription_version_resources
@@ -666,6 +742,67 @@ func (q *Queries) LockKillswitchPrescriptionCurrent(ctx context.Context, arg Loc
 		&i.CurrentVersion,
 	)
 	return i, err
+}
+
+const lockKillswitchVersionForExpiry = `-- name: LockKillswitchVersionForExpiry :one
+SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
+FROM killswitch_prescription_versions
+WHERE organization_id = $1
+  AND prescription_id = $2
+  AND version = $3
+FOR UPDATE
+`
+
+type LockKillswitchVersionForExpiryParams struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+}
+
+type LockKillswitchVersionForExpiryRow struct {
+	State        string
+	ExpiresAt    pgtype.Timestamptz
+	SupersededAt pgtype.Timestamptz
+	DatabaseNow  pgtype.Timestamptz
+}
+
+func (q *Queries) LockKillswitchVersionForExpiry(ctx context.Context, arg LockKillswitchVersionForExpiryParams) (LockKillswitchVersionForExpiryRow, error) {
+	row := q.db.QueryRow(ctx, lockKillswitchVersionForExpiry, arg.OrganizationID, arg.PrescriptionID, arg.Version)
+	var i LockKillswitchVersionForExpiryRow
+	err := row.Scan(
+		&i.State,
+		&i.ExpiresAt,
+		&i.SupersededAt,
+		&i.DatabaseNow,
+	)
+	return i, err
+}
+
+const recordKillswitchExpiryEvent = `-- name: RecordKillswitchExpiryEvent :execrows
+INSERT INTO killswitch_expiry_events (
+  organization_id,
+  prescription_id,
+  version
+) VALUES (
+  $1,
+  $2,
+  $3
+)
+ON CONFLICT (prescription_id, version) DO NOTHING
+`
+
+type RecordKillswitchExpiryEventParams struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+}
+
+func (q *Queries) RecordKillswitchExpiryEvent(ctx context.Context, arg RecordKillswitchExpiryEventParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recordKillswitchExpiryEvent, arg.OrganizationID, arg.PrescriptionID, arg.Version)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const supersedeKillswitchPrescriptionVersion = `-- name: SupersedeKillswitchPrescriptionVersion :execrows

--- a/server/internal/killswitches/repo/queries.sql.go
+++ b/server/internal/killswitches/repo/queries.sql.go
@@ -105,42 +105,6 @@ func (q *Queries) ClaimKillswitchOperation(ctx context.Context, arg ClaimKillswi
 	return operation_id, err
 }
 
-const completeKillswitchExpiryEvent = `-- name: CompleteKillswitchExpiryEvent :one
-WITH inserted_event AS (
-  INSERT INTO killswitch_expiry_events (
-    organization_id,
-    prescription_id,
-    version
-  ) VALUES (
-    $1,
-    $2,
-    $3
-  )
-  ON CONFLICT (prescription_id, version) DO NOTHING
-  RETURNING 1
-)
-UPDATE killswitch_prescription_versions AS version_row
-SET expiry_event_recorded_at = clock_timestamp()
-WHERE version_row.organization_id = $1
-  AND version_row.prescription_id = $2
-  AND version_row.version = $3
-  AND version_row.expiry_event_recorded_at IS NULL
-RETURNING EXISTS (SELECT 1 FROM inserted_event) AS event_inserted
-`
-
-type CompleteKillswitchExpiryEventParams struct {
-	OrganizationID string
-	PrescriptionID uuid.UUID
-	Version        int64
-}
-
-func (q *Queries) CompleteKillswitchExpiryEvent(ctx context.Context, arg CompleteKillswitchExpiryEventParams) (bool, error) {
-	row := q.db.QueryRow(ctx, completeKillswitchExpiryEvent, arg.OrganizationID, arg.PrescriptionID, arg.Version)
-	var event_inserted bool
-	err := row.Scan(&event_inserted)
-	return event_inserted, err
-}
-
 const completeKillswitchOperation = `-- name: CompleteKillswitchOperation :execrows
 UPDATE killswitch_operations
 SET status = 'completed',
@@ -630,8 +594,13 @@ FROM killswitch_prescription_versions
 WHERE state = 'active'
   AND expires_at IS NOT NULL
   AND expires_at <= statement_timestamp()
-  AND expiry_event_recorded_at IS NULL
   AND (superseded_at IS NULL OR expires_at < superseded_at)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM killswitch_expiry_events AS marker
+    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
+      AND marker.version = killswitch_prescription_versions.version
+  )
 ORDER BY expires_at, prescription_id, version
 LIMIT $1
 `
@@ -776,7 +745,7 @@ func (q *Queries) LockKillswitchPrescriptionCurrent(ctx context.Context, arg Loc
 }
 
 const lockKillswitchVersionForExpiry = `-- name: LockKillswitchVersionForExpiry :one
-SELECT state, expires_at, superseded_at, expiry_event_recorded_at, clock_timestamp()::timestamptz AS database_now
+SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
 FROM killswitch_prescription_versions
 WHERE organization_id = $1
   AND prescription_id = $2
@@ -791,11 +760,10 @@ type LockKillswitchVersionForExpiryParams struct {
 }
 
 type LockKillswitchVersionForExpiryRow struct {
-	State                 string
-	ExpiresAt             pgtype.Timestamptz
-	SupersededAt          pgtype.Timestamptz
-	ExpiryEventRecordedAt pgtype.Timestamptz
-	DatabaseNow           pgtype.Timestamptz
+	State        string
+	ExpiresAt    pgtype.Timestamptz
+	SupersededAt pgtype.Timestamptz
+	DatabaseNow  pgtype.Timestamptz
 }
 
 func (q *Queries) LockKillswitchVersionForExpiry(ctx context.Context, arg LockKillswitchVersionForExpiryParams) (LockKillswitchVersionForExpiryRow, error) {
@@ -805,10 +773,36 @@ func (q *Queries) LockKillswitchVersionForExpiry(ctx context.Context, arg LockKi
 		&i.State,
 		&i.ExpiresAt,
 		&i.SupersededAt,
-		&i.ExpiryEventRecordedAt,
 		&i.DatabaseNow,
 	)
 	return i, err
+}
+
+const recordKillswitchExpiryEvent = `-- name: RecordKillswitchExpiryEvent :execrows
+INSERT INTO killswitch_expiry_events (
+  organization_id,
+  prescription_id,
+  version
+) VALUES (
+  $1,
+  $2,
+  $3
+)
+ON CONFLICT (prescription_id, version) DO NOTHING
+`
+
+type RecordKillswitchExpiryEventParams struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+}
+
+func (q *Queries) RecordKillswitchExpiryEvent(ctx context.Context, arg RecordKillswitchExpiryEventParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recordKillswitchExpiryEvent, arg.OrganizationID, arg.PrescriptionID, arg.Version)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const supersedeKillswitchPrescriptionVersion = `-- name: SupersedeKillswitchPrescriptionVersion :execrows

--- a/server/internal/killswitches/repo/queries.sql.go
+++ b/server/internal/killswitches/repo/queries.sql.go
@@ -105,6 +105,42 @@ func (q *Queries) ClaimKillswitchOperation(ctx context.Context, arg ClaimKillswi
 	return operation_id, err
 }
 
+const completeKillswitchExpiryEvent = `-- name: CompleteKillswitchExpiryEvent :one
+WITH inserted_event AS (
+  INSERT INTO killswitch_expiry_events (
+    organization_id,
+    prescription_id,
+    version
+  ) VALUES (
+    $1,
+    $2,
+    $3
+  )
+  ON CONFLICT (prescription_id, version) DO NOTHING
+  RETURNING 1
+)
+UPDATE killswitch_prescription_versions AS version_row
+SET expiry_event_recorded_at = clock_timestamp()
+WHERE version_row.organization_id = $1
+  AND version_row.prescription_id = $2
+  AND version_row.version = $3
+  AND version_row.expiry_event_recorded_at IS NULL
+RETURNING EXISTS (SELECT 1 FROM inserted_event) AS event_inserted
+`
+
+type CompleteKillswitchExpiryEventParams struct {
+	OrganizationID string
+	PrescriptionID uuid.UUID
+	Version        int64
+}
+
+func (q *Queries) CompleteKillswitchExpiryEvent(ctx context.Context, arg CompleteKillswitchExpiryEventParams) (bool, error) {
+	row := q.db.QueryRow(ctx, completeKillswitchExpiryEvent, arg.OrganizationID, arg.PrescriptionID, arg.Version)
+	var event_inserted bool
+	err := row.Scan(&event_inserted)
+	return event_inserted, err
+}
+
 const completeKillswitchOperation = `-- name: CompleteKillswitchOperation :execrows
 UPDATE killswitch_operations
 SET status = 'completed',
@@ -594,13 +630,8 @@ FROM killswitch_prescription_versions
 WHERE state = 'active'
   AND expires_at IS NOT NULL
   AND expires_at <= statement_timestamp()
+  AND expiry_event_recorded_at IS NULL
   AND (superseded_at IS NULL OR expires_at < superseded_at)
-  AND NOT EXISTS (
-    SELECT 1
-    FROM killswitch_expiry_events AS marker
-    WHERE marker.prescription_id = killswitch_prescription_versions.prescription_id
-      AND marker.version = killswitch_prescription_versions.version
-  )
 ORDER BY expires_at, prescription_id, version
 LIMIT $1
 `
@@ -745,7 +776,7 @@ func (q *Queries) LockKillswitchPrescriptionCurrent(ctx context.Context, arg Loc
 }
 
 const lockKillswitchVersionForExpiry = `-- name: LockKillswitchVersionForExpiry :one
-SELECT state, expires_at, superseded_at, clock_timestamp()::timestamptz AS database_now
+SELECT state, expires_at, superseded_at, expiry_event_recorded_at, clock_timestamp()::timestamptz AS database_now
 FROM killswitch_prescription_versions
 WHERE organization_id = $1
   AND prescription_id = $2
@@ -760,10 +791,11 @@ type LockKillswitchVersionForExpiryParams struct {
 }
 
 type LockKillswitchVersionForExpiryRow struct {
-	State        string
-	ExpiresAt    pgtype.Timestamptz
-	SupersededAt pgtype.Timestamptz
-	DatabaseNow  pgtype.Timestamptz
+	State                 string
+	ExpiresAt             pgtype.Timestamptz
+	SupersededAt          pgtype.Timestamptz
+	ExpiryEventRecordedAt pgtype.Timestamptz
+	DatabaseNow           pgtype.Timestamptz
 }
 
 func (q *Queries) LockKillswitchVersionForExpiry(ctx context.Context, arg LockKillswitchVersionForExpiryParams) (LockKillswitchVersionForExpiryRow, error) {
@@ -773,36 +805,10 @@ func (q *Queries) LockKillswitchVersionForExpiry(ctx context.Context, arg LockKi
 		&i.State,
 		&i.ExpiresAt,
 		&i.SupersededAt,
+		&i.ExpiryEventRecordedAt,
 		&i.DatabaseNow,
 	)
 	return i, err
-}
-
-const recordKillswitchExpiryEvent = `-- name: RecordKillswitchExpiryEvent :execrows
-INSERT INTO killswitch_expiry_events (
-  organization_id,
-  prescription_id,
-  version
-) VALUES (
-  $1,
-  $2,
-  $3
-)
-ON CONFLICT (prescription_id, version) DO NOTHING
-`
-
-type RecordKillswitchExpiryEventParams struct {
-	OrganizationID string
-	PrescriptionID uuid.UUID
-	Version        int64
-}
-
-func (q *Queries) RecordKillswitchExpiryEvent(ctx context.Context, arg RecordKillswitchExpiryEventParams) (int64, error) {
-	result, err := q.db.Exec(ctx, recordKillswitchExpiryEvent, arg.OrganizationID, arg.PrescriptionID, arg.Version)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
 }
 
 const supersedeKillswitchPrescriptionVersion = `-- name: SupersedeKillswitchPrescriptionVersion :execrows

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -296,6 +296,25 @@ func TestKillswitchSchemaPinsTenancyAndIdempotency(t *testing.T) {
 	requireConstraint(t, err, "killswitch_operations_pkey")
 }
 
+func TestKillswitchExpiryDiscoveryIndexMatchesEligibilityAndOrder(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "killswitch_expiry_index")
+	require.NoError(t, err)
+
+	var indexDefinition string
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT indexdef
+		FROM pg_indexes
+		WHERE schemaname = 'public'
+		  AND indexname = 'killswitch_prescription_versions_expiry_due_idx'
+	`).Scan(&indexDefinition))
+	require.Contains(t, indexDefinition, "USING btree (expires_at, prescription_id, version)")
+	require.Contains(t, indexDefinition, "state = 'active'::text")
+	require.Contains(t, indexDefinition, "superseded_at IS NULL")
+	require.Contains(t, indexDefinition, "expires_at < superseded_at")
+}
+
 func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {
 	t.Helper()
 

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -302,17 +302,21 @@ func TestKillswitchExpiryDiscoveryIndexMatchesEligibilityAndOrder(t *testing.T) 
 	conn, err := infra.CloneTestDatabase(t, "killswitch_expiry_index")
 	require.NoError(t, err)
 
-	var indexDefinition string
+	var (
+		indexColumns   []string
+		indexPredicate string
+	)
 	require.NoError(t, conn.QueryRow(t.Context(), `
-		SELECT indexdef
-		FROM pg_indexes
-		WHERE schemaname = 'public'
-		  AND indexname = 'killswitch_prescription_versions_expiry_due_idx'
-	`).Scan(&indexDefinition))
-	require.Contains(t, indexDefinition, "USING btree (expires_at, prescription_id, version)")
-	require.Contains(t, indexDefinition, "state = 'active'::text")
-	require.Contains(t, indexDefinition, "superseded_at IS NULL")
-	require.Contains(t, indexDefinition, "expires_at < superseded_at")
+		SELECT ARRAY(
+			SELECT pg_get_indexdef(indexrelid, position, true)
+			FROM generate_series(1, indnkeyatts) AS position
+			ORDER BY position
+		), pg_get_expr(indpred, indrelid)
+		FROM pg_index
+		WHERE indexrelid = 'killswitch_prescription_versions_expiry_due_idx'::regclass
+	`).Scan(&indexColumns, &indexPredicate))
+	require.Equal(t, []string{"expires_at", "prescription_id", "version"}, indexColumns)
+	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
 }
 
 func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -303,20 +303,24 @@ func TestKillswitchExpiryDiscoveryIndexMatchesEligibilityAndOrder(t *testing.T) 
 	require.NoError(t, err)
 
 	var (
-		indexColumns   []string
-		indexPredicate string
+		indexColumns      []string
+		indexPredicate    string
+		indexAccessMethod string
 	)
 	require.NoError(t, conn.QueryRow(t.Context(), `
 		SELECT ARRAY(
 			SELECT pg_get_indexdef(indexrelid, position, true)
 			FROM generate_series(1, indnkeyatts) AS position
 			ORDER BY position
-		), pg_get_expr(indpred, indrelid)
+		), pg_get_expr(indpred, indrelid), access_method.amname
 		FROM pg_index
+		JOIN pg_class index_class ON index_class.oid = indexrelid
+		JOIN pg_am access_method ON access_method.oid = index_class.relam
 		WHERE indexrelid = 'killswitch_prescription_versions_expiry_due_idx'::regclass
-	`).Scan(&indexColumns, &indexPredicate))
+	`).Scan(&indexColumns, &indexPredicate, &indexAccessMethod))
 	require.Equal(t, []string{"expires_at", "prescription_id", "version"}, indexColumns)
-	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
+	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND (expiry_event_recorded_at IS NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
+	require.Equal(t, "btree", indexAccessMethod)
 }
 
 func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -309,18 +309,18 @@ func TestKillswitchExpiryDiscoveryIndexMatchesEligibilityAndOrder(t *testing.T) 
 	)
 	require.NoError(t, conn.QueryRow(t.Context(), `
 		SELECT ARRAY(
-			SELECT pg_get_indexdef(indexrelid, position, true)
-			FROM generate_series(1, indnkeyatts) AS position
+			SELECT pg_get_indexdef(index_metadata.indexrelid, position, true)
+			FROM generate_series(1, index_metadata.indnkeyatts) AS position
 			ORDER BY position
-		), pg_get_expr(indpred, indrelid), access_method.amname
-		FROM pg_index
-		JOIN pg_class index_class ON index_class.oid = indexrelid
-		JOIN pg_am access_method ON access_method.oid = index_class.relam
-		WHERE indexrelid = 'killswitch_prescription_versions_expiry_due_idx'::regclass
+		), pg_get_expr(index_metadata.indpred, index_metadata.indrelid), access_method.amname
+		FROM pg_index AS index_metadata
+		JOIN pg_class AS index_relation ON index_relation.oid = index_metadata.indexrelid
+		JOIN pg_am AS access_method ON access_method.oid = index_relation.relam
+		WHERE index_metadata.indexrelid = 'killswitch_prescription_versions_expiry_due_idx'::regclass
 	`).Scan(&indexColumns, &indexPredicate, &indexAccessMethod))
 	require.Equal(t, []string{"expires_at", "prescription_id", "version"}, indexColumns)
-	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND (expiry_event_recorded_at IS NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
 	require.Equal(t, "btree", indexAccessMethod)
+	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
 }
 
 func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {

--- a/server/internal/killswitches/types.go
+++ b/server/internal/killswitches/types.go
@@ -50,9 +50,10 @@ func (e *VersionConflictError) Unwrap() error { return ErrVersionConflict }
 
 // MutationContext contains trusted tenancy and actor data plus the organization-wide operation ID.
 type MutationContext struct {
-	OrganizationID OrganizationID
-	ActorUserID    string
-	OperationID    uuid.UUID
+	OrganizationID   OrganizationID
+	ActorUserID      string
+	ActorDisplayName string
+	OperationID      uuid.UUID
 }
 
 // DesiredVersionInput is the complete desired mutable payload for an active version. Both the raw
@@ -150,11 +151,12 @@ type LifecycleValidator interface {
 
 // MutationEvent is passed to the before-commit seam for later audit/outbox integration.
 type MutationEvent struct {
-	OrganizationID OrganizationID
-	ActorUserID    string
-	OperationID    uuid.UUID
-	Operation      MutationOperation
-	Result         MutationResult
+	OrganizationID   OrganizationID
+	ActorUserID      string
+	ActorDisplayName string
+	OperationID      uuid.UUID
+	Operation        MutationOperation
+	Result           MutationResult
 }
 
 // BeforeCommitHook may add audit and outbox writes to the lifecycle transaction, but cannot

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -38,6 +38,7 @@ var (
 	GcpKmsKeyV1                            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.gcp_kms_key_event_v1", "Emitted when changes to GCP KMS external keys are made")
 	JsonWebKeyV1                           = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.json_web_key_event_v1", "Emitted when changes to published JSON Web Keys are made")
 	JsonWebKeySetV1                        = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.json_web_key_set_event_v1", "Emitted when changes to JSON Web Key Sets are made")
+	KillswitchV1                           = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.killswitch_event_v1", "Emitted when killswitches are activated, changed, deactivated, or expire")
 	LiteLLMInstanceV1                      = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.litellm_instance_event_v1", "Emitted when changes to LiteLLM instances are made")
 	McpApprovalRequestV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.mcp_approval_request_event_v1", "Emitted when changes to MCP approval requests are made")
 	McpCollectionV1                        = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.mcp_collection_event_v1", "Emitted when changes to MCP collections are made")

--- a/server/internal/outbox/events/catalog_gen.go
+++ b/server/internal/outbox/events/catalog_gen.go
@@ -30,6 +30,7 @@ var All = []outbox.EventRegistration{
 	GcpKmsKeyV1,
 	JsonWebKeySetV1,
 	JsonWebKeyV1,
+	KillswitchV1,
 	LiteLLMInstanceV1,
 	McpApprovalRequestV1,
 	McpCollectionV1,

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1396,6 +1396,64 @@ webhooks:
                                 - subject_type
                             type: object
                 required: true
+    audit_log.killswitch_event_v1:
+        post:
+            description: Emitted when killswitches are activated, changed, deactivated, or expire
+            operationId: audit_log.killswitch_event_v1
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            additionalProperties: false
+                            properties:
+                                acting_client_id:
+                                    type: string
+                                acting_surface:
+                                    type: string
+                                action:
+                                    type: string
+                                actor_display_name:
+                                    type: string
+                                actor_id:
+                                    type: string
+                                actor_slug:
+                                    type: string
+                                actor_type:
+                                    type: string
+                                after_snapshot:
+                                    additionalProperties: true
+                                before_snapshot:
+                                    additionalProperties: true
+                                id:
+                                    format: uuid
+                                    type: string
+                                metadata:
+                                    additionalProperties: true
+                                organization_id:
+                                    type: string
+                                project_id:
+                                    format: uuid
+                                    type:
+                                        - string
+                                        - "null"
+                                subject_display_name:
+                                    type: string
+                                subject_id:
+                                    type: string
+                                subject_slug:
+                                    type: string
+                                subject_type:
+                                    type: string
+                            required:
+                                - id
+                                - organization_id
+                                - actor_id
+                                - actor_type
+                                - action
+                                - subject_id
+                                - subject_type
+                            type: object
+                required: true
     audit_log.litellm_instance_event_v1:
         post:
             description: Emitted when changes to LiteLLM instances are made

--- a/server/internal/urn/killswitch_prescription.go
+++ b/server/internal/urn/killswitch_prescription.go
@@ -1,0 +1,141 @@
+package urn
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const killswitchPrescriptionPrefix = "killswitch_prescription"
+
+type KillswitchPrescription struct {
+	ID uuid.UUID
+}
+
+func NewKillswitchPrescription(id uuid.UUID) KillswitchPrescription {
+	return KillswitchPrescription{ID: id}
+}
+
+func ParseKillswitchPrescription(value string) (KillswitchPrescription, error) {
+	if value == "" {
+		return KillswitchPrescription{}, fmt.Errorf("%w: empty string", ErrInvalid)
+	}
+
+	parts := strings.SplitN(value, delimiter, 2)
+	if len(parts) != 2 || parts[1] == "" || strings.Contains(parts[1], delimiter) {
+		return KillswitchPrescription{}, fmt.Errorf("%w: expected two segments (%s:<uuid>)", ErrInvalid, killswitchPrescriptionPrefix)
+	}
+	if parts[0] != killswitchPrescriptionPrefix {
+		truncated := parts[0][:min(maxSegmentLength, len(parts[0]))]
+		return KillswitchPrescription{}, fmt.Errorf("%w: expected %s urn (got: %q)", ErrInvalid, killswitchPrescriptionPrefix, truncated)
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return KillswitchPrescription{}, fmt.Errorf("%w: invalid killswitch prescription uuid", ErrInvalid)
+	}
+	if id == uuid.Nil {
+		return KillswitchPrescription{}, fmt.Errorf("%w: empty id", ErrInvalid)
+	}
+
+	return KillswitchPrescription{ID: id}, nil
+}
+
+func (u KillswitchPrescription) IsZero() bool {
+	return u.ID == uuid.Nil
+}
+
+func (u KillswitchPrescription) String() string {
+	return killswitchPrescriptionPrefix + delimiter + u.ID.String()
+}
+
+func (u KillswitchPrescription) validate() error {
+	if u.ID == uuid.Nil {
+		return fmt.Errorf("%w: empty id", ErrInvalid)
+	}
+	return nil
+}
+
+func (u KillswitchPrescription) MarshalJSON() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(u.String())
+	if err != nil {
+		return nil, fmt.Errorf("killswitch prescription urn to json: %w", err)
+	}
+
+	return b, nil
+}
+
+func (u *KillswitchPrescription) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("read killswitch prescription urn string from json: %w", err)
+	}
+
+	parsed, err := ParseKillswitchPrescription(s)
+	if err != nil {
+		return fmt.Errorf("parse killswitch prescription urn json string: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u *KillswitchPrescription) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("cannot scan %T into KillswitchPrescription", value)
+	}
+
+	parsed, err := ParseKillswitchPrescription(s)
+	if err != nil {
+		return fmt.Errorf("scan database value: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}
+
+func (u KillswitchPrescription) Value() (driver.Value, error) {
+	if err := u.validate(); err != nil {
+		return nil, err
+	}
+
+	return u.String(), nil
+}
+
+func (u KillswitchPrescription) MarshalText() ([]byte, error) {
+	if err := u.validate(); err != nil {
+		return nil, fmt.Errorf("marshal killswitch prescription urn text: %w", err)
+	}
+
+	return []byte(u.String()), nil
+}
+
+func (u *KillswitchPrescription) UnmarshalText(text []byte) error {
+	parsed, err := ParseKillswitchPrescription(string(text))
+	if err != nil {
+		return fmt.Errorf("unmarshal killswitch prescription urn text: %w", err)
+	}
+
+	*u = parsed
+
+	return nil
+}

--- a/server/internal/urn/killswitch_prescription_test.go
+++ b/server/internal/urn/killswitch_prescription_test.go
@@ -1,0 +1,64 @@
+package urn_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestKillswitchPrescriptionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("6b1e4d2a-8f4c-4b3e-9a51-0c9d2e7f1a23")
+	original := urn.NewKillswitchPrescription(id)
+	require.Equal(t, "killswitch_prescription:"+id.String(), original.String())
+
+	parsed, err := urn.ParseKillswitchPrescription(original.String())
+	require.NoError(t, err)
+	require.Equal(t, original, parsed)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.Equal(t, `"killswitch_prescription:`+id.String()+`"`, string(data))
+	var decoded urn.KillswitchPrescription
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, original, decoded)
+
+	text, err := original.MarshalText()
+	require.NoError(t, err)
+	var fromText urn.KillswitchPrescription
+	require.NoError(t, fromText.UnmarshalText(text))
+	require.Equal(t, original, fromText)
+
+	value, err := original.Value()
+	require.NoError(t, err)
+	var fromDB urn.KillswitchPrescription
+	require.NoError(t, fromDB.Scan(value))
+	require.Equal(t, original, fromDB)
+}
+
+func TestKillswitchPrescriptionRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{
+		"",
+		"killswitch_prescription",
+		"killswitch_prescription:",
+		"wrong:6b1e4d2a-8f4c-4b3e-9a51-0c9d2e7f1a23",
+		"killswitch_prescription:not-a-uuid",
+		"killswitch_prescription:00000000-0000-0000-0000-000000000000",
+		"killswitch_prescription:6b1e4d2a-8f4c-4b3e-9a51-0c9d2e7f1a23:extra",
+	} {
+		_, err := urn.ParseKillswitchPrescription(value)
+		require.ErrorIs(t, err, urn.ErrInvalid)
+	}
+
+	_, err := urn.NewKillswitchPrescription(uuid.Nil).MarshalJSON()
+	require.ErrorIs(t, err, urn.ErrInvalid)
+	_, err = urn.NewKillswitchPrescription(uuid.Nil).Value()
+	require.ErrorIs(t, err, urn.ErrInvalid)
+}

--- a/server/migrations/20260828181110_dno-978-killswitch-expiry-discovery-index.sql
+++ b/server/migrations/20260828181110_dno-978-killswitch-expiry-discovery-index.sql
@@ -1,4 +1,0 @@
--- atlas:txmode none
-
--- Create index "killswitch_prescription_versions_expiry_due_idx" to table: "killswitch_prescription_versions"
-CREATE INDEX CONCURRENTLY "killswitch_prescription_versions_expiry_due_idx" ON "killswitch_prescription_versions" ("expires_at", "prescription_id", "version") WHERE ((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)));

--- a/server/migrations/20260828181110_dno-978-killswitch-expiry-discovery-index.sql
+++ b/server/migrations/20260828181110_dno-978-killswitch-expiry-discovery-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "killswitch_prescription_versions_expiry_due_idx" to table: "killswitch_prescription_versions"
+CREATE INDEX CONCURRENTLY "killswitch_prescription_versions_expiry_due_idx" ON "killswitch_prescription_versions" ("expires_at", "prescription_id", "version") WHERE ((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)));

--- a/server/migrations/20260828190032_dno-978-killswitch-expiry-pending-index.sql
+++ b/server/migrations/20260828190032_dno-978-killswitch-expiry-pending-index.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "killswitch_prescription_versions" table
+ALTER TABLE "killswitch_prescription_versions" ADD COLUMN "expiry_event_recorded_at" timestamptz NULL;
+-- Create index "killswitch_prescription_versions_expiry_due_idx" to table: "killswitch_prescription_versions"
+CREATE INDEX CONCURRENTLY "killswitch_prescription_versions_expiry_due_idx" ON "killswitch_prescription_versions" ("expires_at", "prescription_id", "version") WHERE ((state = 'active'::text) AND (expires_at IS NOT NULL) AND (expiry_event_recorded_at IS NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)));

--- a/server/migrations/20260828190032_dno-978-killswitch-expiry-pending-index.sql
+++ b/server/migrations/20260828190032_dno-978-killswitch-expiry-pending-index.sql
@@ -1,6 +1,0 @@
--- atlas:txmode none
-
--- Modify "killswitch_prescription_versions" table
-ALTER TABLE "killswitch_prescription_versions" ADD COLUMN "expiry_event_recorded_at" timestamptz NULL;
--- Create index "killswitch_prescription_versions_expiry_due_idx" to table: "killswitch_prescription_versions"
-CREATE INDEX CONCURRENTLY "killswitch_prescription_versions_expiry_due_idx" ON "killswitch_prescription_versions" ("expires_at", "prescription_id", "version") WHERE ((state = 'active'::text) AND (expires_at IS NOT NULL) AND (expiry_event_recorded_at IS NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZULnNpKC6tJeSLOohYGzL+arYtf0CIHCYd1MkKWLXyg=
+h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -374,3 +374,4 @@ h1:ZULnNpKC6tJeSLOohYGzL+arYtf0CIHCYd1MkKWLXyg=
 20260828092510_data_exports_fanout.sql h1:qObwb6bsBowCBl4kdIM+xv+QuTDJ1velUTNWleNk5q8=
 20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=
 20260828145942_dno-974-durable-killswitch-prescriptions.sql h1:qPmCeNHQURcvp4RrbtPz9t+vs8iyLy0B5LPcEgO2ejY=
+20260828181110_dno-978-killswitch-expiry-discovery-index.sql h1:O4HoCdj2hCOhQHKbtzOJIza01sNlC+1mD+frDob19f8=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Sw67utG8T1MBIEek31p1IMk+1XGT5on9czDjn5XbfpI=
+h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -374,4 +374,4 @@ h1:Sw67utG8T1MBIEek31p1IMk+1XGT5on9czDjn5XbfpI=
 20260828092510_data_exports_fanout.sql h1:qObwb6bsBowCBl4kdIM+xv+QuTDJ1velUTNWleNk5q8=
 20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=
 20260828145942_dno-974-durable-killswitch-prescriptions.sql h1:qPmCeNHQURcvp4RrbtPz9t+vs8iyLy0B5LPcEgO2ejY=
-20260828190032_dno-978-killswitch-expiry-pending-index.sql h1:tJgNtInTZWYjbrhnqfV+h3xCj59V8Pq1zQmlQsIZAjA=
+20260828181110_dno-978-killswitch-expiry-discovery-index.sql h1:O4HoCdj2hCOhQHKbtzOJIza01sNlC+1mD+frDob19f8=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
+h1:Sw67utG8T1MBIEek31p1IMk+1XGT5on9czDjn5XbfpI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -374,4 +374,4 @@ h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
 20260828092510_data_exports_fanout.sql h1:qObwb6bsBowCBl4kdIM+xv+QuTDJ1velUTNWleNk5q8=
 20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=
 20260828145942_dno-974-durable-killswitch-prescriptions.sql h1:qPmCeNHQURcvp4RrbtPz9t+vs8iyLy0B5LPcEgO2ejY=
-20260828181110_dno-978-killswitch-expiry-discovery-index.sql h1:O4HoCdj2hCOhQHKbtzOJIza01sNlC+1mD+frDob19f8=
+20260828190032_dno-978-killswitch-expiry-pending-index.sql h1:tJgNtInTZWYjbrhnqfV+h3xCj59V8Pq1zQmlQsIZAjA=


### PR DESCRIPTION
## Summary

Adds durable audit and maintenance plumbing for killswitch lifecycle history. Lifecycle mutations can now enlist typed audit and outbox writes in their existing transaction, while a scheduled worker records version-specific expiry events and cleans expired operation receipts without becoming authoritative for enforcement.

## Technical details

### Expiry remains query-time authoritative

The maintenance sweep never changes prescription state. It revalidates due historical versions under lock, records one idempotent expiry marker per version, and emits audit history only when that marker is newly committed.

### Privileged maintenance stays bounded

Global expiry discovery and receipt cleanup use ordered, indexed batches with aggregate-only workflow inputs and outputs. Tenant-qualified mutation queries retain organization isolation after discovery.

Closes [DNO-978](https://linear.app/speakeasy/issue/DNO-978)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable audit history and a scheduled maintenance sweep for killswitch lifecycle so transitions are recorded without making the worker authoritative for enforcement.

- Lifecycle mutations (activate, change, deactivate) now write typed audit entries and outbox events in the same transaction as the state change.
- A scheduled sweep records one idempotent expiry event per expired version and cleans up expired operation receipts every 5 minutes.
- Query-time database state stays authoritative; the sweep never rewrites prescription state.
- Sweep inputs and outputs are batch sizes and aggregate counts only, so tenant data never enters Temporal history.
- Internal notes are deliberately excluded from audit rows and outbox payloads.
- Lifecycle mutations must now include the actor's display name.
- Adds a concurrent partial-index migration whose predicate is pinned to the expiry discovery eligibility filter so the sweep stays index-bound.

Closes DNO-978.

<sup>Written for commit 23775df27e89b9f4f03fbc82c8fe9879ac9e960b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

