### PR TITLE
feat: register authenticated-user and MCP-server killswitch adapters

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1062,6 +1062,7 @@ func newStartCommand() *cli.Command {
 				logger,
 				tracerProvider,
 				meterProvider,
+				db,
 				guardianPolicy,
 				authzEngine,
 				posthogClient,

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -313,7 +313,16 @@ const (
 	// McpSurfaceKey is the inbound MCP serving surface: "hosting" for the
 	// third-party-facing /mcp/{slug} and /x/mcp/{slug} paths (all backends), or
 	// "platform" for the assistant-token-only /platform/mcp/{toolsetSlug} path.
-	McpSurfaceKey                 = attribute.Key("gram.mcp.surface")
+	McpSurfaceKey = attribute.Key("gram.mcp.surface")
+	// McpKillswitchSurfaceKey is the kill-switch enforcement surface a covered
+	// MCP tools/call reached: "hosted" or "private_proxy".
+	McpKillswitchSurfaceKey = attribute.Key("gram.mcp.killswitch.surface")
+	// McpKillswitchIdentityClassKey is the bounded kill-switch identity
+	// coverage class of a covered MCP tools/call. Never a user identifier.
+	McpKillswitchIdentityClassKey = attribute.Key("gram.mcp.killswitch.identity_class")
+	// McpKillswitchResourceClassKey is the bounded kill-switch resource
+	// coverage class of a covered MCP tools/call. Never a server identifier.
+	McpKillswitchResourceClassKey = attribute.Key("gram.mcp.killswitch.resource_class")
 	McpRequestedTagsKey           = attribute.Key("gram.mcp.requested_tags")
 	McpToolsReturnedKey           = attribute.Key("gram.mcp.tools_returned")
 	McpToolsFilteredKey           = attribute.Key("gram.mcp.tools_filtered")
@@ -1995,6 +2004,18 @@ func SlogMcpMethod(v string) slog.Attr      { return slog.String(string(McpMetho
 
 func McpSurface(v string) attribute.KeyValue { return McpSurfaceKey.String(v) }
 func SlogMcpSurface(v string) slog.Attr      { return slog.String(string(McpSurfaceKey), v) }
+
+func McpKillswitchSurface[V ~string](v V) attribute.KeyValue {
+	return McpKillswitchSurfaceKey.String(string(v))
+}
+
+func McpKillswitchIdentityClass[V ~string](v V) attribute.KeyValue {
+	return McpKillswitchIdentityClassKey.String(string(v))
+}
+
+func McpKillswitchResourceClass[V ~string](v V) attribute.KeyValue {
+	return McpKillswitchResourceClassKey.String(string(v))
+}
 
 func MCPRequestedProtocolVersion(v string) attribute.KeyValue {
 	return McpRequestedProtocolVersionKey.String(v)

--- a/server/internal/killswitches/mcptoolexecution/adapters_test.go
+++ b/server/internal/killswitches/mcptoolexecution/adapters_test.go
@@ -1,0 +1,213 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+)
+
+func TestAuthenticatedUserAdapterDeriveCandidates(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_user_adapter")
+	adapter := NewAuthenticatedUserPrincipalAdapter(conn)
+	organization := killswitches.OrganizationID(orgID)
+
+	activeUser := "user_" + uuid.NewString()
+	insertUser(t, conn, activeUser, nil)
+	insertMembership(t, conn, orgID, activeUser, nil)
+
+	inactiveUser := "user_" + uuid.NewString()
+	removedAt := time.Now().UTC()
+	insertUser(t, conn, inactiveUser, nil)
+	insertMembership(t, conn, orgID, inactiveUser, &removedAt)
+
+	deletedUser := "user_" + uuid.NewString()
+	insertUser(t, conn, deletedUser, &removedAt)
+	insertMembership(t, conn, orgID, deletedUser, nil)
+
+	otherOrg := "org_" + uuid.NewString()
+	insertOrganization(t, conn, otherOrg)
+	crossOrgUser := "user_" + uuid.NewString()
+	insertUser(t, conn, crossOrgUser, nil)
+	insertMembership(t, conn, otherOrg, crossOrgUser, nil)
+
+	result, err := adapter.DeriveCandidates(t.Context(), organization, mcpidentity.AuthenticatedUser(activeUser))
+	require.NoError(t, err)
+	require.Equal(t, killswitches.PrincipalCandidateResultCandidates, result.Kind())
+	require.Equal(t, []killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(activeUser)}}, result.Candidates())
+
+	for name, userID := range map[string]string{
+		"inactive member":     inactiveUser,
+		"deleted user":        deletedUser,
+		"cross-tenant member": crossOrgUser,
+		"unknown user":        "user_" + uuid.NewString(),
+	} {
+		result, err := adapter.DeriveCandidates(t.Context(), organization, mcpidentity.AuthenticatedUser(userID))
+		require.NoError(t, err, name)
+		require.Equal(t, killswitches.PrincipalCandidateResultUnsupported, result.Kind(), name)
+		require.Empty(t, result.Candidates(), name)
+	}
+
+	for name, identity := range map[string]mcpidentity.Identity{
+		"anonymous":    {Kind: mcpidentity.KindAnonymous, UserID: ""},
+		"api key":      {Kind: mcpidentity.KindAPIKey, UserID: ""},
+		"assistant":    {Kind: mcpidentity.KindAssistant, UserID: ""},
+		"chat session": {Kind: mcpidentity.KindChatSession, UserID: ""},
+	} {
+		result, err := adapter.DeriveCandidates(t.Context(), organization, identity)
+		require.NoError(t, err, name)
+		require.Equal(t, killswitches.PrincipalCandidateResultUnsupported, result.Kind(), name)
+	}
+
+	// Values that merely name a user — caller strings, hollow or padded
+	// authoritative claims, unknown provenance — are never quietly promoted.
+	_, err = adapter.DeriveCandidates(t.Context(), organization, activeUser)
+	require.Error(t, err)
+	_, err = adapter.DeriveCandidates(t.Context(), organization, mcpidentity.AuthenticatedUser(""))
+	require.Error(t, err)
+	_, err = adapter.DeriveCandidates(t.Context(), organization, mcpidentity.AuthenticatedUser(" "+activeUser))
+	require.Error(t, err)
+	_, err = adapter.DeriveCandidates(t.Context(), organization, mcpidentity.Identity{Kind: "device", UserID: "user_x"})
+	require.Error(t, err)
+	_, err = adapter.DeriveCandidates(t.Context(), "", mcpidentity.AuthenticatedUser(activeUser))
+	require.Error(t, err)
+
+	// A membership lookup failure is an infrastructure error, never an
+	// unsupported classification and never a candidate.
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = adapter.DeriveCandidates(canceled, organization, mcpidentity.AuthenticatedUser(activeUser))
+	require.Error(t, err)
+}
+
+func TestAuthenticatedUserAdapterValidateCurrentOrganization(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_user_validate")
+	adapter := NewAuthenticatedUserPrincipalAdapter(conn)
+	organization := killswitches.OrganizationID(orgID)
+
+	activeUser := "user_" + uuid.NewString()
+	insertUser(t, conn, activeUser, nil)
+	insertMembership(t, conn, orgID, activeUser, nil)
+
+	valid, err := adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.PrincipalKey(activeUser))
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	valid, err = adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.PrincipalKey("user_"+uuid.NewString()))
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	valid, err = adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.PrincipalKey(" malformed "))
+	require.NoError(t, err)
+	require.False(t, valid)
+}
+
+func TestMCPServerAdapterDerive(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_server_adapter")
+	adapter := NewMCPServerResourceAdapter(conn)
+	organization := killswitches.OrganizationID(orgID)
+
+	project := insertProject(t, conn, orgID, "proj-live", nil)
+	liveServer := insertMCPServer(t, conn, orgID, project, nil)
+
+	deletedAt := time.Now().UTC()
+	deletedServer := insertMCPServer(t, conn, orgID, project, &deletedAt)
+
+	deletedProject := insertProject(t, conn, orgID, "proj-deleted", &deletedAt)
+	orphanedServer := insertMCPServer(t, conn, orgID, deletedProject, nil)
+
+	otherOrg := "org_" + uuid.NewString()
+	insertOrganization(t, conn, otherOrg)
+	otherProject := insertProject(t, conn, otherOrg, "proj-other", nil)
+	crossTenantServer := insertMCPServer(t, conn, otherOrg, otherProject, nil)
+
+	result, err := adapter.Derive(t.Context(), organization, ServerSource{FrontingServerID: uuid.NullUUID{UUID: liveServer, Valid: true}})
+	require.NoError(t, err)
+	key, supported, err := result.Key()
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Equal(t, killswitches.ResourceKey(liveServer.String()), key)
+
+	// The runtime-derived key and the management-time canonicalized key must
+	// agree: hosted and private routes carry the same fronting server ID, so
+	// both produce one canonical resource identity.
+	canonical, err := adapter.Canonicalize(organization, liveServer.String())
+	require.NoError(t, err)
+	canonicalKey, supported, err := canonical.Key()
+	require.NoError(t, err)
+	require.True(t, supported)
+	require.Equal(t, key, canonicalKey)
+
+	canonical, err = adapter.Canonicalize(organization, uuid.Nil.String())
+	require.NoError(t, err)
+	_, supported, err = canonical.Key()
+	require.NoError(t, err)
+	require.False(t, supported, "the nil UUID can never name a live server")
+
+	// A serving mode with no fronting server is deliberately unsupported.
+	result, err = adapter.Derive(t.Context(), organization, ServerSource{FrontingServerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}})
+	require.NoError(t, err)
+	_, supported, err = result.Key()
+	require.NoError(t, err)
+	require.False(t, supported)
+
+	// Stale or foreign servers are ownership failures, never unsupported and
+	// never a key.
+	for name, serverID := range map[string]uuid.UUID{
+		"cross-tenant server":       crossTenantServer,
+		"deleted server":            deletedServer,
+		"server in deleted project": orphanedServer,
+		"unknown server":            uuid.New(),
+	} {
+		_, err := adapter.Derive(t.Context(), organization, ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}})
+		require.ErrorIs(t, err, ErrServerNotInOrganization, name)
+	}
+
+	// Caller-provided identifiers never reach ownership validation.
+	_, err = adapter.Derive(t.Context(), organization, liveServer.String())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrServerNotInOrganization)
+
+	_, err = adapter.Derive(t.Context(), "", ServerSource{FrontingServerID: uuid.NullUUID{UUID: liveServer, Valid: true}})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrServerNotInOrganization)
+
+	// A lookup failure stays an infrastructure error distinct from an
+	// ownership rejection.
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = adapter.Derive(canceled, organization, ServerSource{FrontingServerID: uuid.NullUUID{UUID: liveServer, Valid: true}})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrServerNotInOrganization)
+}
+
+func TestMCPServerAdapterValidateCurrentOrganization(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_server_validate")
+	adapter := NewMCPServerResourceAdapter(conn)
+	organization := killswitches.OrganizationID(orgID)
+
+	project := insertProject(t, conn, orgID, "proj-validate", nil)
+	liveServer := insertMCPServer(t, conn, orgID, project, nil)
+
+	valid, err := adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.ResourceKey(liveServer.String()))
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	valid, err = adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.ResourceKey(uuid.NewString()))
+	require.NoError(t, err)
+	require.False(t, valid)
+
+	// Stored canonical keys are lowercase; a non-canonical key is not current.
+	valid, err = adapter.ValidateCurrentOrganization(t.Context(), organization, killswitches.ResourceKey("not-a-uuid"))
+	require.NoError(t, err)
+	require.False(t, valid)
+}

--- a/server/internal/killswitches/mcptoolexecution/classify.go
+++ b/server/internal/killswitches/mcptoolexecution/classify.go
@@ -1,0 +1,69 @@
+package mcptoolexecution
+
+import (
+	"errors"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+)
+
+// ClassifyPrincipalCoverage maps one covered call's principal derivation onto
+// the bounded identity-coverage classes. Inputs are the source handed to
+// DeriveCandidates and its outcome; the class carries no identifier, so it is
+// safe as a metric dimension. Unsupported identity stays visibly classified
+// by provenance kind rather than disappearing into an unmatched bucket.
+func ClassifyPrincipalCoverage(source any, result killswitches.PrincipalCandidateResult, err error) mcpmetrics.KillswitchIdentityClass {
+	if err != nil {
+		return mcpmetrics.KillswitchIdentityUnavailable
+	}
+	identity, ok := source.(mcpidentity.Identity)
+	if !ok {
+		return mcpmetrics.KillswitchIdentityUnattributed
+	}
+	if result.Kind() == killswitches.PrincipalCandidateResultCandidates {
+		return mcpmetrics.KillswitchIdentityActiveUser
+	}
+	switch identity.Kind {
+	case mcpidentity.KindUserSession:
+		return mcpmetrics.KillswitchIdentityInactiveUser
+	case mcpidentity.KindAnonymous:
+		return mcpmetrics.KillswitchIdentityAnonymous
+	case mcpidentity.KindAPIKey:
+		return mcpmetrics.KillswitchIdentityAPIKey
+	case mcpidentity.KindAssistant:
+		return mcpmetrics.KillswitchIdentityAssistant
+	case mcpidentity.KindChatSession:
+		return mcpmetrics.KillswitchIdentityChatSession
+	default:
+		return mcpmetrics.KillswitchIdentityUnattributed
+	}
+}
+
+// ClassifyResourceCoverage maps one covered call's resource derivation onto
+// the bounded resource-coverage classes. Ownership rejections classify as
+// invalid_owner, other failures as unavailable; neither carries an
+// identifier or error text.
+func ClassifyResourceCoverage(source any, result killswitches.CanonicalizationResult[killswitches.ResourceKey], err error) mcpmetrics.KillswitchResourceClass {
+	if errors.Is(err, ErrServerNotInOrganization) {
+		return mcpmetrics.KillswitchResourceInvalidOwner
+	}
+	if err != nil {
+		return mcpmetrics.KillswitchResourceUnavailable
+	}
+	src, ok := source.(ServerSource)
+	if !ok {
+		return mcpmetrics.KillswitchResourceUnsupportedSurface
+	}
+	_, supported, keyErr := result.Key()
+	if keyErr != nil {
+		return mcpmetrics.KillswitchResourceUnavailable
+	}
+	if supported {
+		return mcpmetrics.KillswitchResourceCanonicalServer
+	}
+	if !src.FrontingServerID.Valid {
+		return mcpmetrics.KillswitchResourceLegacyNoServer
+	}
+	return mcpmetrics.KillswitchResourceUnsupportedSurface
+}

--- a/server/internal/killswitches/mcptoolexecution/classify_test.go
+++ b/server/internal/killswitches/mcptoolexecution/classify_test.go
@@ -1,0 +1,87 @@
+package mcptoolexecution
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+)
+
+// TestClassifyIdentityCoverage pins the bounded mapping from derivation
+// outcomes to identity coverage classes. No branch may surface an identifier
+// or fold unsupported identity into a success-looking class.
+func TestClassifyIdentityCoverage(t *testing.T) {
+	t.Parallel()
+
+	candidates, err := killswitches.NewPrincipalCandidateResult([]killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: "user_01J8EXAMPLE"}})
+	require.NoError(t, err)
+	unsupported := killswitches.UnsupportedPrincipalCandidateResult()
+	zero := killswitches.PrincipalCandidateResult{}
+
+	tests := []struct {
+		name   string
+		source any
+		result killswitches.PrincipalCandidateResult
+		err    error
+		want   mcpmetrics.KillswitchIdentityClass
+	}{
+		{name: "active user", source: mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"), result: candidates, err: nil, want: mcpmetrics.KillswitchIdentityActiveUser},
+		{name: "inactive user", source: mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityInactiveUser},
+		{name: "anonymous", source: mcpidentity.Identity{Kind: mcpidentity.KindAnonymous, UserID: ""}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAnonymous},
+		{name: "api key", source: mcpidentity.Identity{Kind: mcpidentity.KindAPIKey, UserID: ""}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAPIKey},
+		{name: "assistant", source: mcpidentity.Identity{Kind: mcpidentity.KindAssistant, UserID: ""}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAssistant},
+		{name: "chat session", source: mcpidentity.Identity{Kind: mcpidentity.KindChatSession, UserID: ""}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityChatSession},
+		{name: "no provenance", source: nil, result: zero, err: nil, want: mcpmetrics.KillswitchIdentityUnattributed},
+		{name: "unknown provenance kind", source: mcpidentity.Identity{Kind: "device", UserID: ""}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityUnattributed},
+		{name: "infrastructure failure", source: mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"), result: zero, err: fmt.Errorf("membership lookup: %w", errors.New("closed")), want: mcpmetrics.KillswitchIdentityUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, ClassifyPrincipalCoverage(tt.source, tt.result, tt.err))
+		})
+	}
+}
+
+// TestClassifyResourceCoverage pins the bounded mapping from resource
+// derivation outcomes to resource coverage classes, keeping ownership
+// rejections distinct from availability failures.
+func TestClassifyResourceCoverage(t *testing.T) {
+	t.Parallel()
+
+	serverID := uuid.MustParse("0198a1b2-c3d4-7000-8000-0123456789ab")
+	canonical, err := killswitches.NewCanonicalizationResult(killswitches.ResourceKey(serverID.String()))
+	require.NoError(t, err)
+	unsupported := killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey]()
+	zero := killswitches.CanonicalizationResult[killswitches.ResourceKey]{}
+	fronting := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
+	noServer := ServerSource{FrontingServerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}}
+
+	tests := []struct {
+		name   string
+		source any
+		result killswitches.CanonicalizationResult[killswitches.ResourceKey]
+		err    error
+		want   mcpmetrics.KillswitchResourceClass
+	}{
+		{name: "canonical server", source: fronting, result: canonical, err: nil, want: mcpmetrics.KillswitchResourceCanonicalServer},
+		{name: "legacy no server", source: noServer, result: unsupported, err: nil, want: mcpmetrics.KillswitchResourceLegacyNoServer},
+		{name: "unsupported surface", source: nil, result: zero, err: nil, want: mcpmetrics.KillswitchResourceUnsupportedSurface},
+		{name: "invalid owner", source: fronting, result: zero, err: fmt.Errorf("derive: %w", ErrServerNotInOrganization), want: mcpmetrics.KillswitchResourceInvalidOwner},
+		{name: "infrastructure failure", source: fronting, result: zero, err: errors.New("connection refused"), want: mcpmetrics.KillswitchResourceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, ClassifyResourceCoverage(tt.source, tt.result, tt.err))
+		})
+	}
+}

--- a/server/internal/killswitches/mcptoolexecution/coverage.go
+++ b/server/internal/killswitches/mcptoolexecution/coverage.go
@@ -1,0 +1,66 @@
+package mcptoolexecution
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+)
+
+// IdentityCoverageRecorder is implemented by each production MCP metric scope.
+type IdentityCoverageRecorder interface {
+	RecordKillswitchIdentityCoverage(context.Context, mcpmetrics.KillswitchCoverageSurface, mcpmetrics.KillswitchIdentityClass, mcpmetrics.KillswitchResourceClass)
+}
+
+// IdentityCoverageCheckpoint derives and records the bounded identity and
+// resource coverage of each tools/call that reaches a covered MCP surface.
+// Derivation deliberately runs on every call so membership and live server
+// ownership cannot become stale. Metrics are observational and never reject a
+// call; enforcement is owned by the separately registered checkpoints.
+type IdentityCoverageCheckpoint struct {
+	principal *AuthenticatedUserPrincipalAdapter
+	resource  *MCPServerResourceAdapter
+	recorder  IdentityCoverageRecorder
+}
+
+// NewIdentityCoverageCheckpoint wires the production adapters to an MCP
+// metric scope. A nil database or recorder produces a disabled checkpoint.
+func NewIdentityCoverageCheckpoint(db *pgxpool.Pool, recorder IdentityCoverageRecorder) *IdentityCoverageCheckpoint {
+	if db == nil || recorder == nil {
+		return nil
+	}
+	return &IdentityCoverageCheckpoint{
+		principal: NewAuthenticatedUserPrincipalAdapter(db),
+		resource:  NewMCPServerResourceAdapter(db),
+		recorder:  recorder,
+	}
+}
+
+// Record observes one covered tools/call using only credential provenance
+// stamped by successful authentication and the fronting server resolved from
+// the live route. Unstamped requests never enter principal derivation.
+func (c *IdentityCoverageCheckpoint) Record(ctx context.Context, organizationID string, surface mcpmetrics.KillswitchCoverageSurface, resourceSource ServerSource) {
+	if c == nil {
+		return
+	}
+
+	organization := killswitches.OrganizationID(organizationID)
+	principalResult := killswitches.UnsupportedPrincipalCandidateResult()
+	var principalSource any
+	var principalErr error
+	if identity, ok := mcpidentity.FromContext(ctx); ok {
+		principalSource = identity
+		principalResult, principalErr = c.principal.DeriveCandidates(ctx, organization, identity)
+	}
+
+	resourceResult, resourceErr := c.resource.Derive(ctx, organization, resourceSource)
+	c.recorder.RecordKillswitchIdentityCoverage(
+		ctx,
+		surface,
+		ClassifyPrincipalCoverage(principalSource, principalResult, principalErr),
+		ClassifyResourceCoverage(resourceSource, resourceResult, resourceErr),
+	)
+}

--- a/server/internal/killswitches/mcptoolexecution/coverage_test.go
+++ b/server/internal/killswitches/mcptoolexecution/coverage_test.go
@@ -1,0 +1,101 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+type coverageObservation struct {
+	surface  mcpmetrics.KillswitchCoverageSurface
+	identity mcpmetrics.KillswitchIdentityClass
+	resource mcpmetrics.KillswitchResourceClass
+}
+
+type coverageRecorder struct {
+	observations []coverageObservation
+}
+
+func (r *coverageRecorder) RecordKillswitchIdentityCoverage(_ context.Context, surface mcpmetrics.KillswitchCoverageSurface, identity mcpmetrics.KillswitchIdentityClass, resource mcpmetrics.KillswitchResourceClass) {
+	r.observations = append(r.observations, coverageObservation{surface: surface, identity: identity, resource: resource})
+}
+
+func TestIdentityCoverageCheckpoint_RevalidatesEachCall(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_coverage_checkpoint")
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "coverage-"+uuid.NewString()[:8], nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+
+	recorder := &coverageRecorder{}
+	checkpoint := NewIdentityCoverageCheckpoint(conn, recorder)
+	ctx := mcpidentity.WithIdentity(t.Context(), mcpidentity.AuthenticatedUser(userID))
+	source := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
+
+	checkpoint.Record(ctx, orgID, mcpmetrics.KillswitchSurfaceHosted, source)
+	require.Equal(t, coverageObservation{
+		surface:  mcpmetrics.KillswitchSurfaceHosted,
+		identity: mcpmetrics.KillswitchIdentityActiveUser,
+		resource: mcpmetrics.KillswitchResourceCanonicalServer,
+	}, recorder.observations[0])
+
+	require.NoError(t, testrepo.New(conn).ForceSoftDeleteOrganizationUserRelationship(t.Context(), testrepo.ForceSoftDeleteOrganizationUserRelationshipParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userID),
+	}))
+	_, err := mcpserversrepo.New(conn).DeleteMCPServer(t.Context(), mcpserversrepo.DeleteMCPServerParams{
+		ID:        serverID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	checkpoint.Record(ctx, orgID, mcpmetrics.KillswitchSurfaceHosted, source)
+	require.Equal(t, coverageObservation{
+		surface:  mcpmetrics.KillswitchSurfaceHosted,
+		identity: mcpmetrics.KillswitchIdentityInactiveUser,
+		resource: mcpmetrics.KillswitchResourceInvalidOwner,
+	}, recorder.observations[1])
+}
+
+func TestIdentityCoverageCheckpoint_UsesOnlyStampedProvenance(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_coverage_provenance")
+	projectID := insertProject(t, conn, orgID, "coverage-"+uuid.NewString()[:8], nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	source := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
+	recorder := &coverageRecorder{}
+	checkpoint := NewIdentityCoverageCheckpoint(conn, recorder)
+
+	checkpoint.Record(t.Context(), orgID, mcpmetrics.KillswitchSurfacePrivateProxy, source)
+	checkpoint.Record(
+		mcpidentity.WithIdentity(t.Context(), mcpidentity.Identity{Kind: mcpidentity.KindAnonymous}),
+		orgID,
+		mcpmetrics.KillswitchSurfacePrivateProxy,
+		source,
+	)
+	checkpoint.Record(
+		mcpidentity.WithIdentity(t.Context(), mcpidentity.Identity{Kind: mcpidentity.KindAPIKey}),
+		orgID,
+		mcpmetrics.KillswitchSurfacePrivateProxy,
+		source,
+	)
+
+	require.Equal(t, mcpmetrics.KillswitchIdentityUnattributed, recorder.observations[0].identity)
+	require.Equal(t, mcpmetrics.KillswitchIdentityAnonymous, recorder.observations[1].identity)
+	require.Equal(t, mcpmetrics.KillswitchIdentityAPIKey, recorder.observations[2].identity)
+	for _, observation := range recorder.observations {
+		require.Equal(t, mcpmetrics.KillswitchResourceCanonicalServer, observation.resource)
+	}
+}

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -1,0 +1,128 @@
+package mcptoolexecution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// TestMCPToolExecutionEvaluationAcrossProjects proves the end-to-end
+// adapter-to-evaluator slice with real database state: authoritative
+// candidates from provenance, canonical server keys from fronting IDs, and
+// selected-one, selected-many (cross-project), and dynamic all-server
+// matching — including a server created after the all-server activation,
+// without materializing the organization's server list.
+func TestMCPToolExecutionEvaluationAcrossProjects(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_mcp_evaluation")
+	organization := killswitches.OrganizationID(orgID)
+
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	evaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
+	require.NoError(t, err)
+
+	pausedUser := "user_" + uuid.NewString()
+	insertUser(t, conn, pausedUser, nil)
+	insertMembership(t, conn, orgID, pausedUser, nil)
+	freeUser := "user_" + uuid.NewString()
+	insertUser(t, conn, freeUser, nil)
+	insertMembership(t, conn, orgID, freeUser, nil)
+
+	projectOne := insertProject(t, conn, orgID, "proj-one", nil)
+	projectTwo := insertProject(t, conn, orgID, "proj-two", nil)
+	serverA := insertMCPServer(t, conn, orgID, projectOne, nil)
+	serverB := insertMCPServer(t, conn, orgID, projectTwo, nil)
+
+	principalAdapter, ok := registry.PrincipalAdapter(PrincipalKindUser)
+	require.True(t, ok)
+	resourceAdapter, ok := registry.ResourceAdapter(ResourceKindMCPServer)
+	require.True(t, ok)
+
+	evaluate := func(t *testing.T, userID string, serverID uuid.UUID) killswitches.EvaluationResult {
+		t.Helper()
+		candidates, err := principalAdapter.DeriveCandidates(t.Context(), organization, mcpidentity.AuthenticatedUser(userID))
+		require.NoError(t, err)
+		require.Equal(t, killswitches.PrincipalCandidateResultCandidates, candidates.Kind())
+		resource, err := resourceAdapter.Derive(t.Context(), organization, ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}})
+		require.NoError(t, err)
+		key, supported, err := resource.Key()
+		require.NoError(t, err)
+		require.True(t, supported)
+		return evaluator.Evaluate(t.Context(), killswitches.EvaluationRequest{
+			OrganizationID:      organization,
+			DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution},
+			PrincipalCandidates: candidates.Candidates(),
+			ResourceKind:        ResourceKindMCPServer,
+			ResourceKey:         key,
+		})
+	}
+	requireMatch := func(t *testing.T, result killswitches.EvaluationResult, note string) {
+		t.Helper()
+		require.Equal(t, killswitches.EvaluationResultMatch, result.Kind())
+		gotNote, ok := result.ExternalNote()
+		require.True(t, ok)
+		require.Equal(t, note, gotNote)
+	}
+	requireNoMatch := func(t *testing.T, result killswitches.EvaluationResult) {
+		t.Helper()
+		require.Equal(t, killswitches.EvaluationResultNoMatch, result.Kind())
+		reason, ok := result.NoMatchReason()
+		require.True(t, ok)
+		require.Equal(t, killswitches.NoMatchReasonNoPrescription, reason)
+	}
+
+	// No prescriptions yet: everything proceeds.
+	requireNoMatch(t, evaluate(t, pausedUser, serverA))
+
+	// Selected-one: only the selected server is blocked, only for the
+	// prescribed user.
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           uuid.New(),
+		PrincipalKey: pausedUser,
+		Scope:        "selected",
+		Resources:    []string{serverA.String()},
+		ExternalNote: "Server A paused.",
+	})
+	requireMatch(t, evaluate(t, pausedUser, serverA), "Server A paused.")
+	requireNoMatch(t, evaluate(t, pausedUser, serverB))
+	requireNoMatch(t, evaluate(t, freeUser, serverA))
+
+	// Selected-many across projects: one prescription can select servers
+	// living in different projects of the same organization.
+	manyID := uuid.New()
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           manyID,
+		PrincipalKey: pausedUser,
+		Scope:        "selected",
+		Resources:    []string{serverA.String(), serverB.String()},
+		ExternalNote: "Both servers paused.",
+	})
+	requireMatch(t, evaluate(t, pausedUser, serverB), "Both servers paused.")
+	requireNoMatch(t, evaluate(t, freeUser, serverB))
+
+	// Dynamic all-server scope covers a server created after activation: the
+	// evaluator matches by scope, not by a materialized server list.
+	clearPrescriptions(t, conn, orgID)
+
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           uuid.New(),
+		PrincipalKey: pausedUser,
+		Scope:        "all",
+		Resources:    nil,
+		ExternalNote: "All servers paused.",
+	})
+	requireMatch(t, evaluate(t, pausedUser, serverA), "All servers paused.")
+	requireMatch(t, evaluate(t, pausedUser, serverB), "All servers paused.")
+
+	projectThree := insertProject(t, conn, orgID, "proj-three", nil)
+	serverC := insertMCPServer(t, conn, orgID, projectThree, nil)
+	requireMatch(t, evaluate(t, pausedUser, serverC), "All servers paused.")
+	requireNoMatch(t, evaluate(t, freeUser, serverC))
+}

--- a/server/internal/killswitches/mcptoolexecution/principal.go
+++ b/server/internal/killswitches/mcptoolexecution/principal.go
@@ -1,0 +1,139 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+// maxUserKeyRunes bounds canonical user keys; users.id is unbounded TEXT and
+// stored kill-switch keys must stay bounded.
+const maxUserKeyRunes = 512
+
+// AuthenticatedUserPrincipalAdapter canonicalizes concrete Gram user
+// principals and derives candidates only from authoritative user-session
+// provenance. Membership is revalidated against the organization on every
+// derivation and is never cached, so a removed member stops producing
+// candidates on their next call.
+type AuthenticatedUserPrincipalAdapter struct {
+	db *pgxpool.Pool
+}
+
+// NewAuthenticatedUserPrincipalAdapter builds the concrete-user principal
+// adapter.
+func NewAuthenticatedUserPrincipalAdapter(db *pgxpool.Pool) *AuthenticatedUserPrincipalAdapter {
+	return &AuthenticatedUserPrincipalAdapter{db: db}
+}
+
+var _ killswitches.PrincipalAdapter = (*AuthenticatedUserPrincipalAdapter)(nil)
+
+// Kind returns the concrete user principal namespace.
+func (a *AuthenticatedUserPrincipalAdapter) Kind() killswitches.PrincipalKind {
+	return PrincipalKindUser
+}
+
+// Canonicalize trims surrounding whitespace and accepts the user ID verbatim.
+// IDs are opaque and case-sensitive, so no folding is applied. Input that can
+// never name a user — empty, control characters, embedded whitespace edges,
+// or unbounded length — is deliberately unsupported, not an error.
+func (a *AuthenticatedUserPrincipalAdapter) Canonicalize(_ killswitches.OrganizationID, input string) (killswitches.CanonicalizationResult[killswitches.PrincipalKey], error) {
+	key, ok := canonicalUserKey(input)
+	if !ok {
+		return killswitches.UnsupportedCanonicalizationResult[killswitches.PrincipalKey](), nil
+	}
+	result, err := killswitches.NewCanonicalizationResult(key)
+	if err != nil {
+		return killswitches.CanonicalizationResult[killswitches.PrincipalKey]{}, fmt.Errorf("canonicalize user key: %w", err)
+	}
+	return result, nil
+}
+
+// ValidateCurrentOrganization reports whether the key names a non-deleted
+// user with an active membership in the organization. A malformed key is not
+// current; only query failures are errors.
+func (a *AuthenticatedUserPrincipalAdapter) ValidateCurrentOrganization(ctx context.Context, organizationID killswitches.OrganizationID, key killswitches.PrincipalKey) (bool, error) {
+	canonical, ok := canonicalUserKey(string(key))
+	if !ok || canonical != key || organizationID == "" {
+		return false, nil
+	}
+	member, err := orgrepo.New(a.db).HasActiveOrganizationUser(ctx, orgrepo.HasActiveOrganizationUserParams{
+		UserID:         string(key),
+		OrganizationID: string(organizationID),
+	})
+	if err != nil {
+		return false, fmt.Errorf("check active organization membership: %w", err)
+	}
+	return member, nil
+}
+
+// DeriveCandidates accepts only mcpidentity.Identity provenance stamped by a
+// serving surface after credential validation. Checkpoints call it only when
+// mcpidentity.FromContext returns ok: unstamped traffic is classified
+// unattributed at the checkpoint and never reaches derivation — that skip is
+// the authoritative unsupported/no-candidate outcome for such traffic, not a
+// failure. Any non-Identity source here is therefore a checkpoint wiring bug
+// and errors.
+//
+// Only KindUserSession claims an authoritative acting user; that claim is
+// then revalidated as an active organization membership before producing the
+// single concrete candidate. Anonymous, API-key, assistant, and chat-session
+// provenance are deliberately unsupported. A stamped identity with a zero or
+// unknown kind, a malformed authoritative claim, or a membership lookup
+// failure is an error and follows the definition's fail-closed policy.
+func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
+	identity, ok := source.(mcpidentity.Identity)
+	if !ok {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unsupported principal source type %T", source)
+	}
+	if organizationID == "" {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("organization ID is required")
+	}
+
+	switch identity.Kind {
+	case mcpidentity.KindUserSession:
+		key, canonical := canonicalUserKey(identity.UserID)
+		if !canonical || string(key) != identity.UserID {
+			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("authoritative user provenance carries a non-canonical user ID")
+		}
+		member, err := a.ValidateCurrentOrganization(ctx, organizationID, key)
+		if err != nil {
+			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("revalidate active organization membership: %w", err)
+		}
+		if !member {
+			return killswitches.UnsupportedPrincipalCandidateResult(), nil
+		}
+		result, err := killswitches.NewPrincipalCandidateResult([]killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: key}})
+		if err != nil {
+			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
+		}
+		return result, nil
+	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindChatSession:
+		return killswitches.UnsupportedPrincipalCandidateResult(), nil
+	default:
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unknown identity provenance kind %q", identity.Kind)
+	}
+}
+
+func canonicalUserKey(input string) (killswitches.PrincipalKey, bool) {
+	if !utf8.ValidString(input) {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" || utf8.RuneCountInString(trimmed) > maxUserKeyRunes {
+		return "", false
+	}
+	for _, r := range trimmed {
+		if unicode.IsControl(r) {
+			return "", false
+		}
+	}
+	return killswitches.PrincipalKey(trimmed), true
+}

--- a/server/internal/killswitches/mcptoolexecution/registration.go
+++ b/server/internal/killswitches/mcptoolexecution/registration.go
@@ -1,0 +1,207 @@
+// Package mcptoolexecution registers the M2 `mcp_tool_execution` kill-switch
+// contracts: the fail-closed definition, the authoritative concrete-user
+// principal adapter, the canonical organization-owned `mcp_server` resource
+// adapter, and the coverage inventory for the hosted and private-proxy MCP
+// tools/call surfaces.
+//
+// Registration declares the contracts only. It does not deploy enforcement:
+// the hosted dispatch checkpoint (DNO-982) and the private forwarding
+// checkpoint (DNO-980) ship separately, and production prescriptions must not
+// be enabled before those checkpoints have reached the fleet.
+package mcptoolexecution
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+const (
+	// DefinitionKeyMCPToolExecution is the M2 capability governing MCP
+	// tools/call execution.
+	DefinitionKeyMCPToolExecution killswitches.DefinitionKey = "mcp_tool_execution"
+
+	// PrincipalKindUser is the concrete Gram user principal namespace; keys
+	// are user IDs of authoritative active organization members.
+	PrincipalKindUser killswitches.PrincipalKind = "user"
+
+	// ResourceKindMCPServer is the canonical MCP server resource namespace;
+	// keys are fronting mcp_servers row IDs.
+	ResourceKindMCPServer killswitches.ResourceKind = "mcp_server"
+
+	// IdentityContractKeyAuthenticatedUserMCPServer pairs the authoritative
+	// user principal with the canonical mcp_server resource.
+	IdentityContractKeyAuthenticatedUserMCPServer killswitches.IdentityContractKey = "authenticated_user_mcp_server"
+
+	// SurfaceHostedToolsCall is hosted MCP tools/call dispatch.
+	SurfaceHostedToolsCall killswitches.Surface = "mcp_hosted_tools_call"
+
+	// SurfacePrivateProxyToolsCall is private proxied or remote MCP
+	// tools/call forwarding.
+	SurfacePrivateProxyToolsCall killswitches.Surface = "mcp_private_proxy_tools_call"
+
+	// TransportAdapterHostedJSONRPC keys the hosted JSON-RPC transport
+	// mapping owned by the hosted dispatch checkpoint.
+	TransportAdapterHostedJSONRPC killswitches.TransportAdapterKey = "mcp_hosted_jsonrpc"
+
+	// TransportAdapterPrivateProxyJSONRPC keys the private-proxy JSON-RPC
+	// transport mapping owned by the forwarding checkpoint.
+	TransportAdapterPrivateProxyJSONRPC killswitches.TransportAdapterKey = "mcp_private_proxy_jsonrpc"
+
+	// DefaultExternalNote is the editable customer-safe starting value for
+	// new prescriptions. It never leaks framework vocabulary.
+	DefaultExternalNote = "MCP tool calls are currently paused by your organization's administrator."
+
+	// EnforcementOwner is the team accountable for the enforcement
+	// checkpoints of this definition.
+	EnforcementOwner = "devices-observability"
+)
+
+// NewRegistration assembles the complete code-owned mcp_tool_execution
+// registration. The database is used by the adapters at evaluation and
+// validation time only; fixture validation during registry construction is
+// pure.
+func NewRegistration(db *pgxpool.Pool) killswitches.Registration {
+	return killswitches.Registration{
+		Definitions: []killswitches.Definition{{
+			Key:                 DefinitionKeyMCPToolExecution,
+			PrincipalKinds:      []killswitches.PrincipalKind{PrincipalKindUser},
+			ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer},
+			FailurePolicy:       killswitches.FailurePolicyFailClosed,
+			DefaultExternalNote: DefaultExternalNote,
+			EnforcementOwner:    EnforcementOwner,
+			IdentityContract:    IdentityContractKeyAuthenticatedUserMCPServer,
+			Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall},
+			TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC},
+		}},
+		IdentityContracts: []killswitches.IdentityContract{{
+			Key:            IdentityContractKeyAuthenticatedUserMCPServer,
+			PrincipalKinds: []killswitches.PrincipalKind{PrincipalKindUser},
+			ResourceKinds:  []killswitches.ResourceKind{ResourceKindMCPServer},
+		}},
+		PrincipalAdapters: []killswitches.PrincipalAdapterRegistration{{
+			Adapter:  NewAuthenticatedUserPrincipalAdapter(db),
+			Fixtures: principalFixtures(),
+		}},
+		ResourceAdapters: []killswitches.ResourceAdapterRegistration{{
+			Adapter:  NewMCPServerResourceAdapter(db),
+			Fixtures: resourceFixtures(),
+		}},
+		Surfaces: []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall},
+		TransportAdapters: []killswitches.TransportAdapterRegistration{
+			{Key: TransportAdapterHostedJSONRPC, Adapter: killswitches.ResolveTransportDisposition},
+			{Key: TransportAdapterPrivateProxyJSONRPC, Adapter: killswitches.ResolveTransportDisposition},
+		},
+		Coverage: []killswitches.CoverageContract{
+			{
+				Definition:       DefinitionKeyMCPToolExecution,
+				Surface:          SurfaceHostedToolsCall,
+				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
+				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route, validated as a live server in a live project of the organization. Never a slug, URL, toolset, backend ID, or caller-provided value.",
+				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on hosted MCP tools/call dispatch. Registration does not deploy this checkpoint; the dispatch wiring ships separately (DNO-982).",
+				ProtectedWork:    "Loading or applying tool configuration and local tool execution.",
+				FailurePolicy:    killswitches.FailurePolicyFailClosed,
+				TransportAdapter: TransportAdapterHostedJSONRPC,
+				EnforcementOwner: EnforcementOwner,
+				IdentityContract: IdentityContractKeyAuthenticatedUserMCPServer,
+			},
+			{
+				Definition:       DefinitionKeyMCPToolExecution,
+				Surface:          SurfacePrivateProxyToolsCall,
+				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
+				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route, validated as a live server in a live project of the organization. The remote or tunneled backend ID is never the key, so hosted and private routes to one server share one canonical resource.",
+				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on private proxied or remote MCP tools/call forwarding. Registration does not deploy this checkpoint; the forwarding wiring ships separately (DNO-980).",
+				ProtectedWork:    "Tool-level authorization-dependent forwarding work and any upstream request; per-server connection configuration may already be loaded.",
+				FailurePolicy:    killswitches.FailurePolicyFailClosed,
+				TransportAdapter: TransportAdapterPrivateProxyJSONRPC,
+				EnforcementOwner: EnforcementOwner,
+				IdentityContract: IdentityContractKeyAuthenticatedUserMCPServer,
+			},
+		},
+	}
+}
+
+// NewRegistry builds and validates the finalized mcp_tool_execution registry.
+func NewRegistry(db *pgxpool.Pool) (*killswitches.Registry, error) {
+	registry, err := killswitches.BuildRegistry(NewRegistration(db))
+	if err != nil {
+		return nil, fmt.Errorf("build mcp_tool_execution registry: %w", err)
+	}
+	return registry, nil
+}
+
+// ExcludedMCPSurface documents an MCP serving mode that deliberately produces
+// no supported principal or resource under mcp_tool_execution M2.
+type ExcludedMCPSurface struct {
+	// Name identifies the serving mode.
+	Name string
+
+	// Reason states why the mode is outside M2 coverage and how covered code
+	// must classify traffic from it.
+	Reason string
+}
+
+// excludedMCPSurfaces is the checked-in exclusion inventory. Every entry is a
+// product limitation to disclose: none of these modes may be reported as
+// M2-covered, and none may have identity inferred from API-key creators,
+// credential owners, emails, external IDs, or organization-only context.
+var excludedMCPSurfaces = []ExcludedMCPSurface{
+	{
+		Name:   "legacy toolset-only /mcp/{slug} fallback",
+		Reason: "Has no fronting mcp_servers row. The resource adapter classifies it as an unsupported resource; a server key must never be synthesized from a toolset.",
+	},
+	{
+		Name:   "meta MCP endpoints",
+		Reason: "Resolve a meta_mcp_servers identity, not an mcp_servers identity, and are excluded until they get their own resource design.",
+	},
+	{
+		Name:   "public anonymous MCP",
+		Reason: "Anonymous subjects have no acting user; the principal adapter classifies them as unsupported identity.",
+	},
+	{
+		Name:   "platform MCP (/platform/mcp)",
+		Reason: "Accepts only assistant-runtime tokens, which are not authoritative acting users.",
+	},
+	{
+		Name:   "internal direct tool callers (HandleToolsCall / HandleToolsList)",
+		Reason: "Agent-workflow callers bypass MCP authentication and have no fronting server; they carry neither supported principal nor resource.",
+	},
+	{
+		Name:   "API-key and chat-session authenticated calls",
+		Reason: "These credentials prove an organization or a machine, never an acting user. Creator or owner attribution must not be promoted to a principal.",
+	},
+}
+
+// ExcludedMCPSurfaces returns the checked-in exclusion inventory.
+func ExcludedMCPSurfaces() []ExcludedMCPSurface {
+	return slices.Clone(excludedMCPSurfaces)
+}
+
+// supportedKey builds a supported fixture expectation from a static key. An
+// invalid static key yields the zero result, which registry construction
+// rejects at startup.
+func supportedKey[T ~string](key T) killswitches.CanonicalizationResult[T] {
+	result, _ := killswitches.NewCanonicalizationResult(key)
+	return result
+}
+
+func principalFixtures() []killswitches.PrincipalCanonicalizationFixture {
+	return []killswitches.PrincipalCanonicalizationFixture{
+		{OrganizationID: "org_fixture", Input: "user_01J8FIXTURE", Expected: supportedKey(killswitches.PrincipalKey("user_01J8FIXTURE"))},
+		{OrganizationID: "org_fixture", Input: "  user_01J8FIXTURE  ", Expected: supportedKey(killswitches.PrincipalKey("user_01J8FIXTURE"))},
+		{OrganizationID: "org_fixture", Input: "   ", Expected: killswitches.UnsupportedCanonicalizationResult[killswitches.PrincipalKey]()},
+		{OrganizationID: "org_fixture", Input: "user\x00id", Expected: killswitches.UnsupportedCanonicalizationResult[killswitches.PrincipalKey]()},
+	}
+}
+
+func resourceFixtures() []killswitches.ResourceCanonicalizationFixture {
+	return []killswitches.ResourceCanonicalizationFixture{
+		{OrganizationID: "org_fixture", Input: "0198A1B2-C3D4-7000-8000-0123456789AB", Expected: supportedKey(killswitches.ResourceKey("0198a1b2-c3d4-7000-8000-0123456789ab"))},
+		{OrganizationID: "org_fixture", Input: " 0198a1b2-c3d4-7000-8000-0123456789ab ", Expected: supportedKey(killswitches.ResourceKey("0198a1b2-c3d4-7000-8000-0123456789ab"))},
+		{OrganizationID: "org_fixture", Input: "not-a-server-id", Expected: killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey]()},
+		{OrganizationID: "org_fixture", Input: "", Expected: killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey]()},
+	}
+}

--- a/server/internal/killswitches/mcptoolexecution/registration_test.go
+++ b/server/internal/killswitches/mcptoolexecution/registration_test.go
@@ -1,0 +1,126 @@
+package mcptoolexecution
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+// TestMCPToolExecutionRegistration proves the checked-in registration builds
+// a complete, fail-closed registry: registry construction validates the
+// canonicalization fixtures and the coverage inventory, so a green build here
+// is the startup-validation guarantee.
+func TestMCPToolExecutionRegistration(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewRegistry(nil)
+	require.NoError(t, err)
+
+	definition, ok := registry.Definition(DefinitionKeyMCPToolExecution)
+	require.True(t, ok)
+	require.Equal(t, killswitches.FailurePolicyFailClosed, definition.FailurePolicy)
+	require.Equal(t, []killswitches.PrincipalKind{PrincipalKindUser}, definition.PrincipalKinds)
+	require.Equal(t, []killswitches.ResourceKind{ResourceKindMCPServer}, definition.ResourceKinds)
+	require.Equal(t, IdentityContractKeyAuthenticatedUserMCPServer, definition.IdentityContract)
+	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, definition.Surfaces)
+	require.ElementsMatch(t, []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC}, definition.TransportAdapters)
+	require.NotEmpty(t, definition.DefaultExternalNote)
+	require.NotEmpty(t, definition.EnforcementOwner)
+
+	adapter, ok := registry.PrincipalAdapter(PrincipalKindUser)
+	require.True(t, ok)
+	require.Equal(t, PrincipalKindUser, adapter.Kind())
+	resourceAdapter, ok := registry.ResourceAdapter(ResourceKindMCPServer)
+	require.True(t, ok)
+	require.Equal(t, ResourceKindMCPServer, resourceAdapter.Kind())
+}
+
+// TestMCPCoverageInventory proves each declared surface has its own coverage
+// entry with the fail-closed policy, and that the exclusion inventory names
+// every serving mode M2 deliberately leaves uncovered.
+func TestMCPCoverageInventory(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewRegistry(nil)
+	require.NoError(t, err)
+
+	inventory := registry.CoverageInventory()
+	require.Len(t, inventory, 2)
+	for _, contract := range inventory {
+		require.Equal(t, DefinitionKeyMCPToolExecution, contract.Definition)
+		require.Equal(t, killswitches.FailurePolicyFailClosed, contract.FailurePolicy)
+		require.Equal(t, IdentityContractKeyAuthenticatedUserMCPServer, contract.IdentityContract)
+		require.NotEmpty(t, contract.PrincipalSource)
+		require.NotEmpty(t, contract.ResourceSource)
+		require.NotEmpty(t, contract.Checkpoint)
+		require.NotEmpty(t, contract.ProtectedWork)
+	}
+
+	hosted, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfaceHostedToolsCall)
+	require.True(t, ok)
+	require.Equal(t, TransportAdapterHostedJSONRPC, hosted.TransportAdapter)
+
+	proxy, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfacePrivateProxyToolsCall)
+	require.True(t, ok)
+	require.Equal(t, TransportAdapterPrivateProxyJSONRPC, proxy.TransportAdapter)
+
+	excluded := ExcludedMCPSurfaces()
+	names := make([]string, 0, len(excluded))
+	for _, surface := range excluded {
+		require.NotEmpty(t, surface.Reason)
+		names = append(names, surface.Name)
+	}
+	for _, expected := range []string{
+		"legacy toolset-only /mcp/{slug} fallback",
+		"meta MCP endpoints",
+		"public anonymous MCP",
+		"platform MCP (/platform/mcp)",
+		"internal direct tool callers (HandleToolsCall / HandleToolsList)",
+		"API-key and chat-session authenticated calls",
+	} {
+		require.Contains(t, names, expected)
+	}
+}
+
+// TestMCPToolExecutionTransportAdaptersFailClosed proves the registered
+// neutral transport behavior under the fail-closed policy: a match denies
+// with only the external note, and an infrastructure failure denies without
+// any match language.
+func TestMCPToolExecutionTransportAdaptersFailClosed(t *testing.T) {
+	t.Parallel()
+
+	registry, err := NewRegistry(nil)
+	require.NoError(t, err)
+
+	match, err := killswitches.NewMatchResult(killswitches.PrescriptionID("0198a1b2-c3d4-7000-8000-0123456789ab"), "Paused by your administrator.")
+	require.NoError(t, err)
+	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonUnsupportedIdentity)
+	require.NoError(t, err)
+	failure, err := killswitches.NewInfrastructureFailureResult(errors.New("database unavailable"))
+	require.NoError(t, err)
+
+	for _, key := range []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC} {
+		adapter, ok := registry.TransportAdapter(key)
+		require.True(t, ok, string(key))
+
+		disposition, err := adapter(match, killswitches.FailurePolicyFailClosed)
+		require.NoError(t, err)
+		require.Equal(t, killswitches.TransportDispositionMatchedDenial, disposition.Kind())
+		note, ok := disposition.ExternalNote()
+		require.True(t, ok)
+		require.Equal(t, "Paused by your administrator.", note)
+
+		disposition, err = adapter(noMatch, killswitches.FailurePolicyFailClosed)
+		require.NoError(t, err)
+		require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+
+		disposition, err = adapter(failure, killswitches.FailurePolicyFailClosed)
+		require.NoError(t, err)
+		require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+		_, hasNote := disposition.ExternalNote()
+		require.False(t, hasNote)
+	}
+}

--- a/server/internal/killswitches/mcptoolexecution/resource.go
+++ b/server/internal/killswitches/mcptoolexecution/resource.go
@@ -1,0 +1,121 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+)
+
+// ErrServerNotInOrganization reports that a resolved fronting server is not a
+// live server in a live project of the organization. It is a data-integrity
+// failure, not a deliberately unsupported resource: the route resolved a
+// server that ownership validation then rejected, so the call must follow the
+// fail-closed policy.
+var ErrServerNotInOrganization = errors.New("mcp server is not a live resource of the organization")
+
+// ServerSource is the authoritative resource input for one covered MCP call.
+// It must be populated from the request's resolved mcp_endpoint route, never
+// from a caller-provided identifier.
+type ServerSource struct {
+	// FrontingServerID is the fronting mcp_servers.id the route resolved for
+	// this request — the same row whether the request arrived via /mcp/{slug}
+	// or /x/mcp/{slug}, and regardless of the toolset, remote, or tunneled
+	// backend behind it. Invalid marks a serving mode with no fronting server
+	// (the legacy toolset-only fallback), which is deliberately unsupported.
+	FrontingServerID uuid.NullUUID
+}
+
+// MCPServerResourceAdapter canonicalizes organization-owned MCP server
+// resources. The canonical key is the fronting mcp_servers.id, giving hosted
+// and private routes to one logical server a single identity.
+type MCPServerResourceAdapter struct {
+	db *pgxpool.Pool
+}
+
+// NewMCPServerResourceAdapter builds the canonical mcp_server resource
+// adapter.
+func NewMCPServerResourceAdapter(db *pgxpool.Pool) *MCPServerResourceAdapter {
+	return &MCPServerResourceAdapter{db: db}
+}
+
+var _ killswitches.ResourceAdapter = (*MCPServerResourceAdapter)(nil)
+
+// Kind returns the canonical MCP server resource namespace.
+func (a *MCPServerResourceAdapter) Kind() killswitches.ResourceKind {
+	return ResourceKindMCPServer
+}
+
+// Canonicalize parses the input as an mcp_servers UUID and normalizes it to
+// its canonical lowercase form. Input that can never name a server is
+// deliberately unsupported, not an error.
+func (a *MCPServerResourceAdapter) Canonicalize(_ killswitches.OrganizationID, input string) (killswitches.CanonicalizationResult[killswitches.ResourceKey], error) {
+	id, err := uuid.Parse(strings.TrimSpace(input))
+	if err != nil || id == uuid.Nil {
+		return killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey](), nil
+	}
+	result, err := killswitches.NewCanonicalizationResult(killswitches.ResourceKey(id.String()))
+	if err != nil {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("canonicalize mcp server key: %w", err)
+	}
+	return result, nil
+}
+
+// ValidateCurrentOrganization reports whether the key names a live server in
+// a live project of the organization. A malformed key is not current; only
+// query failures are errors.
+func (a *MCPServerResourceAdapter) ValidateCurrentOrganization(ctx context.Context, organizationID killswitches.OrganizationID, key killswitches.ResourceKey) (bool, error) {
+	id, err := uuid.Parse(string(key))
+	if err != nil || id.String() != string(key) || organizationID == "" {
+		return false, nil
+	}
+	live, err := mcpserversrepo.New(a.db).HasLiveMCPServerInOrganization(ctx, mcpserversrepo.HasLiveMCPServerInOrganizationParams{
+		ID:             id,
+		OrganizationID: string(organizationID),
+	})
+	if err != nil {
+		return false, fmt.Errorf("check live mcp server ownership: %w", err)
+	}
+	return live, nil
+}
+
+// Derive accepts only a ServerSource built from the resolved route. A source
+// with no fronting server is deliberately unsupported. A fronting server that
+// fails live-ownership validation — deleted, in a deleted project, or in
+// another organization — is an ErrServerNotInOrganization infrastructure
+// failure and follows the fail-closed policy.
+func (a *MCPServerResourceAdapter) Derive(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.CanonicalizationResult[killswitches.ResourceKey], error) {
+	src, ok := source.(ServerSource)
+	if !ok {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("unsupported resource source type %T", source)
+	}
+	if !src.FrontingServerID.Valid {
+		return killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey](), nil
+	}
+	if organizationID == "" {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("organization ID is required")
+	}
+
+	live, err := mcpserversrepo.New(a.db).HasLiveMCPServerInOrganization(ctx, mcpserversrepo.HasLiveMCPServerInOrganizationParams{
+		ID:             src.FrontingServerID.UUID,
+		OrganizationID: string(organizationID),
+	})
+	if err != nil {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("validate live mcp server ownership: %w", err)
+	}
+	if !live {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, ErrServerNotInOrganization
+	}
+
+	result, err := killswitches.NewCanonicalizationResult(killswitches.ResourceKey(src.FrontingServerID.UUID.String()))
+	if err != nil {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("canonicalize mcp server key: %w", err)
+	}
+	return result, nil
+}

--- a/server/internal/killswitches/mcptoolexecution/setup_test.go
+++ b/server/internal/killswitches/mcptoolexecution/setup_test.go
@@ -1,0 +1,158 @@
+//nolint:glint // Integration fixtures intentionally create tenant rows with raw SQL in isolated databases.
+package mcptoolexecution
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("clean up test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func newTestDatabase(t *testing.T, name string) (*pgxpool.Pool, string) {
+	t.Helper()
+	conn, err := infra.CloneTestDatabase(t, name)
+	require.NoError(t, err)
+	orgID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, orgID)
+	return conn, orgID
+}
+
+func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO organization_metadata (id, name, slug)
+		VALUES ($1, 'Test Organization', $1)
+	`, organizationID)
+	require.NoError(t, err)
+}
+
+func insertUser(t *testing.T, conn *pgxpool.Pool, userID string, deletedAt *time.Time) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO users (id, email, display_name, deleted_at)
+		VALUES ($1, $1 || '@example.test', 'Test User', $2)
+	`, userID, deletedAt)
+	require.NoError(t, err)
+}
+
+func insertMembership(t *testing.T, conn *pgxpool.Pool, organizationID, userID string, deletedAt *time.Time) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO organization_user_relationships (organization_id, user_id, deleted_at)
+		VALUES ($1, $2, $3)
+	`, organizationID, userID, deletedAt)
+	require.NoError(t, err)
+}
+
+func insertProject(t *testing.T, conn *pgxpool.Pool, organizationID, slug string, deletedAt *time.Time) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := conn.QueryRow(t.Context(), `
+		INSERT INTO projects (name, slug, organization_id, deleted_at)
+		VALUES ($1, $1, $2, $3)
+		RETURNING id
+	`, slug, organizationID, deletedAt).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+// insertMCPServer creates a toolset-backed mcp_servers row; the table
+// requires exactly one backend reference.
+func insertMCPServer(t *testing.T, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID, deletedAt *time.Time) uuid.UUID {
+	t.Helper()
+	slug := "ts-" + uuid.NewString()[:26]
+	var toolsetID uuid.UUID
+	err := conn.QueryRow(t.Context(), `
+		INSERT INTO toolsets (organization_id, project_id, name, slug)
+		VALUES ($1, $2, $3, $3)
+		RETURNING id
+	`, organizationID, projectID, slug).Scan(&toolsetID)
+	require.NoError(t, err)
+
+	var id uuid.UUID
+	err = conn.QueryRow(t.Context(), `
+		INSERT INTO mcp_servers (project_id, toolset_id, visibility, deleted_at)
+		VALUES ($1, $2, 'private', $3)
+		RETURNING id
+	`, projectID, toolsetID, deletedAt).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+// clearPrescriptions removes every prescription fixture for the organization
+// so a test can stage a fresh scope scenario.
+func clearPrescriptions(t *testing.T, conn *pgxpool.Pool, organizationID string) {
+	t.Helper()
+	for _, table := range []string{
+		"killswitch_prescription_version_resources",
+		"killswitch_prescription_versions",
+		"killswitch_prescriptions",
+	} {
+		_, err := conn.Exec(t.Context(), "DELETE FROM "+table+" WHERE organization_id = $1", organizationID)
+		require.NoError(t, err)
+	}
+}
+
+type prescriptionFixture struct {
+	ID           uuid.UUID
+	PrincipalKey string
+	Scope        string
+	Resources    []string
+	ExternalNote string
+}
+
+// insertPrescription creates an immediately active mcp_tool_execution
+// prescription with the concrete user principal and mcp_server resource kind.
+func insertPrescription(t *testing.T, conn *pgxpool.Pool, organizationID string, fixture prescriptionFixture) {
+	t.Helper()
+	var databaseNow time.Time
+	require.NoError(t, conn.QueryRow(t.Context(), "SELECT clock_timestamp()").Scan(&databaseNow))
+	startsAt := databaseNow.Add(-time.Hour)
+	activatedAt := databaseNow.Add(-time.Hour)
+
+	_, err := conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescriptions (id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
+		VALUES ($1, $2, $3, $4, $5, $6, 1)
+	`, fixture.ID, organizationID, string(DefinitionKeyMCPToolExecution), string(PrincipalKindUser), fixture.PrincipalKey, string(ResourceKindMCPServer))
+	require.NoError(t, err)
+
+	_, err = conn.Exec(t.Context(), `
+		INSERT INTO killswitch_prescription_versions (
+		  organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+		) VALUES ($1, $2, 1, 'active', $3, $4, NULL, $5, 'test fixture context', $6)
+	`, organizationID, fixture.ID, fixture.Scope, startsAt, activatedAt, fixture.ExternalNote)
+	require.NoError(t, err)
+
+	for _, resource := range fixture.Resources {
+		_, err = conn.Exec(t.Context(), `
+			INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
+			VALUES ($1, $2, 1, $3)
+		`, organizationID, fixture.ID, resource)
+		require.NoError(t, err)
+	}
+}

--- a/server/internal/mcp/assistant_resolver_integration_test.go
+++ b/server/internal/mcp/assistant_resolver_integration_test.go
@@ -17,12 +17,17 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/speakeasy-api/gram/server/internal/assistants"
 	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	externalmcp_types "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testmcp"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -31,7 +36,8 @@ import (
 func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestMCPService(t)
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
@@ -66,6 +72,10 @@ func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testi
 	insertRemoteSessionAccessToken(t, ctx, ti, fixture.UserSessionIssuer.ID, fixture.RemoteSessionClient.ID, ownerSubject, "valid-upstream-token", time.Now().Add(time.Hour))
 
 	assistantToken := mintAssistantBearerForOwner(t, ti, authCtx)
+	serveCtx := contextvalues.SetRequestContext(context.Background(), &contextvalues.RequestContext{
+		Host:   "mcp.example.test",
+		ReqURL: "/mcp/" + fixture.Toolset.McpSlug.String,
+	})
 
 	initBody, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0",
@@ -78,7 +88,7 @@ func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testi
 		},
 	})
 	require.NoError(t, err)
-	initResp, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, initBody, assistantToken, nil)
+	initResp, err := servePublicHTTP(t, serveCtx, ti, fixture.Toolset.McpSlug.String, initBody, assistantToken, nil)
 	require.NoError(t, err, "initialize must succeed via the assistant-token fallback")
 	require.Equal(t, http.StatusOK, initResp.Code, "initialize response: %s", initResp.Body.String())
 
@@ -92,13 +102,34 @@ func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testi
 		},
 	})
 	require.NoError(t, err)
-	callResp, err := servePublicHTTP(t, context.Background(), ti, fixture.Toolset.McpSlug.String, callBody, assistantToken, nil)
+	callResp, err := servePublicHTTP(t, serveCtx, ti, fixture.Toolset.McpSlug.String, callBody, assistantToken, nil)
 	require.NoError(t, err, "tools/call must succeed via the assistant-token fallback")
 	require.Equal(t, http.StatusOK, callResp.Code, "tools/call response: %s", callResp.Body.String())
 
 	got, _ := capturedAuth.Load().(string)
 	require.Equal(t, "Bearer valid-upstream-token", got,
 		"resolver must forward the owner's exchanged remote_session token even when the caller authenticated with an assistant JWT")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	coveragePoints := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != mcpmetrics.InstrumentMCPToolCallKillswitchIdentity {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				coveragePoints[point.Attributes] = point.Value
+			}
+		}
+	}
+	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
+		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityAssistant),
+		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
+	)], "production legacy tools/call dispatch must report low coverage and assistant provenance without inferring an acting user")
 }
 
 func TestServePublic_AssistantTokenWithoutRemoteSessionChallenges(t *testing.T) {

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -38,6 +38,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
@@ -332,6 +333,28 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	return newCtx, &subject, toolSelection, nil
 }
 
+// identityForSessionSubject maps a validated user-session subject to its
+// authentication provenance. Only a concrete user subject yields
+// authoritative acting-user provenance; a user subject with no ID yields
+// none at all rather than a hollow authoritative claim. Assistant-runtime
+// tokens never reach this mapping — their acceptance path stamps
+// KindAssistant directly even though it mints a user-shaped subject.
+func identityForSessionSubject(subject urn.SessionSubject) (mcpidentity.Identity, bool) {
+	switch subject.Kind {
+	case urn.SessionSubjectKindUser:
+		if subject.ID == "" {
+			return mcpidentity.Identity{Kind: "", UserID: ""}, false
+		}
+		return mcpidentity.AuthenticatedUser(subject.ID), true
+	case urn.SessionSubjectKindAPIKey:
+		return mcpidentity.Identity{Kind: mcpidentity.KindAPIKey, UserID: ""}, true
+	case urn.SessionSubjectKindAnonymous:
+		return mcpidentity.Identity{Kind: mcpidentity.KindAnonymous, UserID: ""}, true
+	default:
+		return mcpidentity.Identity{Kind: "", UserID: ""}, false
+	}
+}
+
 // contextForSessionSubject stamps the request context for a resolved session
 // subject: the OAuth client id when known, and — for non-anonymous subjects —
 // the endpoint-org AuthContext that downstream RBAC and telemetry read.
@@ -360,6 +383,10 @@ func (s *Service) contextForSessionSubject(
 	// the connection, and an anonymous session is a real connection whose
 	// principal happens to be unknown.
 	s.touchUserSessionLastUsed(ctx, endpoint, sessionID)
+
+	if provenance, ok := identityForSessionSubject(subject); ok {
+		ctx = mcpidentity.WithIdentity(ctx, provenance)
+	}
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
 		return ctx, nil
@@ -497,7 +524,11 @@ func (s *Service) ApplyIssuerGate(
 		// the same user in project B.
 		if assistCtx, claims, aerr := s.assistantTokens.Authorize(ctx, authToken); aerr == nil && claims.ProjectID == endpoint.ProjectID.String() {
 			ssubj := urn.NewUserSubject(claims.UserID)
-			newCtx, subject = assistCtx, &ssubj
+			// The subject reads as a user so downstream session plumbing
+			// works, but the credential was an assistant-runtime token: its
+			// provenance stays KindAssistant and must never be treated as an
+			// authoritative acting user.
+			newCtx, subject = mcpidentity.WithIdentity(assistCtx, mcpidentity.Identity{Kind: mcpidentity.KindAssistant, UserID: ""}), &ssubj
 		}
 	}
 	if subject == nil {

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -365,12 +365,12 @@ func (s *Service) serveConsentProxiedMCP(
 		if herr != nil {
 			return oops.E(oops.CodeUnexpected, herr, "load remote mcp server headers for consent transport").LogError(ctx, logger)
 		}
-		p = s.remoteProxyManager.Build(logger, &remoteServer, serverRow.ID.String(), headers, serverRow.Visibility, endpoint.ProjectID.String(), upstreamToken, "", nil)
+		p = s.remoteProxyManager.Build(logger, &remoteServer, serverRow.ID.String(), headers, serverRow.Visibility, endpoint.OrganizationID, endpoint.ProjectID.String(), upstreamToken, "", nil)
 	} else {
 		// One state-derived affinity key pins the whole consent session
 		// (initialize, list pages, DELETE) to a single gateway.
 		affinity := tunnelrouting.HashedClientAffinityKey("consent", challengeState.ID)
-		p, err = s.tunnelManager.buildProxy(ctx, affinity, logger, endpoint.ProjectID, serverRow, upstreamToken, "", nil)
+		p, err = s.tunnelManager.buildProxy(ctx, affinity, logger, endpoint.ProjectID, endpoint.OrganizationID, serverRow, upstreamToken, "", nil)
 		if err != nil {
 			return err
 		}

--- a/server/internal/mcp/authnchallenge_provenance_internal_test.go
+++ b/server/internal/mcp/authnchallenge_provenance_internal_test.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// TestIdentityForSessionSubject pins the provenance mapping the issuer gate
+// stamps after credential validation: only a concrete user subject yields
+// authoritative acting-user provenance, and a user subject with no ID yields
+// none at all.
+func TestIdentityForSessionSubject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		subject urn.SessionSubject
+		want    mcpidentity.Identity
+		stamped bool
+	}{
+		{
+			name:    "concrete user is authoritative",
+			subject: urn.NewUserSubject("user_01J8EXAMPLE"),
+			want:    mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"),
+			stamped: true,
+		},
+		{
+			name:    "user subject without an ID stamps nothing",
+			subject: urn.SessionSubject{Kind: urn.SessionSubjectKindUser, ID: ""},
+			want:    mcpidentity.Identity{Kind: "", UserID: ""},
+			stamped: false,
+		},
+		{
+			name:    "api key never carries an acting user",
+			subject: urn.SessionSubject{Kind: urn.SessionSubjectKindAPIKey, ID: "key_01J8EXAMPLE"},
+			want:    mcpidentity.Identity{Kind: mcpidentity.KindAPIKey, UserID: ""},
+			stamped: true,
+		},
+		{
+			name:    "anonymous never carries an acting user",
+			subject: urn.SessionSubject{Kind: urn.SessionSubjectKindAnonymous, ID: ""},
+			want:    mcpidentity.Identity{Kind: mcpidentity.KindAnonymous, UserID: ""},
+			stamped: true,
+		},
+		{
+			name:    "unknown subject kind stamps nothing",
+			subject: urn.SessionSubject{Kind: "device", ID: "dev_01J8EXAMPLE"},
+			want:    mcpidentity.Identity{Kind: "", UserID: ""},
+			stamped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, stamped := identityForSessionSubject(tt.subject)
+			require.Equal(t, tt.stamped, stamped)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/server/internal/mcp/hosted_tools_call_coverage_test.go
+++ b/server/internal/mcp/hosted_tools_call_coverage_test.go
@@ -1,0 +1,66 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func TestHostedMalformedToolsCall_RecordsCoverageAtMethodBoundary(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	ctx = mcpidentity.WithIdentity(ctx, mcpidentity.AuthenticatedUser(authCtx.UserID))
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "hosted-coverage-toolset-"+uuid.NewString()[:8])
+	endpointSlug := "hosted-coverage-endpoint-" + uuid.NewString()[:8]
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params":  "malformed params",
+	})
+	require.NoError(t, err)
+	_, err = servePublicHTTP(t, ctx, ti, endpointSlug, body, "", nil)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	coveragePoints := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != mcpmetrics.InstrumentMCPToolCallKillswitchIdentity {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				coveragePoints[point.Attributes] = point.Value
+			}
+		}
+	}
+	require.Equal(t, map[attribute.Set]int64{
+		attribute.NewSet(
+			attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+			attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityActiveUser),
+			attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceCanonicalServer),
+		): 1,
+	}, coveragePoints)
+}

--- a/server/internal/mcp/identity_provenance_test.go
+++ b/server/internal/mcp/identity_provenance_test.go
@@ -1,0 +1,190 @@
+// Regression coverage for DNO-979 trusted provenance classification: the
+// serving surfaces stamp mcpidentity at credential validation, and no
+// non-user credential may ever read as an authoritative acting user.
+package mcp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	keys_gen "github.com/speakeasy-api/gram/server/gen/keys"
+	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
+	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/keys"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// TestApplyIssuerGate_AssistantFallbackStampsAssistantProvenance drives the
+// issuer gate's accepted assistant-runtime fallback end to end and proves the
+// returned context carries KindAssistant provenance with no user ID — never
+// KindUserSession — even though the fallback mints a user-shaped session
+// subject and a user-shaped AuthContext for downstream plumbing.
+func TestApplyIssuerGate_AssistantFallbackStampsAssistantProvenance(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	assistantID := createAssistant(t, ti, authCtx, "Provenance")
+	token := mintAssistantToken(t, ti, authCtx, assistantID)
+
+	endpoint := &mcp.ResolvedMcpEndpoint{
+		AudienceURN:         urn.NewUserSessionIssuer(uuid.New()).String(),
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		ProjectID:           *authCtx.ProjectID,
+		RouteBase:           "mcp",
+		Slug:                "provenance-gate",
+		UserSessionIssuerID: uuid.New(),
+	}
+
+	w := httptest.NewRecorder()
+	newCtx, _, _, err := ti.service.ApplyIssuerGate(t.Context(), w, token, "http://0.0.0.0", endpoint)
+	require.NoError(t, err)
+
+	identity, stamped := mcpidentity.FromContext(newCtx)
+	require.True(t, stamped, "the accepted assistant fallback must stamp provenance")
+	require.Equal(t, mcpidentity.KindAssistant, identity.Kind)
+	require.Empty(t, identity.UserID)
+
+	// The gate's AuthContext deliberately reads as the assistant's owning
+	// user so downstream session plumbing works — which is exactly why the
+	// provenance stamp, not the subject shape, is the enforcement-grade
+	// signal that this caller is not an acting user.
+	gateAuthCtx, ok := contextvalues.GetAuthContext(newCtx)
+	require.True(t, ok)
+	require.Equal(t, authCtx.UserID, gateAuthCtx.UserID)
+}
+
+// TestApplyIssuerGate_RejectedAssistantTokenStampsNothing pins that a
+// cross-project assistant token is rejected with a 401 challenge and the
+// returned context carries no provenance at all.
+func TestApplyIssuerGate_RejectedAssistantTokenStampsNothing(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	assistantID := createAssistant(t, ti, authCtx, "CrossProject")
+	otherProject, err := projectsrepo.New(ti.conn).CreateProject(t.Context(), projectsrepo.CreateProjectParams{
+		Name:           "provenance-other-" + uuid.NewString()[:8],
+		Slug:           "provenance-other-" + uuid.NewString()[:8],
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+
+	token, err := assistanttokens.New("test-jwt-secret", ti.conn, ti.authzEngine).Generate(assistanttokens.GenerateInput{
+		OrgID:       authCtx.ActiveOrganizationID,
+		ProjectID:   otherProject.ID,
+		UserID:      authCtx.UserID,
+		AssistantID: assistantID,
+		ThreadID:    uuid.Nil,
+		TTL:         time.Hour,
+	})
+	require.NoError(t, err)
+
+	endpoint := &mcp.ResolvedMcpEndpoint{
+		AudienceURN:         urn.NewUserSessionIssuer(uuid.New()).String(),
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		ProjectID:           *authCtx.ProjectID,
+		RouteBase:           "mcp",
+		Slug:                "provenance-gate-reject",
+		UserSessionIssuerID: uuid.New(),
+	}
+
+	w := httptest.NewRecorder()
+	newCtx, _, _, err := ti.service.ApplyIssuerGate(t.Context(), w, token, "http://0.0.0.0", endpoint)
+	require.Error(t, err)
+
+	_, stamped := mcpidentity.FromContext(newCtx)
+	require.False(t, stamped, "a rejected credential must leave the context unattributed")
+}
+
+// TestTryPublicIdentityAuth_StampsCredentialProvenance pins the provenance
+// class each legacy authenticateToken strategy stamps at credential
+// validation: assistant tokens, API keys of either accepted scope, and
+// chat-session tokens. None of them may claim an acting user, and a token
+// every strategy rejects leaves the context unattributed.
+func TestTryPublicIdentityAuth_StampsCredentialProvenance(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectSlug)
+
+	authorize := func(t *testing.T, token string) (mcpidentity.Identity, bool) {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodPost, "/mcp/provenance", nil)
+		r.Header.Set("Authorization", "Bearer "+token)
+		authedCtx, err := ti.service.TryPublicIdentityAuth(t.Context(), r, false, uuid.Nil)
+		require.NoError(t, err)
+		return mcpidentity.FromContext(authedCtx)
+	}
+
+	t.Run("assistant token stamps assistant", func(t *testing.T) {
+		t.Parallel()
+		assistantID := createAssistant(t, ti, authCtx, "LegacyAuth")
+		identity, stamped := authorize(t, mintAssistantToken(t, ti, authCtx, assistantID))
+		require.True(t, stamped)
+		require.Equal(t, mcpidentity.KindAssistant, identity.Kind)
+		require.Empty(t, identity.UserID)
+	})
+
+	t.Run("consumer-scope API key stamps api_key", func(t *testing.T) {
+		t.Parallel()
+		identity, stamped := authorize(t, ti.createTestAPIKey(ctx, t))
+		require.True(t, stamped)
+		require.Equal(t, mcpidentity.KindAPIKey, identity.Kind)
+		require.Empty(t, identity.UserID)
+	})
+
+	t.Run("chat-scope API key stamps api_key", func(t *testing.T) {
+		t.Parallel()
+		keysService := keys.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, "local", ti.authzEngine, ti.audit)
+		key, err := keysService.CreateKey(ctx, &keys_gen.CreateKeyPayload{
+			Name:   "chat-scope-key",
+			Scopes: []string{"chat"},
+		})
+		require.NoError(t, err)
+
+		identity, stamped := authorize(t, *key.Key)
+		require.True(t, stamped)
+		require.Equal(t, mcpidentity.KindAPIKey, identity.Kind)
+		require.Empty(t, identity.UserID)
+	})
+
+	t.Run("chat-session token stamps chat_session", func(t *testing.T) {
+		t.Parallel()
+		token, _, err := ti.chatSessionsManager.GenerateToken(t.Context(), chatsessions.ChatSessionClaims{
+			OrgID:            authCtx.ActiveOrganizationID,
+			ProjectID:        authCtx.ProjectID.String(),
+			OrganizationSlug: authCtx.OrganizationSlug,
+			ProjectSlug:      *authCtx.ProjectSlug,
+		}, "http://localhost", 3600)
+		require.NoError(t, err)
+
+		identity, stamped := authorize(t, token)
+		require.True(t, stamped)
+		require.Equal(t, mcpidentity.KindChatSession, identity.Kind)
+		require.Empty(t, identity.UserID)
+	})
+
+	t.Run("rejected token stays unattributed", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodPost, "/mcp/provenance", nil)
+		r.Header.Set("Authorization", "Bearer not-a-real-credential")
+		authedCtx, err := ti.service.TryPublicIdentityAuth(t.Context(), r, false, uuid.Nil)
+		require.Error(t, err)
+
+		_, stamped := mcpidentity.FromContext(authedCtx)
+		require.False(t, stamped)
+	})
+}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -55,6 +55,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
@@ -62,6 +63,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
@@ -96,20 +98,21 @@ type IdentityResolver interface {
 }
 
 type Service struct {
-	logger          *slog.Logger
-	tracer          trace.Tracer
-	metrics         *mcpmetrics.Metrics
-	guardianPolicy  *guardian.Policy
-	db              *pgxpool.Pool
-	authRepo        *auth_repo.Queries
-	toolsetsRepo    *toolsets_repo.Queries
-	mcpMetadataRepo *metadata_repo.Queries
-	orgsRepo        *organizations_repo.Queries
-	auth            *auth.Auth
-	env             toolconfig.EnvironmentLoader
-	serverURL       *url.URL
-	siteURL         *url.URL
-	posthog         *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
+	logger           *slog.Logger
+	tracer           trace.Tracer
+	metrics          *mcpmetrics.Metrics
+	identityCoverage *mcptoolexecution.IdentityCoverageCheckpoint
+	guardianPolicy   *guardian.Policy
+	db               *pgxpool.Pool
+	authRepo         *auth_repo.Queries
+	toolsetsRepo     *toolsets_repo.Queries
+	mcpMetadataRepo  *metadata_repo.Queries
+	orgsRepo         *organizations_repo.Queries
+	auth             *auth.Auth
+	env              toolconfig.EnvironmentLoader
+	serverURL        *url.URL
+	siteURL          *url.URL
+	posthog          *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
 	// features resolves flag-controlled behavior (the managed assistant's
 	// Platform MCP toolset variant). Wired from the environment-aware
 	// provider: the posthog client in production, the CSV-backed in-memory
@@ -249,6 +252,7 @@ func appendRemoteSessionTokenInputs(dst []oauthTokenInputs, tokens map[uuid.UUID
 
 type mcpInputs struct {
 	projectID        uuid.UUID
+	organizationID   string
 	toolset          string
 	environment      string
 	mcpEnvVariables  map[string]string
@@ -283,6 +287,9 @@ type mcpInputs struct {
 	// initialize handler overwrites InEffect with the negotiated answer, which
 	// is the one sanctioned mutation.
 	protocolVersion mcpversions.Resolution
+	// identityCoverageRecorded prevents internal dispatch layers from
+	// recounting a request already observed at the method boundary.
+	identityCoverageRecorded bool
 	// toolSelection is the consent-screen tool policy loaded from the
 	// session row by the issuer gate. Nil means all tools; non-nil is always
 	// restrictive and intersects with the live toolset, ?tags=, and RBAC.
@@ -333,6 +340,7 @@ func NewService(
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
 	logger = logger.With(attr.SlogComponent("mcp"))
+	metrics := mcpmetrics.NewMetrics(meter, logger)
 
 	platformSvc := platformtoolsruntime.NewService(
 		logger,
@@ -348,7 +356,8 @@ func NewService(
 	return &Service{
 		logger:                  logger,
 		tracer:                  tracer,
-		metrics:                 mcpmetrics.NewMetrics(meter, logger),
+		metrics:                 metrics,
+		identityCoverage:        mcptoolexecution.NewIdentityCoverageCheckpoint(db, metrics),
 		guardianPolicy:          guardianPolicy,
 		db:                      db,
 		authRepo:                auth_repo.New(db),
@@ -1017,24 +1026,26 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	}
 
 	mcpInputs := &mcpInputs{
-		projectID:             toolset.ProjectID,
-		toolset:               toolset.Slug,
-		environment:           selectedEnvironment,
-		mcpEnvVariables:       parseMcpEnvVariables(r, headerDisplayNames),
-		authenticated:         authenticated,
-		oauthTokenInputs:      tokenInputs,
-		sessionID:             sessionID,
-		chatID:                r.Header.Get("Gram-Chat-ID"),
-		mode:                  resolveToolMode(r, *toolset),
-		userID:                userID,
-		externalUserID:        externalUserID,
-		apiKeyID:              apiKeyID,
-		toolVariationsGroupID: toolVariationsGroupID,
-		mcpServerID:           mcpServerID,
-		skipProxyTools:        false,
-		tags:                  tags,
-		protocolVersion:       mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
-		toolSelection:         callerToolSelection,
+		projectID:                toolset.ProjectID,
+		organizationID:           toolset.OrganizationID,
+		toolset:                  toolset.Slug,
+		environment:              selectedEnvironment,
+		mcpEnvVariables:          parseMcpEnvVariables(r, headerDisplayNames),
+		authenticated:            authenticated,
+		oauthTokenInputs:         tokenInputs,
+		sessionID:                sessionID,
+		chatID:                   r.Header.Get("Gram-Chat-ID"),
+		mode:                     resolveToolMode(r, *toolset),
+		userID:                   userID,
+		externalUserID:           externalUserID,
+		apiKeyID:                 apiKeyID,
+		toolVariationsGroupID:    toolVariationsGroupID,
+		mcpServerID:              mcpServerID,
+		skipProxyTools:           false,
+		tags:                     tags,
+		protocolVersion:          mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
+		identityCoverageRecorded: false,
+		toolSelection:            callerToolSelection,
 	}
 
 	// Record the resolved variation group and requested tag filter for
@@ -1354,7 +1365,8 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "tools/list":
 		return handleToolsList(ctx, s.logger, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.posthog, &s.toolsetCache, s.vectorToolStore, s.temporal, s.shadowMCPClient, s.platformExtras, s.sessionClientInfo)
 	case "tools/call":
-		return handleToolsCall(ctx, s.logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras, s.sessionClientInfo)
+		recordToolsCallIdentityCoverage(ctx, s.identityCoverage, payload.organizationID, payload)
+		return handleToolsCall(ctx, s.logger, s.metrics, s.identityCoverage, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras, s.sessionClientInfo)
 	case "prompts/list":
 		return handlePromptsList(ctx, s.logger, s.db, payload, req, &s.toolsetCache, s.platformExtras)
 	case "prompts/get":
@@ -1458,13 +1470,22 @@ func (s *Service) TryPublicIdentityAuth(ctx context.Context, r *http.Request, is
 // is true — today that path is exercised only by toolset-backed flows so
 // the resource is a toolset id; remote-backend callers pass false and the
 // id is decorative.
+//
+// Each successful strategy stamps its mcpidentity provenance here, at the
+// point of credential validation: assistant tokens are KindAssistant, API
+// keys (either scope) are KindAPIKey, and chat-session tokens are
+// KindChatSession. None of these credentials proves an acting Gram user, so
+// none stamps KindUserSession — even though every strategy populates an
+// AuthContext whose user-shaped fields exist for attribution only. A token
+// rejected by every strategy leaves the context unstamped, so downstream
+// checkpoints classify the request as unattributed.
 func (s *Service) authenticateToken(ctx context.Context, token string, oauthResourceID uuid.UUID, isOAuthCapable bool) (context.Context, error) {
 	if token == "" {
 		return ctx, oops.C(oops.CodeUnauthorized)
 	}
 
 	if authorizedCtx, _, err := s.assistantTokens.Authorize(ctx, token); err == nil {
-		return authorizedCtx, nil
+		return mcpidentity.WithIdentity(authorizedCtx, mcpidentity.Identity{Kind: mcpidentity.KindAssistant, UserID: ""}), nil
 	}
 
 	var err error
@@ -1478,7 +1499,7 @@ func (s *Service) authenticateToken(ctx context.Context, token string, oauthReso
 
 	ctx, err = s.auth.Authorize(ctx, token, &sc)
 	if err == nil {
-		return ctx, nil
+		return mcpidentity.WithIdentity(ctx, mcpidentity.Identity{Kind: mcpidentity.KindAPIKey, UserID: ""}), nil
 	}
 
 	// Strategy 3: Try API key authentication (chat scope fallback)
@@ -1489,13 +1510,13 @@ func (s *Service) authenticateToken(ctx context.Context, token string, oauthReso
 	}
 	ctx, err = s.auth.Authorize(ctx, token, &sc)
 	if err == nil {
-		return ctx, nil
+		return mcpidentity.WithIdentity(ctx, mcpidentity.Identity{Kind: mcpidentity.KindAPIKey, UserID: ""}), nil
 	}
 
 	// Strategy 4: Try Chat Sessions Token authentication
 	ctx, err = s.chatSessionsManager.Authorize(ctx, token)
 	if err == nil {
-		return ctx, nil
+		return mcpidentity.WithIdentity(ctx, mcpidentity.Identity{Kind: mcpidentity.KindChatSession, UserID: ""}), nil
 	}
 
 	return ctx, oops.E(oops.CodeUnauthorized, errors.New("failed to authorize token using any strategy"), "failed to authorize").LogWarn(ctx, s.logger, attr.SlogToolsetID(oauthResourceID.String()))
@@ -1596,6 +1617,7 @@ func (s *Service) HandleToolsCall(
 		ctx,
 		s.logger,
 		s.metrics,
+		s.identityCoverage,
 		s.authz,
 		s.guardianPolicy,
 		s.db,

--- a/server/internal/mcp/internal_tools_call_coverage_test.go
+++ b/server/internal/mcp/internal_tools_call_coverage_test.go
@@ -1,0 +1,58 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func TestHandleToolsCall_RecordsCoverageWithoutRequestContext(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "internal-coverage-"+uuid.NewString()[:8])
+	_, err := ti.service.HandleToolsCall(context.Background(), &mcp.McpInputs{
+		ProjectID: *authCtx.ProjectID,
+		Toolset:   toolset.Slug,
+		Mode:      mcp.ToolModeStatic,
+	}, "missing_tool", json.RawMessage(`{}`))
+	require.Error(t, err)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	coveragePoints := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != mcpmetrics.InstrumentMCPToolCallKillswitchIdentity {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				coveragePoints[point.Attributes] = point.Value
+			}
+		}
+	}
+	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
+		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityUnattributed),
+		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
+	)])
+}

--- a/server/internal/mcp/mcpmetrics/identitycoverage.go
+++ b/server/internal/mcp/mcpmetrics/identitycoverage.go
@@ -1,0 +1,176 @@
+package mcpmetrics
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// InstrumentMCPToolCallKillswitchIdentity is the OTel instrument name for the
+// kill-switch identity-coverage census: every real tools/call reaching a
+// covered kill-switch checkpoint, dimensioned by bounded server-controlled
+// classes only. It quantifies what share of traffic carries supported
+// authoritative user identity and a canonical server resource, so low
+// coverage is observable instead of being silently folded into "unmatched".
+const InstrumentMCPToolCallKillswitchIdentity = "mcp.tool.call.killswitch_identity"
+
+// KillswitchCoverageSurface is the enforcement checkpoint family that
+// observed a covered tools/call.
+type KillswitchCoverageSurface string
+
+const (
+	// KillswitchSurfaceHosted covers hosted MCP tools/call dispatch.
+	KillswitchSurfaceHosted KillswitchCoverageSurface = "hosted"
+
+	// KillswitchSurfacePrivateProxy covers private proxied or remote MCP
+	// tools/call forwarding.
+	KillswitchSurfacePrivateProxy KillswitchCoverageSurface = "private_proxy"
+)
+
+// KillswitchIdentityClass is the bounded identity-coverage outcome of
+// principal-candidate derivation for one covered tools/call.
+type KillswitchIdentityClass string
+
+const (
+	// KillswitchIdentityActiveUser means an authoritative concrete user was
+	// revalidated as an active organization member and became a candidate.
+	KillswitchIdentityActiveUser KillswitchIdentityClass = "active_user"
+
+	// KillswitchIdentityInactiveUser means an authoritative concrete user was
+	// presented but is no longer an active member of the organization.
+	KillswitchIdentityInactiveUser KillswitchIdentityClass = "inactive_user"
+
+	// KillswitchIdentityAnonymous means the validated session is anonymous.
+	KillswitchIdentityAnonymous KillswitchIdentityClass = "anonymous"
+
+	// KillswitchIdentityAPIKey means the validated credential is an API key,
+	// which has no acting user.
+	KillswitchIdentityAPIKey KillswitchIdentityClass = "api_key"
+
+	// KillswitchIdentityAssistant means the validated credential is an
+	// assistant-runtime token, which is not an authoritative acting user.
+	KillswitchIdentityAssistant KillswitchIdentityClass = "assistant"
+
+	// KillswitchIdentityChatSession means the validated credential is a
+	// chat-session token, which attributes an embedded chat session or
+	// external end-user and is not an authoritative acting user.
+	KillswitchIdentityChatSession KillswitchIdentityClass = "chat_session"
+
+	// KillswitchIdentityUnattributed means the surface established no
+	// authentication provenance at all.
+	KillswitchIdentityUnattributed KillswitchIdentityClass = "unattributed"
+
+	// KillswitchIdentityUnavailable means candidate derivation failed as an
+	// infrastructure error; the call's identity coverage is unknown.
+	KillswitchIdentityUnavailable KillswitchIdentityClass = "unavailable"
+)
+
+// KillswitchResourceClass is the bounded resource-coverage outcome of
+// canonical mcp_server derivation for one covered tools/call.
+type KillswitchResourceClass string
+
+const (
+	// KillswitchResourceCanonicalServer means the call resolved one canonical
+	// organization-owned fronting mcp_servers identity.
+	KillswitchResourceCanonicalServer KillswitchResourceClass = "canonical_server"
+
+	// KillswitchResourceLegacyNoServer means the call arrived on the legacy
+	// toolset-only route, which has no fronting mcp_servers row.
+	KillswitchResourceLegacyNoServer KillswitchResourceClass = "legacy_no_server"
+
+	// KillswitchResourceUnsupportedSurface means the serving mode never
+	// carries a supported mcp_server resource (meta, platform, internal).
+	KillswitchResourceUnsupportedSurface KillswitchResourceClass = "unsupported_surface"
+
+	// KillswitchResourceInvalidOwner means a fronting server was resolved but
+	// is no longer a live server in a live project of the organization.
+	KillswitchResourceInvalidOwner KillswitchResourceClass = "invalid_owner"
+
+	// KillswitchResourceUnavailable means resource derivation failed as an
+	// infrastructure error; the call's resource coverage is unknown.
+	KillswitchResourceUnavailable KillswitchResourceClass = "unavailable"
+)
+
+func validKillswitchCoverageSurface(surface KillswitchCoverageSurface) bool {
+	switch surface {
+	case KillswitchSurfaceHosted, KillswitchSurfacePrivateProxy:
+		return true
+	default:
+		return false
+	}
+}
+
+func validKillswitchIdentityClass(class KillswitchIdentityClass) bool {
+	switch class {
+	case KillswitchIdentityActiveUser, KillswitchIdentityInactiveUser, KillswitchIdentityAnonymous,
+		KillswitchIdentityAPIKey, KillswitchIdentityAssistant, KillswitchIdentityChatSession,
+		KillswitchIdentityUnattributed, KillswitchIdentityUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+func validKillswitchResourceClass(class KillswitchResourceClass) bool {
+	switch class {
+	case KillswitchResourceCanonicalServer, KillswitchResourceLegacyNoServer,
+		KillswitchResourceUnsupportedSurface, KillswitchResourceInvalidOwner,
+		KillswitchResourceUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+// IdentityCoverageCounter owns the kill-switch identity-coverage census. A
+// nil *IdentityCoverageCounter is valid — Record becomes a no-op — so callers
+// that do not care about metrics can pass nil.
+type IdentityCoverageCounter struct {
+	calls metric.Int64Counter
+}
+
+// NewIdentityCoverageCounter constructs the coverage census counter. An
+// instrument creation failure is logged and leaves the instrument nil; Record
+// handles nil instruments so partial construction still produces a usable
+// value.
+func NewIdentityCoverageCounter(meter metric.Meter, logger *slog.Logger) *IdentityCoverageCounter {
+	calls, err := meter.Int64Counter(
+		InstrumentMCPToolCallKillswitchIdentity,
+		metric.WithDescription("MCP tools/call requests observed at kill-switch checkpoints, by surface and bounded identity and resource coverage class"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentMCPToolCallKillswitchIdentity), attr.SlogError(err))
+	}
+
+	return &IdentityCoverageCounter{calls: calls}
+}
+
+// Record counts one covered tools/call. Every dimension is clamped to its
+// bounded set — an unknown value records as the corresponding "unavailable"
+// class (surface falls back to hosted) — so no identifier, URL, note, or
+// free-form error text can ever become a metric dimension.
+func (c *IdentityCoverageCounter) Record(ctx context.Context, surface KillswitchCoverageSurface, identity KillswitchIdentityClass, resource KillswitchResourceClass) {
+	if c == nil || c.calls == nil {
+		return
+	}
+
+	if !validKillswitchCoverageSurface(surface) {
+		surface = KillswitchSurfaceHosted
+	}
+	if !validKillswitchIdentityClass(identity) {
+		identity = KillswitchIdentityUnavailable
+	}
+	if !validKillswitchResourceClass(resource) {
+		resource = KillswitchResourceUnavailable
+	}
+
+	c.calls.Add(ctx, 1, metric.WithAttributes(
+		attr.McpKillswitchSurface(surface),
+		attr.McpKillswitchIdentityClass(identity),
+		attr.McpKillswitchResourceClass(resource),
+	))
+}

--- a/server/internal/mcp/mcpmetrics/identitycoverage_test.go
+++ b/server/internal/mcp/mcpmetrics/identitycoverage_test.go
@@ -1,0 +1,73 @@
+package mcpmetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// TestIdentityCoverageRecord_PinsInstrumentAndDimensions pins the wiring a
+// noop meter cannot see: the instrument name and the three bounded attribute
+// keys the coverage dashboards will query by.
+func TestIdentityCoverageRecord_PinsInstrumentAndDimensions(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+
+	c := NewIdentityCoverageCounter(meter, testenv.NewLogger(t))
+	c.Record(t.Context(), KillswitchSurfacePrivateProxy, KillswitchIdentityActiveUser, KillswitchResourceCanonicalServer)
+
+	got := collectMetric(t, reader, InstrumentMCPToolCallKillswitchIdentity)
+	metricdatatest.AssertHasAttributes(t, got,
+		attr.McpKillswitchSurface(KillswitchSurfacePrivateProxy),
+		attr.McpKillswitchIdentityClass(KillswitchIdentityActiveUser),
+		attr.McpKillswitchResourceClass(KillswitchResourceCanonicalServer),
+	)
+
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "coverage instrument must be an int64 counter")
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(1), sum.DataPoints[0].Value)
+}
+
+// TestIdentityCoverageRecord_ClampsAtRecordSite pins that every dimension is
+// clamped inside Record: out-of-set values must land in the bounded fallback
+// buckets so no identifier, URL, or error text can ever mint a metric series.
+func TestIdentityCoverageRecord_ClampsAtRecordSite(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+
+	c := NewIdentityCoverageCounter(meter, testenv.NewLogger(t))
+	c.Record(t.Context(),
+		KillswitchCoverageSurface("https://mcp.example.com/mcp/demo"),
+		KillswitchIdentityClass("user_01J8SOMEUSER"),
+		KillswitchResourceClass("pg: connection refused"),
+	)
+
+	metricdatatest.AssertHasAttributes(t, collectMetric(t, reader, InstrumentMCPToolCallKillswitchIdentity),
+		attr.McpKillswitchSurface(KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(KillswitchIdentityUnavailable),
+		attr.McpKillswitchResourceClass(KillswitchResourceUnavailable),
+	)
+}
+
+// TestIdentityCoverageRecord_NilSafe pins the documented contract that a nil
+// counter and one whose instrument failed to construct both record safely.
+func TestIdentityCoverageRecord_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var nilCounter *IdentityCoverageCounter
+	nilCounter.Record(t.Context(), KillswitchSurfaceHosted, KillswitchIdentityActiveUser, KillswitchResourceCanonicalServer)
+
+	empty := &IdentityCoverageCounter{calls: nil}
+	empty.Record(t.Context(), KillswitchSurfaceHosted, KillswitchIdentityActiveUser, KillswitchResourceCanonicalServer)
+}

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -72,6 +72,7 @@ type Metrics struct {
 
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
+	identityCoverage   *IdentityCoverageCounter
 
 	// oauthFlow{Started,Completed,Failed,Declined}Counter instrument the
 	// user-facing OAuth flow as a unit. They decompose a flow's terminal
@@ -191,6 +192,7 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 		mcpInitializeCounter:                 mcpInitializeCounter,
 		mcpRequestRejectedCounter:            mcpRequestRejectedCounter,
 		requestCensus:                        NewRequestCounter(meter, logger),
+		identityCoverage:                     NewIdentityCoverageCounter(meter, logger),
 		oauthFlowStartedCounter:              oauthFlowStartedCounter,
 		oauthFlowCompletedCounter:            oauthFlowCompletedCounter,
 		oauthFlowFailedCounter:               oauthFlowFailedCounter,
@@ -210,6 +212,15 @@ func (m *Metrics) RecordMCPToolCall(ctx context.Context, orgID string, mcpURL st
 		attr.OrganizationID(orgID),
 	}
 	m.mcpToolCallCounter.Add(ctx, 1, metric.WithAttributes(kv...))
+}
+
+// RecordKillswitchIdentityCoverage records the bounded coverage classes for
+// one tools/call observed at a registered MCP checkpoint.
+func (m *Metrics) RecordKillswitchIdentityCoverage(ctx context.Context, surface KillswitchCoverageSurface, identity KillswitchIdentityClass, resource KillswitchResourceClass) {
+	if m == nil {
+		return
+	}
+	m.identityCoverage.Record(ctx, surface, identity, resource)
 }
 
 // RecordMCPInitialize counts one observed MCP handshake, dimensioned by the

--- a/server/internal/mcp/mcpmetrics/metrics_test.go
+++ b/server/internal/mcp/mcpmetrics/metrics_test.go
@@ -28,6 +28,7 @@ func TestNewMetrics(t *testing.T) {
 		require.NotNil(t, m)
 		require.NotNil(t, m.mcpToolCallCounter)
 		require.NotNil(t, m.mcpRequestDuration)
+		require.NotNil(t, m.identityCoverage)
 	})
 }
 

--- a/server/internal/mcp/meta_tools_call_coverage_test.go
+++ b/server/internal/mcp/meta_tools_call_coverage_test.go
@@ -1,0 +1,41 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+)
+
+func TestMetaHostedMemberToolsCall_DoesNotReportHostedCoverage(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "meta-coverage-" + uuid.NewString()
+	meta := createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, uuid.Nil)
+	member := seedHostedMetaMember(t, ctx, ti, meta.ID, "hosted member", 1, mcpservers.VisibilityPublic, "alpha_tool")
+	callMetaTool(t, ctx, ti, slug, "execute_tool", map[string]any{
+		"name":      member.slug + "--alpha_tool",
+		"arguments": map[string]any{},
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			require.NotEqual(t, mcpmetrics.InstrumentMCPToolCallKillswitchIdentity, metric.Name,
+				"meta member dispatch must not be represented as hosted mcp_tool_execution coverage")
+		}
+	}
+}

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
@@ -61,6 +62,21 @@ type toolsCallParams struct {
 	Meta *mcprequests.WireMeta `json:"_meta,omitempty"`
 }
 
+func recordToolsCallIdentityCoverage(ctx context.Context, checkpoint *mcptoolexecution.IdentityCoverageCheckpoint, organizationID string, payload *mcpInputs) {
+	if payload == nil || payload.identityCoverageRecorded {
+		return
+	}
+
+	serverSource := mcptoolexecution.ServerSource{
+		FrontingServerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	}
+	if payload.mcpServerID != nil {
+		serverSource.FrontingServerID = uuid.NullUUID{UUID: *payload.mcpServerID, Valid: true}
+	}
+	checkpoint.Record(ctx, organizationID, mcpmetrics.KillswitchSurfaceHosted, serverSource)
+	payload.identityCoverageRecorded = true
+}
+
 const (
 	listToolsToolName     = "list_tools"
 	describeToolsToolName = "describe_tools"
@@ -71,6 +87,7 @@ func handleToolsCall(
 	ctx context.Context,
 	logger *slog.Logger,
 	metrics *mcpmetrics.Metrics,
+	identityCoverage *mcptoolexecution.IdentityCoverageCheckpoint,
 	authzEngine *authz.Engine,
 	guardianPolicy *guardian.Policy,
 	db *pgxpool.Pool,
@@ -105,6 +122,9 @@ func handleToolsCall(
 	if err != nil {
 		return nil, err
 	}
+	// Direct internal callers do not pass through handleRequest's method
+	// boundary, so record them once the toolset supplies the organization.
+	recordToolsCallIdentityCoverage(ctx, identityCoverage, toolset.OrganizationID, payload)
 
 	// Apply the ?tags= filter before any tool resolution — dynamic dispatch,
 	// proxy matching, and the static name lookup all read this slice, so a

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -144,7 +144,7 @@ func (s *Service) dialMetaMember(
 		return func(context.Context) (*proxy.Proxy, error) {
 			// No WWW-Authenticate relay: a member's auth challenge must not
 			// invite the client to re-authenticate against the meta MCP.
-			p := s.remoteProxyManager.Build(logger, &remoteServer, member.serverID.String(), headers, member.visibility, gate.projectID.String(), upstreamToken, "", gate.toolSelection)
+			p := s.remoteProxyManager.Build(logger, &remoteServer, member.serverID.String(), headers, member.visibility, gate.organizationID, gate.projectID.String(), upstreamToken, "", gate.toolSelection, remotemcp.WithoutToolsCallIdentityCoverage())
 			// Meta-MCP-synthesized initializes are not client sessions.
 			p.InitializeRequestInterceptors = nil
 			return p, nil
@@ -159,7 +159,7 @@ func (s *Service) dialMetaMember(
 		// land on one tunnel gateway.
 		affinity := tunnelrouting.HashedClientAffinityKey("meta:"+member.serverID.String(), callerIdentity)
 		return func(ctx context.Context) (*proxy.Proxy, error) {
-			p, berr := s.tunnelManager.buildProxy(ctx, affinity, logger, gate.projectID, &serverRow, upstreamToken, "", gate.toolSelection)
+			p, berr := s.tunnelManager.buildProxy(ctx, affinity, logger, gate.projectID, gate.organizationID, &serverRow, upstreamToken, "", gate.toolSelection, remotemcp.WithoutToolsCallIdentityCoverage())
 			if berr != nil {
 				return nil, fmt.Errorf("build tunnel proxy: %w", berr)
 			}

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -259,7 +259,10 @@ func (s *Service) handleMetaExecuteToolCall(
 		Params:  params,
 	}
 
-	body, err := handleToolsCall(ctx, logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env,
+	// The authoritative route fronts a meta MCP, not the hosted member's
+	// mcp_server. Meta resources are outside the mcp_tool_execution contract,
+	// so do not report the synthetic member dispatch as hosted coverage.
+	body, err := handleToolsCall(ctx, logger, s.metrics, nil, s.authz, s.guardianPolicy, s.db, s.env,
 		inputs, syntheticReq, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache,
 		s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger,
 		s.platformExtras, s.sessionClientInfo)
@@ -437,24 +440,26 @@ func (s *Service) buildMemberDispatch(
 
 	serverID := member.serverID
 	inputs := &mcpInputs{
-		projectID:             projectID,
-		toolset:               toolset.Slug,
-		environment:           environment,
-		mcpEnvVariables:       nil,
-		oauthTokenInputs:      tokenInputs,
-		authenticated:         gate.authenticated,
-		sessionID:             gate.sessionID,
-		chatID:                gate.chatID,
-		mode:                  ToolModeStatic,
-		userID:                gate.userID,
-		externalUserID:        gate.externalUserID,
-		apiKeyID:              gate.apiKeyID,
-		toolVariationsGroupID: variationsGroupID,
-		mcpServerID:           &serverID,
-		skipProxyTools:        true,
-		tags:                  nil,
-		protocolVersion:       gate.protocolVersion,
-		toolSelection:         gate.toolSelection,
+		projectID:                projectID,
+		organizationID:           toolset.OrganizationID,
+		toolset:                  toolset.Slug,
+		environment:              environment,
+		mcpEnvVariables:          nil,
+		oauthTokenInputs:         tokenInputs,
+		authenticated:            gate.authenticated,
+		sessionID:                gate.sessionID,
+		chatID:                   gate.chatID,
+		mode:                     ToolModeStatic,
+		userID:                   gate.userID,
+		externalUserID:           gate.externalUserID,
+		apiKeyID:                 gate.apiKeyID,
+		toolVariationsGroupID:    variationsGroupID,
+		mcpServerID:              &serverID,
+		skipProxyTools:           true,
+		tags:                     nil,
+		protocolVersion:          gate.protocolVersion,
+		identityCoverageRecorded: false,
+		toolSelection:            gate.toolSelection,
 	}
 	return toolset, inputs, nil
 }

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -498,8 +498,7 @@ func (s *Service) serveRemoteBackend(
 	ctx := r.Context()
 	logger = logger.With(attr.SlogRemoteMCPServerID(mcpServer.RemoteMcpServerID.UUID.String()))
 
-	var err error
-	ctx, err = s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
+	ctx, organizationID, err := s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
 	if err != nil {
 		return err
 	}
@@ -524,7 +523,7 @@ func (s *Service) serveRemoteBackend(
 		return oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
 	}
 
-	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth, wwwAuthenticate, selection)
+	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, organizationID, endpoint.ProjectID.String(), upstreamAuth, wwwAuthenticate, selection)
 
 	return serveProxyBackend(w, r.WithContext(ctx), p)
 }
@@ -569,13 +568,12 @@ func (s *Service) serveTunneledBackend(
 		return s.serveTunneledPublicBackend(w, r, logger, endpoint, mcpServer)
 	}
 
-	var err error
-	ctx, err = s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
+	ctx, organizationID, err := s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
 	if err != nil {
 		return err
 	}
 
-	p, err := s.tunnelManager.buildProxy(ctx, tunnelrouting.ClientAffinityKeyFromRequest(r), logger, endpoint.ProjectID, mcpServer, upstreamAuth, wwwAuthenticate, selection)
+	p, err := s.tunnelManager.buildProxy(ctx, tunnelrouting.ClientAffinityKeyFromRequest(r), logger, endpoint.ProjectID, organizationID, mcpServer, upstreamAuth, wwwAuthenticate, selection)
 	if err != nil {
 		return err
 	}
@@ -590,7 +588,15 @@ func (s *Service) prepareProxyBackendContext(
 	logger *slog.Logger,
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
-) (context.Context, error) {
+) (context.Context, string, error) {
+	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, endpoint.ProjectID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, "", oops.E(oops.CodeNotFound, err, "mcp server project not found")
+	case err != nil:
+		return nil, "", oops.E(oops.CodeUnexpected, err, "load mcp server project").LogError(ctx, logger)
+	}
+
 	// Identity auth + access checks, mirroring the relevant cases of
 	// mcp.ServeToolsetResolved. Unrecognised visibility values fail closed
 	// in the default branch — disabled was already filtered upstream in
@@ -605,14 +611,6 @@ func (s *Service) prepareProxyBackendContext(
 	// it and trust the gate.
 	issuerGated := mcpServer.UserSessionIssuerID.Valid && !isTunneledPublic(mcpServer)
 	if issuerGated {
-		project, err := projectsrepo.New(s.db).GetProjectByID(ctx, endpoint.ProjectID)
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			return nil, oops.E(oops.CodeNotFound, err, "issuer-gated mcp server project not found")
-		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "load issuer-gated mcp server project").LogError(ctx, logger)
-		}
-
 		// Public issuer-gated endpoints may carry an anonymous subject, which
 		// intentionally has no dashboard AuthContext. Private endpoints still
 		// require one; when present, always bind it to the owning organization
@@ -620,11 +618,11 @@ func (s *Service) prepareProxyBackendContext(
 		authCtx, ok := contextvalues.GetAuthContext(ctx)
 		if !ok || authCtx == nil {
 			if mcpServer.Visibility == mcpservers.VisibilityPrivate {
-				return nil, oops.C(oops.CodeUnauthorized)
+				return nil, "", oops.C(oops.CodeUnauthorized)
 			}
 		} else {
 			if project.OrganizationID != authCtx.ActiveOrganizationID {
-				return nil, oops.C(oops.CodeUnauthorized)
+				return nil, "", oops.C(oops.CodeUnauthorized)
 			}
 			ctx = setProxyBackendProjectContext(ctx, authCtx, project.ID, project.Slug)
 		}
@@ -638,19 +636,14 @@ func (s *Service) prepareProxyBackendContext(
 		// scoping), so the org-membership check is the meaningful gate
 		// for API-key callers.
 		if !issuerGated {
-			var err error
 			ctx, err = s.RequirePrivateIdentityAuth(ctx, w, r, false, mcpServer.ID, "")
 			if err != nil {
-				return nil, fmt.Errorf("private identity auth: %w", err)
+				return nil, "", fmt.Errorf("private identity auth: %w", err)
 			}
 
-			project, err := projectsrepo.New(s.db).GetProjectByID(ctx, endpoint.ProjectID)
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "load mcp server project").LogError(ctx, logger)
-			}
 			authCtx, ok := contextvalues.GetAuthContext(ctx)
 			if !ok || authCtx == nil || project.OrganizationID != authCtx.ActiveOrganizationID {
-				return nil, oops.C(oops.CodeUnauthorized)
+				return nil, "", oops.C(oops.CodeUnauthorized)
 			}
 			ctx = setProxyBackendProjectContext(ctx, authCtx, project.ID, project.Slug)
 		}
@@ -660,21 +653,21 @@ func (s *Service) prepareProxyBackendContext(
 		// token so authenticated callers carry the right context
 		// downstream. Nothing meaningful to forward upstream.
 		if !issuerGated {
-			var err error
 			ctx, err = s.TryPublicIdentityAuth(ctx, r, false, mcpServer.ID)
 			if err != nil {
-				return nil, fmt.Errorf("public identity auth: %w", err)
+				return nil, "", fmt.Errorf("public identity auth: %w", err)
 			}
-			ctx, err = s.setProxyBackendProjectContextIfOwner(ctx, logger, endpoint.ProjectID)
-			if err != nil {
-				return nil, err
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			if ok && authCtx != nil && authCtx.ProjectID == nil && project.OrganizationID == authCtx.ActiveOrganizationID {
+				ctx = setProxyBackendProjectContext(ctx, authCtx, project.ID, project.Slug)
 			}
 		}
 	default:
-		return nil, oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", mcpServer.Visibility).LogError(ctx, logger)
+		return nil, "", oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", mcpServer.Visibility).LogError(ctx, logger)
 	}
 
-	return s.authorizeProxyBackendAccess(ctx, logger, endpoint.ProjectID, mcpServer)
+	ctx, err = s.authorizeProxyBackendAccess(ctx, logger, endpoint.ProjectID, mcpServer)
+	return ctx, project.OrganizationID, err
 }
 
 // authorizeProxyBackendAccess runs the visibility-scoped RBAC gate for a
@@ -733,27 +726,6 @@ func setProxyBackendProjectContext(ctx context.Context, authCtx *contextvalues.A
 		authCtx.ProjectSlug = &slug
 	}
 	return contextvalues.SetAuthContext(ctx, authCtx)
-}
-
-func (s *Service) setProxyBackendProjectContextIfOwner(ctx context.Context, logger *slog.Logger, projectID uuid.UUID) (context.Context, error) {
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.ProjectID != nil {
-		return ctx, nil
-	}
-
-	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, projectID)
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		return ctx, oops.E(oops.CodeNotFound, err, "project not found")
-	case err != nil:
-		return ctx, oops.E(oops.CodeUnexpected, err, "load mcp server project").LogError(ctx, logger)
-	}
-
-	if project.OrganizationID != authCtx.ActiveOrganizationID {
-		return ctx, nil
-	}
-
-	return setProxyBackendProjectContext(ctx, authCtx, project.ID, project.Slug), nil
 }
 
 // BuildResolvedMcpEndpointForMetaServer materialises a ResolvedMcpEndpoint

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -286,7 +286,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()))
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()))
 	managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemService)
 	feedbackRecorder := feedbackrecorder.NewRecorder(conn, logger, nil)
 	assistantSkillTools := platformtoolsruntime.AssistantSkillTools(logger, conn, feedbackRecorder)

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -49,10 +49,12 @@ func (m *tunnelManager) buildProxy(
 	clientAffinityKey string,
 	logger *slog.Logger,
 	projectID uuid.UUID,
+	organizationID string,
 	mcpServer *mcpserversrepo.McpServer,
 	upstreamAuth string,
 	wwwAuthenticate string,
 	selection *toolfilter.SessionSelection,
+	options ...remotemcp.BuildOption,
 ) (*proxy.Proxy, error) {
 	if m == nil || m.proxyManager == nil {
 		return nil, oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
@@ -94,10 +96,12 @@ func (m *tunnelManager) buildProxy(
 		gatewayURL,
 		tunnelrouting.Headers(tunnelID, m.forwardToken, clientAffinityKey),
 		mcpServer.Visibility,
+		organizationID,
 		projectID.String(),
 		upstreamAuth,
 		wwwAuthenticate,
 		selection,
+		options...,
 	)
 	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	// Redirects won't work across a tunnel boundary; disable.

--- a/server/internal/mcp/tunnelpublic.go
+++ b/server/internal/mcp/tunnelpublic.go
@@ -192,7 +192,8 @@ func (s *Service) serveTunneledPublicBackend(
 		return oops.E(oops.CodeRateLimitExceeded, nil, "too many requests to this MCP server").LogWarn(ctx, logger)
 	}
 
-	ctx, err = s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
+	var organizationID string
+	ctx, organizationID, err = s.prepareProxyBackendContext(ctx, w, r, logger, endpoint, mcpServer)
 	if err != nil {
 		return err
 	}
@@ -200,9 +201,9 @@ func (s *Service) serveTunneledPublicBackend(
 
 	sid := strings.TrimSpace(r.Header.Get(proxy.McpSessionIDHeader))
 	if sid != "" {
-		return s.serveTunneledPublicSession(w, r, logger, endpoint, mcpServer, tunnelID, sid)
+		return s.serveTunneledPublicSession(w, r, logger, endpoint, mcpServer, organizationID, tunnelID, sid)
 	}
-	return s.serveTunneledPublicInit(w, r, logger, endpoint, mcpServer, tunnelID)
+	return s.serveTunneledPublicInit(w, r, logger, endpoint, mcpServer, organizationID, tunnelID)
 }
 
 // stripPublicResponseHeaders removes headers that must never reach an
@@ -236,6 +237,7 @@ func (s *Service) serveTunneledPublicInit(
 	logger *slog.Logger,
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
+	organizationID string,
 	tunnelID string,
 ) error {
 	ctx := r.Context()
@@ -274,7 +276,7 @@ func (s *Service) serveTunneledPublicInit(
 		reserved = true
 	}
 
-	p, err := s.tunnelManager.buildProxy(ctx, tunnelrouting.ClientAffinityKeyFromRequest(r), logger, endpoint.ProjectID, mcpServer, "", "", nil)
+	p, err := s.tunnelManager.buildProxy(ctx, tunnelrouting.ClientAffinityKeyFromRequest(r), logger, endpoint.ProjectID, organizationID, mcpServer, "", "", nil)
 	if err != nil {
 		if reserved {
 			s.rollbackReservation(ctx, logger, tunnelID, mcpServerID, sid)
@@ -446,6 +448,7 @@ func (s *Service) serveTunneledPublicSession(
 	logger *slog.Logger,
 	endpoint *mcpendpointsrepo.McpEndpoint,
 	mcpServer *mcpserversrepo.McpServer,
+	organizationID string,
 	tunnelID string,
 	sid string,
 ) error {
@@ -521,6 +524,7 @@ func (s *Service) serveTunneledPublicSession(
 		session.GatewayAddr,
 		headers,
 		mcpServer.Visibility,
+		organizationID,
 		endpoint.ProjectID.String(),
 		"",
 		"",

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -85,6 +85,7 @@ func (m *McpInputs) toInternal() *mcpInputs {
 
 	return &mcpInputs{
 		projectID:        m.ProjectID,
+		organizationID:   "",
 		toolset:          m.Toolset,
 		environment:      m.Environment,
 		mcpEnvVariables:  m.McpEnvVariables,
@@ -100,11 +101,12 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		// variation group, never filter by tag, have no fronting mcp_servers
 		// row to record, and carry no HTTP request to declare a protocol
 		// version, so they resolve to the unversioned default.
-		toolVariationsGroupID: nil,
-		mcpServerID:           nil,
-		skipProxyTools:        false,
-		tags:                  nil,
-		protocolVersion:       mcpversions.Resolve("", mcpversions.SupportedHostedToolset()),
-		toolSelection:         nil,
+		toolVariationsGroupID:    nil,
+		mcpServerID:              nil,
+		skipProxyTools:           false,
+		tags:                     nil,
+		protocolVersion:          mcpversions.Resolve("", mcpversions.SupportedHostedToolset()),
+		identityCoverageRecorded: false,
+		toolSelection:            nil,
 	}
 }

--- a/server/internal/mcpidentity/identity.go
+++ b/server/internal/mcpidentity/identity.go
@@ -1,0 +1,73 @@
+// Package mcpidentity carries trusted authentication provenance for MCP
+// requests. An Identity records how the serving surface established the
+// caller's identity, so downstream enforcement can distinguish an
+// authoritative acting Gram user from credentials that merely prove an
+// organization, a machine, or nothing at all.
+//
+// Only the code that validates a credential may stamp an Identity. It must
+// never be inferred after the fact from fields on an AuthContext, an API-key
+// creator, a credential owner, an email, an external user ID, or any
+// caller-provided value.
+package mcpidentity
+
+import "context"
+
+// Kind is the bounded provenance class of a validated MCP credential.
+type Kind string
+
+const (
+	// KindUserSession marks a validated Gram user-session token whose subject
+	// is a concrete user. This is the only kind that identifies an
+	// authoritative acting user.
+	KindUserSession Kind = "user_session"
+
+	// KindAnonymous marks a validated session whose subject is anonymous.
+	KindAnonymous Kind = "anonymous"
+
+	// KindAPIKey marks a validated session whose subject is an API key. The
+	// key's creator or owner is not an acting user.
+	KindAPIKey Kind = "api_key"
+
+	// KindAssistant marks a validated assistant-runtime token. Its user claim
+	// attributes the assistant's work but is not an authoritative acting-user
+	// proof for enforcement.
+	KindAssistant Kind = "assistant"
+
+	// KindChatSession marks a validated chat-session token minted for an
+	// embedded chat surface. Its claims may name a Gram user or an external
+	// end-user for attribution, but the credential proves only the session,
+	// so it is never an authoritative acting user.
+	KindChatSession Kind = "chat_session"
+)
+
+// Identity is the provenance stamped by a serving surface after credential
+// validation.
+type Identity struct {
+	// Kind is the provenance class of the validated credential.
+	Kind Kind
+
+	// UserID is the concrete Gram user ID and is set only for
+	// KindUserSession.
+	UserID string
+}
+
+// AuthenticatedUser builds the provenance for a validated user-session
+// subject with a concrete user ID.
+func AuthenticatedUser(userID string) Identity {
+	return Identity{Kind: KindUserSession, UserID: userID}
+}
+
+type contextKey struct{}
+
+// WithIdentity returns a context carrying the validated provenance.
+func WithIdentity(ctx context.Context, identity Identity) context.Context {
+	return context.WithValue(ctx, contextKey{}, identity)
+}
+
+// FromContext returns the stamped provenance. A false result means the
+// surface never established provenance; callers must treat the request as
+// unattributed rather than assuming any identity.
+func FromContext(ctx context.Context) (Identity, bool) {
+	identity, ok := ctx.Value(contextKey{}).(Identity)
+	return identity, ok
+}

--- a/server/internal/mcpidentity/identity_test.go
+++ b/server/internal/mcpidentity/identity_test.go
@@ -1,0 +1,40 @@
+package mcpidentity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+)
+
+func TestFromContext_AbsentMeansUnattributed(t *testing.T) {
+	t.Parallel()
+
+	identity, ok := mcpidentity.FromContext(t.Context())
+	require.False(t, ok)
+	require.Empty(t, identity.Kind)
+	require.Empty(t, identity.UserID)
+}
+
+func TestWithIdentity_RoundTripsAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := mcpidentity.WithIdentity(t.Context(), mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"))
+	identity, ok := mcpidentity.FromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, mcpidentity.KindUserSession, identity.Kind)
+	require.Equal(t, "user_01J8EXAMPLE", identity.UserID)
+}
+
+func TestWithIdentity_LatestStampWins(t *testing.T) {
+	t.Parallel()
+
+	ctx := mcpidentity.WithIdentity(t.Context(), mcpidentity.AuthenticatedUser("user_01J8EXAMPLE"))
+	ctx = mcpidentity.WithIdentity(ctx, mcpidentity.Identity{Kind: mcpidentity.KindAssistant, UserID: ""})
+
+	identity, ok := mcpidentity.FromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, mcpidentity.KindAssistant, identity.Kind)
+	require.Empty(t, identity.UserID)
+}

--- a/server/internal/mcpservers/queries.sql
+++ b/server/internal/mcpservers/queries.sql
@@ -60,6 +60,21 @@ WHERE m.id = @id
   AND p.organization_id = @organization_id
   AND m.deleted IS FALSE;
 
+-- name: HasLiveMCPServerInOrganization :one
+-- Reports whether an MCP server is live and owned by the organization:
+-- the server is not deleted and its project is not deleted. Used by
+-- kill-switch resource validation, where a server under a soft-deleted
+-- project must stop counting as a current organization resource.
+SELECT EXISTS(
+  SELECT 1
+  FROM mcp_servers AS m
+  JOIN projects AS p ON p.id = m.project_id
+  WHERE m.id = @id
+    AND p.organization_id = @organization_id
+    AND m.deleted IS FALSE
+    AND p.deleted IS FALSE
+) AS exists;
+
 -- name: GetMCPServerBySlug :one
 SELECT *
 FROM mcp_servers

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -401,6 +401,34 @@ func (q *Queries) GetMCPServerBySlug(ctx context.Context, arg GetMCPServerBySlug
 	return i, err
 }
 
+const hasLiveMCPServerInOrganization = `-- name: HasLiveMCPServerInOrganization :one
+SELECT EXISTS(
+  SELECT 1
+  FROM mcp_servers AS m
+  JOIN projects AS p ON p.id = m.project_id
+  WHERE m.id = $1
+    AND p.organization_id = $2
+    AND m.deleted IS FALSE
+    AND p.deleted IS FALSE
+) AS exists
+`
+
+type HasLiveMCPServerInOrganizationParams struct {
+	ID             uuid.UUID
+	OrganizationID string
+}
+
+// Reports whether an MCP server is live and owned by the organization:
+// the server is not deleted and its project is not deleted. Used by
+// kill-switch resource validation, where a server under a soft-deleted
+// project must stop counting as a current organization resource.
+func (q *Queries) HasLiveMCPServerInOrganization(ctx context.Context, arg HasLiveMCPServerInOrganizationParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasLiveMCPServerInOrganization, arg.ID, arg.OrganizationID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const listMCPServerToolMetadata = `-- name: ListMCPServerToolMetadata :many
 SELECT id, project_id, mcp_server_id, tool_name, title, read_only_hint, destructive_hint, idempotent_hint, open_world_hint, created_at, updated_at, deleted_at, deleted
 FROM mcp_server_tool_metadata

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -45,6 +45,31 @@ func userRequestMethod(req *UserRequest) string {
 	return ""
 }
 
+// IsToolsCallRequest reports whether req is a single JSON-RPC tools/call
+// request without decoding its method-specific parameters.
+func IsToolsCallRequest(req *UserRequest) bool {
+	return userRequestMethod(req) == methodToolsCall
+}
+
+// ToolsCallName returns the best-effort tool name from a single JSON-RPC
+// tools/call request. The boolean reports method recognition independently of
+// method-parameter validity so method-level observers can include malformed
+// attempts without taking ownership of validation.
+func ToolsCallName(req *UserRequest) (string, bool) {
+	if !IsToolsCallRequest(req) {
+		return "", false
+	}
+
+	var params struct {
+		Name string `json:"name"`
+	}
+	rpcReq, ok := req.JSONRPCMessages[0].(*jsonrpc.Request)
+	if ok {
+		_ = json.Unmarshal(rpcReq.Params, &params)
+	}
+	return params.Name, true
+}
+
 // toolsCallRequestFromUserRequest returns a ToolsCallRequest if req carries
 // exactly one JSON-RPC "tools/call" request whose params decode cleanly.
 // Anything else — notifications, responses, multiple messages, unrelated

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -3,6 +3,7 @@ package remotemcp
 import (
 	"log/slog"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
@@ -31,6 +33,24 @@ import (
 // are constructed once on the factory; the rest are instantiated per-call in
 // [ProxyManager.Build] so the closure over the per-server correlation ids
 // stays request-scoped.
+type proxyBuildOptions struct {
+	recordIdentityCoverage bool
+}
+
+// BuildOption customizes one proxy without changing the defaults used by
+// client-facing MCP routes.
+type BuildOption struct {
+	apply func(*proxyBuildOptions)
+}
+
+// WithoutToolsCallIdentityCoverage omits the mcp_tool_execution census for a
+// synthetic exchange whose authoritative route is outside that contract.
+func WithoutToolsCallIdentityCoverage() BuildOption {
+	return BuildOption{apply: func(options *proxyBuildOptions) {
+		options.recordIdentityCoverage = false
+	}}
+}
+
 type ProxyManager struct {
 	logger         *slog.Logger
 	tracer         trace.Tracer
@@ -39,8 +59,9 @@ type ProxyManager struct {
 	posthog        *posthog.Posthog
 	telemLogger    *tm.Logger
 
-	proxyMetrics *proxy.Metrics
-	mcpMetrics   *ProxyMetrics
+	proxyMetrics     *proxy.Metrics
+	mcpMetrics       *ProxyMetrics
+	identityCoverage *mcptoolexecution.IdentityCoverageCheckpoint
 
 	// requestOTELCounterInterceptor emits the shared per-request census
 	// counter (mcp.request) for the remote- and tunnel-backed /x/mcp traffic,
@@ -70,6 +91,7 @@ func NewProxyManager(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
+	db *pgxpool.Pool,
 	guardianPolicy *guardian.Policy,
 	authzEngine *authz.Engine,
 	posthogClient *posthog.Posthog,
@@ -82,6 +104,7 @@ func NewProxyManager(
 ) *ProxyManager {
 	logger = logger.With(attr.SlogComponent("remotemcp"))
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/remotemcp")
+	mcpMetrics := NewProxyMetrics(meter, logger)
 
 	return &ProxyManager{
 		logger:                                logger,
@@ -91,7 +114,8 @@ func NewProxyManager(
 		posthog:                               posthogClient,
 		telemLogger:                           telemLogger,
 		proxyMetrics:                          proxy.NewMetrics(meter, logger),
-		mcpMetrics:                            NewProxyMetrics(meter, logger),
+		mcpMetrics:                            mcpMetrics,
+		identityCoverage:                      mcptoolexecution.NewIdentityCoverageCheckpoint(db, mcpMetrics),
 		requestOTELCounterInterceptor:         NewRequestOTELCounterInterceptor(mcpmetrics.NewRequestCounter(meter, logger)),
 		toolDispositions:                      toolDispositions,
 		toolsCallUsageLimitsInterceptor:       NewToolsCallUsageLimitsInterceptor(billingRepo, logger),
@@ -136,10 +160,12 @@ func (f *ProxyManager) Build(
 	mcpServerID string,
 	headers []remotemcprepo.RemoteMcpServerHeader,
 	visibility string,
+	organizationID string,
 	projectID string,
 	upstreamAuth string,
 	wwwAuthenticate string,
 	selection *toolfilter.SessionSelection,
+	options ...BuildOption,
 ) *proxy.Proxy {
 	configured := make([]proxy.ConfiguredHeader, 0, len(headers))
 	for _, h := range headers {
@@ -155,7 +181,7 @@ func (f *ProxyManager) Build(
 		RemoteMCPServerID:   server.ID.String(),
 		TunneledMCPServerID: "",
 		McpServerID:         mcpServerID,
-	}, server.Url, configured, visibility, projectID, upstreamAuth, wwwAuthenticate, selection)
+	}, server.Url, configured, visibility, organizationID, projectID, upstreamAuth, wwwAuthenticate, selection, options...)
 }
 
 func (f *ProxyManager) BuildTarget(
@@ -164,11 +190,20 @@ func (f *ProxyManager) BuildTarget(
 	upstreamURL string,
 	headers []proxy.ConfiguredHeader,
 	visibility string,
+	organizationID string,
 	projectID string,
 	upstreamAuth string,
 	wwwAuthenticate string,
 	selection *toolfilter.SessionSelection,
+	buildOptions ...BuildOption,
 ) *proxy.Proxy {
+	options := proxyBuildOptions{recordIdentityCoverage: true}
+	for _, option := range buildOptions {
+		if option.apply != nil {
+			option.apply(&options)
+		}
+	}
+
 	// Per-request instance: the interceptor holds a single nilable start
 	// timestamp set by the request side and consumed by the response side.
 	// A fresh instance per Build makes that field's lifetime match the
@@ -194,7 +229,6 @@ func (f *ProxyManager) BuildTarget(
 	// anything scoped to an identity or a risk policy. It is a no-op for
 	// the arguments that don't carry it.
 	toolsCallReqInterceptors := []proxy.ToolsCallRequestInterceptor{
-		NewToolsCallOTELCounterInterceptor(f.mcpMetrics, identity, logger),
 		f.toolsCallUsageLimitsInterceptor,
 		NewToolsCallStripToolsetIDInterceptor(logger),
 		clickHouseLogInterceptor,
@@ -225,6 +259,16 @@ func (f *ProxyManager) BuildTarget(
 	// and the resources/list RBAC filter are deferred to a follow-up —
 	// the proxy interceptor surface is in place so they can attach later
 	// without touching the proxy package again.
+	userRequestInterceptors := make([]proxy.UserRequestInterceptor, 0, 4)
+	if options.recordIdentityCoverage {
+		userRequestInterceptors = append(userRequestInterceptors, NewToolsCallIdentityCoverageInterceptor(f.identityCoverage, identity, organizationID))
+	}
+	userRequestInterceptors = append(userRequestInterceptors,
+		NewToolsCallOTELCounterInterceptor(f.mcpMetrics, identity, logger),
+		f.requestOTELCounterInterceptor,
+		interceptors.NewFigma(upstreamURL, logger),
+	)
+
 	toolsCallResponseInterceptors := []proxy.ToolsCallResponseInterceptor{
 		f.toolsCallUsageTrackingInterceptor,
 		clickHouseLogInterceptor,
@@ -254,10 +298,7 @@ func (f *ProxyManager) BuildTarget(
 		// The census runs first so every parsed request is counted, including
 		// those a later interceptor rejects — matching the hosted dispatch,
 		// which records before the method switch can refuse a request.
-		UserRequestInterceptors: []proxy.UserRequestInterceptor{
-			f.requestOTELCounterInterceptor,
-			interceptors.NewFigma(upstreamURL, logger),
-		},
+		UserRequestInterceptors: userRequestInterceptors,
 		InitializeRequestInterceptors: []proxy.InitializeRequestInterceptor{
 			NewInitializePostHogEventInterceptor(f.posthog, identity, logger),
 		},

--- a/server/internal/remotemcp/proxymanager_identity_coverage_test.go
+++ b/server/internal/remotemcp/proxymanager_identity_coverage_test.go
@@ -1,0 +1,56 @@
+package remotemcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestProxyBuildOption_ToolsCallIdentityCoverage(t *testing.T) {
+	t.Parallel()
+
+	manager := &ProxyManager{}
+	build := func(options ...BuildOption) *proxy.Proxy {
+		return manager.BuildTarget(
+			testenv.NewLogger(t),
+			proxy.ServerIdentity{},
+			"https://example.com/mcp",
+			nil,
+			"public",
+			"org-test",
+			"project-test",
+			"",
+			"",
+			nil,
+			options...,
+		)
+	}
+	hasUserInterceptor := func(p *proxy.Proxy, name string) bool {
+		for _, interceptor := range p.UserRequestInterceptors {
+			if interceptor != nil && interceptor.Name() == name {
+				return true
+			}
+		}
+		return false
+	}
+	hasTypedInterceptor := func(p *proxy.Proxy, name string) bool {
+		for _, interceptor := range p.ToolsCallRequestInterceptors {
+			if interceptor != nil && interceptor.Name() == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	defaultProxy := build()
+	require.True(t, hasUserInterceptor(defaultProxy, "tools-call-identity-coverage"), "client-facing proxies census tools/call by default")
+	require.True(t, hasUserInterceptor(defaultProxy, "tools-call-otel-counter"), "attempt accounting runs before typed params decode")
+	require.False(t, hasTypedInterceptor(defaultProxy, "tools-call-otel-counter"), "typed params decode must not gate attempt accounting")
+
+	withoutCoverage := build(WithoutToolsCallIdentityCoverage())
+	require.False(t, hasUserInterceptor(withoutCoverage, "tools-call-identity-coverage"), "synthetic meta-member exchanges opt out")
+	require.True(t, hasUserInterceptor(withoutCoverage, "tools-call-otel-counter"), "identity census opt-out must not disable attempt accounting")
+}

--- a/server/internal/remotemcp/proxymetrics.go
+++ b/server/internal/remotemcp/proxymetrics.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
@@ -26,6 +27,7 @@ const instrumentMCPToolCall = "mcp.tool.call"
 // proxy.
 type ProxyMetrics struct {
 	mcpToolCallCounter metric.Int64Counter
+	identityCoverage   *mcpmetrics.IdentityCoverageCounter
 }
 
 // NewProxyMetrics constructs the proxy metrics object. Instrument creation
@@ -43,6 +45,7 @@ func NewProxyMetrics(meter metric.Meter, logger *slog.Logger) *ProxyMetrics {
 
 	return &ProxyMetrics{
 		mcpToolCallCounter: counter,
+		identityCoverage:   mcpmetrics.NewIdentityCoverageCounter(meter, logger),
 	}
 }
 
@@ -71,4 +74,13 @@ func (m *ProxyMetrics) RecordMCPToolCall(ctx context.Context, orgID string, mcpU
 	labels = identity.AppendAttributes(labels)
 
 	m.mcpToolCallCounter.Add(ctx, 1, metric.WithAttributes(labels...))
+}
+
+// RecordKillswitchIdentityCoverage records the bounded coverage classes for
+// one private-proxy tools/call checkpoint.
+func (m *ProxyMetrics) RecordKillswitchIdentityCoverage(ctx context.Context, surface mcpmetrics.KillswitchCoverageSurface, identity mcpmetrics.KillswitchIdentityClass, resource mcpmetrics.KillswitchResourceClass) {
+	if m == nil {
+		return
+	}
+	m.identityCoverage.Record(ctx, surface, identity, resource)
 }

--- a/server/internal/remotemcp/proxymetrics_test.go
+++ b/server/internal/remotemcp/proxymetrics_test.go
@@ -18,6 +18,7 @@ func TestNewProxyMetrics(t *testing.T) {
 	m := NewProxyMetrics(meter, logger)
 	require.NotNil(t, m)
 	require.NotNil(t, m.mcpToolCallCounter)
+	require.NotNil(t, m.identityCoverage)
 }
 
 func TestProxyMetrics_RecordMCPToolCall_RecordsWithValidCounter(t *testing.T) {

--- a/server/internal/remotemcp/tools_call_identity_coverage_interceptor.go
+++ b/server/internal/remotemcp/tools_call_identity_coverage_interceptor.go
@@ -1,0 +1,60 @@
+package remotemcp
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+type identityCoverageCheckpoint interface {
+	Record(context.Context, string, mcpmetrics.KillswitchCoverageSurface, mcptoolexecution.ServerSource)
+}
+
+// ToolsCallIdentityCoverageInterceptor records the private-proxy identity
+// census before typed tools/call parameter decoding. The method-level hook
+// covers malformed params that typed interceptors deliberately leave to the
+// upstream MCP server for validation.
+type ToolsCallIdentityCoverageInterceptor struct {
+	checkpoint     identityCoverageCheckpoint
+	identity       proxy.ServerIdentity
+	organizationID string
+}
+
+var _ proxy.UserRequestInterceptor = (*ToolsCallIdentityCoverageInterceptor)(nil)
+
+func NewToolsCallIdentityCoverageInterceptor(checkpoint identityCoverageCheckpoint, identity proxy.ServerIdentity, organizationID string) *ToolsCallIdentityCoverageInterceptor {
+	return &ToolsCallIdentityCoverageInterceptor{
+		checkpoint:     checkpoint,
+		identity:       identity,
+		organizationID: organizationID,
+	}
+}
+
+func (i *ToolsCallIdentityCoverageInterceptor) Name() string {
+	return "tools-call-identity-coverage"
+}
+
+// InterceptUserRequest records every parsed tools/call request and never
+// rejects it. Validation and enforcement remain owned by their existing
+// interceptors and the upstream MCP server.
+func (i *ToolsCallIdentityCoverageInterceptor) InterceptUserRequest(ctx context.Context, req *proxy.UserRequest) error {
+	if i == nil || i.checkpoint == nil || !proxy.IsToolsCallRequest(req) {
+		return nil
+	}
+
+	frontingServerID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+	if i.identity.McpServerID != "" {
+		// A present but malformed route identity is a data-integrity failure,
+		// not the deliberately unsupported legacy route with no server.
+		frontingServerID.Valid = true
+		frontingServerID.UUID, _ = uuid.Parse(i.identity.McpServerID)
+	}
+	i.checkpoint.Record(ctx, i.organizationID, mcpmetrics.KillswitchSurfacePrivateProxy, mcptoolexecution.ServerSource{
+		FrontingServerID: frontingServerID,
+	})
+	return nil
+}

--- a/server/internal/remotemcp/tools_call_identity_coverage_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_identity_coverage_interceptor_test.go
@@ -1,0 +1,79 @@
+package remotemcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+type recordingIdentityCoverage struct {
+	organizationID string
+	surface        mcpmetrics.KillswitchCoverageSurface
+	source         mcptoolexecution.ServerSource
+	calls          int
+}
+
+func (r *recordingIdentityCoverage) Record(_ context.Context, organizationID string, surface mcpmetrics.KillswitchCoverageSurface, source mcptoolexecution.ServerSource) {
+	r.organizationID = organizationID
+	r.surface = surface
+	r.source = source
+	r.calls++
+}
+
+func TestToolsCallIdentityCoverageInterceptor_RecordsBeforeTypedParamsDecode(t *testing.T) {
+	t.Parallel()
+
+	serverID := uuid.New()
+	coverage := &recordingIdentityCoverage{}
+	interceptor := NewToolsCallIdentityCoverageInterceptor(coverage, proxy.ServerIdentity{McpServerID: serverID.String()}, "org-route")
+	req := &proxy.UserRequest{JSONRPCMessages: []jsonrpc.Message{&jsonrpc.Request{
+		ID:     jsonrpc.ID{},
+		Method: "tools/call",
+		Params: json.RawMessage(`"malformed params"`),
+	}}}
+
+	require.NoError(t, interceptor.InterceptUserRequest(t.Context(), req))
+	require.Equal(t, 1, coverage.calls)
+	require.Equal(t, "org-route", coverage.organizationID)
+	require.Equal(t, mcpmetrics.KillswitchSurfacePrivateProxy, coverage.surface)
+	require.Equal(t, uuid.NullUUID{UUID: serverID, Valid: true}, coverage.source.FrontingServerID)
+}
+
+func TestToolsCallIdentityCoverageInterceptor_PreservesMalformedRouteIdentityAsPresent(t *testing.T) {
+	t.Parallel()
+
+	coverage := &recordingIdentityCoverage{}
+	interceptor := NewToolsCallIdentityCoverageInterceptor(coverage, proxy.ServerIdentity{McpServerID: "not-a-uuid"}, "org-route")
+	req := &proxy.UserRequest{JSONRPCMessages: []jsonrpc.Message{&jsonrpc.Request{
+		ID:     jsonrpc.ID{},
+		Method: "tools/call",
+		Params: json.RawMessage(`{}`),
+	}}}
+
+	require.NoError(t, interceptor.InterceptUserRequest(t.Context(), req))
+	require.Equal(t, 1, coverage.calls)
+	require.Equal(t, uuid.NullUUID{UUID: uuid.Nil, Valid: true}, coverage.source.FrontingServerID)
+}
+
+func TestToolsCallIdentityCoverageInterceptor_IgnoresOtherMethods(t *testing.T) {
+	t.Parallel()
+
+	coverage := &recordingIdentityCoverage{}
+	interceptor := NewToolsCallIdentityCoverageInterceptor(coverage, proxy.ServerIdentity{}, "org-route")
+	req := &proxy.UserRequest{JSONRPCMessages: []jsonrpc.Message{&jsonrpc.Request{
+		ID:     jsonrpc.ID{},
+		Method: "tools/list",
+		Params: json.RawMessage(`{}`),
+	}}}
+
+	require.NoError(t, interceptor.InterceptUserRequest(t.Context(), req))
+	require.Zero(t, coverage.calls)
+}

--- a/server/internal/remotemcp/tools_call_otel_counter_interceptor.go
+++ b/server/internal/remotemcp/tools_call_otel_counter_interceptor.go
@@ -10,16 +10,17 @@ import (
 
 // ToolsCallOTELCounterInterceptor records the per-tool MCP call counter for each
 // tools/call invocation against a Remote MCP Server. It is a
-// [proxy.ToolsCallRequestInterceptor]: counting at the request side mirrors
-// `/mcp` (which records before forwarding to the upstream tool executor) so
-// the same metric tracks attempted calls regardless of upstream success.
+// [proxy.UserRequestInterceptor] so parseable calls with malformed method params
+// are still counted before typed request decoding. This mirrors `/mcp` (which
+// records before forwarding to the upstream tool executor) so the same metric
+// tracks attempted calls regardless of upstream success.
 type ToolsCallOTELCounterInterceptor struct {
 	metrics  *ProxyMetrics
 	identity proxy.ServerIdentity
 	logger   *slog.Logger
 }
 
-var _ proxy.ToolsCallRequestInterceptor = (*ToolsCallOTELCounterInterceptor)(nil)
+var _ proxy.UserRequestInterceptor = (*ToolsCallOTELCounterInterceptor)(nil)
 
 // NewToolsCallOTELCounterInterceptor constructs an interceptor bound to the
 // given metrics object and server correlation ids. Construct one per request
@@ -34,16 +35,20 @@ func NewToolsCallOTELCounterInterceptor(m *ProxyMetrics, identity proxy.ServerId
 	}
 }
 
-// Name implements [proxy.ToolsCallRequestInterceptor].
+// Name implements [proxy.UserRequestInterceptor].
 func (i *ToolsCallOTELCounterInterceptor) Name() string {
 	return "tools-call-otel-counter"
 }
 
-// InterceptToolsCallRequest implements [proxy.ToolsCallRequestInterceptor].
-// Always returns nil — counter recording is best-effort and must not block
-// tool invocation on metrics-backend failures.
-func (i *ToolsCallOTELCounterInterceptor) InterceptToolsCallRequest(ctx context.Context, call *proxy.ToolsCallRequest) error {
-	if i.metrics == nil || call == nil || call.Params == nil {
+// InterceptUserRequest implements [proxy.UserRequestInterceptor]. Always
+// returns nil — counter recording is best-effort and must not block tool
+// invocation or take ownership of method-parameter validation.
+func (i *ToolsCallOTELCounterInterceptor) InterceptUserRequest(ctx context.Context, req *proxy.UserRequest) error {
+	if i == nil || i.metrics == nil {
+		return nil
+	}
+	toolName, isToolsCall := proxy.ToolsCallName(req)
+	if !isToolsCall {
 		return nil
 	}
 
@@ -57,6 +62,6 @@ func (i *ToolsCallOTELCounterInterceptor) InterceptToolsCallRequest(ctx context.
 		mcpURL = requestContext.Host + requestContext.ReqURL
 	}
 
-	i.metrics.RecordMCPToolCall(ctx, authCtx.ActiveOrganizationID, mcpURL, i.identity, call.Params.Name)
+	i.metrics.RecordMCPToolCall(ctx, authCtx.ActiveOrganizationID, mcpURL, i.identity, toolName)
 	return nil
 }

--- a/server/internal/remotemcp/tools_call_otel_counter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_otel_counter_interceptor_test.go
@@ -1,90 +1,121 @@
 package remotemcp
 
 import (
-	"net/http"
+	"context"
+	"encoding/json"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-// newCounterInterceptorForTest builds an interceptor backed by a testenv OTel
-// meter. The interceptor exercises the recording path; we cannot directly
-// observe what dimensions the meter receives, so tests verify the
-// interceptor never rejects (the only contract the rest of the pipeline
-// depends on). This mirrors the assertion shape of /mcp's metrics tests.
-func newCounterInterceptorForTest(t *testing.T) *ToolsCallOTELCounterInterceptor {
+func newCounterInterceptorForTest(t *testing.T) (*ToolsCallOTELCounterInterceptor, *sdkmetric.ManualReader) {
 	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
 	logger := testenv.NewLogger(t)
-	return NewToolsCallOTELCounterInterceptor(NewProxyMetrics(testenv.NewMeterProvider(t).Meter("test"), logger), proxy.ServerIdentity{
-		RemoteMCPServerID:   "srv-test",
-		TunneledMCPServerID: "",
-		McpServerID:         "mcp-test",
-	}, logger)
+	metrics := NewProxyMetrics(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test"), logger)
+	return NewToolsCallOTELCounterInterceptor(metrics, proxy.ServerIdentity{
+		RemoteMCPServerID: "srv-test",
+		McpServerID:       "mcp-test",
+	}, logger), reader
 }
 
-func newToolsCallRequestForCounter(t *testing.T, toolName string) *proxy.ToolsCallRequest {
+func newToolsCallUserRequest(params json.RawMessage) *proxy.UserRequest {
+	return &proxy.UserRequest{JSONRPCMessages: []jsonrpc.Message{&jsonrpc.Request{
+		ID:     jsonrpc.ID{},
+		Method: "tools/call",
+		Params: params,
+	}}}
+}
+
+func collectToolCallCounter(t *testing.T, reader *sdkmetric.ManualReader) (int64, string) {
 	t.Helper()
 
-	httpReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/server", http.NoBody)
-	require.NoError(t, err)
-
-	return &proxy.ToolsCallRequest{
-		UserRequest: &proxy.UserRequest{
-			UserHTTPRequest: httpReq,
-		},
-		Params: &mcp.CallToolParamsRaw{
-			Name:      toolName,
-			Arguments: nil,
-			Meta:      nil,
-		},
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	var calls int64
+	var toolName string
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != instrumentMCPToolCall {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				calls += point.Value
+				value, ok := point.Attributes.Value(attr.ToolName("").Key)
+				require.True(t, ok)
+				toolName = value.AsString()
+			}
+		}
 	}
+	return calls, toolName
 }
 
-func TestToolsCallOTELCounterInterceptor_Name(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "tools-call-otel-counter", newCounterInterceptorForTest(t).Name())
-}
-
-func TestToolsCallOTELCounterInterceptor_NoAuthContextPassesThrough(t *testing.T) {
-	t.Parallel()
-
-	interceptor := newCounterInterceptorForTest(t)
-
-	require.NoError(t, interceptor.InterceptToolsCallRequest(t.Context(), newToolsCallRequestForCounter(t, "any_tool")))
-}
-
-func TestToolsCallOTELCounterInterceptor_AuthenticatedRequestPassesThrough(t *testing.T) {
-	t.Parallel()
-
-	interceptor := newCounterInterceptorForTest(t)
+func authenticatedCounterContext(t *testing.T) context.Context {
+	t.Helper()
 
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID: "org-counter",
 		AccountType:          string(billing.TierPro),
 	})
-	ctx = contextvalues.SetRequestContext(ctx, &contextvalues.RequestContext{
+	return contextvalues.SetRequestContext(ctx, &contextvalues.RequestContext{
 		Host:   "x.example.com",
 		ReqURL: "/x/mcp/abc",
 	})
+}
 
-	require.NoError(t, interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequestForCounter(t, "search_tickets")))
+func TestToolsCallOTELCounterInterceptor_Name(t *testing.T) {
+	t.Parallel()
+
+	interceptor, _ := newCounterInterceptorForTest(t)
+	require.Equal(t, "tools-call-otel-counter", interceptor.Name())
+}
+
+func TestToolsCallOTELCounterInterceptor_NoAuthContextPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	interceptor, _ := newCounterInterceptorForTest(t)
+	require.NoError(t, interceptor.InterceptUserRequest(t.Context(), newToolsCallUserRequest(json.RawMessage(`{"name":"any_tool"}`))))
+}
+
+func TestToolsCallOTELCounterInterceptor_RecordsTypedRequest(t *testing.T) {
+	t.Parallel()
+
+	interceptor, reader := newCounterInterceptorForTest(t)
+	require.NoError(t, interceptor.InterceptUserRequest(authenticatedCounterContext(t), newToolsCallUserRequest(json.RawMessage(`{"name":"search_tickets"}`))))
+
+	calls, toolName := collectToolCallCounter(t, reader)
+	require.Equal(t, int64(1), calls)
+	require.Equal(t, "search_tickets", toolName)
+}
+
+func TestToolsCallOTELCounterInterceptor_RecordsMalformedParamsWithoutRejecting(t *testing.T) {
+	t.Parallel()
+
+	interceptor, reader := newCounterInterceptorForTest(t)
+	require.NoError(t, interceptor.InterceptUserRequest(authenticatedCounterContext(t), newToolsCallUserRequest(json.RawMessage(`"malformed params"`))))
+
+	calls, toolName := collectToolCallCounter(t, reader)
+	require.Equal(t, int64(1), calls)
+	require.Empty(t, toolName)
 }
 
 func TestToolsCallOTELCounterInterceptor_NeverRejects(t *testing.T) {
 	t.Parallel()
 
-	interceptor := newCounterInterceptorForTest(t)
-
-	// Counter recording is best-effort: even with an empty auth context the
-	// interceptor must return nil so the request is not blocked.
+	interceptor, _ := newCounterInterceptorForTest(t)
 	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{})
 
-	require.NoError(t, interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequestForCounter(t, "any_tool")))
+	require.NoError(t, interceptor.InterceptUserRequest(ctx, newToolsCallUserRequest(json.RawMessage(`{}`))))
 }

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -155,7 +155,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()))
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()))
 	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, &feature.InMemory{}, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,


### PR DESCRIPTION
## Summary

Registers the fail-closed `mcp_tool_execution` killswitch contract with authoritative active-user and canonical MCP-server adapters. Adds trusted authentication provenance and bounded coverage classification so unsupported MCP identities remain explicit instead of being inferred from credential metadata.

## Technical details

### Identity provenance is credential-derived

Only validated concrete user sessions can produce a user principal. Assistant, API-key, chat-session, anonymous, legacy, and unattributed paths remain bounded unsupported classifications, and active organization membership is revalidated for each derivation.

### Resource identity uses the fronting server

Hosted and private routes derive the canonical resource from the live fronting `mcp_servers` row, including same-organization servers across projects. Deleted, orphaned, and cross-tenant servers fail closed.

Closes [DNO-979](https://linear.app/speakeasy/issue/DNO-979)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the fail-closed `mcp_tool_execution` killswitch contract with authoritative user and canonical MCP server adapters, and wires identity/resource coverage into hosted and private-proxy tools/call paths. No enforcement is deployed; checkpoints ship separately in DNO-980/DNO-982. Closes [DNO-979](https://linear.app/speakeasy/issue/DNO-979).

**Key details**
- New `mcpidentity` package stamps provenance at credential validation; only `KindUserSession` yields a candidate, and assistant-token fallback is never promoted to a user.
- Adapters revalidate active organization membership and live server ownership on every call, failing closed for deleted, inactive, or cross-tenant resources, or servers under soft-deleted projects.
- Coverage checkpoints run on every covered call and classify identity and resource outcomes into bounded buckets, so low coverage is observable instead of silently broadening.
- Meta-synthesized member dispatch is excluded from the census because its fronting server is outside the contract; malformed tools/call attempts are counted and classified at the method boundary, before typed parameter decoding.

<sup>Written for commit 1cbe265f1b4b47303641462ea9d7c33fccbd2f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

