### PR TITLE
fix: enforce entitlements on product features and WorkOS portal links

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -34420,7 +34420,7 @@ paths:
         name: ProductFeatures
   /rpc/productFeatures.set:
     post:
-      description: Enable or disable an organization feature flag.
+      description: Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.
       operationId: setProductFeature
       parameters:
         - allowEmptyValue: true

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -106,6 +106,8 @@ export const AUDIT_ACTIONS = [
   "organization:hooks_fail_open_enabled",
   "organization:payg_activated",
   "organization:payg_deactivated",
+  "organization:product_feature_disabled",
+  "organization:product_feature_enabled",
   "organization:webhooks_disabled",
   "organization:webhooks_enabled",
   "organization_invitation:create",
@@ -458,6 +460,10 @@ export function staticActionPhrase(action: AuditAction): string {
       return "activated pay-as-you-go billing for";
     case "organization:payg_deactivated":
       return "deactivated pay-as-you-go billing for";
+    case "organization:product_feature_enabled":
+      return "enabled a product feature for";
+    case "organization:product_feature_disabled":
+      return "disabled a product feature for";
 
     case "organization_invitation:create":
       return "invited";

--- a/client/dashboard/src/lib/audit-log-format.test.ts
+++ b/client/dashboard/src/lib/audit-log-format.test.ts
@@ -58,6 +58,29 @@ describe("renderVerb", () => {
         }),
       ),
     ).toBe("sent org admin invite to");
+
+    expect(
+      renderVerb(
+        log({
+          action: "organization:product_feature_enabled",
+          metadata: { feature_name: "sso" },
+        }),
+      ),
+    ).toBe("enabled the sso feature for");
+
+    expect(
+      renderVerb(
+        log({
+          action: "organization:product_feature_disabled",
+          metadata: { feature_name: "custom_model_keys" },
+        }),
+      ),
+    ).toBe("disabled the custom model keys feature for");
+
+    // Without metadata the fixed phrase still reads as a sentence.
+    expect(
+      renderVerb(log({ action: "organization:product_feature_disabled" })),
+    ).toBe("disabled a product feature for");
   });
 
   // Every billing action is recorded against the same fixed subject display

--- a/client/dashboard/src/lib/audit-log-format.ts
+++ b/client/dashboard/src/lib/audit-log-format.ts
@@ -148,14 +148,14 @@ function recordString(value: unknown, key: string): string | undefined {
   return typeof field === "string" && field !== "" ? field : undefined;
 }
 
-function formatRoleSlug(roleSlug: string): string {
-  return roleSlug.replace(/[-_]/g, " ");
+function humanizeSlug(slug: string): string {
+  return slug.replace(/[-_]/g, " ");
 }
 
 function describeInvitation(log: AuditLog): string | undefined {
   if (log.action === "organization_invitation:create") {
     const role = recordString(log.metadata, "role_slug");
-    return role ? `sent ${formatRoleSlug(role)} invite to` : undefined;
+    return role ? `sent ${humanizeSlug(role)} invite to` : undefined;
   }
 
   if (log.action === "organization_invitation:update_role") {
@@ -166,14 +166,24 @@ function describeInvitation(log: AuditLog): string | undefined {
       recordString(log.afterSnapshot, "RoleSlug") ??
       recordString(log.afterSnapshot, "role_slug");
     if (before && after && before !== after) {
-      return `changed invite role from ${formatRoleSlug(before)} to ${formatRoleSlug(after)} for`;
+      return `changed invite role from ${humanizeSlug(before)} to ${humanizeSlug(after)} for`;
     }
     if (after) {
-      return `changed invite role to ${formatRoleSlug(after)} for`;
+      return `changed invite role to ${humanizeSlug(after)} for`;
     }
   }
 
   return undefined;
+}
+
+function describeProductFeatureToggle(log: AuditLog): string | undefined {
+  const feature = recordString(log.metadata, "feature_name");
+  if (!feature) return undefined;
+  const verb =
+    log.action === "organization:product_feature_enabled"
+      ? "enabled"
+      : "disabled";
+  return `${verb} the ${humanizeSlug(feature)} feature for`;
 }
 
 const IRREGULAR_PAST_TENSE: Record<string, string> = {
@@ -281,6 +291,11 @@ export function renderVerb(log: AuditLog): string {
     case "organization_invitation:create":
     case "organization_invitation:update_role":
       return describeInvitation(log) ?? staticActionPhrase(log.action);
+    case "organization:product_feature_enabled":
+    case "organization:product_feature_disabled":
+      return (
+        describeProductFeatureToggle(log) ?? staticActionPhrase(log.action)
+      );
   }
 
   return isAuditAction(log.action)

--- a/client/dashboard/src/pages/platform-admin/PlatformAdminGate.tsx
+++ b/client/dashboard/src/pages/platform-admin/PlatformAdminGate.tsx
@@ -5,8 +5,10 @@ import type { ReactNode } from "react";
 // Chrome-level gate for the Platform Admin pages. Mirrors the visibility rule
 // of the old floating Developer Toolkit: always available in local dev (so
 // non-admins can reach the platform-admin impersonation toggle), platform
-// admins only everywhere else. Presentation only — every endpoint these pages
-// call enforces the platform-admin flag server-side.
+// admins only everywhere else. Presentation only — authorization is enforced
+// server-side by every endpoint these pages call: staff-managed entitlement
+// toggles require the platform-admin flag, org-self-serve features surfaced
+// here (e.g. Platform MCP access) require org:admin.
 export function PlatformAdminGate({
   children,
 }: {

--- a/client/dashboard/src/sdk/src/funcs/featuresSet.ts
+++ b/client/dashboard/src/sdk/src/funcs/featuresSet.ts
@@ -38,7 +38,7 @@ import { Result } from "../types/fp.js";
  * setProductFeature features
  *
  * @remarks
- * Enable or disable an organization feature flag.
+ * Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.
  */
 export function featuresSet(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/react-query/featuresSet.ts
+++ b/client/dashboard/src/sdk/src/react-query/featuresSet.ts
@@ -53,7 +53,7 @@ export type FeaturesSetMutationError =
  * setProductFeature features
  *
  * @remarks
- * Enable or disable an organization feature flag.
+ * Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.
  */
 export function useFeaturesSetMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/features.ts
+++ b/client/dashboard/src/sdk/src/sdk/features.ts
@@ -45,7 +45,7 @@ export class Features extends ClientSDK {
    * setProductFeature features
    *
    * @remarks
-   * Enable or disable an organization feature flag.
+   * Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.
    */
   async set(
     request: SetProductFeatureRequest,

--- a/server/design/productfeatures/design.go
+++ b/server/design/productfeatures/design.go
@@ -58,7 +58,7 @@ var _ = Service("features", func() {
 	})
 
 	Method("setProductFeature", func() {
-		Description("Enable or disable an organization feature flag.")
+		Description("Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.")
 
 		Payload(func() {
 			Attribute("organization_id", String, "Organization whose product feature to update.")

--- a/server/gen/features/service.go
+++ b/server/gen/features/service.go
@@ -18,7 +18,10 @@ import (
 type Service interface {
 	// Get the current state of all product feature flags.
 	GetProductFeatures(context.Context, *GetProductFeaturesPayload) (res *GetProductFeaturesResult, err error)
-	// Enable or disable an organization feature flag.
+	// Enable or disable an organization feature flag. Staff-managed entitlements
+	// (such as sso and scim) additionally require a Speakeasy platform
+	// administrator; organization admins can set only the org-settable operational
+	// toggles.
 	SetProductFeature(context.Context, *SetProductFeaturePayload) (err error)
 	// Set the organization policy for automatic remote-session refresh.
 	SetRemoteSessionAutoRefreshPolicy(context.Context, *SetRemoteSessionAutoRefreshPolicyPayload) (err error)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -17380,7 +17380,7 @@ func featuresUsage() {
 	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] features COMMAND [flags]\n\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "COMMAND:")
 	fmt.Fprintln(os.Stderr, `    get-product-features: Get the current state of all product feature flags.`)
-	fmt.Fprintln(os.Stderr, `    set-product-feature: Enable or disable an organization feature flag.`)
+	fmt.Fprintln(os.Stderr, `    set-product-feature: Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.`)
 	fmt.Fprintln(os.Stderr, `    set-remote-session-auto-refresh-policy: Set the organization policy for automatic remote-session refresh.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
@@ -17415,7 +17415,7 @@ func featuresSetProductFeatureUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Enable or disable an organization feature flag.`)
+	fmt.Fprintln(os.Stderr, `Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -36049,7 +36049,7 @@ paths:
                 name: ProductFeatures
     /rpc/productFeatures.set:
         post:
-            description: Enable or disable an organization feature flag.
+            description: Enable or disable an organization feature flag. Staff-managed entitlements (such as sso and scim) additionally require a Speakeasy platform administrator; organization admins can set only the org-settable operational toggles.
             operationId: setProductFeature
             parameters:
                 - allowEmptyValue: true

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -231,55 +231,15 @@ func (l *Logger) LogOrganizationWebhooksToggled(ctx context.Context, dbtx repo.D
 	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationWebhooksV1})
 }
 
-type LogOrganizationHooksFailOpenToggledEvent struct {
-	OrganizationID string
-
-	Actor            urn.Principal
-	ActorDisplayName *string
-	ActorSlug        *string
-
-	OrganizationName string
-	OrganizationSlug string
-
-	FailOpenEnabled bool
-}
-
-func (l *Logger) LogOrganizationHooksFailOpenToggled(ctx context.Context, dbtx repo.DBTX, event LogOrganizationHooksFailOpenToggledEvent) error {
-	var action Action
-	if event.FailOpenEnabled {
-		action = ActionOrganizationHooksFailOpenEnabled
-	} else {
-		action = ActionOrganizationHooksFailOpenDisabled
-	}
-
-	entry := repo.InsertAuditLogParams{
-		OrganizationID: event.OrganizationID,
-		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-
-		ActorID:          event.Actor.ID,
-		ActorType:        string(event.Actor.Type),
-		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
-		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
-
-		Action: string(action),
-
-		SubjectID:          event.OrganizationID,
-		SubjectType:        "organization",
-		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
-		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
-
-		Metadata:       nil,
-		BeforeSnapshot: nil,
-		AfterSnapshot:  nil,
-	}
-
-	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationHooksFailOpenV1})
-}
+// hooksFailOpenFeatureName mirrors productfeatures.FeatureHooksFailOpen,
+// which this package cannot import without a cycle.
+const hooksFailOpenFeatureName = "hooks_fail_open"
 
 // LogOrganizationProductFeatureToggledEvent records a productFeatures.set
-// change for every feature except hooks_fail_open, which keeps its dedicated
-// action so security-posture changes stay distinguishable. The toggled
-// feature's name is carried in metadata under "feature_name".
+// change. The toggled feature's name is carried in metadata under
+// "feature_name", except for hooks_fail_open, which keeps its dedicated
+// action (and no metadata) so security-posture changes stay distinguishable
+// from ordinary feature toggles.
 type LogOrganizationProductFeatureToggledEvent struct {
 	OrganizationID string
 
@@ -295,18 +255,20 @@ type LogOrganizationProductFeatureToggledEvent struct {
 }
 
 func (l *Logger) LogOrganizationProductFeatureToggled(ctx context.Context, dbtx repo.DBTX, event LogOrganizationProductFeatureToggledEvent) error {
-	var action Action
-	if event.FeatureEnabled {
-		action = ActionOrganizationProductFeatureEnabled
+	action := conv.Ternary(event.FeatureEnabled, ActionOrganizationProductFeatureEnabled, ActionOrganizationProductFeatureDisabled)
+	outboxEvent := events.OrganizationProductFeatureV1
+	var metadata []byte
+	if event.FeatureName == hooksFailOpenFeatureName {
+		action = conv.Ternary(event.FeatureEnabled, ActionOrganizationHooksFailOpenEnabled, ActionOrganizationHooksFailOpenDisabled)
+		outboxEvent = events.OrganizationHooksFailOpenV1
 	} else {
-		action = ActionOrganizationProductFeatureDisabled
-	}
-
-	metadata, err := marshalAuditPayload(map[string]any{
-		"feature_name": event.FeatureName,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal %s metadata: %w", action, err)
+		var err error
+		metadata, err = marshalAuditPayload(map[string]any{
+			"feature_name": event.FeatureName,
+		})
+		if err != nil {
+			return fmt.Errorf("marshal %s metadata: %w", action, err)
+		}
 	}
 
 	entry := repo.InsertAuditLogParams{
@@ -330,7 +292,7 @@ func (l *Logger) LogOrganizationProductFeatureToggled(ctx context.Context, dbtx 
 		AfterSnapshot:  nil,
 	}
 
-	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationProductFeatureV1})
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: outboxEvent})
 }
 
 type DeviceAgentConfigurationSnapshot struct {

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -23,6 +23,9 @@ const (
 	ActionOrganizationHooksFailOpenEnabled  Action = "organization:hooks_fail_open_enabled"
 	ActionOrganizationHooksFailOpenDisabled Action = "organization:hooks_fail_open_disabled"
 
+	ActionOrganizationProductFeatureEnabled  Action = "organization:product_feature_enabled"
+	ActionOrganizationProductFeatureDisabled Action = "organization:product_feature_disabled"
+
 	ActionOrganizationDeviceAgentConfigurationUpdated Action = "organization:device_agent_configuration_updated"
 
 	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
@@ -271,6 +274,63 @@ func (l *Logger) LogOrganizationHooksFailOpenToggled(ctx context.Context, dbtx r
 	}
 
 	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationHooksFailOpenV1})
+}
+
+// LogOrganizationProductFeatureToggledEvent records a productFeatures.set
+// change for every feature except hooks_fail_open, which keeps its dedicated
+// action so security-posture changes stay distinguishable. The toggled
+// feature's name is carried in metadata under "feature_name".
+type LogOrganizationProductFeatureToggledEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	FeatureName    string
+	FeatureEnabled bool
+}
+
+func (l *Logger) LogOrganizationProductFeatureToggled(ctx context.Context, dbtx repo.DBTX, event LogOrganizationProductFeatureToggledEvent) error {
+	var action Action
+	if event.FeatureEnabled {
+		action = ActionOrganizationProductFeatureEnabled
+	} else {
+		action = ActionOrganizationProductFeatureDisabled
+	}
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"feature_name": event.FeatureName,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationProductFeatureV1})
 }
 
 type DeviceAgentConfigurationSnapshot struct {

--- a/server/internal/organizations/generateworkosadminportallink_test.go
+++ b/server/internal/organizations/generateworkosadminportallink_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -18,7 +20,7 @@ const testPortalLink = "https://id.workos.com/portal/launch?secret=abc123"
 func TestService_GenerateWorkOSAdminPortalLink_IntentOnly(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
 
 	ti.orgs.On("GenerateAdminPortalLink", mock.Anything, mock.Anything, thirdpartyworkos.PortalIntentSSO, thirdpartyworkos.GenerateAdminPortalLinkOpts{}).
 		Return(testPortalLink, nil).Once()
@@ -35,7 +37,7 @@ func TestService_GenerateWorkOSAdminPortalLink_IntentOnly(t *testing.T) {
 func TestService_GenerateWorkOSAdminPortalLink_WithReturnAndSuccessURLs(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
 
 	expectedOpts := thirdpartyworkos.GenerateAdminPortalLinkOpts{
 		ReturnURL:  "https://app.example.com/settings",
@@ -58,7 +60,7 @@ func TestService_GenerateWorkOSAdminPortalLink_WithReturnAndSuccessURLs(t *testi
 func TestService_GenerateWorkOSAdminPortalLink_WithITContactEmails(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSCIM))
 
 	expectedOpts := thirdpartyworkos.GenerateAdminPortalLinkOpts{
 		ITContactEmails: []string{"admin@example.com", "security@example.com"},
@@ -79,7 +81,7 @@ func TestService_GenerateWorkOSAdminPortalLink_WithITContactEmails(t *testing.T)
 func TestService_GenerateWorkOSAdminPortalLink_WithSSOIntentOptions(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
 
 	expectedOpts := thirdpartyworkos.GenerateAdminPortalLinkOpts{
 		IntentOptions: &thirdpartyworkos.IntentOptions{
@@ -137,7 +139,7 @@ func TestService_GenerateWorkOSAdminPortalLink_WithDomainVerificationIntentOptio
 func TestService_GenerateWorkOSAdminPortalLink_AllOptions(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
 
 	expectedOpts := thirdpartyworkos.GenerateAdminPortalLinkOpts{
 		ReturnURL:       "https://app.example.com/return",
@@ -174,7 +176,7 @@ func TestService_GenerateWorkOSAdminPortalLink_AllOptions(t *testing.T) {
 func TestService_GenerateWorkOSAdminPortalLink_OrgNotLinkedToWorkOS(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
 
 	// Clear the WorkOS org ID so the handler hits the "not linked" guard.
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -189,4 +191,136 @@ func TestService_GenerateWorkOSAdminPortalLink_OrgNotLinkedToWorkOS(t *testing.T
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_SSONotEntitled(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+
+	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "sso",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+
+	ti.orgs.AssertNotCalled(t, "GenerateAdminPortalLink", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_DSyncNotEntitled(t *testing.T) {
+	t.Parallel()
+
+	// SSO alone must not unlock dsync — the mapping is per intent.
+	ctx, ti := newTestOrganizationsServiceWithFeatures(t, enabledFeatures(productfeatures.FeatureSSO))
+
+	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "dsync",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+
+	ti.orgs.AssertNotCalled(t, "GenerateAdminPortalLink", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_AuditLogsEnterprise(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = string(billing.TierEnterprise)
+
+	ti.orgs.On("GenerateAdminPortalLink", mock.Anything, mock.Anything, thirdpartyworkos.PortalIntentAuditLogs, thirdpartyworkos.GenerateAdminPortalLinkOpts{}).
+		Return(testPortalLink, nil).Once()
+
+	res, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "audit_logs",
+	})
+	require.NoError(t, err)
+	require.Equal(t, testPortalLink, res.URL)
+
+	ti.orgs.AssertExpectations(t)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_AuditLogsNonEnterpriseDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = string(billing.TierPro)
+
+	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "audit_logs",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+
+	ti.orgs.AssertNotCalled(t, "GenerateAdminPortalLink", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_LogStreamsEnterprise(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = string(billing.TierEnterprise)
+
+	ti.orgs.On("GenerateAdminPortalLink", mock.Anything, mock.Anything, thirdpartyworkos.PortalIntentLogStreams, thirdpartyworkos.GenerateAdminPortalLinkOpts{}).
+		Return(testPortalLink, nil).Once()
+
+	res, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "log_streams",
+	})
+	require.NoError(t, err)
+	require.Equal(t, testPortalLink, res.URL)
+
+	ti.orgs.AssertExpectations(t)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_LogStreamsNonEnterpriseDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = string(billing.TierBase)
+
+	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "log_streams",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+
+	ti.orgs.AssertNotCalled(t, "GenerateAdminPortalLink", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestService_GenerateWorkOSAdminPortalLink_UnknownIntentDenied(t *testing.T) {
+	t.Parallel()
+
+	// Fail closed: an intent added at the design layer without an entitlement
+	// mapping must be denied, even for a fully entitled enterprise org.
+	ctx, ti := newTestOrganizationsServiceRBAC(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = string(billing.TierEnterprise)
+
+	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
+		Intent: "certificate_renewal",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+
+	ti.orgs.AssertNotCalled(t, "GenerateAdminPortalLink", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/server/internal/organizations/generateworkosadminportallink_test.go
+++ b/server/internal/organizations/generateworkosadminportallink_test.go
@@ -228,10 +228,7 @@ func TestService_GenerateWorkOSAdminPortalLink_AuditLogsEnterprise(t *testing.T)
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	authCtx.AccountType = string(billing.TierEnterprise)
+	ctx = withAccountType(t, ctx, string(billing.TierEnterprise))
 
 	ti.orgs.On("GenerateAdminPortalLink", mock.Anything, mock.Anything, thirdpartyworkos.PortalIntentAuditLogs, thirdpartyworkos.GenerateAdminPortalLinkOpts{}).
 		Return(testPortalLink, nil).Once()
@@ -249,10 +246,7 @@ func TestService_GenerateWorkOSAdminPortalLink_AuditLogsNonEnterpriseDenied(t *t
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	authCtx.AccountType = string(billing.TierPro)
+	ctx = withAccountType(t, ctx, string(billing.TierPro))
 
 	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
 		Intent: "audit_logs",
@@ -268,10 +262,7 @@ func TestService_GenerateWorkOSAdminPortalLink_LogStreamsEnterprise(t *testing.T
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	authCtx.AccountType = string(billing.TierEnterprise)
+	ctx = withAccountType(t, ctx, string(billing.TierEnterprise))
 
 	ti.orgs.On("GenerateAdminPortalLink", mock.Anything, mock.Anything, thirdpartyworkos.PortalIntentLogStreams, thirdpartyworkos.GenerateAdminPortalLinkOpts{}).
 		Return(testPortalLink, nil).Once()
@@ -289,10 +280,7 @@ func TestService_GenerateWorkOSAdminPortalLink_LogStreamsNonEnterpriseDenied(t *
 	t.Parallel()
 
 	ctx, ti := newTestOrganizationsService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	authCtx.AccountType = string(billing.TierBase)
+	ctx = withAccountType(t, ctx, string(billing.TierBase))
 
 	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
 		Intent: "log_streams",
@@ -310,10 +298,7 @@ func TestService_GenerateWorkOSAdminPortalLink_UnknownIntentDenied(t *testing.T)
 	// Fail closed: an intent added at the design layer without an entitlement
 	// mapping must be denied, even for a fully entitled enterprise org.
 	ctx, ti := newTestOrganizationsServiceRBAC(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	authCtx.AccountType = string(billing.TierEnterprise)
+	ctx = withAccountType(t, ctx, string(billing.TierEnterprise))
 
 	_, err := ti.service.GenerateWorkOSAdminPortalLink(ctx, &gen.GenerateWorkOSAdminPortalLinkPayload{
 		Intent: "certificate_renewal",

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -1184,6 +1185,10 @@ func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *ge
 		return nil, err
 	}
 
+	if err := s.requirePortalIntentEntitlement(ctx, ac, workos.PortalIntent(payload.Intent)); err != nil {
+		return nil, err
+	}
+
 	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, ac.ActiveOrganizationID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to read organization details").LogError(ctx, s.logger)
@@ -1229,6 +1234,39 @@ func (s *Service) GenerateWorkOSAdminPortalLink(ctx context.Context, payload *ge
 	return &gen.GenerateWorkOSAdminPortalLinkResult{
 		URL: link,
 	}, nil
+}
+
+// requirePortalIntentEntitlement fails closed: an intent without an explicit
+// mapping here is denied, so intents added at the design layer cannot bypass
+// entitlement checks.
+func (s *Service) requirePortalIntentEntitlement(ctx context.Context, ac *contextvalues.AuthContext, intent workos.PortalIntent) error {
+	var feature productfeatures.Feature
+	switch intent {
+	case workos.PortalIntentDomainVerification:
+		// Ungated: orgs need domain verification to claim domains regardless of tier.
+		return nil
+	case workos.PortalIntentSSO:
+		feature = productfeatures.FeatureSSO
+	case workos.PortalIntentDSync:
+		feature = productfeatures.FeatureSCIM
+	case workos.PortalIntentAuditLogs, workos.PortalIntentLogStreams:
+		if ac.AccountType != string(billing.TierEnterprise) {
+			return oops.E(oops.CodeForbidden, nil, "an enterprise plan is required for %s", intent).LogError(ctx, s.logger)
+		}
+		return nil
+	default:
+		return oops.E(oops.CodeForbidden, nil, "unsupported admin portal intent").LogError(ctx, s.logger)
+	}
+
+	enabled, err := s.features.IsFeatureEnabled(ctx, ac.ActiveOrganizationID, feature)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "check admin portal entitlement").LogError(ctx, s.logger)
+	}
+	if !enabled {
+		return oops.E(oops.CodeForbidden, nil, "organization is not entitled to %s", intent).LogError(ctx, s.logger)
+	}
+
+	return nil
 }
 
 func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, error) {

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -82,7 +82,8 @@ type InviteIdentityProvider interface {
 }
 
 type orgFeatureChecker interface {
-	IsFeatureEnabled(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
+	// Uncached: revocation must gate the very next portal link request.
+	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
 }
 
 // HookEventReader is the subset of the telemetry repo used by the onboarding
@@ -1250,7 +1251,7 @@ func (s *Service) requirePortalIntentEntitlement(ctx context.Context, ac *contex
 	case workos.PortalIntentDSync:
 		feature = productfeatures.FeatureSCIM
 	case workos.PortalIntentAuditLogs, workos.PortalIntentLogStreams:
-		if ac.AccountType != string(billing.TierEnterprise) {
+		if !isEnterpriseAccount(ac.AccountType) {
 			return oops.E(oops.CodeForbidden, nil, "an enterprise plan is required for %s", intent).LogError(ctx, s.logger)
 		}
 		return nil
@@ -1258,7 +1259,7 @@ func (s *Service) requirePortalIntentEntitlement(ctx context.Context, ac *contex
 		return oops.E(oops.CodeForbidden, nil, "unsupported admin portal intent").LogError(ctx, s.logger)
 	}
 
-	enabled, err := s.features.IsFeatureEnabled(ctx, ac.ActiveOrganizationID, feature)
+	enabled, err := s.features.IsFeatureEnabledUncached(ctx, ac.ActiveOrganizationID, feature)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "check admin portal entitlement").LogError(ctx, s.logger)
 	}
@@ -1267,6 +1268,13 @@ func (s *Service) requirePortalIntentEntitlement(ctx context.Context, ac *contex
 	}
 
 	return nil
+}
+
+// isEnterpriseAccount compares the session's account type against the
+// enterprise tier after normalizing case and whitespace, matching how billing
+// tiers are compared elsewhere.
+func isEnterpriseAccount(accountType string) bool {
+	return billing.Tier(strings.ToLower(strings.TrimSpace(accountType))) == billing.TierEnterprise
 }
 
 func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, error) {

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -58,27 +58,21 @@ func seedLocalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organi
 // orgFeatureStub mirrors the unexported feature-checker interface accepted by
 // organizations.NewService so test constructors can parametrize it.
 type orgFeatureStub interface {
-	IsFeatureEnabled(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
+	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
 }
 
-// stubOrgFeatures returns false for all features — tests use the WorkOS fallback path.
-type stubOrgFeatures struct{}
-
-func (stubOrgFeatures) IsFeatureEnabled(context.Context, string, productfeatures.Feature) (bool, error) {
-	return false, nil
-}
-
-// stubOrgFeaturesEnabled returns true for all features — tests use the RBAC path.
+// stubOrgFeaturesEnabled reports every feature enabled, entitling all
+// feature-gated portal-link intents.
 type stubOrgFeaturesEnabled struct{}
 
-func (stubOrgFeaturesEnabled) IsFeatureEnabled(context.Context, string, productfeatures.Feature) (bool, error) {
+func (stubOrgFeaturesEnabled) IsFeatureEnabledUncached(context.Context, string, productfeatures.Feature) (bool, error) {
 	return true, nil
 }
 
 // featureMapStub enables exactly the features mapped to true.
 type featureMapStub map[productfeatures.Feature]bool
 
-func (m featureMapStub) IsFeatureEnabled(_ context.Context, _ string, feature productfeatures.Feature) (bool, error) {
+func (m featureMapStub) IsFeatureEnabledUncached(_ context.Context, _ string, feature productfeatures.Feature) (bool, error) {
 	return m[feature], nil
 }
 
@@ -89,6 +83,22 @@ func enabledFeatures(features ...productfeatures.Feature) featureMapStub {
 		m[feature] = true
 	}
 	return m
+}
+
+// withAccountType returns a context whose auth context is a copy carrying the
+// given account type. The copy matters: contexts share the underlying auth
+// context pointer, so mutating it in place would retier every context derived
+// from ctx.
+func withAccountType(t *testing.T, ctx context.Context, accountType string) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	clone := *authCtx
+	clone.AccountType = accountType
+
+	return contextvalues.SetAuthContext(ctx, &clone)
 }
 
 // testAuthUserWorkOSID is the WorkOS user id for the session user in tests.
@@ -150,11 +160,13 @@ func (f *fakeTrialNotifier) TrialInactive(context.Context, string) error {
 func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithFeatures(t, stubOrgFeatures{})
+	return newTestOrganizationsServiceWithFeatures(t, enabledFeatures())
 }
 
-// newTestOrganizationsServiceRBAC creates a service instance where RBAC feature is enabled,
-// so requireOrgTeamManagementAccess takes the access.Require path instead of the WorkOS fallback.
+// newTestOrganizationsServiceRBAC creates a service instance whose feature
+// checker reports every feature enabled. The checker only gates portal-link
+// intent entitlements, so that is the sole difference from
+// newTestOrganizationsService.
 func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
@@ -259,7 +271,7 @@ func newTestOrganizationsServiceWithEmail(t *testing.T) (context.Context, *testI
 		"team_invite": "team-invite-test-id",
 	}), true)
 	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, emailService, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, enabledFeatures(), nil, authzEngine, emailService, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -55,6 +55,12 @@ func seedLocalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organi
 	return row.ID.String()
 }
 
+// orgFeatureStub mirrors the unexported feature-checker interface accepted by
+// organizations.NewService so test constructors can parametrize it.
+type orgFeatureStub interface {
+	IsFeatureEnabled(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
+}
+
 // stubOrgFeatures returns false for all features — tests use the WorkOS fallback path.
 type stubOrgFeatures struct{}
 
@@ -67,6 +73,22 @@ type stubOrgFeaturesEnabled struct{}
 
 func (stubOrgFeaturesEnabled) IsFeatureEnabled(context.Context, string, productfeatures.Feature) (bool, error) {
 	return true, nil
+}
+
+// featureMapStub enables exactly the features mapped to true.
+type featureMapStub map[productfeatures.Feature]bool
+
+func (m featureMapStub) IsFeatureEnabled(_ context.Context, _ string, feature productfeatures.Feature) (bool, error) {
+	return m[feature], nil
+}
+
+// enabledFeatures builds a featureMapStub that enables exactly the listed features.
+func enabledFeatures(features ...productfeatures.Feature) featureMapStub {
+	m := make(featureMapStub, len(features))
+	for _, feature := range features {
+		m[feature] = true
+	}
+	return m
 }
 
 // testAuthUserWorkOSID is the WorkOS user id for the session user in tests.
@@ -128,59 +150,18 @@ func (f *fakeTrialNotifier) TrialInactive(context.Context, string) error {
 func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
-	ctx := t.Context()
-
-	logger := testenv.NewLogger(t)
-	tracerProvider := testenv.NewTracerProvider(t)
-	conn, err := infra.CloneTestDatabase(t, "testdb")
-	require.NoError(t, err)
-
-	redisClient, err := infra.NewRedisClient(t, 0)
-	require.NoError(t, err)
-	billingClient := billing.NewStubClient(logger, tracerProvider)
-
-	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
-
-	ctx = authztest.InitAuthContext(t, ctx, conn, sessionManager)
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	require.NotNil(t, authCtx)
-
-	// UpsertUserFromIDP (called inside InitAuthContext) now backfills workos_id
-	// with the mock IDP's user ID. Override it to the test-specific WorkOS user
-	// ID so that mock expectations on GetOrgMembership match.
-	err = userrepo.New(conn).OverwriteUserWorkosID(ctx, userrepo.OverwriteUserWorkosIDParams{
-		ID:       authCtx.UserID,
-		WorkosID: conv.ToPGText(testAuthUserWorkOSID),
-	})
-	require.NoError(t, err)
-
-	orgs := newMockOrganizationProvider(t)
-
-	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, thirdpartyworkos.NewStubClient())
-
-	auditLogger := audit.NewLogger()
-
-	svixSrv := svixtest.NewMockServer(logger)
-	t.Cleanup(svixSrv.Close)
-	svixClient, err := svix.New("test-token", &svix.SvixOptions{ServerUrl: svixSrv.URL()})
-	require.NoError(t, err)
-
-	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
-
-	return ctx, &testInstance{
-		service: svc,
-		conn:    conn,
-		orgs:    orgs,
-		trial:   trialNotifier,
-		svixSrv: svixSrv,
-	}
+	return newTestOrganizationsServiceWithFeatures(t, stubOrgFeatures{})
 }
 
 // newTestOrganizationsServiceRBAC creates a service instance where RBAC feature is enabled,
 // so requireOrgTeamManagementAccess takes the access.Require path instead of the WorkOS fallback.
 func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestOrganizationsServiceWithFeatures(t, stubOrgFeaturesEnabled{})
+}
+
+func newTestOrganizationsServiceWithFeatures(t *testing.T, features orgFeatureStub) (context.Context, *testInstance) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -222,7 +203,7 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 	require.NoError(t, err)
 
 	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeaturesEnabled{}, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, features, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -51,6 +51,7 @@ var (
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
 	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
+	OrganizationProductFeatureV1           = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_product_feature_event_v1", "Emitted when an organization product feature flag is toggled")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")
 	PlatformMcpRegistrationV1              = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.platform_mcp_registration_event_v1", "Emitted when Platform MCP catalog registrations converge private components")

--- a/server/internal/outbox/events/catalog_gen.go
+++ b/server/internal/outbox/events/catalog_gen.go
@@ -43,6 +43,7 @@ var All = []outbox.EventRegistration{
 	OrganizationEnterpriseTrialV1,
 	OrganizationHooksFailOpenV1,
 	OrganizationInviteV1,
+	OrganizationProductFeatureV1,
 	OrganizationWebhooksV1,
 	OtelForwardingV1,
 	PlatformMcpDiagnosticsV1,

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -2150,6 +2150,64 @@ webhooks:
                                 - subject_type
                             type: object
                 required: true
+    audit_log.organization_product_feature_event_v1:
+        post:
+            description: Emitted when an organization product feature flag is toggled
+            operationId: audit_log.organization_product_feature_event_v1
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            additionalProperties: false
+                            properties:
+                                acting_client_id:
+                                    type: string
+                                acting_surface:
+                                    type: string
+                                action:
+                                    type: string
+                                actor_display_name:
+                                    type: string
+                                actor_id:
+                                    type: string
+                                actor_slug:
+                                    type: string
+                                actor_type:
+                                    type: string
+                                after_snapshot:
+                                    additionalProperties: true
+                                before_snapshot:
+                                    additionalProperties: true
+                                id:
+                                    format: uuid
+                                    type: string
+                                metadata:
+                                    additionalProperties: true
+                                organization_id:
+                                    type: string
+                                project_id:
+                                    format: uuid
+                                    type:
+                                        - string
+                                        - "null"
+                                subject_display_name:
+                                    type: string
+                                subject_id:
+                                    type: string
+                                subject_slug:
+                                    type: string
+                                subject_type:
+                                    type: string
+                            required:
+                                - id
+                                - organization_id
+                                - actor_id
+                                - actor_type
+                                - action
+                                - subject_id
+                                - subject_type
+                            type: object
+                required: true
     audit_log.organization_webhooks_event_v1:
         post:
             description: Emitted when changes to organization webhooks are made

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -392,7 +392,7 @@ func SeedEnterpriseTrialBundleTx(ctx context.Context, tx pgx.Tx, organizationID 
 		}
 	}
 
-	if err := EnableSkillsTx(ctx, tx, organizationID); err != nil {
+	if _, err := EnableSkillsTx(ctx, tx, organizationID); err != nil {
 		return fmt.Errorf("enable Skills for enterprise trial: %w", err)
 	}
 
@@ -436,23 +436,25 @@ func SeedPaygEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID strin
 
 // EnableSkillsTx provisions the built-in Skills grants and enables the
 // org-level Skills feature in the caller's transaction. Existing grants and
-// exclusions are preserved.
-func EnableSkillsTx(ctx context.Context, dbtx repo.DBTX, organizationID string) error {
+// exclusions are preserved. It reports whether the feature row was newly
+// inserted, so callers can audit actual transitions without a separate read.
+func EnableSkillsTx(ctx context.Context, dbtx repo.DBTX, organizationID string) (bool, error) {
 	q := repo.New(dbtx)
 	if _, err := q.LockOrganizationMetadata(ctx, organizationID); err != nil {
-		return fmt.Errorf("lock organization for Skills enable: %w", err)
+		return false, fmt.Errorf("lock organization for Skills enable: %w", err)
 	}
 
 	if err := provisionSkillsSystemRoleGrantsTx(ctx, dbtx, organizationID); err != nil {
-		return err
+		return false, err
 	}
 
-	if _, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
+	inserted, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
 		OrganizationID: organizationID,
 		FeatureName:    string(FeatureSkills),
-	}); err != nil {
-		return fmt.Errorf("enable Skills feature flag: %w", err)
+	})
+	if err != nil {
+		return false, fmt.Errorf("enable Skills feature flag: %w", err)
 	}
 
-	return nil
+	return inserted > 0, nil
 }

--- a/server/internal/productfeatures/features.go
+++ b/server/internal/productfeatures/features.go
@@ -53,6 +53,29 @@ const (
 	FeatureConsentToolFiltering Feature = "consent_tool_filtering"
 )
 
+// RequiresPlatformAdmin reports whether toggling f through productFeatures.set
+// requires a platform admin in addition to org:admin on the target
+// organization. The org-settable cases are the toggles organization admins
+// manage themselves through the dashboard's organization settings (Logs,
+// Skills content upload, consent tool filtering, Platform MCP access); every
+// other settable feature is a staff-managed entitlement, and features missing
+// a case fail closed so a new feature cannot silently become self-serve.
+func (f Feature) RequiresPlatformAdmin() bool {
+	switch f {
+	case FeatureLogs,
+		FeatureToolIOLogs,
+		FeatureSessionCapture,
+		FeatureHooksBrowserLogin,
+		FeatureHooksFailOpen,
+		FeatureSkillCaptureMetadataOnly,
+		FeatureConsentToolFiltering,
+		FeaturePlatformMCP:
+		return false
+	default:
+		return true
+	}
+}
+
 type FeatureCache struct {
 	OrganizationID string
 	Feature        Feature

--- a/server/internal/productfeatures/featuretoggleaudit_test.go
+++ b/server/internal/productfeatures/featuretoggleaudit_test.go
@@ -1,0 +1,167 @@
+package productfeatures_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/features"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+)
+
+func TestSetProductFeatureEnableRecordsGenericAudit(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, "organization", record.SubjectType)
+	require.Equal(t, authCtx.ActiveOrganizationID, record.OrganizationID)
+	require.False(t, record.ProjectID.Valid, "org-scoped event must carry no project")
+
+	metadata, err := audittest.DecodeAuditData(record.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, "logs", metadata["feature_name"])
+}
+
+func TestSetProductFeatureDisableRecordsGenericAudit(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureDisabled)
+	require.NoError(t, err)
+
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        false,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureDisabled)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureDisabled)
+	require.NoError(t, err)
+	metadata, err := audittest.DecodeAuditData(record.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, "logs", metadata["feature_name"])
+}
+
+// A no-op set (same value it already holds) must not record an audit event —
+// the trail reflects actual transitions, mirroring the hooks_fail_open tests.
+func TestSetProductFeatureNoOpSkipsGenericAudit(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	count, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	again, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, count, again, "a no-op set must not record a duplicate audit event")
+}
+
+// hooks_fail_open keeps its dedicated audit action; it must not also produce
+// the generic product-feature event.
+func TestSetProductFeatureHooksFailOpenSkipsGenericAudit(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureHooksFailOpen),
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+// Skills enablement flows through EnableSkillsTx rather than the plain
+// enable path; its transition must still land in the audit trail.
+func TestSetProductFeatureSkillsEnableRecordsGenericAudit(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
+
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+
+	record, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	metadata, err := audittest.DecodeAuditData(record.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, string(productfeatures.FeatureSkills), metadata["feature_name"])
+
+	// A replayed enable is a no-op and must not duplicate the event.
+	err = ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	again, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationProductFeatureEnabled)
+	require.NoError(t, err)
+	require.Equal(t, after, again)
+}

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -76,42 +76,52 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	)
 }
 
-func (s *Service) authorizeOrganization(ctx context.Context, organizationID string, scope authz.Scope) (*contextvalues.AuthContext, string, error) {
+// authorizeOrganization returns the organization metadata row when it had to
+// read one to verify a cross-organization request, and nil for the active-org
+// path, so callers that need the row can skip a second lookup.
+func (s *Service) authorizeOrganization(ctx context.Context, organizationID string, scope authz.Scope) (*contextvalues.AuthContext, string, *orgrepo.OrganizationMetadatum, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
-		return nil, "", oops.C(oops.CodeUnauthorized)
+		return nil, "", nil, oops.C(oops.CodeUnauthorized)
 	}
 
 	if organizationID == "" {
-		return nil, "", oops.C(oops.CodeUnauthorized)
+		return nil, "", nil, oops.C(oops.CodeUnauthorized)
 	}
 
 	if organizationID == authCtx.ActiveOrganizationID {
 		check := authz.Check{Scope: scope, ResourceKind: "", ResourceID: organizationID, Dimensions: nil}
 		if err := s.authz.Require(ctx, check); err != nil {
-			return nil, "", fmt.Errorf("require %s: %w", scope, err)
+			return nil, "", nil, fmt.Errorf("require %s: %w", scope, err)
 		}
-		return authCtx, organizationID, nil
+		return authCtx, organizationID, nil, nil
 	}
 
 	if err := s.authz.RequireUserOrganizationScope(ctx, organizationID, authCtx.UserID, scope); err != nil {
-		return nil, "", fmt.Errorf("require %s for requested organization: %w", scope, err)
+		return nil, "", nil, fmt.Errorf("require %s for requested organization: %w", scope, err)
 	}
 
-	if _, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, organizationID); err != nil {
+	org, err := orgrepo.New(s.db).GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, "", oops.E(oops.CodeNotFound, err, "organization not found")
+			return nil, "", nil, oops.E(oops.CodeNotFound, err, "organization not found")
 		}
-		return nil, "", oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, s.logger, attr.SlogOrganizationID(organizationID))
+		return nil, "", nil, oops.E(oops.CodeUnexpected, err, "get organization metadata").LogError(ctx, s.logger, attr.SlogOrganizationID(organizationID))
 	}
 
-	return authCtx, organizationID, nil
+	return authCtx, organizationID, &org, nil
 }
 
 func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProductFeaturePayload) error {
-	authCtx, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
+	authCtx, orgID, org, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
 	if err != nil {
 		return err
+	}
+
+	// Disabling skills is a silent no-op (skills are always on), so it stays
+	// available to org admins and resolves before the staff-only gate below.
+	if payload.FeatureName == string(FeatureSkills) && !payload.Enabled {
+		return nil
 	}
 
 	// Staff-managed entitlements (SSO, SCIM, ...) must not be self-granted by
@@ -120,10 +130,6 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		if _, _, err := auth.RequirePlatformAdmin(ctx, s.logger); err != nil {
 			return err
 		}
-	}
-
-	if payload.FeatureName == string(FeatureSkills) && !payload.Enabled {
-		return nil
 	}
 
 	lockConn, releaseFeatureLock, err := s.featureClient.acquireFeatureCacheLocks(ctx, orgID, []Feature{Feature(payload.FeatureName)})
@@ -178,26 +184,14 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 	}
 
 	if changed {
-		org, err := orgrepo.New(dbtx).GetOrganizationMetadata(ctx, orgID)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "read organization for feature toggle audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
-		}
-		// Fail-open governs whether blocking policies are enforced during a
-		// control-plane outage, so it keeps a dedicated audit action that makes
-		// posture changes distinguishable from ordinary feature toggles.
-		if payload.FeatureName == string(FeatureHooksFailOpen) {
-			if err := s.audit.LogOrganizationHooksFailOpenToggled(ctx, dbtx, audit.LogOrganizationHooksFailOpenToggledEvent{
-				OrganizationID:   orgID,
-				Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
-				ActorDisplayName: authCtx.Email,
-				ActorSlug:        nil,
-				OrganizationName: org.Name,
-				OrganizationSlug: org.Slug,
-				FailOpenEnabled:  payload.Enabled,
-			}); err != nil {
-				return oops.E(oops.CodeUnexpected, err, "record hooks fail-open audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+		if org == nil {
+			row, err := orgrepo.New(dbtx).GetOrganizationMetadata(ctx, orgID)
+			if err != nil {
+				return oops.E(oops.CodeUnexpected, err, "read organization for feature toggle audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 			}
-		} else if err := s.audit.LogOrganizationProductFeatureToggled(ctx, dbtx, audit.LogOrganizationProductFeatureToggledEvent{
+			org = &row
+		}
+		if err := s.audit.LogOrganizationProductFeatureToggled(ctx, dbtx, audit.LogOrganizationProductFeatureToggledEvent{
 			OrganizationID:   orgID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 			ActorDisplayName: authCtx.Email,
@@ -221,7 +215,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 }
 
 func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload *gen.SetRemoteSessionAutoRefreshPolicyPayload) error {
-	_, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
+	_, orgID, _, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgAdmin)
 	if err != nil {
 		return err
 	}
@@ -300,7 +294,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 }
 
 func (s *Service) GetProductFeatures(ctx context.Context, payload *gen.GetProductFeaturesPayload) (*gen.GetProductFeaturesResult, error) {
-	_, orgID, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgRead)
+	_, orgID, _, err := s.authorizeOrganization(ctx, payload.OrganizationID, authz.ScopeOrgRead)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -114,6 +114,14 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		return err
 	}
 
+	// Staff-managed entitlements (SSO, SCIM, ...) must not be self-granted by
+	// organization admins; org-settable operational toggles need org:admin only.
+	if Feature(payload.FeatureName).RequiresPlatformAdmin() {
+		if _, _, err := auth.RequirePlatformAdmin(ctx, s.logger); err != nil {
+			return err
+		}
+	}
+
 	if payload.FeatureName == string(FeatureSkills) && !payload.Enabled {
 		return nil
 	}
@@ -139,9 +147,11 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 	if payload.Enabled && payload.FeatureName == string(FeatureSkills) {
 		// Skills enablement also provisions the built-in RBAC grants, so it
 		// goes through its dedicated transactional path.
-		if err := EnableSkillsTx(ctx, dbtx, orgID); err != nil {
+		inserted, err := EnableSkillsTx(ctx, dbtx, orgID)
+		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "enable Skills feature").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 		}
+		changed = inserted
 	} else if payload.Enabled {
 		inserted, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
 			OrganizationID: orgID,
@@ -167,24 +177,37 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		}
 	}
 
-	// Fail-open governs whether blocking policies are enforced during a
-	// control-plane outage, so flipping it is a security-posture change that
-	// must leave an audit trail.
-	if payload.FeatureName == string(FeatureHooksFailOpen) && changed {
+	if changed {
 		org, err := orgrepo.New(dbtx).GetOrganizationMetadata(ctx, orgID)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "read organization for hooks fail-open audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+			return oops.E(oops.CodeUnexpected, err, "read organization for feature toggle audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 		}
-		if err := s.audit.LogOrganizationHooksFailOpenToggled(ctx, dbtx, audit.LogOrganizationHooksFailOpenToggledEvent{
+		// Fail-open governs whether blocking policies are enforced during a
+		// control-plane outage, so it keeps a dedicated audit action that makes
+		// posture changes distinguishable from ordinary feature toggles.
+		if payload.FeatureName == string(FeatureHooksFailOpen) {
+			if err := s.audit.LogOrganizationHooksFailOpenToggled(ctx, dbtx, audit.LogOrganizationHooksFailOpenToggledEvent{
+				OrganizationID:   orgID,
+				Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+				ActorDisplayName: authCtx.Email,
+				ActorSlug:        nil,
+				OrganizationName: org.Name,
+				OrganizationSlug: org.Slug,
+				FailOpenEnabled:  payload.Enabled,
+			}); err != nil {
+				return oops.E(oops.CodeUnexpected, err, "record hooks fail-open audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+			}
+		} else if err := s.audit.LogOrganizationProductFeatureToggled(ctx, dbtx, audit.LogOrganizationProductFeatureToggledEvent{
 			OrganizationID:   orgID,
 			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
 			ActorDisplayName: authCtx.Email,
 			ActorSlug:        nil,
 			OrganizationName: org.Name,
 			OrganizationSlug: org.Slug,
-			FailOpenEnabled:  payload.Enabled,
+			FeatureName:      payload.FeatureName,
+			FeatureEnabled:   payload.Enabled,
 		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "record hooks fail-open audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
+			return oops.E(oops.CodeUnexpected, err, "record feature toggle audit event").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 		}
 	}
 

--- a/server/internal/productfeatures/setproductfeature_test.go
+++ b/server/internal/productfeatures/setproductfeature_test.go
@@ -222,6 +222,20 @@ func TestProductFeaturesService_SetProductFeatureSSODeniedForOrgAdmin(t *testing
 	require.False(t, enabled, "denied toggle must not write the feature row")
 }
 
+// Disabling skills is a documented silent no-op (skills are always on), so it
+// must stay reachable for org admins instead of tripping the staff-only gate.
+func TestProductFeaturesService_SetProductFeatureSkillsDisableNoopForOrgAdmin(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSkills),
+		Enabled:        false,
+	})
+	require.NoError(t, err)
+}
+
 func TestProductFeaturesService_SetProductFeatureSSOAllowedForPlatformAdmin(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestProductFeaturesService(t)

--- a/server/internal/productfeatures/setproductfeature_test.go
+++ b/server/internal/productfeatures/setproductfeature_test.go
@@ -198,6 +198,118 @@ func TestProductFeaturesService_SetProductFeature(t *testing.T) {
 	})
 }
 
+// The default test session is an org admin without the platform-admin bit, so
+// it must be refused staff-only entitlements like SSO.
+func TestProductFeaturesService_SetProductFeatureSSODeniedForOrgAdmin(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSSO),
+		Enabled:        true,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+
+	enabled, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	require.False(t, enabled, "denied toggle must not write the feature row")
+}
+
+func TestProductFeaturesService_SetProductFeatureSSOAllowedForPlatformAdmin(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    string(productfeatures.FeatureSSO),
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	enabled, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+// Org admins keep self-serve control of the logs toggle even with the
+// platform-admin bit set — staff toggling logs must keep working too.
+func TestProductFeaturesService_SetProductFeatureLogsAllowedForPlatformAdmin(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	err := ti.service.SetProductFeature(ctx, &gen.SetProductFeaturePayload{
+		OrganizationID: requestedOrganizationID(ctx),
+		FeatureName:    "logs",
+		Enabled:        true,
+	})
+	require.NoError(t, err)
+
+	enabled, err := repo.New(ti.conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		FeatureName:    "logs",
+	})
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
+
+// TestFeature_RequiresPlatformAdmin pins the org-settable/staff-only split:
+// the org-settable set mirrors the dashboard's self-serve organization
+// settings, everything else — including features added in the future — fails
+// closed to platform admins.
+func TestFeature_RequiresPlatformAdmin(t *testing.T) {
+	t.Parallel()
+
+	orgSettable := []productfeatures.Feature{
+		productfeatures.FeatureLogs,
+		productfeatures.FeatureToolIOLogs,
+		productfeatures.FeatureSessionCapture,
+		productfeatures.FeatureHooksBrowserLogin,
+		productfeatures.FeatureHooksFailOpen,
+		productfeatures.FeatureSkillCaptureMetadataOnly,
+		productfeatures.FeatureConsentToolFiltering,
+		productfeatures.FeaturePlatformMCP,
+	}
+	for _, feature := range orgSettable {
+		require.Falsef(t, feature.RequiresPlatformAdmin(), "feature %s must stay org-settable", feature)
+	}
+
+	staffOnly := []productfeatures.Feature{
+		productfeatures.FeatureSSO,
+		productfeatures.FeatureSCIM,
+		productfeatures.FeatureSkills,
+		productfeatures.FeatureAuthzChallengeLogging,
+		productfeatures.FeatureCustomModelKeys,
+		productfeatures.FeatureAIPlatformPushIntegrations,
+		productfeatures.FeatureCustomerManagedEncryptionKeys,
+		productfeatures.FeatureSessionPortability,
+		productfeatures.FeatureRemoteSessionAutoRefresh,
+		productfeatures.FeatureRemoteSessionAutoRefreshEnforced,
+	}
+	for _, feature := range staffOnly {
+		require.Truef(t, feature.RequiresPlatformAdmin(), "feature %s must require platform admin", feature)
+	}
+
+	require.True(t, productfeatures.Feature("some_future_feature").RequiresPlatformAdmin(), "unknown features must fail closed")
+}
+
 func TestProductFeaturesService_SetRemoteSessionAutoRefreshPolicy(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -48,6 +48,16 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// withPlatformAdmin marks the test session as a platform admin (users.admin
+// bit), which staff-only feature toggles require in addition to org:admin.
+func withPlatformAdmin(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok, "auth context not found")
+	authCtx.IsAdmin = true
+	return contextvalues.SetAuthContext(ctx, authCtx)
+}
+
 func requestedOrganizationID(ctx context.Context) string {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {

--- a/server/internal/productfeatures/setup_test.go
+++ b/server/internal/productfeatures/setup_test.go
@@ -50,12 +50,15 @@ func TestMain(m *testing.M) {
 
 // withPlatformAdmin marks the test session as a platform admin (users.admin
 // bit), which staff-only feature toggles require in addition to org:admin.
+// The auth context is copied so the admin bit cannot leak into other contexts
+// derived from ctx, which share the underlying pointer.
 func withPlatformAdmin(t *testing.T, ctx context.Context) context.Context {
 	t.Helper()
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok, "auth context not found")
-	authCtx.IsAdmin = true
-	return contextvalues.SetAuthContext(ctx, authCtx)
+	clone := *authCtx
+	clone.IsAdmin = true
+	return contextvalues.SetAuthContext(ctx, &clone)
 }
 
 func requestedOrganizationID(ctx context.Context) string {

--- a/server/internal/productfeatures/skills_test.go
+++ b/server/internal/productfeatures/skills_test.go
@@ -26,6 +26,7 @@ func TestProductFeaturesService_SkillsAlwaysEnabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
 	organizationID := activeOrganizationID(t, ctx)
 	seedOrganization(t, ctx, ti.conn, organizationID)
 	result, err := ti.service.GetProductFeatures(ctx, &gen.GetProductFeaturesPayload{
@@ -50,6 +51,7 @@ func TestProductFeaturesService_EnableSkillsPatchesExistingRBACGrants(t *testing
 	t.Parallel()
 
 	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
 	organizationID := activeOrganizationID(t, ctx)
 	seedOrganization(t, ctx, ti.conn, organizationID)
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
@@ -103,7 +105,7 @@ func TestProductFeatureEnableTx_RequiresExistingOrganization(t *testing.T) {
 
 	ctx, ti := newTestProductFeaturesService(t)
 	skillsTx := testenv.BeginTx(t, ctx, ti.conn)
-	err := productfeatures.EnableSkillsTx(ctx, skillsTx, "org_missing_skills_lock")
+	_, err := productfeatures.EnableSkillsTx(ctx, skillsTx, "org_missing_skills_lock")
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 
 }
@@ -116,7 +118,9 @@ func TestEnableSkillsTx_RollsBackWithCallerTransaction(t *testing.T) {
 	seedOrganization(t, ctx, ti.conn, organizationID)
 	tx := testenv.BeginTx(t, ctx, ti.conn)
 
-	require.NoError(t, productfeatures.EnableSkillsTx(ctx, tx, organizationID))
+	inserted, err := productfeatures.EnableSkillsTx(ctx, tx, organizationID)
+	require.NoError(t, err)
+	require.True(t, inserted)
 	enabled, err := featurerepo.New(tx).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
 		OrganizationID: organizationID,
 		FeatureName:    string(productfeatures.FeatureSkills),
@@ -218,6 +222,7 @@ func TestProductFeaturesService_EnableSkillsTargetsRequestedOrganization(t *test
 	t.Parallel()
 
 	ctx, ti := newTestProductFeaturesService(t)
+	ctx = withPlatformAdmin(t, ctx)
 	activeOrganizationID := activeOrganizationID(t, ctx)
 	targetOrganizationID := uuid.NewString()
 	seedOrganization(t, ctx, ti.conn, targetOrganizationID)

--- a/server/internal/toolsets/addexternaloauthserver_test.go
+++ b/server/internal/toolsets/addexternaloauthserver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 func TestToolsetsService_AddExternalOAuthServer_AuditLog(t *testing.T) {
@@ -56,6 +57,34 @@ func TestToolsetsService_AddExternalOAuthServer_AuditLog(t *testing.T) {
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionToolsetAttachExternalOAuth)
 	require.NoError(t, err)
 	require.Equal(t, beforeCount+1, afterCount)
+}
+
+func TestToolsetsService_AddExternalOAuthServer_FreeTierDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestToolsetsService(t)
+	toolset := createMinimalPublicToolset(t, ctx, ti, "Free Tier External OAuth Toolset")
+	freeCtx := withFreeAccount(t, ctx)
+
+	_, err := ti.service.AddExternalOAuthServer(freeCtx, &gen.AddExternalOAuthServerPayload{
+		SessionToken: nil,
+		ApikeyToken:  nil,
+		Slug:         toolset.Slug,
+		ExternalOauthServer: &types.ExternalOAuthServerForm{
+			Slug: types.Slug("free-tier-external-oauth"),
+			Metadata: map[string]any{
+				"issuer":         "https://example.com",
+				"token_endpoint": "https://example.com/token",
+			},
+		},
+		ProjectSlugInput: nil,
+	})
+	require.Error(t, err)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Contains(t, err.Error(), "free accounts cannot add external OAuth servers")
 }
 
 func TestToolsetsService_AddExternalOAuthServer_PrivateToolset_NoAuditLog(t *testing.T) {

--- a/server/internal/toolsets/addexternaloauthserver_test.go
+++ b/server/internal/toolsets/addexternaloauthserver_test.go
@@ -16,7 +16,7 @@ func TestToolsetsService_AddExternalOAuthServer_AuditLog(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
-	ctx = withProAccount(t, ctx)
+	ctx = withAccountType(t, ctx, "pro")
 	toolset := createMinimalPublicToolset(t, ctx, ti, "Audit External OAuth Toolset")
 
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionToolsetAttachExternalOAuth)
@@ -64,7 +64,7 @@ func TestToolsetsService_AddExternalOAuthServer_FreeTierDenied(t *testing.T) {
 
 	ctx, ti := newTestToolsetsService(t)
 	toolset := createMinimalPublicToolset(t, ctx, ti, "Free Tier External OAuth Toolset")
-	freeCtx := withFreeAccount(t, ctx)
+	freeCtx := withAccountType(t, ctx, "free")
 
 	_, err := ti.service.AddExternalOAuthServer(freeCtx, &gen.AddExternalOAuthServerPayload{
 		SessionToken: nil,
@@ -91,7 +91,7 @@ func TestToolsetsService_AddExternalOAuthServer_PrivateToolset_NoAuditLog(t *tes
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
-	ctx = withProAccount(t, ctx)
+	ctx = withAccountType(t, ctx, "pro")
 	toolset := createMinimalPrivateToolset(t, ctx, ti, "Private External OAuth Toolset")
 
 	beforeCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionToolsetAttachExternalOAuth)

--- a/server/internal/toolsets/removeoauthserver_test.go
+++ b/server/internal/toolsets/removeoauthserver_test.go
@@ -15,7 +15,7 @@ func TestToolsetsService_RemoveOAuthServer_ExternalOAuthAuditLog(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
-	ctx = withProAccount(t, ctx)
+	ctx = withAccountType(t, ctx, "pro")
 	toolset := createMinimalPublicToolset(t, ctx, ti, "Detach External OAuth Toolset")
 	attached, err := ti.service.AddExternalOAuthServer(ctx, &gen.AddExternalOAuthServerPayload{
 		SessionToken: nil,

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -470,32 +470,22 @@ func createFunctionsDeploymentWithResources(t *testing.T, ctx context.Context, t
 	return dep
 }
 
-func withProAccount(t *testing.T, ctx context.Context) context.Context {
+// withAccountType returns a context whose auth context is a copy carrying the
+// given account type. The stub billing repository reports every org as pro
+// during authentication, so tier-specific paths are only reachable through
+// this override. The auth context is copied because contexts share the
+// underlying pointer; mutating it in place would retier every context derived
+// from ctx.
+func withAccountType(t *testing.T, ctx context.Context, accountType string) context.Context {
 	t.Helper()
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 
-	authCtx.AccountType = "pro"
+	clone := *authCtx
+	clone.AccountType = accountType
 
-	return contextvalues.SetAuthContext(ctx, authCtx)
-}
-
-// withFreeAccount returns a context whose account type is "free". The stub
-// billing repository reports every org as pro during authentication, so
-// free-tier denial paths are only reachable through this override. The auth
-// context is copied because contexts share the underlying pointer; mutating
-// it in place would downgrade every context derived from ctx.
-func withFreeAccount(t *testing.T, ctx context.Context) context.Context {
-	t.Helper()
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	freeAuthCtx := *authCtx
-	freeAuthCtx.AccountType = "free"
-
-	return contextvalues.SetAuthContext(ctx, &freeAuthCtx)
+	return contextvalues.SetAuthContext(ctx, &clone)
 }
 
 func createMinimalPrivateToolset(t *testing.T, ctx context.Context, ti *testInstance, name string) *types.Toolset {

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -481,6 +481,23 @@ func withProAccount(t *testing.T, ctx context.Context) context.Context {
 	return contextvalues.SetAuthContext(ctx, authCtx)
 }
 
+// withFreeAccount returns a context whose account type is "free". The stub
+// billing repository reports every org as pro during authentication, so
+// free-tier denial paths are only reachable through this override. The auth
+// context is copied because contexts share the underlying pointer; mutating
+// it in place would downgrade every context derived from ctx.
+func withFreeAccount(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	freeAuthCtx := *authCtx
+	freeAuthCtx.AccountType = "free"
+
+	return contextvalues.SetAuthContext(ctx, &freeAuthCtx)
+}
+
 func createMinimalPrivateToolset(t *testing.T, ctx context.Context, ti *testInstance, name string) *types.Toolset {
 	t.Helper()
 

--- a/server/internal/toolsets/updatetoolset_test.go
+++ b/server/internal/toolsets/updatetoolset_test.go
@@ -635,7 +635,7 @@ func TestToolsetsService_UpdateToolset_ClearsExternalOAuth_AuditLog(t *testing.T
 	t.Parallel()
 
 	ctx, ti := newTestToolsetsService(t)
-	ctx = withProAccount(t, ctx)
+	ctx = withAccountType(t, ctx, "pro")
 	toolset := createMinimalPublicToolset(t, ctx, ti, "Audit Clear External OAuth Toolset")
 	attached, err := ti.service.AddExternalOAuthServer(ctx, &gen.AddExternalOAuthServerPayload{
 		SessionToken: nil,


### PR DESCRIPTION
AIS-392

## Summary

- `productFeatures.set` now distinguishes customer self-serve settings from staff-granted entitlements. Features tied to plans or staff provisioning (`sso`, `scim`, `skills`, custom model keys, and the rest of the platform-admin Features page) require platform admin on top of `org:admin`; settings that customer org pages own (logging options, skill capture, consent tool filtering, Platform MCP) remain org-admin. Unknown or future features fail closed to platform-admin-only, and every feature toggle now emits an audit log event.
- `organizations.generateWorkOSAdminPortalLink` checks the org's entitlement for the requested portal intent before minting a link: `sso` requires the SSO feature, `dsync` requires SCIM, `audit_logs`/`log_streams` require the enterprise tier, and `domain_verification` stays open to all tiers. Unrecognized intents are denied.
- Added the missing free-tier denial test for `toolsets.addExternalOAuthServer`, which already enforced the tier check but had no coverage for it.

## Motivation

These endpoints only checked authorization scopes, not plan entitlements, so an org admin on any tier could enable enterprise features such as SSO/SCIM for their own org and then reach the WorkOS admin portal to configure them. The two fixes land together deliberately: the portal-link check is only meaningful once orgs can no longer self-grant the feature it checks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdrEArdrT87ox7NwXHgyUk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the AIS-392 business-logic bypass where free-tier org admins could self-enable enterprise features and reach the WorkOS admin portal.

- `productFeatures.set` now requires platform admin for staff-granted features (SSO, SCIM, skills, custom model keys, and other platform-admin settings); org-owned toggles (logging, skill capture, consent filtering, Platform MCP) stay org-admin, and disabling skills remains a no-op org admins can still call.
- Unknown or future features fail closed to platform-admin-only, and every actual feature toggle writes an audit log entry — `hooks_fail_open` keeps its distinct security-posture action.
- Dashboard audit rows now name the toggled feature instead of using a generic phrase.
- `organizations.generateWorkOSAdminPortalLink` checks the org's entitlement per intent (`sso` requires SSO, `dsync` requires SCIM, `audit_logs`/`log_streams` require enterprise) using the uncached feature check so revocation gates the very next request; unrecognized intents are denied.
- Adds the missing free-tier denial test for `toolsets.addExternalOAuthServer`, which already enforced the tier check.

<sup>Written for commit 99761eacc87a6d49d718069a7880d3781ae145f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

