### PR TITLE
feat: build a JWKS key source from a trusted workload issuer row

### DIFF
--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -43,9 +43,12 @@ func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *remotesessio
 // charged to.
 //
 // The authorization server's own identifier is the tenant boundary the fetch
-// limiter documents, so it is the base: one endpoint's trusted issuers
-// cannot exhaust another's, and admitting more issuers buys no extra
-// fetches. Never the issuer URL, which two organizations may legitimately
+// limiter documents, and every issuer trusted on that endpoint shares the one
+// budget deliberately. The limiter exists so that no number of registrations
+// buys more fetches; keying per issuer row would hand an operator a fresh
+// budget for each issuer they add, which is the amplification it closes. One
+// tenant's issuers contending for that tenant's own budget is the accepted
+// trade. Never the issuer URL, which two organizations may legitimately
 // share, and never a value derived from the request.
 //
 // The prefix keeps this grant's budget separate from the client

--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -1,0 +1,59 @@
+// Key resolution for the workload assertion grant: turning a trusted issuer
+// row into the key source its assertions are verified against. Sibling of
+// clientKeySource in authnchallenge_clientauth.go, which does the same job
+// for a registered client's assertions.
+
+package mcp
+
+import (
+	"fmt"
+
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+)
+
+// workloadIssuerKeySource builds the key source a trusted workload issuer's
+// assertions verify against.
+//
+// Only one shape exists here, unlike clientKeySource's two: a workload
+// issuer publishes its keys and never registers them with us, so there is no
+// inline key set to consider. The jwks_uri arrives on the row from the RFC
+// 8414 / OIDC discovery the management API runs when an issuer is created or
+// refreshed, which is why nothing is fetched or probed on this path.
+//
+// An issuer row with no jwks_uri is a setup error, not a bad assertion, and
+// says so: discovery either never ran or the issuer's document omitted the
+// field. Answering it like a rejected workload would send an operator
+// hunting through their platform's configuration for a problem that is on
+// ours.
+func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *remotesessions_repo.RemoteSessionIssuer) (jwks.Source, error) {
+	if !issuer.JwksUri.Valid || issuer.JwksUri.String == "" {
+		return jwks.Source{}, fmt.Errorf("trusted issuer %q records no jwks_uri: re-run discovery for it", issuer.Slug)
+	}
+
+	source, err := jwks.NewRemoteSource(issuer.JwksUri.String)
+	if err != nil {
+		return jwks.Source{}, fmt.Errorf("trusted issuer %q jwks_uri: %w", issuer.Slug, err)
+	}
+
+	return source.WithFetchScope(workloadFetchScope(endpoint)), nil
+}
+
+// workloadFetchScope names the budget a workload issuer's key fetches are
+// charged to.
+//
+// The authorization server's own identifier is the tenant boundary the fetch
+// limiter documents, so it is the base: one endpoint's trusted issuers
+// cannot exhaust another's, and admitting more issuers buys no extra
+// fetches. Never the issuer URL, which two organizations may legitimately
+// share, and never a value derived from the request.
+//
+// The prefix keeps this grant's budget separate from the client
+// authentication running against the same key resolver on the same
+// endpoint. Client assertions only reach the resolver behind a registered
+// client, while this grant is reachable by anyone, so an unauthenticated
+// path must not be able to spend the budget an authenticated one depends
+// on.
+func workloadFetchScope(endpoint *ResolvedMcpEndpoint) string {
+	return "workload:" + endpoint.UserSessionIssuerID.String()
+}

--- a/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+func workloadTestEndpoint(issuerID uuid.UUID) *ResolvedMcpEndpoint {
+	return &ResolvedMcpEndpoint{UserSessionIssuerID: issuerID}
+}
+
+func workloadTestIssuer(slug string, jwksURI pgtype.Text) *remotesessions_repo.RemoteSessionIssuer {
+	return &remotesessions_repo.RemoteSessionIssuer{Slug: slug, JwksUri: jwksURI}
+}
+
+func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	source, err := workloadIssuerKeySource(
+		workloadTestEndpoint(issuerID),
+		workloadTestIssuer("gh-actions", pgtype.Text{String: "https://example.test/keys", Valid: true}),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/keys", source.CacheKey(), "the cache key is the jwks_uri, shared across every scope naming it")
+}
+
+func TestWorkloadIssuerKeySource_MissingJwksURIIsASetupError(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		jwksURI pgtype.Text
+	}{
+		{name: "null", jwksURI: pgtype.Text{String: "", Valid: false}},
+		{name: "empty", jwksURI: pgtype.Text{String: "", Valid: true}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := workloadIssuerKeySource(
+				workloadTestEndpoint(uuid.New()),
+				workloadTestIssuer("gh-actions", tt.jwksURI),
+			)
+
+			require.Error(t, err)
+			// The message has to name the issuer and point at discovery: this
+			// is our configuration gap, not the caller's assertion.
+			require.ErrorContains(t, err, "gh-actions")
+			require.ErrorContains(t, err, "re-run discovery")
+		})
+	}
+}
+
+func TestWorkloadIssuerKeySource_RejectsUnusableJwksURI(t *testing.T) {
+	t.Parallel()
+
+	_, err := workloadIssuerKeySource(
+		workloadTestEndpoint(uuid.New()),
+		workloadTestIssuer("gh-actions", pgtype.Text{String: "http://example.test/keys", Valid: true}),
+	)
+
+	require.Error(t, err, "plain http must not become a key source")
+	require.ErrorContains(t, err, "gh-actions")
+}
+
+func TestWorkloadFetchScope_IsPerAuthorizationServerAndSeparateFromClientAuth(t *testing.T) {
+	t.Parallel()
+
+	first, second := uuid.New(), uuid.New()
+
+	require.Equal(t, "workload:"+first.String(), workloadFetchScope(workloadTestEndpoint(first)),
+		"keyed by the authorization server, prefixed so this grant's budget is separate from client auth's on the same endpoint")
+	require.NotEqual(t, workloadFetchScope(workloadTestEndpoint(first)), workloadFetchScope(workloadTestEndpoint(second)),
+		"one endpoint's issuers must not be able to exhaust another's budget")
+}


### PR DESCRIPTION
AIM-146

## Summary

Adds `workloadIssuerKeySource`, which turns a trusted issuer row into the `jwks.Source` a workload assertion's signature is verified against, and `workloadFetchScope`, which names the budget those key fetches are charged to. Sibling of `clientKeySource`, in the same file family.

Three behaviours worth a reviewer's attention:

- **Nothing is fetched or probed on this path.** RFC 8414 / OIDC discovery already runs when an issuer is created or refreshed and persists `jwks_uri` on the row, so this reads a column rather than performing discovery at verification time.
- **A row carrying no `jwks_uri` fails as a setup error naming the issuer**, not as a rejected assertion. Discovery either never ran or the issuer's document omitted the field, and that distinction is what keeps an operator from hunting through their own platform's configuration for a gap on ours.
- **Fetches are charged to a `workload:`-prefixed budget keyed by the authorization server.** The authorization server's own identifier is the tenant boundary the fetch limiter documents; the prefix additionally separates this grant from the client authentication running against the same key resolver on the same endpoint.

No caller yet — the grant handler picks it up, so the tests are currently the only consumer.

## Motivation

Workload identity federation lets an autonomous workload — a CI job, a Kubernetes pod, an agent runtime — present the identity token its platform already issued it and receive a scoped Gram session, with no Gram-issued secret anywhere in the loop. Verifying that assertion needs the issuer's published keys, and this is the piece that says where they come from.

It is deliberately small, because most of the machinery is already here. `usersessions/jwks` resolves and caches keys from a `jwks_uri` with ETag/TTL caching, fetch and refresh rate limits, an algorithm allowlist and guardian egress; `NewRemoteSource` already documents a trusted issuer's discovery document as a valid origin. The management API already performs discovery and persists `jwks_uri` on the issuer row. This connects the two, and does no more than that.

The fetch-scope prefix is the one place this refines a documented convention rather than following it, and so the thing most worth disagreeing with. The rationale: client assertions only reach the key resolver behind a registered client, while this grant is reachable by anyone, so an unauthenticated path should not be able to spend the budget an authenticated one depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PooVYgBd79jFuax4hkyxkd
