### PR TITLE
fix: send users to org home after deleting a project

### DIFF
--- a/.changeset/project-delete-org-home.md
+++ b/.changeset/project-delete-org-home.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Deleting a project now returns the user to the organization home instead of the default project's settings.

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.test.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.test.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -100,8 +101,9 @@ describe("SettingsDangerZone", () => {
       request: { id: "proj-1" },
     });
     expect(mocks.invalidateListProjects).toHaveBeenCalled();
-    expect(mocks.toastSuccess).toHaveBeenCalledWith(
-      "Project deleted successfully",
-    );
+    const toastMessage = mocks.toastSuccess.mock.calls[0]?.[0] as ReactNode;
+    const { container } = render(<>{toastMessage}</>);
+    expect(container.textContent).toBe("Project Sandbox deleted successfully");
+    expect(container.querySelector("strong")?.textContent).toBe("Sandbox");
   });
 });

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.test.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.test.tsx
@@ -1,0 +1,107 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  navigate: vi.fn(),
+  invalidateListProjects: vi.fn(),
+  toastSuccess: vi.fn(),
+  project: {
+    id: "proj-1",
+    name: "Sandbox",
+    slug: "sandbox",
+  },
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: "org-1", slug: "acme" }),
+  useProject: () => mocks.project,
+}));
+
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    home: { href: () => "/acme" },
+  }),
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@gram/client/react-query/deleteProject", () => ({
+  useDeleteProjectMutation: (options?: {
+    onSuccess?: () => Promise<void>;
+  }) => ({
+    mutate: (variables: unknown) => {
+      mocks.mutate(variables);
+      void options?.onSuccess?.();
+    },
+    isPending: false,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/listProjects", () => ({
+  invalidateListProjects: mocks.invalidateListProjects,
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({}),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: vi.fn(),
+  },
+}));
+
+import { SettingsDangerZone } from "./SettingsDangerZone";
+
+beforeEach(() => {
+  mocks.mutate.mockReset();
+  mocks.navigate.mockReset();
+  mocks.invalidateListProjects.mockReset();
+  mocks.invalidateListProjects.mockResolvedValue(undefined);
+  mocks.toastSuccess.mockReset();
+  mocks.project.id = "proj-1";
+  mocks.project.name = "Sandbox";
+  mocks.project.slug = "sandbox";
+});
+
+afterEach(cleanup);
+
+async function confirmDelete() {
+  fireEvent.click(screen.getByRole("button", { name: "Delete Project" }));
+  fireEvent.change(screen.getByLabelText("Type the project name to confirm:"), {
+    target: { value: mocks.project.name },
+  });
+  fireEvent.click(
+    screen.getAllByRole("button", { name: "Delete Project" }).at(-1)!,
+  );
+  await waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+}
+
+describe("SettingsDangerZone", () => {
+  it("sends the user to org home after deleting a project", async () => {
+    render(<SettingsDangerZone />);
+
+    await confirmDelete();
+
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith("/acme", { replace: true }),
+    );
+    expect(mocks.mutate).toHaveBeenCalledWith({
+      request: { id: "proj-1" },
+    });
+    expect(mocks.invalidateListProjects).toHaveBeenCalled();
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Project deleted successfully",
+    );
+  });
+});

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
@@ -4,6 +4,7 @@ import { Label } from "@/components/ui/Label";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Text } from "@/components/ui/Text";
 import { useOrganization, useProject } from "@/contexts/Auth";
+import { useOrgRoutes } from "@/routes";
 import { useDeleteProjectMutation } from "@gram/client/react-query/deleteProject";
 import { invalidateListProjects } from "@gram/client/react-query/listProjects";
 import { Button } from "@/components/ui/Button";
@@ -16,6 +17,7 @@ import { toast } from "sonner";
 export function SettingsDangerZone(): JSX.Element {
   const organization = useOrganization();
   const project = useProject();
+  const orgRoutes = useOrgRoutes();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -34,7 +36,9 @@ export function SettingsDangerZone(): JSX.Element {
         { organizationId: organization.id },
       ]);
       toast.success("Project deleted successfully");
-      void navigate(`/${organization.slug}/default/settings`);
+      // Replace so Back doesn't return to the deleted project's settings
+      // (which falls through to another project's settings).
+      void navigate(orgRoutes.home.href(), { replace: true });
     },
     onError: (error) => {
       console.error("Failed to delete project:", error);

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
@@ -40,8 +40,6 @@ export function SettingsDangerZone(): JSX.Element {
           Project <strong>{project.name}</strong> deleted successfully
         </>,
       );
-      // Replace so Back doesn't return to the deleted project's settings
-      // (which falls through to another project's settings).
       void navigate(orgRoutes.home.href(), { replace: true });
     },
     onError: (error) => {

--- a/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
+++ b/client/dashboard/src/pages/settings/SettingsDangerZone.tsx
@@ -35,7 +35,11 @@ export function SettingsDangerZone(): JSX.Element {
       await invalidateListProjects(queryClient, [
         { organizationId: organization.id },
       ]);
-      toast.success("Project deleted successfully");
+      toast.success(
+        <>
+          Project <strong>{project.name}</strong> deleted successfully
+        </>,
+      );
       // Replace so Back doesn't return to the deleted project's settings
       // (which falls through to another project's settings).
       void navigate(orgRoutes.home.href(), { replace: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes **GRW-14**.

## Problem

After deleting a project, the dashboard navigated to `/{org}/default/settings`. That lands the user in another project's settings — one they did not choose — and makes it look like the delete failed.

## Change

On successful delete, navigate to organization home (`/{org}`) via `orgRoutes.home.href()`. The navigation uses `replace: true` so Back cannot reopen the deleted project's settings URL, which would otherwise fall through to another project.

The success toast now names the deleted project in bold: `Project **{name}** deleted successfully`.

## Test plan

- [x] Unit test: delete confirmation navigates to `/acme` with `{ replace: true }`, and the toast includes the project name in `<strong>`
- [x] Browser: created a throwaway project, deleted it from Project Settings, landed on org home (`/speakeasy`, Home selected). The deleted project is gone from the Projects list; recent activity records the delete. Not default-project settings.

![Project settings Danger Zone before delete](https://cursor.com/artifacts/c/art-731e703d-6fca-4037-a589-62a0ccbd5a5e)
![Organization home after project delete](https://cursor.com/artifacts/c/art-7d6399ea-98ee-4fe5-af18-652578a02c40)
<a href="https://cursor.com/agents/bc-39f9e62c-6a97-4ac7-abcd-cbecaa85ee7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelete_project_redirects_to_org_home.webm"><img src="https://cursor.com/artifacts/c/art-6352844d-4887-4df2-901d-4b440ff5567a" alt="delete_project_redirects_to_org_home.webm" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-14](https://linear.app/speakeasy/issue/GRW-14/fix-when-deleting-a-project-a-user-should-be-sent-to-org-home)

<div><a href="https://cursor.com/agents/bc-39f9e62c-6a97-4ac7-abcd-cbecaa85ee7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39f9e62c-6a97-4ac7-abcd-cbecaa85ee7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GRW-14: deleting a project used to send users to another project's settings, making the delete appear to fail. Now it navigates to the organization home, replaces the history entry so Back can't reopen the deleted project's URL, and names the deleted project in the success toast.

<sup>Written for commit be1b11e73637cb9b9051a729e1b586757f947545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

