### PR TITLE
feat: enforce killswitches before hosted MCP tool execution

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1090,7 +1090,7 @@ func newStartCommand() *cli.Command {
 				}
 			}
 
-			mcpService := mcp.NewService(
+			mcpService, err := mcp.NewService(
 				logger,
 				tracerProvider,
 				meterProvider,
@@ -1139,6 +1139,9 @@ func newStartCommand() *cli.Command {
 					MemberCallTimeout: c.Duration("meta-member-call-timeout"),
 				},
 			)
+			if err != nil {
+				return fmt.Errorf("initialize MCP service: %w", err)
+			}
 
 			chatClient := chat.NewAgenticChatClient(
 				logger,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -781,7 +781,7 @@ func newWorkerCommand() *cli.Command {
 				serverURL,
 			)
 
-			mcpService := mcp.NewService(
+			mcpService, err := mcp.NewService(
 				logger,
 				tracerProvider,
 				meterProvider,
@@ -832,6 +832,9 @@ func newWorkerCommand() *cli.Command {
 				},
 				mcp.MetaRuntimeConfig{MemberCallTimeout: 0},
 			)
+			if err != nil {
+				return fmt.Errorf("initialize MCP service: %w", err)
+			}
 
 			chatClient := chat.NewAgenticChatClient(
 				logger,

--- a/server/internal/killswitches/mcptoolexecution/coverage.go
+++ b/server/internal/killswitches/mcptoolexecution/coverage.go
@@ -2,6 +2,7 @@ package mcptoolexecution
 
 import (
 	"context"
+	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -13,6 +14,58 @@ import (
 // IdentityCoverageRecorder is implemented by each production MCP metric scope.
 type IdentityCoverageRecorder interface {
 	RecordKillswitchIdentityCoverage(context.Context, mcpmetrics.KillswitchCoverageSurface, mcpmetrics.KillswitchIdentityClass, mcpmetrics.KillswitchResourceClass)
+}
+
+type coverageDerivation struct {
+	principalSource any
+	principalResult killswitches.PrincipalCandidateResult
+	principalErr    error
+	resourceSource  ServerSource
+	resourceResult  killswitches.CanonicalizationResult[killswitches.ResourceKey]
+	resourceErr     error
+}
+
+func deriveCoverage(
+	ctx context.Context,
+	organization killswitches.OrganizationID,
+	principal killswitches.PrincipalAdapter,
+	resource killswitches.ResourceAdapter,
+	resourceSource ServerSource,
+) coverageDerivation {
+	result := coverageDerivation{
+		principalSource: nil,
+		principalResult: killswitches.UnsupportedPrincipalCandidateResult(),
+		principalErr:    nil,
+		resourceSource:  resourceSource,
+		resourceResult:  killswitches.CanonicalizationResult[killswitches.ResourceKey]{},
+		resourceErr:     nil,
+	}
+
+	var group sync.WaitGroup
+	if identity, ok := mcpidentity.FromContext(ctx); ok {
+		result.principalSource = identity
+		group.Go(func() {
+			result.principalResult, result.principalErr = principal.DeriveCandidates(ctx, organization, identity)
+		})
+	}
+	group.Go(func() {
+		result.resourceResult, result.resourceErr = resource.Derive(ctx, organization, resourceSource)
+	})
+	group.Wait()
+
+	return result
+}
+
+func (d coverageDerivation) record(ctx context.Context, recorder IdentityCoverageRecorder, surface mcpmetrics.KillswitchCoverageSurface) {
+	if recorder == nil {
+		return
+	}
+	recorder.RecordKillswitchIdentityCoverage(
+		ctx,
+		surface,
+		ClassifyPrincipalCoverage(d.principalSource, d.principalResult, d.principalErr),
+		ClassifyResourceCoverage(d.resourceSource, d.resourceResult, d.resourceErr),
+	)
 }
 
 // IdentityCoverageCheckpoint derives and records the bounded identity and
@@ -47,20 +100,6 @@ func (c *IdentityCoverageCheckpoint) Record(ctx context.Context, organizationID 
 		return
 	}
 
-	organization := killswitches.OrganizationID(organizationID)
-	principalResult := killswitches.UnsupportedPrincipalCandidateResult()
-	var principalSource any
-	var principalErr error
-	if identity, ok := mcpidentity.FromContext(ctx); ok {
-		principalSource = identity
-		principalResult, principalErr = c.principal.DeriveCandidates(ctx, organization, identity)
-	}
-
-	resourceResult, resourceErr := c.resource.Derive(ctx, organization, resourceSource)
-	c.recorder.RecordKillswitchIdentityCoverage(
-		ctx,
-		surface,
-		ClassifyPrincipalCoverage(principalSource, principalResult, principalErr),
-		ClassifyResourceCoverage(resourceSource, resourceResult, resourceErr),
-	)
+	derivation := deriveCoverage(ctx, killswitches.OrganizationID(organizationID), c.principal, c.resource, resourceSource)
+	derivation.record(ctx, c.recorder, surface)
 }

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -1,6 +1,7 @@
 package mcptoolexecution
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,9 +9,116 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
+
+// TestHostedCheckpoint_ReevaluatesAndFailsClosed verifies that each hosted call
+// uses current prescription state and rejects evaluator failures.
+func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_hosted_checkpoint")
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "hosted-checkpoint", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	source := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
+	recorder := &coverageRecorder{}
+	checkpoint, err := NewHostedCheckpoint(conn, testenv.NewMeterProvider(t), nil, recorder)
+	require.NoError(t, err)
+	ctx := mcpidentity.WithIdentity(t.Context(), mcpidentity.AuthenticatedUser(userID))
+
+	disposition, err := checkpoint.Evaluate(ctx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+
+	note := "Exact operator note."
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           uuid.New(),
+		PrincipalKey: userID,
+		Scope:        "selected",
+		Resources:    []string{serverID.String()},
+		ExternalNote: note,
+	})
+
+	disposition, err = checkpoint.Evaluate(ctx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionMatchedDenial, disposition.Kind())
+	gotNote, ok := disposition.ExternalNote()
+	require.True(t, ok)
+	require.Equal(t, note, gotNote)
+	require.Len(t, recorder.observations, 2)
+	for _, observation := range recorder.observations {
+		require.Equal(t, coverageObservation{
+			surface:  mcpmetrics.KillswitchSurfaceHosted,
+			identity: mcpmetrics.KillswitchIdentityActiveUser,
+			resource: mcpmetrics.KillswitchResourceCanonicalServer,
+		}, observation)
+	}
+
+	_, err = conn.Exec(t.Context(), "DROP TABLE killswitch_prescriptions CASCADE") //nolint:glint // notestingrawsql: deterministic DDL breakage in this test's isolated database forces an evaluator failure
+	require.NoError(t, err)
+
+	disposition, err = checkpoint.Evaluate(ctx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+	_, hasNote := disposition.ExternalNote()
+	require.False(t, hasNote)
+
+	unsupportedCtx := mcpidentity.WithIdentity(t.Context(), mcpidentity.Identity{Kind: mcpidentity.KindAnonymous})
+	disposition, err = checkpoint.Evaluate(unsupportedCtx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+}
+
+// TestHostedCheckpoint_DerivationErrorsTakePrecedenceOverUnsupportedInputs verifies
+// that derivation failures reject calls even when another input is unsupported.
+func TestHostedCheckpoint_DerivationErrorsTakePrecedenceOverUnsupportedInputs(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_hosted_checkpoint_derivation_errors")
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "hosted-checkpoint-errors", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	serverSource := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
+	recorder := &coverageRecorder{}
+	checkpoint, err := NewHostedCheckpoint(conn, testenv.NewMeterProvider(t), nil, recorder)
+	require.NoError(t, err)
+
+	unsupportedIdentityCtx := mcpidentity.WithIdentity(t.Context(), mcpidentity.Identity{Kind: mcpidentity.KindAnonymous})
+	disposition, err := checkpoint.Evaluate(unsupportedIdentityCtx, orgID, serverSource)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+
+	unsupportedResourceCtx := mcpidentity.WithIdentity(t.Context(), mcpidentity.AuthenticatedUser(userID))
+	disposition, err = checkpoint.Evaluate(unsupportedResourceCtx, orgID, ServerSource{})
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+
+	resourceFailureCtx, cancelResourceFailure := context.WithCancel(unsupportedIdentityCtx)
+	cancelResourceFailure()
+	disposition, err = checkpoint.Evaluate(resourceFailureCtx, orgID, serverSource)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+
+	principalFailureCtx, cancelPrincipalFailure := context.WithCancel(unsupportedResourceCtx)
+	cancelPrincipalFailure()
+	disposition, err = checkpoint.Evaluate(principalFailureCtx, orgID, ServerSource{})
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+
+	require.Equal(t, []coverageObservation{
+		{surface: mcpmetrics.KillswitchSurfaceHosted, identity: mcpmetrics.KillswitchIdentityAnonymous, resource: mcpmetrics.KillswitchResourceCanonicalServer},
+		{surface: mcpmetrics.KillswitchSurfaceHosted, identity: mcpmetrics.KillswitchIdentityActiveUser, resource: mcpmetrics.KillswitchResourceLegacyNoServer},
+		{surface: mcpmetrics.KillswitchSurfaceHosted, identity: mcpmetrics.KillswitchIdentityAnonymous, resource: mcpmetrics.KillswitchResourceUnavailable},
+		{surface: mcpmetrics.KillswitchSurfaceHosted, identity: mcpmetrics.KillswitchIdentityUnavailable, resource: mcpmetrics.KillswitchResourceLegacyNoServer},
+	}, recorder.observations)
+}
 
 // TestMCPToolExecutionEvaluationAcrossProjects proves the end-to-end
 // adapter-to-evaluator slice with real database state: authoritative

--- a/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
@@ -1,0 +1,131 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+)
+
+const hostedEvaluatorTimeout = 2 * time.Second
+
+// HostedCheckpoint authoritatively evaluates the M2 kill switch before hosted
+// tools/call configuration or execution work begins.
+type HostedCheckpoint struct {
+	principal     killswitches.PrincipalAdapter
+	resource      killswitches.ResourceAdapter
+	evaluator     *killswitches.Evaluator
+	transport     killswitches.TransportAdapter
+	failurePolicy killswitches.FailurePolicy
+	recorder      IdentityCoverageRecorder
+	logger        *slog.Logger
+}
+
+// NewHostedCheckpoint builds the production checkpoint from the registered M2
+// contracts and the authoritative PostgreSQL evaluator.
+func NewHostedCheckpoint(db *pgxpool.Pool, meterProvider metric.MeterProvider, logger *slog.Logger, recorder IdentityCoverageRecorder) (*HostedCheckpoint, error) {
+	registry, err := NewRegistry(db)
+	if err != nil {
+		return nil, err
+	}
+
+	coverage, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfaceHostedToolsCall)
+	if !ok {
+		return nil, errors.New("hosted tools/call coverage contract is not registered")
+	}
+	principal, ok := registry.PrincipalAdapter(PrincipalKindUser)
+	if !ok {
+		return nil, errors.New("authenticated user principal adapter is not registered")
+	}
+	resource, ok := registry.ResourceAdapter(ResourceKindMCPServer)
+	if !ok {
+		return nil, errors.New("mcp server resource adapter is not registered")
+	}
+	transport, ok := registry.TransportAdapter(coverage.TransportAdapter)
+	if !ok {
+		return nil, errors.New("hosted MCP JSON-RPC transport adapter is not registered")
+	}
+
+	eval, err := killswitches.NewEvaluator(db, registry, hostedEvaluatorTimeout, meterProvider, logger)
+	if err != nil {
+		return nil, fmt.Errorf("construct evaluator: %w", err)
+	}
+
+	return &HostedCheckpoint{
+		principal:     principal,
+		resource:      resource,
+		evaluator:     eval,
+		transport:     transport,
+		failurePolicy: coverage.FailurePolicy,
+		recorder:      recorder,
+		logger:        logger,
+	}, nil
+}
+
+// Evaluate revalidates principal membership and server ownership on every call.
+// Unsupported identities and resources remain outside M2 and continue unchanged.
+func (c *HostedCheckpoint) Evaluate(ctx context.Context, organizationID string, resourceSource ServerSource) (killswitches.TransportDisposition, error) {
+	organization := killswitches.OrganizationID(organizationID)
+	evaluationCtx, cancel := context.WithTimeout(ctx, hostedEvaluatorTimeout)
+	defer cancel()
+
+	derivation := deriveCoverage(evaluationCtx, organization, c.principal, c.resource, resourceSource)
+	derivation.record(ctx, c.recorder, mcpmetrics.KillswitchSurfaceHosted)
+
+	if derivation.principalErr != nil {
+		return c.infrastructureRejection(ctx, derivation.principalErr)
+	}
+	if derivation.resourceErr != nil {
+		return c.infrastructureRejection(ctx, derivation.resourceErr)
+	}
+
+	resourceKey, supported, err := derivation.resourceResult.Key()
+	if err != nil {
+		return c.infrastructureRejection(ctx, err)
+	}
+	if derivation.principalResult.Kind() == killswitches.PrincipalCandidateResultUnsupported {
+		return c.noMatch(killswitches.NoMatchReasonUnsupportedIdentity)
+	}
+	if !supported {
+		return c.noMatch(killswitches.NoMatchReasonUnsupportedResource)
+	}
+
+	result := c.evaluator.Evaluate(evaluationCtx, killswitches.EvaluationRequest{
+		OrganizationID:      organization,
+		DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution},
+		PrincipalCandidates: derivation.principalResult.Candidates(),
+		ResourceKind:        ResourceKindMCPServer,
+		ResourceKey:         resourceKey,
+	})
+	if cause := result.InfrastructureError(); cause != nil && c.logger != nil {
+		c.logger.ErrorContext(ctx, "hosted MCP kill-switch evaluation unavailable", attr.SlogError(cause))
+	}
+	return c.transport(result, c.failurePolicy)
+}
+
+func (c *HostedCheckpoint) noMatch(reason killswitches.NoMatchReason) (killswitches.TransportDisposition, error) {
+	result, err := killswitches.NewNoMatchResult(reason)
+	if err != nil {
+		return killswitches.TransportDisposition{}, fmt.Errorf("construct no-match result: %w", err)
+	}
+	return c.transport(result, c.failurePolicy)
+}
+
+func (c *HostedCheckpoint) infrastructureRejection(ctx context.Context, cause error) (killswitches.TransportDisposition, error) {
+	if c.logger != nil {
+		c.logger.ErrorContext(ctx, "hosted MCP kill-switch checkpoint unavailable", attr.SlogError(cause))
+	}
+	result, err := killswitches.NewInfrastructureFailureResult(cause)
+	if err != nil {
+		return killswitches.TransportDisposition{}, fmt.Errorf("construct infrastructure-failure result: %w", err)
+	}
+	return c.transport(result, c.failurePolicy)
+}

--- a/server/internal/killswitches/mcptoolexecution/registration.go
+++ b/server/internal/killswitches/mcptoolexecution/registration.go
@@ -4,10 +4,10 @@
 // adapter, and the coverage inventory for the hosted and private-proxy MCP
 // tools/call surfaces.
 //
-// Registration declares the contracts only. It does not deploy enforcement:
-// the hosted dispatch checkpoint (DNO-982) and the private forwarding
-// checkpoint (DNO-980) ship separately, and production prescriptions must not
-// be enabled before those checkpoints have reached the fleet.
+// Registration declares the contracts consumed by the hosted dispatch
+// checkpoint. Private forwarding enforcement ships separately, and production
+// prescriptions must not be enabled until every covered checkpoint has reached
+// the fleet.
 package mcptoolexecution
 
 import (
@@ -101,8 +101,8 @@ func NewRegistration(db *pgxpool.Pool) killswitches.Registration {
 				Surface:          SurfaceHostedToolsCall,
 				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
 				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route, validated as a live server in a live project of the organization. Never a slug, URL, toolset, backend ID, or caller-provided value.",
-				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on hosted MCP tools/call dispatch. Registration does not deploy this checkpoint; the dispatch wiring ships separately (DNO-982).",
-				ProtectedWork:    "Loading or applying tool configuration and local tool execution.",
+				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on hosted MCP tools/call dispatch.",
+				ProtectedWork:    "Loading or applying tool configuration, resolving protected credentials, and dispatching local, dynamic, function, platform, or external-MCP proxy execution.",
 				FailurePolicy:    killswitches.FailurePolicyFailClosed,
 				TransportAdapter: TransportAdapterHostedJSONRPC,
 				EnforcementOwner: EnforcementOwner,

--- a/server/internal/killswitches/mcptoolexecution/registration_test.go
+++ b/server/internal/killswitches/mcptoolexecution/registration_test.go
@@ -62,6 +62,7 @@ func TestMCPCoverageInventory(t *testing.T) {
 	hosted, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfaceHostedToolsCall)
 	require.True(t, ok)
 	require.Equal(t, TransportAdapterHostedJSONRPC, hosted.TransportAdapter)
+	require.Contains(t, hosted.ProtectedWork, "resolving protected credentials")
 
 	proxy, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfacePrivateProxyToolsCall)
 	require.True(t, ok)

--- a/server/internal/killswitches/mcptoolexecution/setup_test.go
+++ b/server/internal/killswitches/mcptoolexecution/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
 var infra *testenv.Environment
@@ -130,29 +131,18 @@ type prescriptionFixture struct {
 // prescription with the concrete user principal and mcp_server resource kind.
 func insertPrescription(t *testing.T, conn *pgxpool.Pool, organizationID string, fixture prescriptionFixture) {
 	t.Helper()
-	var databaseNow time.Time
-	require.NoError(t, conn.QueryRow(t.Context(), "SELECT clock_timestamp()").Scan(&databaseNow))
-	startsAt := databaseNow.Add(-time.Hour)
-	activatedAt := databaseNow.Add(-time.Hour)
 
-	_, err := conn.Exec(t.Context(), `
-		INSERT INTO killswitch_prescriptions (id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version)
-		VALUES ($1, $2, $3, $4, $5, $6, 1)
-	`, fixture.ID, organizationID, string(DefinitionKeyMCPToolExecution), string(PrincipalKindUser), fixture.PrincipalKey, string(ResourceKindMCPServer))
+	err := testrepo.New(conn).InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
+		PrescriptionID: fixture.ID,
+		OrganizationID: organizationID,
+		DefinitionKey:  string(DefinitionKeyMCPToolExecution),
+		PrincipalKind:  string(PrincipalKindUser),
+		PrincipalKey:   fixture.PrincipalKey,
+		ResourceKind:   string(ResourceKindMCPServer),
+		ResourceScope:  fixture.Scope,
+		InternalNote:   "test fixture context",
+		ExternalNote:   fixture.ExternalNote,
+		ResourceKeys:   fixture.Resources,
+	})
 	require.NoError(t, err)
-
-	_, err = conn.Exec(t.Context(), `
-		INSERT INTO killswitch_prescription_versions (
-		  organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
-		) VALUES ($1, $2, 1, 'active', $3, $4, NULL, $5, 'test fixture context', $6)
-	`, organizationID, fixture.ID, fixture.Scope, startsAt, activatedAt, fixture.ExternalNote)
-	require.NoError(t, err)
-
-	for _, resource := range fixture.Resources {
-		_, err = conn.Exec(t.Context(), `
-			INSERT INTO killswitch_prescription_version_resources (organization_id, prescription_id, version, resource_key)
-			VALUES ($1, $2, 1, $3)
-		`, organizationID, fixture.ID, resource)
-		require.NoError(t, err)
-	}
 }

--- a/server/internal/killswitches/schema_test.go
+++ b/server/internal/killswitches/schema_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -321,6 +322,62 @@ func TestKillswitchExpiryDiscoveryIndexMatchesEligibilityAndOrder(t *testing.T) 
 	require.Equal(t, []string{"expires_at", "prescription_id", "version"}, indexColumns)
 	require.Equal(t, "btree", indexAccessMethod)
 	require.Equal(t, "((state = 'active'::text) AND (expires_at IS NOT NULL) AND ((superseded_at IS NULL) OR (expires_at < superseded_at)))", indexPredicate)
+}
+
+func TestInsertKillswitchPrescriptionFixtureValidatesResourceScope(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "killswitch_fixture_scope")
+	require.NoError(t, err)
+
+	organizationID := "org_" + uuid.NewString()
+	insertOrganization(t, conn, organizationID)
+	fixtures := testrepo.New(conn)
+
+	testCases := []struct {
+		name          string
+		resourceScope ResourceScope
+		resourceKeys  []string
+		wantErr       bool
+	}{
+		{name: "all without resources", resourceScope: ResourceScopeAll},
+		{name: "selected with resources", resourceScope: ResourceScopeSelected, resourceKeys: []string{"resource_1"}},
+		{name: "all with resources", resourceScope: ResourceScopeAll, resourceKeys: []string{"resource_1"}, wantErr: true},
+		{name: "selected without resources", resourceScope: ResourceScopeSelected, wantErr: true},
+		{name: "invalid scope", resourceScope: ResourceScope("invalid"), wantErr: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			prescriptionID := uuid.New()
+			err := fixtures.InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
+				ResourceKeys:   testCase.resourceKeys,
+				PrescriptionID: prescriptionID,
+				OrganizationID: organizationID,
+				DefinitionKey:  "test_capability",
+				PrincipalKind:  "user",
+				PrincipalKey:   "user_1",
+				ResourceKind:   "test_resource",
+				ResourceScope:  string(testCase.resourceScope),
+				InternalNote:   "internal",
+				ExternalNote:   "external",
+			})
+			if !testCase.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			var prescriptions int
+			require.NoError(t, conn.QueryRow(t.Context(), `
+				SELECT count(*)
+				FROM killswitch_prescriptions
+				WHERE id = $1
+			`, prescriptionID).Scan(&prescriptions))
+			require.Zero(t, prescriptions)
+		})
+	}
 }
 
 func insertOrganization(t *testing.T, conn *pgxpool.Pool, organizationID string) {

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -464,38 +464,38 @@ func (s *Service) BaseURLForRequest(r *http.Request) string {
 	return s.serverURL.String()
 }
 
-// ApplyIssuerGate runs the issuer-gated authentication branch shared by
+type issuerGateAuthentication struct {
+	endpoint             *ResolvedMcpEndpoint
+	protectedResourceURL string
+	mcpURL               string
+	surface              mcpmetrics.Surface
+	subject              urn.SessionSubject
+}
+
+// authenticateIssuerGate runs the issuer-gated authentication branch shared by
 // the toolset-keyed (/mcp) and mcp_server-keyed (/x/mcp) MCP runtime
-// paths. It validates the bearer token as a user-session JWT, falls back
-// to an assistant-runtime JWT scoped to the endpoint's project, and on
-// success resolves the upstream remote-session access tokens configured
-// for the issuer.
+// paths. It validates the bearer token as a user-session JWT and falls back
+// to an assistant-runtime JWT scoped to the endpoint's project. Upstream
+// remote-session credentials are deliberately resolved by a separate step so
+// hosted tool calls can evaluate kill switches first.
 //
-// On success: returns the request context stamped with the resolved
-// principal plus a remote_session_issuer_id -> upstream token map. The map
-// is nil/empty when the issuer has no remote_session_clients bound;
-// otherwise it holds one qualified entry (token + grant-time RFC 8707
-// resource) per remote_session_issuer the subject has linked. Proxied
-// backends route the entry matching their upstream resource; toolset
-// dispatch wraps entries into oauthTokenInputs.
-//
-// On failure: writes a 401 + WWW-Authenticate to w and returns the
-// CodeUnauthorized error from WriteAuthenticateChallenge. A re-auth
-// challenge is issued when any attached remote session is missing or
-// invalid (ResolveAccessTokens returns ErrNoValidToken). The
-// resource_metadata URL is built from baseURL + endpoint.RouteBase +
+// On success it returns the stamped request context, the authenticated subject
+// needed for deferred credential resolution, and the caller's tool selection.
+// On failure it writes a 401 + WWW-Authenticate and returns the CodeUnauthorized
+// error from WriteAuthenticateChallenge. The resource_metadata URL is built
+// from baseURL + endpoint.RouteBase +
 // endpoint.Slug so a /x/mcp request gets pointed at /x/mcp's
 // protected-resource metadata, not /mcp's.
 //
 // /x/mcp uses this to gate requests on mcp_servers.user_session_issuer_id
 // before dispatching to its remote backend or delegating to
 // ServeToolsetResolved with the gate skipped.
-func (s *Service) ApplyIssuerGate(
+func (s *Service) authenticateIssuerGate(
 	ctx context.Context,
 	w http.ResponseWriter,
 	authToken, baseURL string,
 	endpoint *ResolvedMcpEndpoint,
-) (context.Context, map[uuid.UUID]remotesessions.UpstreamToken, *toolfilter.SessionSelection, error) {
+) (context.Context, *issuerGateAuthentication, *toolfilter.SessionSelection, error) {
 	protectedResourceURL, err := endpoint.ProtectedResourceURL(baseURL)
 	if err != nil {
 		return ctx, nil, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
@@ -557,41 +557,53 @@ func (s *Service) ApplyIssuerGate(
 		return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
 	}
 
-	// Resolve the upstream remote_sessions for this subject before
-	// running the legacy auth chain. The resolver short-circuits to
-	// no-op when the issuer has no remote_session_clients bound;
-	// otherwise it supplies one upstream access token per linked
-	// remote_session_issuer (fed into tokenInputs so they satisfy the
-	// endpoint's oauth2 schemes downstream) or fails with ErrNoValidToken
-	// when any attached remote session is missing or invalid — which the
-	// user resolves by re-linking via {routeBase}/{slug}/connect.
-	var upstreamTokens map[uuid.UUID]remotesessions.UpstreamToken
-	if subject != nil {
-		tokens, rerr := s.remoteChallengeMgr.ResolveAccessTokens(newCtx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, *subject)
-		switch {
-		case errors.Is(rerr, remotesessions.ErrNoValidToken):
-			// The Gram user-session token is valid, but a required upstream
-			// remote session for this issuer is missing or unusable, so the
-			// runtime issues a re-auth challenge pointing the user at
-			// {routeBase}/{slug}/connect. This 401 is byte-identical to an
-			// invalid-token rejection (both are CodeUnauthorized), so without
-			// this line the two are indistinguishable in production. The
-			// specific broken upstream (and its refresh reason) is logged by
-			// remotesessions.ResolveAccessToken.
-			endpoint.LogWith(s.logger).WarnContext(newCtx, "mcp issuer gate rejected: upstream remote session missing or unusable",
-				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
-				attr.SlogToolsetMCPSlug(endpoint.Slug),
-				attr.SlogMcpURL(mcpURL),
-				attr.SlogOAuthFailureReason(issuerGateReasonInvalidRemoteSession),
-			)
-			s.metrics.RecordMCPRequestRejected(newCtx, issuerGateReasonInvalidRemoteSession, mcpURL, surface)
-			return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
-		case rerr != nil:
-			return ctx, nil, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
-		}
-		upstreamTokens = tokens
+	return newCtx, &issuerGateAuthentication{
+		endpoint:             endpoint,
+		protectedResourceURL: protectedResourceURL,
+		mcpURL:               mcpURL,
+		surface:              surface,
+		subject:              *subject,
+	}, toolSelection, nil
+}
+
+func (s *Service) resolveIssuerGateAccessTokens(ctx context.Context, w http.ResponseWriter, authentication *issuerGateAuthentication) (map[uuid.UUID]remotesessions.UpstreamToken, error) {
+	endpoint := authentication.endpoint
+	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, authentication.subject)
+	switch {
+	case errors.Is(err, remotesessions.ErrNoValidToken):
+		endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected: upstream remote session missing or unusable",
+			attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
+			attr.SlogToolsetMCPSlug(endpoint.Slug),
+			attr.SlogMcpURL(authentication.mcpURL),
+			attr.SlogOAuthFailureReason(issuerGateReasonInvalidRemoteSession),
+		)
+		s.metrics.RecordMCPRequestRejected(ctx, issuerGateReasonInvalidRemoteSession, authentication.mcpURL, authentication.surface)
+		return nil, WriteAuthenticateChallenge(w, authentication.protectedResourceURL, "")
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve remote session").LogError(ctx, s.logger)
+	default:
+		return tokens, nil
 	}
-	return newCtx, upstreamTokens, toolSelection, nil
+}
+
+// ApplyIssuerGate authenticates and immediately resolves upstream credentials.
+// Hosted toolset dispatch uses the split operations so kill-switch evaluation
+// can run between authentication and protected credential work.
+func (s *Service) ApplyIssuerGate(
+	ctx context.Context,
+	w http.ResponseWriter,
+	authToken, baseURL string,
+	endpoint *ResolvedMcpEndpoint,
+) (context.Context, map[uuid.UUID]remotesessions.UpstreamToken, *toolfilter.SessionSelection, error) {
+	newCtx, authentication, toolSelection, err := s.authenticateIssuerGate(ctx, w, authToken, baseURL, endpoint)
+	if err != nil {
+		return ctx, nil, nil, err
+	}
+	tokens, err := s.resolveIssuerGateAccessTokens(newCtx, w, authentication)
+	if err != nil {
+		return ctx, nil, nil, err
+	}
+	return newCtx, tokens, toolSelection, nil
 }
 
 var errToolsetEndpointMismatch = errors.New("authn challenge endpoint does not match toolset")

--- a/server/internal/mcp/hosted_killswitch_test.go
+++ b/server/internal/mcp/hosted_killswitch_test.go
@@ -1,0 +1,141 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestServePublic_HostedToolsCallKillswitch(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotEmpty(t, authCtx.UserID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "killswitch-"+uuid.NewString()[:8])
+	endpointSlug := "killswitch-" + uuid.NewString()
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	mcpServer := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
+	userToken := mintIssuerBearerForEndpointSubject(t, ctx, ti, endpointSlug, mcpServer, authCtx.ActiveOrganizationID, urn.NewUserSubject(authCtx.UserID))
+	sessionHeaders := map[string]string{"Mcp-Session-Id": "same-session"}
+
+	before, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsCallBody("missing_tool"), userToken, sessionHeaders)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, before.Code)
+	require.NotContains(t, before.Body.String(), "mcp_tool_calls_paused")
+
+	note := "Tool calls paused for maintenance."
+	insertHostedKillswitchPrescription(t, ctx, ti, authCtx.ActiveOrganizationID, authCtx.UserID, mcpServer.ID, note)
+
+	initialize, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), userToken, sessionHeaders)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, initialize.Code)
+	require.NotContains(t, initialize.Body.String(), "mcp_tool_calls_paused")
+
+	anonymousToken := mintIssuerBearerForEndpoint(t, ctx, ti, endpointSlug, mcpServer, authCtx.ActiveOrganizationID)
+	unsupported, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeToolsCallBody("missing_tool"), anonymousToken, sessionHeaders)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, unsupported.Code)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":null,"error":{"code":-32002,"message":"tool not found"}}`, unsupported.Body.String())
+	require.NotContains(t, unsupported.Body.String(), "Internal error")
+	require.NotContains(t, unsupported.Body.String(), note)
+	require.NotContains(t, unsupported.Body.String(), "mcp_tool_calls_paused")
+
+	attachMissingRemoteSession(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, issuerID)
+
+	for _, tt := range []struct {
+		name string
+		body []byte
+	}{
+		{name: "non-tools/call", body: makeToolsListBody()},
+		{name: "malformed", body: []byte(`{`)},
+	} {
+		response, err := servePublicHTTP(t, ctx, ti, endpointSlug, tt.body, userToken, sessionHeaders)
+		require.Error(t, err, tt.name)
+		require.Contains(t, err.Error(), "unauthorized", tt.name)
+		require.NotEmpty(t, response.Header().Get("WWW-Authenticate"), tt.name)
+	}
+
+	for _, toolName := range []string{"missing_tool", "search_tools", "describe_tools", "execute_tool"} {
+		response, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsCallBody(toolName), userToken, sessionHeaders)
+		require.NoError(t, err, toolName)
+		require.Equal(t, http.StatusOK, response.Code, toolName)
+		require.Empty(t, response.Header().Get("WWW-Authenticate"), toolName)
+		require.JSONEq(t, `{"jsonrpc":"2.0","id":3,"error":{"code":-32003,"message":"Tool calls paused for maintenance.","data":{"code":"mcp_tool_calls_paused"}}}`, response.Body.String(), toolName)
+	}
+
+	_, err = ti.conn.Exec(ctx, "DROP TABLE killswitch_prescriptions CASCADE") //nolint:glint // notestingrawsql: deterministic DDL breakage in this test's isolated database forces an evaluator failure
+	require.NoError(t, err)
+
+	unavailable, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsCallBody("missing_tool"), userToken, sessionHeaders)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":3,"error":{"code":-32603,"message":"Internal error"}}`, unavailable.Body.String())
+	require.NotContains(t, unavailable.Body.String(), note)
+	require.NotContains(t, unavailable.Body.String(), "mcp_tool_calls_paused")
+}
+
+func attachMissingRemoteSession(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, organizationID string, userSessionIssuerID uuid.UUID) {
+	t.Helper()
+
+	repo := remotesessionsrepo.New(ti.conn)
+	suffix := uuid.NewString()
+	remoteIssuer, err := repo.CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
+		OrganizationID:                    conv.ToPGTextEmpty(organizationID),
+		ProjectID:                         uuid.NullUUID{UUID: projectID, Valid: true},
+		Slug:                              "killswitch-rsi-" + suffix,
+		Issuer:                            "https://upstream.example/" + suffix,
+		AuthorizationEndpoint:             conv.ToPGText("https://upstream.example/authorize"),
+		TokenEndpoint:                     conv.ToPGText("https://upstream.example/token"),
+		ScopesSupported:                   []string{},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+	})
+	require.NoError(t, err)
+	remoteClient, err := repo.CreateRemoteSessionClient(ctx, remotesessionsrepo.CreateRemoteSessionClientParams{
+		ProjectID:             uuid.NullUUID{UUID: projectID, Valid: true},
+		OrganizationID:        conv.ToPGTextEmpty(organizationID),
+		RemoteSessionIssuerID: remoteIssuer.ID,
+		ClientID:              "killswitch-client-" + suffix,
+		ClientIDIssuedAt:      pgtype.Timestamptz{Time: time.Now(), Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: remoteClient.ID,
+		UserSessionIssuerID:   userSessionIssuerID,
+	}))
+}
+
+func insertHostedKillswitchPrescription(t *testing.T, ctx context.Context, ti *testInstance, organizationID, userID string, serverID uuid.UUID, externalNote string) {
+	t.Helper()
+
+	err := testrepo.New(ti.conn).InsertKillswitchPrescriptionFixture(ctx, testrepo.InsertKillswitchPrescriptionFixtureParams{
+		PrescriptionID: uuid.New(),
+		OrganizationID: organizationID,
+		DefinitionKey:  string(mcptoolexecution.DefinitionKeyMCPToolExecution),
+		PrincipalKind:  string(mcptoolexecution.PrincipalKindUser),
+		PrincipalKey:   userID,
+		ResourceKind:   string(mcptoolexecution.ResourceKindMCPServer),
+		ResourceScope:  "selected",
+		InternalNote:   "test context",
+		ExternalNote:   externalNote,
+		ResourceKeys:   []string{serverID.String()},
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/mcp/hosted_tools_call_coverage_test.go
+++ b/server/internal/mcp/hosted_tools_call_coverage_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -41,21 +40,7 @@ func TestHostedMalformedToolsCall_RecordsCoverageAtMethodBoundary(t *testing.T) 
 	_, err = servePublicHTTP(t, ctx, ti, endpointSlug, body, "", nil)
 	require.NoError(t, err)
 
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &rm))
-	coveragePoints := map[attribute.Set]int64{}
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != mcpmetrics.InstrumentMCPToolCallKillswitchIdentity {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			require.True(t, ok)
-			for _, point := range sum.DataPoints {
-				coveragePoints[point.Attributes] = point.Value
-			}
-		}
-	}
+	coveragePoints := collectKillswitchCoverage(t, reader)
 	require.Equal(t, map[attribute.Set]int64{
 		attribute.NewSet(
 			attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -55,6 +55,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
@@ -98,21 +99,22 @@ type IdentityResolver interface {
 }
 
 type Service struct {
-	logger           *slog.Logger
-	tracer           trace.Tracer
-	metrics          *mcpmetrics.Metrics
-	identityCoverage *mcptoolexecution.IdentityCoverageCheckpoint
-	guardianPolicy   *guardian.Policy
-	db               *pgxpool.Pool
-	authRepo         *auth_repo.Queries
-	toolsetsRepo     *toolsets_repo.Queries
-	mcpMetadataRepo  *metadata_repo.Queries
-	orgsRepo         *organizations_repo.Queries
-	auth             *auth.Auth
-	env              toolconfig.EnvironmentLoader
-	serverURL        *url.URL
-	siteURL          *url.URL
-	posthog          *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
+	logger                    *slog.Logger
+	tracer                    trace.Tracer
+	metrics                   *mcpmetrics.Metrics
+	identityCoverage          *mcptoolexecution.IdentityCoverageCheckpoint
+	hostedToolsCallCheckpoint *mcptoolexecution.HostedCheckpoint
+	guardianPolicy            *guardian.Policy
+	db                        *pgxpool.Pool
+	authRepo                  *auth_repo.Queries
+	toolsetsRepo              *toolsets_repo.Queries
+	mcpMetadataRepo           *metadata_repo.Queries
+	orgsRepo                  *organizations_repo.Queries
+	auth                      *auth.Auth
+	env                       toolconfig.EnvironmentLoader
+	serverURL                 *url.URL
+	siteURL                   *url.URL
+	posthog                   *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
 	// features resolves flag-controlled behavior (the managed assistant's
 	// Platform MCP toolset variant). Wired from the environment-aware
 	// provider: the posthog client in production, the CSV-backed in-memory
@@ -336,11 +338,15 @@ func NewService(
 	redisClient *redis.Client,
 	tunnelPublicConfig TunnelPublicConfig,
 	metaRuntimeConfig MetaRuntimeConfig,
-) *Service {
+) (*Service, error) {
 	tracer := tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/mcp")
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
 	logger = logger.With(attr.SlogComponent("mcp"))
 	metrics := mcpmetrics.NewMetrics(meter, logger)
+	hostedToolsCallCheckpoint, err := mcptoolexecution.NewHostedCheckpoint(db, meterProvider, logger, metrics)
+	if err != nil {
+		return nil, fmt.Errorf("initialize hosted MCP kill-switch checkpoint: %w", err)
+	}
 
 	platformSvc := platformtoolsruntime.NewService(
 		logger,
@@ -354,27 +360,28 @@ func NewService(
 	)
 
 	return &Service{
-		logger:                  logger,
-		tracer:                  tracer,
-		metrics:                 metrics,
-		identityCoverage:        mcptoolexecution.NewIdentityCoverageCheckpoint(db, metrics),
-		guardianPolicy:          guardianPolicy,
-		db:                      db,
-		authRepo:                auth_repo.New(db),
-		toolsetsRepo:            toolsets_repo.New(db),
-		mcpMetadataRepo:         metadata_repo.New(db),
-		orgsRepo:                organizations_repo.New(db),
-		deploymentsRepo:         deployments_repo.New(db),
-		externalmcpRepo:         externalmcp_repo.New(db),
-		auth:                    auth.New(logger, db, sessions, authzEngine),
-		env:                     env,
-		serverURL:               serverURL,
-		siteURL:                 siteURL,
-		posthog:                 posthog,
-		features:                features,
-		cimdResolver:            cimd.NewResolver(guardianPolicy, meterProvider, logger),
-		cimdAdmissionMetrics:    admission.NewMetrics(meterProvider, logger),
-		clientAssertionVerifier: newClientAssertionVerifier(redisClient, guardianPolicy, meterProvider, logger),
+		logger:                    logger,
+		tracer:                    tracer,
+		metrics:                   metrics,
+		identityCoverage:          mcptoolexecution.NewIdentityCoverageCheckpoint(db, metrics),
+		hostedToolsCallCheckpoint: hostedToolsCallCheckpoint,
+		guardianPolicy:            guardianPolicy,
+		db:                        db,
+		authRepo:                  auth_repo.New(db),
+		toolsetsRepo:              toolsets_repo.New(db),
+		mcpMetadataRepo:           metadata_repo.New(db),
+		orgsRepo:                  organizations_repo.New(db),
+		deploymentsRepo:           deployments_repo.New(db),
+		externalmcpRepo:           externalmcp_repo.New(db),
+		auth:                      auth.New(logger, db, sessions, authzEngine),
+		env:                       env,
+		serverURL:                 serverURL,
+		siteURL:                   siteURL,
+		posthog:                   posthog,
+		features:                  features,
+		cimdResolver:              cimd.NewResolver(guardianPolicy, meterProvider, logger),
+		cimdAdmissionMetrics:      admission.NewMetrics(meterProvider, logger),
+		clientAssertionVerifier:   newClientAssertionVerifier(redisClient, guardianPolicy, meterProvider, logger),
 		toolProxy: gateway.NewToolProxy(
 			logger,
 			tracerProvider,
@@ -437,7 +444,7 @@ func NewService(
 		tunnelManager:      newTunnelManager(tunnelRoutes, tunnelForwardToken, remoteProxyManager, tunnelGatewayCIDRs),
 		tunnelPublic:       newTunnelPublicRuntime(redisClient, tunnelPublicConfig),
 		metaRuntime:        metaRuntimeConfig.withDefaults(),
-	}
+	}, nil
 }
 
 func (s *Service) requestAccessURL(ctx context.Context, serverID string, serverName string) string {
@@ -818,20 +825,12 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // Nil when the caller ran no gate or the session carries no policy; the
 // in-toolset gate below populates it for /mcp callers.
 func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID) error {
+	return s.serveToolsetResolved(w, r, toolset, mcpSlug, mcpRouteBase, skipIssuerGate, extraUpstreamTokens, callerToolSelection, mcpServerVariationsGroupID, mcpServerID, nil)
+}
+
+func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID, pendingIssuerGate *issuerGateAuthentication) error {
 	ctx := r.Context()
 	var err error
-
-	// Resolve the effective variation group: mcp_servers value first, then the
-	// toolset's own column, else nil (project default).
-	toolVariationsGroupID := mcpServerVariationsGroupID
-	if toolVariationsGroupID == nil && toolset.ToolVariationsGroupID.Valid {
-		id := toolset.ToolVariationsGroupID.UUID
-		toolVariationsGroupID = &id
-	}
-
-	// Parse the ?tags= filter (comma-separated, OR/union). Absent or empty
-	// means no filtering.
-	tags := parseTagsFilter(r.URL.Query().Get("tags"))
 
 	baseURL := s.serverURL.String()
 	if customDomainCtx := customdomains.FromContext(ctx); customDomainCtx != nil {
@@ -840,11 +839,11 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
+	var req rawRequest
+	var bodyDecodeErr error
 	if bodyReadErr == nil {
-		var req struct {
-			ID mcpjsonrpc.ID `json:"id"`
-		}
-		if err := json.Unmarshal(bodyBytes, &req); err == nil {
+		bodyDecodeErr = json.Unmarshal(bodyBytes, &req)
+		if bodyDecodeErr == nil {
 			if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && req.ID.IsSet() {
 				rpcCtx.ID = req.ID
 			}
@@ -857,10 +856,6 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	authToken := httpheaders.AuthorizationBearerToken(r)
 
 	var tokenInputs []oauthTokenInputs
-	tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, extraUpstreamTokens)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
-	}
 
 	// Token extraction — best effort for public MCPs with OAuth.
 	// We collect tokens if present but don't return 401 here.
@@ -892,15 +887,35 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		// all need to match the caller's surface, not the toolset's
 		// canonical /mcp surface.
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, mcpRouteBase)
-		newCtx, gateTokens, gateToolSelection, err := s.ApplyIssuerGate(ctx, w, authToken, baseURL, endpoint)
+		newCtx, authentication, gateToolSelection, err := s.authenticateIssuerGate(ctx, w, authToken, baseURL, endpoint)
 		if err != nil {
 			return err
 		}
 		ctx = newCtx
+		pendingIssuerGate = authentication
 		callerToolSelection = gateToolSelection
+	}
+
+	isHostedToolsCall := bodyReadErr == nil && bodyDecodeErr == nil && req.Method == "tools/call" && mcpServerID != nil
+	resolvePendingIssuerGate := func() error {
+		if pendingIssuerGate == nil {
+			return nil
+		}
+
+		gateTokens, err := s.resolveIssuerGateAccessTokens(ctx, w, pendingIssuerGate)
+		if err != nil {
+			return err
+		}
 		tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, gateTokens)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
+		}
+		pendingIssuerGate = nil
+		return nil
+	}
+	if pendingIssuerGate != nil && !isHostedToolsCall {
+		if err := resolvePendingIssuerGate(); err != nil {
+			return err
 		}
 	}
 
@@ -982,11 +997,6 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			}
 		}
 
-		// IMPORTANT: We should not use gram environments if we are not in an authenticated context
-		selectedEnvironment = conv.PtrValOr(conv.FromPGText[string](toolset.DefaultEnvironmentSlug), "")
-		if passedEnv := r.Header.Get("Gram-Environment"); passedEnv != "" {
-			selectedEnvironment = conv.ToSlug(passedEnv)
-		}
 	}
 
 	// Decode the raw body first to check for batch requests
@@ -1004,9 +1014,37 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		return oops.E(oops.CodeBadRequest, err, "batch requests are not supported").LogError(ctx, s.logger)
 	}
 
-	var req rawRequest
-	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "failed to decode request body").LogError(ctx, s.logger)
+	if bodyDecodeErr != nil {
+		return oops.E(oops.CodeBadRequest, bodyDecodeErr, "failed to decode request body").LogError(ctx, s.logger)
+	}
+	hostedCoverageRecorded := false
+	if isHostedToolsCall {
+		if err := s.enforceHostedToolsCall(ctx, toolset.OrganizationID, mcpServerID); err != nil {
+			return s.respondMCPError(ctx, w, req.ID, err)
+		}
+		hostedCoverageRecorded = true
+	}
+
+	// Resolve tool configuration and credentials only after the hosted checkpoint.
+	toolVariationsGroupID := mcpServerVariationsGroupID
+	if toolVariationsGroupID == nil && toolset.ToolVariationsGroupID.Valid {
+		id := toolset.ToolVariationsGroupID.UUID
+		toolVariationsGroupID = &id
+	}
+	tags := parseTagsFilter(r.URL.Query().Get("tags"))
+	if authenticated {
+		selectedEnvironment = conv.PtrValOr(conv.FromPGText[string](toolset.DefaultEnvironmentSlug), "")
+		if passedEnv := r.Header.Get("Gram-Environment"); passedEnv != "" {
+			selectedEnvironment = conv.ToSlug(passedEnv)
+		}
+	}
+	tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, extraUpstreamTokens)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
+	}
+
+	if err := resolvePendingIssuerGate(); err != nil {
+		return err
 	}
 
 	sessionID := parseMcpSessionID(r.Header)
@@ -1044,7 +1082,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		skipProxyTools:           false,
 		tags:                     tags,
 		protocolVersion:          mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
-		identityCoverageRecorded: false,
+		identityCoverageRecorded: hostedCoverageRecorded,
 		toolSelection:            callerToolSelection,
 	}
 
@@ -1085,15 +1123,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && rpcCtx.ID.IsSet() {
 			mcpID = rpcCtx.ID
 		}
-		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(mcpID, err))
-		if merr != nil {
-			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").LogError(ctx, s.logger)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(bs)
-		return nil
+		return s.respondMCPError(ctx, w, mcpID, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1103,6 +1133,57 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		return oops.E(oops.CodeUnexpected, writeErr, "failed to write response body")
 	}
 
+	return nil
+}
+
+func (s *Service) enforceHostedToolsCall(ctx context.Context, organizationID string, mcpServerID *uuid.UUID) error {
+	if mcpServerID == nil {
+		return nil
+	}
+
+	serverSource := mcptoolexecution.ServerSource{
+		FrontingServerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	}
+	if mcpServerID != nil {
+		serverSource.FrontingServerID = uuid.NullUUID{UUID: *mcpServerID, Valid: true}
+	}
+
+	disposition, err := s.hostedToolsCallCheckpoint.Evaluate(ctx, organizationID, serverSource)
+	if err != nil {
+		return fmt.Errorf("evaluate hosted MCP kill switch: %w", err)
+	}
+	switch disposition.Kind() {
+	case killswitches.TransportDispositionContinue:
+		return nil
+	case killswitches.TransportDispositionMatchedDenial:
+		note, ok := disposition.ExternalNote()
+		if !ok {
+			return errors.New("matched MCP kill-switch disposition has no external note")
+		}
+		return &oops.MCPError{
+			ID:      mcpjsonrpc.ID{Number: 0, String: ""},
+			Code:    oops.MCPCodeForbidden,
+			Message: note,
+			Data:    &oops.MCPErrorData{Code: oops.MCPErrorDataCodeToolCallsPaused},
+		}
+	case killswitches.TransportDispositionInfrastructureRejection:
+		return &oops.MCPError{ID: mcpjsonrpc.ID{Number: 0, String: ""}, Code: oops.MCPCodeInternalError, Message: "", Data: nil}
+	default:
+		return errors.New("invalid hosted MCP kill-switch disposition")
+	}
+}
+
+func (s *Service) respondMCPError(ctx context.Context, w http.ResponseWriter, id mcpjsonrpc.ID, cause error) error {
+	bs, err := json.Marshal(oops.NewMCPErrorFromCause(id, cause))
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to serialize error response").LogError(ctx, s.logger)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bs); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write MCP error response")
+	}
 	return nil
 }
 

--- a/server/internal/mcp/internal_tools_call_coverage_test.go
+++ b/server/internal/mcp/internal_tools_call_coverage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestHandleToolsCall_RecordsCoverageWithoutRequestContext(t *testing.T) {
@@ -35,6 +36,49 @@ func TestHandleToolsCall_RecordsCoverageWithoutRequestContext(t *testing.T) {
 	}, "missing_tool", json.RawMessage(`{}`))
 	require.Error(t, err)
 
+	coveragePoints := collectKillswitchCoverage(t, reader)
+	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
+		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityUnattributed),
+		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
+	)])
+}
+
+func TestServePublic_RecordsCanonicalServerCoverage(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "routed-coverage-"+uuid.NewString()[:8])
+	endpointSlug := "routed-coverage-" + uuid.NewString()
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	mcpServer := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
+	userToken := mintIssuerBearerForEndpointSubject(t, ctx, ti, endpointSlug, mcpServer, authCtx.ActiveOrganizationID, urn.NewUserSubject(authCtx.UserID))
+
+	response, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsCallBody("missing_tool"), userToken, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, response.Code)
+
+	coveragePoints := collectKillswitchCoverage(t, reader)
+	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
+		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityActiveUser),
+		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceCanonicalServer),
+	)])
+	require.Zero(t, coveragePoints[attribute.NewSet(
+		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
+		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityActiveUser),
+		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
+	)])
+}
+
+func collectKillswitchCoverage(t *testing.T, reader *sdkmetric.ManualReader) map[attribute.Set]int64 {
+	t.Helper()
+
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &rm))
 	coveragePoints := map[attribute.Set]int64{}
@@ -50,9 +94,5 @@ func TestHandleToolsCall_RecordsCoverageWithoutRequestContext(t *testing.T) {
 			}
 		}
 	}
-	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
-		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
-		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityUnattributed),
-		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
-	)])
+	return coveragePoints
 }

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -303,6 +303,7 @@ func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) er
 			ID:      req.ID,
 			Code:    oops.MCPCodeInvalidRequest,
 			Message: fmt.Sprintf("conflicting protocol version declarations: MCP-Protocol-Version header %q does not match the request _meta declaration %q", headerVersion, metaVersion),
+			Data:    nil,
 		}
 	}
 
@@ -324,6 +325,7 @@ func unsupportedMetaProtocolVersionError(req *rawRequest, declared string) *oops
 		ID:      req.ID,
 		Code:    oops.MCPCodeInvalidRequest,
 		Message: fmt.Sprintf("unsupported protocol version %q; supported versions: %s", declared, strings.Join(mcpversions.SupportedMetaServer(), ", ")),
+		Data:    nil,
 	}
 }
 

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -154,10 +154,13 @@ func (s *Service) serveResolvedMCPEndpoint(
 
 	// Issuer-gated mcp_servers run the JWT-validation branch here, before
 	// backend dispatch. ServeToolsetResolved then skips its in-toolset
-	// gate (skipIssuerGate=true) so the same request isn't gated twice;
-	// remote-backed proxying forwards the upstream remote-session token
-	// via AuthorizationOverride.
+	// gate (skipIssuerGate=true) so the same request isn't gated twice.
+	// Credential resolution stays pending until backend dispatch: remote
+	// backends resolve immediately, while hosted tools/call waits until after
+	// kill-switch evaluation.
 	var upstreamTokens map[uuid.UUID]remotesessions.UpstreamToken
+	var pendingIssuerGate *issuerGateAuthentication
+	var err error
 	var upstreamResource string
 	var sessionToolSelection *toolfilter.SessionSelection
 	var wwwAuthenticate string
@@ -167,13 +170,13 @@ func (s *Service) serveResolvedMCPEndpoint(
 			return err
 		}
 		upstreamResource = resolvedEndpoint.UpstreamResource
-		newCtx, tokens, toolSelection, err := s.ApplyIssuerGate(ctx, w, httpheaders.AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
+		newCtx, authentication, toolSelection, err := s.authenticateIssuerGate(ctx, w, httpheaders.AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
 		if err != nil {
 			return fmt.Errorf("apply issuer gate: %w", err)
 		}
 		ctx = newCtx
 		r = r.WithContext(ctx)
-		upstreamTokens = tokens
+		pendingIssuerGate = authentication
 		sessionToolSelection = toolSelection
 
 		// Issuer-gated clients authenticate with this server's AS, so an
@@ -189,6 +192,12 @@ func (s *Service) serveResolvedMCPEndpoint(
 
 	switch {
 	case mcpServer.RemoteMcpServerID.Valid, mcpServer.TunneledMcpServerID.Valid:
+		if pendingIssuerGate != nil {
+			upstreamTokens, err = s.resolveIssuerGateAccessTokens(ctx, w, pendingIssuerGate)
+			if err != nil {
+				return fmt.Errorf("resolve issuer-gated upstream tokens: %w", err)
+			}
+		}
 		upstreamToken, err := routeUpstreamToken(ctx, logger, upstreamTokens, upstreamResource)
 		var routeErr *upstreamRoutingError
 		switch {
@@ -229,7 +238,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			mcpServerVariationsGroupID = &id
 		}
 
-		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, sessionToolSelection, mcpServerVariationsGroupID, &mcpServer.ID); err != nil {
+		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, nil, sessionToolSelection, mcpServerVariationsGroupID, &mcpServer.ID, pendingIssuerGate); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -285,8 +285,21 @@ func mintIssuerBearerForEndpoint(
 	organizationID string,
 ) string {
 	t.Helper()
+	return mintIssuerBearerForEndpointSubject(t, ctx, ti, slug, mcpServer, organizationID, urn.NewAnonymousSubject(uuid.NewString()))
+}
 
-	require.True(t, mcpServer.UserSessionIssuerID.Valid, "remote-backed seeds always carry an issuer")
+func mintIssuerBearerForEndpointSubject(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	slug string,
+	mcpServer mcpserversrepo.McpServer,
+	organizationID string,
+	subject urn.SessionSubject,
+) string {
+	t.Helper()
+
+	require.True(t, mcpServer.UserSessionIssuerID.Valid, "endpoint must carry an issuer")
 	mcpEndpoint, err := mcpendpointsrepo.New(ti.conn).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
 		Slug:           slug,
 		CustomDomainID: uuid.NullUUID{},
@@ -318,7 +331,7 @@ func mintIssuerBearerForEndpoint(
 		RedirectURI:         redirectURI,
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: "S256",
-		Subject:             urn.NewAnonymousSubject(uuid.NewString()),
+		Subject:             subject,
 		// Simulate a tampered consent value; token minting must clamp this to
 		// the issuer's one-hour maximum asserted below.
 		DesiredSessionDurationHours: 10_000,

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -311,7 +311,8 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	})
 	tunnelRoutes := route.NewRouteTable()
 	features := &feature.InMemory{}
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, mcpCache, guardianPolicy, funcs, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, featClient.PlatformFeatureCheck, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
+	svc, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, mcpCache, guardianPolicy, funcs, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, featClient.PlatformFeatureCheck, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
+	require.NoError(t, err)
 
 	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](logger, cacheAdapter, cache.SuffixNone)
 

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -36,6 +36,7 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			ID:      mcpID,
 			Code:    MCPCodeInternalError,
 			Message: MCPCodeInternalError.Message(),
+			Data:    nil,
 		}
 
 		var shareableErr *ShareableError
@@ -98,10 +99,24 @@ func (c MCPCode) Message() string {
 	}
 }
 
+// MCPErrorDataCode is a stable machine-readable JSON-RPC error code.
+type MCPErrorDataCode string
+
+const (
+	// MCPErrorDataCodeToolCallsPaused identifies a matched MCP tool-execution pause.
+	MCPErrorDataCodeToolCallsPaused MCPErrorDataCode = "mcp_tool_calls_paused"
+)
+
+// MCPErrorData is the shared typed data envelope for MCP JSON-RPC errors.
+type MCPErrorData struct {
+	Code MCPErrorDataCode `json:"code"`
+}
+
 type MCPError struct {
 	ID      mcpjsonrpc.ID
 	Code    MCPCode
 	Message string
+	Data    *MCPErrorData
 }
 
 func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
@@ -119,12 +134,14 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
 			ID:      id,
 			Code:    shareableErr.Code.MCPCode(),
 			Message: shareableErr.Error(),
+			Data:    nil,
 		}
 	default:
 		return &MCPError{
 			ID:      id,
 			Code:    MCPCodeInternalError,
 			Message: MCPCodeInternalError.Message(),
+			Data:    nil,
 		}
 	}
 }
@@ -144,6 +161,9 @@ func (e *MCPError) MarshalJSON() ([]byte, error) {
 	errorBody := map[string]any{
 		"code":    e.Code,
 		"message": e.message(),
+	}
+	if e.Data != nil {
+		errorBody["data"] = e.Data
 	}
 
 	payload := map[string]any{

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -72,6 +72,7 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 		ID:      mcpjsonrpc.NumberID(1),
 		Code:    MCPCodeMethodNotFound,
 		Message: "tools/unknown: Method not found",
+		Data:    nil,
 	}
 
 	data, marshalErr := json.Marshal(err)
@@ -88,6 +89,11 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 	require.InDelta(t, -32601, errorBody["code"], 0)
 	require.Equal(t, "tools/unknown: Method not found", errorBody["message"])
 	require.NotContains(t, errorBody, "data")
+
+	err.Data = &MCPErrorData{Code: MCPErrorDataCode("typed_code")}
+	data, marshalErr = json.Marshal(err)
+	require.NoError(t, marshalErr)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"tools/unknown: Method not found","data":{"code":"typed_code"}}}`, string(data))
 }
 
 func TestCodeMCPCode(t *testing.T) {
@@ -136,7 +142,7 @@ func TestNewMCPErrorFromCause(t *testing.T) {
 	t.Run("returns_existing_mcp_error", func(t *testing.T) {
 		t.Parallel()
 
-		existing := &MCPError{Code: MCPCodeMethodNotFound, Message: "missing"}
+		existing := &MCPError{ID: mcpjsonrpc.ID{Number: 0, String: ""}, Code: MCPCodeMethodNotFound, Message: "missing", Data: nil}
 		err := NewMCPErrorFromCause(id, existing)
 
 		require.Same(t, existing, err)

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -3,6 +3,48 @@ INSERT INTO chat_messages (chat_id, project_id, role, content)
 VALUES (@chat_id, @project_id, @role, @content)
 RETURNING id;
 
+-- name: InsertKillswitchPrescriptionFixture :exec
+WITH fixture_clock AS (
+  SELECT clock_timestamp() - INTERVAL '1 hour' AS active_since
+),
+inserted_prescription AS (
+  INSERT INTO killswitch_prescriptions (
+    id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version
+  ) VALUES (
+    @prescription_id, @organization_id, @definition_key, @principal_kind, @principal_key, @resource_kind, 1
+  )
+  RETURNING organization_id, id
+),
+inserted_version AS (
+  INSERT INTO killswitch_prescription_versions (
+    organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+  )
+  SELECT
+    organization_id,
+    id,
+    1,
+    'active',
+    CASE
+      WHEN @resource_scope::text = 'all' AND cardinality(COALESCE(@resource_keys::text[], ARRAY[]::text[])) = 0 THEN @resource_scope::text
+      WHEN @resource_scope::text = 'selected' AND cardinality(COALESCE(@resource_keys::text[], ARRAY[]::text[])) > 0 THEN @resource_scope::text
+      ELSE NULL
+    END,
+    active_since,
+    NULL,
+    active_since,
+    @internal_note,
+    @external_note
+  FROM inserted_prescription
+  CROSS JOIN fixture_clock
+  RETURNING organization_id, prescription_id, version
+)
+INSERT INTO killswitch_prescription_version_resources (
+  organization_id, prescription_id, version, resource_key
+)
+SELECT organization_id, prescription_id, version, resource_key
+FROM inserted_version
+CROSS JOIN unnest(@resource_keys::text[]) AS resource(resource_key);
+
 -- name: ForceSoftDeleteChat :exec
 -- Bypasses the production SoftDeleteChat guard (which refuses to delete a chat
 -- backing a live assistant thread) so tests can wedge the database into the

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1001,6 +1001,78 @@ func (q *Queries) InsertDeviceAgentSyncFixture(ctx context.Context, arg InsertDe
 	return err
 }
 
+const insertKillswitchPrescriptionFixture = `-- name: InsertKillswitchPrescriptionFixture :exec
+WITH fixture_clock AS (
+  SELECT clock_timestamp() - INTERVAL '1 hour' AS active_since
+),
+inserted_prescription AS (
+  INSERT INTO killswitch_prescriptions (
+    id, organization_id, definition_key, principal_kind, principal_key, resource_kind, current_version
+  ) VALUES (
+    $2, $3, $4, $5, $6, $7, 1
+  )
+  RETURNING organization_id, id
+),
+inserted_version AS (
+  INSERT INTO killswitch_prescription_versions (
+    organization_id, prescription_id, version, state, resource_scope, starts_at, expires_at, activated_at, internal_note, external_note
+  )
+  SELECT
+    organization_id,
+    id,
+    1,
+    'active',
+    CASE
+      WHEN $8::text = 'all' AND cardinality(COALESCE($1::text[], ARRAY[]::text[])) = 0 THEN $8::text
+      WHEN $8::text = 'selected' AND cardinality(COALESCE($1::text[], ARRAY[]::text[])) > 0 THEN $8::text
+      ELSE NULL
+    END,
+    active_since,
+    NULL,
+    active_since,
+    $9,
+    $10
+  FROM inserted_prescription
+  CROSS JOIN fixture_clock
+  RETURNING organization_id, prescription_id, version
+)
+INSERT INTO killswitch_prescription_version_resources (
+  organization_id, prescription_id, version, resource_key
+)
+SELECT organization_id, prescription_id, version, resource_key
+FROM inserted_version
+CROSS JOIN unnest($1::text[]) AS resource(resource_key)
+`
+
+type InsertKillswitchPrescriptionFixtureParams struct {
+	ResourceKeys   []string
+	PrescriptionID uuid.UUID
+	OrganizationID string
+	DefinitionKey  string
+	PrincipalKind  string
+	PrincipalKey   string
+	ResourceKind   string
+	ResourceScope  string
+	InternalNote   string
+	ExternalNote   string
+}
+
+func (q *Queries) InsertKillswitchPrescriptionFixture(ctx context.Context, arg InsertKillswitchPrescriptionFixtureParams) error {
+	_, err := q.db.Exec(ctx, insertKillswitchPrescriptionFixture,
+		arg.ResourceKeys,
+		arg.PrescriptionID,
+		arg.OrganizationID,
+		arg.DefinitionKey,
+		arg.PrincipalKind,
+		arg.PrincipalKey,
+		arg.ResourceKind,
+		arg.ResourceScope,
+		arg.InternalNote,
+		arg.ExternalNote,
+	)
+	return err
+}
+
 const insertLegacyDenyPrincipalGrantFixture = `-- name: InsertLegacyDenyPrincipalGrantFixture :exec
 INSERT INTO principal_grants (organization_id, principal_urn, scope, effect, selectors)
 VALUES ($1, $2, $3, 'deny', $4)

--- a/server/internal/xmcp/serveruntime_test.go
+++ b/server/internal/xmcp/serveruntime_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -743,6 +744,44 @@ func TestServeMCP_IssuerGatedToolsetBackend_HappyPath(t *testing.T) {
 	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(accessToken), []byte(initializeBody))
 	require.NotEqual(t, http.StatusUnauthorized, rr.Code, "issuer-gated bearer must not be rejected by the legacy auth chain inside ServeToolsetResolved; body=%s", rr.Body.String())
 	require.Equal(t, http.StatusOK, rr.Code, "ServeMCP should respond 200; body=%s", rr.Body.String())
+}
+
+func TestServeMCP_IssuerGatedToolsetBackend_Killswitch(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotEmpty(t, authCtx.UserID)
+
+	slug, mcpServer, issuerID := seedIssuerGatedToolsetMCPEndpoint(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "public")
+	mcpEndpoint, err := mcpendpointsrepo.New(ti.conn).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
+		Slug:           slug,
+		CustomDomainID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, authCtx.ActiveOrganizationID)
+	accessToken := mintIssuerGatedAccessToken(t, ctx, ti, slug, endpoint, issuerID, urn.NewUserSubject(authCtx.UserID))
+
+	err = testrepo.New(ti.conn).InsertKillswitchPrescriptionFixture(ctx, testrepo.InsertKillswitchPrescriptionFixtureParams{
+		PrescriptionID: uuid.New(),
+		OrganizationID: authCtx.ActiveOrganizationID,
+		DefinitionKey:  string(mcptoolexecution.DefinitionKeyMCPToolExecution),
+		PrincipalKind:  string(mcptoolexecution.PrincipalKindUser),
+		PrincipalKey:   authCtx.UserID,
+		ResourceKind:   string(mcptoolexecution.ResourceKindMCPServer),
+		ResourceScope:  "selected",
+		InternalNote:   "test context",
+		ExternalNote:   "Exact x/mcp note.",
+		ResourceKeys:   []string{mcpServer.ID.String()},
+	})
+	require.NoError(t, err)
+
+	body := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"missing_tool","arguments":{}}}`)
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer(accessToken), body)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, `{"jsonrpc":"2.0","id":2,"error":{"code":-32003,"message":"Exact x/mcp note.","data":{"code":"mcp_tool_calls_paused"}}}`, rr.Body.String())
 }
 
 // TestServeMCP_IssuerGatedRemoteBackend_Private_HappyPath exercises the

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -159,13 +159,14 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)
-	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, &feature.InMemory{}, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
+	mcpService, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, &feature.InMemory{}, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		MaxRequestLifetime: 0,
 	}, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
+	require.NoError(t, err)
 
 	svc := xmcp.NewService(logger, conn, enc, mcpService)
 


### PR DESCRIPTION
## Summary

Enforce the registered MCP tool-execution killswitch on every authenticated hosted `/mcp` and `/x/mcp` `tools/call` after identity, tenant, user, and server validation and before tool configuration, protected credential resolution, or execution.

Re-evaluate authoritative membership, server ownership, and active prescriptions on every call. Matched prescriptions preserve the selected external note in JSON-RPC `-32003` responses with `data.code` set to `mcp_tool_calls_paused`; infrastructure failures fail closed with a generic internal response.

Direct callers without a covered fronting server, unsupported identities, legacy resources, and excluded methods retain their existing behavior.

Closes [DNO-982](https://linear.app/speakeasy/issue/DNO-982/feat-enforce-killswitches-before-hosted-mcp-tool-execution)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the MCP tool-execution killswitch on every authenticated hosted `/mcp` and `/x/mcp` `tools/call`, so a matched or fail-closed prescription now blocks tool configuration, credential resolution, and execution instead of silently continuing.

- Re-evaluates membership, server ownership, and active prescriptions on every call, including existing sessions, under a 2-second cap.
- Matched prescriptions return JSON-RPC `-32003` with `data.code=mcp_tool_calls_paused` and exactly the selected external note; evaluator failures return a generic internal error without match language.
- Defers upstream remote-session credential resolution until after the checkpoint for hosted calls; remote-backed dispatch still resolves credentials immediately.
- Uncovered callers (no fronting server, unsupported identities, legacy resources, excluded methods) keep existing behavior.
- `mcp.NewService` now fails at startup if the hosted checkpoint can't be built, so the gram start and worker commands surface the error at boot.
- Production prescriptions must not be enabled until the checkpoint has reached the fleet; private forwarding enforcement ships separately.
- Closes DNO-982.

<sup>Written for commit 75efa4173ba42bd887e0a627d055adc2c3e14227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

