### PR TITLE
chore: remove unused enterprise trials flag

### DIFF
--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -4,7 +4,6 @@ export const FEATURE_FLAGS = {
   deploymentsPage: "gram-deployments-page",
   deviceAgent: "gram-device-agent",
   deviceIntegrations: "gram-device-integrations",
-  enterpriseTrials: "enterprise-trials",
   experimentalChat: "gram-experimental-chat",
   externalMcpUserSessions: "onboard-external-mcp-to-user-sessions",
   functions: "gram-functions",


### PR DESCRIPTION
## Summary
- remove the unused `enterprise-trials` PostHog flag declaration from the dashboard

## Verification
- `aube run -F dashboard type-check`
- confirmed no remaining dashboard references to `enterprise-trials` or `enterpriseTrials`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `enterprise-trials` feature flag declaration from the dashboard, since no code references it anymore.

<sup>Written for commit 9e166fec905384aa06da6ace8814c3608bfe8ca9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

