### PR TITLE
mig: add risk pagination indexes

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -5144,6 +5144,10 @@ CREATE INDEX IF NOT EXISTS risk_policies_project_id_audience_type_idx
 ON risk_policies (project_id, audience_type)
 WHERE deleted IS FALSE;
 
+CREATE INDEX IF NOT EXISTS risk_policies_project_id_created_at_id_idx
+ON risk_policies (project_id, created_at DESC, id DESC)
+WHERE deleted IS FALSE;
+
 -- Durable session quarantine state for hook-ingest enforcement. Active rows
 -- open a Redis-backed session circuit until an org admin releases them.
 CREATE TABLE IF NOT EXISTS session_quarantines (
@@ -5258,6 +5262,14 @@ CREATE TABLE IF NOT EXISTS risk_exclusions (
 
 CREATE INDEX IF NOT EXISTS risk_exclusions_project_policy_idx
 ON risk_exclusions (project_id, risk_policy_id)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS risk_exclusions_project_id_created_at_id_idx
+ON risk_exclusions (project_id, created_at DESC, id DESC)
+WHERE deleted IS FALSE;
+
+CREATE INDEX IF NOT EXISTS risk_exclusions_project_id_risk_policy_id_created_at_id_idx
+ON risk_exclusions (project_id, risk_policy_id, created_at DESC, id DESC)
 WHERE deleted IS FALSE;
 
 -- Individual findings produced by scanning a chat message against a risk policy.

--- a/server/migrations/20260828004317_risk-pagination-indexes.sql
+++ b/server/migrations/20260828004317_risk-pagination-indexes.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Create index "risk_exclusions_project_id_created_at_id_idx" to table: "risk_exclusions"
+CREATE INDEX CONCURRENTLY "risk_exclusions_project_id_created_at_id_idx" ON "risk_exclusions" ("project_id", "created_at" DESC, "id" DESC) WHERE (deleted IS FALSE);
+-- Create index "risk_exclusions_project_id_risk_policy_id_created_at_id_idx" to table: "risk_exclusions"
+CREATE INDEX CONCURRENTLY "risk_exclusions_project_id_risk_policy_id_created_at_id_idx" ON "risk_exclusions" ("project_id", "risk_policy_id", "created_at" DESC, "id" DESC) WHERE (deleted IS FALSE);
+-- Create index "risk_policies_project_id_created_at_id_idx" to table: "risk_policies"
+CREATE INDEX CONCURRENTLY "risk_policies_project_id_created_at_id_idx" ON "risk_policies" ("project_id", "created_at" DESC, "id" DESC) WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0SS6aJBPNoT2Q+L77fTMQxgWFp7/hLl3V7n4Y0SAaDM=
+h1:KPjy0bChaCkDAzjrAquPlljgUTS2CTt4osgCGYESc6Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -370,3 +370,4 @@ h1:0SS6aJBPNoT2Q+L77fTMQxgWFp7/hLl3V7n4Y0SAaDM=
 20260826163849_drop-mcp-server-authorization-exclusivity.sql h1:kTyvUQ+UXxaRY6PirpiwKX23Uq1VvLn5j5LxOHUXu3g=
 20260826174212_add-mcp-servers-user-session-issuer-index.sql h1:bV8x2GJNJerKXp7s1VyyO0GBQygI7ZPXwSdDbhrIftE=
 20260827075204_data_export_routes.sql h1:0jz+w0IdJEIku/z1IFA4Ycpp69EcWegR4tKUJE4F6Ys=
+20260828004317_risk-pagination-indexes.sql h1:Kt04zUHm8wQchZZL6gWP/+3fknMyhlAuiMCClo6MZGQ=


### PR DESCRIPTION
## Why

The Platform MCP risk policy and exclusion keyset pages currently scan and sort all live rows for a project because the existing indexes do not support the requested `(created_at DESC, id DESC)` ordering. This makes database work grow with the number of policies or exclusions even when each request returns only one page.

## What changed

- Added a partial ordering index for live risk policy pagination: `(project_id, created_at DESC, id DESC)`.
- Added partial ordering indexes for live risk exclusion pagination: `(project_id, created_at DESC, id DESC)` and `(project_id, risk_policy_id, created_at DESC, id DESC)`.
- Added the generated Atlas migration and checksum. The migration uses `CREATE INDEX CONCURRENTLY` and `-- atlas:txmode none`.

## Review notes

- This PR is intentionally migration-only: no application code, data changes, or backfills.
- Existing prefix indexes are retained for this additive migration. They may be candidates for a separate follow-up after production usage is confirmed.
- The migration timestamp was generated by Atlas after updating from `main`.

## Testing

- `EXPLAIN (ANALYZE, BUFFERS)` on rollback-only temporary clones with 100,000 policies and 200,000 exclusions:
  - Policies first page: 23.08 ms / 2,500 buffers before → 0.04 ms / 5 buffers after.
  - Policies mid-page: 25.60 ms / 2,500 buffers before → 0.05 ms / 5 buffers after.
  - Exclusions unfiltered: 97.67 ms / 3,279 buffers before → 0.39 ms / 5 buffers after.
  - Exclusions policy-filtered: 27.62 ms / 3,360 buffers before → 0.09 ms / 5 buffers after.
- `mise run db:reset` — passed; all 372 migrations replayed locally, including this migration.
- `mise run db:migrate --dry` — passed; no pending migrations.
- `mise run lint:migrations --file server/migrations/20260828004317_risk-pagination-indexes.sql --no-atlas` — passed.
- Atlas migration lint against a clean ephemeral `pgvector/pg17` dev database — passed.
- Verified all three index definitions in the local PostgreSQL catalog.
- `hk run pre-commit -j 1` — passed.
- `git diff --check` — passed.

## Rollout / deployment notes

- The migration contains only concurrent index creation, so it is non-transactional and does not take a table-wide write-blocking lock for the build.
- Existing indexes remain in place.
- The benchmark used temporary tables and rolled back; the real local risk tables remained empty.
- Atlas lint against the fully migrated local database was not usable because Atlas requires its dev snapshot database to be clean; the same lint was run successfully against Atlas's clean ephemeral dev database.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds partial pagination indexes on `risk_policies` and `risk_exclusions` so keyset pages no longer scan and sort every live row for a project, supporting the `list_risk_policies` and `list_risk_exclusions` MCP tools. Each page request previously scanned all live rows even when returning a single page.

- Migration-only change; no application code, data changes, or backfills.
- Indexes use `CREATE INDEX CONCURRENTLY`, so the migration doesn't block writes while building.

<sup>Written for commit 5b2f723009a3c99b9263a1c67b6e88e8ae11aee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

