### PR TITLE
feat(platform-mcp): remove rollout gates

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -73781,7 +73781,7 @@ components:
           description: Whether Platform MCP successfully added the workflow-bound MCP to the selected project's existing Default plugin.
         enabled:
           type: boolean
-          description: Whether the active organization currently passes the Platform MCP capability and rollout gates.
+          description: Whether the active organization currently has the Platform MCP product feature enabled.
         mcp_url:
           type: string
           description: Canonical Platform MCP endpoint URL supplied by the server.

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useOrganization } from "@/contexts/Auth";
 
 import { AppRoute, useOrgRoutes } from "@/routes";
 import { NavButton, NavGroupProvider } from "@/components/nav-menu";
@@ -12,6 +11,7 @@ import {
   SidebarMenuItem,
   SidebarTrigger,
 } from "@/components/ui/Sidebar";
+import { useIsPlatformAdmin, useOrganization } from "@/contexts/Auth";
 
 import { GramLogo } from "./gram-logo";
 import { HatchRule } from "./hatch-rule";
@@ -24,8 +24,6 @@ import { ScopeGatedNavGroup } from "@/components/scope-gated-nav-group";
 import { SidebarNavSkeleton } from "./sidebar-nav-skeleton";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { TrialStatusCard } from "./trial-status-card";
-import { useIsPlatformAdmin } from "@/contexts/Auth";
-import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useTelemetry } from "@/contexts/Telemetry";
@@ -71,8 +69,6 @@ export function OrgSidebar({
     },
   );
   const isPlatformAdmin = useIsPlatformAdmin();
-  const { enabled: isPlatformMcpDashboardEnabled } =
-    usePlatformMcpDashboardVisibility();
   const isDeviceAgentEnabled =
     telemetry.isFeatureEnabled("gram-device-agent") ?? false;
   const isUserSessionsEnabled =
@@ -84,7 +80,7 @@ export function OrgSidebar({
     orgRoutes.domains,
     orgRoutes.logs,
     orgRoutes.skills,
-    ...(isPlatformMcpDashboardEnabled ? [orgRoutes.platformMcp] : []),
+    orgRoutes.platformMcp,
     orgRoutes.aiIntegrations,
     orgRoutes.webhooks,
     orgRoutes.externalServices,
@@ -132,7 +128,7 @@ export function OrgSidebar({
     orgRoutes.domains,
     orgRoutes.logs,
     orgRoutes.skills,
-    ...(isPlatformMcpDashboardEnabled ? [orgRoutes.platformMcp] : []),
+    orgRoutes.platformMcp,
     orgRoutes.aiIntegrations,
     orgRoutes.webhooks,
     orgRoutes.externalServices,
@@ -221,14 +217,7 @@ export function OrgSidebar({
                   { item: orgRoutes.domains, scope: orgReadOrAdmin },
                   { item: orgRoutes.logs, scope: orgReadOrAdmin },
                   { item: orgRoutes.skills, scope: "org:admin" },
-                  ...(isPlatformMcpDashboardEnabled
-                    ? [
-                        {
-                          item: orgRoutes.platformMcp,
-                          scope: "org:admin" as const,
-                        },
-                      ]
-                    : []),
+                  { item: orgRoutes.platformMcp, scope: "org:admin" },
                   { item: orgRoutes.aiIntegrations, scope: orgReadOrAdmin },
                   { item: orgRoutes.webhooks, scope: orgReadOrAdmin },
                 ]}

--- a/client/dashboard/src/hooks/usePlatformMcpDashboardVisibility.ts
+++ b/client/dashboard/src/hooks/usePlatformMcpDashboardVisibility.ts
@@ -1,6 +1,0 @@
-export function usePlatformMcpDashboardVisibility(): {
-  enabled: boolean;
-  isLoading: boolean;
-} {
-  return { enabled: true, isLoading: false };
-}

--- a/client/dashboard/src/hooks/usePlatformMcpDashboardVisibility.ts
+++ b/client/dashboard/src/hooks/usePlatformMcpDashboardVisibility.ts
@@ -1,19 +1,6 @@
-import { FEATURE_FLAGS } from "@/lib/featureFlags";
-import { useFeatureFlag } from "@/hooks/useFeatureFlag";
-
-// Dashboard discovery requires both engineering-owned rollout flags. Neither
-// flag grants runtime access: the server independently requires platform-mcp
-// and the organization-admin platform_mcp entitlement.
 export function usePlatformMcpDashboardVisibility(): {
   enabled: boolean;
   isLoading: boolean;
 } {
-  const platformMcp = useFeatureFlag(FEATURE_FLAGS.platformMcp);
-  const dashboard = useFeatureFlag(FEATURE_FLAGS.platformMcpDashboard);
-
-  return {
-    enabled: platformMcp.status === "enabled" && dashboard.status === "enabled",
-    isLoading:
-      platformMcp.status === "loading" || dashboard.status === "loading",
-  };
+  return { enabled: true, isLoading: false };
 }

--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -12,8 +12,6 @@ export const FEATURE_FLAGS = {
   mcpResearch: "gram-mcp-research",
   newCostsPage: "gram-new-costs-page",
   paygSelfServeBilling: "gram-payg-self-serve-billing",
-  platformMcp: "platform-mcp",
-  platformMcpDashboard: "platform-mcp-dashboard",
   promptPolicies: "gram-prompt-policies",
   rbac: "gram-rbac",
   riskWatchdog: "gram-risk-watchdog",

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -107,8 +107,8 @@ export default function PlatformMCP(): JSX.Element | null {
   const currentProjectSlug = searchParams.get("projectSlug") ?? undefined;
   const openFromCta = searchParams.get("setup") === "1" && !!sourceSurface;
 
-  // Wait for rollout flags before routing so an eligible organization never
-  // flashes away from a direct dashboard link.
+  // Wait for dashboard visibility to resolve before routing so an eligible
+  // organization never flashes away from a direct link.
   if (isLoading) {
     return null;
   }

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -25,7 +25,7 @@ import type { ClientFamily } from "@gram/client/models/components/recordinstalli
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Dialog } from "@/components/ui/Dialog";
 import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
-import { Navigate, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 import { Page } from "@/components/page-layout";
 import {
   PlatformMCPInstallWalkthrough,
@@ -41,7 +41,6 @@ import { invalidateAllProductFeatures } from "@gram/client/react-query/productFe
 import { useDismissPlatformMCPOnboardingMutation } from "@gram/client/react-query/dismissPlatformMCPOnboarding.js";
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
 import { useFetcher } from "@/contexts/Fetcher";
-import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useOrganizationPlatformMCPOnboarding } from "@/hooks/useOrganizationPlatformMCPOnboarding";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRecordPlatformMCPAgentConfigurationCopiedMutation } from "@gram/client/react-query/recordPlatformMCPAgentConfigurationCopied.js";
@@ -99,22 +98,11 @@ function platformMcpEntrySource(
   return Object.values(SourceSurface).find((surface) => surface === value);
 }
 
-export default function PlatformMCP(): JSX.Element | null {
-  const { enabled: platformMcpDashboardEnabled, isLoading } =
-    usePlatformMcpDashboardVisibility();
+export default function PlatformMCP(): JSX.Element {
   const [searchParams] = useSearchParams();
   const sourceSurface = platformMcpEntrySource(searchParams.get("entrySource"));
   const currentProjectSlug = searchParams.get("projectSlug") ?? undefined;
   const openFromCta = searchParams.get("setup") === "1" && !!sourceSurface;
-
-  // Wait for dashboard visibility to resolve before routing so an eligible
-  // organization never flashes away from a direct link.
-  if (isLoading) {
-    return null;
-  }
-  if (!platformMcpDashboardEnabled) {
-    return <Navigate to=".." replace />;
-  }
 
   return (
     <Page>

--- a/client/dashboard/src/pages/platform-admin/Features.tsx
+++ b/client/dashboard/src/pages/platform-admin/Features.tsx
@@ -12,14 +12,12 @@ import {
 import { Badge } from "@/components/ui/Badge";
 import { useOrganization } from "@/contexts/Auth";
 import { Button } from "@/components/ui/Button";
-import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
 import { Input } from "@/components/ui/Input";
 import { Page } from "@/components/page-layout";
 import { PlatformAdminGate } from "./PlatformAdminGate";
 import { Switch } from "@/components/ui/Switch";
 import { toast } from "sonner";
-import { useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
 import { useOrgMemoryDeveloperToggle } from "@/hooks/useOrgMemoryDeveloperToggle";
 import { useQueryClient } from "@tanstack/react-query";
@@ -210,12 +208,6 @@ function ProductFeaturesSection({
   } = useProductFeatures({
     organizationId,
   });
-  const platformMcp = useFeatureFlag(FEATURE_FLAGS.platformMcp);
-  const visibleFeatures = TOGGLEABLE_FEATURES.filter(
-    (feature) =>
-      feature.featureName !== FeatureName.PlatformMcp ||
-      platformMcp.status === "enabled",
-  );
 
   const {
     mutate,
@@ -249,7 +241,7 @@ function ProductFeaturesSection({
     }
     return (
       <div className="divide-border divide-y">
-        {visibleFeatures.map((feature) => {
+        {TOGGLEABLE_FEATURES.map((feature) => {
           const enabled = features[feature.enabledKey];
           const rowPending =
             isPending && pendingFeature === feature.featureName;

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -1,5 +1,7 @@
-import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { SetupWizard } from "./onboarding-wizard";
 
 vi.mock("react-router", () => ({
   useNavigate: () => vi.fn(),
@@ -15,12 +17,7 @@ vi.mock("@gram/client/react-query/onboardingStatus", () => ({
 vi.mock("@gram/client/react-query/publishStatus", () => ({
   usePublishStatus: () => ({ data: { connected: false }, isLoading: false }),
 }));
-vi.mock("@/hooks/usePlatformMcpDashboardVisibility", () => ({
-  usePlatformMcpDashboardVisibility: () => ({
-    enabled: false,
-    isLoading: false,
-  }),
-}));
+
 vi.mock("@/components/ui/Skeleton", () => ({
   Skeleton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -44,8 +41,6 @@ vi.mock("./steps", () => ({
   ConfigurePoliciesStep: () => null,
   PlatformMCPSetupStep: () => null,
 }));
-
-import { SetupWizard } from "./onboarding-wizard";
 
 afterEach(() => {
   cleanup();

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { usePublishStatus } from "@gram/client/react-query/publishStatus";
-import { usePlatformMcpDashboardVisibility } from "@/hooks/usePlatformMcpDashboardVisibility";
 import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { OnboardingHeader } from "./onboarding-header";
@@ -81,25 +80,16 @@ export function SetupWizard(): JSX.Element {
     markSetupStarted();
   }, [markSetupStarted]);
 
-  const {
-    enabled: platformMcpDashboardEnabled,
-    isLoading: isPlatformMcpDashboardLoading,
-  } = usePlatformMcpDashboardVisibility();
   const setupProjectSlug = searchParams.get("projectSlug") ?? undefined;
   const setupPath = searchParams.get("setupPath");
-  const usesPlatformMcpPath =
-    platformMcpDashboardEnabled && setupPath === "platform-mcp";
-  const steps = useMemo(() => {
-    if (!platformMcpDashboardEnabled) {
-      return [...CORE_STEPS, CONFIGURE_POLICIES_STEP];
-    }
-
-    if (usesPlatformMcpPath) {
-      return [...CORE_STEPS, PLATFORM_MCP_STEP, CONFIGURE_POLICIES_STEP];
-    }
-
-    return [...CORE_STEPS, CONFIGURE_POLICIES_STEP, PLATFORM_MCP_STEP];
-  }, [platformMcpDashboardEnabled, usesPlatformMcpPath]);
+  const usesPlatformMcpPath = setupPath === "platform-mcp";
+  const steps = useMemo(
+    () =>
+      usesPlatformMcpPath
+        ? [...CORE_STEPS, PLATFORM_MCP_STEP, CONFIGURE_POLICIES_STEP]
+        : [...CORE_STEPS, CONFIGURE_POLICIES_STEP, PLATFORM_MCP_STEP],
+    [usesPlatformMcpPath],
+  );
 
   // All steps are accessible — SSO and DSYNC are both skippable.
   const maxAllowedStep = steps.length - 1;
@@ -116,10 +106,7 @@ export function SetupWizard(): JSX.Element {
     useOnboardingStatus();
   const { data: publishStatus, isLoading: isPublishStatusLoading } =
     usePublishStatus();
-  const statusLoading =
-    isOnboardingStatusLoading ||
-    isPublishStatusLoading ||
-    isPlatformMcpDashboardLoading;
+  const statusLoading = isOnboardingStatusLoading || isPublishStatusLoading;
 
   useEffect(() => {
     if (stepSlug) return;
@@ -230,8 +217,7 @@ export function SetupWizard(): JSX.Element {
   // flight), keep the page shell visible with skeletons rather than briefly
   // mounting step 0. The resume-step useEffect above will set the slug as soon
   // as the queries resolve (or error, which falls back to step 0).
-  const resolvingResume =
-    isPlatformMcpDashboardLoading || (!stepSlug && statusLoading);
+  const resolvingResume = !stepSlug && statusLoading;
 
   const startPlatformMcpPath = useCallback(() => {
     setSearchParams(
@@ -293,9 +279,7 @@ export function SetupWizard(): JSX.Element {
             onComplete={completeCurrentStep}
             onSkip={completeCurrentStep}
             onBack={goBack}
-            onSetupPlatformMCP={
-              platformMcpDashboardEnabled ? startPlatformMcpPath : undefined
-            }
+            onSetupPlatformMCP={startPlatformMcpPath}
           />
         );
       case "configure-policies":

--- a/client/dashboard/src/sdk/src/models/components/platformmcponboardingstate.ts
+++ b/client/dashboard/src/sdk/src/models/components/platformmcponboardingstate.ts
@@ -187,7 +187,7 @@ export type PlatformMCPOnboardingState = {
    */
   distributionToolSucceeded: boolean;
   /**
-   * Whether the active organization currently passes the Platform MCP capability and rollout gates.
+   * Whether the active organization currently has the Platform MCP product feature enabled.
    */
   enabled: boolean;
   /**

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -27,7 +27,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -57,7 +56,6 @@ type platformMCPConfig struct {
 	Environment            string
 	JWTSigningKey          string
 	ProductFeatures        *productfeatures.Client
-	FeatureFlags           feature.Provider
 	Authz                  *authz.Engine
 	Encryption             *encryption.Client
 	Identity               *identity.Resolver
@@ -123,11 +121,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		return AssistantSurface{}, fmt.Errorf("clear local Platform MCP fixture registry cache: %w", err)
 	}
 
-	gate := platformmcp.NewOrganizationGate(
-		config.ProductFeatures,
-		config.FeatureFlags,
-		platformmcp.NewPostgresOrganizationSlugResolver(config.DB),
-	)
+	gate := platformmcp.NewOrganizationGate(config.ProductFeatures)
 	authorizer := platformmcp.NewLiveOrgAdminAuthorizer(config.DB, config.Authz)
 	oauthTelemetry := platformmcp.NewOAuthTelemetry(config.Logger, config.MeterProvider)
 	oauthStore := platformmcp.NewPostgresOAuthStore(config.DB).WithTelemetry(oauthTelemetry)
@@ -466,11 +460,7 @@ func loadBrowserPlatformMCPCatalogDescriptors(ctx context.Context, catalog *exte
 }
 
 func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) (AssistantSurface, error) {
-	gate := platformmcp.NewOrganizationGate(
-		config.ProductFeatures,
-		config.FeatureFlags,
-		platformmcp.NewPostgresOrganizationSlugResolver(config.DB),
-	)
+	gate := platformmcp.NewOrganizationGate(config.ProductFeatures)
 	authorizer := platformmcp.NewLiveOrgAdminAuthorizer(config.DB, config.Authz)
 	oauthTelemetry := platformmcp.NewOAuthTelemetry(config.Logger, config.MeterProvider)
 	oauthStore := platformmcp.NewPostgresOAuthStore(config.DB).WithTelemetry(oauthTelemetry)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1538,7 +1538,6 @@ func newStartCommand() *cli.Command {
 				Environment:            c.String("environment"),
 				JWTSigningKey:          c.String(usersessions.JWTSigningKeyFlag),
 				ProductFeatures:        productFeatures,
-				FeatureFlags:           featureFlags,
 				Authz:                  authzEngine,
 				Encryption:             encryptionClient,
 				Identity:               identityResolver,

--- a/server/design/platformmcp/design.go
+++ b/server/design/platformmcp/design.go
@@ -9,7 +9,7 @@ import (
 
 var OnboardingState = Type("PlatformMCPOnboardingState", func() {
 	Description("Safe, session-authenticated Platform MCP onboarding projection. It contains no provider URLs, credentials, OAuth values, setup handoffs, or internal resource identifiers.")
-	Attribute("enabled", Boolean, "Whether the active organization currently passes the Platform MCP capability and rollout gates.")
+	Attribute("enabled", Boolean, "Whether the active organization currently has the Platform MCP product feature enabled.")
 	Attribute("stage", String, "Current server-derived onboarding stage.", func() {
 		Enum("not_started", "install_instructions", "authorized", "connection_ready")
 	})

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -75162,7 +75162,7 @@ components:
                     description: Whether Platform MCP successfully added the workflow-bound MCP to the selected project's existing Default plugin.
                 enabled:
                     type: boolean
-                    description: Whether the active organization currently passes the Platform MCP capability and rollout gates.
+                    description: Whether the active organization currently has the Platform MCP product feature enabled.
                 mcp_url:
                     type: string
                     description: Canonical Platform MCP endpoint URL supplied by the server.

--- a/server/gen/http/platform_mcp/client/types.go
+++ b/server/gen/http/platform_mcp/client/types.go
@@ -65,8 +65,8 @@ type RepairOnboardingPublicationRequestBody struct {
 // GetOnboardingResponseBody is the type of the "platformMcp" service
 // "getOnboarding" endpoint HTTP response body.
 type GetOnboardingResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -137,8 +137,8 @@ type GetOnboardingResponseBody struct {
 // StartOnboardingResponseBody is the type of the "platformMcp" service
 // "startOnboarding" endpoint HTTP response body.
 type StartOnboardingResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -209,8 +209,8 @@ type StartOnboardingResponseBody struct {
 // RecordInstallIntentResponseBody is the type of the "platformMcp" service
 // "recordInstallIntent" endpoint HTTP response body.
 type RecordInstallIntentResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -281,8 +281,8 @@ type RecordInstallIntentResponseBody struct {
 // RecordAgentConfigurationCopiedResponseBody is the type of the "platformMcp"
 // service "recordAgentConfigurationCopied" endpoint HTTP response body.
 type RecordAgentConfigurationCopiedResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -363,8 +363,8 @@ type StartOnboardingSetupResponseBody struct {
 // RecheckOnboardingReadinessResponseBody is the type of the "platformMcp"
 // service "recheckOnboardingReadiness" endpoint HTTP response body.
 type RecheckOnboardingReadinessResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -435,8 +435,8 @@ type RecheckOnboardingReadinessResponseBody struct {
 // DistributeOnboardingCandidateResponseBody is the type of the "platformMcp"
 // service "distributeOnboardingCandidate" endpoint HTTP response body.
 type DistributeOnboardingCandidateResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -507,8 +507,8 @@ type DistributeOnboardingCandidateResponseBody struct {
 // RemoveOnboardingDistributionResponseBody is the type of the "platformMcp"
 // service "removeOnboardingDistribution" endpoint HTTP response body.
 type RemoveOnboardingDistributionResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`
@@ -579,8 +579,8 @@ type RemoveOnboardingDistributionResponseBody struct {
 // RepairOnboardingPublicationResponseBody is the type of the "platformMcp"
 // service "repairOnboardingPublication" endpoint HTTP response body.
 type RepairOnboardingPublicationResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
 	// Current server-derived onboarding stage.
 	Stage *string `form:"stage,omitempty" json:"stage,omitempty" xml:"stage,omitempty"`

--- a/server/gen/http/platform_mcp/server/types.go
+++ b/server/gen/http/platform_mcp/server/types.go
@@ -65,8 +65,8 @@ type RepairOnboardingPublicationRequestBody struct {
 // GetOnboardingResponseBody is the type of the "platformMcp" service
 // "getOnboarding" endpoint HTTP response body.
 type GetOnboardingResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -137,8 +137,8 @@ type GetOnboardingResponseBody struct {
 // StartOnboardingResponseBody is the type of the "platformMcp" service
 // "startOnboarding" endpoint HTTP response body.
 type StartOnboardingResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -209,8 +209,8 @@ type StartOnboardingResponseBody struct {
 // RecordInstallIntentResponseBody is the type of the "platformMcp" service
 // "recordInstallIntent" endpoint HTTP response body.
 type RecordInstallIntentResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -281,8 +281,8 @@ type RecordInstallIntentResponseBody struct {
 // RecordAgentConfigurationCopiedResponseBody is the type of the "platformMcp"
 // service "recordAgentConfigurationCopied" endpoint HTTP response body.
 type RecordAgentConfigurationCopiedResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -363,8 +363,8 @@ type StartOnboardingSetupResponseBody struct {
 // RecheckOnboardingReadinessResponseBody is the type of the "platformMcp"
 // service "recheckOnboardingReadiness" endpoint HTTP response body.
 type RecheckOnboardingReadinessResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -435,8 +435,8 @@ type RecheckOnboardingReadinessResponseBody struct {
 // DistributeOnboardingCandidateResponseBody is the type of the "platformMcp"
 // service "distributeOnboardingCandidate" endpoint HTTP response body.
 type DistributeOnboardingCandidateResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -507,8 +507,8 @@ type DistributeOnboardingCandidateResponseBody struct {
 // RemoveOnboardingDistributionResponseBody is the type of the "platformMcp"
 // service "removeOnboardingDistribution" endpoint HTTP response body.
 type RemoveOnboardingDistributionResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`
@@ -579,8 +579,8 @@ type RemoveOnboardingDistributionResponseBody struct {
 // RepairOnboardingPublicationResponseBody is the type of the "platformMcp"
 // service "repairOnboardingPublication" endpoint HTTP response body.
 type RepairOnboardingPublicationResponseBody struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
 	// Current server-derived onboarding stage.
 	Stage string `form:"stage" json:"stage" xml:"stage"`

--- a/server/gen/platform_mcp/service.go
+++ b/server/gen/platform_mcp/service.go
@@ -112,8 +112,8 @@ type PlatformMCPOnboardingSetupHandoff struct {
 // PlatformMCPOnboardingState is the result type of the platformMcp service
 // getOnboarding method.
 type PlatformMCPOnboardingState struct {
-	// Whether the active organization currently passes the Platform MCP capability
-	// and rollout gates.
+	// Whether the active organization currently has the Platform MCP product
+	// feature enabled.
 	Enabled bool
 	// Current server-derived onboarding stage.
 	Stage string

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -36,15 +36,6 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
-	// FlagPlatformMCP controls the engineering rollout of Platform MCP. The
-	// durable platform_mcp product feature remains the organization-admin opt-in
-	// once this release flag permits access.
-	FlagPlatformMCP Flag = "platform-mcp"
-	// FlagPlatformMCPDashboard controls dashboard discovery and onboarding for
-	// Platform MCP. It is presentation-only; runtime authorization requires
-	// FlagPlatformMCP and the durable organization product feature.
-	FlagPlatformMCPDashboard Flag = "platform-mcp-dashboard"
-
 	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
 	// assistant the Platform MCP read toolset — the "platform" platform
 	// toolset re-serving the Platform MCP read tools over the assistant

--- a/server/internal/platformmcp/gate.go
+++ b/server/internal/platformmcp/gate.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/speakeasy-api/gram/server/internal/feature"
-	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 )
 
@@ -19,65 +15,19 @@ type CapabilityChecker interface {
 	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
 }
 
-type OrganizationSlugResolver interface {
-	OrganizationSlug(ctx context.Context, organizationID string) (string, error)
-}
-
-type PostgresOrganizationSlugResolver struct {
-	db *pgxpool.Pool
-}
-
-func NewPostgresOrganizationSlugResolver(db *pgxpool.Pool) *PostgresOrganizationSlugResolver {
-	return &PostgresOrganizationSlugResolver{db: db}
-}
-
-func (r *PostgresOrganizationSlugResolver) OrganizationSlug(ctx context.Context, organizationID string) (string, error) {
-	if r == nil || r.db == nil || organizationID == "" {
-		return "", ErrUnavailable
-	}
-	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, organizationID)
-	if err != nil {
-		return "", fmt.Errorf("get organization for Platform MCP rollout: %w", err)
-	}
-	return organization.Slug, nil
-}
-
-// OrganizationGate combines the engineering-owned Platform MCP rollout with the
-// organization-admin entitlement. Both must be enabled: the PostHog flag keeps
-// an unreleased surface inaccessible, while the durable product feature lets an
-// organization opt out after release. Any unavailable dependency fails closed.
+// OrganizationGate enforces the durable organization-admin entitlement. Any
+// unavailable dependency fails closed.
 type OrganizationGate struct {
-	capabilities  CapabilityChecker
-	flags         feature.Provider
-	organizations OrganizationSlugResolver
+	capabilities CapabilityChecker
 }
 
-func NewOrganizationGate(capabilities CapabilityChecker, flags feature.Provider, organizations OrganizationSlugResolver) *OrganizationGate {
-	return &OrganizationGate{
-		capabilities:  capabilities,
-		flags:         flags,
-		organizations: organizations,
-	}
+func NewOrganizationGate(capabilities CapabilityChecker) *OrganizationGate {
+	return &OrganizationGate{capabilities: capabilities}
 }
 
 func (g *OrganizationGate) Enabled(ctx context.Context, organizationID string) (bool, error) {
-	if g == nil || g.capabilities == nil || g.flags == nil || g.organizations == nil || organizationID == "" {
+	if g == nil || g.capabilities == nil || organizationID == "" {
 		return false, ErrUnavailable
-	}
-
-	organizationSlug, err := g.organizations.OrganizationSlug(ctx, organizationID)
-	if err != nil {
-		return false, fmt.Errorf("resolve organization for platform mcp rollout: %w", err)
-	}
-	if organizationSlug == "" {
-		return false, ErrUnavailable
-	}
-	rollout, err := g.flags.IsFlagEnabled(ctx, feature.FlagPlatformMCP, organizationID, feature.OrgProjectGroups(organizationSlug, ""))
-	if err != nil {
-		return false, fmt.Errorf("check platform mcp rollout: %w", err)
-	}
-	if !rollout {
-		return false, nil
 	}
 
 	capable, err := g.capabilities.IsFeatureEnabledUncached(ctx, organizationID, productfeatures.FeaturePlatformMCP)
@@ -105,8 +55,8 @@ func (g *CatalogRegistrationGate) Enabled(ctx context.Context, organizationID, p
 	return g.EnabledOrganization(ctx, organizationID)
 }
 
-// EnabledOrganization checks the same rollout and durable entitlement as a
-// mutation without accepting a project selector. Read-only direct inspection
+// EnabledOrganization checks the same durable entitlement as a mutation
+// without accepting a project selector. Read-only direct inspection
 // needs this gate before it can perform user-directed egress.
 func (g *CatalogRegistrationGate) EnabledOrganization(ctx context.Context, organizationID string) (bool, error) {
 	if g == nil || g.platform == nil || organizationID == "" {

--- a/server/internal/platformmcp/gate_test.go
+++ b/server/internal/platformmcp/gate_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 )
 
@@ -25,36 +24,6 @@ func (c testCapabilityChecker) IsFeatureEnabled(_ context.Context, _ string, cap
 
 func (c testCapabilityChecker) IsFeatureEnabledUncached(ctx context.Context, organizationID string, capability productfeatures.Feature) (bool, error) {
 	return c.IsFeatureEnabled(ctx, organizationID, capability)
-}
-
-type testOrganizationSlugResolver struct {
-	slug string
-	err  error
-}
-
-func (r testOrganizationSlugResolver) OrganizationSlug(_ context.Context, _ string) (string, error) {
-	return r.slug, r.err
-}
-
-type testRolloutProvider struct {
-	enabled bool
-	err     error
-	flag    feature.Flag
-	groups  map[string]string
-}
-
-func (p *testRolloutProvider) IsFlagEnabled(_ context.Context, flag feature.Flag, _ string, groups map[string]string) (bool, error) {
-	p.flag = flag
-	p.groups = groups
-	return p.enabled, p.err
-}
-
-func (p *testRolloutProvider) IsFlagEnabledLocal(ctx context.Context, flag feature.Flag, distinctID string, groups, _ map[string]string) (bool, error) {
-	return p.IsFlagEnabled(ctx, flag, distinctID, groups)
-}
-
-func (p *testRolloutProvider) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
-	return nil, nil
 }
 
 func TestCatalogRegistrationGateRequiresPlatformMCPCapability(t *testing.T) {
@@ -104,90 +73,38 @@ func TestCatalogRegistrationGateRequiresPlatformMCPCapability(t *testing.T) {
 	})
 }
 
-func TestOrganizationGateRequiresPlatformMCPRolloutAndCapability(t *testing.T) {
+func TestOrganizationGateAllowsEnabledPlatformMCPCapability(t *testing.T) {
 	t.Parallel()
 
-	const organizationID = "organization-1"
-	const organizationSlug = "organization-slug"
+	enabled, err := NewOrganizationGate(testCapabilityChecker{enabled: true}).Enabled(t.Context(), "organization-1")
 
-	newGate := func(capability testCapabilityChecker, rollout *testRolloutProvider, resolver testOrganizationSlugResolver) *OrganizationGate {
-		return NewOrganizationGate(capability, rollout, resolver)
-	}
+	require.NoError(t, err)
+	require.True(t, enabled)
+}
 
-	t.Run("allows an organization with both rollout and capability enabled", func(t *testing.T) {
-		t.Parallel()
+func TestOrganizationGateDeniesDisabledPlatformMCPCapability(t *testing.T) {
+	t.Parallel()
 
-		rollout := &testRolloutProvider{enabled: true}
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, rollout, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), organizationID)
+	enabled, err := NewOrganizationGate(testCapabilityChecker{}).Enabled(t.Context(), "organization-1")
 
-		require.NoError(t, err)
-		require.True(t, enabled)
-		require.Equal(t, feature.FlagPlatformMCP, rollout.flag)
-		require.Equal(t, feature.OrgProjectGroups(organizationSlug, ""), rollout.groups)
-	})
+	require.NoError(t, err)
+	require.False(t, enabled)
+}
 
-	t.Run("denies when the rollout is disabled", func(t *testing.T) {
-		t.Parallel()
+func TestOrganizationGateFailsClosedWhenCapabilityLookupIsUnavailable(t *testing.T) {
+	t.Parallel()
 
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, &testRolloutProvider{}, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), organizationID)
+	enabled, err := NewOrganizationGate(testCapabilityChecker{err: errors.New("unavailable")}).Enabled(t.Context(), "organization-1")
 
-		require.NoError(t, err)
-		require.False(t, enabled)
-	})
+	require.ErrorContains(t, err, "check platform mcp capability")
+	require.False(t, enabled)
+}
 
-	t.Run("denies when the organization capability is disabled", func(t *testing.T) {
-		t.Parallel()
+func TestOrganizationGateRequiresOrganization(t *testing.T) {
+	t.Parallel()
 
-		enabled, err := newGate(testCapabilityChecker{}, &testRolloutProvider{enabled: true}, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), organizationID)
+	enabled, err := NewOrganizationGate(testCapabilityChecker{enabled: true}).Enabled(t.Context(), "")
 
-		require.NoError(t, err)
-		require.False(t, enabled)
-	})
-
-	t.Run("fails closed when rollout evaluation is unavailable", func(t *testing.T) {
-		t.Parallel()
-
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, &testRolloutProvider{err: errors.New("unavailable")}, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), organizationID)
-
-		require.ErrorContains(t, err, "check platform mcp rollout")
-		require.False(t, enabled)
-	})
-
-	t.Run("fails closed when the organization capability lookup is unavailable", func(t *testing.T) {
-		t.Parallel()
-
-		enabled, err := newGate(testCapabilityChecker{err: errors.New("unavailable")}, &testRolloutProvider{enabled: true}, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), organizationID)
-
-		require.ErrorContains(t, err, "check platform mcp capability")
-		require.False(t, enabled)
-	})
-
-	t.Run("fails closed when the organization cannot be resolved", func(t *testing.T) {
-		t.Parallel()
-
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, &testRolloutProvider{enabled: true}, testOrganizationSlugResolver{err: errors.New("unavailable")}).Enabled(t.Context(), organizationID)
-
-		require.ErrorContains(t, err, "resolve organization for platform mcp rollout")
-		require.False(t, enabled)
-	})
-
-	t.Run("fails closed when the organization slug is empty", func(t *testing.T) {
-		t.Parallel()
-
-		rollout := &testRolloutProvider{enabled: true}
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, rollout, testOrganizationSlugResolver{}).Enabled(t.Context(), organizationID)
-
-		require.ErrorIs(t, err, ErrUnavailable)
-		require.False(t, enabled)
-		require.Zero(t, rollout.flag)
-	})
-
-	t.Run("requires an organization", func(t *testing.T) {
-		t.Parallel()
-
-		enabled, err := newGate(testCapabilityChecker{enabled: true}, &testRolloutProvider{enabled: true}, testOrganizationSlugResolver{slug: organizationSlug}).Enabled(t.Context(), "")
-
-		require.ErrorIs(t, err, ErrUnavailable)
-		require.False(t, enabled)
-	})
+	require.ErrorIs(t, err, ErrUnavailable)
+	require.False(t, enabled)
 }


### PR DESCRIPTION
## Summary
- Remove the `platform-mcp` server rollout flag and the `platform-mcp-dashboard` discovery flag.
- Keep the durable `platform_mcp` product feature as the organization-level runtime and package access control.
- Keep the separate `assistant-platform-mcp` rollout and all other feature flags unchanged.
- Update focused coverage and generated API/SDK descriptions to reflect the remaining product-feature gate.

## Motivation
Platform MCP no longer needs engineering-controlled rollout gates for its core runtime or dashboard discovery. Removing those temporary checks makes the feature discoverable by default while preserving the permanent organization entitlement and its existing disable behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the engineering-owned rollout gates for Platform MCP, so runtime access is now controlled solely by the org-level `platform_mcp` product feature. Previously, organizations needed both a PostHog release flag and the product feature; now only the product feature gates the server, and Dashboard discovery no longer checks the `platform-mcp-dashboard` flag, so Platform MCP is visible to all orgs by default.

- The server gate now checks only the durable product feature; the rollout flag and organization slug resolver were removed.
- Dashboard navigation, onboarding, and platform-admin feature toggling no longer depend on rollout flags.
- The `assistant-platform-mcp` flag and all other flags remain unchanged.
- API/SDK descriptions now say "whether the active organization has the Platform MCP product feature enabled."

<sup>Written for commit 4ac615dbffcfefd1c144ec6654b0c8e15a0436f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

