### PR TITLE
feat: remove OpenRouter disable causes safely (AGE-3219)

### DIFF
--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -733,11 +733,11 @@ func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openr
 	return 0, fmt.Errorf("not implemented in bench")
 }
 func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+	return openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+	return 0, openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -732,6 +732,14 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
 	return fmt.Errorf("not implemented in bench")
 }

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -285,6 +285,14 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
 	return fmt.Errorf("not implemented in bench")
 }

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -286,11 +286,11 @@ func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openr
 	return 0, fmt.Errorf("not implemented in bench")
 }
 func (*devProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+	return openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (*devProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+	return 0, openrouter.DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}, nil
 }
 
 func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -94,11 +94,11 @@ func (p *rearmProvisioner) refreshAPIKeyLimit(ctx context.Context, orgID string,
 	// What the real RefreshAPIKeyLimit does locally.
 	if p.conn != nil {
 		if _, err := orrepo.New(p.conn).UpdateOpenRouterKey(ctx, orrepo.UpdateOpenRouterKeyParams{
-			OrganizationID:  orgID,
-			KeyType:         string(keyType),
-			MonthlyCredits:  int64(conv.PtrValOr(limit, 0)),
-			KeyHash:         "hash-" + orgID + "-" + string(keyType),
-			ReinstateLegacy: true,
+			OrganizationID: orgID,
+			KeyType:        string(keyType),
+			MonthlyCredits: int64(conv.PtrValOr(limit, 0)),
+			KeyHash:        "hash-" + orgID + "-" + string(keyType),
+			Reinstate:      true,
 		}); err != nil {
 			return 0, fmt.Errorf("reinstate %s key: %w", keyType, err)
 		}

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -94,11 +94,11 @@ func (p *rearmProvisioner) refreshAPIKeyLimit(ctx context.Context, orgID string,
 	// What the real RefreshAPIKeyLimit does locally.
 	if p.conn != nil {
 		if _, err := orrepo.New(p.conn).UpdateOpenRouterKey(ctx, orrepo.UpdateOpenRouterKeyParams{
-			OrganizationID: orgID,
-			KeyType:        string(keyType),
-			MonthlyCredits: int64(conv.PtrValOr(limit, 0)),
-			KeyHash:        "hash-" + orgID + "-" + string(keyType),
-			Reinstate:      true,
+			OrganizationID:  orgID,
+			KeyType:         string(keyType),
+			MonthlyCredits:  int64(conv.PtrValOr(limit, 0)),
+			KeyHash:         "hash-" + orgID + "-" + string(keyType),
+			ReinstateLegacy: true,
 		}); err != nil {
 			return 0, fmt.Errorf("reinstate %s key: %w", keyType, err)
 		}

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -46,6 +46,14 @@ func (m *mockPaygChatKeyProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Cont
 	return m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 }
 
+func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (m *mockPaygChatKeyProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
 	return m.Called(ctx, organizationID, keyType).Error(0)
 }

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -67,6 +67,14 @@ func (p *stubProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return 0, nil
 }
 
+func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (p *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
 	return nil
 }

--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -113,6 +113,44 @@ func TestStubProvisionerDisableCausesMirrorLocalState(t *testing.T) {
 	require.Equal(t, openrouter.DisableCauseChange{}, change)
 }
 
+func TestStubProvisionerRemoveLastDisableCauseRestoresOrganizationDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	orgID := seedKey(t, ctx, ti, "stub-default-limit", string(openrouter.KeyTypeChat), "sk-or-stub-default-limit")
+	require.NoError(t, orgmetarepo.New(ti.conn).SetAccountType(ctx, orgmetarepo.SetAccountTypeParams{
+		GramAccountType: string(billing.TierPayg),
+		ID:              orgID,
+	}))
+	require.NoError(t, orgrepo.New(ti.conn).UpdateOpenRouterKeyMonthlyCredits(ctx, orgrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+		MonthlyCredits: 0,
+	}))
+	require.NoError(t, testrepo.New(ti.conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+		Disabled:       true,
+		DisableCauses:  []string{string(openrouter.DisableCauseAdminLock)},
+	}))
+
+	expected, ok := openrouter.ResolveDefaultCreditLimit(ctx, testenv.NewLogger(t), ti.conn, orgID, billing.TierPayg)
+	require.True(t, ok)
+	limit, change, err := ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Equal(t, expected, limit)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+
+	row, err := orgrepo.New(ti.conn).GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, expected, row.MonthlyCredits)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
 func TestListKeys_RequiresPlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -32,6 +32,87 @@ import (
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
+func TestStubProvisionerDisableCausesMirrorLocalState(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	orgID := seedKey(t, ctx, ti, "stub-causes", string(openrouter.KeyTypeChat), "sk-or-stub-causes")
+	queries := orgrepo.New(ti.conn)
+	require.NoError(t, testrepo.New(ti.conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: false, DisableCauses: nil,
+	}))
+
+	_, err := ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock)
+	require.ErrorContains(t, err, "unclassified")
+	_, _, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, nil)
+	require.ErrorContains(t, err, "unclassified")
+	change, err := ti.provisioner.AddAPIKeyDisableCause(ctx, "missing-org", openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, openrouter.DisableCauseChange{}, change)
+	require.NoError(t, testrepo.New(ti.conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: false, DisableCauses: []string{},
+	}))
+
+	change, err = ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	row, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+
+	change, err = ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, openrouter.DisableCauseChange{}, change)
+	change, err = ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true}, change)
+
+	limit, change, err := ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive, new(99))
+	require.NoError(t, err)
+	require.Equal(t, 5, limit)
+	require.Equal(t, openrouter.DisableCauseChange{}, change)
+	limit, change, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseTrialDemotion, new(99))
+	require.NoError(t, err)
+	require.Equal(t, 5, limit)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true}, change)
+	row, err = queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock"}, row.DisableCauses)
+	require.EqualValues(t, 5, row.MonthlyCredits)
+	require.True(t, row.Disabled)
+
+	limit, change, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, new(42))
+	require.NoError(t, err)
+	require.Equal(t, 42, limit)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	row, err = queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+	require.Empty(t, row.DisableCauses)
+	require.EqualValues(t, 42, row.MonthlyCredits)
+	require.False(t, row.Disabled)
+
+	change, err = ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive)
+	require.NoError(t, err)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	limit, change, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive, nil)
+	require.NoError(t, err)
+	require.Equal(t, 42, limit)
+	require.Equal(t, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	row, err = queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+	require.Empty(t, row.DisableCauses)
+	require.EqualValues(t, 42, row.MonthlyCredits)
+	require.False(t, row.Disabled)
+
+	_, _, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, new(0))
+	require.ErrorContains(t, err, "must be positive")
+	limit, change, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, "missing-org", openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Zero(t, limit)
+	require.Equal(t, openrouter.DisableCauseChange{}, change)
+}
+
 func TestListKeys_RequiresPlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -2,14 +2,17 @@ package openrouterkeys_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
@@ -113,12 +116,65 @@ func (s *stubProvisioner) refreshAPIKeyLimit(ctx context.Context, db openrouter.
 	return keyLimit, nil
 }
 
-func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	queries := orgrepo.New(s.conn)
+	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return openrouter.DisableCauseChange{}, nil
+	case err != nil:
+		return openrouter.DisableCauseChange{}, fmt.Errorf("stub add disable cause read: %w", err)
+	case key.DisableCauses == nil:
+		return openrouter.DisableCauseChange{}, errors.New("cannot add OpenRouter disable cause to unclassified key")
+	case slices.Contains(key.DisableCauses, string(cause)):
+		return openrouter.DisableCauseChange{}, nil
+	}
+
+	accessChanged := len(key.DisableCauses) == 0
+	if _, err := queries.AddOpenRouterAPIKeyDisableCause(ctx, orgrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(keyType), KeyHash: key.KeyHash, DisableCause: string(cause),
+	}); err != nil {
+		return openrouter.DisableCauseChange{}, fmt.Errorf("stub add disable cause write: %w", err)
+	}
+	return openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
 }
 
-func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
+func (s *stubProvisioner) RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	if limit != nil && *limit <= 0 {
+		return 0, openrouter.DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+	}
+
+	queries := orgrepo.New(s.conn)
+	key, err := queries.GetOpenRouterAPIKey(ctx, orgrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return 0, openrouter.DisableCauseChange{}, nil
+	case err != nil:
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("stub remove disable cause read: %w", err)
+	case key.DisableCauses == nil:
+		return 0, openrouter.DisableCauseChange{}, errors.New("cannot remove OpenRouter disable cause from unclassified key")
+	case !slices.Contains(key.DisableCauses, string(cause)):
+		return int(key.MonthlyCredits), openrouter.DisableCauseChange{}, nil
+	}
+
+	accessChanged := true
+	for _, existingCause := range key.DisableCauses {
+		if existingCause != string(cause) {
+			accessChanged = false
+			break
+		}
+	}
+	keyLimit := int(key.MonthlyCredits)
+	if accessChanged && limit != nil {
+		keyLimit = *limit
+	}
+	if _, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, orgrepo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(keyType), KeyHash: key.KeyHash, DisableCause: string(cause),
+		MonthlyCredits: int64(keyLimit), UpdateMonthlyCredits: accessChanged && int64(keyLimit) != key.MonthlyCredits,
+	}); err != nil {
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("stub remove disable cause write: %w", err)
+	}
+	return keyLimit, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
 }
 
 func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -113,6 +113,14 @@ func (s *stubProvisioner) refreshAPIKeyLimit(ctx context.Context, db openrouter.
 	return keyLimit, nil
 }
 
+func (*stubProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*stubProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
 	s.mu.Lock()
 	s.disableCalls = append(s.disableCalls, orgID+"/"+string(keyType))

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -63,7 +63,8 @@ type testInstance struct {
 type stubProvisioner struct {
 	mu sync.Mutex
 
-	conn *pgxpool.Pool
+	logger *slog.Logger
+	conn   *pgxpool.Pool
 
 	// usage and usageLimit are returned by GetKeyUsage.
 	usage      float64
@@ -165,8 +166,16 @@ func (s *stubProvisioner) RemoveAPIKeyDisableCause(ctx context.Context, orgID st
 		}
 	}
 	keyLimit := int(key.MonthlyCredits)
-	if accessChanged && limit != nil {
-		keyLimit = *limit
+	if accessChanged {
+		if limit != nil {
+			keyLimit = *limit
+		} else if key.MonthlyCredits == 0 {
+			org, orgErr := orgmetarepo.New(s.conn).GetOrganizationMetadata(ctx, orgID)
+			if orgErr != nil {
+				return 0, openrouter.DisableCauseChange{}, fmt.Errorf("stub remove disable cause organization read: %w", orgErr)
+			}
+			keyLimit, _ = openrouter.ResolveDefaultCreditLimit(ctx, s.logger, s.conn, orgID, billing.Tier(org.GramAccountType))
+		}
 	}
 	if _, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, orgrepo.RemoveOpenRouterAPIKeyDisableCauseParams{
 		OrganizationID: orgID, KeyType: string(keyType), KeyHash: key.KeyHash, DisableCause: string(cause),
@@ -251,6 +260,7 @@ func newTestServiceWithProvisioner(t *testing.T, factory provisionerFactory) (co
 	enc := testenv.NewEncryptionClient(t)
 	stub := &stubProvisioner{
 		mu:           sync.Mutex{},
+		logger:       logger,
 		conn:         conn,
 		usage:        0,
 		usageLimit:   nil,

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -554,6 +554,13 @@ SET disabled = @disabled,
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 
+-- name: SetOpenRouterAPIKeyHashFixture :exec
+-- Test-only fixture: simulates key rotation between an upstream response and CAS.
+UPDATE openrouter_api_keys
+SET key_hash = @key_hash
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
 -- name: SeedOpenRouterSpendRangeFixture :exec
 -- Test-only fixture: records one exact daily spend amount across an inclusive
 -- UTC date range.

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1886,6 +1886,25 @@ func (q *Queries) SetOpenRouterAPIKeyCreatedAtFixture(ctx context.Context, arg S
 	return err
 }
 
+const setOpenRouterAPIKeyHashFixture = `-- name: SetOpenRouterAPIKeyHashFixture :exec
+UPDATE openrouter_api_keys
+SET key_hash = $1
+WHERE organization_id = $2
+  AND key_type = $3
+`
+
+type SetOpenRouterAPIKeyHashFixtureParams struct {
+	KeyHash        string
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only fixture: simulates key rotation between an upstream response and CAS.
+func (q *Queries) SetOpenRouterAPIKeyHashFixture(ctx context.Context, arg SetOpenRouterAPIKeyHashFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyHashFixture, arg.KeyHash, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
 const setOrgWebhookConfig = `-- name: SetOrgWebhookConfig :exec
 UPDATE organization_metadata
 SET svix_app_id = $1,

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -24,6 +24,10 @@ type DisableCauseChange struct {
 	KeyAccessChanged bool
 }
 
+func unchangedDisableCauseChange() DisableCauseChange {
+	return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}
+}
+
 // EffectiveDisabled preserves legacy access for rows that have not been
 // classified yet. Once disable_causes is non-NULL, the cause set is
 // authoritative even if the rollout mirror has drifted.

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -294,9 +294,12 @@ func TestAddAPIKeyDisableCauseCanonicalizesConcurrentDifferentCauses(t *testing.
 
 	firstPatch := make(chan struct{})
 	releasePatch := make(chan struct{})
+	var once sync.Once
 	upstream.interceptPatch(func() {
-		close(firstPatch)
-		<-releasePatch
+		once.Do(func() {
+			close(firstPatch)
+			<-releasePatch
+		})
 	})
 	type addition struct {
 		change DisableCauseChange
@@ -324,7 +327,7 @@ func TestAddAPIKeyDisableCauseCanonicalizesConcurrentDifferentCauses(t *testing.
 	require.True(t, first.change.CauseChanged)
 	require.True(t, second.change.CauseChanged)
 	require.NotEqual(t, first.change.KeyAccessChanged, second.change.KeyAccessChanged)
-	require.Len(t, upstream.recorded(), 1)
+	require.Len(t, upstream.recorded(), 2)
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
 	require.NoError(t, err)
 	require.Equal(t, []string{string(DisableCauseAdminLock), string(DisableCauseTrialDemotion)}, row.DisableCauses)

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -39,19 +39,19 @@ func (o *Development) ReinstateAPIKeyLimitWithDB(ctx context.Context, db DBTX, o
 }
 
 func (o *Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
-	return DisableCauseChange{}, nil
+	return unchangedDisableCauseChange(), nil
 }
 
 func (o *Development) AddAPIKeyDisableCauseWithDB(context.Context, DBTX, string, KeyType, DisableCause) (DisableCauseChange, error) {
-	return DisableCauseChange{}, nil
+	return unchangedDisableCauseChange(), nil
 }
 
 func (o *Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
-	return 0, DisableCauseChange{}, nil
+	return 0, unchangedDisableCauseChange(), nil
 }
 
 func (o *Development) RemoveAPIKeyDisableCauseWithDB(context.Context, DBTX, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
-	return 0, DisableCauseChange{}, nil
+	return 0, unchangedDisableCauseChange(), nil
 }
 
 func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -38,6 +38,22 @@ func (o *Development) ReinstateAPIKeyLimitWithDB(ctx context.Context, db DBTX, o
 	return o.ReinstateAPIKeyLimit(ctx, orgID, keyType, limit)
 }
 
+func (o *Development) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
+	return DisableCauseChange{}, nil
+}
+
+func (o *Development) AddAPIKeyDisableCauseWithDB(context.Context, DBTX, string, KeyType, DisableCause) (DisableCauseChange, error) {
+	return DisableCauseChange{}, nil
+}
+
+func (o *Development) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+	return 0, DisableCauseChange{}, nil
+}
+
+func (o *Development) RemoveAPIKeyDisableCauseWithDB(context.Context, DBTX, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+	return 0, DisableCauseChange{}, nil
+}
+
 func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	return nil
 }

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -824,18 +824,73 @@ func (o *OpenRouter) AddAPIKeyDisableCause(ctx context.Context, orgID string, ke
 	return result, nil
 }
 
+// AddAPIKeyDisableCauseWithDB uses db for every local read and write. The
+// caller must hold the established per-key billing advisory lock.
+func (o *OpenRouter) AddAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return unchangedDisableCauseChange(), fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+	if err := cause.Validate(); err != nil {
+		return unchangedDisableCauseChange(), fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+
+	keyRepo := repo.New(db)
+	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return unchangedDisableCauseChange(), nil
+	case err != nil:
+		return unchangedDisableCauseChange(), fmt.Errorf("read OpenRouter key before adding disable cause: %w", err)
+	case key.DisableCauses == nil:
+		return unchangedDisableCauseChange(), errors.New("cannot add OpenRouter disable cause to unclassified key")
+	case slices.Contains(key.DisableCauses, string(cause)):
+		return unchangedDisableCauseChange(), nil
+	}
+
+	if len(key.DisableCauses) == 0 {
+		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+		response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)})
+		cancel()
+		if patchErr != nil {
+			return unchangedDisableCauseChange(), fmt.Errorf("disable upstream OpenRouter API key: %w", patchErr)
+		}
+		if response.Data.Hash != key.KeyHash {
+			return unchangedDisableCauseChange(), errors.New("OpenRouter key identity mismatch after disable")
+		}
+	}
+
+	latest, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if err != nil || latest.KeyHash != key.KeyHash || latest.DisableCauses == nil {
+		return unchangedDisableCauseChange(), errors.New("OpenRouter key changed concurrently while adding disable cause")
+	}
+	if slices.Contains(latest.DisableCauses, string(cause)) {
+		return unchangedDisableCauseChange(), nil
+	}
+	accessChanged := len(latest.DisableCauses) == 0
+	if _, err = keyRepo.AddOpenRouterAPIKeyDisableCause(ctx, repo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(keyType), KeyHash: key.KeyHash, DisableCause: string(cause),
+	}); errors.Is(err, pgx.ErrNoRows) {
+		return unchangedDisableCauseChange(), errors.New("OpenRouter key changed concurrently while adding disable cause")
+	} else if err != nil {
+		return unchangedDisableCauseChange(), fmt.Errorf("persist OpenRouter API key disable cause: %w", err)
+	}
+
+	return DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
+}
+
 // RemoveAPIKeyDisableCause removes only cause. Standalone calls serialize with
 // all compliant key mutations through the established per-key billing lock.
 func (o *OpenRouter) RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
 	keyType = keyType.OrDefault()
 	if err := keyType.Validate(); err != nil {
-		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	if err := cause.Validate(); err != nil {
-		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	if limit != nil && *limit <= 0 {
-		return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+		return 0, unchangedDisableCauseChange(), errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
 	}
 
 	var keyLimit int
@@ -846,7 +901,7 @@ func (o *OpenRouter) RemoveAPIKeyDisableCause(ctx context.Context, orgID string,
 		return removeErr
 	})
 	if err != nil {
-		return 0, DisableCauseChange{}, err
+		return 0, unchangedDisableCauseChange(), err
 	}
 	return keyLimit, change, nil
 }
@@ -856,13 +911,13 @@ func (o *OpenRouter) RemoveAPIKeyDisableCause(ctx context.Context, orgID string,
 func (o *OpenRouter) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
 	keyType = keyType.OrDefault()
 	if err := keyType.Validate(); err != nil {
-		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	if err := cause.Validate(); err != nil {
-		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
 	}
 	if limit != nil && *limit <= 0 {
-		return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+		return 0, unchangedDisableCauseChange(), errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
 	}
 	return o.removeAPIKeyDisableCauseWithDB(ctx, db, orgID, keyType, cause, limit)
 }
@@ -872,16 +927,22 @@ func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX
 	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return 0, DisableCauseChange{}, nil
+		return 0, unchangedDisableCauseChange(), nil
 	case err != nil:
-		return 0, DisableCauseChange{}, fmt.Errorf("read OpenRouter key before removing disable cause: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("read OpenRouter key before removing disable cause: %w", err)
 	case key.DisableCauses == nil:
-		return 0, DisableCauseChange{}, errors.New("cannot remove OpenRouter disable cause from unclassified key")
+		return 0, unchangedDisableCauseChange(), errors.New("cannot remove OpenRouter disable cause from unclassified key")
 	case !slices.Contains(key.DisableCauses, string(cause)):
-		return int(key.MonthlyCredits), DisableCauseChange{}, nil
+		return int(key.MonthlyCredits), unchangedDisableCauseChange(), nil
 	}
 
-	accessChanged := len(key.DisableCauses) == 1
+	accessChanged := true
+	for _, existingCause := range key.DisableCauses {
+		if existingCause != string(cause) {
+			accessChanged = false
+			break
+		}
+	}
 	keyLimit := int(key.MonthlyCredits)
 	limitChanged := false
 	if accessChanged {
@@ -890,13 +951,13 @@ func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX
 		} else if key.MonthlyCredits == 0 {
 			org, orgErr := orgRepo.New(db).GetOrganizationMetadata(ctx, orgID)
 			if orgErr != nil {
-				return 0, DisableCauseChange{}, oops.E(oops.CodeUnexpected, orgErr, "failed to get organization").LogError(ctx, o.logger)
+				return 0, unchangedDisableCauseChange(), oops.E(oops.CodeUnexpected, orgErr, "failed to get organization").LogError(ctx, o.logger)
 			}
 			keyLimit = o.defaultLimitForOrg(ctx, db, org)
 		}
 		limitChanged = int64(keyLimit) != key.MonthlyCredits
 
-		patch := updateKeyRequest{Disabled: new(false)}
+		patch := updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(false)}
 		if limitChanged {
 			creditLimit := float64(keyLimit)
 			patch.Limit = &creditLimit
@@ -906,10 +967,10 @@ func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX
 		response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, patch)
 		cancel()
 		if patchErr != nil {
-			return 0, DisableCauseChange{}, fmt.Errorf("enable upstream OpenRouter API key: %w", patchErr)
+			return 0, unchangedDisableCauseChange(), fmt.Errorf("enable upstream OpenRouter API key: %w", patchErr)
 		}
 		if response.Data.Hash != key.KeyHash {
-			return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: upstream key identity changed")
+			return 0, unchangedDisableCauseChange(), errors.New("remove OpenRouter API key disable cause: upstream key identity changed")
 		}
 	}
 
@@ -918,10 +979,10 @@ func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX
 		MonthlyCredits: int64(keyLimit), UpdateMonthlyCredits: limitChanged,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		return 0, DisableCauseChange{}, errors.New("OpenRouter key changed concurrently while removing disable cause")
+		return 0, unchangedDisableCauseChange(), errors.New("OpenRouter key changed concurrently while removing disable cause")
 	}
 	if err != nil {
-		return 0, DisableCauseChange{}, fmt.Errorf("persist OpenRouter API key disable cause removal: %w", err)
+		return 0, unchangedDisableCauseChange(), fmt.Errorf("persist OpenRouter API key disable cause removal: %w", err)
 	}
 
 	return keyLimit, DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -328,6 +328,8 @@ type Provisioner interface {
 	// the reinstatement path: a key that DisableAPIKey turned off comes back
 	// enabled, upstream and locally.
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error)
+	AddAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause) (DisableCauseChange, error)
+	RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error)
 
 	// DisableAPIKey turns the org's key off upstream and records that locally,
 	// after which ProvisionAPIKey refuses it with ErrPlatformKeyDisabled. The
@@ -820,6 +822,109 @@ func (o *OpenRouter) AddAPIKeyDisableCause(ctx context.Context, orgID string, ke
 		return DisableCauseChange{}, err
 	}
 	return result, nil
+}
+
+// RemoveAPIKeyDisableCause removes only cause. Standalone calls serialize with
+// all compliant key mutations through the established per-key billing lock.
+func (o *OpenRouter) RemoveAPIKeyDisableCause(ctx context.Context, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if err := cause.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if limit != nil && *limit <= 0 {
+		return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+	}
+
+	var keyLimit int
+	var change DisableCauseChange
+	err := o.withOpenRouterKeyBillingLock(ctx, orgID, keyType, func(conn *pgxpool.Conn) error {
+		var removeErr error
+		keyLimit, change, removeErr = o.removeAPIKeyDisableCauseWithDB(ctx, conn, orgID, keyType, cause, limit)
+		return removeErr
+	})
+	if err != nil {
+		return 0, DisableCauseChange{}, err
+	}
+	return keyLimit, change, nil
+}
+
+// RemoveAPIKeyDisableCauseWithDB uses db for every local read and write. The
+// caller must hold the established per-key billing advisory lock.
+func (o *OpenRouter) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if err := cause.Validate(); err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	if limit != nil && *limit <= 0 {
+		return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: monthly credits must be positive")
+	}
+	return o.removeAPIKeyDisableCauseWithDB(ctx, db, orgID, keyType, cause, limit)
+}
+
+func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, cause DisableCause, limit *int) (int, DisableCauseChange, error) {
+	keyRepo := repo.New(db)
+	key, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return 0, DisableCauseChange{}, nil
+	case err != nil:
+		return 0, DisableCauseChange{}, fmt.Errorf("read OpenRouter key before removing disable cause: %w", err)
+	case key.DisableCauses == nil:
+		return 0, DisableCauseChange{}, errors.New("cannot remove OpenRouter disable cause from unclassified key")
+	case !slices.Contains(key.DisableCauses, string(cause)):
+		return int(key.MonthlyCredits), DisableCauseChange{}, nil
+	}
+
+	accessChanged := len(key.DisableCauses) == 1
+	keyLimit := int(key.MonthlyCredits)
+	limitChanged := false
+	if accessChanged {
+		if limit != nil {
+			keyLimit = *limit
+		} else if key.MonthlyCredits == 0 {
+			org, orgErr := orgRepo.New(db).GetOrganizationMetadata(ctx, orgID)
+			if orgErr != nil {
+				return 0, DisableCauseChange{}, oops.E(oops.CodeUnexpected, orgErr, "failed to get organization").LogError(ctx, o.logger)
+			}
+			keyLimit = o.defaultLimitForOrg(ctx, db, org)
+		}
+		limitChanged = int64(keyLimit) != key.MonthlyCredits
+
+		patch := updateKeyRequest{Disabled: new(false)}
+		if limitChanged {
+			creditLimit := float64(keyLimit)
+			patch.Limit = &creditLimit
+			patch.LimitReset = "monthly"
+		}
+		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+		response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, patch)
+		cancel()
+		if patchErr != nil {
+			return 0, DisableCauseChange{}, fmt.Errorf("enable upstream OpenRouter API key: %w", patchErr)
+		}
+		if response.Data.Hash != key.KeyHash {
+			return 0, DisableCauseChange{}, errors.New("remove OpenRouter API key disable cause: upstream key identity changed")
+		}
+	}
+
+	_, err = keyRepo.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(keyType), KeyHash: key.KeyHash, DisableCause: string(cause),
+		MonthlyCredits: int64(keyLimit), UpdateMonthlyCredits: limitChanged,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, DisableCauseChange{}, errors.New("OpenRouter key changed concurrently while removing disable cause")
+	}
+	if err != nil {
+		return 0, DisableCauseChange{}, fmt.Errorf("persist OpenRouter API key disable cause removal: %w", err)
+	}
+
+	return keyLimit, DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
 }
 
 func (o *OpenRouter) withOpenRouterKeyBillingLock(ctx context.Context, orgID string, keyType KeyType, operation func(*pgxpool.Conn) error) error {

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -785,16 +785,14 @@ func (o *OpenRouter) AddAPIKeyDisableCause(ctx context.Context, orgID string, ke
 			return nil
 		}
 
-		if len(key.DisableCauses) == 0 {
-			patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
-			response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)})
-			cancel()
-			if patchErr != nil {
-				return fmt.Errorf("disable upstream OpenRouter API key: %w", patchErr)
-			}
-			if response.Data.Hash != key.KeyHash {
-				return errors.New("OpenRouter key identity mismatch after disable")
-			}
+		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+		response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)})
+		cancel()
+		if patchErr != nil {
+			return fmt.Errorf("disable upstream OpenRouter API key: %w", patchErr)
+		}
+		if response.Data.Hash != key.KeyHash {
+			return errors.New("OpenRouter key identity mismatch after disable")
 		}
 
 		latest, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
@@ -848,16 +846,14 @@ func (o *OpenRouter) AddAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX, o
 		return unchangedDisableCauseChange(), nil
 	}
 
-	if len(key.DisableCauses) == 0 {
-		patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
-		response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)})
-		cancel()
-		if patchErr != nil {
-			return unchangedDisableCauseChange(), fmt.Errorf("disable upstream OpenRouter API key: %w", patchErr)
-		}
-		if response.Data.Hash != key.KeyHash {
-			return unchangedDisableCauseChange(), errors.New("OpenRouter key identity mismatch after disable")
-		}
+	patchCtx, cancel := context.WithTimeout(ctx, upstreamKeyPatchTimeout)
+	response, patchErr := o.patchOpenRouterAPIKey(patchCtx, key.KeyHash, updateKeyRequest{Limit: nil, LimitReset: "", Disabled: new(true)})
+	cancel()
+	if patchErr != nil {
+		return unchangedDisableCauseChange(), fmt.Errorf("disable upstream OpenRouter API key: %w", patchErr)
+	}
+	if response.Data.Hash != key.KeyHash {
+		return unchangedDisableCauseChange(), errors.New("OpenRouter key identity mismatch after disable")
 	}
 
 	latest, err := keyRepo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -107,7 +107,7 @@ SET disable_causes = CASE
     END,
     disabled = CASE
       WHEN @disable_cause::text = ANY(disable_causes)
-        THEN cardinality(array_remove(disable_causes, @disable_cause::text)) > 0
+        AND cardinality(array_remove(disable_causes, @disable_cause::text)) = 0 THEN FALSE
       ELSE disabled
     END,
     monthly_credits = CASE

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -89,6 +89,44 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: RemoveOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) THEN ARRAY(
+        SELECT cause
+        FROM unnest(array_remove(disable_causes, @disable_cause::text)) AS causes(cause)
+        GROUP BY cause
+        ORDER BY CASE cause
+          WHEN 'admin_lock' THEN 1
+          WHEN 'trial_demotion' THEN 2
+          WHEN 'billing_inactive' THEN 3
+          ELSE 4
+        END, cause
+      )
+      ELSE disable_causes
+    END,
+    disabled = CASE
+      WHEN @disable_cause::text = ANY(disable_causes)
+        THEN cardinality(array_remove(disable_causes, @disable_cause::text)) > 0
+      ELSE disabled
+    END,
+    monthly_credits = CASE
+      WHEN @disable_cause::text = ANY(disable_causes) AND @update_monthly_credits::boolean
+        THEN @monthly_credits::bigint
+      ELSE monthly_credits
+    END,
+    updated_at = CASE
+      WHEN @disable_cause::text = ANY(disable_causes)
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND key_hash = @key_hash
+  AND disable_causes IS NOT NULL
+  AND deleted IS FALSE
+RETURNING *;
+
 -- name: DisableOpenRouterAPIKey :exec
 -- Locks the key down without deleting it, so a reinstated organization keeps
 -- the same upstream key and its ceiling. ProvisionAPIKey reads this flag and

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -1,0 +1,317 @@
+package openrouter
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+)
+
+func TestRemoveOpenRouterAPIKeyDisableCauseQueryNoopDoesNotTouchUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+
+	after, err := queries.RemoveOpenRouterAPIKeyDisableCause(ctx, repo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: before.KeyHash,
+		DisableCause: string(DisableCauseAdminLock), MonthlyCredits: 999, UpdateMonthlyCredits: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, before.DisableCauses, after.DisableCauses)
+	require.Equal(t, before.MonthlyCredits, after.MonthlyCredits)
+	require.Equal(t, before.UpdatedAt, after.UpdatedAt)
+}
+
+func TestRemoveAPIKeyDisableCauseMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		seed        []DisableCause
+		remove      DisableCause
+		limit       *int
+		wantChange  DisableCauseChange
+		wantCauses  []string
+		wantPatches []string
+		wantLimit   int64
+	}{
+		{name: "absent cause is a no-op", seed: []DisableCause{DisableCauseAdminLock}, remove: DisableCauseTrialDemotion, wantCauses: []string{"admin_lock"}},
+		{name: "non-last removal is local only and ignores limit", seed: []DisableCause{DisableCauseBillingInactive, DisableCauseTrialDemotion, DisableCauseAdminLock}, remove: DisableCauseTrialDemotion, limit: new(42), wantChange: DisableCauseChange{CauseChanged: true}, wantCauses: []string{"admin_lock", "billing_inactive"}},
+		{name: "last removal enables without changing a healthy limit", seed: []DisableCause{DisableCauseAdminLock}, remove: DisableCauseAdminLock, wantChange: DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, wantCauses: []string{}, wantPatches: []string{`{"disabled":false}`}},
+		{name: "last removal applies an explicit recovered limit", seed: []DisableCause{DisableCauseBillingInactive}, remove: DisableCauseBillingInactive, limit: new(42), wantChange: DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, wantCauses: []string{}, wantPatches: []string{`{"limit":42,"limit_reset":"monthly","disabled":false}`}, wantLimit: 42},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+			require.NoError(t, err)
+			for _, cause := range tt.seed {
+				_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, cause)
+				require.NoError(t, err)
+			}
+			before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			wantLimit := tt.wantLimit
+			if wantLimit == 0 {
+				wantLimit = before.MonthlyCredits
+			}
+			patchesBefore := len(upstream.recorded())
+
+			gotLimit, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, tt.remove, tt.limit)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantChange, change)
+			require.Equal(t, int(wantLimit), gotLimit)
+			patches := upstream.recorded()[patchesBefore:]
+			require.Len(t, patches, len(tt.wantPatches))
+			for i := range tt.wantPatches {
+				require.JSONEq(t, tt.wantPatches[i], patches[i])
+			}
+			row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCauses, row.DisableCauses)
+			require.Equal(t, wantLimit, row.MonthlyCredits)
+			require.Equal(t, len(tt.wantCauses) > 0, row.Disabled)
+
+			if tt.wantChange.KeyAccessChanged {
+				patchCount := len(upstream.recorded())
+				retryLimit, retryChange, retryErr := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, tt.remove, tt.limit)
+				require.NoError(t, retryErr)
+				require.Equal(t, int(wantLimit), retryLimit)
+				require.Equal(t, DisableCauseChange{}, retryChange)
+				require.Len(t, upstream.recorded(), patchCount, "an idempotent retry must not PATCH upstream")
+			}
+		})
+	}
+}
+
+func TestRemoveAPIKeyDisableCauseRecoversLegacyZeroLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	_, err = queries.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: row.KeyHash, MonthlyCredits: 0, ReinstateLegacy: false})
+	require.NoError(t, err)
+	patchesBefore := len(upstream.recorded())
+
+	gotLimit, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion, nil)
+	require.NoError(t, err)
+	require.Positive(t, gotLimit)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	patches := upstream.recorded()[patchesBefore:]
+	require.Len(t, patches, 1)
+	require.JSONEq(t, fmt.Sprintf(`{"limit":%d,"limit_reset":"monthly","disabled":false}`, gotLimit), patches[0])
+	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.EqualValues(t, gotLimit, row.MonthlyCredits)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
+func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	conn, err := provisioner.db.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+	lockParams := repo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)}
+	require.NoError(t, repo.New(conn).AcquireOpenRouterKeyBillingLock(ctx, lockParams))
+	defer func() {
+		unlocked, releaseErr := repo.New(conn).ReleaseOpenRouterKeyBillingLock(ctx, repo.ReleaseOpenRouterKeyBillingLockParams(lockParams))
+		require.NoError(t, releaseErr)
+		require.True(t, unlocked)
+	}()
+
+	change, err := provisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	_, change, err = provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
+func TestRemoveAPIKeyDisableCauseMissingAndUnclassifiedFailClosed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing key is a no-op", func(t *testing.T) {
+		ctx := t.Context()
+		orgID := "org-" + uuid.NewString()[:8]
+		provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
+		limit, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+		require.NoError(t, err)
+		require.Zero(t, limit)
+		require.Equal(t, DisableCauseChange{}, change)
+		require.Empty(t, upstream.recorded())
+	})
+
+	t.Run("NULL classification fails closed", func(t *testing.T) {
+		ctx := t.Context()
+		orgID := "org-" + uuid.NewString()[:8]
+		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+		_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+		require.NoError(t, err)
+		require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil}))
+
+		_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+		require.ErrorContains(t, err, "unclassified")
+		require.Empty(t, upstream.recorded())
+		row, getErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+		require.NoError(t, getErr)
+		require.Nil(t, row.DisableCauses)
+		require.True(t, row.Disabled)
+	})
+}
+
+func TestRemoveAPIKeyDisableCauseUpstreamFailureAndHashMismatchLeaveLocalUnchanged(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		configure func(*disableTestUpstream)
+	}{
+		{name: "upstream failure", configure: func(u *disableTestUpstream) { u.respondToPatchesWith(http.StatusBadGateway) }},
+		{name: "hash mismatch", configure: func(u *disableTestUpstream) { u.respondWithPatchHash("wrong-hash") }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+			require.NoError(t, err)
+			_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+			require.NoError(t, err)
+			before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			tt.configure(upstream)
+
+			_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+			require.Error(t, err)
+			row, getErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, getErr)
+			require.Equal(t, []string{"admin_lock"}, row.DisableCauses)
+			require.True(t, row.Disabled)
+			require.Equal(t, before.MonthlyCredits, row.MonthlyCredits)
+		})
+	}
+}
+
+func TestRemoveAPIKeyDisableCauseRotationConflictRetryConverges(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+	upstream.interceptPatch(func() {
+		upstream.interceptPatch(nil)
+		_, rotateErr := provisioner.db.Exec(ctx, `UPDATE openrouter_api_keys SET key_hash = 'hash-2' WHERE organization_id = $1 AND key_type = $2`, orgID, string(KeyTypeChat))
+		require.NoError(t, rotateErr)
+	})
+
+	_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+	require.ErrorContains(t, err, "changed concurrently")
+	row, getErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, getErr)
+	require.Equal(t, []string{"admin_lock"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+
+	upstream.respondWithPatchHash("hash-2")
+	_, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
+func TestConcurrentAddAndRemoveDoesNotLoseCause(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+
+	added := make(chan error, 1)
+	var once sync.Once
+	upstream.interceptPatch(func() {
+		once.Do(func() {
+			go func() {
+				_, addErr := provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+				added <- addErr
+			}()
+		})
+	})
+
+	_, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	require.NoError(t, <-added)
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+}
+
+func TestRefreshAPIKeyLimitPreservesDisableCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	patchesBefore := len(upstream.recorded())
+	limit := 77
+
+	got, err := provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeChat, &limit)
+	require.NoError(t, err)
+	require.Equal(t, limit, got)
+	patches := upstream.recorded()[patchesBefore:]
+	require.Len(t, patches, 1)
+	require.JSONEq(t, `{"limit":77,"limit_reset":"monthly"}`, patches[0])
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+	require.EqualValues(t, 77, row.MonthlyCredits)
+}

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -2,7 +2,6 @@ package openrouter
 
 import (
 	"fmt"
-	"net/http"
 	"sync"
 	"testing"
 
@@ -55,6 +54,8 @@ func TestRemoveAPIKeyDisableCauseMatrix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := t.Context()
 			orgID := "org-" + uuid.NewString()[:8]
 			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
@@ -111,7 +112,7 @@ func TestRemoveAPIKeyDisableCauseRecoversLegacyZeroLimit(t *testing.T) {
 	require.NoError(t, err)
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
 	require.NoError(t, err)
-	_, err = queries.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: row.KeyHash, MonthlyCredits: 0, ReinstateLegacy: false})
+	_, err = queries.UpdateOpenRouterKey(ctx, repo.UpdateOpenRouterKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: row.KeyHash, MonthlyCredits: 0, Reinstate: false})
 	require.NoError(t, err)
 	patchesBefore := len(upstream.recorded())
 
@@ -160,10 +161,63 @@ func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
 	require.False(t, row.Disabled)
 }
 
+func TestRemoveAPIKeyDisableCauseUsesCanonicalDistinctCauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate sole cause is the last cause", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		orgID := "org-" + uuid.NewString()[:8]
+		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+		_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+		require.NoError(t, err)
+		require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: []string{"admin_lock", "admin_lock"}}))
+		patchesBefore := len(upstream.recorded())
+
+		_, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+		require.NoError(t, err)
+		require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+		patches := upstream.recorded()[patchesBefore:]
+		require.Len(t, patches, 1)
+		require.JSONEq(t, `{"disabled":false}`, patches[0])
+		row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+		require.NoError(t, err)
+		require.Empty(t, row.DisableCauses)
+		require.False(t, row.Disabled)
+	})
+
+	t.Run("non-last removal preserves a drifted disabled mirror", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		orgID := "org-" + uuid.NewString()[:8]
+		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+		_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+		require.NoError(t, err)
+		require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: false, DisableCauses: []string{"trial_demotion", "admin_lock"}}))
+		before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+		require.NoError(t, err)
+		patchesBefore := len(upstream.recorded())
+
+		_, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion, new(42))
+		require.NoError(t, err)
+		require.Equal(t, DisableCauseChange{CauseChanged: true}, change)
+		require.Len(t, upstream.recorded(), patchesBefore)
+		row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+		require.NoError(t, err)
+		require.Equal(t, []string{"admin_lock"}, row.DisableCauses)
+		require.False(t, row.Disabled)
+		require.Equal(t, before.MonthlyCredits, row.MonthlyCredits)
+	})
+}
+
 func TestRemoveAPIKeyDisableCauseMissingAndUnclassifiedFailClosed(t *testing.T) {
 	t.Parallel()
 
 	t.Run("missing key is a no-op", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := t.Context()
 		orgID := "org-" + uuid.NewString()[:8]
 		provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
@@ -175,6 +229,8 @@ func TestRemoveAPIKeyDisableCauseMissingAndUnclassifiedFailClosed(t *testing.T) 
 	})
 
 	t.Run("NULL classification fails closed", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := t.Context()
 		orgID := "org-" + uuid.NewString()[:8]
 		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
@@ -199,10 +255,12 @@ func TestRemoveAPIKeyDisableCauseUpstreamFailureAndHashMismatchLeaveLocalUnchang
 		name      string
 		configure func(*disableTestUpstream)
 	}{
-		{name: "upstream failure", configure: func(u *disableTestUpstream) { u.respondToPatchesWith(http.StatusBadGateway) }},
+		{name: "upstream failure", configure: func(u *disableTestUpstream) { u.server.Close() }},
 		{name: "hash mismatch", configure: func(u *disableTestUpstream) { u.respondWithPatchHash("wrong-hash") }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := t.Context()
 			orgID := "org-" + uuid.NewString()[:8]
 			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
@@ -237,7 +295,7 @@ func TestRemoveAPIKeyDisableCauseRotationConflictRetryConverges(t *testing.T) {
 	require.NoError(t, err)
 	upstream.interceptPatch(func() {
 		upstream.interceptPatch(nil)
-		_, rotateErr := provisioner.db.Exec(ctx, `UPDATE openrouter_api_keys SET key_hash = 'hash-2' WHERE organization_id = $1 AND key_type = $2`, orgID, string(KeyTypeChat))
+		rotateErr := testrepo.New(provisioner.db).SetOpenRouterAPIKeyHashFixture(ctx, testrepo.SetOpenRouterAPIKeyHashFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: "hash-2"})
 		require.NoError(t, rotateErr)
 	})
 

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -130,12 +130,51 @@ func TestRemoveAPIKeyDisableCauseRecoversLegacyZeroLimit(t *testing.T) {
 	require.False(t, row.Disabled)
 }
 
+func TestAddDisableCauseReconcilesUpstreamAfterRolledBackFinalRemoval(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	_, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock)
+	require.NoError(t, err)
+
+	conn, err := provisioner.db.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+	tx, err := conn.Begin(ctx) //nolint:glint // this transaction only uses SQLc methods and must roll back a local mirror after the upstream call
+	require.NoError(t, err)
+	lockParams := repo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)}
+	require.NoError(t, repo.New(tx).AcquireOpenRouterKeyBillingLock(ctx, lockParams))
+	_, change, err := provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, tx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	require.NoError(t, tx.Rollback(ctx))
+	unlocked, err := repo.New(conn).ReleaseOpenRouterKeyBillingLock(ctx, repo.ReleaseOpenRouterKeyBillingLockParams(lockParams))
+	require.NoError(t, err)
+	require.True(t, unlocked)
+
+	patchesBefore := len(upstream.recorded())
+	change, err = provisioner.AddAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: false}, change)
+	patches := upstream.recorded()[patchesBefore:]
+	require.Len(t, patches, 1)
+	require.JSONEq(t, `{"disabled":true}`, patches[0])
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin_lock", "trial_demotion"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+}
+
 func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
 	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
 	require.NoError(t, err)
 	conn, err := provisioner.db.Acquire(ctx)
@@ -152,6 +191,16 @@ func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
 	change, err := provisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseAdminLock)
 	require.NoError(t, err)
 	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)
+	patchesBefore := len(upstream.recorded())
+	change, err = provisioner.AddAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseTrialDemotion)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: false}, change)
+	patches := upstream.recorded()[patchesBefore:]
+	require.Len(t, patches, 1)
+	require.JSONEq(t, `{"disabled":true}`, patches[0])
+	_, change, err = provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseTrialDemotion, nil)
+	require.NoError(t, err)
+	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: false}, change)
 	_, change, err = provisioner.RemoveAPIKeyDisableCauseWithDB(ctx, conn, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
 	require.NoError(t, err)
 	require.Equal(t, DisableCauseChange{CauseChanged: true, KeyAccessChanged: true}, change)

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -301,7 +301,7 @@ SET disable_causes = CASE
     END,
     disabled = CASE
       WHEN $1::text = ANY(disable_causes)
-        THEN cardinality(array_remove(disable_causes, $1::text)) > 0
+        AND cardinality(array_remove(disable_causes, $1::text)) = 0 THEN FALSE
       ELSE disabled
     END,
     monthly_credits = CASE

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -283,6 +283,81 @@ func (q *Queries) ReleaseOpenRouterKeyBillingLock(ctx context.Context, arg Relea
 	return unlocked, err
 }
 
+const removeOpenRouterAPIKeyDisableCause = `-- name: RemoveOpenRouterAPIKeyDisableCause :one
+UPDATE openrouter_api_keys
+SET disable_causes = CASE
+      WHEN $1::text = ANY(disable_causes) THEN ARRAY(
+        SELECT cause
+        FROM unnest(array_remove(disable_causes, $1::text)) AS causes(cause)
+        GROUP BY cause
+        ORDER BY CASE cause
+          WHEN 'admin_lock' THEN 1
+          WHEN 'trial_demotion' THEN 2
+          WHEN 'billing_inactive' THEN 3
+          ELSE 4
+        END, cause
+      )
+      ELSE disable_causes
+    END,
+    disabled = CASE
+      WHEN $1::text = ANY(disable_causes)
+        THEN cardinality(array_remove(disable_causes, $1::text)) > 0
+      ELSE disabled
+    END,
+    monthly_credits = CASE
+      WHEN $1::text = ANY(disable_causes) AND $2::boolean
+        THEN $3::bigint
+      ELSE monthly_credits
+    END,
+    updated_at = CASE
+      WHEN $1::text = ANY(disable_causes)
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = $4
+  AND key_type = $5
+  AND key_hash = $6
+  AND disable_causes IS NOT NULL
+  AND deleted IS FALSE
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, disable_causes, created_at, updated_at, deleted_at, deleted
+`
+
+type RemoveOpenRouterAPIKeyDisableCauseParams struct {
+	DisableCause         string
+	UpdateMonthlyCredits bool
+	MonthlyCredits       int64
+	OrganizationID       string
+	KeyType              string
+	KeyHash              string
+}
+
+func (q *Queries) RemoveOpenRouterAPIKeyDisableCause(ctx context.Context, arg RemoveOpenRouterAPIKeyDisableCauseParams) (OpenrouterApiKey, error) {
+	row := q.db.QueryRow(ctx, removeOpenRouterAPIKeyDisableCause,
+		arg.DisableCause,
+		arg.UpdateMonthlyCredits,
+		arg.MonthlyCredits,
+		arg.OrganizationID,
+		arg.KeyType,
+		arg.KeyHash,
+	)
+	var i OpenrouterApiKey
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.KeyType,
+		&i.Key,
+		&i.KeyEncrypted,
+		&i.KeyHash,
+		&i.MonthlyCredits,
+		&i.Disabled,
+		&i.DisableCauses,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
 SET monthly_credits = $1, key_hash = $2,

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -61,6 +61,14 @@ func (m *mockProvisioner) ProvisionedKeyTypes() []KeyType {
 	return out
 }
 
+func (m *mockProvisioner) AddAPIKeyDisableCause(context.Context, string, KeyType, DisableCause) (DisableCauseChange, error) {
+	return DisableCauseChange{}, nil
+}
+
+func (m *mockProvisioner) RemoveAPIKeyDisableCause(context.Context, string, KeyType, DisableCause, *int) (int, DisableCauseChange, error) {
+	return 0, DisableCauseChange{}, nil
+}
+
 func (m *mockProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error) {
 	return 0, nil
 }

--- a/server/internal/usage/impl_test.go
+++ b/server/internal/usage/impl_test.go
@@ -164,6 +164,14 @@ func (p *recordingOpenRouterProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Co
 	return p.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
 }
 
+func (*recordingOpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*recordingOpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
+}
+
 func (*recordingOpenRouterProvisioner) DisableAPIKey(context.Context, string, openrouter.KeyType) error {
 	return fmt.Errorf("not implemented")
 }

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -130,11 +130,11 @@ func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db o
 		return 0, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	refreshed, err := openrouterrepo.New(db).UpdateOpenRouterKey(ctx, openrouterrepo.UpdateOpenRouterKeyParams{
-		MonthlyCredits:  int64(*limit),
-		KeyHash:         key.KeyHash,
-		ReinstateLegacy: key.Disabled,
-		OrganizationID:  organizationID,
-		KeyType:         string(keyType),
+		MonthlyCredits: int64(*limit),
+		KeyHash:        key.KeyHash,
+		Reinstate:      key.Disabled,
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("update OpenRouter API key: %w", err)

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -130,17 +130,25 @@ func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db o
 		return 0, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	refreshed, err := openrouterrepo.New(db).UpdateOpenRouterKey(ctx, openrouterrepo.UpdateOpenRouterKeyParams{
-		MonthlyCredits: int64(*limit),
-		KeyHash:        key.KeyHash,
-		Reinstate:      key.Disabled,
-		OrganizationID: organizationID,
-		KeyType:        string(keyType),
+		MonthlyCredits:  int64(*limit),
+		KeyHash:         key.KeyHash,
+		ReinstateLegacy: key.Disabled,
+		OrganizationID:  organizationID,
+		KeyType:         string(keyType),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("update OpenRouter API key: %w", err)
 	}
 	p.refreshCalls = append(p.refreshCalls, keyType)
 	return int(refreshed.MonthlyCredits), nil
+}
+
+func (*m3OpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, nil
+}
+
+func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, nil
 }
 
 func (p *m3OpenRouterProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {


### PR DESCRIPTION
<!-- stack-narrative:start -->
## Why this PR exists

Once a key has a trustworthy cause set, application code needs to change one cause without replacing the entire disabled state. Re-arming a trial, for example, may remove `trial_demotion`, but it must preserve an administrator lock or billing restriction.

## What changes in this layer

This PR introduces the core cause-aware mutation model. Callers add or remove a specific cause under the canonical per-key lock. Desired local state commits before OpenRouter reconciliation, duplicate changes are no-ops, unknown causes are preserved, and legacy `NULL` cause sets fail closed.

## How it advances the stack

This establishes the ownership rule used by the rest of the stack: each workflow may remove only the restriction it owns.
<!-- stack-narrative:end -->

---

## Detailed scope, rollout, and verification

## Rationale

This is Wave C of the deployment-safe AGE-3219 replacement stack. It adds the cause-specific removal primitive needed by later admin and lifecycle callers without performing those cutovers in this PR.

Approved design: [AGE-3219 in Linear](https://linear.app/speakeasy/issue/AGE-3219/re-arming-a-trial-silently-re-enables-a-key-a-platform-admin-locked)

## Scope

- remove only the caller-owned disable cause
- fail closed on unclassified `NULL` cause sets
- preserve unrelated causes and canonical ordering
- keep non-last removal local and disabled
- enable upstream only when removing the final cause
- validate upstream response identity before local persistence
- guard persistence with the stored key hash so rotations cannot affect replacement keys
- serialize standalone mutations with the established per-key advisory lock
- provide caller-locked `WithDB` primitives for later atomic admin/lifecycle integration

## Stack and rollout gate

- base: #5835 (Wave B compatibility/backfill)
- predecessor: #5828 (Wave A schema expand)

This PR must not merge until Wave A is verified in production and Wave B has passed its deployment gate. It does not perform admin, lifecycle, API, UI, backfill execution, or contract migration cutover.

## Verification

- independent pre- and post-restack review: approved
- focused OpenRouter package: 233 tests passed
- affected adapters compile
- `mise run gen:sqlc-server` with no diff
- `mise run lint:server`
- `mise run build:server --readonly`
- patch-identical range-diff across final restack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the cause-specific OpenRouter disable-cause add and remove primitives (Wave C of AGE-3219) so later admin and lifecycle cutovers can disable or recover a key without silently undoing another party's lockdown. Previously any disable was a single boolean; now `disable_causes` tracks independent `admin_lock`, `trial_demotion`, and `billing_inactive` causes, and a key re-enables only when its final cause clears. No admin or lifecycle cutover ships here.

**Behavior**
- Adding a cause always patches upstream disabled, so a rolled-back final removal can't leave the upstream key enabled while the local mirror keeps causes.
- Removal patches upstream only on the final cause, validates the upstream key hash, re-reads the row before persisting, and fills a legacy zero limit from the org default on recovery.
- Leftover causes are deduped and canonicalized; no-op removals leave `updated_at` untouched.
- Concurrent rotation or cause changes surface as retry-convergent errors without losing a cause; `WithDB` variants keep all local reads and writes on the caller's locked connection.
- Generic limit refresh and legacy `DisableAPIKey`/`ReinstateAPIKeyLimit*` never change causes.
- The development provisioner and admin-key test stubs now mirror cause behavior locally; unrelated benches and mocks get no-op implementations.
- Unclassified `NULL` cause sets fail closed until Wave B validation clears them.
- Merging depends on Waves A and B being verified in production first.

<sup>Written for commit c84a7f2dd3750c0e5618078049db21f2fc6751f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


