### PR TITLE
fix: remove authentication form feature gate

### DIFF
--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -1,8 +1,4 @@
-import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { randomSlugSuffix } from "@/lib/slug";
-
-export const ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG =
-  FEATURE_FLAGS.externalMcpUserSessions;
 
 export const DEFAULT_USER_SESSION_DURATION_HOURS = 24 * 14;
 

--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -5,7 +5,6 @@ export const FEATURE_FLAGS = {
   deviceAgent: "gram-device-agent",
   deviceIntegrations: "gram-device-integrations",
   experimentalChat: "gram-experimental-chat",
-  externalMcpUserSessions: "onboard-external-mcp-to-user-sessions",
   functions: "gram-functions",
   gatewayEndpoints: "gram-gateway-endpoints",
   headlessModeSwitcher: "headless-mode-switcher",

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -48,7 +48,6 @@ import {
   EXCLUDED_TAG_KEY,
   MCPToolFilterScopesPanel,
 } from "@/pages/mcp/MCPToolFilterScopesPanel";
-import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import {
   getOAuthParadigm,
   isUserSessionIssuerWired,
@@ -607,10 +606,6 @@ export function MCPStatusDropdown({
     const needsConvertBlock =
       status === "private" &&
       mustConvertOAuthBeforePrivate({
-        flagEnabled:
-          telemetry.isFeatureEnabled(
-            ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG,
-          ) ?? false,
         mcpIsPublic: toolset.mcpIsPublic ?? false,
         userSessionIssuerWired: isUserSessionIssuerWired(toolset),
         oauthParadigm: getOAuthParadigm(toolset),

--- a/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
+++ b/client/dashboard/src/pages/mcp/MCPEnvironmentSettings.tsx
@@ -11,7 +11,6 @@ import {
 import { useSession } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useMissingRequiredEnvVars } from "@/hooks/useMissingEnvironmentVariables";
-import { ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG } from "@/lib/externalMcpUserSessions";
 import { Toolset } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import type { McpEnvironmentConfigInput } from "@gram/client/models/components/mcpenvironmentconfiginput.js";
@@ -58,8 +57,6 @@ import {
   isUserSessionIssuerWired,
   type OAuthParadigm,
   toolsetAuthSurface,
-  type ToolsetConvertAction,
-  toolsetConvertAction,
 } from "./toolsetAuthSurface";
 import { useEnvironmentVariables } from "./useEnvironmentVariables";
 
@@ -946,12 +943,8 @@ type OAuthSectionProps = {
  * convert path.
  */
 function OAuthSection({ toolset }: OAuthSectionProps) {
-  const telemetry = useTelemetry();
   const oauthParadigm = getOAuthParadigm(toolset);
   const surface = toolsetAuthSurface({
-    flagEnabled:
-      telemetry.isFeatureEnabled(ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG) ??
-      false,
     userSessionIssuerWired: isUserSessionIssuerWired(toolset),
     oauthParadigm,
   });
@@ -959,23 +952,10 @@ function OAuthSection({ toolset }: OAuthSectionProps) {
   if (surface === "manage" || surface === "attach") {
     return <ToolsetAuthenticationSection toolset={toolset} />;
   }
-  return (
-    <LegacyOAuthSection
-      toolset={toolset}
-      convertAction={
-        surface === "legacy" ? toolsetConvertAction(oauthParadigm) : null
-      }
-    />
-  );
+  return <LegacyOAuthSection toolset={toolset} />;
 }
 
-function LegacyOAuthSection({
-  toolset,
-  convertAction,
-}: OAuthSectionProps & {
-  /** Migration entry point to render; null when the flag is off. */
-  convertAction: ToolsetConvertAction | null;
-}) {
+function LegacyOAuthSection({ toolset }: OAuthSectionProps) {
   const [isOAuthModalOpen, setIsOAuthModalOpen] = useState(false);
   const [isOAuthDetailsModalOpen, setIsOAuthDetailsModalOpen] = useState(false);
 
@@ -1002,9 +982,8 @@ function LegacyOAuthSection({
     ? "Enable the MCP server to configure OAuth"
     : "This MCP server does not require the OAuth authorization code flow";
 
-  // Flag holders with a wired issuer never reach this component (the
-  // dispatcher sends them to the manage surface), but non-holders can land
-  // here wired, so the legacy display still handles it.
+  // The dispatcher sends wired issuers to the manage surface. Keep this
+  // defensive check aligned in case the legacy section is reused directly.
   const userSessionIssuerWired = !!toolset.userSessionIssuerSlug;
   // Once wired, the external OAuth config is inert — hide Configure so
   // operators aren't steered back into the legacy paradigm.
@@ -1025,9 +1004,7 @@ function LegacyOAuthSection({
               <Badge.Text>Login Secured</Badge.Text>
             </Badge>
           )}
-          {convertAction === "attach-sheet" && (
-            <ConvertToUserSessionsButton toolset={toolset} />
-          )}
+          <ConvertToUserSessionsButton toolset={toolset} />
           {!hideConfigureButton && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
@@ -8,43 +8,23 @@ import {
   isUserSessionIssuerWired,
   mustConvertOAuthBeforePrivate,
   toolsetAuthSurface,
-  toolsetConvertAction,
 } from "./toolsetAuthSurface";
 
 describe("toolsetAuthSurface", () => {
-  it("shows the unchanged legacy UI when the flag is off, regardless of state", () => {
-    expect(
-      toolsetAuthSurface({
-        flagEnabled: false,
-        userSessionIssuerWired: true,
-        oauthParadigm: "external",
-      }),
-    ).toBe("legacy-only");
-    expect(
-      toolsetAuthSurface({
-        flagEnabled: false,
-        userSessionIssuerWired: false,
-        oauthParadigm: null,
-      }),
-    ).toBe("legacy-only");
-  });
-
   it("shows the manage surface once a user_session_issuer is wired", () => {
     expect(
       toolsetAuthSurface({
-        flagEnabled: true,
         userSessionIssuerWired: true,
         oauthParadigm: null,
       }),
     ).toBe("manage");
   });
 
-  it("prefers the manage surface over leftover legacy config", () => {
+  it("always prefers the manage surface over leftover legacy config", () => {
     // Wired toolsets keep their inert external OAuth config; the wired issuer
     // is what gates the serve path, so it wins the tiebreak.
     expect(
       toolsetAuthSurface({
-        flagEnabled: true,
         userSessionIssuerWired: true,
         oauthParadigm: "external",
       }),
@@ -55,7 +35,6 @@ describe("toolsetAuthSurface", () => {
     for (const oauthParadigm of ["external"] as const) {
       expect(
         toolsetAuthSurface({
-          flagEnabled: true,
           userSessionIssuerWired: false,
           oauthParadigm,
         }),
@@ -66,21 +45,10 @@ describe("toolsetAuthSurface", () => {
   it("shows the attach surface when nothing is configured", () => {
     expect(
       toolsetAuthSurface({
-        flagEnabled: true,
         userSessionIssuerWired: false,
         oauthParadigm: null,
       }),
     ).toBe("attach");
-  });
-});
-
-describe("toolsetConvertAction", () => {
-  it("routes external OAuth through the attach sheet", () => {
-    expect(toolsetConvertAction("external")).toBe("attach-sheet");
-  });
-
-  it("offers no convert path without a legacy paradigm", () => {
-    expect(toolsetConvertAction(null)).toBeNull();
   });
 });
 
@@ -137,7 +105,6 @@ describe("mustConvertOAuthBeforePrivate", () => {
     for (const oauthParadigm of ["external"] as const) {
       expect(
         mustConvertOAuthBeforePrivate({
-          flagEnabled: true,
           mcpIsPublic: true,
           userSessionIssuerWired: false,
           oauthParadigm,
@@ -146,21 +113,9 @@ describe("mustConvertOAuthBeforePrivate", () => {
     }
   });
 
-  it("keeps today's silent clear when the flag is off (no convert path)", () => {
-    expect(
-      mustConvertOAuthBeforePrivate({
-        flagEnabled: false,
-        mcpIsPublic: true,
-        userSessionIssuerWired: false,
-        oauthParadigm: "external",
-      }),
-    ).toBe(false);
-  });
-
   it("allows the flip once a user session issuer is wired (leftover config is inert)", () => {
     expect(
       mustConvertOAuthBeforePrivate({
-        flagEnabled: true,
         mcpIsPublic: true,
         userSessionIssuerWired: true,
         oauthParadigm: "external",
@@ -171,7 +126,6 @@ describe("mustConvertOAuthBeforePrivate", () => {
   it("does not block without OAuth config or when already private", () => {
     expect(
       mustConvertOAuthBeforePrivate({
-        flagEnabled: true,
         mcpIsPublic: true,
         userSessionIssuerWired: false,
         oauthParadigm: null,
@@ -179,7 +133,6 @@ describe("mustConvertOAuthBeforePrivate", () => {
     ).toBe(false);
     expect(
       mustConvertOAuthBeforePrivate({
-        flagEnabled: true,
         mcpIsPublic: false,
         userSessionIssuerWired: false,
         oauthParadigm: "external",

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
@@ -30,43 +30,20 @@ export type ToolsetAuthSurface =
   // legacy OAuth configured, unwired → legacy UI plus a convert path.
   | "legacy"
   // nothing configured → shared section, attach state.
-  | "attach"
-  // flag off → pre-user-sessions UI, unchanged.
-  | "legacy-only";
+  | "attach";
 
 export function toolsetAuthSurface({
-  flagEnabled,
   userSessionIssuerWired,
   oauthParadigm,
 }: {
-  flagEnabled: boolean;
   userSessionIssuerWired: boolean;
   oauthParadigm: OAuthParadigm | null;
 }): ToolsetAuthSurface {
-  if (!flagEnabled) return "legacy-only";
   // A wired issuer always wins: the serve path gates on it and any leftover
   // legacy OAuth config is inert.
   if (userSessionIssuerWired) return "manage";
   if (oauthParadigm) return "legacy";
   return "attach";
-}
-
-/**
- * Convert path offered on the "legacy" surface. External OAuth has no upstream
- * client to clone, so it converts by attaching a fresh provider via the attach
- * sheet.
- */
-export type ToolsetConvertAction = "attach-sheet";
-
-export function toolsetConvertAction(
-  oauthParadigm: OAuthParadigm | null,
-): ToolsetConvertAction | null {
-  switch (oauthParadigm) {
-    case "external":
-      return "attach-sheet";
-    case null:
-      return null;
-  }
 }
 
 /**
@@ -93,26 +70,18 @@ export function canConfigureExternalOAuth(
  * Whether the public→private flip must be blocked pending OAuth conversion.
  * The backend silently clears external OAuth / OAuth proxy config on any
  * mcp_is_public flip (UpdateToolset in server/internal/toolsets/impl.go).
- * A wired issuer makes leftover config inert, so the flip is safe. Flag off
- * keeps today's silent behavior since no convert path exists there.
+ * A wired issuer makes leftover config inert, so the flip is safe.
  */
 export function mustConvertOAuthBeforePrivate({
-  flagEnabled,
   mcpIsPublic,
   userSessionIssuerWired,
   oauthParadigm,
 }: {
-  flagEnabled: boolean;
   mcpIsPublic: boolean;
   userSessionIssuerWired: boolean;
   oauthParadigm: OAuthParadigm | null;
 }): boolean {
-  return (
-    flagEnabled &&
-    mcpIsPublic &&
-    !userSessionIssuerWired &&
-    oauthParadigm !== null
-  );
+  return mcpIsPublic && !userSessionIssuerWired && oauthParadigm !== null;
 }
 
 /**

--- a/docs/toolset-remote-session-config.md
+++ b/docs/toolset-remote-session-config.md
@@ -12,20 +12,19 @@ Bring the remote-MCP-server identity-provider configuration (user session issuer
 1. Frontend-only, single PR. Backend already type-agnostic: the serve path gates on `toolsets.user_session_issuer_id`, and when it is set the issuer gate wins and the legacy OAuth chain is skipped entirely (`server/internal/mcp/impl.go`, ~line 642, `runInToolsetGate`).
 2. Shared components parameterized by an `AuthTarget` interface (state-context composition pattern). Remote target links via `mcpServers.update` (keeps its visibility-private side effect); toolset target links via `toolsets.setUserSessionIssuer` and touches nothing else (no `mcpEnabled`/`mcpIsPublic` changes).
 3. State matrix on the toolset Authentication tab, USI-first tiebreak:
-   - Flag off: today's UI, byte-for-byte (`legacy-only`).
    - USI wired: shared manage surface only, even if inert legacy config remains (`manage`).
    - Legacy OAuth configured, unwired: legacy UI plus a convert path (`legacy`). Proxy/gram paradigms convert via the existing wire modal; external OAuth converts via the attach sheet with the issuer URL prefilled from the stored RFC 8414 metadata.
    - Nothing configured: shared attach surface only, legacy wizard unreachable (`attach`).
 4. No full USI unlink anywhere. Once wired, the link is permanent; only the RSI/RSC layer is tweakable (add/edit/remove identity providers).
 5. Convert leaves legacy config in the DB inert (wire-modal precedent). No `removeOAuthServer` call.
-6. Whole matrix gated behind the existing `ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG` PostHog flag. In local dev, `devTelemetry` returns true for every flag, so the new surfaces always show locally.
+6. The matrix is enabled for every user.
 
 ## What changed (all in `client/dashboard/src/pages/mcp/`)
 
 New files:
 
 - `x/tabs/settings/sections/authentication/authTarget.ts`: `AuthTarget` type plus `useMcpServerAuthTarget` and `useToolsetAuthTarget` hooks. Each supplies `slug`, `userSessionIssuerId`, optional `remoteMcpServerId` (probe seed, undefined for toolsets so the RFC 9728 probe stays idle), `linkUserSessionIssuer`, and `invalidate`.
-- `toolsetAuthSurface.ts`: pure matrix logic. `getOAuthParadigm` (moved out of MCPEnvironmentSettings), `toolsetAuthSurface`, `toolsetConvertAction`, `externalOauthIssuerUrl`. Note: `toolsetConvertAction` uses `case null` because oxlint enforces switch exhaustiveness.
+- `toolsetAuthSurface.ts`: pure matrix logic. `getOAuthParadigm` (moved out of MCPEnvironmentSettings), `toolsetAuthSurface`, and `externalOauthIssuerUrl`.
 - `toolsetAuthSurface.test.ts`: 13 unit tests, all passing.
 - `ToolsetAuthenticationSection.tsx`: toolset-page chrome. `ToolsetAuthenticationSection` renders a PageSection "Authentication" wrapping `AuthenticationSectionBody`, plus a PageSection "User sessions" wrapping `UserSessionsList` when wired. `ConvertToUserSessionsButton` is the external-OAuth convert entry (opens the attach sheet with `userSessionIssuer={null}` and all project issuers selectable).
 
@@ -34,8 +33,8 @@ Modified files:
 - `x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx`: prop `mcpServer: McpServer` replaced by `target: AuthTarget`. Slug seeding uses `target.slug`, step 4 first-add link is `target.linkUserSessionIssuer(issuerId)`, and target-specific invalidations go through `target.invalidate(queryClient)` alongside the common USI/RSI/RSC ones.
 - `x/tabs/settings/sections/authentication/AuthenticationSection.tsx`: split into chrome-free exported `AuthenticationSectionBody({ target })` (all queries, fields, and the attach/modify/delete overlays) and the thin `AuthenticationSection({ mcpServer })` wrapper that keeps the SettingsSection chrome and sessions panel. Remote page output unchanged. Gotcha: body converts `target.userSessionIssuerId` (string | null) to undefined for the SDK hooks.
 - `x/tabs/settings/sections/authentication/McpServerSessionsPanel.tsx`: inner list extracted as exported chrome-free `UserSessionsList({ issuerId })`; the panel wrapper is unchanged.
-- `MCPDetails.tsx`: `MCPStatusDropdown` now blocks the public→private flip while legacy OAuth is configured unwired. Backend (`UpdateToolset`, `server/internal/toolsets/impl.go` ~line 413) silently clears external OAuth / OAuth proxy config on any `mcp_is_public` flip; the new `mustConvertOAuthBeforePrivate` guard (in `toolsetAuthSurface.ts`, unit tested) shows a blocking inform-only dialog ("The existing OAuth configuration must be converted to a session issuer before this MCP server can be made private") instead of applying the update. Flag-gated like the rest of the matrix (flag off keeps today's silent clear); once a USI is wired the flip is allowed since leftover config is inert. Guards on `toolset.mcpIsPublic`, not the dropdown's current status, so a disabled-but-still-public server is covered too.
-- `MCPEnvironmentSettings.tsx`: `OAuthSection` is now a small dispatcher (computes paradigm + surface, routes to `ToolsetAuthenticationSection` or legacy). The old body is renamed `LegacyOAuthSection` and takes `convertAction: ToolsetConvertAction | null`; `showWireUserSessionIssuer` is now just `convertAction === "wire-modal"`, and an `attach-sheet` convertAction renders `ConvertToUserSessionsButton` next to it. Everything else in the legacy component (modals, status display, badges) is untouched.
+- `MCPDetails.tsx`: `MCPStatusDropdown` now blocks the public→private flip while legacy OAuth is configured unwired. Backend (`UpdateToolset`, `server/internal/toolsets/impl.go` ~line 413) silently clears external OAuth / OAuth proxy config on any `mcp_is_public` flip; the `mustConvertOAuthBeforePrivate` guard (in `toolsetAuthSurface.ts`, unit tested) shows a blocking inform-only dialog ("The existing OAuth configuration must be converted to a session issuer before this MCP server can be made private") instead of applying the update. The guard applies to every user; once a USI is wired the flip is allowed since leftover config is inert. It guards on `toolset.mcpIsPublic`, not the dropdown's current status, so a disabled-but-still-public server is covered too.
+- `MCPEnvironmentSettings.tsx`: `OAuthSection` is now a small dispatcher (computes paradigm + surface, routes to `ToolsetAuthenticationSection` or legacy). The old body is renamed `LegacyOAuthSection`; because external OAuth is the only remaining legacy paradigm, it renders `ConvertToUserSessionsButton` directly. Everything else in the legacy component (modals, status display, badges) is untouched.
 
 Untouched on purpose: `WireUserSessionIssuerModal` and its machine, `ModifyRemoteIdentityProviderSheet`, `DeleteRemoteIdentityProviderDialog` (both already target-agnostic, keyed by USI/RSI ids only), all backend code.
 


### PR DESCRIPTION
## Summary

- Make the user-session Authentication management surface available to every toolset MCP server without a feature flag.
- Preserve the legacy external OAuth conversion flow and the guard that prevents unsafe public-to-private transitions.
- Remove the retired flag registration, dead conversion abstractions, flag-specific tests, and stale documentation.

## Motivation

Toolsets with an existing user-session issuer could be routed to the legacy OAuth status panel when the rollout flag was disabled. That panel showed authentication as secured but did not let users manage the configuration. The user-session surface is now the single management path for wired and newly configured toolsets.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the feature flag gating the user-session authentication surface so every toolset MCP server gets the single management path.

- Toolsets with a wired user-session issuer now always see the manage surface, instead of falling back to the legacy read-only OAuth panel when the flag was off.
- The external OAuth convert button and the public-to-private conversion guard now apply to all users, not just flag holders.
- Deletes the retired flag registration, the dead `toolsetConvertAction` abstraction, flag-specific tests, and stale docs.

<sup>Written for commit dd0a1776abab02766d8ebefb9c42e74edbade784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

