### PR TITLE
fix: keep Attach Provider available after the first provider

### DIFF
--- a/.changeset/attach-provider-repeat.md
+++ b/.changeset/attach-provider-repeat.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Keep the Attach Provider action available after the first remote identity provider is attached

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
@@ -71,6 +71,16 @@ describe("RemoteIdentityProvidersField", () => {
     vi.clearAllMocks();
   });
 
+  // The gateway (meta MCP) case attaches one provider per member vendor, so
+  // the add action must survive past the first attachment.
+  it("keeps Attach Provider available once providers exist", () => {
+    renderField([issuer()]);
+
+    expect(
+      screen.getByRole("button", { name: /attach provider/i }),
+    ).toBeTruthy();
+  });
+
   it("links the provider name to its detail page", () => {
     renderField([issuer()]);
 

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -59,6 +59,14 @@ export function RemoteIdentityProvidersField({
             onDelete={() => onDelete(issuer)}
           />
         ))}
+        <RequireScope scope="mcp:write" level="component">
+          <Button variant="secondary" onClick={onAdd}>
+            <Button.LeftIcon>
+              <Plus className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text>Attach Provider</Button.Text>
+          </Button>
+        </RequireScope>
       </div>
     );
   }


### PR DESCRIPTION
The Attach Provider action in the authentication settings' Remote Identity Providers section only existed inside the empty state, so once a first provider was attached there was no way to attach another from the UI.

Single-provider servers never exposed this; a gateway (meta MCP server) attaches one provider per member vendor and hits it immediately.

Fix: render the same scope-gated Attach Provider button below the provider rows in the non-empty state. Regression test pins the button's presence with providers attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Attach Provider button available in the Remote Identity Providers section after the first provider is attached, so multi-provider servers can add more without re-entering an empty state.

**Bug Fixes**
- Renders the same scope-gated Attach Provider button below the provider rows when providers exist.
- Adds a regression test pinning the button's presence with providers attached.

<sup>Written for commit 5907aa7edcc9df503f89eca53a883ef2cd96dd15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

