### PR TITLE
feat: default gateway auth wiring and open the surface to mainstream MCP clients

### DIFF
--- a/.changeset/attach-provider-repeat.md
+++ b/.changeset/attach-provider-repeat.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Keep the Attach Provider action available after the first remote identity provider is attached

--- a/.changeset/gateway-auth-defaults.md
+++ b/.changeset/gateway-auth-defaults.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Collapse gateway auth setup into defaults: creating a meta MCP server mints its sign-in issuer, attaching a member binds its OAuth client to the gateway issuer, the Inspect tab diagnoses anonymous sessions, the member sheet links catalog install-and-attach, and Attach Provider stays available after the first provider

--- a/.changeset/meta-mcp-version-negotiation.md
+++ b/.changeset/meta-mcp-version-negotiation.md
@@ -1,5 +1,5 @@
 ---
-"@gram/server": patch
+"server": patch
 ---
 
 Negotiate MCP protocol versions on gateway endpoints instead of serving only 2026-07-28, so mainstream MCP clients can connect

--- a/.changeset/meta-mcp-version-negotiation.md
+++ b/.changeset/meta-mcp-version-negotiation.md
@@ -1,0 +1,5 @@
+---
+"@gram/server": patch
+---
+
+Negotiate MCP protocol versions on gateway endpoints instead of serving only 2026-07-28, so mainstream MCP clients can connect

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -26281,7 +26281,7 @@ paths:
         name: RemoveMetaMcpMember
   /rpc/metaMcp.update:
     post:
-      description: 'Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.'
+      description: Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
       operationId: updateMetaMcpServer
       parameters:
         - allowEmptyValue: true
@@ -83791,7 +83791,7 @@ components:
           enum:
             - disabled
             - private
-      description: 'Form for updating a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.'
+      description: Form for updating a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer (one is minted if the gateway has none); omitting visibility preserves the stored value.
       required:
         - id
         - name

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -23,6 +23,7 @@ import { Stack } from "@/components/ui/Stack";
 import { SearchXIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Outlet, useNavigate, useSearchParams } from "react-router";
+import { toast } from "sonner";
 import {
   useFilterState as useDimensionFilters,
   type FilterValue,
@@ -73,9 +74,11 @@ function CatalogInner() {
   const attachToGatewayId = searchParams.get("attachToGateway");
 
   const attachInstalledToGateway = async (result: {
+    status: "succeeded" | "failed";
     completedMcpServerIds?: string[];
   }) => {
     if (!attachToGatewayId) return;
+    let attachFailures = 0;
     for (const mcpServerId of result.completedMcpServerIds ?? []) {
       try {
         await client.metaMcp.addMember({
@@ -86,10 +89,22 @@ function CatalogInner() {
         });
       } catch (err) {
         console.error("failed to attach installed server to gateway", err);
+        attachFailures += 1;
       }
     }
     await invalidateAllMetaMcpMembers(queryClient);
-    void navigate(routes.mcp.gateway.members.href(attachToGatewayId));
+    if (attachFailures > 0) {
+      toast.error(
+        attachFailures === 1
+          ? "An installed server could not be added to the gateway. Add it from the gateway's Members tab."
+          : `${attachFailures} installed servers could not be added to the gateway. Add them from the gateway's Members tab.`,
+      );
+    }
+    // Redirect only when everything worked; otherwise stay so the dialog's
+    // per-server results (and the toast above) remain visible.
+    if (result.status === "succeeded" && attachFailures === 0) {
+      void navigate(routes.mcp.gateway.members.href(attachToGatewayId));
+    }
   };
 
   // Category + sort stay page state (no UI to change category today; sort is the

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -7,6 +7,9 @@ import { Text } from "@/components/ui/Text";
 import { useViewMode } from "@/components/ui/ViewToggle/use-view-mode";
 import { useProject } from "@/contexts/Auth";
 import { AddServerDialog } from "@/pages/catalog/AddServerDialog";
+import { useSdkClient } from "@/contexts/Sdk";
+import { invalidateAllMetaMcpMembers } from "@gram/client/react-query/metaMcpMembers.js";
+import { useQueryClient } from "@tanstack/react-query";
 import { CommandBar } from "@/pages/catalog/CommandBar";
 import {
   type PulseMCPServer,
@@ -19,7 +22,7 @@ import { Button } from "@/components/ui/Button";
 import { Stack } from "@/components/ui/Stack";
 import { SearchXIcon } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useNavigate, useSearchParams } from "react-router";
 import {
   useFilterState as useDimensionFilters,
   type FilterValue,
@@ -61,6 +64,33 @@ function CatalogInner() {
   const routes = useRoutes();
   const project = useProject();
   const [searchQuery, setSearchQuery] = useState("");
+  const client = useSdkClient();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  // Deep link from a gateway's Add member sheet: servers installed here get
+  // attached to that gateway as members, and the flow returns to it.
+  const [searchParams] = useSearchParams();
+  const attachToGatewayId = searchParams.get("attachToGateway");
+
+  const attachInstalledToGateway = async (result: {
+    completedMcpServerIds?: string[];
+  }) => {
+    if (!attachToGatewayId) return;
+    for (const mcpServerId of result.completedMcpServerIds ?? []) {
+      try {
+        await client.metaMcp.addMember({
+          addMetaMcpMemberForm: {
+            metaMcpServerId: attachToGatewayId,
+            mcpServerId,
+          },
+        });
+      } catch (err) {
+        console.error("failed to attach installed server to gateway", err);
+      }
+    }
+    await invalidateAllMetaMcpMembers(queryClient);
+    void navigate(routes.mcp.gateway.members.href(attachToGatewayId));
+  };
 
   // Category + sort stay page state (no UI to change category today; sort is the
   // SortDropdown). The five granular filters now run through the unified filter
@@ -266,6 +296,11 @@ function CatalogInner() {
             clearSelection();
           }
         }}
+        onInstallFinished={
+          attachToGatewayId
+            ? (result) => void attachInstalledToGateway(result)
+            : undefined
+        }
       />
       <CommandBar
         selectedCount={selectedServers.size}

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -105,6 +105,7 @@ export function GatewayInspectTab({
           error={error}
           hasUrl={!!connectUrl}
           configuredMembers={rows.length}
+          hasIssuer={!!metaMcpServer.userSessionIssuerId}
           connectUrl={connectUrl}
           headers={headers}
           onRetry={refetch}
@@ -123,6 +124,7 @@ function InspectBody({
   error,
   hasUrl,
   configuredMembers,
+  hasIssuer,
   connectUrl,
   headers,
   onRetry,
@@ -135,6 +137,7 @@ function InspectBody({
   error: Error | null;
   hasUrl: boolean;
   configuredMembers: number;
+  hasIssuer: boolean;
   connectUrl: string | undefined;
   headers: Record<string, string> | undefined;
   onRetry: () => void;
@@ -238,7 +241,9 @@ function InspectBody({
               />
               {data.servers.length < configuredMembers && (
                 <Text muted className="text-xs">
-                  {`${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served to you. Private members need mcp:connect, and members with no gateway dispatch path are excluded.`}
+                  {hasIssuer
+                    ? `${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served to you. Private members need mcp:connect on the member server (Team Access on its page), and disabled, unproxied, or slugless members are never served.`
+                    : `${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served. This gateway has no sign-in attached, so every caller — including this tab — is anonymous and private members are hidden. Attach an issuer under Settings → Authentication.`}
                 </Text>
               )}
             </div>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -351,7 +351,7 @@ function InspectCard({
       </div>
       {/* A member catalog runs to dozens of tools; cap the body so one card
           can't push the rest of the page out of view. */}
-      <div className="border-primary/60 bg-muted/20 max-h-[30lh] overflow-auto border-l-2 px-4 py-3">
+      <div className="border-primary/60 bg-muted/20 max-h-[32rem] overflow-auto border-l-2 px-4 py-3">
         {children}
       </div>
     </div>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -247,7 +247,7 @@ function InspectBody({
               {data.servers.length < configuredMembers && (
                 <Text muted className="text-xs">
                   {hasIssuer
-                    ? `${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served to you. Private members need mcp:connect on the member server (Team Access on its page), and disabled, unproxied, or slugless members are never served.`
+                    ? `${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served to you. Private members need mcp:connect on their backing resource (the member server for proxied members, the backing toolset for hosted members), and disabled, unproxied, or slugless members are never served.`
                     : `${configuredMembers - data.servers.length} of ${configuredMembers} configured members aren't served. This gateway has no sign-in attached, so every caller — including this tab — is anonymous and private members are hidden. Attach an issuer under Settings → Authentication.`}
                 </Text>
               )}

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -349,7 +349,9 @@ function InspectCard({
           </Badge>
         )}
       </div>
-      <div className="border-primary/60 bg-muted/20 border-l-2 px-4 py-3">
+      {/* A member catalog runs to dozens of tools; cap the body so one card
+          can't push the rest of the page out of view. */}
+      <div className="border-primary/60 bg-muted/20 max-h-[30lh] overflow-auto border-l-2 px-4 py-3">
         {children}
       </div>
     </div>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -204,7 +204,13 @@ function InspectBody({
       {/* Left column: the tool surface, then one level down into a member. */}
       <div className="flex flex-col gap-6">
         <InspectCard title="tools/list" meta={`${data.tools.length} tools`}>
-          <CodeSnippet language="js" code={toolSignatures} fontSize="small" />
+          <CodeSnippet
+            language="js"
+            code={toolSignatures}
+            fontSize="small"
+            className="min-h-full"
+            snippetClassName="self-start"
+          />
         </InspectCard>
 
         {(data.servers?.length ?? 0) > 0 && (
@@ -354,9 +360,10 @@ function InspectCard({
           </Badge>
         )}
       </div>
-      {/* A member catalog runs to dozens of tools; cap the body so one card
-          can't push the rest of the page out of view. */}
-      <div className="border-primary/60 bg-muted/20 max-h-[32rem] overflow-auto border-l-2 px-4 py-3">
+      {/* Every card body is the same fixed height: long content (a member's
+          full catalog) scrolls inside it, short content sits in calm space,
+          and the four cards read as one aligned grid. */}
+      <div className="border-primary/60 bg-muted/20 h-[28rem] overflow-auto border-l-2 px-4 py-3">
         {children}
       </div>
     </div>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayInspectTab.tsx
@@ -158,9 +158,14 @@ function InspectBody({
   }
 
   if (needsAuth) {
+    // The common cause is an unconnected upstream provider, not a broken
+    // issuer: a session needs every attached provider connected, so one
+    // missing grant rejects the whole session.
     return (
       <Text muted small>
-        This gateway rejected the dashboard&apos;s session. Check its issuer in{" "}
+        This gateway rejected the dashboard&apos;s session. Every attached
+        identity provider must be connected before it will serve — connect them
+        from the gateway&apos;s sign-in page, or review its providers in{" "}
         <Link to={settingsHref}>Settings</Link>.
       </Text>
     );

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
@@ -532,9 +532,12 @@ function AddMemberSheet({
               placeholder="Search MCP servers..."
             />
           </div>
-          <Button variant="secondary" onClick={onAddFromCatalog}>
-            <Button.Text>Add from catalog</Button.Text>
-          </Button>
+          {/* The catalog install flow is page-gated on project:write. */}
+          <RequireScope scope="project:write" level="component">
+            <Button variant="secondary" onClick={onAddFromCatalog}>
+              <Button.Text>Add from catalog</Button.Text>
+            </Button>
+          </RequireScope>
         </div>
 
         <div className="flex-1 space-y-2 overflow-y-auto px-6 py-4">

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
@@ -25,12 +25,23 @@ import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver
 import { invalidateAllMetaMcpMembers } from "@gram/client/react-query/metaMcpMembers.js";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, Loader2, Plus, Trash2 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Cable,
+  Globe,
+  Loader2,
+  Network,
+  Plus,
+  Server,
+  Trash2,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import {
   classifyMemberServer,
+  memberBackendKind,
   nextSortOrder,
   planReorder,
   type MemberClassification,
@@ -46,6 +57,33 @@ const CLASSIFICATION_LABEL: Record<MemberClassification, string> = {
   slugless: "No slug",
   unknown: "Unknown",
 };
+
+// The gateway's whole point is heterogeneous members behind one URL, so the
+// backend column names each member's actual kind rather than a flat
+// hosted/proxied split.
+const BACKEND_KIND_PRESENTATION = {
+  hosted: { label: "Hosted", Icon: Server },
+  remote: { label: "Remote", Icon: Globe },
+  tunneled: { label: "Tunneled", Icon: Cable },
+} as const;
+
+function BackendKindTag({ row }: { row: MemberRow }): JSX.Element {
+  const kind = memberBackendKind(row.server);
+  if (!kind) {
+    return (
+      <Text muted small>
+        {CLASSIFICATION_LABEL[row.classification]}
+      </Text>
+    );
+  }
+  const { label, Icon } = BACKEND_KIND_PRESENTATION[kind];
+  return (
+    <span className="text-muted-foreground inline-flex items-center gap-1.5 font-mono text-xs tracking-wide uppercase">
+      <Icon className="size-3.5" aria-hidden />
+      {label}
+    </span>
+  );
+}
 
 // Status is backend-attested only, and each state says why: a badge reading
 // "Unknown" with no explanation reads as broken rather than as work the
@@ -86,6 +124,15 @@ const STATUS_BY_CLASSIFICATION: Record<
   },
 };
 
+// A filled green dot for attested health, a hollow ring for "unobserved",
+// amber for excluded: quieter than boxed uppercase badges, and "Unknown"
+// stops reading as broken.
+const STATUS_DOT_CLASS: Record<"success" | "neutral" | "warning", string> = {
+  success: "bg-emerald-500",
+  neutral: "border-muted-foreground/60 border bg-transparent",
+  warning: "bg-amber-500",
+};
+
 function MemberStatusBadge({
   classification,
 }: {
@@ -94,9 +141,15 @@ function MemberStatusBadge({
   const status = STATUS_BY_CLASSIFICATION[classification];
   return (
     <SimpleTooltip tooltip={status.why}>
-      <Badge variant={status.variant}>
-        <Badge.Text>{status.label}</Badge.Text>
-      </Badge>
+      <span className="inline-flex cursor-default items-center gap-2">
+        <span
+          className={`size-2 shrink-0 rounded-full ${STATUS_DOT_CLASS[status.variant]}`}
+          aria-hidden
+        />
+        <Text muted small>
+          {status.label}
+        </Text>
+      </span>
     </SimpleTooltip>
   );
 }
@@ -109,7 +162,7 @@ function MemberNameCell({ row }: { row: MemberRow }): JSX.Element {
     <div className="flex min-w-0 items-center gap-2.5">
       <SourceMcpIcon
         mcpServerId={row.member.mcpServerId}
-        className="size-5 shrink-0 object-contain"
+        className="size-6 shrink-0 object-contain"
       />
       <div className="flex min-w-0 flex-col">
         {row.server ? (
@@ -149,11 +202,7 @@ export function MembersStatusTable({
     {
       key: "backend",
       header: "Backend",
-      render: (row) => (
-        <Text muted small>
-          {CLASSIFICATION_LABEL[row.classification]}
-        </Text>
-      ),
+      render: (row) => <BackendKindTag row={row} />,
       width: "140px",
     },
     {
@@ -175,8 +224,13 @@ export function MembersStatusTable({
       <Table.Header columns={columns} />
       {rows.length === 0 ? (
         <Table.NoResultsMessage>
-          <div className="px-4 py-6 text-center">
-            No members yet. Add MCP servers from the Members tab.
+          <div className="flex flex-col items-center gap-2 px-4 py-10 text-center">
+            <Network className="text-muted-foreground/50 size-8" aria-hidden />
+            <Text className="font-medium">No members yet</Text>
+            <Text muted small>
+              Front your first MCP server through this gateway from the Members
+              tab.
+            </Text>
           </div>
         </Table.NoResultsMessage>
       ) : (
@@ -322,11 +376,7 @@ export function GatewayMembersTab({
     {
       key: "backend",
       header: "Backend",
-      render: (row) => (
-        <Text muted small>
-          {CLASSIFICATION_LABEL[row.classification]}
-        </Text>
-      ),
+      render: (row) => <BackendKindTag row={row} />,
       width: "140px",
     },
     {

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
@@ -146,7 +146,7 @@ function MemberStatusBadge({
           className={`size-2 shrink-0 rounded-full ${STATUS_DOT_CLASS[status.variant]}`}
           aria-hidden
         />
-        <Text muted small>
+        <Text as="span" muted small>
           {status.label}
         </Text>
       </span>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
@@ -430,6 +430,7 @@ export function GatewayMembersTab({
           )
         }
         adding={mutating}
+        projectId={metaMcpServer.projectId}
       />
 
       <Dialog
@@ -486,6 +487,7 @@ function AddMemberSheet({
   onAdd,
   onAddFromCatalog,
   adding,
+  projectId,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -494,6 +496,7 @@ function AddMemberSheet({
   onAdd: (server: McpServer) => void;
   onAddFromCatalog: () => void;
   adding: boolean;
+  projectId: string;
 }): JSX.Element {
   const [search, setSearch] = useState("");
 
@@ -532,8 +535,14 @@ function AddMemberSheet({
               placeholder="Search MCP servers..."
             />
           </div>
-          {/* The catalog install flow is page-gated on project:write. */}
-          <RequireScope scope="project:write" level="component">
+          {/* The catalog install flow is page-gated on project:write;
+              scoping to this gateway's project keeps the check exact when a
+              grant is selector-constrained to specific projects. */}
+          <RequireScope
+            scope="project:write"
+            resourceId={projectId}
+            level="component"
+          >
             <Button variant="secondary" onClick={onAddFromCatalog}>
               <Button.Text>Add from catalog</Button.Text>
             </Button>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersTab.tsx
@@ -19,6 +19,7 @@ import { Text } from "@/components/ui/Text";
 import { useSdkClient } from "@/contexts/Sdk";
 import { mcpServerRouteParam } from "@/lib/sources";
 import { useRoutes } from "@/routes";
+import { useNavigate } from "react-router";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
 import { invalidateAllMetaMcpMembers } from "@gram/client/react-query/metaMcpMembers.js";
@@ -194,6 +195,8 @@ export function GatewayMembersTab({
 }: {
   metaMcpServer: MetaMcpServer;
 }): JSX.Element {
+  const routes = useRoutes();
+  const navigate = useNavigate();
   const client = useSdkClient();
   const queryClient = useQueryClient();
   const { rows, isLoading, servers } = useGatewayMemberRows(metaMcpServer.id);
@@ -419,6 +422,13 @@ export function GatewayMembersTab({
         servers={servers}
         memberServerIds={new Set(rows.map((row) => row.member.mcpServerId))}
         onAdd={(server) => void handleAdd(server)}
+        onAddFromCatalog={() =>
+          void navigate(
+            routes.sources.addFromCatalog.href() +
+              "?attachToGateway=" +
+              metaMcpServer.id,
+          )
+        }
         adding={mutating}
       />
 
@@ -474,6 +484,7 @@ function AddMemberSheet({
   servers,
   memberServerIds,
   onAdd,
+  onAddFromCatalog,
   adding,
 }: {
   open: boolean;
@@ -481,6 +492,7 @@ function AddMemberSheet({
   servers: McpServer[];
   memberServerIds: Set<string>;
   onAdd: (server: McpServer) => void;
+  onAddFromCatalog: () => void;
   adding: boolean;
 }): JSX.Element {
   const [search, setSearch] = useState("");
@@ -512,12 +524,17 @@ function AddMemberSheet({
           </SheetDescription>
         </SheetHeader>
 
-        <div className="px-6 pt-4">
-          <SearchBar
-            value={search}
-            onChange={setSearch}
-            placeholder="Search MCP servers..."
-          />
+        <div className="flex items-center gap-2 px-6 pt-4">
+          <div className="flex-1">
+            <SearchBar
+              value={search}
+              onChange={setSearch}
+              placeholder="Search MCP servers..."
+            />
+          </div>
+          <Button variant="secondary" onClick={onAddFromCatalog}>
+            <Button.Text>Add from catalog</Button.Text>
+          </Button>
         </div>
 
         <div className="flex-1 space-y-2 overflow-y-auto px-6 py-4">

--- a/client/dashboard/src/pages/mcp/gateway/GatewayOverviewTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayOverviewTab.tsx
@@ -47,7 +47,10 @@ export function GatewayOverviewTab({
         <Page.Section.Body>
           <div className="flex flex-col gap-6">
             {mcpUrl ? (
-              <div className="border-border bg-card flex items-center gap-2 border px-3 py-2">
+              <div className="border-border bg-muted/30 flex items-center gap-3 border px-4 py-3">
+                <span className="border-border bg-background text-muted-foreground shrink-0 border px-1.5 py-0.5 font-mono text-[10px] tracking-widest uppercase">
+                  mcp
+                </span>
                 <Text className="min-w-0 flex-1 truncate font-mono text-sm">
                   {mcpUrl}
                 </Text>

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
@@ -176,6 +176,14 @@ describe("memberBackendKind", () => {
     expect(memberBackendKind(undefined)).toBeUndefined();
   });
 
+  it("treats unproxied as kindless even when a backend id is present", () => {
+    expect(
+      memberBackendKind(
+        server({ unproxiedMcpServerId: "u-1", toolsetId: "ts-1" }),
+      ),
+    ).toBeUndefined();
+  });
+
   it("prefers hosted, then tunneled, over remote when multiple ids are set", () => {
     expect(
       memberBackendKind(

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
@@ -4,6 +4,7 @@ import type { MetaMcpMember } from "@gram/client/models/components/metamcpmember
 import {
   buildMemberRows,
   classifyMemberServer,
+  memberBackendKind,
   nextSortOrder,
   planReorder,
 } from "./memberRows";
@@ -156,5 +157,35 @@ describe("nextSortOrder", () => {
 
   it("starts at 0 for an empty gateway", () => {
     expect(nextSortOrder([])).toBe(0);
+  });
+});
+
+describe("memberBackendKind", () => {
+  it("names each backend kind", () => {
+    expect(memberBackendKind(server({ toolsetId: "ts-1" }))).toBe("hosted");
+    expect(memberBackendKind(server({ remoteMcpServerId: "r-1" }))).toBe(
+      "remote",
+    );
+    expect(memberBackendKind(server({ tunneledMcpServerId: "t-1" }))).toBe(
+      "tunneled",
+    );
+  });
+
+  it("returns undefined for servers with no backend and for missing servers", () => {
+    expect(memberBackendKind(server())).toBeUndefined();
+    expect(memberBackendKind(undefined)).toBeUndefined();
+  });
+
+  it("prefers hosted, then tunneled, over remote when multiple ids are set", () => {
+    expect(
+      memberBackendKind(
+        server({ toolsetId: "ts-1", remoteMcpServerId: "r-1" }),
+      ),
+    ).toBe("hosted");
+    expect(
+      memberBackendKind(
+        server({ tunneledMcpServerId: "t-1", remoteMcpServerId: "r-1" }),
+      ),
+    ).toBe("tunneled");
   });
 });

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.ts
@@ -99,6 +99,9 @@ export function memberBackendKind(
   server: McpServer | undefined,
 ): MemberBackendKind {
   if (!server) return undefined;
+  // Unproxied trumps any backend id, matching classifyMemberServer: such a
+  // member is not gateway-dispatchable, so naming a kind would mislead.
+  if (server.unproxiedMcpServerId) return undefined;
   if (server.toolsetId) return "hosted";
   if (server.tunneledMcpServerId) return "tunneled";
   if (server.remoteMcpServerId) return "remote";

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.ts
@@ -87,3 +87,20 @@ export function planReorder(
 export function nextSortOrder(members: MetaMcpMember[]): number {
   return members.reduce((max, m) => Math.max(max, m.sortOrder + 1), 0);
 }
+
+/**
+ * Display-only backend kind. Finer-grained than MemberClassification:
+ * "proxied" splits into the remote/tunneled story the operator actually
+ * configured, without disturbing the classification logic serving depends on.
+ */
+export type MemberBackendKind = "hosted" | "remote" | "tunneled" | undefined;
+
+export function memberBackendKind(
+  server: McpServer | undefined,
+): MemberBackendKind {
+  if (!server) return undefined;
+  if (server.toolsetId) return "hosted";
+  if (server.tunneledMcpServerId) return "tunneled";
+  if (server.remoteMcpServerId) return "remote";
+  return undefined;
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -283,6 +283,7 @@ describe("AuthenticationSectionBody", () => {
 
 const remoteTargetWithSessionIssuer: AuthTarget = {
   slug: "remote-server",
+  projectId: "project-1",
   userSessionIssuerId: "user-session-issuer",
   remoteMcpServerId: "remote-mcp-server",
   invalidate: vi.fn(),

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -229,6 +229,7 @@ export function AuthenticationSectionBody({
         )}
         <RemoteIdentityProvidersField
           associatedIssuers={associatedIssuers}
+          allowAdditionalProviders={!!target.multipleProviders}
           isLoading={
             isLoadingIssuers || isLoadingClients || probeStatus === "loading"
           }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -230,6 +230,7 @@ export function AuthenticationSectionBody({
         <RemoteIdentityProvidersField
           associatedIssuers={associatedIssuers}
           allowAdditionalProviders={!!target.multipleProviders}
+          projectId={target.projectId}
           isLoading={
             isLoadingIssuers || isLoadingClients || probeStatus === "loading"
           }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
@@ -58,6 +58,7 @@ function renderField(
         associatedIssuers={issuers}
         isLoading={false}
         allowAdditionalProviders={handlers.allowAdditionalProviders ?? true}
+        projectId="project-1"
         onAdd={vi.fn<() => void>()}
         onEdit={handlers.onEdit ?? vi.fn<() => void>()}
         onDelete={handlers.onDelete ?? vi.fn<() => void>()}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
@@ -71,6 +71,16 @@ describe("RemoteIdentityProvidersField", () => {
     vi.clearAllMocks();
   });
 
+  // The gateway (meta MCP) case attaches one provider per member vendor, so
+  // the add action must survive past the first attachment.
+  it("keeps Attach Provider available once providers exist", () => {
+    renderField([issuer()]);
+
+    expect(
+      screen.getByRole("button", { name: /attach provider/i }),
+    ).toBeTruthy();
+  });
+
   it("links the provider name to its detail page", () => {
     renderField([issuer()]);
 

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.test.tsx
@@ -46,13 +46,18 @@ function issuer(overrides: Partial<RemoteSessionIssuer> = {}) {
 
 function renderField(
   issuers: RemoteSessionIssuer[],
-  handlers: { onEdit?: () => void; onDelete?: () => void } = {},
+  handlers: {
+    onEdit?: () => void;
+    onDelete?: () => void;
+    allowAdditionalProviders?: boolean;
+  } = {},
 ) {
   return render(
     <MemoryRouter>
       <RemoteIdentityProvidersField
         associatedIssuers={issuers}
         isLoading={false}
+        allowAdditionalProviders={handlers.allowAdditionalProviders ?? true}
         onAdd={vi.fn<() => void>()}
         onEdit={handlers.onEdit ?? vi.fn<() => void>()}
         onDelete={handlers.onDelete ?? vi.fn<() => void>()}
@@ -79,6 +84,16 @@ describe("RemoteIdentityProvidersField", () => {
     expect(
       screen.getByRole("button", { name: /attach provider/i }),
     ).toBeTruthy();
+  });
+
+  // Remote/tunneled servers have exactly one upstream: once it is attached,
+  // no further attach may be offered.
+  it("hides Attach Provider for single-upstream targets once a provider exists", () => {
+    renderField([issuer()], { allowAdditionalProviders: false });
+
+    expect(
+      screen.queryByRole("button", { name: /attach provider/i }),
+    ).toBeNull();
   });
 
   it("links the provider name to its detail page", () => {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -14,12 +14,16 @@ import { SettingsInlineEmptyState } from "../../SettingsInlineEmptyState";
 export function RemoteIdentityProvidersField({
   associatedIssuers,
   isLoading,
+  allowAdditionalProviders,
   onAdd,
   onEdit,
   onDelete,
 }: {
   associatedIssuers: RemoteSessionIssuer[];
   isLoading: boolean;
+  /** Gateways bind a provider per member; remote/tunneled servers have one
+   * upstream, so only their empty state may offer an attach. */
+  allowAdditionalProviders: boolean;
   onAdd: () => void;
   onEdit: (issuer: RemoteSessionIssuer) => void;
   onDelete: (issuer: RemoteSessionIssuer) => void;
@@ -59,14 +63,16 @@ export function RemoteIdentityProvidersField({
             onDelete={() => onDelete(issuer)}
           />
         ))}
-        <RequireScope scope="mcp:write" level="component">
-          <Button variant="secondary" onClick={onAdd}>
-            <Button.LeftIcon>
-              <Plus className="size-4" />
-            </Button.LeftIcon>
-            <Button.Text>Attach Provider</Button.Text>
-          </Button>
-        </RequireScope>
+        {allowAdditionalProviders && (
+          <RequireScope scope="mcp:write" level="component">
+            <Button variant="secondary" onClick={onAdd}>
+              <Button.LeftIcon>
+                <Plus className="size-4" />
+              </Button.LeftIcon>
+              <Button.Text>Attach Provider</Button.Text>
+            </Button>
+          </RequireScope>
+        )}
       </div>
     );
   }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -59,6 +59,14 @@ export function RemoteIdentityProvidersField({
             onDelete={() => onDelete(issuer)}
           />
         ))}
+        <RequireScope scope="mcp:write" level="component">
+          <Button variant="secondary" onClick={onAdd}>
+            <Button.LeftIcon>
+              <Plus className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text>Attach Provider</Button.Text>
+          </Button>
+        </RequireScope>
       </div>
     );
   }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -15,6 +15,7 @@ export function RemoteIdentityProvidersField({
   associatedIssuers,
   isLoading,
   allowAdditionalProviders,
+  projectId,
   onAdd,
   onEdit,
   onDelete,
@@ -24,6 +25,8 @@ export function RemoteIdentityProvidersField({
   /** Gateways bind a provider per member; remote/tunneled servers have one
    * upstream, so only their empty state may offer an attach. */
   allowAdditionalProviders: boolean;
+  /** Scopes the mcp:write gates to the target's own project. */
+  projectId: string;
   onAdd: () => void;
   onEdit: (issuer: RemoteSessionIssuer) => void;
   onDelete: (issuer: RemoteSessionIssuer) => void;
@@ -41,7 +44,11 @@ export function RemoteIdentityProvidersField({
         title="No remote identity providers"
         description="Attach a provider if the upstream service requires users to sign in to access their data."
         action={
-          <RequireScope scope="mcp:write" level="component">
+          <RequireScope
+            scope="mcp:write"
+            resourceId={projectId}
+            level="component"
+          >
             <Button variant="secondary" onClick={onAdd}>
               <Button.LeftIcon>
                 <Plus className="size-4" />
@@ -59,12 +66,17 @@ export function RemoteIdentityProvidersField({
           <RemoteIdentityProviderRow
             key={issuer.id}
             issuer={issuer}
+            projectId={projectId}
             onEdit={() => onEdit(issuer)}
             onDelete={() => onDelete(issuer)}
           />
         ))}
         {allowAdditionalProviders && (
-          <RequireScope scope="mcp:write" level="component">
+          <RequireScope
+            scope="mcp:write"
+            resourceId={projectId}
+            level="component"
+          >
             <Button variant="secondary" onClick={onAdd}>
               <Button.LeftIcon>
                 <Plus className="size-4" />
@@ -93,8 +105,10 @@ function RemoteIdentityProviderRow({
   issuer,
   onEdit,
   onDelete,
+  projectId,
 }: {
   issuer: RemoteSessionIssuer;
+  projectId: string;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -128,7 +142,11 @@ function RemoteIdentityProviderRow({
             {issuer.issuer}
           </Text>
         </div>
-        <RequireScope scope="mcp:write" level="component">
+        <RequireScope
+          scope="mcp:write"
+          resourceId={projectId}
+          level="component"
+        >
           <div className="flex shrink-0 items-center gap-2">
             {canEdit && (
               <Button size="md" variant="secondary" onClick={onEdit}>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
@@ -30,6 +30,10 @@ export type AuthTarget = {
   /** Link a freshly created issuer to the target (first add). Absent for
    * targets that always have an issuer (mcp servers). */
   linkUserSessionIssuer?: (userSessionIssuerId: string) => Promise<void>;
+  /** True when the target's issuer may bind several upstream providers
+   * (gateways front many members). Remote/tunneled servers have exactly one
+   * upstream and must not offer additional attachments. */
+  multipleProviders?: boolean;
   /** Invalidate the target-specific queries that embed the link. */
   invalidate: (queryClient: QueryClient) => Promise<void>;
 };
@@ -87,6 +91,7 @@ export function useMetaMcpAuthTarget(
     () => ({
       slug: slugSeed,
       userSessionIssuerId: metaMcpServer.userSessionIssuerId ?? null,
+      multipleProviders: true,
       linkUserSessionIssuer: async (userSessionIssuerId: string) => {
         // update is a full-record replace, so the name rides along.
         await client.metaMcp.update({

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/authTarget.ts
@@ -20,6 +20,8 @@ import { useMemo } from "react";
 export type AuthTarget = {
   /** Seeds auto-derived issuer slugs on first add. */
   slug: string;
+  /** Project owning the target; scopes permission gates to it. */
+  projectId: string;
   /** Current issuer link; null when the target has none yet. */
   userSessionIssuerId: string | null;
   /**
@@ -42,6 +44,7 @@ export function useMcpServerAuthTarget(mcpServer: McpServer): AuthTarget {
   return useMemo(
     () => ({
       slug: mcpServer.slug ?? "mcp",
+      projectId: mcpServer.projectId,
       userSessionIssuerId: mcpServer.userSessionIssuerId ?? null,
       remoteMcpServerId: mcpServer.remoteMcpServerId,
       invalidate: async (queryClient: QueryClient) => {
@@ -61,6 +64,7 @@ export function useToolsetAuthTarget(toolset: Toolset): AuthTarget {
   return useMemo(
     () => ({
       slug: toolset.slug,
+      projectId: toolset.projectId,
       userSessionIssuerId: toolset.userSessionIssuerId ?? null,
       linkUserSessionIssuer: async (userSessionIssuerId: string) => {
         // Toolsets are already live, so linking only flips auth gating —
@@ -90,6 +94,7 @@ export function useMetaMcpAuthTarget(
   return useMemo(
     () => ({
       slug: slugSeed,
+      projectId: metaMcpServer.projectId,
       userSessionIssuerId: metaMcpServer.userSessionIssuerId ?? null,
       multipleProviders: true,
       linkUserSessionIssuer: async (userSessionIssuerId: string) => {

--- a/client/dashboard/src/sdk/src/funcs/metaMcpUpdate.ts
+++ b/client/dashboard/src/sdk/src/funcs/metaMcpUpdate.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * updateMetaMcpServer metaMcp
  *
  * @remarks
- * Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
+ * Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
  */
 export function metaMcpUpdate(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/models/components/updatemetamcpserverform.ts
+++ b/client/dashboard/src/sdk/src/models/components/updatemetamcpserverform.ts
@@ -21,7 +21,7 @@ export type UpdateMetaMcpServerFormVisibility = ClosedEnum<
 >;
 
 /**
- * Form for updating a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
+ * Form for updating a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer (one is minted if the gateway has none); omitting visibility preserves the stored value.
  */
 export type UpdateMetaMcpServerForm = {
   /**

--- a/client/dashboard/src/sdk/src/react-query/updateMetaMcpServer.ts
+++ b/client/dashboard/src/sdk/src/react-query/updateMetaMcpServer.ts
@@ -54,7 +54,7 @@ export type UpdateMetaMcpServerMutationError =
  * updateMetaMcpServer metaMcp
  *
  * @remarks
- * Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
+ * Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
  */
 export function useUpdateMetaMcpServerMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/metamcp.ts
+++ b/client/dashboard/src/sdk/src/sdk/metamcp.ts
@@ -192,7 +192,7 @@ export class MetaMcp extends ClientSDK {
    * updateMetaMcpServer metaMcp
    *
    * @remarks
-   * Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
+   * Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
    */
   async update(
     request: UpdateMetaMcpServerRequest,

--- a/server/design/metamcp/design.go
+++ b/server/design/metamcp/design.go
@@ -94,7 +94,7 @@ var _ = Service("metaMcp", func() {
 	})
 
 	Method("updateMetaMcpServer", func() {
-		Description("Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.")
+		Description("Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.")
 
 		Payload(func() {
 			Extend(UpdateMetaMcpServerForm)
@@ -274,7 +274,7 @@ var CreateMetaMcpServerForm = Type("CreateMetaMcpServerForm", func() {
 })
 
 var UpdateMetaMcpServerForm = Type("UpdateMetaMcpServerForm", func() {
-	Description("Form for updating a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.")
+	Description("Form for updating a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer (one is minted if the gateway has none); omitting visibility preserves the stored value.")
 
 	Attribute("id", String, "The ID of the meta MCP server to update", func() {
 		Format(FormatUUID)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -15414,7 +15414,7 @@ func metaMcpUsage() {
 	fmt.Fprintln(os.Stderr, `    create-meta-mcp-server: Create a new meta MCP server`)
 	fmt.Fprintln(os.Stderr, `    get-meta-mcp-server: Get a meta MCP server by id`)
 	fmt.Fprintln(os.Stderr, `    list-meta-mcp-servers: List meta MCP servers for a project`)
-	fmt.Fprintln(os.Stderr, `    update-meta-mcp-server: Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.`)
+	fmt.Fprintln(os.Stderr, `    update-meta-mcp-server: Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.`)
 	fmt.Fprintln(os.Stderr, `    delete-meta-mcp-server: Delete a meta MCP server. Its live memberships and MCP endpoints are deleted along with it.`)
 	fmt.Fprintln(os.Stderr, `    list-meta-mcp-members: List the members of a meta MCP server, ordered by sort order`)
 	fmt.Fprintln(os.Stderr, `    add-meta-mcp-member: Add an MCP server to a meta MCP server's member set`)
@@ -15505,7 +15505,7 @@ func metaMcpUpdateMetaMcpServerUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.`)
+	fmt.Fprintln(os.Stderr, `Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -27996,7 +27996,7 @@ paths:
                 name: RemoveMetaMcpMember
     /rpc/metaMcp.update:
         post:
-            description: 'Update a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.'
+            description: Update a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer, and a gateway that would end up without one gets a dedicated issuer minted — an update can never leave a gateway serving anonymously. Omitting visibility preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.
             operationId: updateMetaMcpServer
             parameters:
                 - allowEmptyValue: true
@@ -85170,7 +85170,7 @@ components:
                     enum:
                         - disabled
                         - private
-            description: 'Form for updating a meta MCP server. This is a full-record replace: a user_session_issuer_id omitted from the request becomes null on the stored record. Visibility is the exception — omitting it preserves the stored value, so a caller that does not manage visibility cannot re-enable a disabled gateway by saving an unrelated field.'
+            description: Form for updating a meta MCP server. Omitting user_session_issuer_id preserves the stored issuer (one is minted if the gateway has none); omitting visibility preserves the stored value.
             required:
                 - id
                 - name

--- a/server/gen/meta_mcp/service.go
+++ b/server/gen/meta_mcp/service.go
@@ -24,11 +24,12 @@ type Service interface {
 	GetMetaMcpServer(context.Context, *GetMetaMcpServerPayload) (res *types.MetaMcpServer, err error)
 	// List meta MCP servers for a project
 	ListMetaMcpServers(context.Context, *ListMetaMcpServersPayload) (res *ListMetaMcpServersResult, err error)
-	// Update a meta MCP server. This is a full-record replace: a
-	// user_session_issuer_id omitted from the request becomes null on the stored
-	// record. Visibility is the exception — omitting it preserves the stored
-	// value, so a caller that does not manage visibility cannot re-enable a
-	// disabled gateway by saving an unrelated field.
+	// Update a meta MCP server. Omitting user_session_issuer_id preserves the
+	// stored issuer, and a gateway that would end up without one gets a dedicated
+	// issuer minted — an update can never leave a gateway serving anonymously.
+	// Omitting visibility preserves the stored value, so a caller that does not
+	// manage visibility cannot re-enable a disabled gateway by saving an unrelated
+	// field.
 	UpdateMetaMcpServer(context.Context, *UpdateMetaMcpServerPayload) (res *types.MetaMcpServer, err error)
 	// Delete a meta MCP server. Its live memberships and MCP endpoints are deleted
 	// along with it.

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -499,3 +499,30 @@ func TestConsentTemplateToolAccessOmittedOnFirstParty(t *testing.T) {
 	require.NotContains(t, page.String(), "consent-tools-root")
 	require.NotContains(t, page.String(), "consent-tools-")
 }
+
+// A first-party connect page for a server with no per-user providers must not
+// tell the user to connect services that are not there.
+func TestConsentTemplateFirstPartyNoCardCopy(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:         "Gram",
+		MCPSlug:            "example",
+		MCPRouteBase:       "mcp",
+		State:              "state",
+		CSRFToken:          "csrf",
+		SubjectDisplay:     "user@example.com",
+		ScriptURL:          "/mcp/consent-page-test.js",
+		RemoteSessionCards: nil,
+		FirstParty:         true,
+		ConsentEnabled:     true,
+	})
+	require.NoError(t, err)
+
+	html := page.String()
+	require.Contains(t, html, "This MCP server needs no per-user service connections — you're all set.")
+	require.Contains(t, html, "You can close this tab.")
+	require.NotContains(t, html, "Link the services this MCP server needs")
+	require.NotContains(t, html, "connected the services above")
+}

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -501,7 +501,9 @@
           {{if .FirstParty}}
           <h1>Connect {{.MCPSlug}}</h1>
           <p>
-            Link the services this MCP server needs to access on your behalf.
+            {{if .RemoteSessionCards}}Link the services this MCP server needs
+            to access on your behalf.{{else}}This MCP server needs no
+            per-user service connections — you're all set.{{end}}
           </p>
           {{else}}
           <h1>Authorize {{.ClientName}}</h1>
@@ -743,7 +745,8 @@
         </p>
         {{else if .FirstParty}}
         <p class="info">
-          When you've connected the services above, you can close this tab.
+          {{if .RemoteSessionCards}}When you've connected the services above,
+          you can close this tab.{{else}}You can close this tab.{{end}}
         </p>
         {{else}}
         <div class="actions">

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -501,9 +501,7 @@
           {{if .FirstParty}}
           <h1>Connect {{.MCPSlug}}</h1>
           <p>
-            {{if .RemoteSessionCards}}Link the services this MCP server needs
-            to access on your behalf.{{else}}This MCP server needs no
-            per-user service connections — you're all set.{{end}}
+            {{if .RemoteSessionCards}}Link the services this MCP server needs to access on your behalf.{{else}}This MCP server needs no per-user service connections — you're all set.{{end}}
           </p>
           {{else}}
           <h1>Authorize {{.ClientName}}</h1>
@@ -745,8 +743,7 @@
         </p>
         {{else if .FirstParty}}
         <p class="info">
-          {{if .RemoteSessionCards}}When you've connected the services above,
-          you can close this tab.{{else}}You can close this tab.{{end}}
+          {{if .RemoteSessionCards}}When you've connected the services above, you can close this tab.{{else}}You can close this tab.{{end}}
         </p>
         {{else}}
         <div class="actions">

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -58,11 +58,12 @@ var (
 )
 
 // supportedMetaServer is the set negotiated on meta-MCP-backed /mcp/{slug}
-// endpoints. The ceiling is Version20260728 — the surface has served it since
-// birth — but the floor matches the hosted surface's: the clients are the
-// same installed base of ordinary MCP clients, and none of the mainstream
-// ones speak 2026-07-28 yet.
-var supportedMetaServer = []string{Version20241105, Version20250326, Version20250618, Version20251125, Version20260728}
+// endpoints. It matches the hosted surface's range — same installed base of
+// ordinary MCP clients, same Version20251125 ceiling — and gains
+// Version20260728 together with the other surfaces once the remaining
+// 2026-07-28 integration work completes, not before: advertising it early
+// invites clients into the incomplete parts.
+var supportedMetaServer = []string{Version20241105, Version20250326, Version20250618, Version20251125}
 
 // SupportedMetaServer returns the revisions negotiated on meta-MCP-backed
 // /mcp/{slug} endpoints, oldest first.

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -57,12 +57,18 @@ var (
 	supportedPlatformToolset = []string{Version20241105, Version20250326, Version20250618, Version20251125}
 )
 
-// ServedMetaServer is the revision answered on meta-MCP-backed /mcp/{slug}
-// endpoints. That surface is greenfield with no installed client base, so it
-// serves only the current revision — per-request declarations rather than a
-// handshake — and does not participate in [Negotiate]/[Resolve]. Extending it
-// with an older-revision support set is separate, planned work.
-const ServedMetaServer = Version20260728
+// supportedMetaServer is the set negotiated on meta-MCP-backed /mcp/{slug}
+// endpoints. The ceiling is Version20260728 — the surface has served it since
+// birth — but the floor matches the hosted surface's: the clients are the
+// same installed base of ordinary MCP clients, and none of the mainstream
+// ones speak 2026-07-28 yet.
+var supportedMetaServer = []string{Version20241105, Version20250326, Version20250618, Version20251125, Version20260728}
+
+// SupportedMetaServer returns the revisions negotiated on meta-MCP-backed
+// /mcp/{slug} endpoints, oldest first.
+func SupportedMetaServer() []string {
+	return slices.Clone(supportedMetaServer)
+}
 
 // SupportedHostedToolset returns the revisions supported on /mcp/{slug} and on
 // the toolset-backed /x/mcp/{slug}, which share a handler, oldest first. This

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -44,6 +44,7 @@ func TestSupportedSetsAreKnownAndOrdered(t *testing.T) {
 	for _, supported := range [][]string{
 		mcpversions.SupportedHostedToolset(),
 		mcpversions.SupportedPlatformToolset(),
+		mcpversions.SupportedMetaServer(),
 	} {
 		require.NotEmpty(t, supported)
 		require.True(t, slices.IsSorted(supported), "revision identifiers are YYYY-MM-DD, so chronological order is lexical order")

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -248,3 +248,17 @@ func TestSanitizePreservesUnknownButWellFormedValues(t *testing.T) {
 	// not restrict it to known revisions the way Clamp does.
 	require.Equal(t, "1999-12-31", mcpversions.Sanitize("1999-12-31"))
 }
+
+// TestSupportedMetaServerSpansFloorToCeiling pins the meta surface's range:
+// the hosted floor (mainstream clients are the same installed base) up
+// through 2026-07-28, which this surface has served since birth.
+func TestSupportedMetaServerSpansFloorToCeiling(t *testing.T) {
+	t.Parallel()
+
+	set := mcpversions.SupportedMetaServer()
+	require.Equal(t, mcpversions.Version20241105, set[0])
+	require.Equal(t, mcpversions.Version20260728, set[len(set)-1])
+
+	mcpversions.SupportedMetaServer()[0] = "mutated"
+	require.Equal(t, mcpversions.Version20241105, mcpversions.SupportedMetaServer()[0], "SupportedMetaServer must not hand out a mutable view of package state")
+}

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -73,6 +73,7 @@ func TestSupportedSetsExclude20260728(t *testing.T) {
 
 	require.NotContains(t, mcpversions.SupportedHostedToolset(), mcpversions.Version20260728)
 	require.NotContains(t, mcpversions.SupportedPlatformToolset(), mcpversions.Version20260728)
+	require.NotContains(t, mcpversions.SupportedMetaServer(), mcpversions.Version20260728)
 }
 
 func TestNegotiateEchoesEverySupportedVersion(t *testing.T) {
@@ -250,15 +251,15 @@ func TestSanitizePreservesUnknownButWellFormedValues(t *testing.T) {
 	require.Equal(t, "1999-12-31", mcpversions.Sanitize("1999-12-31"))
 }
 
-// TestSupportedMetaServerSpansFloorToCeiling pins the meta surface's range:
-// the hosted floor (mainstream clients are the same installed base) up
-// through 2026-07-28, which this surface has served since birth.
+// TestSupportedMetaServerSpansFloorToCeiling pins the meta surface's range
+// to the hosted surface's: same installed base, same 2025-11-25 ceiling
+// until the 2026-07-28 integration completes everywhere at once.
 func TestSupportedMetaServerSpansFloorToCeiling(t *testing.T) {
 	t.Parallel()
 
 	set := mcpversions.SupportedMetaServer()
 	require.Equal(t, mcpversions.Version20241105, set[0])
-	require.Equal(t, mcpversions.Version20260728, set[len(set)-1])
+	require.Equal(t, mcpversions.Version20251125, set[len(set)-1])
 
 	mcpversions.SupportedMetaServer()[0] = "mutated"
 	require.Equal(t, mcpversions.Version20241105, mcpversions.SupportedMetaServer()[0], "SupportedMetaServer must not hand out a mutable view of package state")

--- a/server/internal/mcp/metamcp/initialize.go
+++ b/server/internal/mcp/metamcp/initialize.go
@@ -11,11 +11,11 @@ const Instructions = `This endpoint fronts a set of MCP servers as one, exposing
 
 Work from the outside in:
 
-1. list_servers — what is reachable, what each system is for, and each member's status: "available", or "unknown" when the gateway cannot observe it yet.
+1. list_servers — what is reachable, what each system is for, and each member's status: "available", "unavailable" when the member's tunnel is down, or "unknown" when the gateway cannot observe the member's health.
 2. describe_server — that server's tools, as qualified names (server--tool) with descriptions but no input schemas.
 3. describe_tools — input schemas for the specific tools you intend to call.
 4. execute_tool — run one, by qualified name.
 
 Never execute a name you have not described: arguments guessed from a tool name will fail validation.
 
-If a call fails, re-check list_servers before retrying. A member reporting "unknown" may not answer describe or execute calls yet: its tools are unavailable rather than missing.`
+If a call fails, re-check list_servers before retrying. "unknown" means unobserved, not broken — such members usually answer describe and execute calls normally. Only "unavailable" means the member cannot currently be reached.`

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -75,10 +76,11 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 
 	logger = logger.With(attr.SlogMetaMcpServerID(metaServer.ID.String()))
 
-	// The version in effect for this exchange is stable regardless of
-	// outcome — this surface always answers ServedMetaServer — so the header
-	// is stamped before the issuer gate and body parsing can bail out.
-	w.Header().Set(mcpversions.HTTPHeader, mcpversions.ServedMetaServer)
+	// Stamped provisionally with the surface's newest revision so responses
+	// that bail before body parsing still carry a version; once the request
+	// is parsed it is re-stamped with the revision in effect.
+	supportedMeta := mcpversions.SupportedMetaServer()
+	w.Header().Set(mcpversions.HTTPHeader, supportedMeta[len(supportedMeta)-1])
 
 	var gateTokens map[uuid.UUID]remotesessions.UpstreamToken
 	var gateToolSelection *toolfilter.SessionSelection
@@ -122,6 +124,16 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, logger)
 	}
 
+	resolution := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), supportedMeta)
+	if req.Method == "initialize" {
+		// A conforming initialize declares nothing, so Resolve lands on the
+		// default; the negotiated answer is what actually governs the
+		// exchange (the write-back Resolution sanctions).
+		params, _, _ := parseInitializeParams(req.Params)
+		resolution.InEffect = mcpversions.Negotiate(params.ProtocolVersion, supportedMeta)
+	}
+	w.Header().Set(mcpversions.HTTPHeader, resolution.InEffect)
+
 	gate := &metaGateContext{
 		projectID:      mcpEndpoint.ProjectID,
 		organizationID: metaServer.OrganizationID,
@@ -133,14 +145,9 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 		userID:         "",
 		externalUserID: "",
 		apiKeyID:       "",
-		// The meta surface serves one revision; InEffect is fixed while
-		// Declared keeps what the request actually said, for telemetry.
-		// Member dispatch carries this InEffect verbatim even though the
-		// hosted set excludes it; nothing on the tools/call path reads it.
-		protocolVersion: mcpversions.Resolution{
-			Declared: mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params),
-			InEffect: mcpversions.ServedMetaServer,
-		},
+		// Member dispatch carries this InEffect verbatim; nothing on the
+		// tools/call path reads it (upstream dials pin their own version).
+		protocolVersion: resolution,
 	}
 	// Identity comes from the issuer gate alone: this surface runs no
 	// identity-auth ladder, so ungated meta endpoints serve anonymously —
@@ -224,7 +231,7 @@ func (s *Service) handleMetaMCPRequest(
 	case "ping":
 		return handlePing(ctx, logger, req.ID, serverInfoMetaServer)
 	case "initialize":
-		return s.handleMetaInitialize(ctx, logger, req)
+		return s.handleMetaInitialize(ctx, logger, req, gate.protocolVersion.InEffect)
 	case "server/discover":
 		return s.handleMetaServerDiscover(ctx, logger, req)
 	case "notifications/initialized", "notifications/cancelled":
@@ -251,10 +258,9 @@ const metaProtocolVersionMetaKey = "io.modelcontextprotocol/protocolVersion"
 // version declaration on the meta surface. A declaration may arrive in the
 // MCP-Protocol-Version header, the params-level
 // io.modelcontextprotocol/protocolVersion _meta key, or both; conflicting,
-// unparseable, or unserved declarations — anything but the served revision,
-// including older revisions this package recognizes, matching the set
-// server/discover advertises — produce deterministic structured errors
-// naming the served set. Only a genuinely absent declaration is
+// unparseable, or unserved declarations — anything outside the served set,
+// matching what server/discover advertises — produce deterministic
+// structured errors naming the served set. Only a genuinely absent declaration is
 // accepted, for backward compatibility with handshake-based clients per the
 // specification's versioning rules — a declaration that is present but
 // unsanitizable (or not a string at all) is a malformed value, not an
@@ -301,7 +307,7 @@ func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) er
 	}
 
 	declared := conv.Default(headerVersion, metaVersion)
-	if declared != "" && declared != mcpversions.ServedMetaServer {
+	if declared != "" && !slices.Contains(mcpversions.SupportedMetaServer(), declared) {
 		return unsupportedMetaProtocolVersionError(req, declared)
 	}
 
@@ -310,14 +316,14 @@ func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) er
 
 // unsupportedMetaProtocolVersionError is the structured error for a declared
 // protocol version this surface does not serve. The named set is the served
-// set — exactly [mcpversions.ServedMetaServer], matching what server/discover
-// advertises — not the wider set of recognized revisions. declared must be
-// sanitized (or a placeholder) — it is echoed to the client.
+// set — exactly [mcpversions.SupportedMetaServer], matching what
+// server/discover advertises — not the wider set of recognized revisions.
+// declared must be sanitized (or a placeholder) — it is echoed to the client.
 func unsupportedMetaProtocolVersionError(req *rawRequest, declared string) *oops.MCPError {
 	return &oops.MCPError{
 		ID:      req.ID,
 		Code:    oops.MCPCodeInvalidRequest,
-		Message: fmt.Sprintf("unsupported protocol version %q; supported versions: %s", declared, mcpversions.ServedMetaServer),
+		Message: fmt.Sprintf("unsupported protocol version %q; supported versions: %s", declared, strings.Join(mcpversions.SupportedMetaServer(), ", ")),
 	}
 }
 
@@ -325,21 +331,22 @@ func (s *Service) handleMetaInitialize(
 	ctx context.Context,
 	logger *slog.Logger,
 	req *rawRequest,
+	negotiated string,
 ) (json.RawMessage, error) {
-	// Parsed purely for telemetry: this surface answers ServedMetaServer
-	// unconditionally, and malformed params must not fail the handshake.
+	// Parsed purely for telemetry — negotiation already ran at gate
+	// construction — and malformed params must not fail the handshake.
 	params, _, err := parseInitializeParams(req.Params)
 	if err != nil {
 		logger.WarnContext(ctx, "failed to parse meta mcp initialize params", attr.SlogError(err))
 	}
 
-	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, mcpversions.ServedMetaServer)
-	s.metrics.RecordMCPInitialize(ctx, params.ProtocolVersion, mcpversions.ServedMetaServer)
+	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, negotiated)
+	s.metrics.RecordMCPInitialize(ctx, params.ProtocolVersion, negotiated)
 
 	result := &result[initializeResult]{
 		ID: req.ID,
 		Result: initializeResult{
-			ProtocolVersion: mcpversions.ServedMetaServer,
+			ProtocolVersion: negotiated,
 			Capabilities: map[string]json.RawMessage{
 				"tools": json.RawMessage("{}"),
 			},
@@ -363,7 +370,7 @@ func (s *Service) handleMetaServerDiscover(
 	result := &result[metamcp.DiscoverResult]{
 		ID: req.ID,
 		Result: metamcp.DiscoverResult{
-			ProtocolVersions: []string{mcpversions.ServedMetaServer},
+			ProtocolVersions: mcpversions.SupportedMetaServer(),
 			Capabilities: map[string]json.RawMessage{
 				"tools": json.RawMessage("{}"),
 			},

--- a/server/internal/mcp/serve_meta_proxied_test.go
+++ b/server/internal/mcp/serve_meta_proxied_test.go
@@ -8,13 +8,16 @@
 package mcp_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -253,6 +256,69 @@ func TestServePublic_MetaEndpoint_ExecuteTool_ForwardsEachMembersOwnBearer(t *te
 	require.False(t, isError, "member B execute_tool must succeed")
 	require.Equal(t, "Bearer token-member-b", upstreamB.capturedAuth(),
 		"member B's upstream must receive exactly member B's bearer and never A's")
+}
+
+// A caller's _meta must not reach a proxied member: WireMeta re-serializes
+// lossily (empty/null fields) and strict vendors reject the result with 400.
+// Regression for a real-client failure — MCP clients attach _meta routinely.
+func TestServePublic_MetaEndpoint_ExecuteTool_DropsCallerMetaUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	sharedIssuerID := createUserSessionIssuer(t, ctx, ti.conn, projectID)
+	metaSlug := "meta-nometa-e2e-" + uuid.NewString()[:8]
+	meta := createMetaMcpEndpoint(t, ctx, ti.conn, projectID, orgID, metaSlug, sharedIssuerID)
+
+	upstream := newRecordingUpstream(t, "ping")
+	var bodies sync.Map
+	var bodyIdx atomic.Int64
+	target, perr := url.Parse(upstream.url)
+	require.NoError(t, perr)
+	reverse := httputil.NewSingleHostReverseProxy(target)
+	recorder := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, rerr := io.ReadAll(r.Body)
+		if rerr != nil {
+			http.Error(w, rerr.Error(), http.StatusInternalServerError)
+			return
+		}
+		bodies.Store(bodyIdx.Add(1), string(raw))
+		r.Body = io.NopCloser(bytes.NewReader(raw))
+		reverse.ServeHTTP(w, r)
+	}))
+	t.Cleanup(recorder.Close)
+	seedMetaMemberWithUpstream(t, ctx, ti.conn, projectID, meta.ID, "Member", "member-nometa", 0, recorder.URL)
+
+	subject := urn.NewUserSubject("meta-nometa-user-" + uuid.NewString())
+	bearer := mintMetaIssuerBearer(t, ti, metaSlug, sharedIssuerID, subject)
+
+	body := makeMetaRPCBody(t, "tools/call", map[string]any{
+		"_meta":     map[string]any{"progressToken": 1, "claudecode/toolUseId": "toolu_regression"},
+		"name":      "execute_tool",
+		"arguments": map[string]any{"name": "member-nometa--ping", "arguments": map[string]any{}},
+	})
+	resp, err := servePublicHTTP(t, context.Background(), ti, metaSlug, body, bearer, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Code, "execute_tool response: %s", resp.Body.String())
+	text, isError := metaToolResultText(t, decodeRPCResponse(t, resp))
+	require.False(t, isError, "execute_tool with caller _meta must succeed: %s", text)
+	require.Contains(t, text, "pong from ping")
+
+	seen := 0
+	bodies.Range(func(_, v any) bool {
+		seen++
+		body, isString := v.(string)
+		require.True(t, isString)
+		require.NotContains(t, body, `"_meta"`,
+			"no upstream request may carry a _meta object")
+		return true
+	})
+	require.Positive(t, seen, "the upstream recorder must have observed requests")
 }
 
 // An ambiguous credential map — two stored tokens claiming one member's

--- a/server/internal/mcp/serve_meta_proxied_test.go
+++ b/server/internal/mcp/serve_meta_proxied_test.go
@@ -285,7 +285,7 @@ func TestServePublic_MetaEndpoint_ExecuteTool_AmbiguousCredentialMakesNoCall(t *
 	rpc := executeMetaTool(t, ti, metaSlug, bearer, "member--ping")
 	text, isError := metaToolResultText(t, rpc)
 	require.True(t, isError, "an ambiguous credential map must fail the member call")
-	require.Contains(t, text, "not configured unambiguously")
+	require.Contains(t, text, "recorded for the same upstream", "the message must name the duplication, not just report misconfiguration")
 	require.Zero(t, upstream.requests.Load(), "no call may be made when the credential is ambiguous")
 }
 

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -56,8 +56,13 @@ const memberSessionCloseTimeout = 5 * time.Second
 // token can be its credential; several tokens fail member-scoped.
 func routeMetaMemberToken(tokens map[uuid.UUID]remotesessions.UpstreamToken, member metaMember, upstreamResource string) (string, error) {
 	if member.tunneledServerID.Valid {
+		// A tunneled backend records no RFC 8707 resource, so there is nothing
+		// to match a credential against. One credential is that member's by
+		// construction (matching routeUpstreamToken on the direct surface);
+		// several are unroutable, so say which situation this is rather than
+		// leaving the operator to guess at "misconfiguration".
 		if len(tokens) > 1 {
-			return "", &metaMemberError{message: fmt.Sprintf("server %q upstream credentials are not configured unambiguously for this meta MCP", member.slug)}
+			return "", &metaMemberError{message: fmt.Sprintf("server %q is tunneled and has no upstream identity of its own, but this session holds %d upstream credentials, so none can be matched to it; connect only the provider it needs, or reach it through its own endpoint", member.slug, len(tokens))}
 		}
 		for _, entry := range tokens {
 			if entry.Resource == "" {
@@ -85,7 +90,9 @@ func routeMetaMemberToken(tokens map[uuid.UUID]remotesessions.UpstreamToken, mem
 	case 1:
 		return matched, nil
 	default:
-		return "", &metaMemberError{message: fmt.Sprintf("server %q upstream credentials are not configured unambiguously for this meta MCP", member.slug)}
+		// Several credentials claim the same upstream, so forwarding any one
+		// would be a guess. Name the duplication rather than the symptom.
+		return "", &metaMemberError{message: fmt.Sprintf("server %q has %d upstream credentials recorded for the same upstream, so none can be chosen; disconnect the duplicates from this gateway's sign-in and reconnect once", member.slug, found)}
 	}
 }
 

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -517,10 +517,14 @@ func (s *Service) executeProxiedMemberTool(
 		return nil, oops.E(oops.CodeUnexpected, err, "dial meta MCP member").LogError(ctx, logger)
 	}
 
+	// The caller's _meta stays on our side of the wire: WireMeta is a lossy
+	// observability parse (re-serializing it emits empty/null fields that
+	// strict vendors reject with 400), and the per-call handshake already
+	// declares this proxy's identity and protocol version to the upstream.
 	upstreamResult, rpcErr, err := s.callProxiedMember(ctx, logger, build, member, "tools/call", toolsCallParams{
 		Name:      toolName,
 		Arguments: arguments,
-		Meta:      memberWireMeta(meta),
+		Meta:      nil,
 	})
 	if err != nil {
 		if memberErr, ok := errors.AsType[*metaMemberError](err); ok {
@@ -547,18 +551,6 @@ func (s *Service) executeProxiedMemberTool(
 		return nil, oops.E(oops.CodeUnexpected, err, "serialize member tool result").LogError(ctx, logger)
 	}
 	return bs, nil
-}
-
-// memberWireMeta rewrites the client's declared protocol version to the one
-// this upstream hop actually speaks, so the forwarded _meta cannot contradict
-// the member session's handshake; the rest of _meta rides along.
-func memberWireMeta(meta *mcprequests.WireMeta) *mcprequests.WireMeta {
-	if meta == nil || meta.ProtocolVersion == metaMemberUpstreamProtocolVersion {
-		return meta
-	}
-	m := *meta
-	m.ProtocolVersion = metaMemberUpstreamProtocolVersion
-	return &m
 }
 
 // maxProxiedListPages bounds cursor-following on a member's tools/list.

--- a/server/internal/mcp/serve_meta_proxy_internal_test.go
+++ b/server/internal/mcp/serve_meta_proxy_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
@@ -116,18 +115,4 @@ func TestMemberSessionClose_DetachedContext(t *testing.T) {
 	}
 	sess.close(canceled)
 	require.NoError(t, buildCtxErr, "the session DELETE must not be built on the expired call context")
-}
-
-// The forwarded _meta declares the upstream hop's own protocol version, never
-// the client's, so it cannot contradict the member handshake.
-func TestMemberWireMeta_ProtocolVersionRewrite(t *testing.T) {
-	t.Parallel()
-
-	require.Nil(t, memberWireMeta(nil))
-
-	meta := &mcprequests.WireMeta{ProtocolVersion: "2026-07-28", ClientInfo: &mcprequests.WireClientInfo{Name: "c", Version: "1"}, Capabilities: nil}
-	got := memberWireMeta(meta)
-	require.Equal(t, metaMemberUpstreamProtocolVersion, got.ProtocolVersion)
-	require.Equal(t, meta.ClientInfo, got.ClientInfo)
-	require.Equal(t, "2026-07-28", meta.ProtocolVersion, "the caller's _meta must not be mutated")
 }

--- a/server/internal/mcp/serve_meta_runtime_test.go
+++ b/server/internal/mcp/serve_meta_runtime_test.go
@@ -921,3 +921,27 @@ func TestServePublic_MetaEndpoint_ExecuteTool_HostedMember_MultiCredentialSessio
 	require.Equal(t, int(oops.MCPCodeInvalidParams), rpcErr.Code)
 	require.NotContains(t, rpcErr.Message, "remote-session upstream tokens")
 }
+
+// A hosted member whose tools cannot resolve a server URL (no environment
+// bound anywhere) must fail member-scoped — a tool result with isError — not
+// abort the JSON-RPC call: on a multi-member gateway one member's
+// misconfiguration must not read as a gateway fault.
+func TestServePublic_MetaEndpoint_ExecuteTool_HostedConfigFailureIsMemberScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	slug := "meta-" + uuid.NewString()
+	meta := createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, uuid.Nil)
+	fixture := seedHostedMetaMember(t, ctx, ti, meta.ID, "Env-less member", 0, mcpservers.VisibilityPublic, "echo_tool")
+
+	rpc := executeMetaTool(t, ti, slug, "", fixture.slug+"--echo_tool")
+	require.NotContains(t, rpc, "error", "a member config failure must not abort the call: %s", string(rpc["error"]))
+	text, isError := metaToolResultText(t, rpc)
+	require.True(t, isError, "the member's failure must surface as a tool error result")
+	require.Contains(t, text, fixture.slug, "the failure must name the member")
+	require.Contains(t, text, "no server URL", "the failure must carry the actionable cause")
+}

--- a/server/internal/mcp/serve_meta_runtime_test.go
+++ b/server/internal/mcp/serve_meta_runtime_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
@@ -250,16 +249,14 @@ func TestServePublic_MetaEndpoint_ExecuteTool_HostedMember_Dispatches(t *testing
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	envelope := decodeRPCResponse(t, w)
 
-	var rpcErr struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	require.NoError(t, json.Unmarshal(envelope["error"], &rpcErr))
-	// The fixture tool has no server URL, which real execution rejects as
-	// invalid; what matters is that dispatch reached execution at all.
-	require.Equal(t, int(oops.MCPCodeInvalidParams), rpcErr.Code)
-	require.NotContains(t, rpcErr.Message, "unknown server")
-	require.NotContains(t, rpcErr.Message, "tool not found")
+	// The fixture tool has no server URL, which execution rejects as a
+	// member-scoped tool error; what matters is that dispatch reached
+	// execution at all.
+	text, isError := metaToolResultText(t, envelope)
+	require.True(t, isError)
+	require.Contains(t, text, "no server URL")
+	require.NotContains(t, text, "unknown server")
+	require.NotContains(t, text, "tool not found")
 }
 
 func TestServePublic_MetaEndpoint_ExecuteTool_UnknownToolOnKnownMember(t *testing.T) {
@@ -277,7 +274,9 @@ func TestServePublic_MetaEndpoint_ExecuteTool_UnknownToolOnKnownMember(t *testin
 		"name":      member.slug + "--no_such_tool",
 		"arguments": map[string]any{},
 	})
-	require.Contains(t, string(envelope["error"]), "tool not found")
+	text, isError := metaToolResultText(t, envelope)
+	require.True(t, isError, "an unknown tool on a known member is a member-scoped failure")
+	require.Contains(t, text, "tool not found")
 }
 
 // Discovery and execution agree on an ambiguous name: a variation renaming one
@@ -321,7 +320,9 @@ func TestServePublic_MetaEndpoint_AmbiguousToolName(t *testing.T) {
 		"name":      member.slug + "--beta_tool",
 		"arguments": map[string]any{},
 	})
-	require.Contains(t, string(envelope["error"]), "ambiguous tool name")
+	ambiguousText, ambiguousIsError := metaToolResultText(t, envelope)
+	require.True(t, ambiguousIsError, "an ambiguous name refuses member-scoped rather than aborting the call")
+	require.Contains(t, ambiguousText, "ambiguous tool name")
 }
 
 func TestServePublic_MetaEndpoint_ListServers_StatusByBackend(t *testing.T) {
@@ -910,16 +911,13 @@ func TestServePublic_MetaEndpoint_ExecuteTool_HostedMember_MultiCredentialSessio
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	envelope := decodeRPCResponse(t, w)
 
-	var rpcErr struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	}
-	require.NoError(t, json.Unmarshal(envelope["error"], &rpcErr))
-	// The fixture tool has no server URL, so execution still fails as invalid
-	// params — the point is that the multi-credential map no longer aborts
-	// dispatch before execution.
-	require.Equal(t, int(oops.MCPCodeInvalidParams), rpcErr.Code)
-	require.NotContains(t, rpcErr.Message, "remote-session upstream tokens")
+	// The fixture tool has no server URL, so execution still fails — as a
+	// member-scoped tool error — the point is that the multi-credential map
+	// no longer aborts dispatch before execution.
+	text, isError := metaToolResultText(t, envelope)
+	require.True(t, isError)
+	require.Contains(t, text, "no server URL")
+	require.NotContains(t, text, "remote-session upstream tokens")
 }
 
 // A hosted member whose tools cannot resolve a server URL (no environment

--- a/server/internal/mcp/serve_meta_test.go
+++ b/server/internal/mcp/serve_meta_test.go
@@ -155,7 +155,9 @@ func TestServePublic_MetaEndpoint_Initialize(t *testing.T) {
 	w, err := servePublicHTTP(t, ctx, ti, slug, makeInitializeBody(), "", nil)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
-	require.Equal(t, mcpversions.ServedMetaServer, w.Header().Get(mcpversions.HTTPHeader))
+	// makeInitializeBody requests 2025-03-26; a supported requested revision
+	// is echoed, not upgraded — this is what lets mainstream clients connect.
+	require.Equal(t, mcpversions.Version20250326, w.Header().Get(mcpversions.HTTPHeader))
 
 	envelope := decodeRPCResponse(t, w)
 	var result struct {
@@ -166,7 +168,7 @@ func TestServePublic_MetaEndpoint_Initialize(t *testing.T) {
 		Instructions string `json:"instructions"`
 	}
 	require.NoError(t, json.Unmarshal(envelope["result"], &result))
-	require.Equal(t, mcpversions.ServedMetaServer, result.ProtocolVersion)
+	require.Equal(t, mcpversions.Version20250326, result.ProtocolVersion)
 	require.Equal(t, "Gram Gateway", result.ServerInfo.Name)
 	// Instructions are deliberately generic: the member inventory belongs to
 	// list_servers, so neither the meta server's name nor its members appear.
@@ -202,7 +204,7 @@ func TestServePublic_MetaEndpoint_ServerDiscover(t *testing.T) {
 		} `json:"serverInfo"`
 	}
 	require.NoError(t, json.Unmarshal(envelope["result"], &result))
-	require.Equal(t, []string{mcpversions.ServedMetaServer}, result.ProtocolVersions)
+	require.Equal(t, mcpversions.SupportedMetaServer(), result.ProtocolVersions)
 	require.Equal(t, "Gram Gateway", result.ServerInfo.Name)
 }
 
@@ -335,18 +337,18 @@ func TestServePublic_MetaEndpoint_UnsupportedDeclaredVersion(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, mcpversions.ServedMetaServer, w.Header().Get(mcpversions.HTTPHeader))
+	require.Equal(t, mcpversions.DefaultInEffect, w.Header().Get(mcpversions.HTTPHeader))
 
 	envelope := decodeRPCResponse(t, w)
 	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
-	require.Contains(t, string(envelope["error"]), mcpversions.ServedMetaServer)
+	require.Contains(t, string(envelope["error"]), mcpversions.Version20260728)
 }
 
-// TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionRejected pins the
-// accept set to exactly the served revision: an older revision this codebase
-// recognizes is still rejected, matching what server/discover advertises, and
-// the error names only the served set rather than every known revision.
-func TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionRejected(t *testing.T) {
+// TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted pins the
+// accept set to the full served range: mainstream clients negotiate older
+// revisions at initialize and then stamp them on every request, so a
+// declaration anywhere in the served set must pass.
+func TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -364,17 +366,17 @@ func TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionRejected(t *testing.T
 	require.Equal(t, http.StatusOK, w.Code)
 
 	envelope := decodeRPCResponse(t, w)
-	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
-	require.Contains(t, string(envelope["error"]), mcpversions.ServedMetaServer)
-	require.NotContains(t, string(envelope["error"]), mcpversions.Version20241105, "the error must name the served set, not every known revision")
+	require.NotContains(t, envelope, "error", "an older served revision must be accepted")
+	require.Equal(t, mcpversions.Version20250326, w.Header().Get(mcpversions.HTTPHeader))
 
 	w, err = servePublicHTTP(t, ctx, ti, slug, makeMetaRPCBody(t, "tools/list", map[string]any{}), "", map[string]string{
-		mcpversions.HTTPHeader: mcpversions.ServedMetaServer,
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	envelope = decodeRPCResponse(t, w)
 	require.NotContains(t, envelope, "error")
+	require.Equal(t, mcpversions.Version20260728, w.Header().Get(mcpversions.HTTPHeader))
 }
 
 // TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion pins that a
@@ -398,7 +400,7 @@ func TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, mcpversions.ServedMetaServer, w.Header().Get(mcpversions.HTTPHeader))
+	require.Equal(t, mcpversions.DefaultInEffect, w.Header().Get(mcpversions.HTTPHeader))
 
 	envelope := decodeRPCResponse(t, w)
 	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
@@ -480,9 +482,9 @@ func TestServePublic_MetaEndpoint_IssuerGated_NoAuth_EmitsChallenge(t *testing.T
 	wwwAuth := w.Header().Get("WWW-Authenticate")
 	expected := `Bearer resource_metadata="` + ti.serverURL.String() + `/.well-known/oauth-protected-resource/mcp/` + slug + `"`
 	require.Equal(t, expected, wwwAuth)
-	// The served-version header is stable regardless of outcome and is
+	// The provisional version header (the surface's newest revision) is
 	// stamped before the issuer gate can bail out.
-	require.Equal(t, mcpversions.ServedMetaServer, w.Header().Get(mcpversions.HTTPHeader))
+	require.Equal(t, mcpversions.Version20260728, w.Header().Get(mcpversions.HTTPHeader))
 }
 
 func TestServeMCPEndpoint_MetaEndpoint_NoXmcpExposure(t *testing.T) {
@@ -600,4 +602,43 @@ func TestHandleConsentMCP_MetaEndpoint_NotFound(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+}
+
+// TestServePublic_MetaEndpoint_Initialize_Negotiation pins the negotiation
+// table that lets mainstream clients (which top out below 2026-07-28)
+// connect: a supported requested revision is echoed, an unknown one is
+// answered with the surface's newest, and an absent one lands on the
+// omitted-version default rather than the ceiling.
+func TestServePublic_MetaEndpoint_Initialize_Negotiation(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	slug := "meta-" + uuid.NewString()
+	createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, uuid.Nil)
+
+	cases := []struct {
+		name      string
+		requested string
+		want      string
+	}{
+		{"echoes 2025-06-18", mcpversions.Version20250618, mcpversions.Version20250618},
+		{"echoes 2025-11-25", mcpversions.Version20251125, mcpversions.Version20251125},
+		{"echoes the ceiling", mcpversions.Version20260728, mcpversions.Version20260728},
+		{"unknown gets the newest", "2031-01-01", mcpversions.Version20260728},
+		{"absent gets the default", "", mcpversions.DefaultInEffect},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w, err := servePublicHTTP(t, ctx, ti, slug, makeInitializeBodyWithVersion(tc.requested), "", nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+			require.Equal(t, tc.want, answeredProtocolVersion(t, w))
+			require.Equal(t, tc.want, w.Header().Get(mcpversions.HTTPHeader))
+		})
+	}
 }

--- a/server/internal/mcp/serve_meta_test.go
+++ b/server/internal/mcp/serve_meta_test.go
@@ -341,7 +341,7 @@ func TestServePublic_MetaEndpoint_UnsupportedDeclaredVersion(t *testing.T) {
 
 	envelope := decodeRPCResponse(t, w)
 	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
-	require.Contains(t, string(envelope["error"]), mcpversions.Version20260728)
+	require.Contains(t, string(envelope["error"]), mcpversions.Version20251125)
 }
 
 // TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted pins the
@@ -370,13 +370,23 @@ func TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted(t *testing.T
 	require.Equal(t, mcpversions.Version20250326, w.Header().Get(mcpversions.HTTPHeader))
 
 	w, err = servePublicHTTP(t, ctx, ti, slug, makeMetaRPCBody(t, "tools/list", map[string]any{}), "", map[string]string{
-		mcpversions.HTTPHeader: mcpversions.Version20260728,
+		mcpversions.HTTPHeader: mcpversions.Version20251125,
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	envelope = decodeRPCResponse(t, w)
 	require.NotContains(t, envelope, "error")
-	require.Equal(t, mcpversions.Version20260728, w.Header().Get(mcpversions.HTTPHeader))
+	require.Equal(t, mcpversions.Version20251125, w.Header().Get(mcpversions.HTTPHeader))
+
+	// A recognized-but-unserved declaration (2026-07-28 before the
+	// platform-wide flip) is rejected like any other unserved revision.
+	w, err = servePublicHTTP(t, ctx, ti, slug, makeMetaRPCBody(t, "tools/list", map[string]any{}), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	envelope = decodeRPCResponse(t, w)
+	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
 }
 
 // TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion pins that a
@@ -484,7 +494,7 @@ func TestServePublic_MetaEndpoint_IssuerGated_NoAuth_EmitsChallenge(t *testing.T
 	require.Equal(t, expected, wwwAuth)
 	// The provisional version header (the surface's newest revision) is
 	// stamped before the issuer gate can bail out.
-	require.Equal(t, mcpversions.Version20260728, w.Header().Get(mcpversions.HTTPHeader))
+	require.Equal(t, mcpversions.Version20251125, w.Header().Get(mcpversions.HTTPHeader))
 }
 
 func TestServeMCPEndpoint_MetaEndpoint_NoXmcpExposure(t *testing.T) {
@@ -626,9 +636,9 @@ func TestServePublic_MetaEndpoint_Initialize_Negotiation(t *testing.T) {
 		want      string
 	}{
 		{"echoes 2025-06-18", mcpversions.Version20250618, mcpversions.Version20250618},
-		{"echoes 2025-11-25", mcpversions.Version20251125, mcpversions.Version20251125},
-		{"echoes the ceiling", mcpversions.Version20260728, mcpversions.Version20260728},
-		{"unknown gets the newest", "2031-01-01", mcpversions.Version20260728},
+		{"echoes the ceiling", mcpversions.Version20251125, mcpversions.Version20251125},
+		{"unserved 2026-07-28 gets the newest served", mcpversions.Version20260728, mcpversions.Version20251125},
+		{"unknown gets the newest", "2031-01-01", mcpversions.Version20251125},
 		{"absent gets the default", "", mcpversions.DefaultInEffect},
 	}
 	for _, tc := range cases {

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -259,10 +259,29 @@ func (s *Service) handleMetaExecuteToolCall(
 		Params:  params,
 	}
 
-	return handleToolsCall(ctx, logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env,
+	body, err := handleToolsCall(ctx, logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env,
 		inputs, syntheticReq, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache,
 		s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger,
 		s.platformExtras, s.sessionClientInfo)
+	if err != nil {
+		// A member's execution failure must degrade that member, not the
+		// call: on a multi-member gateway an aborted JSON-RPC call reads as
+		// a gateway fault. Internal faults keep the error envelope. The
+		// innermost shareable message carries the actionable cause (every
+		// ShareableError public is written to be client-safe).
+		if shareable, ok := errors.AsType[*oops.ShareableError](err); ok && shareable.Code != oops.CodeUnexpected {
+			deepest := shareable
+			for inner := errors.Unwrap(error(deepest)); inner != nil; inner = errors.Unwrap(inner) {
+				if innerShareable, ok := errors.AsType[*oops.ShareableError](inner); ok {
+					deepest = innerShareable
+				}
+			}
+			return marshalMetaToolError(ctx, logger, req.ID,
+				fmt.Sprintf("server %q failed to execute %q: %s", member.slug, toolName, deepest.Error()))
+		}
+		return nil, err
+	}
+	return body, nil
 }
 
 // memberCatalog is one hosted member's described tool inventory.

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -266,10 +266,12 @@ func (s *Service) handleMetaExecuteToolCall(
 	if err != nil {
 		// A member's execution failure must degrade that member, not the
 		// call: on a multi-member gateway an aborted JSON-RPC call reads as
-		// a gateway fault. Internal faults keep the error envelope. The
-		// innermost shareable message carries the actionable cause (every
+		// a gateway fault. Internal faults — unexpected errors and server
+		// invariant violations — keep the error envelope. The innermost
+		// shareable message carries the actionable cause (every
 		// ShareableError public is written to be client-safe).
-		if shareable, ok := errors.AsType[*oops.ShareableError](err); ok && shareable.Code != oops.CodeUnexpected {
+		if shareable, ok := errors.AsType[*oops.ShareableError](err); ok &&
+			shareable.Code != oops.CodeUnexpected && shareable.Code != oops.CodeInvariantViolation {
 			deepest := shareable
 			for inner := errors.Unwrap(error(deepest)); inner != nil; inner = errors.Unwrap(inner) {
 				if innerShareable, ok := errors.AsType[*oops.ShareableError](inner); ok {

--- a/server/internal/mcp/serve_meta_tunneled_test.go
+++ b/server/internal/mcp/serve_meta_tunneled_test.go
@@ -122,6 +122,6 @@ func TestServePublic_MetaEndpoint_ExecuteTool_TunneledMemberForwardsLoneToken(t 
 	rpc = executeMetaTool(t, ti, metaSlug, bearer, "member-tunnel--ping")
 	text, isError = metaToolResultText(t, rpc)
 	require.True(t, isError, "an ambiguous credential map must fail the tunneled member call")
-	require.Contains(t, text, "not configured unambiguously")
+	require.Contains(t, text, "no upstream identity of its own", "the message must explain why a tunneled member cannot match a credential")
 	require.Equal(t, forwardsBefore, gateway.forwardCount(), "the failed call must not produce any tunnel forward")
 }

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -628,7 +628,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// mcp_servers_issuer_required_check.
 	issuerID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if (ids.RemoteMcpServerID.Valid || ids.TunneledMcpServerID.Valid) && !existing.UserSessionIssuerID.Valid {
-		issuerID, err = mintServerUserSessionIssuer(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, slug)
+		issuerID, err = MintServerUserSessionIssuer(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, slug)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "mint mcp server issuer").LogError(ctx, logger)
 		}
@@ -1081,7 +1081,7 @@ func (s *Service) reconcileMcpServerCustomDomains(ctx context.Context, customDom
 // positional argument list.
 type serverIDs struct {
 	EnvironmentID uuid.NullUUID
-	// Set by mintServerUserSessionIssuer during create, never parsed from a payload.
+	// Set by MintServerUserSessionIssuer during create, never parsed from a payload.
 	UserSessionIssuerID   uuid.NullUUID
 	RemoteMcpServerID     uuid.NullUUID
 	TunneledMcpServerID   uuid.NullUUID

--- a/server/internal/mcpservers/transaction.go
+++ b/server/internal/mcpservers/transaction.go
@@ -51,7 +51,7 @@ func CreateMCPServerInTransaction(ctx context.Context, tx pgx.Tx, auditLogger *a
 
 	issuerID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if input.RemoteMCPServerID.Valid || input.TunneledMCPServerID.Valid {
-		issuerID, err = mintServerUserSessionIssuer(ctx, tx, input.OrganizationID, input.ProjectID, slug)
+		issuerID, err = MintServerUserSessionIssuer(ctx, tx, input.OrganizationID, input.ProjectID, slug)
 		if err != nil {
 			return repo.McpServer{}, fmt.Errorf("mint MCP server issuer: %w", err)
 		}

--- a/server/internal/mcpservers/usersessionissuer.go
+++ b/server/internal/mcpservers/usersessionissuer.go
@@ -45,12 +45,13 @@ func buildUserSessionResourceSlug(baseSlug string) (string, error) {
 	return normalizedBase + "-" + suffix, nil
 }
 
-// mintServerUserSessionIssuer creates the user_session_issuer a remote- or
+// MintServerUserSessionIssuer creates the user_session_issuer a remote- or
 // tunneled-backed server carries for its lifetime, inside the caller's create
 // transaction so a failed create can never leak an orphan issuer. The issuer
-// is slugged after the server, so it reads naturally in the issuer list and
-// stays unique per server.
-func mintServerUserSessionIssuer(
+// is slugged after the given resource, so it reads naturally in the issuer
+// list and stays unique per resource. Meta MCP creation mints its gateway
+// issuer through this too.
+func MintServerUserSessionIssuer(
 	ctx context.Context,
 	dbtx pgx.Tx,
 	organizationID string,

--- a/server/internal/metamcp/addmetamcpmember_test.go
+++ b/server/internal/metamcp/addmetamcpmember_test.go
@@ -3,6 +3,7 @@ package metamcp_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -18,6 +19,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	unproxiedmcprepo "github.com/speakeasy-api/gram/server/internal/unproxiedmcp/repo"
 )
 
@@ -511,4 +514,139 @@ func TestAddMetaMcpMember_RejectsUnproxiedServer(t *testing.T) {
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)
 	require.ErrorContains(t, err, "unproxied")
+}
+
+// Attaching a member whose upstream identity pieces exist binds the member's
+// OAuth client to the gateway's issuer, so consent offers the provider with
+// no manual attach. A second member on the same upstream is a no-op: one
+// client per upstream per issuer.
+func TestAddMetaMcpMember_AutoAttachesProviderClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "auto attach host")
+	require.NotNil(t, meta.UserSessionIssuerID, "create mints the gateway issuer")
+	gatewayIssuerID := uuid.MustParse(*meta.UserSessionIssuerID)
+
+	rsRepo := remotesessionsrepo.New(ti.conn)
+	newRemoteIssuer := func() uuid.UUID {
+		issuer, err := rsRepo.CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
+			ProjectID:                         conv.ToNullUUID(projectID),
+			OrganizationID:                    conv.ToPGText(authCtx.ActiveOrganizationID),
+			Slug:                              "auto-attach-rsi-" + uuid.NewString()[:8],
+			Issuer:                            "https://as.example.com/" + uuid.NewString(),
+			Name:                              conv.ToPGTextEmpty(""),
+			LogoAssetID:                       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+			ClientSetupDocumentationUrl:       conv.ToPGTextEmpty(""),
+			AuthorizationEndpoint:             conv.ToPGTextEmpty(""),
+			TokenEndpoint:                     conv.ToPGTextEmpty(""),
+			RevocationEndpoint:                conv.ToPGTextEmpty(""),
+			RegistrationEndpoint:              conv.ToPGTextEmpty(""),
+			JwksUri:                           conv.ToPGTextEmpty(""),
+			ServiceDocumentation:              conv.ToPGTextEmpty(""),
+			OpPolicyUri:                       conv.ToPGTextEmpty(""),
+			OpTosUri:                          conv.ToPGTextEmpty(""),
+			ScopesSupported:                   []string{},
+			GrantTypesSupported:               []string{"authorization_code"},
+			ResponseTypesSupported:            []string{"code"},
+			TokenEndpointAuthMethodsSupported: []string{"none"},
+			CodeChallengeMethodsSupported:     []string{"S256"},
+			ClientIDMetadataDocumentSupported: false,
+			Oidc:                              false,
+			Passthrough:                       false,
+		})
+		require.NoError(t, err)
+		return issuer.ID
+	}
+	newClient := func(remoteIssuerID uuid.UUID, externalID string) uuid.UUID {
+		client, err := rsRepo.CreateRemoteSessionClient(ctx, remotesessionsrepo.CreateRemoteSessionClientParams{
+			ProjectID:               conv.ToNullUUID(projectID),
+			OrganizationID:          conv.ToPGText(authCtx.ActiveOrganizationID),
+			RemoteSessionIssuerID:   remoteIssuerID,
+			ClientID:                externalID,
+			ClientSecretEncrypted:   conv.ToPGTextEmpty(""),
+			ClientIDIssuedAt:        pgtype.Timestamptz{Time: time.Now(), Valid: true},
+			ClientSecretExpiresAt:   pgtype.Timestamptz{Time: time.Time{}, Valid: false},
+			TokenEndpointAuthMethod: conv.ToPGTextEmpty(""),
+			Scope:                   []string{},
+			Audience:                conv.ToPGTextEmpty(""),
+			LegacyCallbackUrl:       false,
+		})
+		require.NoError(t, err)
+		return client.ID
+	}
+	memberIssuerOf := func(serverID uuid.UUID) uuid.UUID {
+		server, err := mcpserversrepo.New(ti.conn).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
+			ID:        serverID,
+			ProjectID: projectID,
+		})
+		require.NoError(t, err)
+		require.True(t, server.UserSessionIssuerID.Valid)
+		return server.UserSessionIssuerID.UUID
+	}
+	stampAndWire := func(serverID, remoteIssuerID, clientID uuid.UUID) {
+		require.NoError(t, rsRepo.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{
+			RemoteSessionClientID: clientID,
+			UserSessionIssuerID:   memberIssuerOf(serverID),
+		}))
+		stamped, err := testrepo.New(ti.conn).SetMCPServerRemoteSessionIssuerFixture(ctx, testrepo.SetMCPServerRemoteSessionIssuerFixtureParams{
+			RemoteSessionIssuerID: conv.ToNullUUID(remoteIssuerID),
+			ID:                    serverID,
+			ProjectID:             projectID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), stamped)
+	}
+	gatewayClientsForUpstream := func(remoteIssuerID uuid.UUID) int {
+		rows, err := rsRepo.ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
+			UserSessionIssuerID: gatewayIssuerID,
+			ProjectID:           conv.ToNullUUID(projectID),
+			OrganizationID:      conv.ToPGText(authCtx.ActiveOrganizationID),
+		})
+		require.NoError(t, err)
+		count := 0
+		for _, row := range rows {
+			if row.RemoteSessionIssuerID == remoteIssuerID {
+				count++
+			}
+		}
+		return count
+	}
+
+	remoteIssuerID := newRemoteIssuer()
+	serverID := seedMcpServer(t, ctx, ti.conn, projectID)
+	stampAndWire(serverID, remoteIssuerID, newClient(remoteIssuerID, "auto-attach-client"))
+
+	_, err := ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  meta.ID,
+		McpServerID:      serverID.String(),
+		SortOrder:        nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, gatewayClientsForUpstream(remoteIssuerID),
+		"member's client must be bound to the gateway issuer")
+
+	// Second member on the same upstream: attach succeeds, binding count for
+	// that upstream stays at one.
+	secondID := seedMcpServer(t, ctx, ti.conn, projectID)
+	stampAndWire(secondID, remoteIssuerID, newClient(remoteIssuerID, "auto-attach-client-2"))
+
+	_, err = ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  meta.ID,
+		McpServerID:      secondID.String(),
+		SortOrder:        nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, gatewayClientsForUpstream(remoteIssuerID),
+		"one client per upstream per issuer")
 }

--- a/server/internal/metamcp/createmetamcpserver_test.go
+++ b/server/internal/metamcp/createmetamcpserver_test.go
@@ -40,7 +40,9 @@ func TestCreateMetaMcpServer_Success(t *testing.T) {
 	require.Equal(t, "my gateway", result.Name)
 	require.Equal(t, authCtx.ActiveOrganizationID, result.OrganizationID)
 	require.Equal(t, authCtx.ProjectID.String(), result.ProjectID)
-	require.Nil(t, result.UserSessionIssuerID)
+	// A gateway without sign-in is a trap (anonymous callers, no member
+	// credentials), so omitting the issuer mints a dedicated one.
+	require.NotNil(t, result.UserSessionIssuerID)
 
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionMetaMcpServerCreate)
 	require.NoError(t, err)

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -115,6 +116,16 @@ func (s *Service) CreateMetaMcpServer(ctx context.Context, payload *gen.CreateMe
 
 	if err := s.lockIssuerReference(ctx, txRepo, *authCtx.ProjectID, issuerID); err != nil {
 		return nil, err
+	}
+
+	// A gateway without sign-in serves everyone anonymously, which hides
+	// every private member and can hold no member credentials — a trap, not
+	// a use case. Mint a dedicated issuer when the caller supplies none.
+	if !issuerID.Valid {
+		issuerID, err = mcpservers.MintServerUserSessionIssuer(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, payload.Name)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "mint meta mcp issuer").LogError(ctx, logger)
+		}
 	}
 
 	created, err := txRepo.CreateMetaMCPServer(ctx, repo.CreateMetaMCPServerParams{
@@ -575,6 +586,27 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 			return nil, oops.E(oops.CodeConflict, err, "mcp server is already a member of this meta mcp server").LogError(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "add meta mcp member").LogError(ctx, logger)
+	}
+
+	// Best-effort consent wiring: when both sides have the identity pieces —
+	// the gateway an issuer, the member a stamped upstream AS with a client —
+	// bind that client to the gateway's issuer so consent offers the member's
+	// provider without a manual attach ceremony.
+	if meta.UserSessionIssuerID.Valid && server.RemoteSessionIssuerID.Valid && server.UserSessionIssuerID.Valid {
+		attached, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
+			GatewayIssuerID: meta.UserSessionIssuerID.UUID,
+			ProjectID:       *authCtx.ProjectID,
+			MemberIssuerID:  server.UserSessionIssuerID.UUID,
+			RemoteIssuerID:  server.RemoteSessionIssuerID.UUID,
+		})
+		if aerr != nil {
+			return nil, oops.E(oops.CodeUnexpected, aerr, "attach member provider client").LogError(ctx, logger)
+		}
+		if attached > 0 {
+			logger.InfoContext(ctx, "attached member provider client to meta mcp issuer",
+				attr.SlogMetaMcpServerID(meta.ID.String()),
+				attr.SlogMcpServerID(server.ID.String()))
+		}
 	}
 
 	if err := s.audit.LogMetaMcpMemberAdd(ctx, dbtx, audit.LogMetaMcpMemberEvent{

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -593,6 +593,11 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 	// bind that client to the gateway's issuer so consent offers the member's
 	// provider without a manual attach ceremony.
 	if meta.UserSessionIssuerID.Valid && server.RemoteSessionIssuerID.Valid && server.UserSessionIssuerID.Valid {
+		// No DB constraint enforces one client per (issuer, upstream); every
+		// client-binding writer serializes on this advisory lock instead.
+		if lerr := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, server.RemoteSessionIssuerID.UUID); lerr != nil {
+			return nil, oops.E(oops.CodeUnexpected, lerr, "lock remote session issuer for client binding").LogError(ctx, logger)
+		}
 		attached, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
 			GatewayIssuerID: meta.UserSessionIssuerID.UUID,
 			ProjectID:       *authCtx.ProjectID,

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -36,6 +36,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -251,6 +253,20 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 		return nil, oops.E(oops.CodeUnexpected, err, "lock meta mcp server").LogError(ctx, logger)
 	}
 
+	// Defensive issuer wiring, mirroring create: an omitted issuer preserves
+	// the existing one (matching UpdateMCPServer's COALESCE) and a gateway
+	// that would end up issuer-less gets one minted, so no update path can
+	// strand a gateway in the anonymous trap.
+	if !issuerID.Valid {
+		issuerID = existing.UserSessionIssuerID
+	}
+	if !issuerID.Valid {
+		issuerID, err = mcpservers.MintServerUserSessionIssuer(ctx, dbtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, payload.Name)
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "mint meta mcp issuer").LogError(ctx, logger)
+		}
+	}
+
 	if err := s.lockIssuerReference(ctx, txRepo, *authCtx.ProjectID, issuerID); err != nil {
 		return nil, err
 	}
@@ -271,6 +287,7 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 	// pointing the gateway at a different issuer (or gaining one) would
 	// silently orphan every members' tiles. Re-run the member attachment
 	// against the new issuer instead of leaving that to a manual ceremony.
+	rewiredIssuer := false
 	if issuerID.Valid && (!existing.UserSessionIssuerID.Valid || existing.UserSessionIssuerID.UUID != issuerID.UUID) {
 		identities, ierr := txRepo.ListMemberProviderIdentities(ctx, repo.ListMemberProviderIdentitiesParams{
 			MetaMcpServerID: serverID,
@@ -280,7 +297,7 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 			return nil, oops.E(oops.CodeUnexpected, ierr, "list member provider identities").LogError(ctx, logger)
 		}
 		for _, identity := range identities {
-			if lerr := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, identity.RemoteSessionIssuerID.UUID); lerr != nil {
+			if lerr := remotesessionsrepo.New(dbtx).LockRemoteSessionIssuerForClientBinding(ctx, identity.RemoteSessionIssuerID.UUID); lerr != nil {
 				return nil, oops.E(oops.CodeUnexpected, lerr, "lock remote session issuer for client binding").LogError(ctx, logger)
 			}
 			if _, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
@@ -292,6 +309,7 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 				return nil, oops.E(oops.CodeUnexpected, aerr, "attach member provider client").LogError(ctx, logger)
 			}
 		}
+		rewiredIssuer = true
 	}
 
 	afterView := mv.BuildMetaMcpServerView(updated)
@@ -312,6 +330,13 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
+	}
+
+	// Client-binding writers follow their commit with this resync so the
+	// denormalized mcp_servers.remote_session_issuer_id cannot go stale when
+	// the gateway issuer is shared with a server row.
+	if rewiredIssuer {
+		remotesessions.BestEffortResyncMCPServerRemoteSessionIssuers(ctx, logger, s.db, authCtx.ActiveOrganizationID, *authCtx.ProjectID, []uuid.UUID{issuerID.UUID})
 	}
 
 	return afterView, nil
@@ -619,10 +644,11 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 	// the gateway an issuer, the member a stamped upstream AS with a client —
 	// bind that client to the gateway's issuer so consent offers the member's
 	// provider without a manual attach ceremony.
+	wiredGatewayIssuer := false
 	if meta.UserSessionIssuerID.Valid && server.RemoteSessionIssuerID.Valid && server.UserSessionIssuerID.Valid {
 		// No DB constraint enforces one client per (issuer, upstream); every
 		// client-binding writer serializes on this advisory lock instead.
-		if lerr := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, server.RemoteSessionIssuerID.UUID); lerr != nil {
+		if lerr := remotesessionsrepo.New(dbtx).LockRemoteSessionIssuerForClientBinding(ctx, server.RemoteSessionIssuerID.UUID); lerr != nil {
 			return nil, oops.E(oops.CodeUnexpected, lerr, "lock remote session issuer for client binding").LogError(ctx, logger)
 		}
 		attached, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
@@ -638,7 +664,15 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 			logger.InfoContext(ctx, "attached member provider client to meta mcp issuer",
 				attr.SlogMetaMcpServerID(meta.ID.String()),
 				attr.SlogMcpServerID(server.ID.String()))
+		} else {
+			// No bindable client, or the upstream is already bound: either
+			// way the skip should be visible, matching autoConfigureAuth's
+			// every-skip-has-a-reason posture.
+			logger.InfoContext(ctx, "no member provider client attached to meta mcp issuer",
+				attr.SlogMetaMcpServerID(meta.ID.String()),
+				attr.SlogMcpServerID(server.ID.String()))
 		}
+		wiredGatewayIssuer = true
 	}
 
 	if err := s.audit.LogMetaMcpMemberAdd(ctx, dbtx, audit.LogMetaMcpMemberEvent{
@@ -658,6 +692,13 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
+	}
+
+	// Every client-binding writer follows its commit with this resync so the
+	// denormalized mcp_servers.remote_session_issuer_id cannot go stale when
+	// the gateway issuer is shared with a server row.
+	if wiredGatewayIssuer {
+		remotesessions.BestEffortResyncMCPServerRemoteSessionIssuers(ctx, logger, s.db, authCtx.ActiveOrganizationID, *authCtx.ProjectID, []uuid.UUID{meta.UserSessionIssuerID.UUID})
 	}
 
 	return mv.BuildMetaMcpMemberViewFromParts(member, server), nil

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -267,6 +267,33 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 		return nil, oops.E(oops.CodeUnexpected, err, "update meta mcp server").LogError(ctx, logger)
 	}
 
+	// Consent wiring binds member provider clients to a specific issuer, so
+	// pointing the gateway at a different issuer (or gaining one) would
+	// silently orphan every members' tiles. Re-run the member attachment
+	// against the new issuer instead of leaving that to a manual ceremony.
+	if issuerID.Valid && (!existing.UserSessionIssuerID.Valid || existing.UserSessionIssuerID.UUID != issuerID.UUID) {
+		identities, ierr := txRepo.ListMemberProviderIdentities(ctx, repo.ListMemberProviderIdentitiesParams{
+			MetaMcpServerID: serverID,
+			ProjectID:       *authCtx.ProjectID,
+		})
+		if ierr != nil {
+			return nil, oops.E(oops.CodeUnexpected, ierr, "list member provider identities").LogError(ctx, logger)
+		}
+		for _, identity := range identities {
+			if lerr := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, identity.RemoteSessionIssuerID.UUID); lerr != nil {
+				return nil, oops.E(oops.CodeUnexpected, lerr, "lock remote session issuer for client binding").LogError(ctx, logger)
+			}
+			if _, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
+				GatewayIssuerID: issuerID.UUID,
+				ProjectID:       *authCtx.ProjectID,
+				MemberIssuerID:  identity.UserSessionIssuerID.UUID,
+				RemoteIssuerID:  identity.RemoteSessionIssuerID.UUID,
+			}); aerr != nil {
+				return nil, oops.E(oops.CodeUnexpected, aerr, "attach member provider client").LogError(ctx, logger)
+			}
+		}
+	}
+
 	afterView := mv.BuildMetaMcpServerView(updated)
 
 	if err := s.audit.LogMetaMcpServerUpdate(ctx, dbtx, audit.LogMetaMcpServerUpdateEvent{

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -303,12 +303,6 @@ WHERE m.meta_mcp_server_id = @meta_mcp_server_id
   AND s.remote_session_issuer_id = @remote_session_issuer_id
 ORDER BY m.sort_order, m.created_at, m.id;
 
--- name: LockRemoteSessionIssuerForClientBinding :exec
--- Same advisory key as remotesessions' lock of the same name: every writer
--- binding a client to a remote issuer takes it, so the auto-attach guard
--- below cannot race a concurrent manual attach into a double binding.
-SELECT pg_advisory_xact_lock(hashtextextended((@remote_session_issuer_id::uuid)::text, 0));
-
 -- name: AutoAttachMemberProviderClient :execrows
 -- Bind the member's upstream OAuth client to the gateway's issuer so consent
 -- can offer the member's provider. No-op when the gateway's issuer already

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -303,6 +303,12 @@ WHERE m.meta_mcp_server_id = @meta_mcp_server_id
   AND s.remote_session_issuer_id = @remote_session_issuer_id
 ORDER BY m.sort_order, m.created_at, m.id;
 
+-- name: LockRemoteSessionIssuerForClientBinding :exec
+-- Same advisory key as remotesessions' lock of the same name: every writer
+-- binding a client to a remote issuer takes it, so the auto-attach guard
+-- below cannot race a concurrent manual attach into a double binding.
+SELECT pg_advisory_xact_lock(hashtextextended((@remote_session_issuer_id::uuid)::text, 0));
+
 -- name: AutoAttachMemberProviderClient :execrows
 -- Bind the member's upstream OAuth client to the gateway's issuer so consent
 -- can offer the member's provider. No-op when the gateway's issuer already

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -302,3 +302,34 @@ WHERE m.meta_mcp_server_id = @meta_mcp_server_id
   AND s.slug IS NOT NULL
   AND s.remote_session_issuer_id = @remote_session_issuer_id
 ORDER BY m.sort_order, m.created_at, m.id;
+
+-- name: AutoAttachMemberProviderClient :execrows
+-- Bind the member's upstream OAuth client to the gateway's issuer so consent
+-- can offer the member's provider. No-op when the gateway's issuer already
+-- holds a client for that upstream (one client per upstream per issuer), or
+-- when the member has no derivable client. Tenancy mirrors the resync
+-- derivation: the member's own project client, or an org-level client.
+INSERT INTO remote_session_client_user_session_issuers (remote_session_client_id, user_session_issuer_id)
+SELECT c.id, @gateway_issuer_id
+FROM remote_session_clients AS c
+JOIN remote_session_client_user_session_issuers AS l
+  ON l.remote_session_client_id = c.id
+JOIN projects AS p
+  ON p.id = @project_id
+WHERE l.user_session_issuer_id = @member_issuer_id
+  AND c.remote_session_issuer_id = @remote_issuer_id
+  AND c.deleted IS FALSE
+  AND (c.project_id = @project_id
+       OR (c.project_id IS NULL AND c.organization_id = p.organization_id))
+  AND NOT EXISTS (
+    SELECT 1
+    FROM remote_session_client_user_session_issuers AS l2
+    JOIN remote_session_clients AS c2
+      ON c2.id = l2.remote_session_client_id
+     AND c2.deleted IS FALSE
+    WHERE l2.user_session_issuer_id = @gateway_issuer_id
+      AND c2.remote_session_issuer_id = @remote_issuer_id
+  )
+ORDER BY c.created_at
+LIMIT 1
+ON CONFLICT DO NOTHING;

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -339,3 +339,20 @@ WHERE l.user_session_issuer_id = @member_issuer_id
 ORDER BY c.created_at
 LIMIT 1
 ON CONFLICT DO NOTHING;
+
+-- name: ListMemberProviderIdentities :many
+-- Distinct provider identity pairs across a meta server's live members, for
+-- re-running consent wiring when the gateway's issuer changes. Ordered so
+-- callers take the per-remote-issuer binding locks deterministically.
+SELECT DISTINCT s.remote_session_issuer_id, s.user_session_issuer_id
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = @meta_mcp_server_id
+  AND m.project_id = @project_id
+  AND m.deleted IS FALSE
+  AND s.remote_session_issuer_id IS NOT NULL
+  AND s.user_session_issuer_id IS NOT NULL
+ORDER BY s.remote_session_issuer_id, s.user_session_issuer_id;

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -66,9 +66,11 @@ WHERE meta_mcp_servers.organization_id = @organization_id
 ORDER BY meta_mcp_servers.created_at DESC, meta_mcp_servers.id DESC;
 
 -- name: UpdateMetaMCPServer :one
--- Full-record replace: a null user_session_issuer_id clears the reference. A
--- null visibility preserves the stored value so callers that do not manage
--- visibility cannot re-enable a disabled gateway.
+-- The service always supplies user_session_issuer_id (an omitted payload
+-- issuer resolves to the preserved or freshly minted one), so the narg here
+-- never arrives null from production code. A null visibility preserves the
+-- stored value so callers that do not manage visibility cannot re-enable a
+-- disabled gateway.
 UPDATE meta_mcp_servers
 SET name = @name,
     user_session_issuer_id = sqlc.narg('user_session_issuer_id'),

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -539,6 +539,54 @@ func (q *Queries) GetMetaMCPServerByIDAndProjectID(ctx context.Context, arg GetM
 	return i, err
 }
 
+const listMemberProviderIdentities = `-- name: ListMemberProviderIdentities :many
+SELECT DISTINCT s.remote_session_issuer_id, s.user_session_issuer_id
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = $1
+  AND m.project_id = $2
+  AND m.deleted IS FALSE
+  AND s.remote_session_issuer_id IS NOT NULL
+  AND s.user_session_issuer_id IS NOT NULL
+ORDER BY s.remote_session_issuer_id, s.user_session_issuer_id
+`
+
+type ListMemberProviderIdentitiesParams struct {
+	MetaMcpServerID uuid.UUID
+	ProjectID       uuid.UUID
+}
+
+type ListMemberProviderIdentitiesRow struct {
+	RemoteSessionIssuerID uuid.NullUUID
+	UserSessionIssuerID   uuid.NullUUID
+}
+
+// Distinct provider identity pairs across a meta server's live members, for
+// re-running consent wiring when the gateway's issuer changes. Ordered so
+// callers take the per-remote-issuer binding locks deterministically.
+func (q *Queries) ListMemberProviderIdentities(ctx context.Context, arg ListMemberProviderIdentitiesParams) ([]ListMemberProviderIdentitiesRow, error) {
+	rows, err := q.db.Query(ctx, listMemberProviderIdentities, arg.MetaMcpServerID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMemberProviderIdentitiesRow
+	for rows.Next() {
+		var i ListMemberProviderIdentitiesRow
+		if err := rows.Scan(&i.RemoteSessionIssuerID, &i.UserSessionIssuerID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMetaMCPMembers = `-- name: ListMetaMCPMembers :many
 SELECT
     m.id,

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -919,18 +919,6 @@ func (q *Queries) LockMetaMCPServer(ctx context.Context, arg LockMetaMCPServerPa
 	return i, err
 }
 
-const lockRemoteSessionIssuerForClientBinding = `-- name: LockRemoteSessionIssuerForClientBinding :exec
-SELECT pg_advisory_xact_lock(hashtextextended(($1::uuid)::text, 0))
-`
-
-// Same advisory key as remotesessions' lock of the same name: every writer
-// binding a client to a remote issuer takes it, so the auto-attach guard
-// below cannot race a concurrent manual attach into a double binding.
-func (q *Queries) LockRemoteSessionIssuerForClientBinding(ctx context.Context, remoteSessionIssuerID uuid.UUID) error {
-	_, err := q.db.Exec(ctx, lockRemoteSessionIssuerForClientBinding, remoteSessionIssuerID)
-	return err
-}
-
 const lockUserSessionIssuerForMetaMCP = `-- name: LockUserSessionIssuerForMetaMCP :one
 SELECT id
 FROM user_session_issuers

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -12,6 +12,58 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const autoAttachMemberProviderClient = `-- name: AutoAttachMemberProviderClient :execrows
+INSERT INTO remote_session_client_user_session_issuers (remote_session_client_id, user_session_issuer_id)
+SELECT c.id, $1
+FROM remote_session_clients AS c
+JOIN remote_session_client_user_session_issuers AS l
+  ON l.remote_session_client_id = c.id
+JOIN projects AS p
+  ON p.id = $2
+WHERE l.user_session_issuer_id = $3
+  AND c.remote_session_issuer_id = $4
+  AND c.deleted IS FALSE
+  AND (c.project_id = $2
+       OR (c.project_id IS NULL AND c.organization_id = p.organization_id))
+  AND NOT EXISTS (
+    SELECT 1
+    FROM remote_session_client_user_session_issuers AS l2
+    JOIN remote_session_clients AS c2
+      ON c2.id = l2.remote_session_client_id
+     AND c2.deleted IS FALSE
+    WHERE l2.user_session_issuer_id = $1
+      AND c2.remote_session_issuer_id = $4
+  )
+ORDER BY c.created_at
+LIMIT 1
+ON CONFLICT DO NOTHING
+`
+
+type AutoAttachMemberProviderClientParams struct {
+	GatewayIssuerID uuid.UUID
+	ProjectID       uuid.UUID
+	MemberIssuerID  uuid.UUID
+	RemoteIssuerID  uuid.UUID
+}
+
+// Bind the member's upstream OAuth client to the gateway's issuer so consent
+// can offer the member's provider. No-op when the gateway's issuer already
+// holds a client for that upstream (one client per upstream per issuer), or
+// when the member has no derivable client. Tenancy mirrors the resync
+// derivation: the member's own project client, or an org-level client.
+func (q *Queries) AutoAttachMemberProviderClient(ctx context.Context, arg AutoAttachMemberProviderClientParams) (int64, error) {
+	result, err := q.db.Exec(ctx, autoAttachMemberProviderClient,
+		arg.GatewayIssuerID,
+		arg.ProjectID,
+		arg.MemberIssuerID,
+		arg.RemoteIssuerID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countMetaMCPMembersSharingBackend = `-- name: CountMetaMCPMembersSharingBackend :one
 SELECT count(*)
 FROM meta_mcp_server_members m

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -998,9 +998,11 @@ type UpdateMetaMCPServerParams struct {
 	ProjectID           uuid.UUID
 }
 
-// Full-record replace: a null user_session_issuer_id clears the reference. A
-// null visibility preserves the stored value so callers that do not manage
-// visibility cannot re-enable a disabled gateway.
+// The service always supplies user_session_issuer_id (an omitted payload
+// issuer resolves to the preserved or freshly minted one), so the narg here
+// never arrives null from production code. A null visibility preserves the
+// stored value so callers that do not manage visibility cannot re-enable a
+// disabled gateway.
 func (q *Queries) UpdateMetaMCPServer(ctx context.Context, arg UpdateMetaMCPServerParams) (MetaMcpServer, error) {
 	row := q.db.QueryRow(ctx, updateMetaMCPServer,
 		arg.Name,

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -871,6 +871,18 @@ func (q *Queries) LockMetaMCPServer(ctx context.Context, arg LockMetaMCPServerPa
 	return i, err
 }
 
+const lockRemoteSessionIssuerForClientBinding = `-- name: LockRemoteSessionIssuerForClientBinding :exec
+SELECT pg_advisory_xact_lock(hashtextextended(($1::uuid)::text, 0))
+`
+
+// Same advisory key as remotesessions' lock of the same name: every writer
+// binding a client to a remote issuer takes it, so the auto-attach guard
+// below cannot race a concurrent manual attach into a double binding.
+func (q *Queries) LockRemoteSessionIssuerForClientBinding(ctx context.Context, remoteSessionIssuerID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, lockRemoteSessionIssuerForClientBinding, remoteSessionIssuerID)
+	return err
+}
+
 const lockUserSessionIssuerForMetaMCP = `-- name: LockUserSessionIssuerForMetaMCP :one
 SELECT id
 FROM user_session_issuers

--- a/server/internal/metamcp/updatemetamcpserver_test.go
+++ b/server/internal/metamcp/updatemetamcpserver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
@@ -63,7 +64,10 @@ func TestUpdateMetaMcpServer_RenamesAndAttachesIssuer(t *testing.T) {
 	require.Equal(t, beforeCount+1, afterCount)
 }
 
-func TestUpdateMetaMcpServer_OmittedIssuerClearsReference(t *testing.T) {
+// An omitted issuer preserves the stored one (matching UpdateMCPServer's
+// COALESCE), and an update can never strand a gateway issuer-less: a gateway
+// that would end up without one gets one minted defensively.
+func TestUpdateMetaMcpServer_OmittedIssuerPreservesReference(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -92,7 +96,40 @@ func TestUpdateMetaMcpServer_OmittedIssuerClearsReference(t *testing.T) {
 		UserSessionIssuerID: nil,
 	})
 	require.NoError(t, err)
-	require.Nil(t, updated.UserSessionIssuerID)
+	require.NotNil(t, updated.UserSessionIssuerID)
+	require.Equal(t, issuerID.String(), *updated.UserSessionIssuerID)
+}
+
+// A pre-defaults gateway row with no issuer gains a minted one on its next
+// update rather than staying in the anonymous trap.
+func TestUpdateMetaMcpServer_MintsIssuerWhenNoneStored(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	row, err := metamcprepo.New(ti.conn).CreateMetaMCPServer(ctx, metamcprepo.CreateMetaMCPServerParams{
+		OrganizationID:      authCtx.ActiveOrganizationID,
+		ProjectID:           *authCtx.ProjectID,
+		Name:                "legacy issuerless",
+		UserSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:          "private",
+	})
+	require.NoError(t, err)
+	require.False(t, row.UserSessionIssuerID.Valid)
+
+	updated, err := ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
+		SessionToken:        nil,
+		ApikeyToken:         nil,
+		ProjectSlugInput:    nil,
+		ID:                  row.ID.String(),
+		Name:                "legacy issuerless",
+		UserSessionIssuerID: nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.UserSessionIssuerID, "update must mint an issuer for an issuerless gateway")
 }
 
 func TestUpdateMetaMcpServer_NotFound(t *testing.T) {
@@ -283,18 +320,7 @@ func TestUpdateMetaMcpServer_RewiresProviderClientsOnIssuerChange(t *testing.T) 
 	require.Equal(t, 1, boundCount(newIssuerID),
 		"issuer change must re-bind member provider clients to the new issuer")
 
-	// Clearing the issuer and attaching another later wires members then too:
-	// the previously-anonymous gateway arc.
-	_, err = ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
-		SessionToken:        nil,
-		ApikeyToken:         nil,
-		ProjectSlugInput:    nil,
-		ID:                  meta.ID,
-		Name:                meta.Name,
-		UserSessionIssuerID: nil,
-	})
-	require.NoError(t, err)
-
+	// A second swap wires the members again: rewiring is not a one-shot.
 	thirdIssuerID := seedUserSessionIssuer(t, ctx, ti.conn, projectID)
 	_, err = ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
 		SessionToken:        nil,
@@ -306,5 +332,5 @@ func TestUpdateMetaMcpServer_RewiresProviderClientsOnIssuerChange(t *testing.T) 
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, boundCount(thirdIssuerID),
-		"gaining an issuer must wire existing members' provider clients")
+		"each issuer change must re-wire member provider clients")
 }

--- a/server/internal/metamcp/updatemetamcpserver_test.go
+++ b/server/internal/metamcp/updatemetamcpserver_test.go
@@ -2,6 +2,7 @@ package metamcp_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/metamcp"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
 func TestUpdateMetaMcpServer_RenamesAndAttachesIssuer(t *testing.T) {
@@ -162,4 +169,142 @@ func TestUpdateMetaMcpServer_ChangesVisibility(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, disabled, updated.Visibility)
+}
+
+// A gateway's consent wiring binds member provider clients to a specific
+// issuer, so changing the gateway's issuer must re-run member attachment
+// against the new one rather than silently orphaning every provider tile.
+func TestUpdateMetaMcpServer_RewiresProviderClientsOnIssuerChange(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "issuer rewire host")
+	require.NotNil(t, meta.UserSessionIssuerID, "create mints the gateway issuer")
+
+	rsRepo := remotesessionsrepo.New(ti.conn)
+	remoteIssuer, err := rsRepo.CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         conv.ToNullUUID(projectID),
+		OrganizationID:                    conv.ToPGText(authCtx.ActiveOrganizationID),
+		Slug:                              "rewire-rsi-" + uuid.NewString()[:8],
+		Issuer:                            "https://as.example.com/" + uuid.NewString(),
+		Name:                              conv.ToPGTextEmpty(""),
+		LogoAssetID:                       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ClientSetupDocumentationUrl:       conv.ToPGTextEmpty(""),
+		AuthorizationEndpoint:             conv.ToPGTextEmpty(""),
+		TokenEndpoint:                     conv.ToPGTextEmpty(""),
+		RevocationEndpoint:                conv.ToPGTextEmpty(""),
+		RegistrationEndpoint:              conv.ToPGTextEmpty(""),
+		JwksUri:                           conv.ToPGTextEmpty(""),
+		ServiceDocumentation:              conv.ToPGTextEmpty(""),
+		OpPolicyUri:                       conv.ToPGTextEmpty(""),
+		OpTosUri:                          conv.ToPGTextEmpty(""),
+		ScopesSupported:                   []string{},
+		GrantTypesSupported:               []string{"authorization_code"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		ClientIDMetadataDocumentSupported: false,
+		Oidc:                              false,
+		Passthrough:                       false,
+	})
+	require.NoError(t, err)
+
+	client, err := rsRepo.CreateRemoteSessionClient(ctx, remotesessionsrepo.CreateRemoteSessionClientParams{
+		ProjectID:               conv.ToNullUUID(projectID),
+		OrganizationID:          conv.ToPGText(authCtx.ActiveOrganizationID),
+		RemoteSessionIssuerID:   remoteIssuer.ID,
+		ClientID:                "rewire-client",
+		ClientSecretEncrypted:   conv.ToPGTextEmpty(""),
+		ClientIDIssuedAt:        pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		ClientSecretExpiresAt:   pgtype.Timestamptz{Time: time.Time{}, Valid: false},
+		TokenEndpointAuthMethod: conv.ToPGTextEmpty(""),
+		Scope:                   []string{},
+		Audience:                conv.ToPGTextEmpty(""),
+		LegacyCallbackUrl:       false,
+	})
+	require.NoError(t, err)
+
+	serverID := seedMcpServer(t, ctx, ti.conn, projectID)
+	memberServer, err := mcpserversrepo.New(ti.conn).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
+		ID:        serverID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	require.True(t, memberServer.UserSessionIssuerID.Valid)
+	require.NoError(t, rsRepo.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{
+		RemoteSessionClientID: client.ID,
+		UserSessionIssuerID:   memberServer.UserSessionIssuerID.UUID,
+	}))
+	stamped, err := testrepo.New(ti.conn).SetMCPServerRemoteSessionIssuerFixture(ctx, testrepo.SetMCPServerRemoteSessionIssuerFixtureParams{
+		RemoteSessionIssuerID: conv.ToNullUUID(remoteIssuer.ID),
+		ID:                    serverID,
+		ProjectID:             projectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stamped)
+
+	boundCount := func(issuerID uuid.UUID) int {
+		rows, lerr := rsRepo.ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
+			UserSessionIssuerID: issuerID,
+			ProjectID:           conv.ToNullUUID(projectID),
+			OrganizationID:      conv.ToPGText(authCtx.ActiveOrganizationID),
+		})
+		require.NoError(t, lerr)
+		return len(rows)
+	}
+
+	_, err = ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  meta.ID,
+		McpServerID:      serverID.String(),
+		SortOrder:        nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, boundCount(uuid.MustParse(*meta.UserSessionIssuerID)),
+		"add binds the member's client to the original issuer")
+
+	newIssuerID := seedUserSessionIssuer(t, ctx, ti.conn, projectID)
+	_, err = ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
+		SessionToken:        nil,
+		ApikeyToken:         nil,
+		ProjectSlugInput:    nil,
+		ID:                  meta.ID,
+		Name:                meta.Name,
+		UserSessionIssuerID: conv.PtrEmpty(newIssuerID.String()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, boundCount(newIssuerID),
+		"issuer change must re-bind member provider clients to the new issuer")
+
+	// Clearing the issuer and attaching another later wires members then too:
+	// the previously-anonymous gateway arc.
+	_, err = ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
+		SessionToken:        nil,
+		ApikeyToken:         nil,
+		ProjectSlugInput:    nil,
+		ID:                  meta.ID,
+		Name:                meta.Name,
+		UserSessionIssuerID: nil,
+	})
+	require.NoError(t, err)
+
+	thirdIssuerID := seedUserSessionIssuer(t, ctx, ti.conn, projectID)
+	_, err = ti.service.UpdateMetaMcpServer(ctx, &gen.UpdateMetaMcpServerPayload{
+		SessionToken:        nil,
+		ApikeyToken:         nil,
+		ProjectSlugInput:    nil,
+		ID:                  meta.ID,
+		Name:                meta.Name,
+		UserSessionIssuerID: conv.PtrEmpty(thirdIssuerID.String()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, boundCount(thirdIssuerID),
+		"gaining an issuer must wire existing members' provider clients")
 }


### PR DESCRIPTION
Setting up a working gateway took six hand-assembled concepts — member visibility, resource grants, session issuers, remote identity providers, session clients, and the all-or-nothing credential rule — the UI misled at several steps, and no mainstream MCP client could complete a connection. This PR collapses the ceremony into defaults, makes the failure modes explain themselves, and opens the surface to the installed client base — with the underlying security model unchanged.

## Auth defaults

**Create mints the gateway's sign-in** — `metaMcp.create` without a `user_session_issuer_id` mints a dedicated issuer in the create transaction, via the same `MintServerUserSessionIssuer` remote/tunneled servers use (exported; rename-only outside meta code). A gateway without sign-in serves everyone anonymously — which hides every private member and can hold no member credentials — so it was a trap, not a use case.

**Member attach wires consent** — `metaMcp.addMember` binds the member's upstream OAuth client to the gateway's issuer (new `AutoAttachMemberProviderClient` query): tenancy-scoped, idempotent, one client per upstream per issuer, logged either way. It takes remotesessions' per-remote-issuer advisory lock (shared, not copied) and follows its commit with the standard issuer resync, like every other binding writer.

**Update can never strand a gateway** — `metaMcp.update` with an omitted issuer preserves the stored one (matching the regular server's COALESCE), mints one if the gateway has none, and on any issuer change re-runs member provider attachment against the new issuer so consent tiles survive the swap. Contract text updated across design, OpenAPI, and SDK docs.

**Multi-provider stays meta-only** — `AuthTarget` gained a `multipleProviders` capability set only by the gateway target; the in-list Attach Provider action renders only for it, so remote/tunneled servers keep exactly one upstream provider. All the field's `mcp:write` gates are scoped to the owning project.

## Client compatibility

**Protocol version negotiation** — the gateway surface served only MCP 2026-07-28, so real connections died after OAuth with "server's protocol version is not supported". It now negotiates exactly the hosted surface's range (2024-11-05 → 2025-11-25): supported requested revisions are echoed, unknown or unserved ones get the newest served, and `server/discover` advertises the set. The surface gains 2026-07-28 together with the other endpoints when the platform-wide integration flips it on.

**Caller `_meta` stays off upstream calls** — forwarding the re-serialized `WireMeta` parse emitted empty/null fields that strict vendors reject with 400; the per-call handshake already declares this proxy's identity and version, so member dispatch now sends no `_meta`.

## Diagnostics

**Inspect diagnoses instead of hinting** — the members-shortfall note distinguishes the anonymous case (no sign-in attached) from the grants case, names the backing resource `mcp:connect` is checked against (member server for proxied members, toolset for hosted), and the rejected-session message names the real cause: every attached provider must be connected. Card bodies are capped so a long member catalog can't push the page out of view.

**Credential routing failures name the situation** — a tunneled member has no upstream identity to match against N credentials; several credentials claiming one upstream need cleanup. Both replace the old "not configured unambiguously".

## Dashboard flow

**Add member reaches the catalog** — the sheet links "Add from catalog" (gated on `project:write` scoped to the gateway's project); servers installed there via `?attachToGateway=<id>` are attached as members and the flow returns to the Members tab. The redirect only fires on full success — install failures keep the per-server results visible, and attach failures toast with the Members tab as the retry path.

**Attach Provider survives the first attachment** — the action only existed in the section's empty state, so a second provider could never be attached from the UI. It now renders below the provider rows too. (Supersedes #5852.)

## Tests

- Issuer minted on create; auto-attach binding lands on the gateway issuer, second member on the same upstream leaves exactly one client bound.
- Initialize negotiation table (echo / unknown→newest / absent→default); older-revision declarations accepted; meta set pinned in the shared known-and-ordered test.
- Reworded routing errors pinned by meaning; Attach Provider presence regression.

Full mcp+metamcp server suites, dashboard gateway tests, lint and type-check green.

Found while dogfooding the first prod gateway end to end — every change maps to a step that failed silently, demanded auth-model archaeology, or stopped a stock MCP client from connecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
