### PR TITLE
feat: describe non-obvious filters in the filter sheet

### DIFF
--- a/client/dashboard/src/components/filters/FilterSheet.tsx
+++ b/client/dashboard/src/components/filters/FilterSheet.tsx
@@ -102,6 +102,11 @@ export function FilterSheet({
               <label className="text-foreground text-sm font-medium">
                 {dim.label}
               </label>
+              {dim.description && (
+                <p className="text-muted-foreground text-xs">
+                  {dim.description}
+                </p>
+              )}
               <FilterControl
                 dim={dim}
                 value={values[dim.id] ?? defaultValueForDimension(dim)}

--- a/client/dashboard/src/components/filters/filter-schema.ts
+++ b/client/dashboard/src/components/filters/filter-schema.ts
@@ -75,6 +75,12 @@ interface BaseDimension<K extends FilterKind> {
   /** Human label shown on the control and chips. */
   label: string;
   kind: K;
+  /**
+   * Optional one-line explanation rendered under the label in the sheet. Use it
+   * for dimensions whose concept isn't obvious from the label alone (e.g.
+   * "Account type", "Unique matches only"); leave it off for self-evident ones.
+   */
+  description?: string;
   icon?: ComponentType<{ className?: string }>;
   /** Pinned dimensions render inline in the bar; the rest live in the sheet. */
   pinned?: boolean;

--- a/client/dashboard/src/components/observe/InsightsAgents.tsx
+++ b/client/dashboard/src/components/observe/InsightsAgents.tsx
@@ -156,6 +156,7 @@ const COST_FILTERS = defineFilters([
     label: "Account type",
     kind: "select",
     allLabel: "All",
+    description: "Usage on personal accounts versus team-managed ones.",
   },
 ]);
 

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -100,6 +100,7 @@ const EMPLOYEE_FILTERS = defineFilters([
     label: "Account type",
     kind: "select",
     allLabel: "All",
+    description: "Usage on personal accounts versus team-managed ones.",
   },
   { id: "role", label: "Role", kind: "select" },
   { id: "user", label: "User", kind: "select" },

--- a/client/dashboard/src/components/observe/LogsAgents.tsx
+++ b/client/dashboard/src/components/observe/LogsAgents.tsx
@@ -123,6 +123,7 @@ const SESSION_FILTERS = defineFilters([
     label: "Account type",
     kind: "select",
     allLabel: "All",
+    description: "Usage on personal accounts versus team-managed ones.",
   },
   {
     id: "min_risk_score",
@@ -130,6 +131,7 @@ const SESSION_FILTERS = defineFilters([
     kind: "number",
     min: 1,
     placeholder: "e.g. 3 (≥ 3 findings)",
+    description: "Only sessions with at least this many risk findings.",
   },
 ]);
 

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -108,6 +108,7 @@ const ACCOUNT_TYPE_DIMENSION: FilterDimension = {
   label: "Account type",
   kind: "select",
   allLabel: "All",
+  description: "Usage on personal accounts versus team-managed ones.",
 };
 const STATUS_DIMENSION: FilterDimension = {
   id: "status",

--- a/client/dashboard/src/components/sources/source-filter-schema.ts
+++ b/client/dashboard/src/components/sources/source-filter-schema.ts
@@ -25,11 +25,22 @@ export const SOURCE_FILTERS = defineFilters([
     label: "MCP usage",
     kind: "select",
     allLabel: "Any MCP usage",
+    description: "Whether the source's tools are served by an MCP server.",
   },
   { id: "transport", label: "Transport", kind: "multiselect" },
   { id: "format", label: "Format", kind: "multiselect" },
-  { id: "catalogKind", label: "Catalog kind", kind: "multiselect" },
-  { id: "failing", label: "Deployment errors", kind: "boolean" },
+  {
+    id: "catalogKind",
+    label: "Catalog kind",
+    kind: "multiselect",
+    description: "Whether the entry is one server or a collection of them.",
+  },
+  {
+    id: "failing",
+    label: "Deployment errors",
+    kind: "boolean",
+    description: "Only sources whose latest deployment failed.",
+  },
 ]);
 
 export type SourceFilterValues = FilterValues<typeof SOURCE_FILTERS>;

--- a/client/dashboard/src/pages/catalog/catalog-filter-schema.ts
+++ b/client/dashboard/src/pages/catalog/catalog-filter-schema.ts
@@ -26,8 +26,18 @@ import {
  */
 export const CATALOG_FILTERS = defineFilters([
   { id: "auth", label: "Auth type", kind: "multiselect" },
-  { id: "setup", label: "Setup", kind: "multiselect" },
-  { id: "behavior", label: "Tool behavior", kind: "multiselect" },
+  {
+    id: "setup",
+    label: "Setup",
+    kind: "multiselect",
+    description: "Whether clients register themselves or you add credentials.",
+  },
+  {
+    id: "behavior",
+    label: "Tool behavior",
+    kind: "multiselect",
+    description: "Whether the tools only read data or can also change it.",
+  },
   { id: "minUsers", label: "Popularity", kind: "select", allLabel: "All" },
   { id: "updated", label: "Last updated", kind: "select", allLabel: "All" },
   { id: "minTools", label: "Tool count", kind: "select", allLabel: "All" },

--- a/client/dashboard/src/pages/mcp/mcp-filter-schema.ts
+++ b/client/dashboard/src/pages/mcp/mcp-filter-schema.ts
@@ -11,7 +11,12 @@ import {
 // No auth facet: hosted list rows lack issuer/OAuth fields, so filtering would hide valid rows.
 export const MCP_FILTERS = defineFilters([
   { id: "status", label: "Status", kind: "multiselect" },
-  { id: "source", label: "Source", kind: "multiselect" },
+  {
+    id: "source",
+    label: "Source",
+    kind: "multiselect",
+    description: "Where the server came from and how Gram reaches it.",
+  },
   { id: "plugins", label: "Included in plugins", kind: "multiselect" },
 ]);
 

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -136,7 +136,12 @@ const RISK_FILTERS = defineFilters([
     kind: "text",
     placeholder: "User contains...",
   },
-  { id: "unique", label: "Unique matches only", kind: "boolean" },
+  {
+    id: "unique",
+    label: "Unique matches only",
+    kind: "boolean",
+    description: "Keep the latest row per policy, rule and matched value.",
+  },
   { id: "assistant", label: "Assistant", kind: "select" },
 ]);
 

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -54,6 +54,7 @@ const SKILL_FILTERS = defineFilters([
     label: "Classification",
     kind: "multiselect",
     pinned: true,
+    description: "Whether a skill is your own or ships with a plugin.",
   },
   {
     id: "tags",


### PR DESCRIPTION
## Summary

Adds an optional `description` to `FilterDimension` in the shared filter schema, rendered as a one-line hint under the label in the filter sheet (bar chips are untouched), and fills it in for the eleven dimensions whose concept is not obvious from the label alone:

- **Catalog** — `setup`, `behavior`
- **MCP servers** — `source`
- **Sources** — `usedInMcp`, `catalogKind`, `failing`
- **Observe** — `account_type` on the shared filter bar, Employees, Agent costs and Agent sessions; `min_risk_score`
- **Risk events** — `unique`
- **Skills** — `classification`

Copy is derived from the behaviour it describes rather than guessed: the `unique` wording follows the `unique_match` contract in `server/internal/risk/queries.sql`, and `account_type` follows the comment on `ACCOUNT_TYPE_OPTIONS`.

Dimensions whose labels already say it (Status, Type, Format, Transport, Severity, Tags, Project, User, Date range) are deliberately left without one, as are the threshold selects whose options are self-explaining ("100+ users", "5+ tools").

## Motivation

Several filters name a concept the reader has to already know: "Account type" does not say personal-versus-team, "Unique matches only" does not say what is collapsed, "Setup" does not say that automatic means DCR. The sheet is where someone goes when the bar chip was not enough, so it is the right surface for the explanation — and putting the text in the schema keeps it next to the dimension it describes instead of hard-coded in one page's markup.

`FilterOption` already carried a `description` for the same reason at option level (Skills uses it for Custom vs Built-in). This mirrors that one level up, so a filter can explain itself and its individual values.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional descriptions to filter dimensions, shown as one-line hints under labels in the filter sheet, so filters like "Account type" and "Unique matches only" explain themselves without cluttering the bar chips. Bar chips and existing filter behavior are unchanged, and self-evident dimensions are left without descriptions.

Copy follows the actual behavior definitions, such as the `unique_match` contract and the `ACCOUNT_TYPE_OPTIONS` comment.

**Dimensions with new descriptions**
- Catalog: Setup, Tool behavior.
- MCP servers: Source.
- Sources: MCP usage, Catalog kind, Deployment errors.
- Observe: Account type (filter bar, Employees, Agents, Agent sessions), Min risk score.
- Risk events: Unique matches only.
- Skills: Classification.

<sup>Written for commit 2552253a8f54d4dd13a1ac6acb72a6e8314daf79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

