### PR TITLE
fix: parallelize and limit Fly image pushes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2132,23 +2132,26 @@ jobs:
             docker tag "${{ steps.apko.outputs.image }}-amd64" "$TAG"
           done
 
-      - name: "[DEV] Push images"
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
-        run: |
-          set -x
-          fly auth docker
-          docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
+      - parallel:
+          - name: "[DEV] Push images"
+            if: github.event.pull_request.user.login != 'dependabot[bot]'
+            env:
+              DOCKER_CONFIG: ${{ runner.temp }}/docker-dev
+              FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+            run: |
+              mkdir -p "$DOCKER_CONFIG"
+              fly auth docker
+              docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
 
-      - name: "[PROD] Push images"
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
-        run: |
-          set -x
-          fly auth docker
-          docker push --all-tags "${{ steps.flyCreateProd.outputs.flyAppRegistry }}"
+          - name: "[PROD] Push images"
+            if: github.event.pull_request.user.login != 'dependabot[bot]'
+            env:
+              DOCKER_CONFIG: ${{ runner.temp }}/docker-prod
+              FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+            run: |
+              mkdir -p "$DOCKER_CONFIG"
+              fly auth docker
+              docker push --all-tags "${{ steps.flyCreateProd.outputs.flyAppRegistry }}"
 
       - name: Prune aube store
         if: success()

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2153,7 +2153,7 @@ jobs:
               done <<< "$CURRENT_TAGS"
 
               if [[ "$matched" != true ]]; then
-                echo "::error::No current image tags matched $FLY_APP_REGISTRY" >&2
+                echo "::error::No current image tags matched $FLY_APP_REGISTRY"
                 exit 1
               fi
 
@@ -2177,7 +2177,7 @@ jobs:
               done <<< "$CURRENT_TAGS"
 
               if [[ "$matched" != true ]]; then
-                echo "::error::No current image tags matched $FLY_APP_REGISTRY" >&2
+                echo "::error::No current image tags matched $FLY_APP_REGISTRY"
                 exit 1
               fi
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2138,20 +2138,48 @@ jobs:
             env:
               DOCKER_CONFIG: ${{ runner.temp }}/docker-dev
               FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+              CURRENT_TAGS: ${{ steps.meta.outputs.tags }}
+              FLY_APP_REGISTRY: ${{ steps.flyCreateDev.outputs.flyAppRegistry }}
             run: |
+              set -euo pipefail
               mkdir -p "$DOCKER_CONFIG"
               fly auth docker
-              docker push --all-tags "${{ steps.flyCreateDev.outputs.flyAppRegistry }}"
+
+              matched=false
+              while IFS= read -r tag; do
+                [[ "$tag" == "$FLY_APP_REGISTRY":* ]] || continue
+                docker push "$tag"
+                matched=true
+              done <<< "$CURRENT_TAGS"
+
+              if [[ "$matched" != true ]]; then
+                echo "::error::No current image tags matched $FLY_APP_REGISTRY" >&2
+                exit 1
+              fi
 
           - name: "[PROD] Push images"
             if: github.event.pull_request.user.login != 'dependabot[bot]'
             env:
               DOCKER_CONFIG: ${{ runner.temp }}/docker-prod
               FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
+              CURRENT_TAGS: ${{ steps.meta.outputs.tags }}
+              FLY_APP_REGISTRY: ${{ steps.flyCreateProd.outputs.flyAppRegistry }}
             run: |
+              set -euo pipefail
               mkdir -p "$DOCKER_CONFIG"
               fly auth docker
-              docker push --all-tags "${{ steps.flyCreateProd.outputs.flyAppRegistry }}"
+
+              matched=false
+              while IFS= read -r tag; do
+                [[ "$tag" == "$FLY_APP_REGISTRY":* ]] || continue
+                docker push "$tag"
+                matched=true
+              done <<< "$CURRENT_TAGS"
+
+              if [[ "$matched" != true ]]; then
+                echo "::error::No current image tags matched $FLY_APP_REGISTRY" >&2
+                exit 1
+              fi
 
       - name: Prune aube store
         if: success()


### PR DESCRIPTION
## Summary

- Run the development and production Gram Functions image pushes concurrently with GitHub Actions parallel steps.
- Isolate each Fly registry login with its own Docker configuration directory so concurrent authentication does not race.
- Push only the current tags emitted by Docker metadata for each registry instead of every cached repository tag.
- Fail the push step when its metadata contains no tags for the authenticated registry.

## Motivation

The development and production pushes are independent, but previously ran sequentially. They also used `docker push --all-tags`, which included stale tags from Blacksmith's persistent Docker image store and made job duration grow with cached history. Parallel, explicitly scoped pushes shorten the publishing path without disabling useful caches or pruning unrelated images.
