### PR TITLE
mig: enforce one data export route per source

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4117,10 +4117,10 @@ CREATE TABLE IF NOT EXISTS data_export_routes (
   CONSTRAINT data_export_routes_destination_tenant_fkey FOREIGN KEY (organization_id, project_id, otel_destination_id) REFERENCES otel_destinations (organization_id, project_id, id) ON DELETE RESTRICT
 );
 
--- One source can fan out to multiple destinations, while the same destination
--- can appear at most once for that source.
-CREATE UNIQUE INDEX IF NOT EXISTS data_export_routes_project_source_destination_key
-  ON data_export_routes (project_id, data_source, otel_destination_id)
+-- Each project can configure at most one non-deleted route per data source.
+-- Disabled routes still reserve the source until they are deleted.
+CREATE UNIQUE INDEX IF NOT EXISTS data_export_routes_project_source_key
+  ON data_export_routes (project_id, data_source)
   WHERE deleted IS FALSE;
 
 -- AI integration configs: encrypted provider credentials and activation

--- a/server/migrations/20260828101442_data_export_routes_single_destination.sql
+++ b/server/migrations/20260828101442_data_export_routes_single_destination.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Drop index "data_export_routes_project_source_destination_key" from table: "data_export_routes"
+DROP INDEX CONCURRENTLY "data_export_routes_project_source_destination_key";
+-- Create index "data_export_routes_project_source_key" to table: "data_export_routes"
+CREATE UNIQUE INDEX CONCURRENTLY "data_export_routes_project_source_key" ON "data_export_routes" ("project_id", "data_source") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nWYU4rimE4wRqN+T+ZdUNC+euY023BzyHWtRq3u8aLo=
+h1:lb40cA7pY12pxHzHw9f9CmtMcc+xAPef3qNMVhl36/Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -372,3 +372,4 @@ h1:nWYU4rimE4wRqN+T+ZdUNC+euY023BzyHWtRq3u8aLo=
 20260827075204_data_export_routes.sql h1:0jz+w0IdJEIku/z1IFA4Ycpp69EcWegR4tKUJE4F6Ys=
 20260828004317_risk-pagination-indexes.sql h1:Kt04zUHm8wQchZZL6gWP/+3fknMyhlAuiMCClo6MZGQ=
 20260828092510_data_exports_fanout.sql h1:qObwb6bsBowCBl4kdIM+xv+QuTDJ1velUTNWleNk5q8=
+20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=


### PR DESCRIPTION
## Summary

- Replace the data export route uniqueness key with a partial unique index on `(project_id, data_source)`.
- Keep disabled routes within the uniqueness boundary so each source has one editable route row until that route is deleted.
- Preserve support for multiple destination types on that route: `otel_destination_id` today, with future destination types represented by their own columns.
- Ship the Atlas-generated concurrent index migration and updated migration checksum.

## Motivation

A data source owns one route row, not one destination in total. Each typed destination column can reference one destination of that type and use its own delivery topic and retry state. The previous `(project_id, data_source, otel_destination_id)` key allowed several rows for one source; this migration restores one row per source without preventing future SIEM, S3, or other typed destinations from coexisting on that row.

The data export tables are empty and unused, and this migration lands before the management API introduces writers, so no backfill or compatibility period is required.
