### PR TITLE
chore: seed the shared demo org locally as well

### DIFF
--- a/.mise-tasks/seed.sh
+++ b/.mise-tasks/seed.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 # The local seed is the demo org seed retargeted at the dev-idp's default org
 # (see server/internal/demoseed/spec.go): the same SQL, the same code path
 # production runs daily, but writable and with you adopted into it as an admin.
+# It also seeds the shared demo org itself, untargeted, so /explore-demo shows
+# the same data locally as it does in production. You are not a member there —
+# the session enters it through auth.enterDemo, exactly as in production.
 #
 # Idempotent and fast, so there is no completion marker to short-circuit on —
 # just run it. Everything it used to write back into mise.local.toml

--- a/server/cmd/gram/demoseed.go
+++ b/server/cmd/gram/demoseed.go
@@ -93,15 +93,12 @@ func newDemoSeedCommand() *cli.Command {
 			// demo org — as in production, it is reached through auth.enterDemo,
 			// not the org switcher.
 			//
-			// The developer's own org goes first: it is the one that lifts the
-			// BookDemo gate, so a demo-org failure (ClickHouse is the flaky
-			// half locally) leaves a usable environment behind.
+			// The developer's own org goes first, fixtures included: it is the
+			// one that lifts the BookDemo gate, so a demo-org failure
+			// (ClickHouse is the flaky half locally) leaves a usable
+			// environment behind.
 			if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.LocalSpec()); err != nil {
 				return fmt.Errorf("apply seed: %w", err)
-			}
-
-			if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.DefaultSpec()); err != nil {
-				return fmt.Errorf("apply demo org seed: %w", err)
 			}
 
 			// A missing or unreachable cache is not fatal: the fixtures just
@@ -127,11 +124,19 @@ func newDemoSeedCommand() *cli.Command {
 				observed[name] = os.Getenv(name)
 			}
 
-			return demoseed.RunLocalFixtures(ctx, logger, db, blob, redisClient, demoseed.LocalFixturesOptions{
+			if err := demoseed.RunLocalFixtures(ctx, logger, db, blob, redisClient, demoseed.LocalFixturesOptions{
 				DeveloperEmail: c.String("local-user-email"),
 				Environment:    c.String("environment"),
 				ObservedEnv:    observed,
-			})
+			}); err != nil {
+				return fmt.Errorf("apply local fixtures: %w", err)
+			}
+
+			if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.DefaultSpec()); err != nil {
+				return fmt.Errorf("apply demo org seed: %w", err)
+			}
+
+			return nil
 		},
 	}
 }

--- a/server/cmd/gram/demoseed.go
+++ b/server/cmd/gram/demoseed.go
@@ -19,7 +19,7 @@ func newDemoSeedCommand() *cli.Command {
 		Flags: append([]cli.Flag{
 			&cli.BoolFlag{
 				Name: "local",
-				Usage: "Seed the local development organization instead of the shared demo org: same data, " +
+				Usage: "Seed the local development organization as well as the shared demo org: the same data " +
 					"retargeted at the dev-idp org, writable, plus the local-only fixtures (your user, API key).",
 				EnvVars: []string{"GRAM_DEMO_SEED_LOCAL"},
 			},
@@ -80,17 +80,28 @@ func newDemoSeedCommand() *cli.Command {
 			}
 			defer o11y.NoLogDefer(func() error { return blobShutdown(ctx) })
 
-			spec := demoseed.DefaultSpec()
-			if c.Bool("local") {
-				spec = demoseed.LocalSpec()
+			if !c.Bool("local") {
+				if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.DefaultSpec()); err != nil {
+					return fmt.Errorf("apply seed: %w", err)
+				}
+				return nil
 			}
 
-			if err := demoseed.Run(ctx, logger, db, ch, blob, spec); err != nil {
+			// Locally both tenants are seeded: the dev-idp org the developer
+			// logs into, and the shared demo org so /explore-demo renders the
+			// same data it does in production. No membership is granted in the
+			// demo org — as in production, it is reached through auth.enterDemo,
+			// not the org switcher.
+			//
+			// The developer's own org goes first: it is the one that lifts the
+			// BookDemo gate, so a demo-org failure (ClickHouse is the flaky
+			// half locally) leaves a usable environment behind.
+			if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.LocalSpec()); err != nil {
 				return fmt.Errorf("apply seed: %w", err)
 			}
 
-			if !c.Bool("local") {
-				return nil
+			if err := demoseed.Run(ctx, logger, db, ch, blob, demoseed.DefaultSpec()); err != nil {
+				return fmt.Errorf("apply demo org seed: %w", err)
 			}
 
 			// A missing or unreachable cache is not fatal: the fixtures just


### PR DESCRIPTION
## Summary

`gram demo-seed --local` now applies both tenants instead of one: the developer's
own dev-idp org (`LocalSpec`, plus the local-only fixtures) and then the shared
demo org itself (`DefaultSpec`, unrewritten). `mise run seed` picks this up
unchanged.

No membership is granted in the demo org — a session reaches it through
`auth.enterDemo`, exactly as in production, so `/explore-demo` and the
`Book a demo` page's escape hatch now work against a local stack.

The developer's own org is seeded first, deliberately: it is the org that lifts
the `whitelisted` gate, so a failure in the demo half still leaves a usable
environment behind. ClickHouse is the flaky half locally — its 1 GiB container
limit can abort the telemetry delete mutation — and that ordering keeps such a
failure from costing you your own seeded org.

The non-local path (`mise run seed:demo`, and the daily production CronJob) is
unchanged: one `DefaultSpec` run, no local fixtures.

## Motivation

The demo org is how customers explore Gram before their own org exists, and the
seed is expected to keep it in step with every feature change. Locally, though,
`--local` seeded *only* the retargeted copy, so the demo org did not exist at
all: `/explore-demo` was unverifiable without deploying, and the one route out
of the demo gate dead-ended on a local stack.

Both halves are idempotent and tenant-scoped, so seeding them together is just
two runs of the same code path — verified by reseeding twice and checking that
both orgs' row counts stay stable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`gram demo-seed --local` now seeds the shared demo org as well as the developer's own org, so `/explore-demo` and the demo escape hatch work against a local stack. No membership is granted in the demo org — sessions reach it through `auth.enterDemo`, exactly as in production.

**Behavior notes**
- The developer's own org and local fixtures (membership, API key) are applied before the demo org seed, so a failed demo-org seed leaves a usable environment.
- The non-local path is unchanged: `mise run seed:demo` and the production CronJob still run only `demoseed.DefaultSpec()`.
- Both halves are idempotent and tenant-scoped, so reseeding is safe.

<sup>Written for commit 07026174241e3bc8feb5faaedcb085f77589b8a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

