### PR TITLE
feat(dashboard): add contextual Killswitch controls

### DIFF
--- a/.changeset/contextual-killswitch-entry-points.md
+++ b/.changeset/contextual-killswitch-entry-points.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add contextual Killswitch status and actions to Team and MCP session surfaces, with safe member/server prefill and direct audit links.

--- a/client/dashboard/src/components/auditlogs/subject-href.test.ts
+++ b/client/dashboard/src/components/auditlogs/subject-href.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import type { AuditLog } from "@gram/client/models/components/auditlog.js";
+import { subjectHref } from "./subject-href";
+
+function log(subjectType: string, subjectId = "prescription-1"): AuditLog {
+  return {
+    id: "audit-1",
+    actingSurface: "dashboard",
+    action: "killswitch:activate",
+    actorId: "actor-1",
+    actorType: "user",
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    subjectId,
+    subjectType,
+    metadata: { internal_note: "must-not-enter-a-link" },
+  };
+}
+
+describe("audit subject links", () => {
+  it("links a Killswitch prescription directly by stable subject id", () => {
+    expect(subjectHref(log("killswitch_prescription"), "example")).toBe(
+      "/example/killswitch/prescription-1",
+    );
+  });
+
+  it("returns the unknown-subject fallback without using metadata", () => {
+    expect(subjectHref(log("future_subject"), "example")).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/auditlogs/subject-href.ts
+++ b/client/dashboard/src/components/auditlogs/subject-href.ts
@@ -52,6 +52,10 @@ export function subjectHref(log: AuditLog, orgSlug: string): string | null {
       return `/${orgSlug}/access/roles?editRole=${log.subjectId}`;
     case "access_member":
       return `/${orgSlug}/access/members`;
+    case "killswitch_prescription":
+      // The stable prescription id is sufficient. Do not fetch detail while
+      // formatting the feed, which could expose private notes or create N+1s.
+      return log.subjectId ? `/${orgSlug}/killswitch/${log.subjectId}` : null;
     case "api_key":
       return `/${orgSlug}/api-keys`;
     case "json_web_key_set":

--- a/client/dashboard/src/components/connections/ConnectionsList.tsx
+++ b/client/dashboard/src/components/connections/ConnectionsList.tsx
@@ -1,5 +1,6 @@
 import { IdentityLink } from "@/components/identity-link";
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
 import { ChevronRight } from "lucide-react";
 
 import {
@@ -34,6 +35,16 @@ import { providerLabel } from "@/lib/provider-label";
 import { subjectLabel } from "@/lib/user-session-status";
 import { cn } from "@/lib/utils";
 import { AgentProviderIcon } from "@/components/agent-providers/AgentProviderIcon";
+import { useOrgRoutes } from "@/routes";
+import { KillswitchUserBadgeLink } from "@/components/killswitch/KillswitchUserBadgeLink";
+import {
+  canonicalUserId,
+  killswitchCreateHref,
+  killswitchStatusHref,
+  useKillswitchUserBadges,
+} from "@/components/killswitch/KillswitchUserStatus";
+import type { KillswitchUserBadge } from "@gram/client/models/components/killswitchuserbadge.js";
+import type { KillswitchCapabilityKey } from "@gram/client/models/components/killswitchcapabilitykey.js";
 
 import type { UserSession } from "@gram/client/models/components/usersession.js";
 import type { UserSessionClient } from "@gram/client/models/components/usersessionclient.js";
@@ -85,6 +96,18 @@ function useNow(): number {
 }
 
 /** What a sub-row stands for, given what its parent row stands for. */
+export type ConnectionKillswitchContext = {
+  capabilityKey: KillswitchCapabilityKey;
+  originatingMcpServerId?: string;
+};
+
+type PersonKillswitch = {
+  badge?: KillswitchUserBadge;
+  unavailable: boolean;
+  createHref: string;
+  statusHref: string;
+};
+
 const CHILD_OF: Record<ConnectionGrouping, "agent" | "person"> = {
   subject: "agent",
   issuer: "person",
@@ -121,32 +144,81 @@ function providerNames(group: ConnectionGroup): string[] {
   );
 }
 
+function personKillswitch(
+  subjectUrn: string,
+  context: ConnectionKillswitchContext | undefined,
+  badges: ReadonlyMap<string, KillswitchUserBadge>,
+  unavailableUserIds: ReadonlySet<string>,
+  baseHref: string,
+): PersonKillswitch | undefined {
+  const userId = canonicalUserId(subjectUrn);
+  if (!userId || !context) return undefined;
+  return {
+    badge: badges.get(userId),
+    unavailable: unavailableUserIds.has(userId),
+    statusHref: killswitchStatusHref(baseHref, userId),
+    createHref: killswitchCreateHref(baseHref, {
+      userId,
+      capabilityKey: context.capabilityKey,
+      originatingMcpServerId: context.originatingMcpServerId,
+    }),
+  };
+}
+
 function ConnectionRowActions({
   session,
+  canRevoke,
+  killswitch,
+  onOpenKillswitch,
   onRevoked,
 }: {
   session: UserSession;
+  canRevoke: boolean;
+  killswitch?: PersonKillswitch;
+  onOpenKillswitch: (href: string) => void;
   onRevoked: () => void;
-}): JSX.Element {
+}): JSX.Element | null {
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  return (
-    <>
-      <MoreActions
-        actions={[
+  const actions = [
+    ...(killswitch
+      ? [
+          {
+            label: "View killswitches",
+            onClick: () => onOpenKillswitch(killswitch.statusHref),
+          },
+          {
+            label: "New killswitch…",
+            onClick: () => onOpenKillswitch(killswitch.createHref),
+          },
+        ]
+      : []),
+    ...(canRevoke
+      ? [
           {
             label: "Revoke connection",
             destructive: true,
             onClick: () => setConfirmOpen(true),
           },
-        ]}
+        ]
+      : []),
+  ];
+  if (actions.length === 0) return null;
+
+  return (
+    <>
+      <MoreActions
+        actions={actions}
+        triggerAriaLabel={`Actions for ${subjectLabel(session)}`}
       />
-      <RevokeSessionDialog
-        session={session}
-        open={confirmOpen}
-        onOpenChange={setConfirmOpen}
-        onRevoked={onRevoked}
-      />
+      {canRevoke && (
+        <RevokeSessionDialog
+          session={session}
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          onRevoked={onRevoked}
+        />
+      )}
     </>
   );
 }
@@ -226,11 +298,13 @@ function ConnectionSubRow({
   grouping,
   now,
   actions,
+  killswitch,
 }: {
   session: UserSession;
   grouping: ConnectionGrouping;
   now: number;
   actions?: React.ReactNode;
+  killswitch?: PersonKillswitch;
 }): JSX.Element {
   const state = connectionState(session, now);
   const presentation = CONNECTION_STATE_PRESENTATION[state];
@@ -271,6 +345,13 @@ function ConnectionSubRow({
             <ClientIcon label={label} />
           )}
           <span className="text-foreground truncate text-sm">{label}</span>
+          {childIsPerson && killswitch ? (
+            <KillswitchUserBadgeLink
+              badge={killswitch.badge}
+              unavailable={killswitch.unavailable}
+              href={killswitch.statusHref}
+            />
+          ) : null}
           {/* Only where the row names an agent. A sub-row names a person under
               provider and agent grouping alike, and a person has no credential
               of their own. */}
@@ -324,6 +405,13 @@ function ConnectionGroupRow({
   canRevoke,
   onRevoked,
   project,
+  killswitchContext,
+  killswitchBadges,
+  killswitchUnavailableUserIds,
+  killswitchBaseHref,
+  expanded,
+  onExpandedChange,
+  onOpenKillswitch,
 }: {
   group: ConnectionGroup;
   grouping: ConnectionGrouping;
@@ -333,8 +421,14 @@ function ConnectionGroupRow({
   project?: { slug: string; id: string };
   canRevoke: boolean;
   onRevoked: () => void;
+  killswitchContext?: ConnectionKillswitchContext;
+  killswitchBadges: ReadonlyMap<string, KillswitchUserBadge>;
+  killswitchUnavailableUserIds: ReadonlySet<string>;
+  killswitchBaseHref: string;
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+  onOpenKillswitch: (href: string) => void;
 }): JSX.Element {
-  const [expanded, setExpanded] = useState(false);
   const [revokeAllOpen, setRevokeAllOpen] = useState(false);
   const [revokeClientOpen, setRevokeClientOpen] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -344,6 +438,16 @@ function ConnectionGroupRow({
   const [detailMounted, setDetailMounted] = useState(false);
 
   const providers = grouping === "provider" ? [] : providerNames(group);
+  const groupKillswitch =
+    grouping === "subject"
+      ? personKillswitch(
+          group.key,
+          killswitchContext,
+          killswitchBadges,
+          killswitchUnavailableUserIds,
+          killswitchBaseHref,
+        )
+      : undefined;
 
   const actions = [
     // Reading a registration needs project read, which every viewer of this
@@ -358,6 +462,18 @@ function ConnectionGroupRow({
               setDetailMounted(true);
               setDetailOpen(true);
             },
+          },
+        ]
+      : []),
+    ...(groupKillswitch
+      ? [
+          {
+            label: "View killswitches",
+            onClick: () => onOpenKillswitch(groupKillswitch.statusHref),
+          },
+          {
+            label: "New killswitch…",
+            onClick: () => onOpenKillswitch(groupKillswitch.createHref),
           },
         ]
       : []),
@@ -435,7 +551,7 @@ function ConnectionGroupRow({
             ) {
               return;
             }
-            setExpanded((open) => !open);
+            onExpandedChange(!expanded);
           }}
           className={cn(CONNECTION_ROW_GRID, "cursor-pointer text-left")}
         >
@@ -443,7 +559,7 @@ function ConnectionGroupRow({
             type="button"
             aria-expanded={expanded}
             aria-label={`${expanded ? "Collapse" : "Expand"} ${group.label}`}
-            onClick={() => setExpanded((open) => !open)}
+            onClick={() => onExpandedChange(!expanded)}
             className="focus-visible:ring-ring flex size-3.5 shrink-0 items-center justify-center rounded-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             <ChevronRight
@@ -469,6 +585,13 @@ function ConnectionGroupRow({
                 {group.label}
               </span>
             )}
+            {groupKillswitch ? (
+              <KillswitchUserBadgeLink
+                badge={groupKillswitch.badge}
+                unavailable={groupKillswitch.unavailable}
+                href={groupKillswitch.statusHref}
+              />
+            ) : null}
             {/* Absent unless the row names a registration, which is what
                 grouping by agent makes it. */}
             <ClientCredentialBadge
@@ -520,7 +643,12 @@ function ConnectionGroupRow({
         </div>
 
         <span className={CONNECTION_ACTIONS_SLOT}>
-          {actions.length > 0 ? <MoreActions actions={actions} /> : null}
+          {actions.length > 0 ? (
+            <MoreActions
+              actions={actions}
+              triggerAriaLabel={`Actions for ${group.label}`}
+            />
+          ) : null}
         </span>
       </div>
 
@@ -537,31 +665,46 @@ function ConnectionGroupRow({
             </div>
           ) : null}
 
-          {group.sessions.map((session) => (
-            <ConnectionSubRow
-              key={session.id}
-              session={session}
-              grouping={grouping}
-              now={now}
-              actions={
-                // Gated on this session being revocable, not merely on the
-                // viewer's scope: a revoked or expired connection has nothing
-                // left to cut off, and offering the action opened a dialog that
-                // could only fail.
-                canRevoke && group.revocableIds.includes(session.id) ? (
-                  <ConnectionRowActions
-                    session={session}
-                    onRevoked={onRevoked}
-                  />
-                ) : null
-              }
-            />
-          ))}
+          {group.sessions.map((session) => {
+            const sessionKillswitch =
+              CHILD_OF[grouping] === "person"
+                ? personKillswitch(
+                    session.subjectUrn,
+                    killswitchContext,
+                    killswitchBadges,
+                    killswitchUnavailableUserIds,
+                    killswitchBaseHref,
+                  )
+                : undefined;
+            const sessionCanRevoke =
+              canRevoke && group.revocableIds.includes(session.id);
+            return (
+              <ConnectionSubRow
+                key={session.id}
+                session={session}
+                grouping={grouping}
+                now={now}
+                killswitch={sessionKillswitch}
+                actions={
+                  sessionCanRevoke || sessionKillswitch ? (
+                    <ConnectionRowActions
+                      session={session}
+                      canRevoke={sessionCanRevoke}
+                      killswitch={sessionKillswitch}
+                      onOpenKillswitch={onOpenKillswitch}
+                      onRevoked={onRevoked}
+                    />
+                  ) : null
+                }
+              />
+            );
+          })}
         </div>
       ) : null}
 
       <RevokeSessionsDialog
         sessionIds={group.revocableIds}
+        newKillswitchHref={groupKillswitch?.createHref}
         open={revokeAllOpen}
         onOpenChange={setRevokeAllOpen}
         onRevoked={onRevoked}
@@ -605,6 +748,7 @@ export function ConnectionsList({
   clients,
   project,
   bordered = true,
+  killswitchContext,
 }: {
   sessions: UserSession[];
   grouping: ConnectionGrouping;
@@ -629,32 +773,76 @@ export function ConnectionsList({
    * inside the first reads as a table nested in a table.
    */
   bordered?: boolean;
+  /** Enables user-only Killswitch status/actions on this sessions surface. */
+  killswitchContext?: ConnectionKillswitchContext;
 }): JSX.Element {
   const now = useNow();
+  const navigate = useNavigate();
+  const orgRoutes = useOrgRoutes();
+  const [expandedGroups, setExpandedGroups] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const { active, inactive } = useMemo(
     () =>
       splitByActivity(groupConnections(sessions, grouping, { clients, now })),
     [sessions, grouping, clients, now],
   );
+  const allGroups = useMemo(() => [...active, ...inactive], [active, inactive]);
+  const killswitchUserIds = useMemo(() => {
+    const visibleSessions =
+      grouping === "subject"
+        ? sessions
+        : allGroups
+            .filter((group) => expandedGroups.has(`${grouping}:${group.key}`))
+            .flatMap((group) => group.sessions);
+    return visibleSessions.flatMap((session) => {
+      const userId = canonicalUserId(session.subjectUrn);
+      return userId ? [userId] : [];
+    });
+  }, [allGroups, expandedGroups, grouping, sessions]);
+  const killswitch = useKillswitchUserBadges(
+    killswitchUserIds,
+    killswitchContext != null,
+  );
 
   const rows = (groups: ConnectionGroup[]) => (
     <div className="divide-border divide-y">
-      {groups.map((group) => (
-        <ConnectionGroupRow
-          key={group.key}
-          group={group}
-          grouping={grouping}
-          now={now}
-          canRevoke={canRevoke}
-          onRevoked={onRevoked}
-          project={project}
-        />
-      ))}
+      {groups.map((group) => {
+        const expandedKey = `${grouping}:${group.key}`;
+        return (
+          <ConnectionGroupRow
+            key={group.key}
+            group={group}
+            grouping={grouping}
+            now={now}
+            canRevoke={canRevoke}
+            onRevoked={onRevoked}
+            project={project}
+            killswitchContext={
+              killswitch.canAccess ? killswitchContext : undefined
+            }
+            killswitchBadges={killswitch.badges}
+            killswitchUnavailableUserIds={killswitch.unavailableUserIds}
+            killswitchBaseHref={orgRoutes.killswitch.href()}
+            expanded={expandedGroups.has(expandedKey)}
+            onExpandedChange={(expanded) =>
+              setExpandedGroups((current) => {
+                const next = new Set(current);
+                if (expanded) next.add(expandedKey);
+                else next.delete(expandedKey);
+                return next;
+              })
+            }
+            onOpenKillswitch={(href) => void navigate(href)}
+          />
+        );
+      })}
     </div>
   );
 
   return (
     <div className="space-y-6">
+      {killswitch.loader}
       {/* Header and rows share one box rather than the header floating above
           it: unenclosed, the column labels read as a caption hanging off the
           grouping control above them instead of as the top of this table. */}

--- a/client/dashboard/src/components/connections/ConnectionsListSection.tsx
+++ b/client/dashboard/src/components/connections/ConnectionsListSection.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
 
-import { ConnectionsList } from "@/components/connections/ConnectionsList";
+import {
+  ConnectionsList,
+  type ConnectionKillswitchContext,
+} from "@/components/connections/ConnectionsList";
 import {
   CONNECTION_GROUPING_LABELS,
   type ConnectionGrouping,
@@ -55,10 +58,12 @@ export function ConnectionsListSection({
   emptyHeading = "No connections yet",
   emptyDescription = "Connections agents establish will appear here.",
   clients,
+  killswitchContext,
 }: {
   sessions: UserSession[];
   /** Registrations for this scope; surfaced by the client grouping. */
   clients?: UserSessionClient[];
+  killswitchContext?: ConnectionKillswitchContext;
   isPending: boolean;
   isError: boolean;
   onRetry: () => void;
@@ -152,6 +157,7 @@ export function ConnectionsListSection({
         canRevoke={canRevoke}
         onRevoked={onRevoked}
         clients={clients}
+        killswitchContext={killswitchContext}
       />
     </Stack>
   );

--- a/client/dashboard/src/components/filters/FilterChip.tsx
+++ b/client/dashboard/src/components/filters/FilterChip.tsx
@@ -45,8 +45,10 @@ export function FilterChip({
   active = false,
   onClick,
   onRemove,
+  ariaLabel,
 }: {
   label: string;
+  ariaLabel?: string;
   /**
    * The dimension's accent, from the brand spectrum. Identity, not state: the
    * square says *which* filter this is at a glance, while the border and text
@@ -77,6 +79,7 @@ export function FilterChip({
     >
       <button
         type="button"
+        aria-label={ariaLabel}
         onClick={onClick}
         className="hover:text-foreground flex items-center gap-2 transition-colors"
       >

--- a/client/dashboard/src/components/filters/FilterControl.tsx
+++ b/client/dashboard/src/components/filters/FilterControl.tsx
@@ -82,7 +82,10 @@ export function FilterControl({
           value={(value as string | null) ?? SELECT_ALL_VALUE}
           onValueChange={(v) => onChange(v === SELECT_ALL_VALUE ? null : v)}
         >
-          <SelectTrigger className={className}>
+          <SelectTrigger
+            className={className}
+            aria-label={`Filter by ${dim.label.toLowerCase()}`}
+          >
             <SelectValue
               placeholder={
                 dim.placeholder ?? `Filter by ${dim.label.toLowerCase()}`

--- a/client/dashboard/src/components/killswitch/KillswitchUserBadgeLink.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchUserBadgeLink.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router";
+
+import { Badge } from "@/components/ui/Badge";
+import type { KillswitchUserBadge } from "@gram/client/models/components/killswitchuserbadge.js";
+
+export function KillswitchUserBadgeLink({
+  badge,
+  href,
+  unavailable = false,
+}: {
+  badge?: KillswitchUserBadge;
+  href: string;
+  unavailable?: boolean;
+}): JSX.Element | null {
+  if (!unavailable && !badge?.affectedNow && !badge?.scheduled) return null;
+
+  const affectedNow = badge?.affectedNow === true;
+  const label = unavailable
+    ? "Killswitch status unavailable"
+    : affectedNow
+      ? "Killswitched"
+      : "Scheduled killswitch";
+  return (
+    <Badge
+      asChild
+      size="sm"
+      variant={
+        unavailable ? "neutral" : affectedNow ? "destructive" : "warning"
+      }
+    >
+      <Link
+        className="min-h-6 min-w-6"
+        to={href}
+        aria-label={`${label}; view filtered killswitches`}
+      >
+        {label}
+      </Link>
+    </Badge>
+  );
+}

--- a/client/dashboard/src/components/killswitch/KillswitchUserStatus.test.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchUserStatus.test.tsx
@@ -1,0 +1,294 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KillswitchUserBadgeLink } from "./KillswitchUserBadgeLink";
+import { MCP_TOOL_CALLS_CAPABILITY } from "./killswitch-routing";
+import {
+  BADGE_REFRESH_INTERVAL_MS,
+  canonicalUserId,
+  killswitchCreateHref,
+  killswitchStatusHref,
+  mcpSessionsUserHref,
+  useKillswitchUserBadges,
+} from "./KillswitchUserStatus";
+
+const state = vi.hoisted(() => ({
+  canAccess: true,
+  session: "session-1",
+  organizationId: "org-1",
+  mutationHookFactory: vi.fn(),
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock("@/hooks/useKillswitchAccess", () => ({
+  useKillswitchAccess: () => ({
+    canAccess: state.canAccess,
+    isLoading: false,
+    reason: state.canAccess ? "allowed" : "scope",
+  }),
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useSession: () => ({
+    session: state.session,
+    organization: { id: state.organizationId },
+  }),
+}));
+vi.mock("@gram/client/react-query/batchKillswitchUserBadges.js", () => ({
+  useBatchKillswitchUserBadgesMutation: () => state.mutationHookFactory(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+beforeEach(() => {
+  state.canAccess = true;
+  state.session = "session-1";
+  state.organizationId = "org-1";
+  state.mutateAsync.mockReset().mockResolvedValue({ badges: [] });
+  state.mutationHookFactory
+    .mockReset()
+    .mockReturnValue({ mutateAsync: state.mutateAsync });
+});
+
+function BadgeHarness({
+  userIds,
+  enabled = true,
+}: {
+  userIds: string[];
+  enabled?: boolean;
+}): JSX.Element {
+  const result = useKillswitchUserBadges(userIds, enabled);
+  return (
+    <>
+      <output data-testid="badges">
+        {[...result.badges.keys()].join(",")}
+      </output>
+      <output data-testid="unavailable">
+        {[...result.unavailableUserIds].join(",")}
+      </output>
+      {result.loader}
+    </>
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("Killswitch user status", () => {
+  it("accepts only canonical user subjects and builds exact contextual URLs", () => {
+    expect(canonicalUserId("user:user-1")).toBe("user-1");
+    expect(canonicalUserId("apikey:user-1")).toBeUndefined();
+    expect(canonicalUserId("anonymous:user-1")).toBeUndefined();
+    expect(canonicalUserId("user:user-1:other")).toBeUndefined();
+
+    expect(killswitchStatusHref("/org/killswitch", "user-1")).toBe(
+      "/org/killswitch?user=user-1",
+    );
+    expect(mcpSessionsUserHref("/org/mcp-sessions", "user-1")).toBe(
+      "/org/mcp-sessions?subjectUrn=user%3Auser-1",
+    );
+    expect(
+      killswitchCreateHref("/org/killswitch", {
+        userId: "user-1",
+        capabilityKey: MCP_TOOL_CALLS_CAPABILITY,
+        originatingMcpServerId: "server-1",
+      }),
+    ).toBe(
+      "/org/killswitch?create=1&createUser=user-1&createCapability=mcp_tool_calls&originServer=server-1",
+    );
+  });
+
+  it("bounds chunk concurrency and preserves successes when one chunk fails", async () => {
+    const requests = [
+      deferred<{
+        badges: Array<{
+          userId: string;
+          affected: boolean;
+          affectedNow: boolean;
+          scheduled: boolean;
+        }>;
+      }>(),
+      deferred<{
+        badges: Array<{
+          userId: string;
+          affected: boolean;
+          affectedNow: boolean;
+          scheduled: boolean;
+        }>;
+      }>(),
+      deferred<{
+        badges: Array<{
+          userId: string;
+          affected: boolean;
+          affectedNow: boolean;
+          scheduled: boolean;
+        }>;
+      }>(),
+    ];
+    state.mutateAsync.mockImplementation(
+      () => requests[state.mutateAsync.mock.calls.length - 1]?.promise,
+    );
+    const uniqueIds = Array.from({ length: 205 }, (_, i) => `user-${i + 1}`);
+    render(
+      <StrictMode>
+        <BadgeHarness userIds={[...uniqueIds, "user-1", "user-205"]} />
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(state.mutateAsync).toHaveBeenCalledTimes(2));
+    const firstTwoChunks = state.mutateAsync.mock.calls.map(
+      ([request]) =>
+        request.request.killswitchBatchUserBadgesRequest.userIds as string[],
+    );
+    expect(firstTwoChunks.every((chunk) => chunk.length <= 100)).toBe(true);
+
+    await act(async () => {
+      requests[0]!.resolve({
+        badges: [
+          {
+            userId: firstTwoChunks[0]![0]!,
+            affected: true,
+            affectedNow: true,
+            scheduled: false,
+          },
+        ],
+      });
+      requests[1]!.reject(new Error("chunk unavailable"));
+    });
+    await waitFor(() => expect(state.mutateAsync).toHaveBeenCalledTimes(3));
+    const thirdChunk = state.mutateAsync.mock.calls[2]![0].request
+      .killswitchBatchUserBadgesRequest.userIds as string[];
+    await act(async () => {
+      requests[2]!.resolve({
+        badges: [
+          {
+            userId: thirdChunk[0]!,
+            affected: true,
+            affectedNow: false,
+            scheduled: true,
+          },
+        ],
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("badges").textContent).toContain(
+        thirdChunk[0]!,
+      ),
+    );
+    expect(screen.getByTestId("unavailable").textContent?.split(",")).toEqual(
+      firstTwoChunks[1],
+    );
+    expect(
+      state.mutateAsync.mock.calls.flatMap(
+        ([request]) => request.request.killswitchBatchUserBadgesRequest.userIds,
+      ),
+    ).toEqual([...uniqueIds].sort());
+  });
+
+  it("keys results by session and organization and suppresses them when disabled or denied", async () => {
+    state.mutateAsync.mockResolvedValue({
+      badges: [
+        {
+          userId: "user-1",
+          affected: true,
+          affectedNow: true,
+          scheduled: false,
+        },
+      ],
+    });
+    const view = render(<BadgeHarness userIds={["user-1"]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("badges").textContent).toBe("user-1"),
+    );
+
+    view.rerender(<BadgeHarness userIds={["user-1"]} enabled={false} />);
+    expect(screen.getByTestId("badges").textContent).toBe("");
+
+    view.rerender(<BadgeHarness userIds={["user-1"]} />);
+    await waitFor(() => expect(state.mutateAsync).toHaveBeenCalledTimes(2));
+    state.organizationId = "org-2";
+    view.rerender(<BadgeHarness userIds={["user-1"]} />);
+    expect(screen.getByTestId("badges").textContent).toBe("");
+    await waitFor(() => expect(state.mutateAsync).toHaveBeenCalledTimes(3));
+
+    state.session = "session-2";
+    view.rerender(<BadgeHarness userIds={["user-1"]} />);
+    expect(screen.getByTestId("badges").textContent).toBe("");
+    await waitFor(() => expect(state.mutateAsync).toHaveBeenCalledTimes(4));
+
+    state.canAccess = false;
+    view.rerender(<BadgeHarness userIds={["user-1"]} />);
+    expect(screen.getByTestId("badges").textContent).toBe("");
+  });
+
+  it("refreshes status on a bounded interval", async () => {
+    vi.useFakeTimers();
+    render(<BadgeHarness userIds={["user-1"]} />);
+    await act(async () => Promise.resolve());
+    expect(state.mutateAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(BADGE_REFRESH_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    expect(state.mutateAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not instantiate the badge API hook before access is allowed", () => {
+    state.canAccess = false;
+    render(<BadgeHarness userIds={["user-1"]} />);
+    expect(state.mutationHookFactory).not.toHaveBeenCalled();
+    expect(state.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("links effective, scheduled, and unavailable states with a 24px hit target", () => {
+    const view = render(
+      <MemoryRouter>
+        <div>
+          <KillswitchUserBadgeLink
+            href="/org/killswitch?user=user-1"
+            badge={{
+              userId: "user-1",
+              affected: true,
+              affectedNow: true,
+              scheduled: true,
+            }}
+          />
+          <KillswitchUserBadgeLink
+            href="/org/killswitch?user=user-2"
+            badge={{
+              userId: "user-2",
+              affected: true,
+              affectedNow: false,
+              scheduled: true,
+            }}
+          />
+          <KillswitchUserBadgeLink
+            href="/org/killswitch?user=user-3"
+            unavailable
+          />
+        </div>
+      </MemoryRouter>,
+    );
+    const links = view.getAllByRole("link");
+    expect(links.map((link) => link.textContent)).toEqual([
+      "Killswitched",
+      "Scheduled killswitch",
+      "Killswitch status unavailable",
+    ]);
+    expect(links.every((link) => link.classList.contains("min-h-6"))).toBe(
+      true,
+    );
+  });
+});

--- a/client/dashboard/src/components/killswitch/KillswitchUserStatus.test.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchUserStatus.test.tsx
@@ -186,6 +186,9 @@ describe("Killswitch user status", () => {
         thirdChunk[0]!,
       ),
     );
+    expect(screen.getByTestId("badges").textContent?.split(",")).toContain(
+      "user-1",
+    );
     expect(screen.getByTestId("unavailable").textContent?.split(",")).toEqual(
       firstTwoChunks[1],
     );

--- a/client/dashboard/src/components/killswitch/KillswitchUserStatus.ts
+++ b/client/dashboard/src/components/killswitch/KillswitchUserStatus.ts
@@ -1,0 +1,223 @@
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { useSession } from "@/contexts/Auth";
+import { useKillswitchAccess } from "@/hooks/useKillswitchAccess";
+import { useBatchKillswitchUserBadgesMutation } from "@gram/client/react-query/batchKillswitchUserBadges.js";
+import type { KillswitchUserBadge } from "@gram/client/models/components/killswitchuserbadge.js";
+import { killswitchCreateHref } from "./killswitch-routing";
+
+export { killswitchCreateHref };
+
+const MAX_BADGE_USERS_PER_REQUEST = 100;
+const MAX_CONCURRENT_BADGE_REQUESTS = 2;
+export const BADGE_REFRESH_INTERVAL_MS = 60_000;
+const EMPTY_BADGES = new Map<string, KillswitchUserBadge>();
+const EMPTY_USER_IDS = new Set<string>();
+
+type BadgeLoadResult = {
+  badges: KillswitchUserBadge[];
+  unavailableUserIds: string[];
+};
+
+const inFlightBadgeRequests = new Map<string, Promise<BadgeLoadResult>>();
+
+export function canonicalUserId(subjectUrn: string): string | undefined {
+  if (!subjectUrn.startsWith("user:")) return undefined;
+  const userId = subjectUrn.slice(5);
+  return userId !== "" && !userId.includes(":") ? userId : undefined;
+}
+
+export function killswitchStatusHref(baseHref: string, userId: string): string {
+  const params = new URLSearchParams({ user: userId });
+  return `${baseHref}?${params.toString()}`;
+}
+
+export function mcpSessionsUserHref(baseHref: string, userId: string): string {
+  const params = new URLSearchParams({ subjectUrn: `user:${userId}` });
+  return `${baseHref}?${params.toString()}`;
+}
+
+type BadgeLoaderProps = {
+  loadKey: string;
+  sessionToken: string;
+  userIds: string[];
+  onLoading: () => void;
+  onLoaded: (result: BadgeLoadResult) => void;
+};
+
+function KillswitchUserBadgesLoader({
+  loadKey,
+  sessionToken,
+  userIds,
+  onLoading,
+  onLoaded,
+}: BadgeLoaderProps): null {
+  const { mutateAsync: batchUserBadges } =
+    useBatchKillswitchUserBadgesMutation();
+
+  useEffect(() => {
+    let current = true;
+    onLoading();
+    let request = inFlightBadgeRequests.get(loadKey);
+    if (!request) {
+      const chunks = Array.from(
+        { length: Math.ceil(userIds.length / MAX_BADGE_USERS_PER_REQUEST) },
+        (_, index) =>
+          userIds.slice(
+            index * MAX_BADGE_USERS_PER_REQUEST,
+            (index + 1) * MAX_BADGE_USERS_PER_REQUEST,
+          ),
+      );
+      request = (async () => {
+        const badges: KillswitchUserBadge[] = [];
+        const unavailableUserIds: string[] = [];
+        for (
+          let index = 0;
+          index < chunks.length;
+          index += MAX_CONCURRENT_BADGE_REQUESTS
+        ) {
+          const wave = chunks.slice(
+            index,
+            index + MAX_CONCURRENT_BADGE_REQUESTS,
+          );
+          const results = await Promise.allSettled(
+            wave.map((chunk) =>
+              Promise.resolve().then(() =>
+                batchUserBadges({
+                  security: { sessionHeaderGramSession: sessionToken },
+                  request: {
+                    killswitchBatchUserBadgesRequest: { userIds: chunk },
+                  },
+                }),
+              ),
+            ),
+          );
+          results.forEach((result, resultIndex) => {
+            if (result.status === "fulfilled") {
+              badges.push(...result.value.badges);
+            } else {
+              unavailableUserIds.push(...(wave[resultIndex] ?? []));
+            }
+          });
+        }
+        return { badges, unavailableUserIds };
+      })();
+      inFlightBadgeRequests.set(loadKey, request);
+      const clearInFlight = () => {
+        if (inFlightBadgeRequests.get(loadKey) === request) {
+          inFlightBadgeRequests.delete(loadKey);
+        }
+      };
+      void request.then(clearInFlight, clearInFlight);
+    }
+
+    void request.then((result) => {
+      if (current) onLoaded(result);
+    });
+
+    return () => {
+      current = false;
+    };
+  }, [batchUserBadges, loadKey, onLoaded, onLoading, sessionToken, userIds]);
+
+  return null;
+}
+
+/** One access-gated, chunked aggregate for the visible users on a surface. */
+export function useKillswitchUserBadges(
+  userIds: readonly string[],
+  enabled = true,
+): {
+  badges: ReadonlyMap<string, KillswitchUserBadge>;
+  unavailableUserIds: ReadonlySet<string>;
+  canAccess: boolean;
+  isLoading: boolean;
+  loader: ReactNode;
+} {
+  const session = useSession();
+  const access = useKillswitchAccess();
+  const requestKey = JSON.stringify([...new Set(userIds)].sort());
+  const deduplicatedUserIds = useMemo<string[]>(
+    () => JSON.parse(requestKey) as string[],
+    [requestKey],
+  );
+  const cacheIdentity = JSON.stringify([
+    session.session,
+    session.organization.id,
+  ]);
+  const canLoad = enabled && access.canAccess && deduplicatedUserIds.length > 0;
+  const [refreshGeneration, setRefreshGeneration] = useState(0);
+  const resultKey = JSON.stringify([cacheIdentity, requestKey]);
+  const loadKey = JSON.stringify([resultKey, refreshGeneration]);
+  const [result, setResult] = useState<{
+    resultKey: string;
+    badges: ReadonlyMap<string, KillswitchUserBadge>;
+    unavailableUserIds: ReadonlySet<string>;
+    isLoading: boolean;
+  }>({
+    resultKey: "",
+    badges: EMPTY_BADGES,
+    unavailableUserIds: EMPTY_USER_IDS,
+    isLoading: false,
+  });
+
+  const current = result.resultKey === resultKey;
+  useEffect(() => {
+    if (!canLoad || !current || result.isLoading) return;
+    const timer = window.setTimeout(
+      () => setRefreshGeneration((generation) => generation + 1),
+      BADGE_REFRESH_INTERVAL_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [canLoad, current, result.isLoading]);
+
+  const onLoading = useCallback(
+    () =>
+      setResult((previous) =>
+        previous.resultKey === resultKey
+          ? { ...previous, isLoading: true }
+          : {
+              resultKey,
+              badges: EMPTY_BADGES,
+              unavailableUserIds: EMPTY_USER_IDS,
+              isLoading: true,
+            },
+      ),
+    [resultKey],
+  );
+  const onLoaded = useCallback(
+    ({ badges, unavailableUserIds }: BadgeLoadResult) =>
+      setResult({
+        resultKey,
+        badges: new Map(badges.map((badge) => [badge.userId, badge])),
+        unavailableUserIds: new Set(unavailableUserIds),
+        isLoading: false,
+      }),
+    [resultKey],
+  );
+
+  return {
+    badges: canLoad && current ? result.badges : EMPTY_BADGES,
+    unavailableUserIds:
+      canLoad && current ? result.unavailableUserIds : EMPTY_USER_IDS,
+    canAccess: enabled && access.canAccess,
+    isLoading: canLoad && (!current || result.isLoading),
+    loader: canLoad
+      ? createElement(KillswitchUserBadgesLoader, {
+          key: loadKey,
+          loadKey,
+          sessionToken: session.session,
+          userIds: deduplicatedUserIds,
+          onLoading,
+          onLoaded,
+        })
+      : null,
+  };
+}

--- a/client/dashboard/src/components/killswitch/killswitch-routing.ts
+++ b/client/dashboard/src/components/killswitch/killswitch-routing.ts
@@ -1,0 +1,83 @@
+import {
+  KillswitchCapabilityKey as KillswitchCapabilityKeys,
+  type KillswitchCapabilityKey,
+} from "@gram/client/models/components/killswitchcapabilitykey.js";
+
+const CREATE_PARAM = "create";
+const CREATE_USER_PARAM = "createUser";
+const CREATE_CAPABILITY_PARAM = "createCapability";
+const ORIGIN_SERVER_PARAM = "originServer";
+
+export const MCP_TOOL_CALLS_CAPABILITY: KillswitchCapabilityKey =
+  KillswitchCapabilityKeys.McpToolCalls;
+
+export type KillswitchCreateContext = {
+  userId: string;
+  capabilityKey?: KillswitchCapabilityKey;
+  originatingMcpServerId?: string;
+};
+
+export type KillswitchCreateRoute = {
+  open: boolean;
+  context?: KillswitchCreateContext;
+};
+
+export function parseKillswitchCreateRoute(
+  params: URLSearchParams,
+): KillswitchCreateRoute {
+  if (params.get(CREATE_PARAM) !== "1") return { open: false };
+
+  const userId = params.get(CREATE_USER_PARAM);
+  if (!userId) return { open: true };
+
+  const capability = params.get(CREATE_CAPABILITY_PARAM);
+  const originatingMcpServerId = params.get(ORIGIN_SERVER_PARAM) ?? undefined;
+  return {
+    open: true,
+    context: {
+      userId,
+      capabilityKey:
+        capability === MCP_TOOL_CALLS_CAPABILITY
+          ? MCP_TOOL_CALLS_CAPABILITY
+          : undefined,
+      originatingMcpServerId,
+    },
+  };
+}
+
+export function cleanKillswitchCreateRoute(
+  params: URLSearchParams,
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  next.delete(CREATE_PARAM);
+  next.delete(CREATE_USER_PARAM);
+  next.delete(CREATE_CAPABILITY_PARAM);
+  next.delete(ORIGIN_SERVER_PARAM);
+  return next;
+}
+
+export function openKillswitchCreateRoute(
+  params: URLSearchParams,
+  context?: KillswitchCreateContext,
+): URLSearchParams {
+  const next = cleanKillswitchCreateRoute(params);
+  next.set(CREATE_PARAM, "1");
+  if (context) {
+    next.set(CREATE_USER_PARAM, context.userId);
+    if (context.capabilityKey) {
+      next.set(CREATE_CAPABILITY_PARAM, context.capabilityKey);
+    }
+    if (context.originatingMcpServerId) {
+      next.set(ORIGIN_SERVER_PARAM, context.originatingMcpServerId);
+    }
+  }
+  return next;
+}
+
+export function killswitchCreateHref(
+  baseHref: string,
+  context: KillswitchCreateContext,
+): string {
+  const params = openKillswitchCreateRoute(new URLSearchParams(), context);
+  return `${baseHref}?${params.toString()}`;
+}

--- a/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
+++ b/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
@@ -70,6 +70,11 @@ vi.mock("@/components/ui/MoreActions", () => ({
 
 vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({ killswitch: { href: () => "/example/killswitch" } }),
+  useRoutes: () => ({
+    identities: {
+      detail: { overview: { href: (urn: string) => `/identities/${urn}` } },
+    },
+  }),
 }));
 
 vi.mock("@/hooks/useKillswitchAccess", () => ({

--- a/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
+++ b/client/dashboard/src/components/sessions/ClientsAndSessionsTab.test.tsx
@@ -10,11 +10,13 @@ const {
   useUserSessionsInfinite,
   invalidateAllUserSessionClients,
   revokeSessionMutate,
+  batchBadgesMutate,
 } = vi.hoisted(() => ({
   useUserSessionClientsInfinite: vi.fn(),
   useUserSessionsInfinite: vi.fn(),
   invalidateAllUserSessionClients: vi.fn(),
   revokeSessionMutate: vi.fn(),
+  batchBadgesMutate: vi.fn(),
 }));
 
 vi.mock("@gram/client/react-query/userSessionClients.js", () => ({
@@ -66,6 +68,24 @@ vi.mock("@/components/ui/MoreActions", () => ({
   ),
 }));
 
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({ killswitch: { href: () => "/example/killswitch" } }),
+}));
+
+vi.mock("@/hooks/useKillswitchAccess", () => ({
+  useKillswitchAccess: () => ({
+    canAccess: true,
+    isLoading: false,
+    reason: "allowed",
+  }),
+}));
+
+vi.mock("@gram/client/react-query/batchKillswitchUserBadges.js", () => ({
+  useBatchKillswitchUserBadgesMutation: () => ({
+    mutateAsync: batchBadgesMutate,
+  }),
+}));
+
 vi.mock("@/hooks/useRBAC", () => ({
   useRBAC: () => ({ hasScope: () => true, hasAnyScope: () => true }),
 }));
@@ -102,6 +122,10 @@ vi.mock("./RevokeClientDialog", () => ({
 
 vi.mock("@/contexts/Auth", () => ({
   useProject: () => ({ id: "project-1", slug: "project-1" }),
+  useSession: () => ({
+    session: "session-1",
+    organization: { id: "org-1" },
+  }),
 }));
 
 function client(overrides: Record<string, unknown>) {
@@ -177,6 +201,16 @@ describe("ClientsAndSessionsTab", () => {
   beforeEach(() => {
     useUserSessionsInfinite.mockReturnValue(queryResult([]));
     useUserSessionClientsInfinite.mockReturnValue(queryResult([]));
+    batchBadgesMutate.mockResolvedValue({
+      badges: [
+        {
+          userId: "u1",
+          affected: true,
+          affectedNow: true,
+          scheduled: false,
+        },
+      ],
+    });
   });
 
   afterEach(() => {
@@ -300,6 +334,68 @@ describe("ClientsAndSessionsTab", () => {
     renderTab(<ClientsAndSessionsTab issuerId="issuer-1" />);
 
     expect(screen.getByText("Needs re-auth")).toBeDefined();
+  });
+
+  it("batches deduplicated people once and links status/actions to the exact user", async () => {
+    useUserSessionsInfinite.mockReturnValue(
+      queryResult([session({ id: "session-1" }), session({ id: "session-2" })]),
+    );
+
+    renderTab(
+      <ClientsAndSessionsTab
+        issuerId="issuer-1"
+        originatingMcpServerId="mcp-server-1"
+      />,
+    );
+
+    await vi.waitFor(() => expect(batchBadgesMutate).toHaveBeenCalledTimes(1));
+    expect(batchBadgesMutate.mock.calls[0]?.[0]).toMatchObject({
+      request: {
+        killswitchBatchUserBadgesRequest: { userIds: ["u1"] },
+      },
+    });
+    expect(
+      (await screen.findByRole("link", { name: /Killswitched/ })).getAttribute(
+        "href",
+      ),
+    ).toBe("/example/killswitch?user=u1");
+    expect(screen.getByText("View killswitches")).toBeDefined();
+    fireEvent.click(screen.getByText("New killswitch…"));
+    expect(revokeSessionMutate).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Revoke all connections"));
+    expect(
+      screen
+        .getByRole("link", { name: "New killswitch…" })
+        .getAttribute("href"),
+    ).toBe(
+      "/example/killswitch?create=1&createUser=u1&createCapability=mcp_tool_calls&originServer=mcp-server-1",
+    );
+  });
+
+  it("batches only people revealed under an expanded agent", async () => {
+    useUserSessionsInfinite.mockReturnValue(queryResult([session({})]));
+    useUserSessionClientsInfinite.mockReturnValue(
+      queryResult([client({ clientName: "Visible Agent" })]),
+    );
+
+    renderTab(
+      <ClientsAndSessionsTab
+        issuerId="issuer-1"
+        originatingMcpServerId="mcp-server-1"
+      />,
+    );
+    fireEvent.click(screen.getByText("Agent"));
+    batchBadgesMutate.mockClear();
+
+    expect(batchBadgesMutate).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Visible Agent"));
+
+    await vi.waitFor(() => expect(batchBadgesMutate).toHaveBeenCalledTimes(1));
+    expect(batchBadgesMutate.mock.calls[0]?.[0]).toMatchObject({
+      request: {
+        killswitchBatchUserBadgesRequest: { userIds: ["u1"] },
+      },
+    });
   });
 
   it("no longer offers the client drill-down that filtered the table above", () => {

--- a/client/dashboard/src/components/sessions/ClientsAndSessionsTab.tsx
+++ b/client/dashboard/src/components/sessions/ClientsAndSessionsTab.tsx
@@ -33,9 +33,12 @@ import { ConnectionsListSection } from "@/components/connections/ConnectionsList
  */
 export function ClientsAndSessionsTab({
   issuerId,
+  originatingMcpServerId,
   authTabPath = "settings",
 }: {
   issuerId: string | undefined;
+  /** Canonical mcp_servers.id only; never an issuer, toolset, or gateway id. */
+  originatingMcpServerId?: string;
   /**
    * Sibling tab where authentication is configured, for the no-issuer empty
    * state to point at. Differs between the two server pages this tab is shared
@@ -187,6 +190,10 @@ export function ClientsAndSessionsTab({
         <ConnectionsListSection
           sessions={sessions}
           clients={clients}
+          killswitchContext={{
+            capabilityKey: "mcp_tool_calls",
+            originatingMcpServerId,
+          }}
           isPending={sessionsQuery.isPending || clientsQuery.isPending}
           isError={sessionsQuery.isError && sessions.length === 0}
           onRetry={() => {

--- a/client/dashboard/src/components/sessions/RevokeSessionsDialog.test.tsx
+++ b/client/dashboard/src/components/sessions/RevokeSessionsDialog.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RevokeSessionsDialog } from "./RevokeSessionsDialog";
+
+const state = vi.hoisted(() => ({
+  revoke: vi.fn(),
+  createKillswitch: vi.fn(),
+}));
+
+vi.mock("@gram/client/react-query/revokeUserSession.js", () => ({
+  useRevokeUserSessionMutation: () => ({ mutateAsync: state.revoke }),
+}));
+vi.mock("@gram/client/react-query/createKillswitch.js", () => ({
+  useCreateKillswitchMutation: () => ({ mutateAsync: state.createKillswitch }),
+}));
+
+beforeEach(() => {
+  state.revoke.mockReset().mockResolvedValue(undefined);
+  state.createKillswitch.mockReset();
+});
+afterEach(cleanup);
+
+describe("RevokeSessionsDialog", () => {
+  it("cross-links an exact user while keeping revocation independent", async () => {
+    const user = userEvent.setup();
+    const onRevoked = vi.fn();
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <RevokeSessionsDialog
+            sessionIds={["session-1", "session-2"]}
+            newKillswitchHref="/example/killswitch?create=1&createUser=user-1&createCapability=mcp_tool_calls"
+            open
+            onOpenChange={() => {}}
+            onRevoked={(ids) => {
+              onRevoked(ids);
+            }}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByText(/clients can authenticate and reconnect/i),
+    ).not.toBeNull();
+    expect(
+      screen.getByText(/Revocation never creates or lifts/i),
+    ).not.toBeNull();
+    const link = screen.getByRole("link", { name: "New killswitch…" });
+    expect(link.getAttribute("href")).toContain("createUser=user-1");
+    await user.click(link);
+    expect(state.revoke).not.toHaveBeenCalled();
+    expect(state.createKillswitch).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Revoke 2" }));
+    await waitFor(() => expect(state.revoke).toHaveBeenCalledTimes(2));
+    expect(state.createKillswitch).not.toHaveBeenCalled();
+    expect(onRevoked).toHaveBeenCalledWith(["session-1", "session-2"]);
+  });
+
+  it("does not show a Killswitch action without one exact user context", () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <RevokeSessionsDialog
+            sessionIds={["session-1", "session-2"]}
+            open
+            onOpenChange={() => {}}
+            onRevoked={() => {}}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByRole("link", { name: "New killswitch…" })).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
+++ b/client/dashboard/src/components/sessions/RevokeSessionsDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { Link } from "react-router";
 import { useMutation } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/Button";
@@ -10,10 +11,13 @@ export function RevokeSessionsDialog({
   open,
   onOpenChange,
   onRevoked,
+  newKillswitchHref,
 }: {
   sessionIds: string[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Only supplied when the group identifies one exact canonical user. */
+  newKillswitchHref?: string;
   /** Reports the ids that were successfully revoked so the caller can clear them. */
   onRevoked: (succeededIds: string[]) => void;
 }): JSX.Element {
@@ -65,11 +69,24 @@ export function RevokeSessionsDialog({
             Revoke {count} session{count === 1 ? "" : "s"}?
           </Dialog.Title>
           <Dialog.Description>
-            This immediately invalidates{" "}
-            {count === 1 ? "this session" : "these sessions"}. The affected
-            clients will need to re-authenticate.
+            This immediately ends{" "}
+            {count === 1 ? "this session" : "these sessions"}, but clients can
+            authenticate and reconnect. A killswitch is separate: it blocks
+            matching MCP tool calls without ending sessions. Revocation never
+            creates or lifts a killswitch.
           </Dialog.Description>
         </Dialog.Header>
+        {newKillswitchHref && (
+          <div className="space-y-1">
+            <Button variant="secondary" size="sm" asChild>
+              <Link to={newKillswitchHref}>New killswitch…</Link>
+            </Button>
+            <p className="text-muted-foreground text-xs">
+              This separate action blocks matching tool calls; it does not
+              revoke or prevent connections.
+            </p>
+          </div>
+        )}
         {failedCount > 0 && (
           <p className="text-destructive text-sm">
             {failedCount} session{failedCount === 1 ? "" : "s"} couldn&apos;t be

--- a/client/dashboard/src/components/ui/MoreActions/index.test.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.test.tsx
@@ -1,6 +1,15 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MoreActions } from ".";
+
+afterEach(cleanup);
 
 describe("MoreActions", () => {
   it("restores trigger focus when an ordinary menu close finishes", async () => {
@@ -48,6 +57,26 @@ describe("MoreActions", () => {
     );
 
     expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("names row triggers and returns keyboard focus after closing", async () => {
+    const user = userEvent.setup();
+    render(
+      <MoreActions
+        triggerAriaLabel="Actions for Alex Morgan"
+        actions={[{ label: "New killswitch…", onClick: () => {} }]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Actions for Alex Morgan",
+    });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    expect(
+      await screen.findByRole("menuitem", { name: "New killswitch…" }),
+    ).not.toBeNull();
+    await user.keyboard("{Escape}");
     expect(document.activeElement).toBe(trigger);
   });
 });

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -112,11 +112,11 @@ export function MoreActions({
               name={triggerLoading ? "loader-circle" : "ellipsis-vertical"}
               className={cn("size-4", triggerLoading && "animate-spin")}
             />
-            <span className="sr-only">
+            <Button.Text className="sr-only">
               {triggerLoading
                 ? "Action in progress"
                 : (triggerAriaLabel ?? "Open menu")}
-            </span>
+            </Button.Text>
           </Button>
         )}
       </DropdownMenuTrigger>

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -107,16 +107,16 @@ export function MoreActions({
             disabled={triggerLoading || triggerDisabled}
             aria-busy={triggerLoading === true}
             style={triggerStyle}
-            aria-label={
-              triggerLoading
-                ? "Action in progress"
-                : (triggerAriaLabel ?? "Open menu")
-            }
           >
             <Icon
               name={triggerLoading ? "loader-circle" : "ellipsis-vertical"}
               className={cn("size-4", triggerLoading && "animate-spin")}
             />
+            <span className="sr-only">
+              {triggerLoading
+                ? "Action in progress"
+                : (triggerAriaLabel ?? "Open menu")}
+            </span>
           </Button>
         )}
       </DropdownMenuTrigger>

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -25,12 +25,15 @@ export type Action = {
 export function MoreActions({
   actions,
   triggerLabel,
+  triggerAriaLabel,
   triggerLoading,
   triggerDisabled,
   triggerStyle,
 }: {
   actions: Action[];
   triggerLabel?: string;
+  /** Accessible name for an icon-only trigger. */
+  triggerAriaLabel?: string;
   /** Shows a spinner in place of the trigger icon, disables it, and restores
    * trigger focus when the async action completes. */
   triggerLoading?: boolean;
@@ -104,14 +107,16 @@ export function MoreActions({
             disabled={triggerLoading || triggerDisabled}
             aria-busy={triggerLoading === true}
             style={triggerStyle}
+            aria-label={
+              triggerLoading
+                ? "Action in progress"
+                : (triggerAriaLabel ?? "Open menu")
+            }
           >
             <Icon
               name={triggerLoading ? "loader-circle" : "ellipsis-vertical"}
               className={cn("size-4", triggerLoading && "animate-spin")}
             />
-            <span className="sr-only">
-              {triggerLoading ? "Action in progress" : "Open menu"}
-            </span>
           </Button>
         )}
       </DropdownMenuTrigger>

--- a/client/dashboard/src/components/ui/Toolbar/index.tsx
+++ b/client/dashboard/src/components/ui/Toolbar/index.tsx
@@ -327,25 +327,29 @@ function ToolbarFilters({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      {pillDims.map((dim) => (
-        <FilterChip
-          key={dim.id}
-          label={chipLabel(dim, values[dim.id]!, optionsById[dim.id])}
-          color={accents[dim.id]}
-          active={!isDimensionAtDefault(dim, values[dim.id]!)}
-          onClick={() => setSheetOpen(true)}
-          // A default pinned chip ("All …", default daterange) has nothing to
-          // clear, and a `required` dimension has nothing to clear *to* —
-          // clearing it just resolves back to a value, so the × would look
-          // broken. Omit onRemove in both cases so it is hidden rather than a
-          // no-op.
-          onRemove={
-            dim.required || isDimensionAtDefault(dim, values[dim.id]!)
-              ? undefined
-              : () => onClear(dim.id)
-          }
-        />
-      ))}
+      {pillDims.map((dim) => {
+        const label = chipLabel(dim, values[dim.id]!, optionsById[dim.id]);
+        return (
+          <FilterChip
+            key={dim.id}
+            label={label}
+            ariaLabel={`${dim.label} filter: ${label}`}
+            color={accents[dim.id]}
+            active={!isDimensionAtDefault(dim, values[dim.id]!)}
+            onClick={() => setSheetOpen(true)}
+            // A default pinned chip ("All …", default daterange) has nothing to
+            // clear, and a `required` dimension has nothing to clear *to* —
+            // clearing it just resolves back to a value, so the × would look
+            // broken. Omit onRemove in both cases so it is hidden rather than a
+            // no-op.
+            onRemove={
+              dim.required || isDimensionAtDefault(dim, values[dim.id]!)
+                ? undefined
+                : () => onClear(dim.id)
+            }
+          />
+        );
+      })}
 
       {customFilters.map((filter) => (
         <CustomFilterChip

--- a/client/dashboard/src/components/ui/Toolbar/index.tsx
+++ b/client/dashboard/src/components/ui/Toolbar/index.tsx
@@ -329,11 +329,17 @@ function ToolbarFilters({
     <div className="flex flex-wrap items-center gap-2">
       {pillDims.map((dim) => {
         const label = chipLabel(dim, values[dim.id]!, optionsById[dim.id]);
+        const ariaLabel =
+          dim.kind === "select" ||
+          dim.kind === "multiselect" ||
+          dim.kind === "daterange"
+            ? `${dim.label} filter: ${label}`
+            : label;
         return (
           <FilterChip
             key={dim.id}
             label={label}
-            ariaLabel={`${dim.label} filter: ${label}`}
+            ariaLabel={ariaLabel}
             color={accents[dim.id]}
             active={!isDimensionAtDefault(dim, values[dim.id]!)}
             onClick={() => setSheetOpen(true)}

--- a/client/dashboard/src/pages/killswitch/KillswitchEditorSheet.test.tsx
+++ b/client/dashboard/src/pages/killswitch/KillswitchEditorSheet.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { KillswitchDetail } from "@gram/client/models/components/killswitchdetail.js";
 import { KillswitchEditorSheet } from "./KillswitchEditorSheet";
@@ -63,7 +64,11 @@ function renderEditor(
       .mockResolvedValue({ id: "ks-1", version: 1, replayed: false }),
     ...overrides,
   };
-  const view = render(<KillswitchEditorSheet {...props} />);
+  const view = render(
+    <MemoryRouter>
+      <KillswitchEditorSheet {...props} />
+    </MemoryRouter>,
+  );
   return { ...props, componentProps: props, ...view };
 }
 
@@ -116,6 +121,65 @@ describe("KillswitchEditorSheet", () => {
     ).toBe(true);
     await userEvent.click(screen.getByRole("button", { name: "Try again" }));
     expect(onRetryCapabilities).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a contextual member fixed and applies a pending server only after Selected servers", async () => {
+    const view = renderEditor({
+      createContext: {
+        userId: "user-1",
+        capabilityKey: "mcp_tool_calls",
+        originatingMcpServerId: "server-a",
+      },
+    });
+
+    expect(screen.queryByLabelText("Team member")).toBeNull();
+    expect(screen.getByText(/Alex Morgan — alex@example.test/)).not.toBeNull();
+    expect(
+      (screen.getByLabelText("MCP tool calls") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText(/All MCP servers/) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(
+      (screen.getByLabelText(/Selected servers/) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(screen.queryByText("Server A")).toBeNull();
+
+    await userEvent.click(screen.getByLabelText(/Selected servers/));
+    expect(
+      screen.getByRole("button", { name: "Choose servers (1)" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Server A")).not.toBeNull();
+    await userEvent.type(
+      screen.getByLabelText("Public message shown to the member"),
+      "Access is temporarily paused.",
+    );
+    await userEvent.type(
+      screen.getByLabelText("Internal note"),
+      "Incident response.",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Review impact" }),
+    );
+    expect(view.onPreview).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        capabilityKey: "mcp_tool_calls",
+        scopeType: "selected_servers",
+        serverIds: ["server-a"],
+      }),
+    );
+
+    await userEvent.click(screen.getByLabelText(/All MCP servers/));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Review impact" }),
+    );
+    expect(view.onPreview).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        scopeType: "all_servers",
+        serverIds: [],
+      }),
+    );
   });
 
   it("keeps coming-soon capabilities non-selectable and opens the request path", async () => {
@@ -480,7 +544,11 @@ describe("KillswitchEditorSheet", () => {
     const onSubmit = vi
       .fn()
       .mockResolvedValue({ id: "ks-1", version: 1, replayed: false });
-    renderEditor({ onSubmit });
+    renderEditor({
+      onSubmit,
+      mcpSessionsHref: (userId) =>
+        `/example/mcp-sessions?subjectUrn=${encodeURIComponent(`user:${userId}`)}`,
+    });
     await userEvent.selectOptions(
       screen.getByLabelText("Team member"),
       "user-1",
@@ -504,6 +572,11 @@ describe("KillswitchEditorSheet", () => {
       expect.any(String),
       undefined,
     );
+    expect(
+      screen
+        .getByRole("link", { name: "View this member in MCP Sessions" })
+        .getAttribute("href"),
+    ).toBe("/example/mcp-sessions?subjectUrn=user%3Auser-1");
   });
 
   it("ignores a deferred overlap preview after the draft changes", async () => {

--- a/client/dashboard/src/pages/killswitch/KillswitchEditorSheet.tsx
+++ b/client/dashboard/src/pages/killswitch/KillswitchEditorSheet.tsx
@@ -1,4 +1,5 @@
 import { FeatureRequestModal } from "@/components/FeatureRequestModal";
+import type { KillswitchCreateContext } from "@/components/killswitch/killswitch-routing";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 import { Button } from "@/components/ui/Button";
 import { Dialog } from "@/components/ui/Dialog";
@@ -20,6 +21,7 @@ import type { KillswitchMCPServer } from "@gram/client/models/components/killswi
 import type { KillswitchMutationReceipt } from "@gram/client/models/components/killswitchmutationreceipt.js";
 import type { KillswitchPreviewOverlapsResult } from "@gram/client/models/components/killswitchpreviewoverlapsresult.js";
 import { useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
 import {
   conflictName,
   draftToSchedule,
@@ -47,6 +49,7 @@ type Props = {
   onRetryCapabilities?: () => void;
   initial?: KillswitchDetail;
   initiallyStale?: boolean;
+  createContext?: KillswitchCreateContext;
   onPreview: (draft: EditorDraft) => Promise<KillswitchPreviewOverlapsResult>;
   onSubmit: (
     draft: EditorDraft,
@@ -55,6 +58,7 @@ type Props = {
   ) => Promise<KillswitchMutationReceipt>;
   onRefreshConflict?: () => Promise<KillswitchDetail>;
   onView?: (id: string) => void;
+  mcpSessionsHref?: (userId: string) => string;
 };
 
 function concurrentChanges(
@@ -78,11 +82,14 @@ function toLocalInput(value: Date): string {
   return local.toISOString().slice(0, 16);
 }
 
-function initialDraft(initial?: KillswitchDetail): EditorDraft {
+function initialDraft(
+  initial?: KillswitchDetail,
+  createContext?: KillswitchCreateContext,
+): EditorDraft {
   if (!initial) {
     return {
-      userId: "",
-      capabilityKey: "",
+      userId: createContext?.userId ?? "",
+      capabilityKey: createContext?.capabilityKey ?? "",
       scopeType: "",
       serverIds: [],
       startType: "now",
@@ -132,7 +139,7 @@ export function KillswitchEditorSheet(props: Props): JSX.Element {
     <Sheet open={props.open} onOpenChange={handleOpenChange}>
       {props.open && (
         <EditorContents
-          key={`${props.mode}-${props.initial?.id ?? "new"}`}
+          key={`${props.mode}-${props.initial?.id ?? "new"}-${props.createContext?.userId ?? ""}-${props.createContext?.capabilityKey ?? ""}-${props.createContext?.originatingMcpServerId ?? ""}`}
           {...props}
           onOpenChange={handleOpenChange}
           isSubmitting={isSubmitting}
@@ -155,14 +162,18 @@ function EditorContents({
   onRetryCapabilities,
   initial,
   initiallyStale,
+  createContext,
   onPreview,
   onSubmit,
   onRefreshConflict,
   onView,
+  mcpSessionsHref,
   isSubmitting,
   setIsSubmitting,
 }: EditorContentsProps): JSX.Element {
-  const [draft, setDraft] = useState<EditorDraft>(() => initialDraft(initial));
+  const [draft, setDraft] = useState<EditorDraft>(() =>
+    initialDraft(initial, createContext),
+  );
   const [errors, setErrors] = useState<DraftErrors>({});
   const [operationId, setOperationId] = useState(newOperationId);
   const [expectedVersion, setExpectedVersion] = useState(initial?.version);
@@ -229,6 +240,39 @@ function EditorContents({
     conflictRefreshRequest.current += 1;
     setDraft(nextDraft);
     setErrors((current) => ({ ...current, [key]: undefined }));
+    setPreview(undefined);
+    setPreviewFingerprint("");
+    setIsReviewing(false);
+    setMutationError(undefined);
+    setOperationId(newOperationId());
+  };
+
+  const selectScope = (scopeType: EditorDraft["scopeType"]) => {
+    if (submittingRef.current) return;
+    const current = draftRef.current;
+    const nextDraft = {
+      ...current,
+      scopeType,
+      serverIds:
+        scopeType === "all_servers"
+          ? []
+          : current.serverIds.length > 0
+            ? current.serverIds
+            : createContext?.originatingMcpServerId
+              ? [createContext.originatingMcpServerId]
+              : [],
+    };
+    draftRef.current = nextDraft;
+    draftGeneration.current += 1;
+    draftFingerprint.current = JSON.stringify(nextDraft);
+    previewRequest.current += 1;
+    conflictRefreshRequest.current += 1;
+    setDraft(nextDraft);
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      scopeType: undefined,
+      serverIds: undefined,
+    }));
     setPreview(undefined);
     setPreviewFingerprint("");
     setIsReviewing(false);
@@ -373,7 +417,10 @@ function EditorContents({
               variant="secondary"
               onClick={() => {
                 const retainedUser = draft.userId;
-                const nextDraft = { ...initialDraft(), userId: retainedUser };
+                const nextDraft = {
+                  ...initialDraft(undefined, createContext),
+                  userId: retainedUser,
+                };
                 draftRef.current = nextDraft;
                 draftGeneration.current += 1;
                 draftFingerprint.current = JSON.stringify(nextDraft);
@@ -388,6 +435,13 @@ function EditorContents({
             </Button>
           )}
           <Button onClick={() => onView?.(receipt.id)}>View killswitch</Button>
+          {mcpSessionsHref && (
+            <Button variant="secondary" asChild>
+              <Link to={mcpSessionsHref(draft.userId)}>
+                View this member in MCP Sessions
+              </Link>
+            </Button>
+          )}
         </div>
       </SheetContent>
     );
@@ -413,8 +467,11 @@ function EditorContents({
         >
           <fieldset className="space-y-3">
             <legend className="font-medium">Who</legend>
-            {mode === "edit" ? (
-              <p>{member?.name ?? "Deleted member"}</p>
+            {mode === "edit" || createContext ? (
+              <p>
+                {member?.name ?? "Deleted member"}
+                {member?.email ? ` — ${member.email}` : ""}
+              </p>
             ) : (
               <select
                 aria-label="Team member"
@@ -526,7 +583,7 @@ function EditorContents({
                 name="scope"
                 aria-invalid={Boolean(errors.scopeType)}
                 checked={draft.scopeType === "all_servers"}
-                onChange={() => update("scopeType", "all_servers")}
+                onChange={() => selectScope("all_servers")}
               />
               <span>
                 <strong>All MCP servers</strong>
@@ -542,7 +599,7 @@ function EditorContents({
                 name="scope"
                 aria-invalid={Boolean(errors.scopeType || errors.serverIds)}
                 checked={draft.scopeType === "selected_servers"}
-                onChange={() => update("scopeType", "selected_servers")}
+                onChange={() => selectScope("selected_servers")}
               />
               <span>
                 <strong>Selected servers</strong>

--- a/client/dashboard/src/pages/killswitch/Killswitches.test.tsx
+++ b/client/dashboard/src/pages/killswitch/Killswitches.test.tsx
@@ -200,6 +200,64 @@ describe("KillswitchesRoot", () => {
 });
 
 describe("Killswitches list", () => {
+  it("renders the standard filter bar and Killswitch table", () => {
+    listHook.mockReturnValue({
+      data: {
+        pages: [
+          {
+            result: {
+              items: [
+                {
+                  id: "ks-1",
+                  userId: "user-1",
+                  capabilityKey: "mcp_tool_calls",
+                  capabilityLabel: "MCP tool calls",
+                  scope: { type: "all_servers" },
+                  schedule: { start: "now", end: "until_lifted" },
+                  status: "active",
+                  version: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/acme/killswitch"]}>
+        <Routes>
+          <Route path=":orgSlug/killswitch" element={<Killswitches />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Member filter: All members" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Status filter: All statuses" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Capability filter: All capabilities",
+      }),
+    ).not.toBeNull();
+    expect(screen.getByRole("table")).not.toBeNull();
+    expect(
+      screen.getAllByRole("columnheader").map((header) => header.textContent),
+    ).toEqual(["Member", "Capability", "Status", "Schedule", ""]);
+    expect(screen.getByRole("link", { name: "Alex Morgan" })).not.toBeNull();
+    expect(screen.getByText("All MCP servers")).not.toBeNull();
+    expect(screen.getByText("Active")).not.toBeNull();
+  });
+
   it("scopes every cached query by session", () => {
     listHook.mockReturnValue({
       data: { pages: [{ result: { items: [] } }] },
@@ -224,6 +282,43 @@ describe("Killswitches list", () => {
     expect(dependencies.membersRequest).toEqual({ gramSession: "session" });
     expect(dependencies.capabilityRequest).toEqual({ gramSession: "session" });
     expect(dependencies.serverRequest).toEqual({ gramSession: "session" });
+  });
+
+  it("ignores unsupported status and capability URL filters", () => {
+    listHook.mockReturnValue({
+      data: { pages: [{ result: { items: [] } }] },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/acme/killswitch?status=unknown&capability=deprecated",
+        ]}
+      >
+        <Routes>
+          <Route path=":orgSlug/killswitch" element={<Killswitches />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(listHook.mock.calls.at(-1)?.[1]).toMatchObject({
+      status: undefined,
+      capabilityKey: undefined,
+    });
+    expect(
+      screen.getByRole("button", { name: "Status filter: All statuses" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Capability filter: All capabilities",
+      }),
+    ).not.toBeNull();
   });
 
   it("retries every list dependency that can make rows inaccurate", async () => {

--- a/client/dashboard/src/pages/killswitch/Killswitches.test.tsx
+++ b/client/dashboard/src/pages/killswitch/Killswitches.test.tsx
@@ -1,7 +1,13 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router";
 import Killswitches from "./Killswitches";
 import { KillswitchesRoot } from "./KillswitchesRoot";
 
@@ -49,6 +55,7 @@ vi.mock("@/routes", () => ({
       href: () => "/acme/killswitch",
       detail: { href: (id: string) => `/acme/killswitch/${id}`, goTo: vi.fn() },
     },
+    mcpSessions: { href: () => "/acme/mcp-sessions" },
   }),
 }));
 vi.mock("@tanstack/react-query", async (importOriginal) => ({
@@ -87,7 +94,10 @@ vi.mock("@gram/client/react-query/killswitchCapabilities.js", () => ({
     dependencies.capabilityRequest = args[1];
     dependencies.capabilityOptions = args[2];
     return {
-      data: { capabilities: [], comingSoon: [] },
+      data: {
+        capabilities: [{ key: "mcp_tool_calls", label: "MCP tool calls" }],
+        comingSoon: [],
+      },
       isLoading: dependencies.capabilitiesLoading,
       error: dependencies.capabilitiesError,
       refetch: dependencies.refetchCapabilities,
@@ -99,7 +109,9 @@ vi.mock("@gram/client/react-query/killswitchMCPServers.js", () => ({
     dependencies.serverRequest = args[1];
     dependencies.serverOptions = args[2];
     return {
-      data: { servers: [] },
+      data: {
+        servers: [{ id: "server-1", name: "Server 1", projectId: "project-1" }],
+      },
       isLoading: false,
       error: dependencies.serversError,
       refetch: dependencies.refetchServers,
@@ -115,12 +127,24 @@ vi.mock("@gram/client/react-query/previewKillswitchOverlaps.js", () => ({
 vi.mock("./KillswitchEditorSheet", () => ({
   KillswitchEditorSheet: (props: Record<string, unknown>) => {
     dependencies.editorProps = props;
-    return null;
+    return <div data-testid="killswitch-editor" />;
   },
 }));
 vi.mock("@/components/FeatureRequestModal", () => ({
   FeatureRequestModal: () => null,
 }));
+
+function NavigationProbe(): JSX.Element {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <output data-testid="location">{location.search}</output>
+      <button onClick={() => void navigate(-1)}>Back</button>
+      <button onClick={() => void navigate(1)}>Forward</button>
+    </>
+  );
+}
 
 afterEach(() => {
   cleanup();
@@ -276,6 +300,99 @@ describe("Killswitches list", () => {
     expect(dependencies.refetchCapabilities).toHaveBeenCalledTimes(1);
   });
 
+  it("fails closed for contextual catalog errors and retries every failed dependency", async () => {
+    dependencies.membersError = new Error("members unavailable");
+    dependencies.serversError = new Error("servers unavailable");
+    dependencies.capabilitiesError = new Error("capabilities unavailable");
+    listHook.mockReturnValue({
+      data: { pages: [{ result: { items: [] } }] },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/acme/killswitch?create=1&createUser=user-1&createCapability=mcp_tool_calls&originServer=server-1",
+        ]}
+      >
+        <Routes>
+          <Route path=":orgSlug/killswitch" element={<Killswitches />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(dependencies.editorProps).toMatchObject({
+      open: true,
+      capabilitiesError: dependencies.capabilitiesError,
+    });
+    const retry = dependencies.editorProps?.onRetryCapabilities as () => void;
+    act(() => retry());
+    expect(dependencies.refetchMembers).toHaveBeenCalledTimes(1);
+    expect(dependencies.refetchServers).toHaveBeenCalledTimes(1);
+    expect(dependencies.refetchCapabilities).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the create URL as editor state across open, close, back, and forward", async () => {
+    listHook.mockReturnValue({
+      data: { pages: [{ result: { items: [] } }] },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/acme/killswitch?status=active"]}>
+        <Routes>
+          <Route
+            path=":orgSlug/killswitch"
+            element={
+              <>
+                <Killswitches />
+                <NavigationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "New killswitch" }),
+    );
+    expect(screen.getByTestId("location").textContent).toBe(
+      "?status=active&create=1",
+    );
+    expect(dependencies.editorProps).toMatchObject({ open: true });
+    expect(screen.getByTestId("killswitch-editor")).not.toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByTestId("location").textContent).toBe("?status=active");
+    expect(screen.queryByTestId("killswitch-editor")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Forward" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "?status=active&create=1",
+    );
+    expect(screen.getByTestId("killswitch-editor")).not.toBeNull();
+    const onOpenChange = dependencies.editorProps?.onOpenChange as (
+      open: boolean,
+    ) => void;
+    act(() => onOpenChange(false));
+    await waitFor(() =>
+      expect(screen.getByTestId("location").textContent).toBe("?status=active"),
+    );
+    expect(screen.queryByTestId("killswitch-editor")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByTestId("location").textContent).toBe("?status=active");
+  });
+
   it("passes raw notes to the create API", async () => {
     listHook.mockReturnValue({
       data: { pages: [{ result: { items: [] } }] },
@@ -325,6 +442,68 @@ describe("Killswitches list", () => {
         },
       }),
     );
+  });
+
+  it("validates reload-safe create context and drops a stale server hint", () => {
+    listHook.mockReturnValue({
+      data: { pages: [{ result: { items: [] } }] },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/acme/killswitch?create=1&createUser=user-1&createCapability=mcp_tool_calls&originServer=deleted-server",
+        ]}
+      >
+        <Routes>
+          <Route path=":orgSlug/killswitch" element={<Killswitches />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(dependencies.editorProps).toMatchObject({
+      open: true,
+      createContext: {
+        userId: "user-1",
+        capabilityKey: "mcp_tool_calls",
+        originatingMcpServerId: undefined,
+      },
+    });
+    const mcpSessionsHref = dependencies.editorProps?.mcpSessionsHref as (
+      userId: string,
+    ) => string;
+    expect(mcpSessionsHref("user-1")).toBe(
+      "/acme/mcp-sessions?subjectUrn=user%3Auser-1",
+    );
+  });
+
+  it("falls back to an unbound editor for a stale contextual member", () => {
+    listHook.mockReturnValue({
+      data: { pages: [{ result: { items: [] } }] },
+      error: null,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      refetch: vi.fn(),
+      fetchNextPage: vi.fn(),
+    });
+    render(
+      <MemoryRouter
+        initialEntries={["/acme/killswitch?create=1&createUser=deleted-user"]}
+      >
+        <Routes>
+          <Route path=":orgSlug/killswitch" element={<Killswitches />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(dependencies.editorProps).toMatchObject({
+      open: true,
+      createContext: undefined,
+    });
   });
 
   it("preserves the principal filter in the URL and renders a dedicated empty state", () => {

--- a/client/dashboard/src/pages/killswitch/Killswitches.tsx
+++ b/client/dashboard/src/pages/killswitch/Killswitches.tsx
@@ -1,6 +1,14 @@
+import {
+  defineFilters,
+  useFilterState,
+  type FilterValue,
+  type OptionsById,
+} from "@/components/filters";
+import { Page } from "@/components/page-layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { type Column, Table } from "@/components/ui/Table";
 import { useSession } from "@/contexts/Auth";
 import { useOrgRoutes } from "@/routes";
 import { useQueryClient } from "@tanstack/react-query";
@@ -50,25 +58,64 @@ const statuses: KillswitchListStatus[] = [
   "lifted",
 ];
 
+const KILLSWITCH_FILTERS = defineFilters([
+  {
+    id: "user",
+    label: "Member",
+    kind: "select",
+    pinned: true,
+    allLabel: "All members",
+  },
+  {
+    id: "status",
+    label: "Status",
+    kind: "select",
+    pinned: true,
+    allLabel: "All statuses",
+  },
+  {
+    id: "capability",
+    label: "Capability",
+    kind: "select",
+    pinned: true,
+    allLabel: "All capabilities",
+  },
+]);
+
+const STATUS_FILTER_OPTIONS = statuses.map((status) => ({
+  value: status,
+  label: capitalize(status),
+}));
+const CAPABILITY_FILTER_OPTIONS = [
+  { value: MCP_TOOL_CALLS_CAPABILITY, label: "MCP tool calls" },
+];
+
 export default function Killswitches(): JSX.Element {
   const session = useSession();
   const security = { sessionHeaderGramSession: session.session };
   const routes = useOrgRoutes();
   const queryClient = useQueryClient();
   const [params, setParams] = useSearchParams();
+  const { values, setValue, clearValue, clearAll } =
+    useFilterState(KILLSWITCH_FILTERS);
   const createRoute = parseKillswitchCreateRoute(params);
   const editorOpen = createRoute.open;
   const [requestOpen, setRequestOpen] = useState(false);
-  const userId = params.get("user") || undefined;
-  const statusParam = params.get("status");
+  const userId = values.user || undefined;
+  const statusParam = values.status;
   const status = statuses.includes(statusParam as KillswitchListStatus)
     ? (statusParam as KillswitchListStatus)
     : undefined;
-  const capabilityParam = params.get("capability");
+  const capabilityParam = values.capability;
   const capabilityKey =
     capabilityParam === MCP_TOOL_CALLS_CAPABILITY
       ? (capabilityParam as KillswitchCapabilityKey)
       : undefined;
+  const toolbarValues = {
+    ...values,
+    status: status ?? null,
+    capability: capabilityKey ?? null,
+  };
 
   const listQuery = useKillswitchesInfinite(
     security,
@@ -133,6 +180,71 @@ export default function Killswitches(): JSX.Element {
     () => new Map(servers.map((server) => [server.id, server.name])),
     [servers],
   );
+  const filterOptions: OptionsById = useMemo(
+    () => ({
+      user: members.map((member) => ({
+        value: member.id,
+        label: member.name,
+      })),
+      status: STATUS_FILTER_OPTIONS,
+      capability: CAPABILITY_FILTER_OPTIONS,
+    }),
+    [members],
+  );
+  const columns: Column<KillswitchSummary>[] = [
+    {
+      key: "member",
+      header: "Member",
+      width: "1fr",
+      render: (item) => (
+        <Link
+          className="font-medium hover:underline"
+          to={routes.killswitch.detail.href(item.id)}
+        >
+          {memberNames.get(item.userId) ?? "Deleted member"}
+        </Link>
+      ),
+    },
+    {
+      key: "capability",
+      header: "Capability",
+      width: "1.4fr",
+      render: (item) => (
+        <div>
+          <div>{item.capabilityLabel}</div>
+          <div className="text-muted-foreground">
+            {scopeLabel(item.scope, serverNames)}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      width: "140px",
+      render: (item) => (
+        <Badge variant={item.status === "active" ? "success" : "neutral"}>
+          {capitalize(item.status)}
+        </Badge>
+      ),
+    },
+    {
+      key: "schedule",
+      header: "Schedule",
+      width: "1.2fr",
+      render: (item) => scheduleLabel(item.schedule),
+    },
+    {
+      key: "actions",
+      header: "",
+      width: "auto",
+      render: (item) => (
+        <Button variant="secondary" size="sm" asChild>
+          <Link to={routes.killswitch.detail.href(item.id)}>View details</Link>
+        </Button>
+      ),
+    },
+  ];
   const readError = listQuery.error ?? membersQuery.error ?? serversQuery.error;
   const editorCatalogError =
     capabilitiesQuery.error ?? membersQuery.error ?? serversQuery.error;
@@ -165,15 +277,6 @@ export default function Killswitches(): JSX.Element {
     if (membersQuery.error) retries.push(membersQuery.refetch());
     if (serversQuery.error) retries.push(serversQuery.refetch());
     void Promise.allSettled(retries);
-  };
-
-  const setFilter = (key: string, value: string) => {
-    setParams((current) => {
-      const next = new URLSearchParams(current);
-      if (value) next.set(key, value);
-      else next.delete(key);
-      return next;
-    });
   };
 
   const preview = (draft: EditorDraft) =>
@@ -226,52 +329,16 @@ export default function Killswitches(): JSX.Element {
         </Button>
       </header>
 
-      <div className="grid gap-3 border p-4 sm:grid-cols-3">
-        <label className="space-y-1 text-sm">
-          Member
-          <select
-            aria-label="Filter by member"
-            className="border-input bg-background block h-9 w-full border px-2"
-            value={userId ?? ""}
-            onChange={(event) => setFilter("user", event.target.value)}
-          >
-            <option value="">All members</option>
-            {members.map((member) => (
-              <option key={member.id} value={member.id}>
-                {member.name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="space-y-1 text-sm">
-          Status
-          <select
-            aria-label="Filter by status"
-            className="border-input bg-background block h-9 w-full border px-2"
-            value={status ?? ""}
-            onChange={(event) => setFilter("status", event.target.value)}
-          >
-            <option value="">All statuses</option>
-            {statuses.map((item) => (
-              <option key={item} value={item}>
-                {capitalize(item)}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="space-y-1 text-sm">
-          Capability
-          <select
-            aria-label="Filter by capability"
-            className="border-input bg-background block h-9 w-full border px-2"
-            value={capabilityKey ?? ""}
-            onChange={(event) => setFilter("capability", event.target.value)}
-          >
-            <option value="">All capabilities</option>
-            <option value={MCP_TOOL_CALLS_CAPABILITY}>MCP tool calls</option>
-          </select>
-        </label>
-      </div>
+      <Page.Toolbar>
+        <Page.Toolbar.Filters
+          schema={KILLSWITCH_FILTERS}
+          values={toolbarValues}
+          optionsById={filterOptions}
+          onChange={setValue as (id: string, value: FilterValue) => void}
+          onClear={clearValue as (id: string) => void}
+          onClearAll={clearAll}
+        />
+      </Page.Toolbar>
 
       {readError ? (
         <Alert variant="error">
@@ -301,38 +368,44 @@ export default function Killswitches(): JSX.Element {
         <div className="border p-8 text-center text-sm text-muted-foreground">
           Loading Killswitches…
         </div>
-      ) : items.length === 0 ? (
-        <div className="border border-dashed p-10 text-center">
-          <h2 className="font-medium">No Killswitches match these filters</h2>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Create one or clear a filter to see organization-wide restrictions.
-          </p>
-        </div>
       ) : (
-        <ul className="grid gap-3">
-          {items.map((item) => (
-            <KillswitchRow
-              key={item.id}
-              item={item}
-              memberName={memberNames.get(item.userId)}
-              serverNames={serverNames}
-              href={routes.killswitch.detail.href(item.id)}
-            />
-          ))}
-        </ul>
+        <div className="w-full overflow-x-auto">
+          <Table
+            columns={columns}
+            data={items}
+            rowKey={(item) => item.id}
+            cellPadding="spacious"
+            className="min-w-[840px]"
+            noResultsMessage={
+              <div className="py-4 text-center">
+                <h2 className="text-foreground font-medium">
+                  No Killswitches match these filters
+                </h2>
+                <p className="mt-1">
+                  Create one or clear a filter to see organization-wide
+                  restrictions.
+                </p>
+              </div>
+            }
+          />
+        </div>
       )}
 
-      {listQuery.hasNextPage && (
-        <div className="text-center">
-          <Button
-            variant="secondary"
-            disabled={listQuery.isFetchingNextPage}
-            onClick={() => void listQuery.fetchNextPage()}
-          >
-            {listQuery.isFetchingNextPage ? "Loading…" : "Load more"}
-          </Button>
-        </div>
-      )}
+      {!readError &&
+        !listQuery.isLoading &&
+        !membersQuery.isLoading &&
+        !serversQuery.isLoading &&
+        listQuery.hasNextPage && (
+          <div className="text-center">
+            <Button
+              variant="secondary"
+              disabled={listQuery.isFetchingNextPage}
+              onClick={() => void listQuery.fetchNextPage()}
+            >
+              {listQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        )}
 
       <section className="border border-dashed p-5">
         <h2 className="font-medium">More capabilities coming soon</h2>
@@ -392,41 +465,5 @@ export default function Killswitches(): JSX.Element {
         }}
       />
     </main>
-  );
-}
-
-function KillswitchRow({
-  item,
-  memberName,
-  serverNames,
-  href,
-}: {
-  item: KillswitchSummary;
-  memberName?: string;
-  serverNames: ReadonlyMap<string, string>;
-  href: string;
-}): JSX.Element {
-  return (
-    <li className="grid gap-4 border p-4 text-sm md:grid-cols-[minmax(10rem,1fr)_minmax(14rem,2fr)_auto_minmax(12rem,1fr)_auto] md:items-center">
-      <div>
-        <div className="text-muted-foreground text-xs md:hidden">Member</div>
-        <Link className="font-medium hover:underline" to={href}>
-          {memberName ?? "Deleted member"}
-        </Link>
-      </div>
-      <div>
-        <div>{item.capabilityLabel}</div>
-        <div className="text-muted-foreground">
-          {scopeLabel(item.scope, serverNames)}
-        </div>
-      </div>
-      <Badge variant={item.status === "active" ? "success" : "neutral"}>
-        {capitalize(item.status)}
-      </Badge>
-      <div>{scheduleLabel(item.schedule)}</div>
-      <Button className="w-full md:w-auto" variant="secondary" asChild>
-        <Link to={href}>View details</Link>
-      </Button>
-    </li>
   );
 }

--- a/client/dashboard/src/pages/killswitch/Killswitches.tsx
+++ b/client/dashboard/src/pages/killswitch/Killswitches.tsx
@@ -375,7 +375,7 @@ export default function Killswitches(): JSX.Element {
             data={items}
             rowKey={(item) => item.id}
             cellPadding="spacious"
-            className="min-w-[840px]"
+            className="min-w-max"
             noResultsMessage={
               <div className="py-4 text-center">
                 <h2 className="text-foreground font-medium">

--- a/client/dashboard/src/pages/killswitch/Killswitches.tsx
+++ b/client/dashboard/src/pages/killswitch/Killswitches.tsx
@@ -19,6 +19,14 @@ import type { KillswitchSummary } from "@gram/client/models/components/killswitc
 import { Link, useSearchParams } from "react-router";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { FeatureRequestModal } from "@/components/FeatureRequestModal";
+import { mcpSessionsUserHref } from "@/components/killswitch/KillswitchUserStatus";
+import {
+  cleanKillswitchCreateRoute,
+  MCP_TOOL_CALLS_CAPABILITY,
+  openKillswitchCreateRoute,
+  parseKillswitchCreateRoute,
+  type KillswitchCreateContext,
+} from "@/components/killswitch/killswitch-routing";
 import { capitalize } from "@/lib/utils";
 import {
   draftToSchedule,
@@ -48,7 +56,8 @@ export default function Killswitches(): JSX.Element {
   const routes = useOrgRoutes();
   const queryClient = useQueryClient();
   const [params, setParams] = useSearchParams();
-  const [editorOpen, setEditorOpen] = useState(false);
+  const createRoute = parseKillswitchCreateRoute(params);
+  const editorOpen = createRoute.open;
   const [requestOpen, setRequestOpen] = useState(false);
   const userId = params.get("user") || undefined;
   const statusParam = params.get("status");
@@ -57,7 +66,7 @@ export default function Killswitches(): JSX.Element {
     : undefined;
   const capabilityParam = params.get("capability");
   const capabilityKey =
-    capabilityParam === "mcp_tool_calls"
+    capabilityParam === MCP_TOOL_CALLS_CAPABILITY
       ? (capabilityParam as KillswitchCapabilityKey)
       : undefined;
 
@@ -93,6 +102,29 @@ export default function Killswitches(): JSX.Element {
   const capabilities = capabilitiesQuery.data?.capabilities ?? EMPTY;
   const comingSoon = capabilitiesQuery.data?.comingSoon ?? EMPTY;
   const servers = serversQuery.data?.servers ?? EMPTY;
+  const contextualUserId = createRoute.context?.userId;
+  const contextualCapability = createRoute.context?.capabilityKey;
+  const contextualServerId = createRoute.context?.originatingMcpServerId;
+  const createContext: KillswitchCreateContext | undefined =
+    editorOpen &&
+    contextualUserId != null &&
+    members.some((member) => member.id === contextualUserId)
+      ? {
+          userId: contextualUserId,
+          capabilityKey:
+            contextualCapability === MCP_TOOL_CALLS_CAPABILITY &&
+            capabilities.some(
+              (capability) => capability.key === contextualCapability,
+            )
+              ? MCP_TOOL_CALLS_CAPABILITY
+              : undefined,
+          originatingMcpServerId:
+            contextualServerId != null &&
+            servers.some((server) => server.id === contextualServerId)
+              ? contextualServerId
+              : undefined,
+        }
+      : undefined;
   const memberNames = useMemo(
     () => new Map(members.map((member) => [member.id, member.name])),
     [members],
@@ -102,8 +134,12 @@ export default function Killswitches(): JSX.Element {
     [servers],
   );
   const readError = listQuery.error ?? membersQuery.error ?? serversQuery.error;
-  const editorCatalogError = capabilitiesQuery.error;
-  const editorCatalogLoading = capabilitiesQuery.isLoading;
+  const editorCatalogError =
+    capabilitiesQuery.error ?? membersQuery.error ?? serversQuery.error;
+  const editorCatalogLoading =
+    capabilitiesQuery.isLoading ||
+    membersQuery.isLoading ||
+    serversQuery.isLoading;
   const refetchList = listQuery.refetch;
 
   useEffect(() => {
@@ -112,6 +148,24 @@ export default function Killswitches(): JSX.Element {
     const timer = window.setTimeout(() => void refetchList(), delay);
     return () => window.clearTimeout(timer);
   }, [items, refetchList]);
+
+  const setEditorOpen = (open: boolean) => {
+    if (open) {
+      setParams((current) => openKillswitchCreateRoute(current));
+    } else {
+      setParams((current) => cleanKillswitchCreateRoute(current), {
+        replace: true,
+      });
+    }
+  };
+
+  const retryEditorCatalog = () => {
+    const retries: Promise<unknown>[] = [];
+    if (capabilitiesQuery.error) retries.push(capabilitiesQuery.refetch());
+    if (membersQuery.error) retries.push(membersQuery.refetch());
+    if (serversQuery.error) retries.push(serversQuery.refetch());
+    void Promise.allSettled(retries);
+  };
 
   const setFilter = (key: string, value: string) => {
     setParams((current) => {
@@ -128,7 +182,7 @@ export default function Killswitches(): JSX.Element {
       request: {
         killswitchPreviewOverlapsRequest: {
           userId: draft.userId,
-          capabilityKey: "mcp_tool_calls",
+          capabilityKey: MCP_TOOL_CALLS_CAPABILITY,
           scope: draftToScope(draft),
           schedule: draftToSchedule(draft),
         },
@@ -141,7 +195,7 @@ export default function Killswitches(): JSX.Element {
       request: {
         killswitchCreateRequest: {
           userId: draft.userId,
-          capabilityKey: "mcp_tool_calls",
+          capabilityKey: MCP_TOOL_CALLS_CAPABILITY,
           scope: draftToScope(draft),
           schedule: draftToSchedule(draft),
           externalNote: draft.externalNote,
@@ -214,7 +268,7 @@ export default function Killswitches(): JSX.Element {
             onChange={(event) => setFilter("capability", event.target.value)}
           >
             <option value="">All capabilities</option>
-            <option value="mcp_tool_calls">MCP tool calls</option>
+            <option value={MCP_TOOL_CALLS_CAPABILITY}>MCP tool calls</option>
           </select>
         </label>
       </div>
@@ -308,18 +362,20 @@ export default function Killswitches(): JSX.Element {
             open
             onOpenChange={setEditorOpen}
             mode="create"
+            createContext={createContext}
             members={members}
             servers={servers}
             capabilities={capabilities}
             comingSoon={comingSoon}
             capabilitiesLoading={editorCatalogLoading}
             capabilitiesError={editorCatalogError}
-            onRetryCapabilities={() => {
-              void capabilitiesQuery.refetch();
-            }}
+            onRetryCapabilities={retryEditorCatalog}
             onPreview={preview}
             onSubmit={create}
             onView={(id) => routes.killswitch.detail.goTo(id)}
+            mcpSessionsHref={(userId) =>
+              mcpSessionsUserHref(routes.mcpSessions.href(), userId)
+            }
           />
         </Suspense>
       )}

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -179,7 +179,10 @@ export default function MCPServerDetails(): JSX.Element {
         return (
           mcpServer && (
             <RequireScope scope="project:read" level="page">
-              <ClientsAndSessionsTab issuerId={mcpServer.userSessionIssuerId} />
+              <ClientsAndSessionsTab
+                issuerId={mcpServer.userSessionIssuerId}
+                originatingMcpServerId={mcpServer.id}
+              />
             </RequireScope>
           )
         );

--- a/client/dashboard/src/pages/org/UserSessions.tsx
+++ b/client/dashboard/src/pages/org/UserSessions.tsx
@@ -253,6 +253,7 @@ function UserSessionsInner(): JSX.Element {
         grouping={grouping}
         canRevoke={canRevoke}
         onRevoked={() => void refetch()}
+        killswitchContext={{ capabilityKey: "mcp_tool_calls" }}
         project={
           selectedProjectId
             ? { slug: projectSlug, id: selectedProjectId }
@@ -266,7 +267,7 @@ function UserSessionsInner(): JSX.Element {
     <ResourceListPage
       scope="org:read"
       title="MCP Sessions"
-      description="Every connection Gram brokers: what an agent connects through, the MCP server it reaches, and the upstream provider Gram holds credentials for on that person's behalf. Revoke a connection to immediately cut off access."
+      description="Every connection Gram brokers. Revoking ends current sessions immediately, but clients can authenticate and reconnect. A killswitch is a separate action that blocks matching MCP tool calls without ending sessions; revocation never creates or lifts one."
     >
       <div className="space-y-8">
         {/* `Page.Section` stacks two `mb-6`s under the description, which reads

--- a/client/dashboard/src/pages/team/Team.test.ts
+++ b/client/dashboard/src/pages/team/Team.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getMemberKillswitchMenuModel } from "./team-member-killswitch-menu";
+
+describe("Team member Killswitch menu model", () => {
+  it("uses the exact member ID for both view and create URLs", () => {
+    expect(
+      getMemberKillswitchMenuModel("/example/killswitch", "member-42"),
+    ).toEqual({
+      viewHref: "/example/killswitch?user=member-42",
+      newHref: "/example/killswitch?create=1&createUser=member-42",
+    });
+  });
+});

--- a/client/dashboard/src/pages/team/Team.tsx
+++ b/client/dashboard/src/pages/team/Team.tsx
@@ -74,6 +74,12 @@ import { cn } from "@/lib/utils";
 import { getIdentityTint, useIsDarkTheme } from "@/components/gradient-colors";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import { ChangeRoleDialog } from "@/pages/access/ChangeRoleDialog";
+import { KillswitchUserBadgeLink } from "@/components/killswitch/KillswitchUserBadgeLink";
+import {
+  killswitchStatusHref,
+  useKillswitchUserBadges,
+} from "@/components/killswitch/KillswitchUserStatus";
+import { getMemberKillswitchMenuModel } from "./team-member-killswitch-menu";
 
 /**
  * Everything from TeamInner's scope that the member actions menu needs,
@@ -85,6 +91,8 @@ type MemberMenuDeps = {
   adminCount: number;
   adminRoleId: string | undefined;
   challengesHref: string;
+  killswitchHref: string;
+  canUseKillswitch: boolean;
   navigate: ReturnType<typeof useNavigate>;
   roleIdsByUserId: Map<string, string[]>;
   scimManaged: boolean;
@@ -97,10 +105,13 @@ type MemberMenuModel = {
   accessMember: AccessMember | undefined;
   canRemove: boolean;
   openChallenges: () => void;
+  openKillswitch: () => void;
   openManageRoles: () => void;
+  openViewKillswitches: () => void;
   openRemove: () => void;
   scimManaged: boolean;
   showChallenges: boolean;
+  showKillswitch: boolean;
   showManageRoles: boolean;
 };
 
@@ -114,6 +125,10 @@ function getMemberMenuModel(
   deps: MemberMenuDeps,
 ): MemberMenuModel {
   const memberRoleIds = deps.roleIdsByUserId.get(member.userId) ?? [];
+  const killswitchMenu = getMemberKillswitchMenuModel(
+    deps.killswitchHref,
+    member.userId,
+  );
   const isLastAdmin =
     deps.adminRoleId != null &&
     memberRoleIds.includes(deps.adminRoleId) &&
@@ -143,6 +158,12 @@ function getMemberMenuModel(
         );
       }, 0);
     },
+    openKillswitch: () => {
+      void deps.navigate(killswitchMenu.newHref);
+    },
+    openViewKillswitches: () => {
+      void deps.navigate(killswitchMenu.viewHref);
+    },
     openManageRoles: () => {
       if (!accessMember) return;
       void setTimeout(() => deps.setChangingMember(accessMember), 0);
@@ -152,6 +173,7 @@ function getMemberMenuModel(
     },
     scimManaged: deps.scimManaged,
     showChallenges: true,
+    showKillswitch: deps.canUseKillswitch,
     showManageRoles: true,
   };
 }
@@ -173,6 +195,14 @@ function MemberRowContextMenu({
   const model = getMemberMenuModel(member, deps);
   const identityHref = useIdentityHrefBuilder();
   const profileHref = identityHref({ userId: member.userId });
+  const hasManageRoles =
+    model.showManageRoles && (model.scimManaged || model.accessMember != null);
+  const hasItemsAbove =
+    hasManageRoles || model.showChallenges || model.showKillswitch;
+
+  if (!profileHref && !hasItemsAbove && !model.canRemove) {
+    return <>{children}</>;
+  }
 
   return (
     <ContextMenu>
@@ -199,6 +229,16 @@ function MemberRowContextMenu({
           <ContextMenuItem onSelect={model.openChallenges}>
             View challenges
           </ContextMenuItem>
+        )}
+        {model.showKillswitch && (
+          <>
+            <ContextMenuItem onSelect={model.openViewKillswitches}>
+              View killswitches
+            </ContextMenuItem>
+            <ContextMenuItem onSelect={model.openKillswitch}>
+              New killswitch…
+            </ContextMenuItem>
+          </>
         )}
         {model.canRemove && (
           <>
@@ -280,6 +320,9 @@ function TeamInner() {
   const visibleMembers = members.slice(
     safePage * MEMBERS_PAGE_SIZE,
     (safePage + 1) * MEMBERS_PAGE_SIZE,
+  );
+  const killswitchBadges = useKillswitchUserBadges(
+    visibleMembers.map((member) => member.userId),
   );
   const invites = invitesData?.invitations ?? [];
   const roles = rolesData?.roles ?? [];
@@ -503,6 +546,8 @@ function TeamInner() {
     adminCount,
     adminRoleId,
     challengesHref: orgRoutes.access.challenges.href(),
+    killswitchHref: orgRoutes.killswitch.href(),
+    canUseKillswitch: killswitchBadges.canAccess,
     navigate,
     roleIdsByUserId,
     scimManaged: Boolean(organization.scimEnabled),
@@ -538,15 +583,27 @@ function TeamInner() {
             </div>
           )}
           <Stack direction="vertical" gap={0}>
-            {/* The row click opens the same page, but a handler is not a
-                link: no cmd+click, no middle-click, no copy-link, and nothing
-                a screen reader announces as navigation. Keyed on userId, the
-                same field the row click uses. */}
-            <Text variant="body" className="font-medium">
-              <IdentityLink identifier={{ userId: member.userId }}>
-                {member.name}
-              </IdentityLink>
-            </Text>
+            <div className="flex flex-wrap items-center gap-2">
+              {/* The row click opens the same page, but a handler is not a
+                  link: no cmd+click, no middle-click, no copy-link, and nothing
+                  a screen reader announces as navigation. Keyed on userId, the
+                  same field the row click uses. */}
+              <Text variant="body" className="font-medium">
+                <IdentityLink identifier={{ userId: member.userId }}>
+                  {member.name}
+                </IdentityLink>
+              </Text>
+              <KillswitchUserBadgeLink
+                badge={killswitchBadges.badges.get(member.userId)}
+                unavailable={killswitchBadges.unavailableUserIds.has(
+                  member.userId,
+                )}
+                href={killswitchStatusHref(
+                  orgRoutes.killswitch.href(),
+                  member.userId,
+                )}
+              />
+            </div>
             <Text variant="body" className="text-muted-foreground text-sm">
               {member.email}
             </Text>
@@ -631,6 +688,7 @@ function TeamInner() {
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
+                aria-label={`Actions for ${member.name}`}
                 className={cn(
                   "text-muted-foreground hover:bg-accent hover:text-foreground flex h-8 w-8 cursor-pointer items-center justify-center transition-colors",
                 )}
@@ -668,6 +726,16 @@ function TeamInner() {
                 <DropdownMenuItem onSelect={model.openChallenges}>
                   View challenges
                 </DropdownMenuItem>
+              )}
+              {model.showKillswitch && (
+                <>
+                  <DropdownMenuItem onSelect={model.openViewKillswitches}>
+                    View killswitches
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={model.openKillswitch}>
+                    New killswitch…
+                  </DropdownMenuItem>
+                </>
               )}
               {model.canRemove && (
                 <>
@@ -890,6 +958,7 @@ function TeamInner() {
 
   return (
     <>
+      {killswitchBadges.loader}
       <ResourceListPage
         title="Team Members"
         description={`Manage who has access to ${organization.name}`}

--- a/client/dashboard/src/pages/team/team-member-killswitch-menu.ts
+++ b/client/dashboard/src/pages/team/team-member-killswitch-menu.ts
@@ -1,0 +1,14 @@
+import {
+  killswitchCreateHref,
+  killswitchStatusHref,
+} from "@/components/killswitch/KillswitchUserStatus";
+
+export function getMemberKillswitchMenuModel(
+  killswitchHref: string,
+  memberId: string,
+): { viewHref: string; newHref: string } {
+  return {
+    viewHref: killswitchStatusHref(killswitchHref, memberId),
+    newHref: killswitchCreateHref(killswitchHref, { userId: memberId }),
+  };
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -1257,6 +1257,7 @@ const ORG_ROUTE_STRUCTURE = {
     title: "Killswitch",
     url: "killswitch",
     icon: "shield-off",
+    stage: "beta",
     component: KillswitchesRoot,
     indexComponent: Killswitches,
     subPages: {

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -351,6 +351,14 @@ func PlantMCPServerDependents(ctx context.Context, db *pgxpool.Pool, orgID, proj
 				$2::uuid, registration.id, clock_timestamp() + interval '1 day'
 			FROM registration
 			RETURNING id
+		), milestone AS (
+			INSERT INTO platform_mcp_onboarding_milestones (
+				organization_id, milestone, project_id, mcp_key, attempt_id
+			)
+			SELECT $1, 'registration_succeeded', $2::uuid,
+				'reseed-safety:reseed-safety-server', registration.id
+			FROM registration
+			RETURNING id
 		), distribution AS (
 			INSERT INTO platform_mcp_distributions (
 				organization_id, project_id, registration_id, default_plugin_id, plugin_id,
@@ -381,7 +389,7 @@ func PlantMCPServerDependents(ctx context.Context, db *pgxpool.Pool, orgID, proj
 			distribution.version, workflow.id, 'reseed_safety_tool', 'productivity',
 			clock_timestamp()
 		FROM distribution CROSS JOIN workflow CROSS JOIN receipt CROSS JOIN feedback
-			CROSS JOIN assistant_attachment`, orgID, projectID)
+			CROSS JOIN assistant_attachment CROSS JOIN milestone`, orgID, projectID)
 	if err != nil {
 		return fmt.Errorf("plant MCP server dependents: %w", err)
 	}
@@ -389,6 +397,23 @@ func PlantMCPServerDependents(ctx context.Context, db *pgxpool.Pool, orgID, proj
 		return fmt.Errorf("plant MCP server dependents: expected 1 complete dependent set, got %d", tag.RowsAffected())
 	}
 	return nil
+}
+
+// CountReseedSafetyProjectMilestones returns the number of project-scoped
+// onboarding milestones planted by PlantMCPServerDependents.
+func CountReseedSafetyProjectMilestones(ctx context.Context, db *pgxpool.Pool, orgID, projectID string) (int, error) {
+	var count int
+	err := db.QueryRow(ctx, `
+		SELECT count(*)
+		FROM platform_mcp_onboarding_milestones
+		WHERE organization_id = $1
+		  AND project_id = $2::uuid
+		  AND milestone = 'registration_succeeded'
+		  AND mcp_key = 'reseed-safety:reseed-safety-server'`, orgID, projectID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count reseed safety project milestones: %w", err)
+	}
+	return count, nil
 }
 
 // CreateProjectWithoutMCPServer adds a project used to prove the dependent

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -283,11 +283,54 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 		return fmt.Errorf("tamper postgres api key: %w", err)
 	}
 
+	if err := PlantMCPServerDependents(ctx, db, orgID, projectID); err != nil {
+		return fmt.Errorf("tamper postgres MCP server dependents: %w", err)
+	}
+
 	err = ch.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO telemetry_logs
 		SELECT * FROM telemetry_logs WHERE gram_project_id = toUUID('%s') LIMIT 1`, projectID))
 	if err != nil {
 		return fmt.Errorf("tamper clickhouse telemetry row: %w", err)
+	}
+	return nil
+}
+
+// PlantMCPServerDependents adds the realistic tenant-owned rows that block a
+// hard MCP server delete unless reseed cleanup removes them in FK order.
+func PlantMCPServerDependents(ctx context.Context, db *pgxpool.Pool, orgID, projectID string) error {
+	tag, err := db.Exec(ctx, `
+		WITH target_server AS MATERIALIZED (
+			SELECT id FROM mcp_servers WHERE project_id = $2::uuid ORDER BY id LIMIT 1
+		), new_assistant AS (
+			INSERT INTO assistants (project_id, organization_id, name, model, instructions)
+			VALUES ($2::uuid, $1, 'Reseed safety assistant', 'openai/gpt-4o-mini', 'Test reseed cleanup.')
+			RETURNING id
+		), assistant_attachment AS (
+			INSERT INTO assistant_mcp_servers (assistant_id, mcp_server_id, project_id)
+			SELECT new_assistant.id, target_server.id, $2::uuid
+			FROM new_assistant CROSS JOIN target_server
+		), new_plugin AS (
+			INSERT INTO plugins (organization_id, project_id, name, slug)
+			VALUES ($1, $2::uuid, 'Reseed safety plugin', 'reseed-safety-plugin')
+			RETURNING id
+		), plugin_attachment AS (
+			INSERT INTO plugin_servers (plugin_id, mcp_server_id, display_name)
+			SELECT new_plugin.id, target_server.id, 'Reseed safety server'
+			FROM new_plugin CROSS JOIN target_server
+		)
+		INSERT INTO platform_mcp_catalog_registrations (
+			organization_id, project_id, source_kind, catalog_provider,
+			catalog_reference, status, mcp_server_id, acting_surface
+		)
+		SELECT $1, $2::uuid, 'catalog', 'reseed-safety',
+			'reseed-safety-server', 'ready', target_server.id, 'dashboard'
+		FROM target_server`, orgID, projectID)
+	if err != nil {
+		return fmt.Errorf("plant MCP server dependents: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("plant MCP server dependents: expected 1 catalog registration, got %d", tag.RowsAffected())
 	}
 	return nil
 }

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -296,41 +296,114 @@ func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID
 	return nil
 }
 
-// PlantMCPServerDependents adds the realistic tenant-owned rows that block a
-// hard MCP server delete unless reseed cleanup removes them in FK order.
+// PlantMCPServerDependents adds realistic tenant-owned rows across the full
+// catalog-registration FK closure. Every insert is gated on target_server so a
+// project without an MCP server cannot retain unattached fixture parents.
 func PlantMCPServerDependents(ctx context.Context, db *pgxpool.Pool, orgID, projectID string) error {
 	tag, err := db.Exec(ctx, `
 		WITH target_server AS MATERIALIZED (
 			SELECT id FROM mcp_servers WHERE project_id = $2::uuid ORDER BY id LIMIT 1
 		), new_assistant AS (
 			INSERT INTO assistants (project_id, organization_id, name, model, instructions)
-			VALUES ($2::uuid, $1, 'Reseed safety assistant', 'openai/gpt-4o-mini', 'Test reseed cleanup.')
+			SELECT $2::uuid, $1, 'Reseed safety assistant', 'openai/gpt-4o-mini', 'Test reseed cleanup.'
+			FROM target_server
 			RETURNING id
 		), assistant_attachment AS (
 			INSERT INTO assistant_mcp_servers (assistant_id, mcp_server_id, project_id)
 			SELECT new_assistant.id, target_server.id, $2::uuid
 			FROM new_assistant CROSS JOIN target_server
+			RETURNING id
 		), new_plugin AS (
 			INSERT INTO plugins (organization_id, project_id, name, slug)
-			VALUES ($1, $2::uuid, 'Reseed safety plugin', 'reseed-safety-plugin')
+			SELECT $1, $2::uuid, 'Reseed safety plugin', 'reseed-safety-plugin'
+			FROM target_server
 			RETURNING id
 		), plugin_attachment AS (
 			INSERT INTO plugin_servers (plugin_id, mcp_server_id, display_name)
 			SELECT new_plugin.id, target_server.id, 'Reseed safety server'
 			FROM new_plugin CROSS JOIN target_server
+			RETURNING id
+		), registration AS (
+			INSERT INTO platform_mcp_catalog_registrations (
+				organization_id, project_id, source_kind, catalog_provider,
+				catalog_reference, status, mcp_server_id, acting_surface
+			)
+			SELECT $1, $2::uuid, 'catalog', 'reseed-safety',
+				'reseed-safety-server', 'ready', target_server.id, 'dashboard'
+			FROM target_server
+			RETURNING id
+		), receipt AS (
+			INSERT INTO platform_mcp_operation_receipts (
+				organization_id, project_id, registration_id, user_id, acting_surface,
+				operation, idempotency_key, input_hash, status, expires_at
+			)
+			SELECT $1, $2::uuid, registration.id, 'user_reseed_safety', 'dashboard',
+				'install', 'reseed-safety-install', 'reseed-safety-input', 'completed',
+				clock_timestamp() + interval '1 day'
+			FROM registration
+			RETURNING id
+		), workflow AS (
+			INSERT INTO platform_mcp_onboarding_workflows (
+				organization_id, initiating_subject_urn, source_surface, client_family,
+				selected_project_id, selected_registration_id, expires_at
+			)
+			SELECT $1, 'user:user_reseed_safety', 'dashboard', 'claude',
+				$2::uuid, registration.id, clock_timestamp() + interval '1 day'
+			FROM registration
+			RETURNING id
+		), distribution AS (
+			INSERT INTO platform_mcp_distributions (
+				organization_id, project_id, registration_id, default_plugin_id, plugin_id,
+				plugin_server_id, state, version, attachment_was_created, publication_state,
+				user_id, acting_surface
+			)
+			SELECT $1, $2::uuid, registration.id, new_plugin.id, new_plugin.id,
+				plugin_attachment.id, 'installed', 1, true, 'published',
+				'user_reseed_safety', 'dashboard'
+			FROM registration CROSS JOIN new_plugin CROSS JOIN plugin_attachment
+			RETURNING id, registration_id, version
+		), feedback AS (
+			INSERT INTO platform_mcp_feedback (
+				organization_id, subject_urn, project_id, workflow_id, category,
+				idempotency_key, input_hash, rating, success, expires_at
+			)
+			SELECT $1, 'user:user_reseed_safety', $2::uuid, workflow.id, 'onboarding',
+				'reseed-safety-feedback', 'reseed-safety-feedback-input', 5, true,
+				clock_timestamp() + interval '1 day'
+			FROM workflow
+			RETURNING id
 		)
-		INSERT INTO platform_mcp_catalog_registrations (
-			organization_id, project_id, source_kind, catalog_provider,
-			catalog_reference, status, mcp_server_id, acting_surface
+		INSERT INTO platform_mcp_selected_use_evidence (
+			organization_id, project_id, registration_id, distribution_id,
+			distribution_version, workflow_id, tool_name, tool_category, succeeded_at
 		)
-		SELECT $1, $2::uuid, 'catalog', 'reseed-safety',
-			'reseed-safety-server', 'ready', target_server.id, 'dashboard'
-		FROM target_server`, orgID, projectID)
+		SELECT $1, $2::uuid, distribution.registration_id, distribution.id,
+			distribution.version, workflow.id, 'reseed_safety_tool', 'productivity',
+			clock_timestamp()
+		FROM distribution CROSS JOIN workflow CROSS JOIN receipt CROSS JOIN feedback
+			CROSS JOIN assistant_attachment`, orgID, projectID)
 	if err != nil {
 		return fmt.Errorf("plant MCP server dependents: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("plant MCP server dependents: expected 1 catalog registration, got %d", tag.RowsAffected())
+		return fmt.Errorf("plant MCP server dependents: expected 1 complete dependent set, got %d", tag.RowsAffected())
+	}
+	return nil
+}
+
+// CreateProjectWithoutMCPServer adds a project used to prove the dependent
+// fixture is a no-op when its required target server is absent.
+func CreateProjectWithoutMCPServer(ctx context.Context, db *pgxpool.Pool, orgID, projectID string) error {
+	tag, err := db.Exec(ctx, `
+		INSERT INTO projects (id, organization_id, name, slug)
+		VALUES ($2::uuid, $1, 'Reseed safety no-server project', 'reseed-safety-no-server')`,
+		orgID, projectID,
+	)
+	if err != nil {
+		return fmt.Errorf("create project without MCP server: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("create project without MCP server: expected 1 project, got %d", tag.RowsAffected())
 	}
 	return nil
 }

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -382,6 +382,8 @@ BEGIN
       AND (project_id = proj_a OR workflow_id IN
         (SELECT id FROM platform_mcp_onboarding_workflows
          WHERE organization_id = demo_org AND selected_project_id = proj_a));
+  DELETE FROM platform_mcp_onboarding_milestones
+    WHERE organization_id = demo_org AND project_id = proj_a;
   DELETE FROM platform_mcp_onboarding_workflows
     WHERE organization_id = demo_org AND selected_project_id = proj_a;
   DELETE FROM platform_mcp_operation_receipts

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -366,15 +366,39 @@ BEGIN
   DELETE FROM killswitch_operations WHERE organization_id = demo_org;
   DELETE FROM killswitch_prescriptions WHERE organization_id = demo_org;
 
-  -- Platform catalog registrations use NO ACTION for their component FKs,
-  -- while assistant_mcp_servers and plugin_servers RESTRICT hard server
-  -- deletion. Local users can create all three kinds of attachment, so detach
-  -- this tenant's rows before replacing its canonical servers. Other direct
-  -- mcp_servers dependents (meta members, collection attachments, metadata,
-  -- endpoints, and tool metadata) cascade. mcp_servers in turn pins its
-  -- toolset with RESTRICT, so it must still go before the toolsets delete.
+  -- Catalog registrations have both direct and transitive NO ACTION children.
+  -- Evidence pins its distribution and selected workflow; feedback also pins
+  -- selected workflows. Remove those rows first, then every project-scoped
+  -- registration child, before replacing the canonical registrations. Keep the
+  -- workflow subqueries organization-scoped so another tenant's rows cannot be
+  -- reached even if identifiers are malformed.
+  DELETE FROM platform_mcp_selected_use_evidence
+    WHERE organization_id = demo_org
+      AND (project_id = proj_a OR workflow_id IN
+        (SELECT id FROM platform_mcp_onboarding_workflows
+         WHERE organization_id = demo_org AND selected_project_id = proj_a));
+  DELETE FROM platform_mcp_feedback
+    WHERE organization_id = demo_org
+      AND (project_id = proj_a OR workflow_id IN
+        (SELECT id FROM platform_mcp_onboarding_workflows
+         WHERE organization_id = demo_org AND selected_project_id = proj_a));
+  DELETE FROM platform_mcp_onboarding_workflows
+    WHERE organization_id = demo_org AND selected_project_id = proj_a;
+  DELETE FROM platform_mcp_operation_receipts
+    WHERE organization_id = demo_org AND project_id = proj_a;
+  DELETE FROM platform_mcp_setup_handoffs
+    WHERE organization_id = demo_org AND project_id = proj_a;
+  DELETE FROM platform_mcp_readiness
+    WHERE organization_id = demo_org AND project_id = proj_a;
+  DELETE FROM platform_mcp_distributions
+    WHERE organization_id = demo_org AND project_id = proj_a;
   DELETE FROM platform_mcp_catalog_registrations
     WHERE organization_id = demo_org AND project_id = proj_a;
+
+  -- assistant_mcp_servers and plugin_servers RESTRICT hard server deletion.
+  -- Other direct mcp_servers dependents (meta members, collection attachments,
+  -- metadata, endpoints, and tool metadata) cascade. mcp_servers in turn pins
+  -- its toolset with RESTRICT, so it must still go before the toolsets delete.
   DELETE FROM assistant_mcp_servers WHERE project_id = proj_a;
   DELETE FROM plugin_servers WHERE plugin_id IN
     (SELECT id FROM plugins

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -366,14 +366,19 @@ BEGIN
   DELETE FROM killswitch_operations WHERE organization_id = demo_org;
   DELETE FROM killswitch_prescriptions WHERE organization_id = demo_org;
 
-  -- plugin_servers RESTRICTs the mcp_server it attaches, and adding a server
-  -- auto-attaches it to the Default plugin — so in the writable local tenant
-  -- a developer's own servers block the delete below. mcp_servers in turn
-  -- pins its toolset with RESTRICT, so it must go before the toolsets delete.
-  -- Members and both backends' endpoints cascade from mcp_servers and
-  -- meta_mcp_servers.
+  -- Platform catalog registrations use NO ACTION for their component FKs,
+  -- while assistant_mcp_servers and plugin_servers RESTRICT hard server
+  -- deletion. Local users can create all three kinds of attachment, so detach
+  -- this tenant's rows before replacing its canonical servers. Other direct
+  -- mcp_servers dependents (meta members, collection attachments, metadata,
+  -- endpoints, and tool metadata) cascade. mcp_servers in turn pins its
+  -- toolset with RESTRICT, so it must still go before the toolsets delete.
+  DELETE FROM platform_mcp_catalog_registrations
+    WHERE organization_id = demo_org AND project_id = proj_a;
+  DELETE FROM assistant_mcp_servers WHERE project_id = proj_a;
   DELETE FROM plugin_servers WHERE plugin_id IN
-    (SELECT id FROM plugins WHERE organization_id = demo_org);
+    (SELECT id FROM plugins
+     WHERE organization_id = demo_org AND project_id = proj_a);
   DELETE FROM mcp_servers WHERE project_id = proj_a;
   DELETE FROM meta_mcp_servers WHERE organization_id = demo_org;
   -- meta_mcp_servers RESTRICTs its issuer, so issuers clear after it.

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -85,8 +85,12 @@ func TestDemoSeedSafety(t *testing.T) {
 	pgBaseline, err := demoseedtest.SnapshotPostgres(ctx, db)
 	require.NoError(t, err)
 
-	// Provision the other tenant from the transformed seed scripts.
+	// Provision the other tenant from the transformed seed scripts, including
+	// realistic MCP server dependents that the demo cleanup must not touch.
 	require.NoError(t, demoseedtest.ExecPostgresScript(ctx, db, asOtherTenant(t, postgresSQL)))
+	require.NoError(t, demoseedtest.PlantMCPServerDependents(
+		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
+	))
 	require.NoError(t, demoseedtest.ExecClickHouseStatements(ctx, ch, splitStatements(asOtherTenant(t, clickhouseSQL))))
 
 	demoProjects := []string{DefaultSpec().ProjectID()}

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -91,6 +91,12 @@ func TestDemoSeedSafety(t *testing.T) {
 	require.NoError(t, demoseedtest.PlantMCPServerDependents(
 		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
 	))
+	milestoneCount, err := demoseedtest.CountReseedSafetyProjectMilestones(
+		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, milestoneCount,
+		"MCP dependent fixture must plant one project-scoped onboarding milestone")
 
 	// A missing target server must not leave the fixture's assistant or plugin
 	// parents behind. Snapshot every table so the regression covers all orphans,
@@ -136,12 +142,24 @@ func TestDemoSeedSafety(t *testing.T) {
 	require.NoError(t, err)
 
 	requirePostgresRowsPreserved(t, pgBefore, pgAfter1)
+	milestoneCount, err = demoseedtest.CountReseedSafetyProjectMilestones(
+		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, milestoneCount,
+		"demo seed modified or deleted another tenant's onboarding milestone")
 	requireNoLeakIntoOtherTenants(t, addedRows(pgBefore, pgAfter1), fixtureUUIDs)
 	requireClickHouseOutsideUnchanged(t, chBefore, chAfter1)
 
 	// Plant stray demo-scope rows: the next run must clean them up, restoring
 	// the exact per-table counts of the first run.
 	require.NoError(t, demoseedtest.TamperDemoRows(ctx, db, ch, constants.DemoOrganizationID, DefaultSpec().ProjectID()))
+	milestoneCount, err = demoseedtest.CountReseedSafetyProjectMilestones(
+		ctx, db, constants.DemoOrganizationID, DefaultSpec().ProjectID(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, milestoneCount,
+		"demo tamper fixture must plant one project-scoped onboarding milestone")
 
 	// Second real seed run.
 	require.NoError(t, Run(ctx, logger, db, ch, blob, DefaultSpec()))
@@ -152,6 +170,18 @@ func TestDemoSeedSafety(t *testing.T) {
 	require.NoError(t, err)
 
 	requirePostgresRowsPreserved(t, pgBefore, pgAfter2)
+	milestoneCount, err = demoseedtest.CountReseedSafetyProjectMilestones(
+		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, milestoneCount,
+		"demo reseed modified or deleted another tenant's onboarding milestone")
+	milestoneCount, err = demoseedtest.CountReseedSafetyProjectMilestones(
+		ctx, db, constants.DemoOrganizationID, DefaultSpec().ProjectID(),
+	)
+	require.NoError(t, err)
+	require.Zero(t, milestoneCount,
+		"demo reseed did not clean up the project-scoped onboarding milestone")
 	requireNoLeakIntoOtherTenants(t, addedRows(pgBefore, pgAfter2), fixtureUUIDs)
 	requireClickHouseOutsideUnchanged(t, chBefore, chAfter2)
 

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -91,6 +91,23 @@ func TestDemoSeedSafety(t *testing.T) {
 	require.NoError(t, demoseedtest.PlantMCPServerDependents(
 		ctx, db, otherTenantSpec.OrgID, otherTenantSpec.ProjectID(),
 	))
+
+	// A missing target server must not leave the fixture's assistant or plugin
+	// parents behind. Snapshot every table so the regression covers all orphans,
+	// not only the two parent classes that exposed the bug.
+	const noServerProjectID = "0ddba110-0000-4000-8000-0000000000ff"
+	require.NoError(t, demoseedtest.CreateProjectWithoutMCPServer(
+		ctx, db, otherTenantSpec.OrgID, noServerProjectID,
+	))
+	pgBeforeNoServer, err := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, err)
+	err = demoseedtest.PlantMCPServerDependents(ctx, db, otherTenantSpec.OrgID, noServerProjectID)
+	require.ErrorContains(t, err, "expected 1 complete dependent set, got 0")
+	pgAfterNoServer, snapshotErr := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, snapshotErr)
+	require.Equal(t, pgBeforeNoServer, pgAfterNoServer,
+		"MCP dependent fixture created orphan rows without a target server")
+
 	require.NoError(t, demoseedtest.ExecClickHouseStatements(ctx, ch, splitStatements(asOtherTenant(t, clickhouseSQL))))
 
 	demoProjects := []string{DefaultSpec().ProjectID()}


### PR DESCRIPTION
## Summary

- add overlap-aware Killswitch status and exact-member actions to Team, MCP Sessions, and server Clients and Sessions
- preserve reload-safe member and capability context while keeping a canonical origin server pending until Selected servers is explicitly chosen
- keep connection revocation independent and cross-linked, and link Killswitch audit subjects to retained detail

## Review guide

- start with `KillswitchUserStatus.ts` and `killswitch-routing.ts` for access-gated, deduplicated badge batching and contextual URL safety
- review `ConnectionsList.tsx` and `Team.tsx` for responsive member badges and keyboard-accessible menus
- review `Killswitches.tsx`, `KillswitchEditorSheet.tsx`, and `RevokeSessionsDialog.tsx` for safe prefill and revocation guidance

Closes [DNO-985](https://linear.app/speakeasy/issue/DNO-985/feat-add-contextual-killswitch-entry-points-and-status)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements [DNO-985](https://linear.app/speakeasy/issue/DNO-985) by adding contextual Killswitch status and actions to Team, MCP Sessions, and MCP server Clients and Sessions, and by moving the Killswitches page to a table and filters. Users with Killswitch access can inspect or create an exact-member killswitch; connection revocation stays separate and clients can reconnect.

- The Killswitches page now renders as a filterable table, and its route is marked beta.
- Badges show active, scheduled, or unavailable status from deduplicated, batched reads for visible users with bounded concurrency and 60-second refreshes. Icon-only action menus gain accessible names and restore trigger focus after closing.
- Contextual URLs preserve member and capability context, apply the originating server only after "Selected servers" is chosen, and discard stale hints while keeping create state reload-safe.
- Revoke dialogs link to killswitch creation without creating or lifting one, and audit events link directly to prescription details.
- Demo seed cleanup removes project-scoped MCP registration dependents, including onboarding milestones, without affecting other tenants or leaving orphan rows.

<sup>Written for commit b686ec97493b2eec6ec44f08656733bbed545677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

