### PR TITLE
feat: show OpenRouter disable causes to admins

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -62304,6 +62304,14 @@ components:
           type: number
           description: Credits spent this month in USD.
           format: double
+        disable_causes:
+          type: array
+          items:
+            type: string
+          description: Active internal disable causes. Omitted for legacy unclassified rows.
+        disable_causes_classified:
+          type: boolean
+          description: Whether disable_causes is classified, including an explicitly empty cause set.
         disabled:
           type: boolean
         key_type:
@@ -62317,6 +62325,7 @@ components:
         - credits_used
         - monthly_credits
         - disabled
+        - disable_causes_classified
     AdminInferenceKeyLimit:
       type: object
       properties:

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -215,7 +215,7 @@ describe("organization billing endpoints", () => {
   function stubFetch(): ReturnType<typeof vi.fn> {
     const fetch = vi.fn().mockImplementation(() =>
       Promise.resolve(
-        new Response(JSON.stringify({}), {
+        new Response(JSON.stringify([]), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -224,6 +224,38 @@ describe("organization billing endpoints", () => {
     vi.stubGlobal("fetch", fetch);
     return fetch;
   }
+
+  it("preserves classified empty and legacy unclassified cause semantics", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              key_type: "chat",
+              credits_used: 0,
+              monthly_credits: 100,
+              disabled: false,
+              disable_causes_classified: true,
+            },
+            {
+              key_type: "internal",
+              credits_used: 0,
+              monthly_credits: 50,
+              disabled: true,
+              disable_causes_classified: false,
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(getInferenceKeys("org one")).resolves.toMatchObject([
+      { disable_causes: [], disable_causes_classified: true },
+      { disable_causes: null, disable_causes_classified: false },
+    ]);
+  });
 
   it("reads billing state from explicit admin organization endpoints", async () => {
     const fetch = stubFetch();

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -527,11 +527,20 @@ export function listOrganizationMembers(
   );
 }
 
-export type AdminInferenceKey = {
+type AdminInferenceKeyResponse = {
   key_type: string;
   credits_used: number;
   monthly_credits: number;
   disabled: boolean;
+  disable_causes?: string[];
+  disable_causes_classified: boolean;
+};
+
+export type AdminInferenceKey = Omit<
+  AdminInferenceKeyResponse,
+  "disable_causes"
+> & {
+  disable_causes: string[] | null;
 };
 
 export type AdminOrganizationFeatures = {
@@ -641,13 +650,19 @@ export function setOrganizationChatAnalysisSetting(input: {
   );
 }
 
-export function getInferenceKeys(
+export async function getInferenceKeys(
   organizationID: string,
 ): Promise<AdminInferenceKey[]> {
   const qs = toSearchParams({ organization_id: organizationID });
-  return gramAdminFetch<AdminInferenceKey[]>(
+  const keys = await gramAdminFetch<AdminInferenceKeyResponse[]>(
     `/admin/organization.inferenceKeys?${qs}`,
   );
+  return keys.map((key) => ({
+    ...key,
+    disable_causes: key.disable_causes_classified
+      ? (key.disable_causes ?? [])
+      : null,
+  }));
 }
 
 export type AdminInferenceKeyType = "chat" | "internal";

--- a/client/admin/src/pages/organization/Billing.test.tsx
+++ b/client/admin/src/pages/organization/Billing.test.tsx
@@ -76,18 +76,29 @@ beforeEach(() => {
       credits_used: 42.75,
       monthly_credits: 100,
       disabled: false,
+      disable_causes: [],
+      disable_causes_classified: true,
     },
     {
       key_type: "internal",
       credits_used: 12.5,
       monthly_credits: 0,
       disabled: true,
+      disable_causes: [
+        "admin_lock",
+        "billing_inactive",
+        "future_policy",
+        "constructor",
+      ],
+      disable_causes_classified: true,
     },
     {
       key_type: "future-purpose",
       credits_used: 1.25,
       monthly_credits: 25,
       disabled: false,
+      disable_causes: null,
+      disable_causes_classified: false,
     },
   ]);
   mocks.getInferenceSpendHistory.mockImplementation((organizationID: string) =>
@@ -180,6 +191,13 @@ describe("Billing", () => {
     );
     expect(screen.getAllByText("Enabled")).toHaveLength(2);
     expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.getByText("No disable causes")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Admin lock, Billing inactive, future_policy, constructor",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Unclassified (legacy)")).toBeTruthy();
     expect(screen.getByText(/This is an estimate, not a bill/)).toBeTruthy();
     expect(screen.getByLabelText("Monthly inference spend graph")).toBeTruthy();
     expect(screen.getByText("$3.25")).toBeTruthy();

--- a/client/admin/src/pages/organization/Billing.tsx
+++ b/client/admin/src/pages/organization/Billing.tsx
@@ -88,6 +88,27 @@ function inferenceKeyPurpose(keyType: AdminInferenceKey["key_type"]): string {
   }
 }
 
+function inferenceKeyDisableCauseLabel(cause: string): string {
+  switch (cause) {
+    case "admin_lock":
+      return "Admin lock";
+    case "trial_demotion":
+      return "Trial demotion";
+    case "billing_inactive":
+      return "Billing inactive";
+    default:
+      return cause;
+  }
+}
+
+function inferenceKeyDisableCauses(key: AdminInferenceKey): string {
+  if (!key.disable_causes_classified) return "Unclassified (legacy)";
+  if (key.disable_causes === null || key.disable_causes.length === 0)
+    return "No disable causes";
+
+  return key.disable_causes.map(inferenceKeyDisableCauseLabel).join(", ");
+}
+
 function formatCredits(value: number): string {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -286,6 +307,7 @@ function InferenceKeys({
               : formatCredits(key.monthly_credits)}
           </Row>
           <Row label="State">{key.disabled ? "Disabled" : "Enabled"}</Row>
+          <Row label="Disable causes">{inferenceKeyDisableCauses(key)}</Row>
           {isWritableInferenceKey(key) && (
             <InferenceKeyLimitEditor
               organizationID={organizationID}

--- a/client/dashboard/src/components/ui/MoreActions/index.test.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MoreActions } from ".";
 
 describe("MoreActions", () => {
@@ -14,5 +14,40 @@ describe("MoreActions", () => {
     fireEvent.keyDown(item, { key: "Escape" });
 
     await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("waits to restore focus until loading and disabled are both false", () => {
+    const { rerender } = render(
+      <MoreActions
+        actions={[{ label: "Inspect", onClick: () => {} }]}
+        triggerLoading
+        triggerDisabled
+      />,
+    );
+    const trigger = screen.getByRole("button", {
+      name: "Action in progress",
+    });
+    const focus = vi.spyOn(trigger, "focus");
+
+    rerender(
+      <MoreActions
+        actions={[{ label: "Inspect", onClick: () => {} }]}
+        triggerLoading={false}
+        triggerDisabled
+      />,
+    );
+
+    expect(focus).not.toHaveBeenCalled();
+
+    rerender(
+      <MoreActions
+        actions={[{ label: "Inspect", onClick: () => {} }]}
+        triggerLoading={false}
+        triggerDisabled={false}
+      />,
+    );
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/client/dashboard/src/components/ui/MoreActions/index.test.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.test.tsx
@@ -1,0 +1,18 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MoreActions } from ".";
+
+describe("MoreActions", () => {
+  it("restores trigger focus when an ordinary menu close finishes", async () => {
+    render(<MoreActions actions={[{ label: "Inspect", onClick: () => {} }]} />);
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    trigger.focus();
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+
+    const item = screen.getByRole("menuitem", { name: "Inspect" });
+    item.focus();
+    fireEvent.keyDown(item, { key: "Escape" });
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -49,13 +49,25 @@ export function MoreActions({
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const wasTriggerLoading = useRef(false);
+  const pendingFocusRestore = useRef(false);
 
   useEffect(() => {
     if (wasTriggerLoading.current && !triggerLoading) {
-      triggerRef.current?.focus();
+      pendingFocusRestore.current = true;
     }
     wasTriggerLoading.current = triggerLoading === true;
-  }, [triggerLoading]);
+
+    const trigger = triggerRef.current;
+    if (
+      pendingFocusRestore.current &&
+      !triggerLoading &&
+      !triggerDisabled &&
+      trigger
+    ) {
+      trigger.focus();
+      pendingFocusRestore.current = false;
+    }
+  }, [triggerDisabled, triggerLoading]);
 
   const wrapOnClick =
     (onClick: () => void) => (e: React.MouseEvent<HTMLDivElement>) => {

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -106,7 +106,7 @@ export function MoreActions({
       <DropdownMenuContent
         align="end"
         onCloseAutoFocus={(e) => {
-          e.preventDefault();
+          if (triggerLoading) e.preventDefault();
         }}
       >
         {actions.map((action, index) => (

--- a/client/dashboard/src/components/ui/MoreActions/index.tsx
+++ b/client/dashboard/src/components/ui/MoreActions/index.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/Dropdown";
 import { Icon } from "@/components/ui/Icon";
 import { IconName } from "@/components/ui/Icon/names";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/Button";
 
 export type Action = {
@@ -26,14 +26,16 @@ export function MoreActions({
   actions,
   triggerLabel,
   triggerLoading,
+  triggerDisabled,
   triggerStyle,
 }: {
   actions: Action[];
   triggerLabel?: string;
-  /** Shows a spinner in place of the trigger's kebab icon and disables it —
-   * for an async action (e.g. an AI suggestion) already in flight from a
-   * previous click. Only meaningful alongside `triggerLabel`. */
+  /** Shows a spinner in place of the trigger icon, disables it, and restores
+   * trigger focus when the async action completes. */
   triggerLoading?: boolean;
+  /** Disables the trigger without presenting it as the active async action. */
+  triggerDisabled?: boolean;
   /** Inline style for the trigger button. Every `Button` carries a 200ms
    * `transition-all` (`button.tsx`'s `.trans`), which per the CSS
    * Transitions spec holds a `visible → hidden` element at `visible` for
@@ -45,6 +47,15 @@ export function MoreActions({
   triggerStyle?: React.CSSProperties;
 }): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const wasTriggerLoading = useRef(false);
+
+  useEffect(() => {
+    if (wasTriggerLoading.current && !triggerLoading) {
+      triggerRef.current?.focus();
+    }
+    wasTriggerLoading.current = triggerLoading === true;
+  }, [triggerLoading]);
 
   const wrapOnClick =
     (onClick: () => void) => (e: React.MouseEvent<HTMLDivElement>) => {
@@ -59,10 +70,11 @@ export function MoreActions({
       <DropdownMenuTrigger asChild>
         {triggerLabel ? (
           <Button
+            ref={triggerRef}
             variant="tertiary"
             size="sm"
-            disabled={triggerLoading}
-            aria-busy={triggerLoading}
+            disabled={triggerLoading || triggerDisabled}
+            aria-busy={triggerLoading === true}
             style={triggerStyle}
           >
             <Icon
@@ -73,13 +85,21 @@ export function MoreActions({
           </Button>
         ) : (
           <Button
+            ref={triggerRef}
             variant="tertiary"
             size="sm"
             className="mx-[-4px] h-8 w-8 p-0"
+            disabled={triggerLoading || triggerDisabled}
+            aria-busy={triggerLoading === true}
             style={triggerStyle}
           >
-            <Icon name="ellipsis-vertical" className="size-4" />
-            <span className="sr-only">Open menu</span>
+            <Icon
+              name={triggerLoading ? "loader-circle" : "ellipsis-vertical"}
+              className={cn("size-4", triggerLoading && "animate-spin")}
+            />
+            <span className="sr-only">
+              {triggerLoading ? "Action in progress" : "Open menu"}
+            </span>
           </Button>
         )}
       </DropdownMenuTrigger>

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
@@ -15,8 +15,9 @@ import type { AdminOpenRouterKey } from "@gram/client/models/components/adminope
 type MutationOptions = {
   onSuccess: (
     key: Pick<AdminOpenRouterKey, "keyType" | "organizationName">,
-  ) => void;
+  ) => void | Promise<void>;
   onError: (error: unknown) => void;
+  onSettled: () => void;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -179,14 +180,18 @@ describe("PlatformAdminOpenRouterKeys", () => {
     mocks.enablePending = false;
   });
 
-  function renderPage(): QueryClient {
+  function renderPage(): {
+    queryClient: QueryClient;
+    rerenderPage: () => void;
+  } {
     const queryClient = new QueryClient();
-    render(
+    const page = () => (
       <QueryClientProvider client={queryClient}>
         <PlatformAdminOpenRouterKeys />
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
-    return queryClient;
+    const { rerender } = render(page());
+    return { queryClient, rerenderPage: () => rerender(page()) };
   }
 
   function openRowActions(testId: string): void {
@@ -252,8 +257,8 @@ describe("PlatformAdminOpenRouterKeys", () => {
     expect(classifiedEmpty.queryByText("Unclassified legacy state")).toBeNull();
   });
 
-  it("locks row actions while a mutation is pending and restores trigger focus", () => {
-    renderPage();
+  it("keeps stale row actions closed and restores focus only after settlement is usable", async () => {
+    const { rerenderPage } = renderPage();
     const activeTrigger = within(
       screen.getByTestId("automatic-cause"),
     ).getByRole("button", { name: "Open menu" });
@@ -262,6 +267,7 @@ describe("PlatformAdminOpenRouterKeys", () => {
     ).getByRole("button", { name: "Open menu" });
 
     openRowActions("automatic-cause");
+    mocks.disablePending = true;
     fireEvent.click(screen.getByRole("menuitem", { name: "Disable key" }));
 
     expect(activeTrigger.getAttribute("aria-busy")).toBe("true");
@@ -270,15 +276,46 @@ describe("PlatformAdminOpenRouterKeys", () => {
     expect((oppositeTrigger as HTMLButtonElement).disabled).toBe(true);
     expect(mocks.enableMutate).not.toHaveBeenCalled();
 
-    act(() => mocks.disableOptions?.onError(new Error("disable failed")));
+    const focus = vi.spyOn(activeTrigger, "focus");
+    let finishInvalidation!: () => void;
+    mocks.invalidate.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishInvalidation = resolve;
+      }),
+    );
+    let success!: Promise<void>;
+    act(() => {
+      success = Promise.resolve(
+        mocks.disableOptions?.onSuccess({
+          keyType: "chat",
+          organizationName: "Automatic cause",
+        }),
+      );
+    });
+
+    expect(activeTrigger.getAttribute("aria-busy")).toBe("true");
+    fireEvent.click(oppositeTrigger);
+    expect(screen.queryByRole("menuitem")).toBeNull();
+
+    finishInvalidation();
+    await act(async () => success);
+    expect(activeTrigger.getAttribute("aria-busy")).toBe("true");
+
+    act(() => mocks.disableOptions?.onSettled());
     expect(activeTrigger.getAttribute("aria-busy")).toBe("false");
+    expect((activeTrigger as HTMLButtonElement).disabled).toBe(true);
+    expect(focus).not.toHaveBeenCalled();
+
+    mocks.disablePending = false;
+    rerenderPage();
     expect((activeTrigger as HTMLButtonElement).disabled).toBe(false);
     expect((oppositeTrigger as HTMLButtonElement).disabled).toBe(false);
+    expect(focus).toHaveBeenCalledTimes(1);
     expect(document.activeElement).toBe(activeTrigger);
   });
 
-  it("uses generated cause-specific mutations and preserves refetch and errors", () => {
-    const queryClient = renderPage();
+  it("uses generated cause-specific mutations and preserves refetch and errors", async () => {
+    const { queryClient } = renderPage();
     openRowActions("automatic-cause");
     fireEvent.click(screen.getByRole("menuitem", { name: "Disable key" }));
     expect(mocks.disableMutate).toHaveBeenCalledWith({
@@ -290,12 +327,13 @@ describe("PlatformAdminOpenRouterKeys", () => {
       },
     });
 
-    act(() =>
+    await act(async () =>
       mocks.disableOptions?.onSuccess({
         keyType: "chat",
         organizationName: "Automatic cause",
       }),
     );
+    act(() => mocks.disableOptions?.onSettled());
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Admin lock added to the chat key for Automatic cause.",
     );
@@ -314,12 +352,13 @@ describe("PlatformAdminOpenRouterKeys", () => {
       },
     });
 
-    act(() =>
+    await act(async () =>
       mocks.enableOptions?.onSuccess({
         keyType: "internal",
         organizationName: "Combined causes",
       }),
     );
+    act(() => mocks.enableOptions?.onSettled());
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Admin lock removed from the internal key for Combined causes.",
     );
@@ -329,14 +368,20 @@ describe("PlatformAdminOpenRouterKeys", () => {
     fireEvent.click(
       screen.getByRole("menuitem", { name: "Remove admin lock" }),
     );
-    act(() => mocks.enableOptions?.onError(new Error("remove failed")));
+    act(() => {
+      mocks.enableOptions?.onError(new Error("remove failed"));
+      mocks.enableOptions?.onSettled();
+    });
     expect(mocks.toastError).toHaveBeenCalledWith("remove failed");
 
     openRowActions("combined-causes");
     fireEvent.click(
       screen.getByRole("menuitem", { name: "Remove admin lock" }),
     );
-    act(() => mocks.enableOptions?.onError("non-error rejection"));
+    act(() => {
+      mocks.enableOptions?.onError("non-error rejection");
+      mocks.enableOptions?.onSettled();
+    });
     expect(mocks.toastError).toHaveBeenLastCalledWith(
       "Failed to remove admin lock",
     );

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -8,7 +9,6 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Action } from "@/components/ui/MoreActions";
 import type { Column } from "@/components/ui/Table";
 import type { AdminOpenRouterKey } from "@gram/client/models/components/adminopenrouterkey.js";
 
@@ -22,8 +22,10 @@ type MutationOptions = {
 const mocks = vi.hoisted(() => ({
   disableMutate: vi.fn(),
   disableOptions: undefined as MutationOptions | undefined,
+  disablePending: false,
   enableMutate: vi.fn(),
   enableOptions: undefined as MutationOptions | undefined,
+  enablePending: false,
   invalidate: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -59,21 +61,6 @@ vi.mock("@/components/ui/Table", () => ({
             <div key={String(column.key)}>{column.render?.(row)}</div>
           ))}
         </div>
-      ))}
-    </div>
-  ),
-}));
-vi.mock("@/components/ui/MoreActions", () => ({
-  MoreActions: ({ actions }: { actions: Action[] }) => (
-    <div>
-      {actions.map((action) => (
-        <button
-          key={action.label}
-          disabled={action.disabled}
-          onClick={action.onClick}
-        >
-          {action.label}
-        </button>
       ))}
     </div>
   ),
@@ -133,6 +120,30 @@ vi.mock("@gram/client/react-query/adminOpenRouterKeys.js", () => ({
           organizationSlug: "legacy-state",
           updatedAt: new Date("2026-01-01"),
         },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          disableCauses: null,
+          gramAccountType: "pro",
+          keyType: "internal",
+          monthlyCredits: 50,
+          organizationId: "legacy-null-id",
+          organizationName: "Legacy null state",
+          organizationSlug: "legacy-null-state",
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: false,
+          disableCauses: [],
+          gramAccountType: "pro",
+          keyType: "chat",
+          monthlyCredits: 60,
+          organizationId: "classified-empty-id",
+          organizationName: "Classified empty state",
+          organizationSlug: "classified-empty-state",
+          updatedAt: new Date("2026-01-01"),
+        },
       ],
     },
     isLoading: false,
@@ -145,13 +156,13 @@ vi.mock("@gram/client/react-query/adminOpenRouterKeyUsage.js", () => ({
 vi.mock("@gram/client/react-query/disableAdminOpenRouterKey.js", () => ({
   useDisableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
     mocks.disableOptions = options;
-    return { mutate: mocks.disableMutate, isPending: false };
+    return { mutate: mocks.disableMutate, isPending: mocks.disablePending };
   },
 }));
 vi.mock("@gram/client/react-query/enableAdminOpenRouterKey.js", () => ({
   useEnableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
     mocks.enableOptions = options;
-    return { mutate: mocks.enableMutate, isPending: false };
+    return { mutate: mocks.enableMutate, isPending: mocks.enablePending };
   },
 }));
 vi.mock("sonner", () => ({
@@ -162,7 +173,11 @@ import PlatformAdminOpenRouterKeys from "./OpenRouterKeys";
 
 describe("PlatformAdminOpenRouterKeys", () => {
   afterEach(cleanup);
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.disablePending = false;
+    mocks.enablePending = false;
+  });
 
   function renderPage(): QueryClient {
     const queryClient = new QueryClient();
@@ -174,43 +189,98 @@ describe("PlatformAdminOpenRouterKeys", () => {
     return queryClient;
   }
 
-  it("shows all causes and offers only the admin-lock action", () => {
+  function openRowActions(testId: string): void {
+    fireEvent.pointerDown(
+      within(screen.getByTestId(testId)).getByRole("button", {
+        name: "Open menu",
+      }),
+      { button: 0, ctrlKey: false },
+    );
+  }
+
+  it("shows classified causes and fails closed for unclassified legacy rows", () => {
     renderPage();
 
     const automatic = within(screen.getByTestId("automatic-cause"));
     expect(automatic.getByText("Trial demotion")).toBeDefined();
+    openRowActions("automatic-cause");
+    expect(screen.getByRole("menuitem", { name: "Disable key" })).toBeDefined();
     expect(
-      automatic.getByRole("button", { name: "Disable key" }),
-    ).toBeDefined();
-    expect(
-      automatic.queryByRole("button", { name: "Remove admin lock" }),
+      screen.queryByRole("menuitem", { name: "Remove admin lock" }),
     ).toBeNull();
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
 
     const combined = within(screen.getByTestId("combined-causes"));
     expect(combined.getByText("Admin lock")).toBeDefined();
     expect(combined.getByText("Billing inactive")).toBeDefined();
+    openRowActions("combined-causes");
     expect(
-      combined.getByRole("button", { name: "Remove admin lock" }),
+      screen.getByRole("menuitem", { name: "Remove admin lock" }),
     ).toBeDefined();
-    expect(combined.queryByRole("button", { name: "Disable key" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Disable key" })).toBeNull();
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
 
     const future = within(screen.getByTestId("future-cause"));
     expect(future.getByText("future_cause")).toBeDefined();
     expect(future.getByText("Disabled")).toBeDefined();
-    expect(future.getByRole("button", { name: "Disable key" })).toBeDefined();
+    openRowActions("future-cause");
+    expect(screen.getByRole("menuitem", { name: "Disable key" })).toBeDefined();
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
 
-    const legacy = within(screen.getByTestId("legacy-state"));
-    expect(legacy.getByText("Disabled")).toBeDefined();
-    expect(legacy.getByRole("button", { name: "Disable key" })).toBeDefined();
+    for (const testId of ["legacy-state", "legacy-null-state"]) {
+      const legacy = within(screen.getByTestId(testId));
+      expect(legacy.getByText("Disabled")).toBeDefined();
+      expect(legacy.getByText("Unclassified legacy state")).toBeDefined();
+      expect(
+        legacy.getByText(
+          "Disable causes were not recorded for this legacy key.",
+        ),
+      ).toBeDefined();
+      expect(legacy.queryByRole("button", { name: "Open menu" })).toBeNull();
+    }
+
+    const classifiedEmpty = within(
+      screen.getByTestId("classified-empty-state"),
+    );
+    expect(classifiedEmpty.getByText("No disable causes")).toBeDefined();
+    expect(classifiedEmpty.queryByText("Unclassified legacy state")).toBeNull();
+  });
+
+  it("locks row actions while a mutation is pending and restores trigger focus", () => {
+    renderPage();
+    const activeTrigger = within(
+      screen.getByTestId("automatic-cause"),
+    ).getByRole("button", { name: "Open menu" });
+    const oppositeTrigger = within(
+      screen.getByTestId("combined-causes"),
+    ).getByRole("button", { name: "Open menu" });
+
+    openRowActions("automatic-cause");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable key" }));
+
+    expect(activeTrigger.getAttribute("aria-busy")).toBe("true");
+    expect(activeTrigger.textContent).toContain("Action in progress");
+    expect((activeTrigger as HTMLButtonElement).disabled).toBe(true);
+    expect((oppositeTrigger as HTMLButtonElement).disabled).toBe(true);
+    expect(mocks.enableMutate).not.toHaveBeenCalled();
+
+    act(() => mocks.disableOptions?.onError(new Error("disable failed")));
+    expect(activeTrigger.getAttribute("aria-busy")).toBe("false");
+    expect((activeTrigger as HTMLButtonElement).disabled).toBe(false);
+    expect((oppositeTrigger as HTMLButtonElement).disabled).toBe(false);
+    expect(document.activeElement).toBe(activeTrigger);
   });
 
   it("uses generated cause-specific mutations and preserves refetch and errors", () => {
     const queryClient = renderPage();
-    fireEvent.click(
-      within(screen.getByTestId("automatic-cause")).getByRole("button", {
-        name: "Disable key",
-      }),
-    );
+    openRowActions("automatic-cause");
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disable key" }));
     expect(mocks.disableMutate).toHaveBeenCalledWith({
       request: {
         disableOpenRouterKeyRequestBody: {
@@ -220,10 +290,20 @@ describe("PlatformAdminOpenRouterKeys", () => {
       },
     });
 
-    fireEvent.click(
-      within(screen.getByTestId("combined-causes")).getByRole("button", {
-        name: "Remove admin lock",
+    act(() =>
+      mocks.disableOptions?.onSuccess({
+        keyType: "chat",
+        organizationName: "Automatic cause",
       }),
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Admin lock added to the chat key for Automatic cause.",
+    );
+    expect(mocks.invalidate).toHaveBeenCalledWith(queryClient);
+
+    openRowActions("combined-causes");
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Remove admin lock" }),
     );
     expect(mocks.enableMutate).toHaveBeenCalledWith({
       request: {
@@ -234,25 +314,31 @@ describe("PlatformAdminOpenRouterKeys", () => {
       },
     });
 
-    mocks.disableOptions?.onSuccess({
-      keyType: "chat",
-      organizationName: "Automatic cause",
-    });
-    expect(mocks.toastSuccess).toHaveBeenCalledWith(
-      "Admin lock added to the chat key for Automatic cause.",
+    act(() =>
+      mocks.enableOptions?.onSuccess({
+        keyType: "internal",
+        organizationName: "Combined causes",
+      }),
     );
-    expect(mocks.invalidate).toHaveBeenCalledWith(queryClient);
-
-    mocks.enableOptions?.onSuccess({
-      keyType: "internal",
-      organizationName: "Combined causes",
-    });
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Admin lock removed from the internal key for Combined causes.",
     );
     expect(mocks.invalidate).toHaveBeenCalledTimes(2);
 
-    mocks.enableOptions?.onError(new Error("remove failed"));
+    openRowActions("combined-causes");
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Remove admin lock" }),
+    );
+    act(() => mocks.enableOptions?.onError(new Error("remove failed")));
     expect(mocks.toastError).toHaveBeenCalledWith("remove failed");
+
+    openRowActions("combined-causes");
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Remove admin lock" }),
+    );
+    act(() => mocks.enableOptions?.onError("non-error rejection"));
+    expect(mocks.toastError).toHaveBeenLastCalledWith(
+      "Failed to remove admin lock",
+    );
   });
 });

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.test.tsx
@@ -1,0 +1,258 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Action } from "@/components/ui/MoreActions";
+import type { Column } from "@/components/ui/Table";
+import type { AdminOpenRouterKey } from "@gram/client/models/components/adminopenrouterkey.js";
+
+type MutationOptions = {
+  onSuccess: (
+    key: Pick<AdminOpenRouterKey, "keyType" | "organizationName">,
+  ) => void;
+  onError: (error: unknown) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  disableMutate: vi.fn(),
+  disableOptions: undefined as MutationOptions | undefined,
+  enableMutate: vi.fn(),
+  enableOptions: undefined as MutationOptions | undefined,
+  invalidate: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({ useIsPlatformAdmin: () => true }));
+vi.mock("@/components/page-layout", () => {
+  const Wrapper = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    Page: Object.assign(Wrapper, {
+      Header: Object.assign(Wrapper, { Breadcrumbs: Wrapper }),
+      Body: Wrapper,
+      Section: Object.assign(Wrapper, {
+        Title: Wrapper,
+        Description: Wrapper,
+        Body: Wrapper,
+      }),
+    }),
+  };
+});
+vi.mock("@/components/ui/Table", () => ({
+  Table: ({
+    columns,
+    data,
+  }: {
+    columns: Column<AdminOpenRouterKey>[];
+    data: AdminOpenRouterKey[];
+  }) => (
+    <div>
+      {data.map((row) => (
+        <div key={row.organizationSlug} data-testid={row.organizationSlug}>
+          {columns.map((column) => (
+            <div key={String(column.key)}>{column.render?.(row)}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+vi.mock("@/components/ui/MoreActions", () => ({
+  MoreActions: ({ actions }: { actions: Action[] }) => (
+    <div>
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          disabled={action.disabled}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+vi.mock("@/components/ui/Tooltip", () => ({
+  SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("@gram/client/react-query/adminOpenRouterKeys.js", () => ({
+  invalidateAllAdminOpenRouterKeys: mocks.invalidate,
+  useAdminOpenRouterKeys: () => ({
+    data: {
+      keys: [
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          disableCauses: ["trial_demotion"],
+          gramAccountType: "free",
+          keyType: "chat",
+          monthlyCredits: 10,
+          organizationId: "automatic-id",
+          organizationName: "Automatic cause",
+          organizationSlug: "automatic-cause",
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          disableCauses: ["admin_lock", "billing_inactive"],
+          gramAccountType: "pro",
+          keyType: "internal",
+          monthlyCredits: 20,
+          organizationId: "combined-id",
+          organizationName: "Combined causes",
+          organizationSlug: "combined-causes",
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: false,
+          disableCauses: ["future_cause"],
+          gramAccountType: "pro",
+          keyType: "chat",
+          monthlyCredits: 30,
+          organizationId: "future-id",
+          organizationName: "Future cause",
+          organizationSlug: "future-cause",
+          updatedAt: new Date("2026-01-01"),
+        },
+        {
+          createdAt: new Date("2026-01-01"),
+          disabled: true,
+          gramAccountType: "pro",
+          keyType: "chat",
+          monthlyCredits: 40,
+          organizationId: "legacy-id",
+          organizationName: "Legacy state",
+          organizationSlug: "legacy-state",
+          updatedAt: new Date("2026-01-01"),
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+vi.mock("@gram/client/react-query/adminOpenRouterKeyUsage.js", () => ({
+  useAdminOpenRouterKeyUsage: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock("@gram/client/react-query/disableAdminOpenRouterKey.js", () => ({
+  useDisableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
+    mocks.disableOptions = options;
+    return { mutate: mocks.disableMutate, isPending: false };
+  },
+}));
+vi.mock("@gram/client/react-query/enableAdminOpenRouterKey.js", () => ({
+  useEnableAdminOpenRouterKeyMutation: (options: MutationOptions) => {
+    mocks.enableOptions = options;
+    return { mutate: mocks.enableMutate, isPending: false };
+  },
+}));
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}));
+
+import PlatformAdminOpenRouterKeys from "./OpenRouterKeys";
+
+describe("PlatformAdminOpenRouterKeys", () => {
+  afterEach(cleanup);
+  beforeEach(() => vi.clearAllMocks());
+
+  function renderPage(): QueryClient {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PlatformAdminOpenRouterKeys />
+      </QueryClientProvider>,
+    );
+    return queryClient;
+  }
+
+  it("shows all causes and offers only the admin-lock action", () => {
+    renderPage();
+
+    const automatic = within(screen.getByTestId("automatic-cause"));
+    expect(automatic.getByText("Trial demotion")).toBeDefined();
+    expect(
+      automatic.getByRole("button", { name: "Disable key" }),
+    ).toBeDefined();
+    expect(
+      automatic.queryByRole("button", { name: "Remove admin lock" }),
+    ).toBeNull();
+
+    const combined = within(screen.getByTestId("combined-causes"));
+    expect(combined.getByText("Admin lock")).toBeDefined();
+    expect(combined.getByText("Billing inactive")).toBeDefined();
+    expect(
+      combined.getByRole("button", { name: "Remove admin lock" }),
+    ).toBeDefined();
+    expect(combined.queryByRole("button", { name: "Disable key" })).toBeNull();
+
+    const future = within(screen.getByTestId("future-cause"));
+    expect(future.getByText("future_cause")).toBeDefined();
+    expect(future.getByText("Disabled")).toBeDefined();
+    expect(future.getByRole("button", { name: "Disable key" })).toBeDefined();
+
+    const legacy = within(screen.getByTestId("legacy-state"));
+    expect(legacy.getByText("Disabled")).toBeDefined();
+    expect(legacy.getByRole("button", { name: "Disable key" })).toBeDefined();
+  });
+
+  it("uses generated cause-specific mutations and preserves refetch and errors", () => {
+    const queryClient = renderPage();
+    fireEvent.click(
+      within(screen.getByTestId("automatic-cause")).getByRole("button", {
+        name: "Disable key",
+      }),
+    );
+    expect(mocks.disableMutate).toHaveBeenCalledWith({
+      request: {
+        disableOpenRouterKeyRequestBody: {
+          organizationId: "automatic-id",
+          keyType: "chat",
+        },
+      },
+    });
+
+    fireEvent.click(
+      within(screen.getByTestId("combined-causes")).getByRole("button", {
+        name: "Remove admin lock",
+      }),
+    );
+    expect(mocks.enableMutate).toHaveBeenCalledWith({
+      request: {
+        enableOpenRouterKeyRequestBody: {
+          organizationId: "combined-id",
+          keyType: "internal",
+        },
+      },
+    });
+
+    mocks.disableOptions?.onSuccess({
+      keyType: "chat",
+      organizationName: "Automatic cause",
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Admin lock added to the chat key for Automatic cause.",
+    );
+    expect(mocks.invalidate).toHaveBeenCalledWith(queryClient);
+
+    mocks.enableOptions?.onSuccess({
+      keyType: "internal",
+      organizationName: "Combined causes",
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Admin lock removed from the internal key for Combined causes.",
+    );
+    expect(mocks.invalidate).toHaveBeenCalledTimes(2);
+
+    mocks.enableOptions?.onError(new Error("remove failed"));
+    expect(mocks.toastError).toHaveBeenCalledWith("remove failed");
+  });
+});

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
@@ -133,6 +133,7 @@ function KeysTable(): JSX.Element {
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useAdminOpenRouterKeys();
   const [search, setSearch] = useState("");
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
 
   const invalidate = () => {
     void invalidateAllAdminOpenRouterKeys(queryClient);
@@ -144,11 +145,13 @@ function KeysTable(): JSX.Element {
         `Admin lock added to the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
+      setPendingKey(null);
     },
     onError: (err) => {
       toast.error(
         err instanceof Error ? err.message : "Failed to disable the key",
       );
+      setPendingKey(null);
     },
   });
   const enable = useEnableAdminOpenRouterKeyMutation({
@@ -157,11 +160,13 @@ function KeysTable(): JSX.Element {
         `Admin lock removed from the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
+      setPendingKey(null);
     },
     onError: (err) => {
       toast.error(
-        err instanceof Error ? err.message : "Failed to enable the key",
+        err instanceof Error ? err.message : "Failed to remove admin lock",
       );
+      setPendingKey(null);
     },
   });
 
@@ -186,30 +191,43 @@ function KeysTable(): JSX.Element {
     resetOn: [search],
   });
 
+  const mutationPending =
+    pendingKey !== null || disable.isPending || enable.isPending;
+
   const rowActions = (row: AdminOpenRouterKey): Action[] => {
     const keyType = row.keyType === "internal" ? "internal" : "chat";
     const body = { organizationId: row.organizationId, keyType } as const;
+    const action = keyAction(row.disableCauses);
+    if (action === null) return [];
+
+    const rowKey = `${row.organizationId}:${keyType}`;
     const actions: Action[] = [];
-    if (keyAction(row.disableCauses) === "remove-admin-lock") {
+    if (action === "remove-admin-lock") {
       actions.push({
         icon: "play",
         label: "Remove admin lock",
-        disabled: enable.isPending,
-        onClick: () =>
+        disabled: mutationPending,
+        onClick: () => {
+          if (mutationPending) return;
+          setPendingKey(rowKey);
           enable.mutate({
             request: { enableOpenRouterKeyRequestBody: body },
-          }),
+          });
+        },
       });
     } else {
       actions.push({
         icon: "ban",
         label: "Disable key",
         destructive: true,
-        disabled: disable.isPending,
-        onClick: () =>
+        disabled: mutationPending,
+        onClick: () => {
+          if (mutationPending) return;
+          setPendingKey(rowKey);
           disable.mutate({
             request: { disableOpenRouterKeyRequestBody: body },
-          }),
+          });
+        },
       });
     }
     return actions;
@@ -287,9 +305,16 @@ function KeysTable(): JSX.Element {
               </Text>
             ))}
           </div>
+        ) : row.disableCauses == null ? (
+          <Text muted small>
+            Unclassified legacy state{" "}
+            <span className="sr-only">
+              Disable causes were not recorded for this legacy key.
+            </span>
+          </Text>
         ) : (
           <Text muted small>
-            —
+            No disable causes
           </Text>
         );
       },
@@ -298,7 +323,19 @@ function KeysTable(): JSX.Element {
       key: "actions",
       header: "",
       width: "56px",
-      render: (row) => <MoreActions actions={rowActions(row)} />,
+      render: (row) => {
+        const actions = rowActions(row);
+        if (actions.length === 0) return null;
+        const keyType = row.keyType === "internal" ? "internal" : "chat";
+        const rowKey = `${row.organizationId}:${keyType}`;
+        return (
+          <MoreActions
+            actions={actions}
+            triggerLoading={pendingKey === rowKey}
+            triggerDisabled={mutationPending}
+          />
+        );
+      },
     },
   ];
 

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
@@ -20,6 +20,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
+import {
+  causeLabels,
+  effectiveDisabled,
+  keyAction,
+} from "./openRouterKeyState";
 
 // Rows per page; also the ceiling on concurrent live usage fetches, since
 // only mounted rows request usage.
@@ -78,6 +83,7 @@ function StrictPlatformAdminGate({
 // database records current spend, and the periodic credits monitor only emits
 // metrics for alerting.
 function UsageCell({ row }: { row: AdminOpenRouterKey }): JSX.Element {
+  const disabled = effectiveDisabled(row);
   const usage = useAdminOpenRouterKeyUsage(
     {
       organizationId: row.organizationId,
@@ -85,14 +91,14 @@ function UsageCell({ row }: { row: AdminOpenRouterKey }): JSX.Element {
     },
     undefined,
     {
-      enabled: !row.disabled,
+      enabled: !disabled,
       staleTime: 5 * 60 * 1000,
       retry: false,
       throwOnError: false,
     },
   );
 
-  if (row.disabled) {
+  if (disabled) {
     return (
       <SimpleTooltip tooltip="Disabled keys are not polled for usage.">
         <Text muted small>
@@ -135,7 +141,7 @@ function KeysTable(): JSX.Element {
   const disable = useDisableAdminOpenRouterKeyMutation({
     onSuccess: (key) => {
       toast.success(
-        `Disabled the ${key.keyType} key for ${key.organizationName}.`,
+        `Admin lock added to the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
     },
@@ -148,7 +154,7 @@ function KeysTable(): JSX.Element {
   const enable = useEnableAdminOpenRouterKeyMutation({
     onSuccess: (key) => {
       toast.success(
-        `Enabled the ${key.keyType} key for ${key.organizationName}.`,
+        `Admin lock removed from the ${key.keyType} key for ${key.organizationName}.`,
       );
       invalidate();
     },
@@ -184,10 +190,10 @@ function KeysTable(): JSX.Element {
     const keyType = row.keyType === "internal" ? "internal" : "chat";
     const body = { organizationId: row.organizationId, keyType } as const;
     const actions: Action[] = [];
-    if (row.disabled) {
+    if (keyAction(row.disableCauses) === "remove-admin-lock") {
       actions.push({
         icon: "play",
-        label: "Enable key",
+        label: "Remove admin lock",
         disabled: enable.isPending,
         onClick: () =>
           enable.mutate({
@@ -257,7 +263,7 @@ function KeysTable(): JSX.Element {
       header: "Status",
       width: "110px",
       render: (row) =>
-        row.disabled ? (
+        effectiveDisabled(row) ? (
           <Badge variant="destructive" background className="shrink-0">
             <Badge.Text>Disabled</Badge.Text>
           </Badge>
@@ -266,6 +272,27 @@ function KeysTable(): JSX.Element {
             <Badge.Text>Enabled</Badge.Text>
           </Badge>
         ),
+    },
+    {
+      key: "causes",
+      header: "Causes",
+      width: "180px",
+      render: (row) => {
+        const labels = causeLabels(row.disableCauses);
+        return labels.length > 0 ? (
+          <div className="space-y-1">
+            {labels.map((label) => (
+              <Text key={label} small>
+                {label}
+              </Text>
+            ))}
+          </div>
+        ) : (
+          <Text muted small>
+            —
+          </Text>
+        );
+      },
     },
     {
       key: "actions",

--- a/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
+++ b/client/dashboard/src/pages/platform-admin/OpenRouterKeys.tsx
@@ -135,39 +135,35 @@ function KeysTable(): JSX.Element {
   const [search, setSearch] = useState("");
   const [pendingKey, setPendingKey] = useState<string | null>(null);
 
-  const invalidate = () => {
-    void invalidateAllAdminOpenRouterKeys(queryClient);
-  };
+  const invalidate = () => invalidateAllAdminOpenRouterKeys(queryClient);
 
   const disable = useDisableAdminOpenRouterKeyMutation({
-    onSuccess: (key) => {
+    onSuccess: async (key) => {
       toast.success(
         `Admin lock added to the ${key.keyType} key for ${key.organizationName}.`,
       );
-      invalidate();
-      setPendingKey(null);
+      await invalidate();
     },
     onError: (err) => {
       toast.error(
         err instanceof Error ? err.message : "Failed to disable the key",
       );
-      setPendingKey(null);
     },
+    onSettled: () => setPendingKey(null),
   });
   const enable = useEnableAdminOpenRouterKeyMutation({
-    onSuccess: (key) => {
+    onSuccess: async (key) => {
       toast.success(
         `Admin lock removed from the ${key.keyType} key for ${key.organizationName}.`,
       );
-      invalidate();
-      setPendingKey(null);
+      await invalidate();
     },
     onError: (err) => {
       toast.error(
         err instanceof Error ? err.message : "Failed to remove admin lock",
       );
-      setPendingKey(null);
     },
+    onSettled: () => setPendingKey(null),
   });
 
   const keys = useMemo(() => {

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
@@ -16,6 +16,11 @@ describe("OpenRouter key state", () => {
       "Billing inactive",
       "future_cause",
     ]);
+    expect(causeLabels(["toString", "constructor", "__proto__"])).toEqual([
+      "toString",
+      "constructor",
+      "__proto__",
+    ]);
     expect(causeLabels(undefined)).toEqual([]);
   });
 

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
@@ -52,7 +52,8 @@ describe("OpenRouter key state", () => {
   });
 
   it("bases the admin action only on the admin lock cause", () => {
-    expect(keyAction(undefined)).toBe("disable");
+    expect(keyAction(undefined)).toBeNull();
+    expect(keyAction(null)).toBeNull();
     expect(keyAction([])).toBe("disable");
     expect(keyAction(["trial_demotion"])).toBe("disable");
     expect(keyAction(["future_cause"])).toBe("disable");

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.test.ts
@@ -1,0 +1,64 @@
+import { adminOpenRouterKeyFromJSON } from "@gram/client/models/components/adminopenrouterkey.js";
+import { describe, expect, it } from "vitest";
+import {
+  causeLabels,
+  effectiveDisabled,
+  keyAction,
+} from "./openRouterKeyState";
+
+describe("OpenRouter key state", () => {
+  it("renders every known and unknown disable cause", () => {
+    expect(causeLabels(["admin_lock", "trial_demotion"])).toEqual([
+      "Admin lock",
+      "Trial demotion",
+    ]);
+    expect(causeLabels(["billing_inactive", "future_cause"])).toEqual([
+      "Billing inactive",
+      "future_cause",
+    ]);
+    expect(causeLabels(undefined)).toEqual([]);
+  });
+
+  it("preserves an unknown cause through SDK response decoding", () => {
+    const result = adminOpenRouterKeyFromJSON(
+      JSON.stringify({
+        created_at: "2026-01-01T00:00:00Z",
+        disable_causes: ["future_cause"],
+        disabled: true,
+        gram_account_type: "pro",
+        key_type: "chat",
+        monthly_credits: 10,
+        organization_id: "organization-id",
+        organization_name: "Example organization",
+        organization_slug: "example-organization",
+        updated_at: "2026-01-01T00:00:00Z",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    expect(causeLabels(result.value.disableCauses)).toEqual(["future_cause"]);
+  });
+
+  it("uses writable disabled only for legacy unclassified rows", () => {
+    expect(effectiveDisabled({ disabled: true })).toBe(true);
+    expect(effectiveDisabled({ disabled: false })).toBe(false);
+    expect(effectiveDisabled({ disabled: true, disableCauses: [] })).toBe(
+      false,
+    );
+    expect(
+      effectiveDisabled({ disabled: false, disableCauses: ["future_cause"] }),
+    ).toBe(true);
+  });
+
+  it("bases the admin action only on the admin lock cause", () => {
+    expect(keyAction(undefined)).toBe("disable");
+    expect(keyAction([])).toBe("disable");
+    expect(keyAction(["trial_demotion"])).toBe("disable");
+    expect(keyAction(["future_cause"])).toBe("disable");
+    expect(keyAction(["admin_lock"])).toBe("remove-admin-lock");
+    expect(keyAction(["admin_lock", "billing_inactive"])).toBe(
+      "remove-admin-lock",
+    );
+  });
+});

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
@@ -12,9 +12,10 @@ type OpenRouterKeyState = {
 export function causeLabels(
   causes: readonly string[] | null | undefined,
 ): string[] {
-  return (causes ?? []).map(
-    (cause) =>
-      DISABLE_CAUSE_LABELS[cause as keyof typeof DISABLE_CAUSE_LABELS] ?? cause,
+  return (causes ?? []).map((cause) =>
+    Object.hasOwn(DISABLE_CAUSE_LABELS, cause)
+      ? DISABLE_CAUSE_LABELS[cause as keyof typeof DISABLE_CAUSE_LABELS]
+      : cause,
   );
 }
 

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
@@ -1,0 +1,33 @@
+const DISABLE_CAUSE_LABELS = {
+  admin_lock: "Admin lock",
+  trial_demotion: "Trial demotion",
+  billing_inactive: "Billing inactive",
+} as const;
+
+type OpenRouterKeyState = {
+  disabled: boolean;
+  disableCauses?: readonly string[] | null;
+};
+
+export function causeLabels(
+  causes: readonly string[] | null | undefined,
+): string[] {
+  return (causes ?? []).map(
+    (cause) =>
+      DISABLE_CAUSE_LABELS[cause as keyof typeof DISABLE_CAUSE_LABELS] ?? cause,
+  );
+}
+
+export function effectiveDisabled(key: OpenRouterKeyState): boolean {
+  return key.disableCauses == null
+    ? key.disabled
+    : key.disableCauses.length > 0;
+}
+
+export function keyAction(
+  causes: readonly string[] | null | undefined,
+): "disable" | "remove-admin-lock" {
+  return causes?.includes("admin_lock") === true
+    ? "remove-admin-lock"
+    : "disable";
+}

--- a/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
+++ b/client/dashboard/src/pages/platform-admin/openRouterKeyState.ts
@@ -26,8 +26,7 @@ export function effectiveDisabled(key: OpenRouterKeyState): boolean {
 
 export function keyAction(
   causes: readonly string[] | null | undefined,
-): "disable" | "remove-admin-lock" {
-  return causes?.includes("admin_lock") === true
-    ? "remove-admin-lock"
-    : "disable";
+): "disable" | "remove-admin-lock" | null {
+  if (causes == null) return null;
+  return causes.includes("admin_lock") ? "remove-admin-lock" : "disable";
 }

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -189,7 +189,9 @@ var AdminInferenceKey = Type("AdminInferenceKey", func() {
 	Attribute("credits_used", Float64, "Credits spent this month in USD.")
 	Attribute("monthly_credits", Int64)
 	Attribute("disabled", Boolean)
-	Required("key_type", "credits_used", "monthly_credits", "disabled")
+	Attribute("disable_causes", ArrayOf(String), "Active internal disable causes. Omitted for legacy unclassified rows.")
+	Attribute("disable_causes_classified", Boolean, "Whether disable_causes is classified, including an explicitly empty cause set.")
+	Required("key_type", "credits_used", "monthly_credits", "disabled", "disable_causes_classified")
 })
 
 var AdminInferenceKeyLimit = Type("AdminInferenceKeyLimit", func() {

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -645,7 +645,7 @@ var _ = Service("admin", func() {
 
 	// Appended, not inserted: see the note above extendTrial. New methods go last.
 	Method("rearmTrial", func() {
-		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.")
+		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.")
 
 		Payload(func() {
 			security.AdminAuthPayload()

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -645,7 +645,7 @@ var _ = Service("admin", func() {
 
 	// Appended, not inserted: see the note above extendTrial. New methods go last.
 	Method("rearmTrial", func() {
-		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.")
+		Description("Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.")
 
 		Payload(func() {
 			security.AdminAuthPayload()

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -61,9 +61,11 @@ type Service interface {
 	// so both writers converge on one row.
 	CreateOrganization(context.Context, *CreateOrganizationPayload) (res *AdminOrganization, err error)
 	// Puts a demoted enterprise trial back on: restores the organization's account
-	// type and whitelist flag, revives its model provider keys, and gives the
-	// trial a fresh run of the given length counted from now. Only a demoted trial
-	// can be re-armed; one that has converted or is already running is rejected.
+	// type and whitelist flag, removes only the trial-demotion block from its
+	// model provider keys, and gives the trial a fresh run of the given length
+	// counted from now. Other key protections remain in force. Retrying a
+	// committed re-arm reconciles key state without extending the trial again; a
+	// converted or independently running trial is rejected.
 	RearmTrial(context.Context, *RearmTrialPayload) (res *AdminOrganization, err error)
 	// Returns platform-wide organization counts for the strip above the
 	// organizations list. Every figure counts the whole platform: none of them

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -61,11 +61,9 @@ type Service interface {
 	// so both writers converge on one row.
 	CreateOrganization(context.Context, *CreateOrganizationPayload) (res *AdminOrganization, err error)
 	// Puts a demoted enterprise trial back on: restores the organization's account
-	// type and whitelist flag, removes only the trial-demotion block from its
-	// model provider keys, and gives the trial a fresh run of the given length
-	// counted from now. Other key protections remain in force. Retrying a
-	// committed re-arm reconciles key state without extending the trial again; a
-	// converted or independently running trial is rejected.
+	// type and whitelist flag, revives its model provider keys, and gives the
+	// trial a fresh run of the given length counted from now. Only a demoted trial
+	// can be re-armed; one that has converted or is already running is rejected.
 	RearmTrial(context.Context, *RearmTrialPayload) (res *AdminOrganization, err error)
 	// Returns platform-wide organization counts for the strip above the
 	// organizations list. Every figure counts the whole platform: none of them

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -130,6 +130,11 @@ type AdminInferenceKey struct {
 	CreditsUsed    float64
 	MonthlyCredits int64
 	Disabled       bool
+	// Active internal disable causes. Omitted for legacy unclassified rows.
+	DisableCauses []string
+	// Whether disable_causes is classified, including an explicitly empty cause
+	// set.
+	DisableCausesClassified bool
 }
 
 // AdminInferenceKeyLimit is the result type of the admin service

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -5808,10 +5808,17 @@ func unmarshalAdminOrganizationResponseBodyToAdminAdminOrganization(v *AdminOrga
 // *AdminInferenceKeyResponse.
 func unmarshalAdminInferenceKeyResponseToAdminAdminInferenceKey(v *AdminInferenceKeyResponse) *admin.AdminInferenceKey {
 	res := &admin.AdminInferenceKey{
-		KeyType:        *v.KeyType,
-		CreditsUsed:    *v.CreditsUsed,
-		MonthlyCredits: *v.MonthlyCredits,
-		Disabled:       *v.Disabled,
+		KeyType:                 *v.KeyType,
+		CreditsUsed:             *v.CreditsUsed,
+		MonthlyCredits:          *v.MonthlyCredits,
+		Disabled:                *v.Disabled,
+		DisableCausesClassified: *v.DisableCausesClassified,
+	}
+	if v.DisableCauses != nil {
+		res.DisableCauses = make([]string, len(v.DisableCauses))
+		for i, val := range v.DisableCauses {
+			res.DisableCauses[i] = val
+		}
 	}
 
 	return res

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -5051,6 +5051,11 @@ type AdminInferenceKeyResponse struct {
 	CreditsUsed    *float64 `form:"credits_used,omitempty" json:"credits_used,omitempty" xml:"credits_used,omitempty"`
 	MonthlyCredits *int64   `form:"monthly_credits,omitempty" json:"monthly_credits,omitempty" xml:"monthly_credits,omitempty"`
 	Disabled       *bool    `form:"disabled,omitempty" json:"disabled,omitempty" xml:"disabled,omitempty"`
+	// Active internal disable causes. Omitted for legacy unclassified rows.
+	DisableCauses []string `form:"disable_causes,omitempty" json:"disable_causes,omitempty" xml:"disable_causes,omitempty"`
+	// Whether disable_causes is classified, including an explicitly empty cause
+	// set.
+	DisableCausesClassified *bool `form:"disable_causes_classified,omitempty" json:"disable_causes_classified,omitempty" xml:"disable_causes_classified,omitempty"`
 }
 
 // AdminInferenceSpendMonthResponse is used to define fields on response body
@@ -15823,6 +15828,9 @@ func ValidateAdminInferenceKeyResponse(body *AdminInferenceKeyResponse) (err err
 	}
 	if body.Disabled == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("disabled", "body"))
+	}
+	if body.DisableCausesClassified == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("disable_causes_classified", "body"))
 	}
 	return
 }

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -5143,10 +5143,17 @@ func marshalAdminAdminOrganizationToAdminOrganizationResponseBody(v *admin.Admin
 // *admin.AdminInferenceKey.
 func marshalAdminAdminInferenceKeyToAdminInferenceKeyResponse(v *admin.AdminInferenceKey) *AdminInferenceKeyResponse {
 	res := &AdminInferenceKeyResponse{
-		KeyType:        v.KeyType,
-		CreditsUsed:    v.CreditsUsed,
-		MonthlyCredits: v.MonthlyCredits,
-		Disabled:       v.Disabled,
+		KeyType:                 v.KeyType,
+		CreditsUsed:             v.CreditsUsed,
+		MonthlyCredits:          v.MonthlyCredits,
+		Disabled:                v.Disabled,
+		DisableCausesClassified: v.DisableCausesClassified,
+	}
+	if v.DisableCauses != nil {
+		res.DisableCauses = make([]string, len(v.DisableCauses))
+		for i, val := range v.DisableCauses {
+			res.DisableCauses[i] = val
+		}
 	}
 
 	return res

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -5060,6 +5060,11 @@ type AdminInferenceKeyResponse struct {
 	CreditsUsed    float64 `form:"credits_used" json:"credits_used" xml:"credits_used"`
 	MonthlyCredits int64   `form:"monthly_credits" json:"monthly_credits" xml:"monthly_credits"`
 	Disabled       bool    `form:"disabled" json:"disabled" xml:"disabled"`
+	// Active internal disable causes. Omitted for legacy unclassified rows.
+	DisableCauses []string `form:"disable_causes,omitempty" json:"disable_causes,omitempty" xml:"disable_causes,omitempty"`
+	// Whether disable_causes is classified, including an explicitly empty cause
+	// set.
+	DisableCausesClassified bool `form:"disable_causes_classified" json:"disable_causes_classified" xml:"disable_causes_classified"`
 }
 
 // AdminInferenceSpendMonthResponse is used to define fields on response body

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11128,7 +11128,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
 	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr, `    create-organization: Creates an organization in WorkOS and in Gram, so an operator does not have to leave the admin app for the WorkOS dashboard. The organization starts with no members, is not whitelisted, and gets no trial. Idempotent against the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID, so both writers converge on one row.`)
-	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
+	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.`)
 	fmt.Fprintln(os.Stderr, `    get-organization-stats: Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.`)
 	fmt.Fprintln(os.Stderr, `    get-inference-keys: Returns the configured state of every materialized platform-managed OpenRouter key for an organization.`)
 	fmt.Fprintln(os.Stderr, `    set-inference-key-monthly-limit: Sets the monthly limit for one materialized platform-managed OpenRouter key.`)
@@ -11478,7 +11478,7 @@ func adminRearmTrialUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
+	fmt.Fprintln(os.Stderr, `Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11128,7 +11128,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
 	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr, `    create-organization: Creates an organization in WorkOS and in Gram, so an operator does not have to leave the admin app for the WorkOS dashboard. The organization starts with no members, is not whitelisted, and gets no trial. Idempotent against the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID, so both writers converge on one row.`)
-	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.`)
+	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
 	fmt.Fprintln(os.Stderr, `    get-organization-stats: Returns platform-wide organization counts for the strip above the organizations list. Every figure counts the whole platform: none of them narrows to the caller's list filters, so the strip does not move when an operator filters.`)
 	fmt.Fprintln(os.Stderr, `    get-inference-keys: Returns the configured state of every materialized platform-managed OpenRouter key for an organization.`)
 	fmt.Fprintln(os.Stderr, `    set-inference-key-monthly-limit: Sets the monthly limit for one materialized platform-managed OpenRouter key.`)
@@ -11478,7 +11478,7 @@ func adminRearmTrialUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.`)
+	fmt.Fprintln(os.Stderr, `Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1929,7 +1929,7 @@ paths:
             tags:
                 - admin
             summary: rearmTrial admin
-            description: 'Puts a demoted enterprise trial back on: restores the organization''s account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.'
+            description: 'Puts a demoted enterprise trial back on: restores the organization''s account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.'
             operationId: adminRearmTrial
             requestBody:
                 required: true

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1929,7 +1929,7 @@ paths:
             tags:
                 - admin
             summary: rearmTrial admin
-            description: 'Puts a demoted enterprise trial back on: restores the organization''s account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.'
+            description: 'Puts a demoted enterprise trial back on: restores the organization''s account type and whitelist flag, removes only the trial-demotion block from its model provider keys, and gives the trial a fresh run of the given length counted from now. Other key protections remain in force. Retrying a committed re-arm reconciles key state without extending the trial again; a converted or independently running trial is rejected.'
             operationId: adminRearmTrial
             requestBody:
                 required: true

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -63693,6 +63693,14 @@ components:
                     type: number
                     description: Credits spent this month in USD.
                     format: double
+                disable_causes:
+                    type: array
+                    items:
+                        type: string
+                    description: Active internal disable causes. Omitted for legacy unclassified rows.
+                disable_causes_classified:
+                    type: boolean
+                    description: Whether disable_causes is classified, including an explicitly empty cause set.
                 disabled:
                     type: boolean
                 key_type:
@@ -63706,6 +63714,7 @@ components:
                 - credits_used
                 - monthly_credits
                 - disabled
+                - disable_causes_classified
         AdminInferenceKeyLimit:
             type: object
             properties:

--- a/server/internal/admin/billing.go
+++ b/server/internal/admin/billing.go
@@ -58,10 +58,12 @@ func (s *Service) GetInferenceKeys(ctx context.Context, payload *gen.GetInferenc
 				return fmt.Errorf("read %s inference key usage: %w", keyType, err)
 			}
 			result[index] = &gen.AdminInferenceKey{
-				KeyType:        key.KeyType,
-				CreditsUsed:    creditsUsed,
-				MonthlyCredits: key.MonthlyCredits,
-				Disabled:       key.Disabled,
+				KeyType:                 key.KeyType,
+				CreditsUsed:             creditsUsed,
+				MonthlyCredits:          key.MonthlyCredits,
+				Disabled:                key.Disabled,
+				DisableCauses:           key.DisableCauses,
+				DisableCausesClassified: key.DisableCausesClassified,
 			}
 			return nil
 		})

--- a/server/internal/admin/billing_test.go
+++ b/server/internal/admin/billing_test.go
@@ -104,6 +104,14 @@ func TestGetInferenceKeysUsesCanonicalOrganizationIDAndReturnsConfiguredState(t 
 		OrganizationID: "org_inference", KeyType: "internal", KeyEncrypted: pgtype.Text{}, KeyHash: "hash-internal", MonthlyCredits: 50,
 	})
 	require.NoError(t, err)
+	_, err = openRouterRepo.AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: "org_inference", KeyType: "chat", KeyHash: "hash-chat", DisableCause: "admin_lock",
+	})
+	require.NoError(t, err)
+	_, err = openRouterRepo.AddOpenRouterAPIKeyDisableCause(ctx, orrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: "org_inference", KeyType: "chat", KeyHash: "hash-chat", DisableCause: "future_policy",
+	})
+	require.NoError(t, err)
 	err = openRouterRepo.DisableOpenRouterAPIKey(ctx, orrepo.DisableOpenRouterAPIKeyParams{
 		OrganizationID: "org_inference", KeyType: "internal",
 	})
@@ -112,8 +120,8 @@ func TestGetInferenceKeysUsesCanonicalOrganizationIDAndReturnsConfiguredState(t 
 	result, err := svc.GetInferenceKeys(ctx, &gen.GetInferenceKeysPayload{OrganizationID: "org_inference"})
 	require.NoError(t, err)
 	require.Equal(t, []*gen.AdminInferenceKey{
-		{KeyType: "chat", CreditsUsed: 42.75, MonthlyCredits: 100, Disabled: false},
-		{KeyType: "internal", CreditsUsed: 12.5, MonthlyCredits: 50, Disabled: true},
+		{KeyType: "chat", CreditsUsed: 42.75, MonthlyCredits: 100, Disabled: true, DisableCauses: []string{"admin_lock", "future_policy"}, DisableCausesClassified: true},
+		{KeyType: "internal", CreditsUsed: 12.5, MonthlyCredits: 50, Disabled: true, DisableCauses: nil, DisableCausesClassified: false},
 	}, result)
 }
 
@@ -150,7 +158,7 @@ func TestGetInferenceKeysOmitsUnsupportedAndAbsentKeys(t *testing.T) {
 	result, err := svc.GetInferenceKeys(ctx, &gen.GetInferenceKeysPayload{OrganizationID: "org_inference_filtered"})
 	require.NoError(t, err)
 	require.Equal(t, []*gen.AdminInferenceKey{
-		{KeyType: "chat", CreditsUsed: 7.25, MonthlyCredits: 100, Disabled: false},
+		{KeyType: "chat", CreditsUsed: 7.25, MonthlyCredits: 100, Disabled: false, DisableCauses: []string{}, DisableCausesClassified: true},
 	}, result)
 
 }

--- a/server/internal/admin/extendtrial_test.go
+++ b/server/internal/admin/extendtrial_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -34,6 +35,36 @@ func readTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID stri
 	row, err := trialsRepo.New(conn).GetTrial(ctx, orgID)
 	require.NoError(t, err)
 	return row
+}
+
+func TestExtendTrial_IsCauseCapAndOpenRouterLockNeutral(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+	const orgID = "org_extend_key_neutral"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(24 * time.Hour)})
+	for i, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: int64(31 + i), disabled: true})
+		classifyRearmKey(t, ctx, conn, orgID, keyType, []string{string(openrouter.DisableCauseBillingInactive)})
+	}
+
+	blocker := testenv.BeginTx(t, ctx, conn)
+	defer func() { _ = blocker.Rollback(context.WithoutCancel(ctx)) }()
+	for _, keyType := range openrouter.AllKeyTypes {
+		require.NoError(t, openrouter.AcquireAPIKeyBillingTransactionLock(ctx, blocker, orgID, keyType))
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_, err := svc.ExtendTrial(callCtx, &gen.ExtendTrialPayload{ID: orgID, Days: 2})
+	require.NoError(t, err, "extension must not wait for any OpenRouter lock")
+	for i, keyType := range openrouter.AllKeyTypes {
+		row := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.Equal(t, []string{string(openrouter.DisableCauseBillingInactive)}, row.DisableCauses)
+		require.EqualValues(t, 31+i, row.MonthlyCredits)
+		require.True(t, row.Disabled)
+	}
 }
 
 func TestExtendTrial_MovesEndsAtByExactlyTheGivenDays(t *testing.T) {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -1169,11 +1169,13 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	}
 
 	if !lockedTrial.DemotedAt.Valid {
-		wasRearmed, auditErr := repo.New(tx).AdminHasEnterpriseTrialRearmAudit(ctx, payload.ID)
-		if auditErr != nil {
-			return nil, oops.E(oops.CodeUnexpected, auditErr, "check prior trial re-arm").LogError(ctx, logger)
+		recordedEndsAt, auditErr := repo.New(tx).AdminGetLatestEnterpriseTrialRearmEndsAt(ctx, payload.ID)
+		if auditErr != nil && !errors.Is(auditErr, pgx.ErrNoRows) {
+			return nil, oops.E(oops.CodeUnexpected, auditErr, "check prior trial re-arm generation").LogError(ctx, logger)
 		}
-		if wasRearmed && lockedTrial.EndsAt.Valid && lockedTrial.EndsAt.Time.After(time.Now()) {
+		parsedEndsAt, parseErr := time.Parse(time.RFC3339Nano, recordedEndsAt)
+		sameGeneration := auditErr == nil && parseErr == nil && lockedTrial.EndsAt.Valid && parsedEndsAt.Equal(lockedTrial.EndsAt.Time)
+		if sameGeneration && lockedTrial.EndsAt.Time.After(time.Now()) {
 			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
 				return nil, oops.E(oops.CodeUnexpected, rollbackErr, "close trial re-arm retry transaction").LogError(ctx, logger)
 			}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -29,7 +29,7 @@ import (
 	auditrepo "github.com/speakeasy-api/gram/server/internal/audit/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth/orgslug"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
 	"github.com/speakeasy-api/gram/server/internal/constants"
@@ -44,7 +44,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/supporthandoff"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
-	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -86,11 +85,15 @@ type BillingOperations interface {
 	SetStripeSubscriptionCancelAtPeriodEndForOrganization(context.Context, string, usage.BillingActor, bool) (*usage.StripeSubscription, error)
 }
 
-// TrialKeyReviver is the OpenRouter surface a trial re-arm needs.
+// TrialKeyReviver is the OpenRouter surface used by admin key operations and
+// trial lifecycle replacement. The WithDB removal records local desired state
+// only; reconciliation happens after the business transaction commits.
 type TrialKeyReviver interface {
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
 	ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
 	ReinstateAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
+	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error)
+	ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error
 }
 
 type OpenRouterSpendCapScheduler interface {
@@ -119,8 +122,6 @@ func (ChatAnalysisTriggerUnavailable) Signal(context.Context, uuid.UUID) error {
 	return ErrChatAnalysisTriggerUnavailable
 }
 
-const keyBillingLockWaitTimeout = 5 * time.Second
-
 // TrialKeysUnavailable lets the admin server boot without OpenRouter.
 type TrialKeysUnavailable struct{}
 
@@ -134,6 +135,14 @@ func (TrialKeysUnavailable) ReinstateAPIKeyLimit(context.Context, string, openro
 
 func (TrialKeysUnavailable) ReinstateAPIKeyLimitWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, *int) (int, error) {
 	return 0, ErrOpenRouterUnavailable
+}
+
+func (TrialKeysUnavailable) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
+	return 0, openrouter.DisableCauseChange{}, ErrOpenRouterUnavailable
+}
+
+func (TrialKeysUnavailable) ReconcileAPIKeyDisabled(context.Context, string, openrouter.KeyType) error {
+	return ErrOpenRouterUnavailable
 }
 
 func (TrialKeysUnavailable) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
@@ -1131,71 +1140,13 @@ func (s *Service) CreateOrganization(ctx context.Context, payload *gen.CreateOrg
 	return s.readOrganizationAfterWrite(ctx, org.ID, "fetch organization after create")
 }
 
-// RearmTrial puts a demoted enterprise trial back on.
-//
-// The keys come back up before the restore commits, deliberately not mirroring
-// the demotion's ordering: a partial failure must leave the organization
-// demoted with live keys, never a running trial with dead ones.
+// RearmTrial atomically replaces trial_demotion with the active-trial key policy.
 func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload) (*gen.AdminOrganization, error) {
-	// Defence in depth against a non-HTTP caller: the design's bounds are
-	// generated into the request decoder alone. Keep this on the wide
-	// payload.Days, above the int32 narrowing, or 1<<32 + 1 truncates into range.
 	if payload.Days < constants.MinTrialRearmDays || payload.Days > constants.MaxTrialRearmDays {
 		return nil, oops.E(oops.CodeInvalid, nil, "days must be between %d and %d", constants.MinTrialRearmDays, constants.MaxTrialRearmDays)
 	}
 
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
-	lockedKeys := make(map[openrouter.KeyType]*pgxpool.Conn, len(openrouter.AllKeyTypes))
-	var result *gen.AdminOrganization
-	err := s.withTrialKeyBillingLocks(ctx, logger, payload.ID, openrouter.AllKeyTypes, lockedKeys, func() error {
-		var lockedErr error
-		result, lockedErr = s.rearmTrialLocked(ctx, logger, payload, lockedKeys)
-		return lockedErr
-	})
-	if err == nil {
-		return result, nil
-	}
-
-	if shareable, ok := errors.AsType[*oops.ShareableError](err); ok {
-		return nil, shareable
-	}
-	if errors.Is(err, keybillinglock.ErrAcquireTimeout) {
-		return nil, oops.E(oops.CodeUnavailable, err, "another billing operation is in progress; retry shortly").LogWarn(ctx, logger)
-	}
-	return nil, oops.E(oops.CodeUnexpected, err, "lock inference keys for trial re-arm").LogError(ctx, logger)
-}
-
-func (s *Service) withTrialKeyBillingLocks(
-	ctx context.Context,
-	logger *slog.Logger,
-	organizationID string,
-	keyTypes []openrouter.KeyType,
-	locked map[openrouter.KeyType]*pgxpool.Conn,
-	operation func() error,
-) error {
-	if len(keyTypes) == 0 {
-		return operation()
-	}
-
-	keyType := keyTypes[0]
-	err := keybillinglock.WithAcquireTimeout(ctx, logger, s.db, organizationID, keyType, keyBillingLockWaitTimeout, func(conn *pgxpool.Conn) error {
-		locked[keyType] = conn
-		defer delete(locked, keyType)
-		return s.withTrialKeyBillingLocks(ctx, logger, organizationID, keyTypes[1:], locked, operation)
-	})
-	if err != nil {
-		return fmt.Errorf("hold OpenRouter %s key billing lock for trial re-arm: %w", keyType, err)
-	}
-	return nil
-}
-
-func (s *Service) rearmTrialLocked(
-	ctx context.Context,
-	logger *slog.Logger,
-	payload *gen.RearmTrialPayload,
-	lockedKeys map[openrouter.KeyType]*pgxpool.Conn,
-) (*gen.AdminOrganization, error) {
-
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "begin trial re-arm transaction").LogError(ctx, logger)
@@ -1203,50 +1154,87 @@ func (s *Service) rearmTrialLocked(
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	trials := trialsRepo.New(tx)
-
-	rearmed, err := trials.RearmTrial(ctx, trialsRepo.RearmTrialParams{
-		OrganizationID: payload.ID,
-		RearmForDays:   conv.SafeInt32(payload.Days),
-	})
+	lockedTrial, err := trials.LockTrialLifecycleForRearm(ctx, payload.ID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// rejectTrialChange reads on the pool, so this connection goes back
-		// before it asks for a second one. The deferred rollback is idempotent.
 		_ = tx.Rollback(ctx)
-		return nil, s.rejectTrialChange(ctx, logger, payload.ID,
-			"look up organization after unrearmed trial",
-			"organization has no demoted enterprise trial to re-arm")
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unrearmed trial", "organization has no demoted enterprise trial to re-arm")
 	case err != nil:
-		return nil, oops.E(oops.CodeUnexpected, err, "re-arm trial").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "lock trial lifecycle for re-arm").LogError(ctx, logger)
 	}
 
-	uncapped, err := s.reviveTrialKeys(ctx, logger, lockedKeys, payload.ID)
+	if lockedTrial.ConvertedAt.Valid {
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unrearmed trial", "organization has no demoted enterprise trial to re-arm")
+	}
+
+	if !lockedTrial.DemotedAt.Valid {
+		wasRearmed, auditErr := repo.New(tx).AdminHasEnterpriseTrialRearmAudit(ctx, payload.ID)
+		if auditErr != nil {
+			return nil, oops.E(oops.CodeUnexpected, auditErr, "check prior trial re-arm").LogError(ctx, logger)
+		}
+		if wasRearmed && lockedTrial.EndsAt.Valid && lockedTrial.EndsAt.Time.After(time.Now()) {
+			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+				return nil, oops.E(oops.CodeUnexpected, rollbackErr, "close trial re-arm retry transaction").LogError(ctx, logger)
+			}
+			s.updateTrialFeatureCache(ctx, payload.ID)
+			if err := s.reconcileRearmedTrialKeys(ctx, logger, payload.ID, openrouter.AllKeyTypes); err != nil {
+				return nil, err
+			}
+			return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm retry")
+		}
+
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unrearmed trial", "organization has no demoted enterprise trial to re-arm")
+	}
+
+	// The lifecycle row is locked first. Every transaction advisory lock then
+	// follows in canonical order before any key-row access.
+	for _, keyType := range openrouter.AllKeyTypes {
+		if err := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, tx, payload.ID, keyType); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter %s key for trial re-arm", keyType).LogError(ctx, logger)
+		}
+	}
+
+	rearmed, err := trials.RearmTrial(ctx, trialsRepo.RearmTrialParams{OrganizationID: payload.ID, RearmForDays: conv.SafeInt32(payload.Days)})
 	if err != nil {
-		return nil, err
+		return nil, oops.E(oops.CodeUnexpected, err, "re-arm locked trial").LogError(ctx, logger)
 	}
 
-	organization, err := trials.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{
-		OrganizationID: payload.ID,
-		AccountType:    rearmed.Tier,
-	})
+	desiredLimit, ok := openrouter.DefaultCreditLimit(payload.ID, billing.Tier(rearmed.Tier), true)
+	if !ok || desiredLimit <= 0 {
+		return nil, oops.E(oops.CodeUnexpected, nil, "trial tier %q has no OpenRouter credit policy", rearmed.Tier).LogError(ctx, logger)
+	}
+
+	reconcile := make([]openrouter.KeyType, 0, len(openrouter.AllKeyTypes))
+	keyAccessChanged := false
+	for _, keyType := range openrouter.AllKeyTypes {
+		_, change, removeErr := s.openRouter.RemoveAPIKeyDisableCauseWithDB(ctx, tx, payload.ID, keyType, openrouter.DisableCauseTrialDemotion, &desiredLimit)
+		switch {
+		case errors.Is(removeErr, ErrOpenRouterUnavailable):
+			return nil, oops.E(oops.CodeInvalid, removeErr, "this server cannot update model provider key lifecycle state")
+		case removeErr != nil:
+			return nil, oops.E(oops.CodeUnexpected, removeErr, "remove trial demotion cause from openrouter %s key", keyType).LogError(ctx, logger)
+		}
+		keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
+		if change.KeyAccessChanged {
+			reconcile = append(reconcile, keyType)
+		}
+	}
+
+	organization, err := trials.RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{OrganizationID: payload.ID, AccountType: rearmed.Tier})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "restore organization from trial").LogError(ctx, logger)
 	}
-
 	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, payload.ID, true); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "restore trial runtime features").LogError(ctx, logger)
 	}
 
 	actor, actorDisplayName, operatorEmail := adminActor(ctx)
 	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
-		OrganizationID:   payload.ID,
-		Actor:            actor,
-		ActorDisplayName: actorDisplayName,
-		ActorSlug:        nil,
-		OrganizationName: organization.Name,
-		OrganizationSlug: organization.Slug,
-		AccountType:      rearmed.Tier,
-		TrialEndsAt:      rearmed.EndsAt.Time,
+		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil,
+		OrganizationName: organization.Name, OrganizationSlug: organization.Slug, AccountType: rearmed.Tier,
+		TrialEndsAt: rearmed.EndsAt.Time, KeyAccessChanged: keyAccessChanged,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log trial re-arm").LogError(ctx, logger)
 	}
@@ -1255,91 +1243,27 @@ func (s *Service) rearmTrialLocked(
 		return nil, oops.E(oops.CodeUnexpected, err, "commit trial re-arm").LogError(ctx, logger)
 	}
 
-	s.recapRevivedKeys(ctx, logger, lockedKeys, payload.ID, uncapped)
-	for _, feature := range productfeatures.TrialRuntimeFeatures {
-		s.productFeatures.UpdateFeatureCache(ctx, payload.ID, feature, true)
+	s.updateTrialFeatureCache(ctx, payload.ID)
+	if err := s.reconcileRearmedTrialKeys(ctx, logger, payload.ID, reconcile); err != nil {
+		return nil, err
 	}
-
-	// Speakeasy-only, and the only place the email meets the entry's subject.
-	logger.InfoContext(ctx, "re-armed enterprise trial",
-		attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")),
-	)
-
+	logger.InfoContext(ctx, "re-armed enterprise trial", attr.SlogAuthUserEmail(conv.PtrValOr(operatorEmail, "unknown")))
 	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after trial re-arm")
 }
 
-// reviveTrialKeys brings every platform key the organization holds back up, and
-// returns the types revived at a pre-commit ceiling, for recapRevivedKeys.
-//
-// Shaped like openrouterkeys.EnableKey rather than the demotion's blind loop:
-// DisableAPIKey no-ops on a missing key row, RefreshAPIKeyLimit errors on one.
-//
-// The caller holds both per-key session locks through commit. Key revival uses
-// those locked sessions but stays outside the organization transaction, so a
-// later rollback leaves the org demoted with live keys instead of exposing an
-// admitted trial whose keys are still disabled.
-func (s *Service) reviveTrialKeys(ctx context.Context, logger *slog.Logger, lockedKeys map[openrouter.KeyType]*pgxpool.Conn, organizationID string) ([]openrouter.KeyType, error) {
-	var uncapped []openrouter.KeyType
-
-	for _, keyType := range openrouter.AllKeyTypes {
-		conn := lockedKeys[keyType]
-		if conn == nil {
-			return nil, oops.E(oops.CodeUnexpected, nil, "missing openrouter %s key lock", keyType).LogError(ctx, logger)
-		}
-		row, err := orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{
-			OrganizationID: organizationID,
-			KeyType:        string(keyType),
-		})
-		switch {
-		case errors.Is(err, pgx.ErrNoRows):
-			continue
-		case err != nil:
-			return nil, oops.E(oops.CodeUnexpected, err, "read openrouter %s key", keyType).LogError(ctx, logger)
-		case !row.Disabled:
-			continue
-		}
-
-		// The ceiling recorded on the row, not the policy default: a trial
-		// key is minted well below that default. A zero resolves from the
-		// pre-commit free-tier projection and is corrected after commit.
-		if row.MonthlyCredits == 0 {
-			uncapped = append(uncapped, keyType)
-		}
-		limit := conv.PtrEmpty(int(row.MonthlyCredits))
-		_, err = s.openRouter.ReinstateAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, limit)
-		switch {
-		case errors.Is(err, ErrOpenRouterUnavailable):
-			return nil, oops.E(oops.CodeInvalid, err, "this server cannot revive model provider keys: it is missing either the OpenRouter provisioning key or a usable encryption key. The server log says which at startup")
-		case err != nil:
-			return nil, oops.E(oops.CodeGatewayError, err, "revive openrouter %s key", keyType).LogError(ctx, logger)
-		}
+func (s *Service) updateTrialFeatureCache(ctx context.Context, organizationID string) {
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		s.productFeatures.UpdateFeatureCache(ctx, organizationID, feature, true)
 	}
-
-	return uncapped, nil
 }
 
-// recapRevivedKeys puts the trial's own ceiling on the keys reviveTrialKeys
-// could only revive at the free-tier one. It must run after the commit, because
-// a nil limit resolves from the now-committed organization tier.
-//
-// A failure is logged and swallowed: the re-arm is already durable, so an error
-// here would report an armed trial as unarmed.
-func (s *Service) recapRevivedKeys(ctx context.Context, logger *slog.Logger, lockedKeys map[openrouter.KeyType]*pgxpool.Conn, organizationID string, keyTypes []openrouter.KeyType) {
+func (s *Service) reconcileRearmedTrialKeys(ctx context.Context, logger *slog.Logger, organizationID string, keyTypes []openrouter.KeyType) error {
 	for _, keyType := range keyTypes {
-		conn := lockedKeys[keyType]
-		if conn == nil {
-			logger.ErrorContext(ctx, "re-armed trial key kept the free-tier allowance: missing key lock",
-				attr.SlogOpenRouterKeyType(string(keyType)),
-			)
-			continue
-		}
-		if _, err := s.openRouter.ReinstateAPIKeyLimitWithDB(ctx, conn, organizationID, keyType, nil); err != nil {
-			logger.ErrorContext(ctx, "re-armed trial key kept the free-tier allowance: refresh it from the platform admin key page",
-				attr.SlogError(err),
-				attr.SlogOpenRouterKeyType(string(keyType)),
-			)
+		if err := s.openRouter.ReconcileAPIKeyDisabled(ctx, organizationID, keyType); err != nil {
+			return oops.E(oops.CodeGatewayError, err, "reconcile openrouter %s key after trial re-arm", keyType).LogError(ctx, logger)
 		}
 	}
+	return nil
 }
 
 // adminActor identifies the operator behind an admin-app write. An admin session

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -1168,13 +1168,15 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unrearmed trial", "organization has no demoted enterprise trial to re-arm")
 	}
 
+	retryOperations, auditErr := repo.New(tx).AdminGetEnterpriseTrialRetryOperationIDs(ctx, payload.ID)
+	if auditErr != nil {
+		return nil, oops.E(oops.CodeUnexpected, auditErr, "check trial generation audit operations").LogError(ctx, logger)
+	}
+	armOperationID, armErr := uuid.Parse(retryOperations.ArmOperationID)
+	rearmArmOperationID, rearmErr := uuid.Parse(retryOperations.RearmArmOperationID)
+
 	if !lockedTrial.DemotedAt.Valid {
-		recordedGeneration, auditErr := repo.New(tx).AdminGetLatestEnterpriseTrialRearmGeneration(ctx, payload.ID)
-		if auditErr != nil && !errors.Is(auditErr, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, auditErr, "check prior trial re-arm generation").LogError(ctx, logger)
-		}
-		parsedGeneration, parseErr := time.Parse(time.RFC3339Nano, recordedGeneration)
-		sameGeneration := auditErr == nil && parseErr == nil && parsedGeneration.Equal(lockedTrial.CreatedAt.Time)
+		sameGeneration := armErr == nil && rearmErr == nil && armOperationID == rearmArmOperationID && retryOperations.MatchingRearmCount == 1
 		if sameGeneration && lockedTrial.EndsAt.Valid && lockedTrial.EndsAt.Time.After(time.Now()) {
 			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
 				return nil, oops.E(oops.CodeUnexpected, rollbackErr, "close trial re-arm retry transaction").LogError(ctx, logger)
@@ -1188,6 +1190,10 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 
 		_ = tx.Rollback(ctx)
 		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unrearmed trial", "organization has no demoted enterprise trial to re-arm")
+	}
+	if armErr != nil {
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization after unaudited trial", "organization trial generation has no valid arm operation")
 	}
 
 	// The lifecycle row is locked first. Every transaction advisory lock then
@@ -1236,7 +1242,7 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
 		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil,
 		OrganizationName: organization.Name, OrganizationSlug: organization.Slug, AccountType: rearmed.Tier,
-		TrialEndsAt: rearmed.EndsAt.Time, TrialGenerationCreatedAt: lockedTrial.CreatedAt.Time, KeyAccessChanged: keyAccessChanged,
+		TrialEndsAt: rearmed.EndsAt.Time, ArmAuditOperation: armOperationID.String(), KeyAccessChanged: keyAccessChanged,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log trial re-arm").LogError(ctx, logger)
 	}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -1169,13 +1169,13 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	}
 
 	if !lockedTrial.DemotedAt.Valid {
-		recordedEndsAt, auditErr := repo.New(tx).AdminGetLatestEnterpriseTrialRearmEndsAt(ctx, payload.ID)
+		recordedGeneration, auditErr := repo.New(tx).AdminGetLatestEnterpriseTrialRearmGeneration(ctx, payload.ID)
 		if auditErr != nil && !errors.Is(auditErr, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeUnexpected, auditErr, "check prior trial re-arm generation").LogError(ctx, logger)
 		}
-		parsedEndsAt, parseErr := time.Parse(time.RFC3339Nano, recordedEndsAt)
-		sameGeneration := auditErr == nil && parseErr == nil && lockedTrial.EndsAt.Valid && parsedEndsAt.Equal(lockedTrial.EndsAt.Time)
-		if sameGeneration && lockedTrial.EndsAt.Time.After(time.Now()) {
+		parsedGeneration, parseErr := time.Parse(time.RFC3339Nano, recordedGeneration)
+		sameGeneration := auditErr == nil && parseErr == nil && parsedGeneration.Equal(lockedTrial.CreatedAt.Time)
+		if sameGeneration && lockedTrial.EndsAt.Valid && lockedTrial.EndsAt.Time.After(time.Now()) {
 			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
 				return nil, oops.E(oops.CodeUnexpected, rollbackErr, "close trial re-arm retry transaction").LogError(ctx, logger)
 			}
@@ -1236,7 +1236,7 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	if err := s.audit.LogOrganizationEnterpriseTrialRearmed(ctx, tx, audit.LogOrganizationEnterpriseTrialRearmedEvent{
 		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil,
 		OrganizationName: organization.Name, OrganizationSlug: organization.Slug, AccountType: rearmed.Tier,
-		TrialEndsAt: rearmed.EndsAt.Time, KeyAccessChanged: keyAccessChanged,
+		TrialEndsAt: rearmed.EndsAt.Time, TrialGenerationCreatedAt: lockedTrial.CreatedAt.Time, KeyAccessChanged: keyAccessChanged,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log trial re-arm").LogError(ctx, logger)
 	}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -1,8 +1,8 @@
--- name: AdminGetLatestEnterpriseTrialRearmEndsAt :one
--- A re-arm retry is valid only for the exact lifecycle generation recorded in
--- the latest matching audit. The organization-first index bounds this backward
--- seq scan, while action filtering and LIMIT 1 select one candidate.
-SELECT COALESCE(metadata->>'trial_ends_at', '')::text AS trial_ends_at
+-- name: AdminGetLatestEnterpriseTrialRearmGeneration :one
+-- A post-commit retry is valid only for the immutable trial-row generation
+-- recorded in the latest matching audit. Extensions intentionally change ends_at
+-- without creating a new generation.
+SELECT COALESCE(metadata->>'trial_generation_created_at', '')::text AS trial_generation_created_at
 FROM audit_logs
 WHERE organization_id = @organization_id
   AND action = 'organization:enterprise_trial_rearmed'

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -12,29 +12,34 @@ WITH latest_arm AS (
       AND armed.subject_type = 'organization'
     ORDER BY armed.seq DESC, armed.id DESC
     LIMIT 1
-), latest_rearm AS (
-    SELECT rearmed.metadata->>'arm_operation_id' AS arm_operation_id
+), latest_demotion AS (
+    SELECT demoted.id, demoted.seq
+    FROM audit_logs AS demoted
+    JOIN latest_arm ON (demoted.seq, demoted.id) > (latest_arm.seq, latest_arm.id)
+    WHERE demoted.organization_id = @target_organization_id
+      AND demoted.project_id IS NULL
+      AND demoted.action = 'organization:enterprise_trial_demoted'
+      AND demoted.subject_id = @target_organization_id
+      AND demoted.subject_type = 'organization'
+    ORDER BY demoted.seq DESC, demoted.id DESC
+    LIMIT 1
+), current_rearms AS (
+    SELECT rearmed.id, rearmed.seq, rearmed.metadata->>'arm_operation_id' AS arm_operation_id
     FROM audit_logs AS rearmed
+    JOIN latest_demotion ON (rearmed.seq, rearmed.id) > (latest_demotion.seq, latest_demotion.id)
     WHERE rearmed.organization_id = @target_organization_id
       AND rearmed.project_id IS NULL
       AND rearmed.action = 'organization:enterprise_trial_rearmed'
       AND rearmed.subject_id = @target_organization_id
       AND rearmed.subject_type = 'organization'
-    ORDER BY rearmed.seq DESC, rearmed.id DESC
-    LIMIT 1
 )
 SELECT
     COALESCE((SELECT id::text FROM latest_arm), '')::text AS arm_operation_id,
-    COALESCE((SELECT arm_operation_id FROM latest_rearm), '')::text AS rearm_arm_operation_id,
+    COALESCE((SELECT arm_operation_id FROM current_rearms ORDER BY seq DESC, id DESC LIMIT 1), '')::text AS rearm_arm_operation_id,
     (
         SELECT count(*)
-        FROM audit_logs AS rearmed
-        JOIN latest_arm ON rearmed.metadata->>'arm_operation_id' = latest_arm.id::text
-        WHERE rearmed.organization_id = @target_organization_id
-          AND rearmed.project_id IS NULL
-          AND rearmed.action = 'organization:enterprise_trial_rearmed'
-          AND rearmed.subject_id = @target_organization_id
-          AND rearmed.subject_type = 'organization'
+        FROM current_rearms
+        JOIN latest_arm ON current_rearms.arm_operation_id = latest_arm.id::text
     )::bigint AS matching_rearm_count;
 
 -- name: GetProjectByID :one

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -1,3 +1,11 @@
+-- name: AdminHasEnterpriseTrialRearmAudit :one
+SELECT EXISTS (
+    SELECT 1
+    FROM audit_logs
+    WHERE organization_id = @organization_id
+      AND action = 'organization:enterprise_trial_rearmed'
+);
+
 -- name: GetProjectByID :one
 SELECT id, slug
 FROM projects

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -1,13 +1,41 @@
--- name: AdminGetLatestEnterpriseTrialRearmGeneration :one
--- A post-commit retry is valid only for the immutable trial-row generation
--- recorded in the latest matching audit. Extensions intentionally change ends_at
--- without creating a new generation.
-SELECT COALESCE(metadata->>'trial_generation_created_at', '')::text AS trial_generation_created_at
-FROM audit_logs
-WHERE organization_id = @organization_id
-  AND action = 'organization:enterprise_trial_rearmed'
-ORDER BY seq DESC
-LIMIT 1;
+-- name: AdminGetEnterpriseTrialRetryOperationIDs :one
+-- The arm audit id is the immutable generation token. Every production trial
+-- creation writes exactly one arm audit in the creation transaction; extension
+-- writes neither. seq orders generations; id breaks any equal-seq tie.
+WITH latest_arm AS (
+    SELECT armed.id, armed.seq
+    FROM audit_logs AS armed
+    WHERE armed.organization_id = @target_organization_id
+      AND armed.project_id IS NULL
+      AND armed.action = 'organization:enterprise_trial_armed'
+      AND armed.subject_id = @target_organization_id
+      AND armed.subject_type = 'organization'
+    ORDER BY armed.seq DESC, armed.id DESC
+    LIMIT 1
+), latest_rearm AS (
+    SELECT rearmed.metadata->>'arm_operation_id' AS arm_operation_id
+    FROM audit_logs AS rearmed
+    WHERE rearmed.organization_id = @target_organization_id
+      AND rearmed.project_id IS NULL
+      AND rearmed.action = 'organization:enterprise_trial_rearmed'
+      AND rearmed.subject_id = @target_organization_id
+      AND rearmed.subject_type = 'organization'
+    ORDER BY rearmed.seq DESC, rearmed.id DESC
+    LIMIT 1
+)
+SELECT
+    COALESCE((SELECT id::text FROM latest_arm), '')::text AS arm_operation_id,
+    COALESCE((SELECT arm_operation_id FROM latest_rearm), '')::text AS rearm_arm_operation_id,
+    (
+        SELECT count(*)
+        FROM audit_logs AS rearmed
+        JOIN latest_arm ON rearmed.metadata->>'arm_operation_id' = latest_arm.id::text
+        WHERE rearmed.organization_id = @target_organization_id
+          AND rearmed.project_id IS NULL
+          AND rearmed.action = 'organization:enterprise_trial_rearmed'
+          AND rearmed.subject_id = @target_organization_id
+          AND rearmed.subject_type = 'organization'
+    )::bigint AS matching_rearm_count;
 
 -- name: GetProjectByID :one
 SELECT id, slug

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -1,10 +1,13 @@
--- name: AdminHasEnterpriseTrialRearmAudit :one
-SELECT EXISTS (
-    SELECT 1
-    FROM audit_logs
-    WHERE organization_id = @organization_id
-      AND action = 'organization:enterprise_trial_rearmed'
-);
+-- name: AdminGetLatestEnterpriseTrialRearmEndsAt :one
+-- A re-arm retry is valid only for the exact lifecycle generation recorded in
+-- the latest matching audit. The organization-first index bounds this backward
+-- seq scan, while action filtering and LIMIT 1 select one candidate.
+SELECT COALESCE(metadata->>'trial_ends_at', '')::text AS trial_ends_at
+FROM audit_logs
+WHERE organization_id = @organization_id
+  AND action = 'organization:enterprise_trial_rearmed'
+ORDER BY seq DESC
+LIMIT 1;
 
 -- name: GetProjectByID :one
 SELECT id, slug

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -260,6 +260,7 @@ func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 	// id, name and slug all differ, so an assertion on one cannot pass on another.
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tier, endsAt: endsAt, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
 	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseTrialDemotion)})
@@ -509,6 +510,20 @@ func TestRearmTrial_UnclassifiedKeyRollsBackLifecycleAndAllKeyChanges(t *testing
 	require.Equal(t, beforeOutbox, afterOutbox)
 }
 
+func seedArmAudit(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) string {
+	t.Helper()
+	operationID, err := testrepo.New(conn).SeedTrialArmAuditFixture(ctx, orgID)
+	require.NoError(t, err)
+	return operationID
+}
+
+func latestArmAuditID(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) string {
+	t.Helper()
+	operationID, err := testrepo.New(conn).GetLatestTrialArmAuditIDFixture(ctx, orgID)
+	require.NoError(t, err)
+	return operationID
+}
+
 func seedRearmAuditMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, metadata string) {
 	t.Helper()
 	err := testrepo.New(conn).SeedRearmAuditMetadataFixture(ctx, testrepo.SeedRearmAuditMetadataFixtureParams{
@@ -529,9 +544,8 @@ func TestRearmTrial_HistoricalRearmAuditDoesNotAuthorizeNewActiveGenerationRetry
 	for _, keyType := range openrouter.AllKeyTypes {
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
 	}
-	currentGeneration := readTrial(t, ctx, conn, orgID).CreatedAt.Time
-	staleGeneration := currentGeneration.Add(-time.Hour)
-	seedRearmAuditMetadata(t, ctx, conn, orgID, fmt.Sprintf(`{"trial_generation_created_at":%q}`, staleGeneration.Format(time.RFC3339Nano)))
+	seedArmAudit(t, ctx, conn, orgID)
+	seedRearmAuditMetadata(t, ctx, conn, orgID, `{"arm_operation_id":"00000000-0000-0000-0000-000000000001"}`)
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
@@ -546,8 +560,8 @@ func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
 		name     string
 		metadata string
 	}{
-		{name: "missing trial generation", metadata: `{}`},
-		{name: "malformed trial generation", metadata: `{"trial_generation_created_at":"not-a-time"}`},
+		{name: "missing arm operation", metadata: `{}`},
+		{name: "malformed arm operation", metadata: `{"arm_operation_id":"not-a-uuid"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -560,6 +574,7 @@ func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
 			for _, keyType := range openrouter.AllKeyTypes {
 				seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
 			}
+			seedArmAudit(t, ctx, conn, orgID)
 			seedRearmAuditMetadata(t, ctx, conn, orgID, tt.metadata)
 
 			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
@@ -568,6 +583,40 @@ func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
 			require.True(t, endsAt.Equal(readTrial(t, ctx, conn, orgID).EndsAt.Time))
 		})
 	}
+}
+
+func TestRearmTrial_MissingArmAuditIsRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_missing_arm_audit"
+	endsAt := time.Now().UTC().Add(14 * 24 * time.Hour).Truncate(time.Microsecond)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt})
+	seedRearmAuditMetadata(t, ctx, conn, orgID, `{"arm_operation_id":"00000000-0000-0000-0000-000000000001"}`)
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Zero(t, upstream.count())
+}
+
+func TestRearmTrial_AmbiguousRetryAuditIsRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_ambiguous_audit"
+	endsAt := time.Now().UTC().Add(14 * 24 * time.Hour).Truncate(time.Microsecond)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt})
+	armOperationID := seedArmAudit(t, ctx, conn, orgID)
+	metadata := fmt.Sprintf(`{"arm_operation_id":%q}`, armOperationID)
+	seedRearmAuditMetadata(t, ctx, conn, orgID, metadata)
+	seedRearmAuditMetadata(t, ctx, conn, orgID, metadata)
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Zero(t, upstream.count())
+	require.True(t, endsAt.Equal(readTrial(t, ctx, conn, orgID).EndsAt.Time))
 }
 
 func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing.T) {
@@ -590,6 +639,14 @@ func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing
 	}
 
 	committedEndsAt := readTrial(t, ctx, conn, orgID).EndsAt
+	rearmAudit, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	var retryMetadata struct {
+		ArmOperationID string `json:"arm_operation_id"`
+	}
+	require.NoError(t, json.Unmarshal(rearmAudit.Metadata, &retryMetadata))
+	require.Equal(t, latestArmAuditID(t, ctx, conn, orgID), retryMetadata.ArmOperationID)
+
 	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: 2})
 	require.NoError(t, err)
 	extendedEndsAt := readTrial(t, ctx, conn, orgID).EndsAt
@@ -606,6 +663,37 @@ func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing
 	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
 	require.NoError(t, err)
 	require.Equal(t, beforeOutbox+2, afterOutbox, "extension and initial re-arm each emit once; retry must not emit")
+}
+
+func TestRearmTrial_RecreatedGenerationWithSameCreatedAtRejectsStaleRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_recreated_generation"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	upstream.setFail(true)
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	committed := readTrial(t, ctx, conn, orgID)
+	staleArmOperationID := latestArmAuditID(t, ctx, conn, orgID)
+
+	err = testrepo.New(conn).RecreateTrialGenerationFixture(ctx, testrepo.RecreateTrialGenerationFixtureParams{
+		TargetOrganizationID: orgID,
+		Tier:                 "enterprise",
+		CreatedAt:            committed.CreatedAt,
+		EndsAt:               committed.EndsAt,
+	})
+	require.NoError(t, err)
+	currentArmOperationID := seedArmAudit(t, ctx, conn, orgID)
+	require.NotEqual(t, staleArmOperationID, currentArmOperationID)
+	require.Equal(t, committed.CreatedAt, readTrial(t, ctx, conn, orgID).CreatedAt, "fixture must hold timestamp precision constant")
+
+	requestsBeforeRetry := upstream.count()
+	upstream.setFail(false)
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Equal(t, requestsBeforeRetry, upstream.count(), "a stale generation must not reconcile keys")
 }
 
 func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
@@ -828,6 +916,7 @@ func TestRearmTrial_MovesEndsAtIntoTheFuture(t *testing.T) {
 	demotedAt := time.Now().UTC().Add(-99 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: longExpired, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 3})
 	require.NoError(t, err)
@@ -891,6 +980,7 @@ func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 
 		seedOrg(t, ctx, conn, orgFixture{id: tc.orgID, name: tc.orgID, slug: tc.orgID, accountType: "free", whitelisted: false})
 		seedTrial(t, ctx, conn, f)
+		seedArmAudit(t, ctx, conn, tc.orgID)
 	}
 
 	for _, tc := range cases {
@@ -1067,6 +1157,7 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
 
@@ -1097,6 +1188,7 @@ func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
@@ -1121,6 +1213,7 @@ func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
 	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: false})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
 
@@ -1384,6 +1477,7 @@ func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *test
 	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", disabledAt: &disabledAt})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, endsAt: endsAt, demotedAt: &demotedAt})
+	seedArmAudit(t, ctx, conn, orgID)
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err)

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -473,6 +474,66 @@ func TestRearmTrial_UnclassifiedKeyRollsBackLifecycleAndAllKeyChanges(t *testing
 	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
 	require.NoError(t, err)
 	require.Equal(t, beforeOutbox, afterOutbox)
+}
+
+func seedRearmAuditMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, metadata string) {
+	t.Helper()
+	_, err := conn.Exec(ctx, `
+		INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
+		VALUES ($1, 'system', 'user', 'organization:enterprise_trial_rearmed', $1, 'organization', $2::jsonb)
+	`, orgID, metadata)
+	require.NoError(t, err)
+}
+
+func TestRearmTrial_HistoricalRearmAuditDoesNotAuthorizeNewActiveGenerationRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_old_generation"
+	currentEndsAt := time.Now().UTC().Add(21 * 24 * time.Hour).Truncate(time.Microsecond)
+	oldEndsAt := currentEndsAt.Add(-7 * 24 * time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: currentEndsAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
+	}
+	seedRearmAuditMetadata(t, ctx, conn, orgID, fmt.Sprintf(`{"trial_ends_at":%q}`, oldEndsAt.Format(time.RFC3339Nano)))
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Zero(t, upstream.count(), "an unrelated generation must not reconcile keys")
+	require.True(t, currentEndsAt.Equal(readTrial(t, ctx, conn, orgID).EndsAt.Time))
+}
+
+func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		metadata string
+	}{
+		{name: "missing trial end", metadata: `{}`},
+		{name: "malformed trial end", metadata: `{"trial_ends_at":"not-a-time"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, svc, conn, upstream := newProductionRearmService(t)
+			orgID := "org_rearm_bad_metadata_" + strings.ReplaceAll(tt.name, " ", "_")
+			endsAt := time.Now().UTC().Add(14 * 24 * time.Hour).Truncate(time.Microsecond)
+			seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+			seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt})
+			for _, keyType := range openrouter.AllKeyTypes {
+				seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
+			}
+			seedRearmAuditMetadata(t, ctx, conn, orgID, tt.metadata)
+
+			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+			requireOopsCode(t, err, oops.CodeConflict)
+			require.Zero(t, upstream.count())
+			require.True(t, endsAt.Equal(readTrial(t, ctx, conn, orgID).EndsAt.Time))
+		})
+	}
 }
 
 func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing.T) {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -524,13 +524,14 @@ func TestRearmTrial_HistoricalRearmAuditDoesNotAuthorizeNewActiveGenerationRetry
 	ctx, svc, conn, upstream := newProductionRearmService(t)
 	const orgID = "org_rearm_old_generation"
 	currentEndsAt := time.Now().UTC().Add(21 * 24 * time.Hour).Truncate(time.Microsecond)
-	oldEndsAt := currentEndsAt.Add(-7 * 24 * time.Hour)
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: currentEndsAt})
 	for _, keyType := range openrouter.AllKeyTypes {
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
 	}
-	seedRearmAuditMetadata(t, ctx, conn, orgID, fmt.Sprintf(`{"trial_ends_at":%q}`, oldEndsAt.Format(time.RFC3339Nano)))
+	currentGeneration := readTrial(t, ctx, conn, orgID).CreatedAt.Time
+	staleGeneration := currentGeneration.Add(-time.Hour)
+	seedRearmAuditMetadata(t, ctx, conn, orgID, fmt.Sprintf(`{"trial_generation_created_at":%q}`, staleGeneration.Format(time.RFC3339Nano)))
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
@@ -545,8 +546,8 @@ func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
 		name     string
 		metadata string
 	}{
-		{name: "missing trial end", metadata: `{}`},
-		{name: "malformed trial end", metadata: `{"trial_ends_at":"not-a-time"}`},
+		{name: "missing trial generation", metadata: `{}`},
+		{name: "malformed trial generation", metadata: `{"trial_generation_created_at":"not-a-time"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -589,17 +590,22 @@ func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing
 	}
 
 	committedEndsAt := readTrial(t, ctx, conn, orgID).EndsAt
+	_, err = svc.ExtendTrial(ctx, &gen.ExtendTrialPayload{ID: orgID, Days: 2})
+	require.NoError(t, err)
+	extendedEndsAt := readTrial(t, ctx, conn, orgID).EndsAt
+	require.True(t, extendedEndsAt.Time.After(committedEndsAt.Time), "extension must move the same trial generation forward")
+
 	upstream.setFail(false)
 	result, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 365})
 	require.NoError(t, err)
 	require.Equal(t, orgID, result.ID)
-	require.Equal(t, committedEndsAt, readTrial(t, ctx, conn, orgID).EndsAt, "retry must not replay the lifecycle window")
+	require.Equal(t, extendedEndsAt, readTrial(t, ctx, conn, orgID).EndsAt, "retry must not replay the lifecycle window")
 	afterAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
 	require.NoError(t, err)
 	require.Equal(t, beforeAudit+1, afterAudit, "retry must not invent another lifecycle audit event")
 	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
 	require.NoError(t, err)
-	require.Equal(t, beforeOutbox+1, afterOutbox, "retry must not invent another lifecycle outbox event")
+	require.Equal(t, beforeOutbox+2, afterOutbox, "extension and initial re-arm each emit once; retry must not emit")
 }
 
 func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
+	"net/http"
+	"net/http/httptest"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -68,6 +74,45 @@ func (p *rearmProvisioner) ReinstateAPIKeyLimit(ctx context.Context, orgID strin
 
 func (p *rearmProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
 	return p.refreshAPIKeyLimit(ctx, orgID, keyType, limit)
+}
+
+func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	q := orrepo.New(db)
+	row, err := q.GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, openrouter.DisableCauseChange{}, nil
+	}
+	if err != nil {
+		return 0, openrouter.DisableCauseChange{}, err
+	}
+	if row.DisableCauses == nil {
+		return 0, openrouter.DisableCauseChange{}, errors.New("unclassified key")
+	}
+	if !slices.Contains(row.DisableCauses, string(cause)) {
+		return int(row.MonthlyCredits), openrouter.DisableCauseChange{}, nil
+	}
+	accessChanged := len(row.DisableCauses) == 1
+	keyLimit := int(row.MonthlyCredits)
+	if accessChanged && limit != nil {
+		keyLimit = *limit
+	}
+	_, err = q.RemoveOpenRouterAPIKeyDisableCause(ctx, orrepo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: orgID, KeyType: string(keyType), KeyHash: row.KeyHash, DisableCause: string(cause),
+		MonthlyCredits: int64(keyLimit), UpdateMonthlyCredits: accessChanged && int64(keyLimit) != row.MonthlyCredits,
+	})
+	return keyLimit, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, err
+}
+
+func (p *rearmProvisioner) ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
+	row, err := orrepo.New(p.conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, err = p.refreshAPIKeyLimit(ctx, orgID, keyType, conv.PtrEmpty(int(row.MonthlyCredits)))
+	return err
 }
 
 func (p *rearmProvisioner) refreshAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error) {
@@ -179,9 +224,9 @@ func seedOpenRouterKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, or
 	require.NoError(t, err)
 
 	if f.disabled {
-		require.NoError(t, keys.DisableOpenRouterAPIKey(ctx, orrepo.DisableOpenRouterAPIKeyParams{
-			OrganizationID: orgID,
-			KeyType:        string(f.keyType),
+		require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+			OrganizationID: orgID, KeyType: string(f.keyType), Disabled: true,
+			DisableCauses: []string{string(openrouter.DisableCauseTrialDemotion)},
 		}))
 	}
 }
@@ -211,6 +256,8 @@ func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tier, endsAt: endsAt, demotedAt: &demotedAt})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
+	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseTrialDemotion)})
+	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal, []string{string(openrouter.DisableCauseTrialDemotion)})
 
 	return endsAt
 }
@@ -235,6 +282,232 @@ func seedDisabledTrialRuntimeFeatures(t *testing.T, ctx context.Context, svc *Se
 	}
 }
 
+type rearmUpstream struct {
+	mu      sync.Mutex
+	patches []string
+	fail    bool
+}
+
+func (u *rearmUpstream) record(body string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.patches = append(u.patches, body)
+}
+
+func (u *rearmUpstream) setFail(fail bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.fail = fail
+}
+
+func (u *rearmUpstream) count() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.patches)
+}
+
+func newProductionRearmService(t *testing.T) (context.Context, *Service, *pgxpool.Pool, *rearmUpstream) {
+	t.Helper()
+
+	ctx, svc, conn := newTestAdminService(t)
+	upstream := &rearmUpstream{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		upstream.record(string(body))
+		upstream.mu.Lock()
+		fail := upstream.fail
+		upstream.mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		hash := r.URL.Path[len("/v1/keys/"):]
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 50}}))
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	option, err := openrouter.WithTestBaseURL(server.URL)
+	require.NoError(t, err)
+	svc.openRouter = openrouter.New(
+		testenv.NewLogger(t), testenv.NewTracerProvider(t), policy, conn, "test", "provisioning-key",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	return ctx, svc, conn, upstream
+}
+
+func classifyRearmKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, keyType openrouter.KeyType, causes []string) {
+	t.Helper()
+	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID, KeyType: string(keyType), Disabled: len(causes) > 0, DisableCauses: causes,
+	}))
+}
+
+func TestRearmTrial_RemovesOnlyTrialDemotionForBothKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_causes"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	for _, keyType := range openrouter.AllKeyTypes {
+		classifyRearmKey(t, ctx, conn, orgID, keyType, []string{string(openrouter.DisableCauseTrialDemotion)})
+	}
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+
+	for _, keyType := range openrouter.AllKeyTypes {
+		row := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.Empty(t, row.DisableCauses)
+		require.False(t, row.Disabled)
+		require.EqualValues(t, 50, row.MonthlyCredits, "last-cause removal restores active-trial policy for %s", keyType)
+	}
+	require.Equal(t, len(openrouter.AllKeyTypes), upstream.count())
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, true, metadata["key_access_changed"])
+}
+
+func TestRearmTrial_PreservesLayeredProtectionAndCaps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		cause openrouter.DisableCause
+		limit int64
+	}{
+		{name: "admin lock preserves zero cap", cause: openrouter.DisableCauseAdminLock, limit: 0},
+		{name: "billing inactive preserves cap", cause: openrouter.DisableCauseBillingInactive, limit: 23},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, svc, conn, upstream := newProductionRearmService(t)
+			orgID := "org_rearm_layered_" + string(tt.cause)
+			seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+			for _, keyType := range openrouter.AllKeyTypes {
+				classifyRearmKey(t, ctx, conn, orgID, keyType, []string{string(tt.cause), string(openrouter.DisableCauseTrialDemotion)})
+				row := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+				_, err := orrepo.New(conn).UpdateOpenRouterKey(ctx, orrepo.UpdateOpenRouterKeyParams{OrganizationID: orgID, KeyType: string(keyType), KeyHash: row.KeyHash, MonthlyCredits: tt.limit, Reinstate: false})
+				require.NoError(t, err)
+			}
+
+			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+			require.NoError(t, err)
+			for _, keyType := range openrouter.AllKeyTypes {
+				row := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+				require.Equal(t, []string{string(tt.cause)}, row.DisableCauses)
+				require.True(t, row.Disabled)
+				require.Equal(t, tt.limit, row.MonthlyCredits)
+			}
+			require.Zero(t, upstream.count(), "a remaining cause must keep protected local state without HTTP")
+		})
+	}
+}
+
+func TestRearmTrial_AbsentCauseHasNoKeySideEffectOrInventedAccessAudit(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_absent_cause"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	for _, keyType := range openrouter.AllKeyTypes {
+		classifyRearmKey(t, ctx, conn, orgID, keyType, []string{string(openrouter.DisableCauseAdminLock)})
+	}
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+	require.Zero(t, upstream.count())
+	for _, keyType := range openrouter.AllKeyTypes {
+		row := readOpenRouterKey(t, ctx, conn, orgID, keyType)
+		require.Equal(t, []string{string(openrouter.DisableCauseAdminLock)}, row.DisableCauses)
+		require.True(t, row.Disabled)
+	}
+
+	entry, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, false, metadata["key_access_changed"])
+}
+
+func TestRearmTrial_UnclassifiedKeyRollsBackLifecycleAndAllKeyChanges(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_null_causes"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, orgID)
+	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseTrialDemotion)})
+	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal, nil)
+	beforeTrial := readTrial(t, ctx, conn, orgID)
+	beforeAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.Zero(t, upstream.count(), "no HTTP belongs inside the transaction or after rollback")
+	afterTrial := readTrial(t, ctx, conn, orgID)
+	require.Equal(t, beforeTrial.DemotedAt, afterTrial.DemotedAt)
+	require.Equal(t, beforeTrial.EndsAt, afterTrial.EndsAt)
+	require.Equal(t, []string{string(openrouter.DisableCauseTrialDemotion)}, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).DisableCauses)
+	require.Nil(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).DisableCauses)
+	require.Equal(t, "free", readOrgState(t, ctx, conn, orgID).GramAccountType)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		enabled, featureErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, featureErr)
+		require.False(t, enabled)
+	}
+	afterAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	require.Equal(t, beforeAudit, afterAudit)
+	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeOutbox, afterOutbox)
+}
+
+func TestRearmTrial_PostCommitReconcileFailureConvergesOnRequestRetry(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_reconcile_retry"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+	upstream.setFail(true)
+	beforeAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	require.False(t, readTrial(t, ctx, conn, orgID).DemotedAt.Valid, "the local transaction commits before HTTP reconciliation")
+	for _, keyType := range openrouter.AllKeyTypes {
+		require.Empty(t, readOpenRouterKey(t, ctx, conn, orgID, keyType).DisableCauses)
+	}
+
+	committedEndsAt := readTrial(t, ctx, conn, orgID).EndsAt
+	upstream.setFail(false)
+	result, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 365})
+	require.NoError(t, err)
+	require.Equal(t, orgID, result.ID)
+	require.Equal(t, committedEndsAt, readTrial(t, ctx, conn, orgID).EndsAt, "retry must not replay the lifecycle window")
+	afterAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
+	require.NoError(t, err)
+	require.Equal(t, beforeAudit+1, afterAudit, "retry must not invent another lifecycle audit event")
+	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeOutbox+1, afterOutbox, "retry must not invent another lifecycle outbox event")
+}
+
 func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	t.Parallel()
 
@@ -251,7 +524,7 @@ func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {
 	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
 	require.Equal(t, map[openrouter.KeyType]*int{
 		openrouter.KeyTypeChat:     conv.PtrEmpty(50),
-		openrouter.KeyTypeInternal: conv.PtrEmpty(37),
+		openrouter.KeyTypeInternal: conv.PtrEmpty(50),
 	}, provisioner.revivedLimits(), "every key type the demotion disables must come back up on its own ceiling")
 	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeChat).Disabled)
 	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm", openrouter.KeyTypeInternal).Disabled)
@@ -299,6 +572,123 @@ func TestRearmTrial_DoesNotRestartLoopsSequence(t *testing.T) {
 	require.Empty(t, notifier.inactive)
 }
 
+func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_rearm_lock_order"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+
+	rowLock := testenv.BeginTx(t, ctx, conn)
+	_, err := rowLock.Exec(ctx, `SELECT 1 FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID)
+	require.NoError(t, err)
+
+	rearmed := make(chan error, 1)
+	go func() {
+		_, callErr := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+		rearmed <- callErr
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelWait()
+	requireAdminCondition(t, waitCtx, conn, func(check context.Context) (bool, error) {
+		var blocked bool
+		err := conn.QueryRow(check, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_stat_activity
+				WHERE datname = current_database()
+				  AND state = 'active'
+				  AND wait_event_type = 'Lock'
+				  AND query LIKE '%SELECT tier, ends_at, converted_at, demoted_at%'
+			)
+		`).Scan(&blocked)
+		return blocked, err
+	}, "re-arm did not block on the lifecycle row")
+
+	probe, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer probe.Release()
+	for _, keyType := range openrouter.AllKeyTypes {
+		var acquired bool
+		require.NoError(t, probe.QueryRow(ctx, `SELECT pg_try_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(keyType), orgID).Scan(&acquired))
+		require.Truef(t, acquired, "%s lock must remain available while lifecycle is blocked", keyType)
+		var unlocked bool
+		require.NoError(t, probe.QueryRow(ctx, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(keyType), orgID).Scan(&unlocked))
+		require.True(t, unlocked)
+	}
+
+	internalLock, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer internalLock.Release()
+	_, err = internalLock.Exec(ctx, `SELECT pg_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID)
+	require.NoError(t, err)
+	internalHeld := true
+	defer func() {
+		if internalHeld {
+			_, _ = internalLock.Exec(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID)
+		}
+	}()
+
+	require.NoError(t, rowLock.Commit(ctx))
+	chatCtx, cancelChat := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelChat()
+	requireAdminCondition(t, chatCtx, conn, func(check context.Context) (bool, error) {
+		var acquired bool
+		err := probe.QueryRow(check, `SELECT pg_try_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeChat), orgID).Scan(&acquired)
+		if err != nil || !acquired {
+			return !acquired, err
+		}
+		var unlocked bool
+		err = probe.QueryRow(check, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeChat), orgID).Scan(&unlocked)
+		return false, err
+	}, "chat lock was not acquired before the blocked internal lock")
+
+	keyProbe := testenv.BeginTx(t, ctx, conn)
+	rows, err := keyProbe.Query(ctx, `SELECT disable_causes FROM openrouter_api_keys WHERE organization_id = $1 ORDER BY key_type FOR UPDATE NOWAIT`, orgID)
+	require.NoError(t, err, "key rows must remain unlocked until every advisory lock is held")
+	count := 0
+	for rows.Next() {
+		count++
+		var causes []string
+		require.NoError(t, rows.Scan(&causes))
+		require.Equal(t, []string{string(openrouter.DisableCauseTrialDemotion)}, causes)
+	}
+	require.NoError(t, rows.Err())
+	rows.Close()
+	require.Equal(t, len(openrouter.AllKeyTypes), count)
+	require.NoError(t, keyProbe.Rollback(ctx))
+
+	var unlocked bool
+	require.NoError(t, internalLock.QueryRow(ctx, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID).Scan(&unlocked))
+	require.True(t, unlocked)
+	internalHeld = false
+
+	select {
+	case err := <-rearmed:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "re-arm did not finish after releasing locks")
+	}
+}
+
+func requireAdminCondition(t *testing.T, ctx context.Context, _ *pgxpool.Pool, condition func(context.Context) (bool, error), message string) {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		met, err := condition(ctx)
+		require.NoError(t, err)
+		if met {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			require.FailNow(t, message, ctx.Err().Error())
+		case <-ticker.C:
+		}
+	}
+}
+
 // MarkTrialDemoted only demotes an already-past ends_at, so a re-arm that
 // cleared the stamp and left the date would be re-demoted on the next sweep.
 // The trial here ended 100 days ago, so a date computed from it is still past.
@@ -330,67 +720,6 @@ func TestRearmTrial_MovesEndsAtIntoTheFuture(t *testing.T) {
 	require.NoError(t, err, "a re-armed trial must be extendable")
 }
 
-// The fake reads through the pool, so while the handler's transaction is open
-// the organization must still read free and the trial must still read demoted.
-func TestRearmTrial_RevivesKeysBeforeTheRestoreCommits(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, provisioner := newRearmService(t)
-	seedDemotedTrial(t, ctx, conn, "org_rearm_order", "enterprise")
-
-	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_order", Days: 14})
-	require.NoError(t, err)
-
-	require.Len(t, provisioner.revivals, len(openrouter.AllKeyTypes))
-	for _, revival := range provisioner.revivals {
-		require.Equal(t, "free", revival.accountTypeSeen,
-			"the %s key must come back up before the restore commits, or a failure leaves a running trial with dead keys", revival.keyType)
-		require.True(t, revival.demotedSeen,
-			"the %s key must come back up while the trial still reads demoted", revival.keyType)
-	}
-}
-
-// The failure lands on the second key type, so the first is already back up.
-func TestRearmTrial_KeyRevivalFailureLeavesTheOrganizationDemoted(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn := newTestAdminService(t)
-	provisioner := &rearmProvisioner{
-		conn:      conn,
-		mu:        sync.Mutex{},
-		revivals:  nil,
-		failOn:    openrouter.KeyTypeInternal,
-		failAfter: 0,
-		failWith:  errors.New("openrouter is down"),
-	}
-	svc.openRouter = provisioner
-
-	seededEndsAt := seedDemotedTrial(t, ctx, conn, "org_rearm_fail", "enterprise")
-	auditsBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
-	require.NoError(t, err)
-
-	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_fail", Days: 14})
-	requireOopsCode(t, err, oops.CodeGatewayError)
-
-	after := readTrial(t, ctx, conn, "org_rearm_fail")
-	require.True(t, after.DemotedAt.Valid, "a failed re-arm must leave the trial demoted")
-	require.WithinDuration(t, seededEndsAt, after.EndsAt.Time, time.Second, "a failed re-arm must not move ends_at")
-
-	state := readOrgState(t, ctx, conn, "org_rearm_fail")
-	require.Equal(t, "free", state.GramAccountType, "a failed re-arm must not restore the account type")
-	require.False(t, state.Whitelisted)
-
-	auditsAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
-	require.NoError(t, err)
-	require.Equal(t, auditsBefore, auditsAfter, "a failed re-arm must not claim one happened")
-
-	require.False(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeChat).Disabled,
-		"a revived key must survive the rollback, which is what makes a retry cheap")
-	require.True(t, readOpenRouterKey(t, ctx, conn, "org_rearm_fail", openrouter.KeyTypeInternal).Disabled)
-}
-
-// Walks the guard's whole eight-row state space. The demoted-and-not-expired
-// row is unreachable today, and is here because the query does not test ends_at.
 func TestRearmTrial_OnlyADemotedTrialCanBeRearmed(t *testing.T) {
 	t.Parallel()
 
@@ -605,7 +934,7 @@ func TestRearmTrial_ReleasesRejectedTransactionBeforeClassificationLookup(t *tes
 func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	t.Parallel()
 
-	ctx, svc, conn, provisioner := newRearmService(t)
+	ctx, svc, conn, _ := newProductionRearmService(t)
 
 	orgID := "org_rearm_nokeys"
 	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
@@ -618,9 +947,12 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err, "an organization with no key of a type must still be re-armable")
 
-	//nolint:exhaustive // the absent key type is the assertion: it must not appear
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeChat: conv.PtrEmpty(50)}, provisioner.revivedLimits(),
-		"a key type the organization has no row for must not be refreshed")
+	chat := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	require.Empty(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
+	require.EqualValues(t, 50, chat.MonthlyCredits)
+	_, err = orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "missing key types remain safe and absent")
 
 	state := readOrgState(t, ctx, conn, orgID)
 	require.Equal(t, "enterprise", state.GramAccountType)
@@ -632,7 +964,7 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	t.Parallel()
 
-	ctx, svc, conn, provisioner := newRearmService(t)
+	ctx, svc, conn, _ := newProductionRearmService(t)
 
 	orgID := "org_rearm_internal_only"
 	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
@@ -644,10 +976,12 @@ func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err)
 
-	//nolint:exhaustive // the absent key type is the assertion: it must not appear
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
-		"a key that follows an absent one must still come back up")
-	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
+	internal := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal)
+	require.Empty(t, internal.DisableCauses)
+	require.False(t, internal.Disabled)
+	require.EqualValues(t, 50, internal.MonthlyCredits)
+	_, err = orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "a missing first key must not stop processing the second")
 }
 
 // A live key needs no round trip, which is what makes retrying a re-arm cheap.
@@ -668,87 +1002,10 @@ func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
 	require.NoError(t, err)
 
 	//nolint:exhaustive // the omitted key type is the assertion: it was already live
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
-		"an already-enabled key needs no upstream round trip")
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(50)}, provisioner.revivedLimits(),
+		"only the key carrying trial_demotion needs reconciliation")
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
-}
-
-// A key minted before the ceiling column existed records none, so its revival
-// resolves one from the pool: pre-commit that reads a free organization and
-// answers the free-tier allowance. Nothing else corrects it on a schedule.
-func TestRearmTrial_ZeroCeilingKeyIsRecappedAfterTheRestoreCommits(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, provisioner := newRearmService(t)
-
-	orgID := "org_rearm_zero_ceiling"
-	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
-	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
-	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
-	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 0, disabled: true})
-	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
-
-	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
-	require.NoError(t, err)
-
-	var chat, internal []keyRevival
-	for _, r := range provisioner.revivals {
-		if r.keyType == openrouter.KeyTypeChat {
-			chat = append(chat, r)
-			continue
-		}
-		internal = append(internal, r)
-	}
-
-	// A second ask for this row would overwrite a ceiling raised by hand.
-	require.Len(t, internal, 1, "a key with a recorded ceiling must not be asked twice")
-	require.Equal(t, conv.PtrEmpty(37), internal[0].limit)
-
-	require.Len(t, chat, 2, "a key with no recorded ceiling must be asked again after the commit")
-	require.Nil(t, chat[0].limit, "the first ask has no ceiling to pass")
-	require.Equal(t, "free", chat[0].accountTypeSeen, "the first ask runs before the restore commits")
-	require.True(t, chat[0].demotedSeen)
-
-	require.Nil(t, chat[1].limit, "the second ask resolves the ceiling rather than passing the stale one")
-	require.Equal(t, "enterprise", chat[1].accountTypeSeen, "the second ask must see the committed restore, or it resolves the same free-tier ceiling again")
-	require.False(t, chat[1].demotedSeen, "the second ask must see the trial running, or defaultLimitForOrg misses it")
-
-	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
-}
-
-// The re-arm is already committed, so an error here would misreport it.
-func TestRearmTrial_RecapFailureStillReportsSuccess(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, provisioner := newRearmService(t)
-
-	orgID := "org_rearm_recap_fails"
-	endsAt := time.Now().UTC().Add(-10 * 24 * time.Hour)
-	demotedAt := time.Now().UTC().Add(-9 * 24 * time.Hour)
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
-	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
-	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 0, disabled: true})
-
-	// Failing every call would abort at the revival and never reach the recap.
-	provisioner.failAfter = 1
-	provisioner.failWith = errors.New("openrouter is down")
-
-	res, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
-	require.NoError(t, err, "a failed recap must not report the committed re-arm as failed")
-	require.Equal(t, orgID, res.ID)
-
-	// Without this the test passes on an implementation that never recaps.
-	require.Len(t, provisioner.revivals, 2, "the recap must have been attempted")
-	failed := provisioner.revivals[1]
-	require.Nil(t, failed.limit)
-	require.Equal(t, "enterprise", failed.accountTypeSeen, "the swallowed failure must be the post-commit ask")
-
-	state := readOrgState(t, ctx, conn, orgID)
-	require.Equal(t, "enterprise", state.GramAccountType)
-	require.True(t, state.Whitelisted)
-	require.False(t, readTrial(t, ctx, conn, orgID).DemotedAt.Valid)
 }
 
 func TestRearmTrial_WritesAnAuditEntry(t *testing.T) {
@@ -989,25 +1246,6 @@ func TestRearmTrial_TouchesOnlyTheTargetRow(t *testing.T) {
 
 // A half-failed re-arm ends with the operator pressing the button again. The
 // second call must be a conflict, or re-arm becomes an unbounded extend.
-func TestRearmTrial_IsIdempotentAcrossARetry(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, _ := newRearmService(t)
-	seedDemotedTrial(t, ctx, conn, "org_rearm_twice", "enterprise")
-
-	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_twice", Days: 14})
-	require.NoError(t, err)
-	first := readTrial(t, ctx, conn, "org_rearm_twice")
-
-	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: "org_rearm_twice", Days: 365})
-	requireOopsCode(t, err, oops.CodeConflict)
-
-	second := readTrial(t, ctx, conn, "org_rearm_twice")
-	require.Equal(t, first.EndsAt.Time, second.EndsAt.Time,
-		"a second re-arm must not move a trial that is already running")
-	require.Equal(t, first.UpdatedAt.Time, second.UpdatedAt.Time)
-}
-
 func TestRearmTrial_RestoresADisabledOrganizationsTrialWithoutEnablingIt(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -261,6 +261,7 @@ func seedDemotedTrial(t *testing.T, ctx context.Context, conn *pgxpool.Pool, org
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID + " Name", slug: orgID + "-slug", accountType: "free", whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tier, endsAt: endsAt, demotedAt: &demotedAt})
 	seedArmAudit(t, ctx, conn, orgID)
+	require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 50, disabled: true})
 	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 37, disabled: true})
 	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseTrialDemotion)})
@@ -533,7 +534,7 @@ func seedRearmAuditMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Poo
 	require.NoError(t, err)
 }
 
-func TestRearmTrial_HistoricalRearmAuditDoesNotAuthorizeNewActiveGenerationRetry(t *testing.T) {
+func TestRearmTrial_PriorCycleRearmAuditDoesNotAuthorizeCurrentCycleRetry(t *testing.T) {
 	t.Parallel()
 
 	ctx, svc, conn, upstream := newProductionRearmService(t)
@@ -544,8 +545,10 @@ func TestRearmTrial_HistoricalRearmAuditDoesNotAuthorizeNewActiveGenerationRetry
 	for _, keyType := range openrouter.AllKeyTypes {
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
 	}
-	seedArmAudit(t, ctx, conn, orgID)
-	seedRearmAuditMetadata(t, ctx, conn, orgID, `{"arm_operation_id":"00000000-0000-0000-0000-000000000001"}`)
+	armOperationID := seedArmAudit(t, ctx, conn, orgID)
+	require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
+	seedRearmAuditMetadata(t, ctx, conn, orgID, fmt.Sprintf(`{"arm_operation_id":%q}`, armOperationID))
+	require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
 
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
@@ -575,6 +578,7 @@ func TestRearmTrial_MalformedOrMissingRetryMetadataIsRejected(t *testing.T) {
 				seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 50, disabled: false})
 			}
 			seedArmAudit(t, ctx, conn, orgID)
+			require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
 			seedRearmAuditMetadata(t, ctx, conn, orgID, tt.metadata)
 
 			_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
@@ -609,6 +613,7 @@ func TestRearmTrial_AmbiguousRetryAuditIsRejected(t *testing.T) {
 	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt})
 	armOperationID := seedArmAudit(t, ctx, conn, orgID)
+	require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
 	metadata := fmt.Sprintf(`{"arm_operation_id":%q}`, armOperationID)
 	seedRearmAuditMetadata(t, ctx, conn, orgID, metadata)
 	seedRearmAuditMetadata(t, ctx, conn, orgID, metadata)
@@ -694,6 +699,37 @@ func TestRearmTrial_RecreatedGenerationWithSameCreatedAtRejectsStaleRetry(t *tes
 	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	requireOopsCode(t, err, oops.CodeConflict)
 	require.Equal(t, requestsBeforeRetry, upstream.count(), "a stale generation must not reconcile keys")
+}
+
+func TestRearmTrial_RetryUsesOnlyCurrentDemotionCycle(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, upstream := newProductionRearmService(t)
+	const orgID = "org_rearm_current_demotion_cycle"
+	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
+
+	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+	firstCyclePatches := upstream.count()
+	require.Positive(t, firstCyclePatches)
+
+	require.NoError(t, testrepo.New(conn).RedemoteTrialLifecycleFixture(ctx, orgID))
+	require.NoError(t, testrepo.New(conn).SeedTrialDemotionAuditFixture(ctx, orgID))
+	for _, keyType := range openrouter.AllKeyTypes {
+		classifyRearmKey(t, ctx, conn, orgID, keyType, []string{string(openrouter.DisableCauseTrialDemotion)})
+	}
+
+	upstream.setFail(true)
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	requireOopsCode(t, err, oops.CodeGatewayError)
+	failedCyclePatches := upstream.count()
+	require.Greater(t, failedCyclePatches, firstCyclePatches)
+	require.False(t, readTrial(t, ctx, conn, orgID).DemotedAt.Valid, "re-arm commit must survive its post-commit reconciliation failure")
+
+	upstream.setFail(false)
+	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
+	require.NoError(t, err)
+	require.Greater(t, upstream.count(), failedCyclePatches, "retry must reconcile the committed current cycle")
 }
 
 func TestRearmTrial_RestoresTheOrganizationAndRevivesEveryKey(t *testing.T) {

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -672,6 +672,31 @@ func TestRearmTrial_DoesNotRestartLoopsSequence(t *testing.T) {
 	require.Empty(t, notifier.inactive)
 }
 
+func TestOpenRouterKeyLockProbeIgnoresSoftDeletedRows(t *testing.T) {
+	t.Parallel()
+
+	ctx, _, conn, _ := newRearmService(t)
+	const orgID = "org_rearm_probe_deleted"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, disabled: true})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, disabled: true})
+	fixtures := testrepo.New(conn)
+	require.NoError(t, fixtures.SoftDeleteOpenRouterAPIKeyFixture(ctx, testrepo.SoftDeleteOpenRouterAPIKeyFixtureParams{
+		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal),
+	}))
+
+	deletedRowLock := testenv.BeginTx(t, ctx, conn)
+	_, err := testrepo.New(deletedRowLock).LockOpenRouterAPIKeyForUpdateFixture(ctx, testrepo.LockOpenRouterAPIKeyForUpdateFixtureParams{
+		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, deletedRowLock.Rollback(ctx)) }()
+
+	activeCauses, err := testrepo.New(conn).ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture(ctx, orgID)
+	require.NoError(t, err, "soft-deleted key must not participate in the lock probe")
+	require.Equal(t, [][]string{{"trial_demotion"}}, activeCauses)
+}
+
 func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -84,7 +85,7 @@ func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, d
 		return 0, openrouter.DisableCauseChange{}, nil
 	}
 	if err != nil {
-		return 0, openrouter.DisableCauseChange{}, err
+		return 0, openrouter.DisableCauseChange{}, fmt.Errorf("get OpenRouter API key: %w", err)
 	}
 	if row.DisableCauses == nil {
 		return 0, openrouter.DisableCauseChange{}, errors.New("unclassified key")
@@ -101,7 +102,11 @@ func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, d
 		OrganizationID: orgID, KeyType: string(keyType), KeyHash: row.KeyHash, DisableCause: string(cause),
 		MonthlyCredits: int64(keyLimit), UpdateMonthlyCredits: accessChanged && int64(keyLimit) != row.MonthlyCredits,
 	})
-	return keyLimit, openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, err
+	change := openrouter.DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}
+	if err != nil {
+		return keyLimit, change, fmt.Errorf("remove OpenRouter API key disable cause: %w", err)
+	}
+	return keyLimit, change, nil
 }
 
 func (p *rearmProvisioner) ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
@@ -110,7 +115,7 @@ func (p *rearmProvisioner) ReconcileAPIKeyDisabled(ctx context.Context, orgID st
 		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("get OpenRouter API key for reconciliation: %w", err)
 	}
 	_, err = p.refreshAPIKeyLimit(ctx, orgID, keyType, conv.PtrEmpty(int(row.MonthlyCredits)))
 	return err
@@ -284,15 +289,30 @@ func seedDisabledTrialRuntimeFeatures(t *testing.T, ctx context.Context, svc *Se
 }
 
 type rearmUpstream struct {
-	mu      sync.Mutex
-	patches []string
-	fail    bool
+	mu         sync.Mutex
+	patches    []string
+	fail       bool
+	handlerErr error
 }
 
 func (u *rearmUpstream) record(body string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	u.patches = append(u.patches, body)
+}
+
+func (u *rearmUpstream) recordHandlerError(err error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.handlerErr == nil {
+		u.handlerErr = err
+	}
+}
+
+func (u *rearmUpstream) getHandlerError() error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.handlerErr
 }
 
 func (u *rearmUpstream) setFail(fail bool) {
@@ -313,9 +333,17 @@ func newProductionRearmService(t *testing.T) (context.Context, *Service, *pgxpoo
 	ctx, svc, conn := newTestAdminService(t)
 	upstream := &rearmUpstream{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPatch, r.Method)
+		if r.Method != http.MethodPatch {
+			upstream.recordHandlerError(fmt.Errorf("unexpected request method: %s", r.Method))
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			upstream.recordHandlerError(fmt.Errorf("read request body: %w", err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		upstream.record(string(body))
 		upstream.mu.Lock()
 		fail := upstream.fail
@@ -326,9 +354,14 @@ func newProductionRearmService(t *testing.T) (context.Context, *Service, *pgxpoo
 		}
 		w.Header().Set("Content-Type", "application/json")
 		hash := r.URL.Path[len("/v1/keys/"):]
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 50}}))
+		if err := json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 50}}); err != nil {
+			upstream.recordHandlerError(fmt.Errorf("encode response: %w", err))
+		}
 	}))
-	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		server.Close()
+		require.NoError(t, upstream.getHandlerError())
+	})
 
 	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
 	require.NoError(t, err)
@@ -478,10 +511,10 @@ func TestRearmTrial_UnclassifiedKeyRollsBackLifecycleAndAllKeyChanges(t *testing
 
 func seedRearmAuditMetadata(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string, metadata string) {
 	t.Helper()
-	_, err := conn.Exec(ctx, `
-		INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
-		VALUES ($1, 'system', 'user', 'organization:enterprise_trial_rearmed', $1, 'organization', $2::jsonb)
-	`, orgID, metadata)
+	err := testrepo.New(conn).SeedRearmAuditMetadataFixture(ctx, testrepo.SeedRearmAuditMetadataFixtureParams{
+		OrganizationID: orgID,
+		Metadata:       []byte(metadata),
+	})
 	require.NoError(t, err)
 }
 
@@ -641,7 +674,7 @@ func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
 
 	rowLock := testenv.BeginTx(t, ctx, conn)
-	_, err := rowLock.Exec(ctx, `SELECT 1 FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID)
+	_, err := trialsRepo.New(rowLock).LockTrialLifecycleForRearm(ctx, orgID)
 	require.NoError(t, err)
 
 	rearmed := make(chan error, 1)
@@ -653,40 +686,39 @@ func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
 	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
 	defer cancelWait()
 	requireAdminCondition(t, waitCtx, conn, func(check context.Context) (bool, error) {
-		var blocked bool
-		err := conn.QueryRow(check, `
-			SELECT EXISTS (
-				SELECT 1 FROM pg_stat_activity
-				WHERE datname = current_database()
-				  AND state = 'active'
-				  AND wait_event_type = 'Lock'
-				  AND query LIKE '%SELECT tier, ends_at, converted_at, demoted_at%'
-			)
-		`).Scan(&blocked)
-		return blocked, err
+		blocked, err := testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%SELECT tier, ends_at, converted_at, demoted_at%")
+		if err != nil {
+			return false, fmt.Errorf("check blocked trial re-arm query: %w", err)
+		}
+		return blocked, nil
 	}, "re-arm did not block on the lifecycle row")
 
 	probe, err := conn.Acquire(ctx)
 	require.NoError(t, err)
 	defer probe.Release()
 	for _, keyType := range openrouter.AllKeyTypes {
-		var acquired bool
-		require.NoError(t, probe.QueryRow(ctx, `SELECT pg_try_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(keyType), orgID).Scan(&acquired))
+		acquired, err := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(ctx, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{
+			KeyType: string(keyType), OrganizationID: orgID,
+		})
+		require.NoError(t, err)
 		require.Truef(t, acquired, "%s lock must remain available while lifecycle is blocked", keyType)
-		var unlocked bool
-		require.NoError(t, probe.QueryRow(ctx, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(keyType), orgID).Scan(&unlocked))
+		unlocked, err := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{
+			OrganizationID: orgID, KeyType: string(keyType),
+		})
+		require.NoError(t, err)
 		require.True(t, unlocked)
 	}
 
 	internalLock, err := conn.Acquire(ctx)
 	require.NoError(t, err)
 	defer internalLock.Release()
-	_, err = internalLock.Exec(ctx, `SELECT pg_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID)
+	internalParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
+	err = activitiesrepo.New(internalLock).AcquireOpenRouterKeyBillingLock(ctx, internalParams)
 	require.NoError(t, err)
 	internalHeld := true
 	defer func() {
 		if internalHeld {
-			_, _ = internalLock.Exec(context.WithoutCancel(ctx), `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID)
+			_, _ = activitiesrepo.New(internalLock).ReleaseOpenRouterKeyBillingLock(context.WithoutCancel(ctx), activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
 		}
 	}()
 
@@ -694,33 +726,35 @@ func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
 	chatCtx, cancelChat := context.WithTimeout(ctx, 2*time.Second)
 	defer cancelChat()
 	requireAdminCondition(t, chatCtx, conn, func(check context.Context) (bool, error) {
-		var acquired bool
-		err := probe.QueryRow(check, `SELECT pg_try_advisory_lock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeChat), orgID).Scan(&acquired)
-		if err != nil || !acquired {
-			return !acquired, err
+		acquired, err := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(check, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{
+			KeyType: string(openrouter.KeyTypeChat), OrganizationID: orgID,
+		})
+		if err != nil {
+			return false, fmt.Errorf("probe chat billing lock: %w", err)
 		}
-		var unlocked bool
-		err = probe.QueryRow(check, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeChat), orgID).Scan(&unlocked)
-		return false, err
+		if !acquired {
+			return true, nil
+		}
+		_, err = activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(check, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{
+			OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat),
+		})
+		if err != nil {
+			return false, fmt.Errorf("release chat billing lock probe: %w", err)
+		}
+		return false, nil
 	}, "chat lock was not acquired before the blocked internal lock")
 
 	keyProbe := testenv.BeginTx(t, ctx, conn)
-	rows, err := keyProbe.Query(ctx, `SELECT disable_causes FROM openrouter_api_keys WHERE organization_id = $1 ORDER BY key_type FOR UPDATE NOWAIT`, orgID)
+	causesByKey, err := testrepo.New(keyProbe).ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture(ctx, orgID)
 	require.NoError(t, err, "key rows must remain unlocked until every advisory lock is held")
-	count := 0
-	for rows.Next() {
-		count++
-		var causes []string
-		require.NoError(t, rows.Scan(&causes))
+	for _, causes := range causesByKey {
 		require.Equal(t, []string{string(openrouter.DisableCauseTrialDemotion)}, causes)
 	}
-	require.NoError(t, rows.Err())
-	rows.Close()
-	require.Equal(t, len(openrouter.AllKeyTypes), count)
+	require.Len(t, causesByKey, len(openrouter.AllKeyTypes))
 	require.NoError(t, keyProbe.Rollback(ctx))
 
-	var unlocked bool
-	require.NoError(t, internalLock.QueryRow(ctx, `SELECT pg_advisory_unlock(hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0))`, string(openrouter.KeyTypeInternal), orgID).Scan(&unlocked))
+	unlocked, err := activitiesrepo.New(internalLock).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
+	require.NoError(t, err)
 	require.True(t, unlocked)
 	internalHeld = false
 

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -158,6 +158,25 @@ func (q *Queries) AdminEnableOrganization(ctx context.Context, id string) (int64
 	return result.RowsAffected(), nil
 }
 
+const adminGetLatestEnterpriseTrialRearmEndsAt = `-- name: AdminGetLatestEnterpriseTrialRearmEndsAt :one
+SELECT COALESCE(metadata->>'trial_ends_at', '')::text AS trial_ends_at
+FROM audit_logs
+WHERE organization_id = $1
+  AND action = 'organization:enterprise_trial_rearmed'
+ORDER BY seq DESC
+LIMIT 1
+`
+
+// A re-arm retry is valid only for the exact lifecycle generation recorded in
+// the latest matching audit. The organization-first index bounds this backward
+// seq scan, while action filtering and LIMIT 1 select one candidate.
+func (q *Queries) AdminGetLatestEnterpriseTrialRearmEndsAt(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, adminGetLatestEnterpriseTrialRearmEndsAt, organizationID)
+	var trial_ends_at string
+	err := row.Scan(&trial_ends_at)
+	return trial_ends_at, err
+}
+
 const adminGetOrganization = `-- name: AdminGetOrganization :one
 SELECT
     om.id,
@@ -375,22 +394,6 @@ func (q *Queries) AdminGetProjectDetailByID(ctx context.Context, id uuid.UUID) (
 		&i.AssistantCount,
 	)
 	return i, err
-}
-
-const adminHasEnterpriseTrialRearmAudit = `-- name: AdminHasEnterpriseTrialRearmAudit :one
-SELECT EXISTS (
-    SELECT 1
-    FROM audit_logs
-    WHERE organization_id = $1
-      AND action = 'organization:enterprise_trial_rearmed'
-)
-`
-
-func (q *Queries) AdminHasEnterpriseTrialRearmAudit(ctx context.Context, organizationID string) (bool, error) {
-	row := q.db.QueryRow(ctx, adminHasEnterpriseTrialRearmAudit, organizationID)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
 }
 
 const adminListOrganizationMembers = `-- name: AdminListOrganizationMembers :many

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -158,8 +158,8 @@ func (q *Queries) AdminEnableOrganization(ctx context.Context, id string) (int64
 	return result.RowsAffected(), nil
 }
 
-const adminGetLatestEnterpriseTrialRearmEndsAt = `-- name: AdminGetLatestEnterpriseTrialRearmEndsAt :one
-SELECT COALESCE(metadata->>'trial_ends_at', '')::text AS trial_ends_at
+const adminGetLatestEnterpriseTrialRearmGeneration = `-- name: AdminGetLatestEnterpriseTrialRearmGeneration :one
+SELECT COALESCE(metadata->>'trial_generation_created_at', '')::text AS trial_generation_created_at
 FROM audit_logs
 WHERE organization_id = $1
   AND action = 'organization:enterprise_trial_rearmed'
@@ -167,14 +167,14 @@ ORDER BY seq DESC
 LIMIT 1
 `
 
-// A re-arm retry is valid only for the exact lifecycle generation recorded in
-// the latest matching audit. The organization-first index bounds this backward
-// seq scan, while action filtering and LIMIT 1 select one candidate.
-func (q *Queries) AdminGetLatestEnterpriseTrialRearmEndsAt(ctx context.Context, organizationID string) (string, error) {
-	row := q.db.QueryRow(ctx, adminGetLatestEnterpriseTrialRearmEndsAt, organizationID)
-	var trial_ends_at string
-	err := row.Scan(&trial_ends_at)
-	return trial_ends_at, err
+// A post-commit retry is valid only for the immutable trial-row generation
+// recorded in the latest matching audit. Extensions intentionally change ends_at
+// without creating a new generation.
+func (q *Queries) AdminGetLatestEnterpriseTrialRearmGeneration(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, adminGetLatestEnterpriseTrialRearmGeneration, organizationID)
+	var trial_generation_created_at string
+	err := row.Scan(&trial_generation_created_at)
+	return trial_generation_created_at, err
 }
 
 const adminGetOrganization = `-- name: AdminGetOrganization :one

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -377,6 +377,22 @@ func (q *Queries) AdminGetProjectDetailByID(ctx context.Context, id uuid.UUID) (
 	return i, err
 }
 
+const adminHasEnterpriseTrialRearmAudit = `-- name: AdminHasEnterpriseTrialRearmAudit :one
+SELECT EXISTS (
+    SELECT 1
+    FROM audit_logs
+    WHERE organization_id = $1
+      AND action = 'organization:enterprise_trial_rearmed'
+)
+`
+
+func (q *Queries) AdminHasEnterpriseTrialRearmAudit(ctx context.Context, organizationID string) (bool, error) {
+	row := q.db.QueryRow(ctx, adminHasEnterpriseTrialRearmAudit, organizationID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const adminListOrganizationMembers = `-- name: AdminListOrganizationMembers :many
 SELECT
     u.id,

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -158,23 +158,57 @@ func (q *Queries) AdminEnableOrganization(ctx context.Context, id string) (int64
 	return result.RowsAffected(), nil
 }
 
-const adminGetLatestEnterpriseTrialRearmGeneration = `-- name: AdminGetLatestEnterpriseTrialRearmGeneration :one
-SELECT COALESCE(metadata->>'trial_generation_created_at', '')::text AS trial_generation_created_at
-FROM audit_logs
-WHERE organization_id = $1
-  AND action = 'organization:enterprise_trial_rearmed'
-ORDER BY seq DESC
-LIMIT 1
+const adminGetEnterpriseTrialRetryOperationIDs = `-- name: AdminGetEnterpriseTrialRetryOperationIDs :one
+WITH latest_arm AS (
+    SELECT armed.id, armed.seq
+    FROM audit_logs AS armed
+    WHERE armed.organization_id = $1
+      AND armed.project_id IS NULL
+      AND armed.action = 'organization:enterprise_trial_armed'
+      AND armed.subject_id = $1
+      AND armed.subject_type = 'organization'
+    ORDER BY armed.seq DESC, armed.id DESC
+    LIMIT 1
+), latest_rearm AS (
+    SELECT rearmed.metadata->>'arm_operation_id' AS arm_operation_id
+    FROM audit_logs AS rearmed
+    WHERE rearmed.organization_id = $1
+      AND rearmed.project_id IS NULL
+      AND rearmed.action = 'organization:enterprise_trial_rearmed'
+      AND rearmed.subject_id = $1
+      AND rearmed.subject_type = 'organization'
+    ORDER BY rearmed.seq DESC, rearmed.id DESC
+    LIMIT 1
+)
+SELECT
+    COALESCE((SELECT id::text FROM latest_arm), '')::text AS arm_operation_id,
+    COALESCE((SELECT arm_operation_id FROM latest_rearm), '')::text AS rearm_arm_operation_id,
+    (
+        SELECT count(*)
+        FROM audit_logs AS rearmed
+        JOIN latest_arm ON rearmed.metadata->>'arm_operation_id' = latest_arm.id::text
+        WHERE rearmed.organization_id = $1
+          AND rearmed.project_id IS NULL
+          AND rearmed.action = 'organization:enterprise_trial_rearmed'
+          AND rearmed.subject_id = $1
+          AND rearmed.subject_type = 'organization'
+    )::bigint AS matching_rearm_count
 `
 
-// A post-commit retry is valid only for the immutable trial-row generation
-// recorded in the latest matching audit. Extensions intentionally change ends_at
-// without creating a new generation.
-func (q *Queries) AdminGetLatestEnterpriseTrialRearmGeneration(ctx context.Context, organizationID string) (string, error) {
-	row := q.db.QueryRow(ctx, adminGetLatestEnterpriseTrialRearmGeneration, organizationID)
-	var trial_generation_created_at string
-	err := row.Scan(&trial_generation_created_at)
-	return trial_generation_created_at, err
+type AdminGetEnterpriseTrialRetryOperationIDsRow struct {
+	ArmOperationID      string
+	RearmArmOperationID string
+	MatchingRearmCount  int64
+}
+
+// The arm audit id is the immutable generation token. Every production trial
+// creation writes exactly one arm audit in the creation transaction; extension
+// writes neither. seq orders generations; id breaks any equal-seq tie.
+func (q *Queries) AdminGetEnterpriseTrialRetryOperationIDs(ctx context.Context, targetOrganizationID string) (AdminGetEnterpriseTrialRetryOperationIDsRow, error) {
+	row := q.db.QueryRow(ctx, adminGetEnterpriseTrialRetryOperationIDs, targetOrganizationID)
+	var i AdminGetEnterpriseTrialRetryOperationIDsRow
+	err := row.Scan(&i.ArmOperationID, &i.RearmArmOperationID, &i.MatchingRearmCount)
+	return i, err
 }
 
 const adminGetOrganization = `-- name: AdminGetOrganization :one

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -169,29 +169,34 @@ WITH latest_arm AS (
       AND armed.subject_type = 'organization'
     ORDER BY armed.seq DESC, armed.id DESC
     LIMIT 1
-), latest_rearm AS (
-    SELECT rearmed.metadata->>'arm_operation_id' AS arm_operation_id
+), latest_demotion AS (
+    SELECT demoted.id, demoted.seq
+    FROM audit_logs AS demoted
+    JOIN latest_arm ON (demoted.seq, demoted.id) > (latest_arm.seq, latest_arm.id)
+    WHERE demoted.organization_id = $1
+      AND demoted.project_id IS NULL
+      AND demoted.action = 'organization:enterprise_trial_demoted'
+      AND demoted.subject_id = $1
+      AND demoted.subject_type = 'organization'
+    ORDER BY demoted.seq DESC, demoted.id DESC
+    LIMIT 1
+), current_rearms AS (
+    SELECT rearmed.id, rearmed.seq, rearmed.metadata->>'arm_operation_id' AS arm_operation_id
     FROM audit_logs AS rearmed
+    JOIN latest_demotion ON (rearmed.seq, rearmed.id) > (latest_demotion.seq, latest_demotion.id)
     WHERE rearmed.organization_id = $1
       AND rearmed.project_id IS NULL
       AND rearmed.action = 'organization:enterprise_trial_rearmed'
       AND rearmed.subject_id = $1
       AND rearmed.subject_type = 'organization'
-    ORDER BY rearmed.seq DESC, rearmed.id DESC
-    LIMIT 1
 )
 SELECT
     COALESCE((SELECT id::text FROM latest_arm), '')::text AS arm_operation_id,
-    COALESCE((SELECT arm_operation_id FROM latest_rearm), '')::text AS rearm_arm_operation_id,
+    COALESCE((SELECT arm_operation_id FROM current_rearms ORDER BY seq DESC, id DESC LIMIT 1), '')::text AS rearm_arm_operation_id,
     (
         SELECT count(*)
-        FROM audit_logs AS rearmed
-        JOIN latest_arm ON rearmed.metadata->>'arm_operation_id' = latest_arm.id::text
-        WHERE rearmed.organization_id = $1
-          AND rearmed.project_id IS NULL
-          AND rearmed.action = 'organization:enterprise_trial_rearmed'
-          AND rearmed.subject_id = $1
-          AND rearmed.subject_type = 'organization'
+        FROM current_rearms
+        JOIN latest_arm ON current_rearms.arm_operation_id = latest_arm.id::text
     )::bigint AS matching_rearm_count
 `
 

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -392,18 +392,20 @@ type LogOrganizationEnterpriseTrialRearmedEvent struct {
 	OrganizationName string
 	OrganizationSlug string
 
-	AccountType      string
-	TrialEndsAt      time.Time
-	KeyAccessChanged bool
+	AccountType              string
+	TrialEndsAt              time.Time
+	TrialGenerationCreatedAt time.Time
+	KeyAccessChanged         bool
 }
 
 func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialRearmedEvent) error {
 	action := ActionOrganizationEnterpriseTrialRearmed
 
 	metadata, err := marshalAuditPayload(map[string]any{
-		"account_type":       event.AccountType,
-		"trial_ends_at":      event.TrialEndsAt,
-		"key_access_changed": event.KeyAccessChanged,
+		"account_type":                event.AccountType,
+		"trial_ends_at":               event.TrialEndsAt,
+		"trial_generation_created_at": event.TrialGenerationCreatedAt,
+		"key_access_changed":          event.KeyAccessChanged,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -392,20 +392,20 @@ type LogOrganizationEnterpriseTrialRearmedEvent struct {
 	OrganizationName string
 	OrganizationSlug string
 
-	AccountType              string
-	TrialEndsAt              time.Time
-	TrialGenerationCreatedAt time.Time
-	KeyAccessChanged         bool
+	AccountType       string
+	TrialEndsAt       time.Time
+	ArmAuditOperation string
+	KeyAccessChanged  bool
 }
 
 func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialRearmedEvent) error {
 	action := ActionOrganizationEnterpriseTrialRearmed
 
 	metadata, err := marshalAuditPayload(map[string]any{
-		"account_type":                event.AccountType,
-		"trial_ends_at":               event.TrialEndsAt,
-		"trial_generation_created_at": event.TrialGenerationCreatedAt,
-		"key_access_changed":          event.KeyAccessChanged,
+		"account_type":       event.AccountType,
+		"trial_ends_at":      event.TrialEndsAt,
+		"arm_operation_id":   event.ArmAuditOperation,
+		"key_access_changed": event.KeyAccessChanged,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -510,6 +510,7 @@ type LogOrganizationEnterpriseTrialDemotedEvent struct {
 
 	PreviousAccountType string
 	TrialEndsAt         time.Time
+	KeyAccessChanged    bool
 }
 
 func (l *Logger) LogOrganizationEnterpriseTrialDemoted(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialDemotedEvent) error {
@@ -518,6 +519,7 @@ func (l *Logger) LogOrganizationEnterpriseTrialDemoted(ctx context.Context, dbtx
 	metadata, err := marshalAuditPayload(map[string]any{
 		"previous_account_type": event.PreviousAccountType,
 		"trial_ends_at":         event.TrialEndsAt,
+		"key_access_changed":    event.KeyAccessChanged,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -392,16 +392,18 @@ type LogOrganizationEnterpriseTrialRearmedEvent struct {
 	OrganizationName string
 	OrganizationSlug string
 
-	AccountType string
-	TrialEndsAt time.Time
+	AccountType      string
+	TrialEndsAt      time.Time
+	KeyAccessChanged bool
 }
 
 func (l *Logger) LogOrganizationEnterpriseTrialRearmed(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialRearmedEvent) error {
 	action := ActionOrganizationEnterpriseTrialRearmed
 
 	metadata, err := marshalAuditPayload(map[string]any{
-		"account_type":  event.AccountType,
-		"trial_ends_at": event.TrialEndsAt,
+		"account_type":       event.AccountType,
+		"trial_ends_at":      event.TrialEndsAt,
+		"key_access_changed": event.KeyAccessChanged,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usage"
 )
 
 type ReconcilePaygOpenRouterChatKey struct {
@@ -44,10 +45,8 @@ func (r *ReconcilePaygOpenRouterChatKey) Do(ctx context.Context, args ReconcileP
 		return fmt.Errorf("invalid PAYG OpenRouter chat key desired state %q", args.DesiredState)
 	}
 
-	if err := withOpenRouterKeyBillingConnectionLock(ctx, r.logger, r.db, args.OrganizationID, openrouter.KeyTypeChat, func(conn *pgxpool.Conn, queries *repo.Queries) error {
-		return r.reconcileLocked(ctx, conn, queries, args)
-	}); err != nil {
-		return err
+	if err := usage.RepairPaygOpenRouterChatKey(ctx, r.logger, r.db, r.openRouter, args.OrganizationID, args.DesiredState); err != nil {
+		return fmt.Errorf("repair PAYG OpenRouter chat key: %w", err)
 	}
 	if args.DesiredState != openrouter.KeyDesiredStateEnabled {
 		return nil
@@ -60,95 +59,6 @@ func (r *ReconcilePaygOpenRouterChatKey) Do(ctx context.Context, args ReconcileP
 	return withOpenRouterKeyBillingConnectionLock(ctx, r.logger, r.db, args.OrganizationID, openrouter.KeyTypeInternal, func(conn *pgxpool.Conn, queries *repo.Queries) error {
 		return r.reenableSecurityLocked(ctx, conn, queries, args.OrganizationID)
 	})
-}
-
-func (r *ReconcilePaygOpenRouterChatKey) reconcileLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, args ReconcilePaygOpenRouterChatKeyArgs) error {
-	projection, err := queries.GetPaygOpenRouterChatKeyProjection(ctx, args.OrganizationID)
-	switch {
-	case errors.Is(err, pgx.ErrNoRows):
-		// Organization deletion also removes its platform keys. An old outbox
-		// delivery has no remaining desired state to apply.
-		return nil
-	case err != nil:
-		return fmt.Errorf("read PAYG Other inference key billing projection: %w", err)
-	}
-
-	hasSubscription := projection.StripeSubscriptionID.Valid && projection.StripeSubscriptionID.String != ""
-	switch {
-	case projection.GramAccountType == string(billing.TierPayg) && hasSubscription:
-		if args.DesiredState != openrouter.KeyDesiredStateEnabled {
-			return nil
-		}
-		limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
-		if !ok {
-			return errors.New("PAYG OpenRouter credit policy is unavailable")
-		}
-		key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
-			OrganizationID: args.OrganizationID,
-			KeyType:        string(openrouter.KeyTypeChat),
-		})
-		if errors.Is(err, pgx.ErrNoRows) {
-			// Keys are provisioned lazily. Billing activation must not create one.
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("read PAYG Other inference key: %w", err)
-		}
-		if key.DisableCauses != nil && openrouter.EffectiveDisabled(key.Disabled, key.DisableCauses) {
-			// Wave B cannot remove billing_inactive without also risking unrelated
-			// classified causes. Leave classified lockdowns untouched until the
-			// cause-aware activation path lands.
-			return nil
-		}
-		if !openrouter.EffectiveDisabled(key.Disabled, key.DisableCauses) {
-			if key.MonthlyCredits == int64(limit) {
-				return nil
-			}
-			chosen, err := auditrepo.New(conn).GetLatestOpenRouterSpendCapAuditOperation(ctx, auditrepo.GetLatestOpenRouterSpendCapAuditOperationParams{
-				OrganizationID: args.OrganizationID,
-				SubjectID:      urn.NewOpenRouterAPIKey(args.OrganizationID, string(openrouter.KeyTypeChat)).ID,
-			})
-			if err != nil {
-				return fmt.Errorf("read latest Other inference cap selection: %w", err)
-			}
-			if chosen.OperationID != "" {
-				// A customer cap completed after this activation wake-up began. Do
-				// not let a retry overwrite that newer intent with the default.
-				return nil
-			}
-		}
-		dbProvisioner, ok := r.openRouter.(openRouterSpendCapDBProvisioner)
-		if !ok {
-			return errors.New("OpenRouter key provisioner cannot use the locked database session")
-		}
-		if _, err := dbProvisioner.ReinstateAPIKeyLimitWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat, &limit); errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		} else if err != nil {
-			return fmt.Errorf("enable PAYG Other inference key: %w", err)
-		}
-	case projection.GramAccountType == string(billing.TierBase) && !hasSubscription:
-		if args.DesiredState != openrouter.KeyDesiredStateDisabled {
-			return nil
-		}
-		dbProvisioner, ok := r.openRouter.(openRouterKeyBillingDBProvisioner)
-		if !ok {
-			return errors.New("OpenRouter key provisioner cannot use the locked database session")
-		}
-		if err := dbProvisioner.DisableAPIKeyWithDB(ctx, conn, args.OrganizationID, openrouter.KeyTypeChat); err != nil {
-			return fmt.Errorf("disable PAYG Other inference key: %w", err)
-		}
-	case projection.GramAccountType != string(billing.TierPayg) && projection.GramAccountType != string(billing.TierBase):
-		// Enterprise and Polar-managed tiers are outside self-serve Stripe
-		// billing. Old PAYG events must not mutate their keys.
-		return nil
-	default:
-		// The billing transition writes both halves in one transaction. A mixed
-		// projection means another writer did not honor that invariant; retrying
-		// is safer than granting or revoking access from partial state.
-		return fmt.Errorf("inconsistent PAYG Other inference key billing projection: account_type=%q has_subscription=%t", projection.GramAccountType, hasSubscription)
-	}
-
-	return nil
 }
 
 func (r *ReconcilePaygOpenRouterChatKey) reenableSecurityLocked(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, organizationID string) error {

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -2,7 +2,12 @@ package activities_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -137,6 +143,114 @@ func setupPaygChatKeyReconciler(t *testing.T, accountType string, subscriptionID
 	provisioner := &mockPaygChatKeyProvisioner{Mock: mock.Mock{}}
 	reconciler := activities.NewReconcilePaygOpenRouterChatKey(testenv.NewLogger(t), db, provisioner)
 	return reconciler, provisioner, db, organizationID
+}
+
+type recordedOpenRouterPatch struct {
+	hash string
+	body string
+}
+
+type openRouterPatchRecorder struct {
+	mu      sync.Mutex
+	patches []recordedOpenRouterPatch
+}
+
+func (r *openRouterPatchRecorder) handler(w http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPatch {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(request.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	hash := strings.TrimPrefix(request.URL.Path, "/v1/keys/")
+	r.mu.Lock()
+	r.patches = append(r.patches, recordedOpenRouterPatch{hash: hash, body: string(body)})
+	r.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 100.0}})
+}
+
+func (r *openRouterPatchRecorder) snapshot() []recordedOpenRouterPatch {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedOpenRouterPatch(nil), r.patches...)
+}
+
+func setupProductionPaygChatKeyReconciler(t *testing.T, causes []string) (*activities.ReconcilePaygOpenRouterChatKey, *pgxpool.Pool, string, *openRouterPatchRecorder) {
+	t.Helper()
+
+	_, _, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 999)
+	require.NoError(t, testrepo.New(db).SetOpenRouterAPIKeyClassificationFixture(t.Context(), testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: organizationID,
+		KeyType:        string(openrouter.KeyTypeChat),
+		Disabled:       len(causes) > 0,
+		DisableCauses:  causes,
+	}))
+
+	recorder := &openRouterPatchRecorder{}
+	upstream := httptest.NewServer(http.HandlerFunc(recorder.handler))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	production := openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+	return activities.NewReconcilePaygOpenRouterChatKey(testenv.NewLogger(t), db, production), db, organizationID, recorder
+}
+
+func TestReconcilePaygOpenRouterChatKeyProductionReconcilesCommittedCurrentCapExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		causes []string
+	}{
+		{name: "billing cause present", causes: []string{string(openrouter.DisableCauseBillingInactive)}},
+		{name: "billing cause absent", causes: []string{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			reconciler, db, organizationID, recorder := setupProductionPaygChatKeyReconciler(t, test.causes)
+			require.NoError(t, audit.NewLogger().LogOpenRouterAPIKeySetSpendCap(t.Context(), db, audit.LogOpenRouterAPIKeySetSpendCapEvent{
+				OrganizationID:      organizationID,
+				Actor:               urn.NewPrincipal(urn.PrincipalTypeUser, "user_placeholder"),
+				OpenRouterAPIKeyURN: urn.NewOpenRouterAPIKey(organizationID, string(openrouter.KeyTypeChat)),
+				KeyType:             string(openrouter.KeyTypeChat),
+				OperationIdentifier: "operation_stale_oversized_placeholder",
+				OpenRouterAPIKeySnapshotBefore: &audit.OpenRouterAPIKeySpendCapSnapshot{
+					MonthlyCredits: 999,
+				},
+				OpenRouterAPIKeySnapshotAfter: &audit.OpenRouterAPIKeySpendCapSnapshot{
+					MonthlyCredits: 9999,
+				},
+			}))
+
+			require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
+				OrganizationID: organizationID,
+				DesiredState:   openrouter.KeyDesiredStateEnabled,
+			}))
+
+			patches := recorder.snapshot()
+			require.Len(t, patches, 1)
+			require.Equal(t, "hash_placeholder_chat", patches[0].hash)
+			require.JSONEq(t, `{"limit":100,"limit_reset":"monthly","disabled":false}`, patches[0].body)
+			key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
+				OrganizationID: organizationID, KeyType: string(openrouter.KeyTypeChat),
+			})
+			require.NoError(t, err)
+			require.Empty(t, key.DisableCauses)
+			require.False(t, key.Disabled)
+			require.EqualValues(t, 100, key.MonthlyCredits)
+		})
+	}
 }
 
 func TestReconcilePaygOpenRouterChatKeyRemovesOnlyBillingCauseAndRefreshesCurrentCap(t *testing.T) {

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -50,8 +50,21 @@ func (*mockPaygChatKeyProvisioner) AddAPIKeyDisableCause(context.Context, string
 	return openrouter.DisableCauseChange{}, nil
 }
 
+func (m *mockPaygChatKeyProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, _ openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return openrouter.DisableCauseChange{}, m.DisableAPIKey(ctx, organizationID, keyType)
+}
+
 func (*mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
 	return 0, openrouter.DisableCauseChange{}, nil
+}
+
+func (m *mockPaygChatKeyProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, _ openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error) {
+	refreshed, err := m.RefreshAPIKeyLimit(ctx, organizationID, keyType, limit)
+	return refreshed, openrouter.DisableCauseChange{}, err
+}
+
+func (*mockPaygChatKeyProvisioner) ReconcileAPIKeyDisabledWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType) error {
+	return nil
 }
 
 func (m *mockPaygChatKeyProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
@@ -126,7 +139,7 @@ func setupPaygChatKeyReconciler(t *testing.T, accountType string, subscriptionID
 	return reconciler, provisioner, db, organizationID
 }
 
-func TestReconcilePaygOpenRouterChatKeyDoesNotReinstateClassifiedKey(t *testing.T) {
+func TestReconcilePaygOpenRouterChatKeyRemovesOnlyBillingCauseAndRefreshesCurrentCap(t *testing.T) {
 	t.Parallel()
 
 	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
@@ -138,19 +151,21 @@ func TestReconcilePaygOpenRouterChatKeyDoesNotReinstateClassifiedKey(t *testing.
 		DisableCauses:  []string{"admin_lock", "billing_inactive"},
 	}))
 
+	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 100 })).Return(100, nil).Once()
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
 		OrganizationID: organizationID,
 		DesiredState:   openrouter.KeyDesiredStateEnabled,
 	}))
-	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertExpectations(t)
 
 	row, err := openrouterrepo.New(db).GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
 		OrganizationID: organizationID,
 		KeyType:        string(openrouter.KeyTypeChat),
 	})
 	require.NoError(t, err)
-	require.False(t, row.Disabled, "the stale rollout mirror must remain untouched")
-	require.Equal(t, []string{"admin_lock", "billing_inactive"}, row.DisableCauses)
+	require.True(t, row.Disabled)
+	require.Equal(t, []string{"admin_lock"}, row.DisableCauses)
+	require.EqualValues(t, 100, row.MonthlyCredits)
 }
 
 func createPaygReconcilerKey(t *testing.T, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, monthlyCredits int64) {
@@ -206,7 +221,7 @@ func TestReconcilePaygOpenRouterChatKeyCurrentPaidStateLeavesEnabledSecurityUnto
 	provisioner.AssertExpectations(t)
 }
 
-func TestReconcilePaygOpenRouterChatKeyActivationRetryPreservesSelectedOtherCap(t *testing.T) {
+func TestReconcilePaygOpenRouterChatKeyActivationRetryUsesCurrentPaygCap(t *testing.T) {
 	t.Parallel()
 
 	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{String: "subscription_placeholder", Valid: true})
@@ -227,8 +242,12 @@ func TestReconcilePaygOpenRouterChatKeyActivationRetryPreservesSelectedOtherCap(
 		},
 	}))
 
+	provisioner.On("RefreshAPIKeyLimit", mock.Anything, organizationID, openrouter.KeyTypeChat, mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 100 })).Return(100, nil).Once()
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
-	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	provisioner.AssertExpectations(t)
+	key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{OrganizationID: organizationID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+	require.EqualValues(t, 100, key.MonthlyCredits)
 }
 
 func TestReconcilePaygOpenRouterChatKeyReenablesDisabledSecurityAtRecordedCap(t *testing.T) {
@@ -311,7 +330,8 @@ func TestReconcilePaygOpenRouterChatKeyCurrentPaidStateWithoutKeyIsNoop(t *testi
 func TestReconcilePaygOpenRouterChatKeyCurrentFreeStateDisablesOtherOnly(t *testing.T) {
 	t.Parallel()
 
-	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
 	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}))
@@ -322,7 +342,8 @@ func TestReconcilePaygOpenRouterChatKeyCurrentFreeStateDisablesOtherOnly(t *test
 func TestReconcilePaygOpenRouterChatKeyStaleActivationWakeupCannotOverrideCurrentFreeState(t *testing.T) {
 	t.Parallel()
 
-	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
 	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}), "newer deactivation wake-up")
@@ -349,12 +370,13 @@ func TestReconcilePaygOpenRouterChatKeyStaleDeactivationWakeupCannotOverrideCurr
 func TestReconcilePaygOpenRouterChatKeyExternalFailureIsRetryableAndIdempotent(t *testing.T) {
 	t.Parallel()
 
-	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	reconciler, provisioner, db, organizationID := setupPaygChatKeyReconciler(t, "free", pgtype.Text{})
+	createPaygReconcilerKey(t, db, organizationID, openrouter.KeyTypeChat, 50)
 	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(errors.New("upstream unavailable")).Once()
 	provisioner.On("DisableAPIKey", mock.Anything, organizationID, openrouter.KeyTypeChat).Return(nil).Once()
 
 	args := activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateDisabled}
-	require.ErrorContains(t, reconciler.Do(t.Context(), args), "disable PAYG Other inference key")
+	require.ErrorContains(t, reconciler.Do(t.Context(), args), "add inactive PAYG billing cause")
 	require.NoError(t, reconciler.Do(t.Context(), args))
 	provisioner.AssertExpectations(t)
 }
@@ -365,7 +387,7 @@ func TestReconcilePaygOpenRouterChatKeyRejectsMixedProjection(t *testing.T) {
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{})
 
 	err := reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled})
-	require.ErrorContains(t, err, "inconsistent PAYG Other inference key billing projection")
+	require.ErrorContains(t, err, "inconsistent PAYG OpenRouter chat key billing projection")
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -85,10 +86,22 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 			d.logger.InfoContext(ctx, "expired trial changed before demotion", attr.SlogOrganizationID(args.OrganizationID))
 			return nil
 		}
+		if _, lockErr := tx.LockTrialLifecycleForRearm(ctx, args.OrganizationID); lockErr != nil {
+			return fmt.Errorf("lock no-op trial demotion lifecycle: %w", lockErr)
+		}
+		for _, keyType := range openrouter.AllKeyTypes {
+			if lockErr := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, dbtx, args.OrganizationID, keyType); lockErr != nil {
+				return fmt.Errorf("acquire no-op OpenRouter %s key billing lock: %w", keyType, lockErr)
+			}
+		}
+		changedKeyTypes, selectErr := trialDemotionChangedKeyTypes(ctx, dbtx, args.OrganizationID)
+		if selectErr != nil {
+			return selectErr
+		}
 		if rollbackErr := dbtx.Rollback(ctx); rollbackErr != nil {
 			return fmt.Errorf("close no-op trial demotion transaction: %w", rollbackErr)
 		}
-		return d.reconcileOpenRouterKeys(ctx, args.OrganizationID)
+		return d.reconcileOpenRouterKeys(ctx, args.OrganizationID, changedKeyTypes)
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
 	}
@@ -106,12 +119,16 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		return errors.New("OpenRouter key provisioner cannot persist and reconcile trial demotion causes")
 	}
 	keyAccessChanged := false
+	changedKeyTypes := make([]openrouter.KeyType, 0, len(openrouter.AllKeyTypes))
 	for _, keyType := range openrouter.AllKeyTypes {
 		change, err := provisioner.AddAPIKeyDisableCauseWithDB(ctx, dbtx, args.OrganizationID, keyType, openrouter.DisableCauseTrialDemotion)
 		if err != nil {
 			return fmt.Errorf("add trial demotion cause to OpenRouter %s key: %w", keyType, err)
 		}
 		keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
+		if change.KeyAccessChanged {
+			changedKeyTypes = append(changedKeyTypes, keyType)
+		}
 	}
 
 	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, dbtx, args.OrganizationID, false); err != nil {
@@ -149,17 +166,38 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		}
 	}
 
-	return d.reconcileOpenRouterKeys(ctx, args.OrganizationID)
+	return d.reconcileOpenRouterKeys(ctx, args.OrganizationID, changedKeyTypes)
 }
 
-func (d *DemoteExpiredTrials) reconcileOpenRouterKeys(ctx context.Context, organizationID string) error {
+func trialDemotionChangedKeyTypes(ctx context.Context, db openrouter.DBTX, organizationID string) ([]openrouter.KeyType, error) {
+	changedKeyTypes := make([]openrouter.KeyType, 0, len(openrouter.AllKeyTypes))
+	for _, keyType := range openrouter.AllKeyTypes {
+		key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
+			OrganizationID: organizationID,
+			KeyType:        string(keyType),
+		})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			continue
+		case err != nil:
+			return nil, fmt.Errorf("read OpenRouter %s key after no-op trial demotion: %w", keyType, err)
+		case key.DisableCauses == nil:
+			return nil, fmt.Errorf("OpenRouter %s key has unclassified causes after trial demotion", keyType)
+		case len(key.DisableCauses) == 1 && key.DisableCauses[0] == string(openrouter.DisableCauseTrialDemotion):
+			changedKeyTypes = append(changedKeyTypes, keyType)
+		}
+	}
+	return changedKeyTypes, nil
+}
+
+func (d *DemoteExpiredTrials) reconcileOpenRouterKeys(ctx context.Context, organizationID string, keyTypes []openrouter.KeyType) error {
 	provisioner, ok := d.openRouter.(trialDemotionOpenRouter)
 	if !ok {
 		return errors.New("OpenRouter key provisioner cannot reconcile trial demotion causes")
 	}
 
 	var reconcileErrors []error
-	for _, keyType := range openrouter.AllKeyTypes {
+	for _, keyType := range keyTypes {
 		if err := provisioner.ReconcileAPIKeyDisabled(ctx, organizationID, keyType); err != nil {
 			reconcileErrors = append(reconcileErrors, fmt.Errorf("reconcile OpenRouter %s key after trial demotion: %w", keyType, err))
 		}

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -97,7 +97,7 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	// canonical order before any key-row access, retaining them until commit.
 	for _, keyType := range openrouter.AllKeyTypes {
 		if err := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, dbtx, args.OrganizationID, keyType); err != nil {
-			return err
+			return fmt.Errorf("acquire OpenRouter %s key billing lock: %w", keyType, err)
 		}
 	}
 

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
-	"github.com/speakeasy-api/gram/server/internal/background/activities/keybillinglock"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -62,6 +61,11 @@ type DemoteExpiredTrialArgs struct {
 	OrganizationID string
 }
 
+type trialDemotionOpenRouter interface {
+	AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error)
+	ReconcileAPIKeyDisabled(context.Context, string, openrouter.KeyType) error
+}
+
 func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTrialArgs) error {
 	dbtx, err := d.db.Begin(ctx)
 	if err != nil {
@@ -70,38 +74,44 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	tx := trialsrepo.New(dbtx)
-
 	trial, err := tx.MarkTrialDemoted(ctx, args.OrganizationID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		// A conversion or a manual reinstatement landed between the list and
-		// this write. The organization is no longer ours to demote.
-		d.logger.InfoContext(ctx, "expired trial changed before demotion",
-			attr.SlogOrganizationID(args.OrganizationID))
-		return nil
+		existing, getErr := tx.GetTrial(ctx, args.OrganizationID)
+		if getErr != nil && !errors.Is(getErr, pgx.ErrNoRows) {
+			return fmt.Errorf("read trial after no-op demotion: %w", getErr)
+		}
+		if errors.Is(getErr, pgx.ErrNoRows) || !existing.DemotedAt.Valid {
+			d.logger.InfoContext(ctx, "expired trial changed before demotion", attr.SlogOrganizationID(args.OrganizationID))
+			return nil
+		}
+		if rollbackErr := dbtx.Rollback(ctx); rollbackErr != nil {
+			return fmt.Errorf("close no-op trial demotion transaction: %w", rollbackErr)
+		}
+		return d.reconcileOpenRouterKeys(ctx, args.OrganizationID)
 	case err != nil:
 		return fmt.Errorf("mark trial demoted: %w", err)
 	}
 
-	// The stamp above holds a row lock until this transaction ends, so a
-	// conversion cannot land while the keys go down. A failure here rolls the
-	// stamp back and leaves the trial armed for the next sweep, which a lockdown
-	// after the commit would not get: a stamped row drops out of the sweep.
-	//
-	// DisableAPIKeyWithDB writes its disabled flag on the locked key session,
-	// outside dbtx, so a key already taken down stays down through an
-	// organization-transaction rollback. The organization reads as enterprise
-	// with a dead key until the next sweep completes the demotion.
+	// MarkTrialDemoted locks the lifecycle row first. Take every key lock in the
+	// canonical order before any key-row access, retaining them until commit.
 	for _, keyType := range openrouter.AllKeyTypes {
-		if err := keybillinglock.With(ctx, d.logger, d.db, args.OrganizationID, keyType, func(conn *pgxpool.Conn) error {
-			dbProvisioner, ok := d.openRouter.(openRouterKeyBillingDBProvisioner)
-			if !ok {
-				return errors.New("OpenRouter key provisioner cannot use the locked database session")
-			}
-			return dbProvisioner.DisableAPIKeyWithDB(ctx, conn, args.OrganizationID, keyType)
-		}); err != nil {
-			return fmt.Errorf("disable openrouter %s key: %w", keyType, err)
+		if err := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, dbtx, args.OrganizationID, keyType); err != nil {
+			return err
 		}
+	}
+
+	provisioner, ok := d.openRouter.(trialDemotionOpenRouter)
+	if !ok {
+		return errors.New("OpenRouter key provisioner cannot persist and reconcile trial demotion causes")
+	}
+	keyAccessChanged := false
+	for _, keyType := range openrouter.AllKeyTypes {
+		change, err := provisioner.AddAPIKeyDisableCauseWithDB(ctx, dbtx, args.OrganizationID, keyType, openrouter.DisableCauseTrialDemotion)
+		if err != nil {
+			return fmt.Errorf("add trial demotion cause to OpenRouter %s key: %w", keyType, err)
+		}
+		keyAccessChanged = keyAccessChanged || change.KeyAccessChanged
 	}
 
 	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, dbtx, args.OrganizationID, false); err != nil {
@@ -122,6 +132,7 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		OrganizationSlug:    organization.Slug,
 		PreviousAccountType: organization.PreviousAccountType,
 		TrialEndsAt:         trial.EndsAt.Time,
+		KeyAccessChanged:    keyAccessChanged,
 	}); err != nil {
 		return fmt.Errorf("log trial demotion: %w", err)
 	}
@@ -138,5 +149,20 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 		}
 	}
 
-	return nil
+	return d.reconcileOpenRouterKeys(ctx, args.OrganizationID)
+}
+
+func (d *DemoteExpiredTrials) reconcileOpenRouterKeys(ctx context.Context, organizationID string) error {
+	provisioner, ok := d.openRouter.(trialDemotionOpenRouter)
+	if !ok {
+		return errors.New("OpenRouter key provisioner cannot reconcile trial demotion causes")
+	}
+
+	var reconcileErrors []error
+	for _, keyType := range openrouter.AllKeyTypes {
+		if err := provisioner.ReconcileAPIKeyDisabled(ctx, organizationID, keyType); err != nil {
+			reconcileErrors = append(reconcileErrors, fmt.Errorf("reconcile OpenRouter %s key after trial demotion: %w", keyType, err))
+		}
+	}
+	return errors.Join(reconcileErrors...)
 }

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -15,22 +15,25 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
-// trialProvisioner records which of an organization's keys were locked down and
-// can be made to fail, which is the only openrouter.Provisioner behaviour the
-// sweeper depends on.
+// trialProvisioner uses the production local cause mutation against real
+// PostgreSQL while faking only the post-commit OpenRouter reconciliation.
 type trialProvisioner struct {
 	*openrouter.Development
+	local *openrouter.OpenRouter
 
-	disabled []string
-	failWith error
+	reconciled        []string
+	reconcileFailures int
 }
 
 type recordingTrialNotifier struct {
@@ -52,17 +55,17 @@ func (n *recordingTrialNotifier) TrialInactive(_ context.Context, organizationID
 
 var _ openrouter.Provisioner = (*trialProvisioner)(nil)
 
-func (p *trialProvisioner) DisableAPIKey(_ context.Context, orgID string, keyType openrouter.KeyType) error {
-	if p.failWith != nil {
-		return p.failWith
-	}
-	p.disabled = append(p.disabled, orgID+":"+string(keyType))
-
-	return nil
+func (p *trialProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
+	return p.local.AddAPIKeyDisableCauseWithDB(ctx, db, orgID, keyType, cause)
 }
 
-func (p *trialProvisioner) DisableAPIKeyWithDB(ctx context.Context, _ openrouter.DBTX, orgID string, keyType openrouter.KeyType) error {
-	return p.DisableAPIKey(ctx, orgID, keyType)
+func (p *trialProvisioner) ReconcileAPIKeyDisabled(_ context.Context, orgID string, keyType openrouter.KeyType) error {
+	p.reconciled = append(p.reconciled, orgID+":"+string(keyType))
+	if p.reconcileFailures > 0 {
+		p.reconcileFailures--
+		return errors.New("openrouter unavailable")
+	}
+	return nil
 }
 
 type trialTestInstance struct {
@@ -83,7 +86,7 @@ func newTrialTestInstance(t *testing.T) (context.Context, *trialTestInstance) {
 	conn, err := infra.CloneTestDatabase(t, "trialdemotion")
 	require.NoError(t, err)
 
-	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), disabled: nil, failWith: nil}
+	provisioner := &trialProvisioner{Development: openrouter.NewDevelopment(""), local: new(openrouter.OpenRouter)}
 	notifier := &recordingTrialNotifier{inactive: nil}
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
@@ -138,12 +141,41 @@ func newTrialOrg(t *testing.T, ctx context.Context, ti *trialTestInstance, endsA
 	return orgID
 }
 
+func materializeTrialKey(t *testing.T, ctx context.Context, ti *trialTestInstance, orgID string, keyType openrouter.KeyType, causes []string) {
+	t.Helper()
+
+	_, err := openrouterrepo.New(ti.conn).CreateOpenRouterAPIKey(ctx, openrouterrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+		KeyEncrypted:   pgtype.Text{},
+		KeyHash:        "hash-" + string(keyType),
+		MonthlyCredits: 100,
+	})
+	require.NoError(t, err)
+	_, err = ti.conn.Exec(ctx, `
+		UPDATE openrouter_api_keys
+		SET disable_causes = $3::text[], disabled = COALESCE(cardinality($3::text[]) > 0, TRUE)
+		WHERE organization_id = $1 AND key_type = $2
+	`, orgID, string(keyType), causes)
+	require.NoError(t, err)
+}
+
+func trialKey(t *testing.T, ctx context.Context, ti *trialTestInstance, orgID string, keyType openrouter.KeyType) openrouterrepo.OpenrouterApiKey {
+	t.Helper()
+	key, err := openrouterrepo.New(ti.conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
+	require.NoError(t, err)
+	return key
+}
+
 func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTrialTestInstance(t)
 	endsAt := time.Now().Add(-time.Hour).UTC()
 	orgID := newTrialOrg(t, ctx, ti, endsAt)
+	for _, keyType := range openrouter.AllKeyTypes {
+		materializeTrialKey(t, ctx, ti, orgID, keyType, []string{})
+	}
 	tx := testenv.BeginTx(t, ctx, ti.conn)
 	require.NoError(t, productfeatures.SeedOrganizationDefaultsTx(ctx, tx, orgID))
 	q := featurerepo.New(tx)
@@ -182,7 +214,12 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, trial.DemotedAt.Valid)
 
-	require.ElementsMatch(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.disabled)
+	require.Equal(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.reconciled)
+	for _, keyType := range openrouter.AllKeyTypes {
+		key := trialKey(t, ctx, ti, orgID, keyType)
+		require.Equal(t, []string{"trial_demotion"}, key.DisableCauses)
+		require.True(t, key.Disabled)
+	}
 	require.Equal(t, []string{orgID}, ti.notifier.inactive)
 	for _, feature := range productfeatures.TrialRuntimeFeatures {
 		enabled, err := ti.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
@@ -211,6 +248,7 @@ func TestDemoteExpiredTrials_LocksOutExpiredTrial(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "enterprise", metadata["previous_account_type"])
 	require.NotEmpty(t, metadata["trial_ends_at"])
+	require.Equal(t, true, metadata["key_access_changed"])
 }
 
 // The sweep predicate is the only thing standing between a paying customer and
@@ -262,7 +300,7 @@ func TestDemoteExpiredTrials_DemoteSkipsTrialConvertedAfterListing(t *testing.T)
 	require.NoError(t, err)
 	require.False(t, trial.DemotedAt.Valid)
 
-	require.Empty(t, ti.provisioner.disabled, "a trial that converted keeps its keys")
+	require.Empty(t, ti.provisioner.reconciled, "a trial that converted keeps its keys")
 	require.Empty(t, ti.notifier.inactive, "a no-op demotion must not publish trial inactivity")
 }
 
@@ -295,29 +333,158 @@ func TestDemoteExpiredTrials_DemoteIsIdempotent(t *testing.T) {
 	require.Equal(t, []string{orgID}, ti.notifier.inactive, "a retried demotion notifies exactly once")
 }
 
-// The lockdown runs inside the demotion transaction on purpose: a stamped
-// demoted_at drops the row out of the next sweep, so a lockdown that failed
-// after the commit would never be retried.
-func TestDemoteExpiredTrials_KeyLockdownFailureLeavesTrialArmed(t *testing.T) {
+func TestDemoteExpiredTrials_PostCommitReconcileFailureRetriesCommittedIntent(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTrialTestInstance(t)
 	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
-	ti.provisioner.failWith = errors.New("openrouter unavailable")
+	for _, keyType := range openrouter.AllKeyTypes {
+		materializeTrialKey(t, ctx, ti, orgID, keyType, []string{})
+	}
+	ti.provisioner.reconcileFailures = 1
 
-	require.Error(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	require.ErrorContains(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}), "openrouter unavailable")
 
 	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
 	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	require.False(t, org.Whitelisted)
+	trial, err := ti.trials.GetTrial(ctx, orgID)
+	require.NoError(t, err)
+	require.True(t, trial.DemotedAt.Valid)
+	for _, keyType := range openrouter.AllKeyTypes {
+		require.Equal(t, []string{"trial_demotion"}, trialKey(t, ctx, ti, orgID, keyType).DisableCauses)
+	}
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	require.Equal(t, []string{orgID + ":chat", orgID + ":internal", orgID + ":chat", orgID + ":internal"}, ti.provisioner.reconciled)
+	require.Equal(t, []string{orgID}, ti.notifier.inactive)
+}
+
+func TestDemoteExpiredTrials_PreservesLayeredDisableCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat, []string{"admin_lock"})
+	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeInternal, []string{"billing_inactive"})
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+
+	chatKey := trialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "trial_demotion"}, chatKey.DisableCauses)
+	require.True(t, chatKey.Disabled, "adding trial_demotion over admin_lock remains disabled")
+	internalKey := trialKey(t, ctx, ti, orgID, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"trial_demotion", "billing_inactive"}, internalKey.DisableCauses)
+	require.True(t, internalKey.Disabled)
+	entry, err := audittest.LatestAuditLogByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted)
+	require.NoError(t, err)
+	metadata, err := audittest.DecodeAuditData(entry.Metadata)
+	require.NoError(t, err)
+	require.Equal(t, false, metadata["key_access_changed"], "layering a cause onto disabled keys does not change access")
+}
+
+func TestDemoteExpiredTrials_MissingKeysAreSafe(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	require.Equal(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.reconciled)
+}
+
+func TestDemoteExpiredTrials_NullDisableCausesFailClosedAndRollBack(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat, nil)
+
+	err := ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID})
+	require.ErrorContains(t, err, "unclassified key")
+
+	trial, getErr := ti.trials.GetTrial(ctx, orgID)
+	require.NoError(t, getErr)
+	require.False(t, trial.DemotedAt.Valid)
+	org, getErr := ti.orgs.GetOrganizationMetadata(ctx, orgID)
+	require.NoError(t, getErr)
 	require.Equal(t, "enterprise", org.GramAccountType)
-	require.True(t, org.Whitelisted)
+	key := trialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat)
+	require.Nil(t, key.DisableCauses)
+	require.True(t, key.Disabled, "NULL cause state remains fail-closed")
+	require.Empty(t, ti.provisioner.reconciled)
+}
+
+func TestDemoteExpiredTrials_AuditFailureRollsBackLifecycleCausesAndOutbox(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	for _, keyType := range openrouter.AllKeyTypes {
+		materializeTrialKey(t, ctx, ti, orgID, keyType, []string{})
+	}
+	beforeOutbox, err := testrepo.New(ti.conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+	require.NoError(t, audittest.RejectAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialDemoted))
+
+	require.Error(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
 
 	trial, err := ti.trials.GetTrial(ctx, orgID)
 	require.NoError(t, err)
 	require.False(t, trial.DemotedAt.Valid)
-
-	due, err := ti.activity.List(ctx)
+	org, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
 	require.NoError(t, err)
-	require.Equal(t, []string{orgID}, due)
-	require.Empty(t, ti.notifier.inactive, "a rolled-back demotion must not publish trial inactivity")
+	require.Equal(t, "enterprise", org.GramAccountType)
+	for _, keyType := range openrouter.AllKeyTypes {
+		key := trialKey(t, ctx, ti, orgID, keyType)
+		require.Empty(t, key.DisableCauses)
+		require.False(t, key.Disabled)
+	}
+	afterOutbox, err := testrepo.New(ti.conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+	require.Equal(t, beforeOutbox, afterOutbox)
+	require.Empty(t, ti.provisioner.reconciled)
+	require.Empty(t, ti.notifier.inactive)
+}
+
+func TestDemoteExpiredTrials_AcquiresAllKeyLocksInAllKeyTypesOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	internalLockConn, err := ti.conn.Acquire(ctx)
+	require.NoError(t, err)
+	internalParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
+	require.NoError(t, activitiesrepo.New(internalLockConn).AcquireOpenRouterKeyBillingLock(ctx, internalParams))
+	defer internalLockConn.Release()
+
+	demoted := make(chan error, 1)
+	go func() { demoted <- ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}) }()
+
+	chatWasHeld := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		probe, acquireErr := ti.conn.Acquire(ctx)
+		require.NoError(t, acquireErr)
+		probeCtx, cancel := context.WithTimeout(ctx, 25*time.Millisecond)
+		chatParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)}
+		lockErr := activitiesrepo.New(probe).AcquireOpenRouterKeyBillingLock(probeCtx, chatParams)
+		cancel()
+		if lockErr != nil {
+			_ = probe.Hijack().Close(ctx)
+			chatWasHeld = true
+			break
+		}
+		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(chatParams))
+		require.NoError(t, unlockErr)
+		require.True(t, unlocked)
+		probe.Release()
+	}
+	require.True(t, chatWasHeld, "chat lock must remain held while demotion waits for the later internal lock")
+
+	unlocked, err := activitiesrepo.New(internalLockConn).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
+	require.NoError(t, err)
+	require.True(t, unlocked)
+	require.NoError(t, <-demoted)
 }

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -3,6 +3,7 @@ package activities_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -56,7 +57,11 @@ func (n *recordingTrialNotifier) TrialInactive(_ context.Context, organizationID
 var _ openrouter.Provisioner = (*trialProvisioner)(nil)
 
 func (p *trialProvisioner) AddAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return p.local.AddAPIKeyDisableCauseWithDB(ctx, db, orgID, keyType, cause)
+	change, err := p.local.AddAPIKeyDisableCauseWithDB(ctx, db, orgID, keyType, cause)
+	if err != nil {
+		return change, fmt.Errorf("add OpenRouter API key disable cause: %w", err)
+	}
+	return change, nil
 }
 
 func (p *trialProvisioner) ReconcileAPIKeyDisabled(_ context.Context, orgID string, keyType openrouter.KeyType) error {
@@ -152,11 +157,12 @@ func materializeTrialKey(t *testing.T, ctx context.Context, ti *trialTestInstanc
 		MonthlyCredits: 100,
 	})
 	require.NoError(t, err)
-	_, err = ti.conn.Exec(ctx, `
-		UPDATE openrouter_api_keys
-		SET disable_causes = $3::text[], disabled = COALESCE(cardinality($3::text[]) > 0, TRUE)
-		WHERE organization_id = $1 AND key_type = $2
-	`, orgID, string(keyType), causes)
+	err = testrepo.New(ti.conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+		DisableCauses:  causes,
+		Disabled:       causes == nil || len(causes) > 0,
+	})
 	require.NoError(t, err)
 }
 
@@ -458,7 +464,7 @@ func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	}
 
 	rowLock := testenv.BeginTx(t, ctx, ti.conn)
-	_, err := rowLock.Exec(ctx, `SELECT 1 FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID)
+	_, err := trialsrepo.New(rowLock).LockTrialLifecycleForRearm(ctx, orgID)
 	require.NoError(t, err)
 
 	demoted := make(chan error, 1)
@@ -467,29 +473,21 @@ func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
 	defer cancelWait()
 	requireCondition(t, waitCtx, func() (bool, error) {
-		var blocked bool
-		err := ti.conn.QueryRow(waitCtx, `
-			SELECT EXISTS (
-				SELECT 1 FROM pg_stat_activity
-				WHERE datname = current_database()
-				  AND state = 'active'
-				  AND wait_event_type = 'Lock'
-				  AND query LIKE '%UPDATE trials%'
-			)
-		`).Scan(&blocked)
-		return blocked, err
+		blocked, err := testrepo.New(ti.conn).IsQueryBlockedOnLockFixture(waitCtx, "%UPDATE trials%")
+		if err != nil {
+			return false, fmt.Errorf("check blocked trial demotion query: %w", err)
+		}
+		return blocked, nil
 	}, "demotion did not block on the trial row")
 
 	probe, err := ti.conn.Acquire(ctx)
 	require.NoError(t, err)
 	defer probe.Release()
 	for _, keyType := range openrouter.AllKeyTypes {
-		var acquired bool
-		require.NoError(t, probe.QueryRow(ctx, `
-			SELECT pg_try_advisory_lock(
-				hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
-			)
-		`, string(keyType), orgID).Scan(&acquired))
+		acquired, err := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(ctx, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{
+			KeyType: string(keyType), OrganizationID: orgID,
+		})
+		require.NoError(t, err)
 		require.Truef(t, acquired, "%s lock must remain acquirable while the trial row is blocked", keyType)
 		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(keyType)})
 		require.NoError(t, unlockErr)
@@ -514,18 +512,18 @@ func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	chatHeldCtx, cancelChatHeld := context.WithTimeout(ctx, 2*time.Second)
 	defer cancelChatHeld()
 	requireCondition(t, chatHeldCtx, func() (bool, error) {
-		var acquired bool
-		err := probe.QueryRow(chatHeldCtx, `
-			SELECT pg_try_advisory_lock(
-				hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
-			)
-		`, string(openrouter.KeyTypeChat), orgID).Scan(&acquired)
-		if err != nil || !acquired {
-			return !acquired, err
+		acquired, err := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(chatHeldCtx, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{
+			KeyType: string(openrouter.KeyTypeChat), OrganizationID: orgID,
+		})
+		if err != nil {
+			return false, fmt.Errorf("probe chat billing lock: %w", err)
+		}
+		if !acquired {
+			return true, nil
 		}
 		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(chatHeldCtx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
 		if unlockErr != nil {
-			return false, unlockErr
+			return false, fmt.Errorf("release chat billing lock probe: %w", unlockErr)
 		}
 		if !unlocked {
 			return false, errors.New("probe chat lock was not released")
@@ -534,24 +532,12 @@ func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	}, "chat lock was not acquired before the blocked internal lock")
 
 	keyProbe := testenv.BeginTx(t, ctx, ti.conn)
-	rows, err := keyProbe.Query(ctx, `
-		SELECT disable_causes
-		FROM openrouter_api_keys
-		WHERE organization_id = $1
-		ORDER BY key_type
-		FOR UPDATE NOWAIT
-	`, orgID)
+	causesByKey, err := testrepo.New(keyProbe).ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture(ctx, orgID)
 	require.NoError(t, err, "key rows must remain unlocked until every advisory lock is held")
-	keyRows := 0
-	for rows.Next() {
-		keyRows++
-		var causes []string
-		require.NoError(t, rows.Scan(&causes))
+	for _, causes := range causesByKey {
 		require.Empty(t, causes, "trial_demotion must not be written before the internal lock is acquired")
 	}
-	require.NoError(t, rows.Err())
-	require.Equal(t, len(openrouter.AllKeyTypes), keyRows)
-	rows.Close()
+	require.Len(t, causesByKey, len(openrouter.AllKeyTypes))
 	require.NoError(t, keyProbe.Rollback(ctx))
 
 	unlocked, err := activitiesrepo.New(internalLockConn).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -2,9 +2,14 @@ package activities_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
@@ -388,6 +394,57 @@ func TestDemoteExpiredTrials_PreservesLayeredDisableCauses(t *testing.T) {
 	metadata, err := audittest.DecodeAuditData(entry.Metadata)
 	require.NoError(t, err)
 	require.Equal(t, false, metadata["key_access_changed"], "layering a cause onto disabled keys does not change access")
+	require.Empty(t, ti.provisioner.reconciled, "keys whose effective access did not change must not be patched upstream")
+}
+
+func TestDemoteExpiredTrials_ProductionOpenRouterPatchesOnlyChangedKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTrialTestInstance(t)
+	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
+	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseAdminLock)})
+	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeInternal, []string{})
+
+	var mu sync.Mutex
+	var patchedHashes []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		hash := strings.TrimPrefix(r.URL.Path, "/v1/keys/")
+		mu.Lock()
+		patchedHashes = append(patchedHashes, hash)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 100.0}})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	production := openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, ti.conn, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+	ti.activity = activities.NewDemoteExpiredTrials(
+		testenv.NewLogger(t), ti.conn, production, audit.NewLogger(), ti.notifier, ti.productFeatures,
+	)
+
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	mu.Lock()
+	gotPatchedHashes := append([]string(nil), patchedHashes...)
+	mu.Unlock()
+	require.Equal(t, []string{"hash-internal"}, gotPatchedHashes)
+	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
+	mu.Lock()
+	gotPatchedHashes = append([]string(nil), patchedHashes...)
+	mu.Unlock()
+	require.Equal(t, []string{"hash-internal", "hash-internal"}, gotPatchedHashes, "retry repairs only the key whose demotion changed access")
+	require.Equal(t, []string{"admin_lock", "trial_demotion"}, trialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat).DisableCauses)
+	require.Equal(t, []string{"trial_demotion"}, trialKey(t, ctx, ti, orgID, openrouter.KeyTypeInternal).DisableCauses)
 }
 
 func TestDemoteExpiredTrials_MissingKeysAreSafe(t *testing.T) {
@@ -397,7 +454,7 @@ func TestDemoteExpiredTrials_MissingKeysAreSafe(t *testing.T) {
 	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
 
 	require.NoError(t, ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}))
-	require.Equal(t, []string{orgID + ":chat", orgID + ":internal"}, ti.provisioner.reconciled)
+	require.Empty(t, ti.provisioner.reconciled)
 }
 
 func TestDemoteExpiredTrials_NullDisableCausesFailClosedAndRollBack(t *testing.T) {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -448,43 +448,151 @@ func TestDemoteExpiredTrials_AuditFailureRollsBackLifecycleCausesAndOutbox(t *te
 	require.Empty(t, ti.notifier.inactive)
 }
 
-func TestDemoteExpiredTrials_AcquiresAllKeyLocksInAllKeyTypesOrder(t *testing.T) {
+func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTrialTestInstance(t)
 	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
-	internalLockConn, err := ti.conn.Acquire(ctx)
+	for _, keyType := range openrouter.AllKeyTypes {
+		materializeTrialKey(t, ctx, ti, orgID, keyType, []string{})
+	}
+
+	rowLock := testenv.BeginTx(t, ctx, ti.conn)
+	_, err := rowLock.Exec(ctx, `SELECT 1 FROM trials WHERE organization_id = $1 FOR UPDATE`, orgID)
 	require.NoError(t, err)
-	internalParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
-	require.NoError(t, activitiesrepo.New(internalLockConn).AcquireOpenRouterKeyBillingLock(ctx, internalParams))
-	defer internalLockConn.Release()
 
 	demoted := make(chan error, 1)
 	go func() { demoted <- ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID}) }()
 
-	chatWasHeld := false
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		probe, acquireErr := ti.conn.Acquire(ctx)
-		require.NoError(t, acquireErr)
-		probeCtx, cancel := context.WithTimeout(ctx, 25*time.Millisecond)
-		chatParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)}
-		lockErr := activitiesrepo.New(probe).AcquireOpenRouterKeyBillingLock(probeCtx, chatParams)
-		cancel()
-		if lockErr != nil {
-			_ = probe.Hijack().Close(ctx)
-			chatWasHeld = true
-			break
-		}
-		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(chatParams))
+	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelWait()
+	requireCondition(t, waitCtx, func() (bool, error) {
+		var blocked bool
+		err := ti.conn.QueryRow(waitCtx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_stat_activity
+				WHERE datname = current_database()
+				  AND state = 'active'
+				  AND wait_event_type = 'Lock'
+				  AND query LIKE '%UPDATE trials%'
+			)
+		`).Scan(&blocked)
+		return blocked, err
+	}, "demotion did not block on the trial row")
+
+	probe, err := ti.conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer probe.Release()
+	for _, keyType := range openrouter.AllKeyTypes {
+		var acquired bool
+		require.NoError(t, probe.QueryRow(ctx, `
+			SELECT pg_try_advisory_lock(
+				hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
+			)
+		`, string(keyType), orgID).Scan(&acquired))
+		require.Truef(t, acquired, "%s lock must remain acquirable while the trial row is blocked", keyType)
+		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(keyType)})
 		require.NoError(t, unlockErr)
 		require.True(t, unlocked)
-		probe.Release()
 	}
-	require.True(t, chatWasHeld, "chat lock must remain held while demotion waits for the later internal lock")
+
+	internalLockConn, err := ti.conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer internalLockConn.Release()
+	internalParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
+	require.NoError(t, activitiesrepo.New(internalLockConn).AcquireOpenRouterKeyBillingLock(ctx, internalParams))
+	internalLocked := true
+	defer func() {
+		if !internalLocked {
+			return
+		}
+		_, _ = activitiesrepo.New(internalLockConn).ReleaseOpenRouterKeyBillingLock(context.WithoutCancel(ctx), activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
+	}()
+
+	require.NoError(t, rowLock.Commit(ctx))
+
+	chatHeldCtx, cancelChatHeld := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelChatHeld()
+	requireCondition(t, chatHeldCtx, func() (bool, error) {
+		var acquired bool
+		err := probe.QueryRow(chatHeldCtx, `
+			SELECT pg_try_advisory_lock(
+				hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
+			)
+		`, string(openrouter.KeyTypeChat), orgID).Scan(&acquired)
+		if err != nil || !acquired {
+			return !acquired, err
+		}
+		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(chatHeldCtx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+		if unlockErr != nil {
+			return false, unlockErr
+		}
+		if !unlocked {
+			return false, errors.New("probe chat lock was not released")
+		}
+		return false, nil
+	}, "chat lock was not acquired before the blocked internal lock")
+
+	keyProbe := testenv.BeginTx(t, ctx, ti.conn)
+	rows, err := keyProbe.Query(ctx, `
+		SELECT disable_causes
+		FROM openrouter_api_keys
+		WHERE organization_id = $1
+		ORDER BY key_type
+		FOR UPDATE NOWAIT
+	`, orgID)
+	require.NoError(t, err, "key rows must remain unlocked until every advisory lock is held")
+	keyRows := 0
+	for rows.Next() {
+		keyRows++
+		var causes []string
+		require.NoError(t, rows.Scan(&causes))
+		require.Empty(t, causes, "trial_demotion must not be written before the internal lock is acquired")
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, len(openrouter.AllKeyTypes), keyRows)
+	rows.Close()
+	require.NoError(t, keyProbe.Rollback(ctx))
 
 	unlocked, err := activitiesrepo.New(internalLockConn).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
 	require.NoError(t, err)
 	require.True(t, unlocked)
-	require.NoError(t, <-demoted)
+	internalLocked = false
+
+	resultCtx, cancelResult := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelResult()
+	select {
+	case err := <-demoted:
+		require.NoError(t, err)
+	case <-resultCtx.Done():
+		require.FailNow(t, "demotion did not finish after releasing the internal lock", resultCtx.Err().Error())
+	}
+	for _, keyType := range openrouter.AllKeyTypes {
+		require.Equal(t, []string{"trial_demotion"}, trialKey(t, ctx, ti, orgID, keyType).DisableCauses)
+	}
+	trial, err := ti.trials.GetTrial(ctx, orgID)
+	require.NoError(t, err)
+	require.True(t, trial.DemotedAt.Valid)
+	organization, err := ti.orgs.GetOrganizationMetadata(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, "free", organization.GramAccountType)
+}
+
+func requireCondition(t *testing.T, ctx context.Context, condition func() (bool, error), message string) {
+	t.Helper()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		met, err := condition()
+		require.NoError(t, err)
+		if met {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			require.FailNow(t, message, ctx.Err().Error())
+		case <-ticker.C:
+		}
+	}
 }

--- a/server/internal/openrouterkeys/setup_test.go
+++ b/server/internal/openrouterkeys/setup_test.go
@@ -132,7 +132,6 @@ type stubProvisioner struct {
 	usageLimit *int64
 
 	usageCalls       []string
-	disableCalls     []string
 	refreshCalls     []string
 	addCauseCalls    []string
 	removeCauseCalls []string
@@ -287,10 +286,6 @@ func (s *stubProvisioner) ReconcileCalls() int {
 }
 
 func (s *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
-	s.mu.Lock()
-	s.disableCalls = append(s.disableCalls, orgID+"/"+string(keyType))
-	s.mu.Unlock()
-
 	if err := orgrepo.New(s.conn).DisableOpenRouterAPIKey(ctx, orgrepo.DisableOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(keyType),
@@ -389,7 +384,6 @@ func newTestServiceWithOptions(t *testing.T, factory provisionerFactory, options
 		usage:        0,
 		usageLimit:   nil,
 		usageCalls:   nil,
-		disableCalls: nil,
 		refreshCalls: nil,
 	}
 	var provisioner openrouter.Provisioner = stub

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -620,11 +620,27 @@ SELECT pg_try_advisory_lock(
     hashtextextended('openrouter-' || @key_type::text || '-billing:' || @organization_id::text, 0)
 );
 
+-- name: SoftDeleteOpenRouterAPIKeyFixture :exec
+-- Test-only fixture: soft-deletes one classified key row.
+UPDATE openrouter_api_keys
+SET deleted_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
+-- name: LockOpenRouterAPIKeyForUpdateFixture :one
+-- Test-only synchronization: holds a row lock even when the key is soft-deleted.
+SELECT 1
+FROM openrouter_api_keys
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+FOR UPDATE;
+
 -- name: ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture :many
 -- Test-only lock-order probe: fails immediately if any matching key row is locked.
 SELECT disable_causes
 FROM openrouter_api_keys
 WHERE organization_id = @organization_id
+  AND deleted IS FALSE
 ORDER BY key_type
 FOR UPDATE NOWAIT;
 

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -598,10 +598,36 @@ SET key_hash = @key_hash
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 
+-- name: SeedTrialArmAuditFixture :one
+-- Test-only fixture: records the immutable audit operation for a trial generation.
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type)
+VALUES (@organization_id, 'system', 'user', 'organization:enterprise_trial_armed', @organization_id, 'organization')
+RETURNING id::text;
+
+-- name: GetLatestTrialArmAuditIDFixture :one
+-- Test-only fixture: reads the arm operation selected by the production ordering.
+SELECT id::text
+FROM audit_logs
+WHERE organization_id = @organization_id
+  AND action = 'organization:enterprise_trial_armed'
+ORDER BY seq DESC, id DESC
+LIMIT 1;
+
 -- name: SeedRearmAuditMetadataFixture :exec
 -- Test-only fixture: seeds a historical re-arm audit with caller-provided metadata.
 INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
 VALUES (@organization_id, 'system', 'user', 'organization:enterprise_trial_rearmed', @organization_id, 'organization', @metadata::jsonb);
+
+-- name: RecreateTrialGenerationFixture :exec
+-- Test-only fixture: replaces a trial while preserving timestamp precision.
+WITH deleted AS (
+    DELETE FROM trials AS doomed
+    WHERE doomed.organization_id = @target_organization_id
+    RETURNING doomed.organization_id
+)
+INSERT INTO trials (organization_id, tier, created_at, ends_at)
+SELECT deleted.organization_id, @tier, @created_at, @ends_at
+FROM deleted;
 
 -- name: IsQueryBlockedOnLockFixture :one
 -- Test-only synchronization: reports whether a matching active query is waiting on a lock.

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -125,6 +125,16 @@ UPDATE deployments_functions SET memory_mib_override = @memory_mib_override, sca
 
 -- name: GetDeploymentFunctionInfraOverrides :many
 SELECT memory_mib_override, scale_override FROM deployments_functions WHERE deployment_id = @deployment_id;
+-- name: SetOpenRouterKeyLifecycleFixture :execrows
+-- Test-only fixture for Stripe lifecycle tests.
+UPDATE openrouter_api_keys
+SET disabled = @disabled,
+    disable_causes = @disable_causes,
+    monthly_credits = @monthly_credits
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE;
+
 -- name: SeedAuditLogFixture :one
 INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
 VALUES (@organization_id, 'user:<USER_ID>', 'user', @action, 'subject:<SUBJECT_ID>', 'subject', jsonb_build_object('key_type', @key_type::text))

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -604,6 +604,24 @@ INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_i
 VALUES (@organization_id, 'system', 'user', 'organization:enterprise_trial_armed', @organization_id, 'organization')
 RETURNING id::text;
 
+-- name: SeedTrialDemotionAuditFixture :exec
+-- Test-only fixture: records the committed demotion boundary for a retry cycle.
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type)
+VALUES (@organization_id, 'system', 'user', 'organization:enterprise_trial_demoted', @organization_id, 'organization');
+
+-- name: RedemoteTrialLifecycleFixture :exec
+-- Test-only fixture: starts another demotion/re-arm cycle in the same generation.
+WITH demoted_trial AS (
+    UPDATE trials
+    SET ends_at = clock_timestamp() - interval '1 day',
+        demoted_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+    WHERE organization_id = @organization_id
+)
+UPDATE organization_metadata
+SET gram_account_type = 'free', whitelisted = FALSE
+WHERE id = @organization_id;
+
 -- name: GetLatestTrialArmAuditIDFixture :one
 -- Test-only fixture: reads the arm operation selected by the production ordering.
 SELECT id::text

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -588,6 +588,36 @@ SET key_hash = @key_hash
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 
+-- name: SeedRearmAuditMetadataFixture :exec
+-- Test-only fixture: seeds a historical re-arm audit with caller-provided metadata.
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
+VALUES (@organization_id, 'system', 'user', 'organization:enterprise_trial_rearmed', @organization_id, 'organization', @metadata::jsonb);
+
+-- name: IsQueryBlockedOnLockFixture :one
+-- Test-only synchronization: reports whether a matching active query is waiting on a lock.
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_stat_activity
+    WHERE datname = current_database()
+      AND state = 'active'
+      AND wait_event_type = 'Lock'
+      AND query LIKE @query_pattern::text
+);
+
+-- name: TryAcquireOpenRouterKeyBillingLockFixture :one
+-- Test-only non-blocking probe of the production OpenRouter billing lock key.
+SELECT pg_try_advisory_lock(
+    hashtextextended('openrouter-' || @key_type::text || '-billing:' || @organization_id::text, 0)
+);
+
+-- name: ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture :many
+-- Test-only lock-order probe: fails immediately if any matching key row is locked.
+SELECT disable_causes
+FROM openrouter_api_keys
+WHERE organization_id = @organization_id
+ORDER BY key_type
+FOR UPDATE NOWAIT;
+
 -- name: SeedOpenRouterSpendRangeFixture :exec
 -- Test-only fixture: records one exact daily spend amount across an inclusive
 -- UTC date range.

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1643,6 +1643,25 @@ func (q *Queries) RecreateTrialGenerationFixture(ctx context.Context, arg Recrea
 	return err
 }
 
+const redemoteTrialLifecycleFixture = `-- name: RedemoteTrialLifecycleFixture :exec
+WITH demoted_trial AS (
+    UPDATE trials
+    SET ends_at = clock_timestamp() - interval '1 day',
+        demoted_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+    WHERE organization_id = $1
+)
+UPDATE organization_metadata
+SET gram_account_type = 'free', whitelisted = FALSE
+WHERE id = $1
+`
+
+// Test-only fixture: starts another demotion/re-arm cycle in the same generation.
+func (q *Queries) RedemoteTrialLifecycleFixture(ctx context.Context, organizationID string) error {
+	_, err := q.db.Exec(ctx, redemoteTrialLifecycleFixture, organizationID)
+	return err
+}
+
 const scrubDeploymentFunctionMachineSpecs = `-- name: ScrubDeploymentFunctionMachineSpecs :exec
 UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deployment_id = $1
 `
@@ -1940,6 +1959,17 @@ func (q *Queries) SeedTrialArmAuditFixture(ctx context.Context, organizationID s
 	var id string
 	err := row.Scan(&id)
 	return id, err
+}
+
+const seedTrialDemotionAuditFixture = `-- name: SeedTrialDemotionAuditFixture :exec
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type)
+VALUES ($1, 'system', 'user', 'organization:enterprise_trial_demoted', $1, 'organization')
+`
+
+// Test-only fixture: records the committed demotion boundary for a retry cycle.
+func (q *Queries) SeedTrialDemotionAuditFixture(ctx context.Context, organizationID string) error {
+	_, err := q.db.Exec(ctx, seedTrialDemotionAuditFixture, organizationID)
+	return err
 }
 
 const seedUnrelatedAuditHistoryFixture = `-- name: SeedUnrelatedAuditHistoryFixture :exec

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1420,6 +1420,7 @@ const listOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture = `-- name: ListOp
 SELECT disable_causes
 FROM openrouter_api_keys
 WHERE organization_id = $1
+  AND deleted IS FALSE
 ORDER BY key_type
 FOR UPDATE NOWAIT
 `
@@ -1559,6 +1560,27 @@ func (q *Queries) ListRiskResultsAll(ctx context.Context, arg ListRiskResultsAll
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockOpenRouterAPIKeyForUpdateFixture = `-- name: LockOpenRouterAPIKeyForUpdateFixture :one
+SELECT 1
+FROM openrouter_api_keys
+WHERE organization_id = $1
+  AND key_type = $2
+FOR UPDATE
+`
+
+type LockOpenRouterAPIKeyForUpdateFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only synchronization: holds a row lock even when the key is soft-deleted.
+func (q *Queries) LockOpenRouterAPIKeyForUpdateFixture(ctx context.Context, arg LockOpenRouterAPIKeyForUpdateFixtureParams) (int32, error) {
+	row := q.db.QueryRow(ctx, lockOpenRouterAPIKeyForUpdateFixture, arg.OrganizationID, arg.KeyType)
+	var column_1 int32
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const pauseDeviceIntegrationSyncsFixture = `-- name: PauseDeviceIntegrationSyncsFixture :exec
@@ -2190,6 +2212,24 @@ type SetWorkosLastEventIDFixtureParams struct {
 // get wrong while still compiling.
 func (q *Queries) SetWorkosLastEventIDFixture(ctx context.Context, arg SetWorkosLastEventIDFixtureParams) error {
 	_, err := q.db.Exec(ctx, setWorkosLastEventIDFixture, arg.WorkosLastEventID, arg.ID)
+	return err
+}
+
+const softDeleteOpenRouterAPIKeyFixture = `-- name: SoftDeleteOpenRouterAPIKeyFixture :exec
+UPDATE openrouter_api_keys
+SET deleted_at = clock_timestamp()
+WHERE organization_id = $1
+  AND key_type = $2
+`
+
+type SoftDeleteOpenRouterAPIKeyFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only fixture: soft-deletes one classified key row.
+func (q *Queries) SoftDeleteOpenRouterAPIKeyFixture(ctx context.Context, arg SoftDeleteOpenRouterAPIKeyFixtureParams) error {
+	_, err := q.db.Exec(ctx, softDeleteOpenRouterAPIKeyFixture, arg.OrganizationID, arg.KeyType)
 	return err
 }
 

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -592,6 +592,23 @@ func (q *Queries) GetDeviceIntegrationSyncPushDigests(ctx context.Context, devic
 	return items, nil
 }
 
+const getLatestTrialArmAuditIDFixture = `-- name: GetLatestTrialArmAuditIDFixture :one
+SELECT id::text
+FROM audit_logs
+WHERE organization_id = $1
+  AND action = 'organization:enterprise_trial_armed'
+ORDER BY seq DESC, id DESC
+LIMIT 1
+`
+
+// Test-only fixture: reads the arm operation selected by the production ordering.
+func (q *Queries) GetLatestTrialArmAuditIDFixture(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, getLatestTrialArmAuditIDFixture, organizationID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getOrganizationMetadataStateFixture = `-- name: GetOrganizationMetadataStateFixture :one
 SELECT disabled_at, workos_last_event_id, whitelisted, gram_account_type, created_at, updated_at
 FROM organization_metadata
@@ -1597,6 +1614,35 @@ func (q *Queries) PauseDeviceIntegrationSyncsFixture(ctx context.Context, device
 	return err
 }
 
+const recreateTrialGenerationFixture = `-- name: RecreateTrialGenerationFixture :exec
+WITH deleted AS (
+    DELETE FROM trials AS doomed
+    WHERE doomed.organization_id = $4
+    RETURNING doomed.organization_id
+)
+INSERT INTO trials (organization_id, tier, created_at, ends_at)
+SELECT deleted.organization_id, $1, $2, $3
+FROM deleted
+`
+
+type RecreateTrialGenerationFixtureParams struct {
+	Tier                 string
+	CreatedAt            pgtype.Timestamptz
+	EndsAt               pgtype.Timestamptz
+	TargetOrganizationID string
+}
+
+// Test-only fixture: replaces a trial while preserving timestamp precision.
+func (q *Queries) RecreateTrialGenerationFixture(ctx context.Context, arg RecreateTrialGenerationFixtureParams) error {
+	_, err := q.db.Exec(ctx, recreateTrialGenerationFixture,
+		arg.Tier,
+		arg.CreatedAt,
+		arg.EndsAt,
+		arg.TargetOrganizationID,
+	)
+	return err
+}
+
 const scrubDeploymentFunctionMachineSpecs = `-- name: ScrubDeploymentFunctionMachineSpecs :exec
 UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deployment_id = $1
 `
@@ -1878,6 +1924,20 @@ func (q *Queries) SeedRiskResultFixture(ctx context.Context, arg SeedRiskResultF
 		arg.Spans,
 	)
 	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const seedTrialArmAuditFixture = `-- name: SeedTrialArmAuditFixture :one
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type)
+VALUES ($1, 'system', 'user', 'organization:enterprise_trial_armed', $1, 'organization')
+RETURNING id::text
+`
+
+// Test-only fixture: records the immutable audit operation for a trial generation.
+func (q *Queries) SeedTrialArmAuditFixture(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, seedTrialArmAuditFixture, organizationID)
+	var id string
 	err := row.Scan(&id)
 	return id, err
 }

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -2040,6 +2040,39 @@ func (q *Queries) SetOpenRouterAPIKeyHashFixture(ctx context.Context, arg SetOpe
 	return err
 }
 
+const setOpenRouterKeyLifecycleFixture = `-- name: SetOpenRouterKeyLifecycleFixture :execrows
+UPDATE openrouter_api_keys
+SET disabled = $1,
+    disable_causes = $2,
+    monthly_credits = $3
+WHERE organization_id = $4
+  AND key_type = $5
+  AND deleted IS FALSE
+`
+
+type SetOpenRouterKeyLifecycleFixtureParams struct {
+	Disabled       bool
+	DisableCauses  []string
+	MonthlyCredits int64
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only fixture for Stripe lifecycle tests.
+func (q *Queries) SetOpenRouterKeyLifecycleFixture(ctx context.Context, arg SetOpenRouterKeyLifecycleFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setOpenRouterKeyLifecycleFixture,
+		arg.Disabled,
+		arg.DisableCauses,
+		arg.MonthlyCredits,
+		arg.OrganizationID,
+		arg.KeyType,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const setOrgWebhookConfig = `-- name: SetOrgWebhookConfig :exec
 UPDATE organization_metadata
 SET svix_app_id = $1,

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1195,6 +1195,25 @@ func (q *Queries) InstallOpenRouterAdminDisableAuditFailureFixture(ctx context.C
 	return err
 }
 
+const isQueryBlockedOnLockFixture = `-- name: IsQueryBlockedOnLockFixture :one
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_stat_activity
+    WHERE datname = current_database()
+      AND state = 'active'
+      AND wait_event_type = 'Lock'
+      AND query LIKE $1::text
+)
+`
+
+// Test-only synchronization: reports whether a matching active query is waiting on a lock.
+func (q *Queries) IsQueryBlockedOnLockFixture(ctx context.Context, queryPattern string) (bool, error) {
+	row := q.db.QueryRow(ctx, isQueryBlockedOnLockFixture, queryPattern)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const listDeploymentFunctionsResources = `-- name: ListDeploymentFunctionsResources :many
 SELECT id, resource_urn, project_id, deployment_id, function_id, runtime, name, description, uri, title, mime_type, variables, meta, created_at, updated_at, deleted_at, deleted
 FROM function_resource_definitions
@@ -1390,6 +1409,35 @@ func (q *Queries) ListDeviceAgentDeviceSyncsFixture(ctx context.Context, organiz
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture = `-- name: ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture :many
+SELECT disable_causes
+FROM openrouter_api_keys
+WHERE organization_id = $1
+ORDER BY key_type
+FOR UPDATE NOWAIT
+`
+
+// Test-only lock-order probe: fails immediately if any matching key row is locked.
+func (q *Queries) ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture(ctx context.Context, organizationID string) ([][]string, error) {
+	rows, err := q.db.Query(ctx, listOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items [][]string
+	for rows.Next() {
+		var disable_causes []string
+		if err := rows.Scan(&disable_causes); err != nil {
+			return nil, err
+		}
+		items = append(items, disable_causes)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -1729,6 +1777,22 @@ func (q *Queries) SeedPublishOutboxRow(ctx context.Context, arg SeedPublishOutbo
 	var i SeedPublishOutboxRowRow
 	err := row.Scan(&i.ID, &i.PublicID)
 	return i, err
+}
+
+const seedRearmAuditMetadataFixture = `-- name: SeedRearmAuditMetadataFixture :exec
+INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type, metadata)
+VALUES ($1, 'system', 'user', 'organization:enterprise_trial_rearmed', $1, 'organization', $2::jsonb)
+`
+
+type SeedRearmAuditMetadataFixtureParams struct {
+	OrganizationID string
+	Metadata       []byte
+}
+
+// Test-only fixture: seeds a historical re-arm audit with caller-provided metadata.
+func (q *Queries) SeedRearmAuditMetadataFixture(ctx context.Context, arg SeedRearmAuditMetadataFixtureParams) error {
+	_, err := q.db.Exec(ctx, seedRearmAuditMetadataFixture, arg.OrganizationID, arg.Metadata)
+	return err
 }
 
 const seedRiskPolicyFixture = `-- name: SeedRiskPolicyFixture :one
@@ -2094,6 +2158,25 @@ type SetWorkosLastEventIDFixtureParams struct {
 func (q *Queries) SetWorkosLastEventIDFixture(ctx context.Context, arg SetWorkosLastEventIDFixtureParams) error {
 	_, err := q.db.Exec(ctx, setWorkosLastEventIDFixture, arg.WorkosLastEventID, arg.ID)
 	return err
+}
+
+const tryAcquireOpenRouterKeyBillingLockFixture = `-- name: TryAcquireOpenRouterKeyBillingLockFixture :one
+SELECT pg_try_advisory_lock(
+    hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
+)
+`
+
+type TryAcquireOpenRouterKeyBillingLockFixtureParams struct {
+	KeyType        string
+	OrganizationID string
+}
+
+// Test-only non-blocking probe of the production OpenRouter billing lock key.
+func (q *Queries) TryAcquireOpenRouterKeyBillingLockFixture(ctx context.Context, arg TryAcquireOpenRouterKeyBillingLockFixtureParams) (bool, error) {
+	row := q.db.QueryRow(ctx, tryAcquireOpenRouterKeyBillingLockFixture, arg.KeyType, arg.OrganizationID)
+	var pg_try_advisory_lock bool
+	err := row.Scan(&pg_try_advisory_lock)
+	return pg_try_advisory_lock, err
 }
 
 const updateChatMessageCreatedAt = `-- name: UpdateChatMessageCreatedAt :exec

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -3,6 +3,8 @@ package openrouter
 import (
 	"context"
 	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 )
 
 type DisableCause string
@@ -36,6 +38,24 @@ type DisableCauseChange struct {
 
 func unchangedDisableCauseChange() DisableCauseChange {
 	return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}
+}
+
+// AcquireAPIKeyBillingTransactionLock serializes a caller-owned business
+// transaction with key replacement and upstream reconciliation. Callers that
+// fan out must acquire these locks in AllKeyTypes order before reading key rows.
+func AcquireAPIKeyBillingTransactionLock(ctx context.Context, db DBTX, orgID string, keyType KeyType) error {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return fmt.Errorf("acquire OpenRouter API key billing transaction lock: %w", err)
+	}
+
+	if err := repo.New(db).AcquireOpenRouterBillingLock(ctx, repo.AcquireOpenRouterBillingLockParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	}); err != nil {
+		return fmt.Errorf("acquire OpenRouter %s key billing transaction lock: %w", keyType, err)
+	}
+	return nil
 }
 
 // EffectiveDisabled preserves legacy access for rows that have not been

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -416,8 +416,8 @@ func TestDisableAPIKey_IsIdempotent(t *testing.T) {
 	require.True(t, row.Disabled)
 }
 
-// An organization that never provisioned a key of this type has nothing to
-// lock down, and the sweeper must not fail on it.
+// A missing key is already effectively disabled, so disabling it is a no-op
+// and must not issue an upstream mutation.
 func TestDisableAPIKey_NoKeyIsNoop(t *testing.T) {
 	t.Parallel()
 
@@ -429,8 +429,8 @@ func TestDisableAPIKey_NoKeyIsNoop(t *testing.T) {
 	require.Empty(t, upstream.recorded())
 }
 
-// Sales reinstate a demoted organization by raising its limit, so the refresh
-// path has to clear the flag on both sides.
+// Refreshing a classified key updates its limit without discarding the causes
+// that still determine whether it is disabled.
 func TestRefreshAPIKeyLimit_PreservesClassifiedDisableCauses(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -54,6 +54,10 @@ func (o *Development) RemoveAPIKeyDisableCauseWithDB(context.Context, DBTX, stri
 	return 0, unchangedDisableCauseChange(), nil
 }
 
+func (o *Development) ReconcileAPIKeyDisabled(context.Context, string, KeyType) error {
+	return nil
+}
+
 func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	return nil
 }

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -169,6 +169,12 @@ func TestAddDisableCauseReconcilesUpstreamAfterRolledBackFinalRemoval(t *testing
 	require.True(t, row.Disabled)
 }
 
+func TestDevelopmentReconcileAPIKeyDisabledIsSafe(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, NewDevelopment("local-key").ReconcileAPIKeyDisabled(t.Context(), "org-local", KeyTypeChat))
+}
+
 func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -155,9 +155,6 @@ FOR UPDATE;
 -- ends_at moves to a window measured from now, not left where it is:
 -- MarkTrialDemoted only demotes an already-past ends_at, so clearing demoted_at
 -- alone leaves a row the next sweep demotes again.
---
--- converted_at IS NULL guards nothing today, because MarkTrialConverted has no
--- production caller. It is written for the conversion path that will (AGE-3218).
 UPDATE trials
 SET demoted_at = NULL,
     ends_at = clock_timestamp() + make_interval(days => @rearm_for_days::int),

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -141,6 +141,13 @@ FROM previous
 WHERE trials.organization_id = previous.organization_id
 RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
+-- name: LockTrialLifecycleForRearm :one
+-- Lifecycle operations lock this row before taking OpenRouter advisory locks.
+SELECT tier, ends_at, converted_at, demoted_at
+FROM trials
+WHERE organization_id = @organization_id
+FOR UPDATE;
+
 -- name: RearmTrial :one
 -- Operator-initiated reinstatement of a demoted trial. Returns the tier the
 -- trial grants, which the handler writes back onto the organization.

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -143,7 +143,7 @@ RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
 -- name: LockTrialLifecycleForRearm :one
 -- Lifecycle operations lock this row before taking OpenRouter advisory locks.
-SELECT tier, ends_at, converted_at, demoted_at
+SELECT tier, ends_at, converted_at, demoted_at, created_at
 FROM trials
 WHERE organization_id = @organization_id
 FOR UPDATE;

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -143,7 +143,7 @@ RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
 -- name: LockTrialLifecycleForRearm :one
 -- Lifecycle operations lock this row before taking OpenRouter advisory locks.
-SELECT tier, ends_at, converted_at, demoted_at, created_at
+SELECT tier, ends_at, converted_at, demoted_at
 FROM trials
 WHERE organization_id = @organization_id
 FOR UPDATE;

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -285,7 +285,7 @@ func (q *Queries) ListExpiredTrials(ctx context.Context) ([]string, error) {
 }
 
 const lockTrialLifecycleForRearm = `-- name: LockTrialLifecycleForRearm :one
-SELECT tier, ends_at, converted_at, demoted_at, created_at
+SELECT tier, ends_at, converted_at, demoted_at
 FROM trials
 WHERE organization_id = $1
 FOR UPDATE
@@ -296,7 +296,6 @@ type LockTrialLifecycleForRearmRow struct {
 	EndsAt      pgtype.Timestamptz
 	ConvertedAt pgtype.Timestamptz
 	DemotedAt   pgtype.Timestamptz
-	CreatedAt   pgtype.Timestamptz
 }
 
 // Lifecycle operations lock this row before taking OpenRouter advisory locks.
@@ -308,7 +307,6 @@ func (q *Queries) LockTrialLifecycleForRearm(ctx context.Context, organizationID
 		&i.EndsAt,
 		&i.ConvertedAt,
 		&i.DemotedAt,
-		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -383,9 +383,6 @@ type RearmTrialRow struct {
 // ends_at moves to a window measured from now, not left where it is:
 // MarkTrialDemoted only demotes an already-past ends_at, so clearing demoted_at
 // alone leaves a row the next sweep demotes again.
-//
-// converted_at IS NULL guards nothing today, because MarkTrialConverted has no
-// production caller. It is written for the conversion path that will (AGE-3218).
 func (q *Queries) RearmTrial(ctx context.Context, arg RearmTrialParams) (RearmTrialRow, error) {
 	row := q.db.QueryRow(ctx, rearmTrial, arg.RearmForDays, arg.OrganizationID)
 	var i RearmTrialRow

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -284,6 +284,33 @@ func (q *Queries) ListExpiredTrials(ctx context.Context) ([]string, error) {
 	return items, nil
 }
 
+const lockTrialLifecycleForRearm = `-- name: LockTrialLifecycleForRearm :one
+SELECT tier, ends_at, converted_at, demoted_at
+FROM trials
+WHERE organization_id = $1
+FOR UPDATE
+`
+
+type LockTrialLifecycleForRearmRow struct {
+	Tier        string
+	EndsAt      pgtype.Timestamptz
+	ConvertedAt pgtype.Timestamptz
+	DemotedAt   pgtype.Timestamptz
+}
+
+// Lifecycle operations lock this row before taking OpenRouter advisory locks.
+func (q *Queries) LockTrialLifecycleForRearm(ctx context.Context, organizationID string) (LockTrialLifecycleForRearmRow, error) {
+	row := q.db.QueryRow(ctx, lockTrialLifecycleForRearm, organizationID)
+	var i LockTrialLifecycleForRearmRow
+	err := row.Scan(
+		&i.Tier,
+		&i.EndsAt,
+		&i.ConvertedAt,
+		&i.DemotedAt,
+	)
+	return i, err
+}
+
 const markTrialConverted = `-- name: MarkTrialConverted :execrows
 UPDATE trials
 SET converted_at = clock_timestamp(),

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -285,7 +285,7 @@ func (q *Queries) ListExpiredTrials(ctx context.Context) ([]string, error) {
 }
 
 const lockTrialLifecycleForRearm = `-- name: LockTrialLifecycleForRearm :one
-SELECT tier, ends_at, converted_at, demoted_at
+SELECT tier, ends_at, converted_at, demoted_at, created_at
 FROM trials
 WHERE organization_id = $1
 FOR UPDATE
@@ -296,6 +296,7 @@ type LockTrialLifecycleForRearmRow struct {
 	EndsAt      pgtype.Timestamptz
 	ConvertedAt pgtype.Timestamptz
 	DemotedAt   pgtype.Timestamptz
+	CreatedAt   pgtype.Timestamptz
 }
 
 // Lifecycle operations lock this row before taking OpenRouter advisory locks.
@@ -307,6 +308,7 @@ func (q *Queries) LockTrialLifecycleForRearm(ctx context.Context, organizationID
 		&i.EndsAt,
 		&i.ConvertedAt,
 		&i.DemotedAt,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -3,7 +3,6 @@ package usage_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,9 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
-	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
@@ -99,101 +96,9 @@ func (*m3StripeWebhookClient) Catalog() stripeclient.Catalog {
 	return stripeclient.Catalog{PriceIDTUM: "", MeterIDTUM: "", MeterEventName: "", PortalConfigurationID: ""}
 }
 
-type m3OpenRouterProvisioner struct {
-	db           openrouterrepo.DBTX
-	disableCalls []openrouter.KeyType
-	refreshCalls []openrouter.KeyType
-}
-
-func (*m3OpenRouterProvisioner) ProvisionAPIKey(context.Context, string, openrouter.KeyType) (string, error) {
-	return "", errors.New("not implemented")
-}
-
-func (p *m3OpenRouterProvisioner) RefreshAPIKeyLimit(ctx context.Context, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, p.db, organizationID, keyType, limit)
-}
-
-func (p *m3OpenRouterProvisioner) RefreshAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, db, organizationID, keyType, limit)
-}
-
-func (p *m3OpenRouterProvisioner) ReinstateAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	return p.reinstateAPIKeyLimit(ctx, db, organizationID, keyType, limit)
-}
-
-func (p *m3OpenRouterProvisioner) reinstateAPIKeyLimit(ctx context.Context, db openrouterrepo.DBTX, organizationID string, keyType openrouter.KeyType, limit *int) (int, error) {
-	key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
-		OrganizationID: organizationID,
-		KeyType:        string(keyType),
-	})
-	if err != nil {
-		return 0, fmt.Errorf("get OpenRouter API key: %w", err)
-	}
-	refreshed, err := openrouterrepo.New(db).UpdateOpenRouterKey(ctx, openrouterrepo.UpdateOpenRouterKeyParams{
-		MonthlyCredits: int64(*limit),
-		KeyHash:        key.KeyHash,
-		Reinstate:      key.Disabled,
-		OrganizationID: organizationID,
-		KeyType:        string(keyType),
-	})
-	if err != nil {
-		return 0, fmt.Errorf("update OpenRouter API key: %w", err)
-	}
-	p.refreshCalls = append(p.refreshCalls, keyType)
-	return int(refreshed.MonthlyCredits), nil
-}
-
-func (*m3OpenRouterProvisioner) AddAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error) {
-	return openrouter.DisableCauseChange{}, nil
-}
-
-func (*m3OpenRouterProvisioner) RemoveAPIKeyDisableCause(context.Context, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
-	return 0, openrouter.DisableCauseChange{}, nil
-}
-
-func (p *m3OpenRouterProvisioner) DisableAPIKey(ctx context.Context, organizationID string, keyType openrouter.KeyType) error {
-	return p.disableAPIKey(ctx, p.db, organizationID, keyType)
-}
-
-func (p *m3OpenRouterProvisioner) DisableAPIKeyWithDB(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType) error {
-	return p.disableAPIKey(ctx, db, organizationID, keyType)
-}
-
-func (p *m3OpenRouterProvisioner) disableAPIKey(ctx context.Context, db openrouter.DBTX, organizationID string, keyType openrouter.KeyType) error {
-	p.disableCalls = append(p.disableCalls, keyType)
-	if err := openrouterrepo.New(db).DisableOpenRouterAPIKey(ctx, openrouterrepo.DisableOpenRouterAPIKeyParams{
-		OrganizationID: organizationID,
-		KeyType:        string(keyType),
-	}); err != nil {
-		return fmt.Errorf("disable OpenRouter API key: %w", err)
-	}
-	return nil
-}
-
-func (*m3OpenRouterProvisioner) GetCreditsUsed(context.Context, string, openrouter.KeyType) (float64, int, error) {
-	return 0, 0, errors.New("not implemented")
-}
-
-func (*m3OpenRouterProvisioner) GetKeyUsage(context.Context, string) (float64, *int64, error) {
-	return 0, nil, errors.New("not implemented")
-}
-
-func (*m3OpenRouterProvisioner) ReconcileMonthlyCredits(context.Context, string, openrouter.KeyType, int64, int64, *int64) (int64, error) {
-	return 0, errors.New("not implemented")
-}
-
-func (p *m3OpenRouterProvisioner) ReconcileMonthlyCreditsWithDB(ctx context.Context, _ openrouter.DBTX, organizationID string, keyType openrouter.KeyType, currentLimit int64, currentGeneration int64, upstreamLimit *int64) (int64, error) {
-	return p.ReconcileMonthlyCredits(ctx, organizationID, keyType, currentLimit, currentGeneration, upstreamLimit)
-}
-
-func (*m3OpenRouterProvisioner) GetModelUsage(context.Context, string, string, openrouter.KeyType) (*openrouter.ModelUsage, error) {
-	return nil, errors.New("not implemented")
-}
-
 func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	t.Parallel()
 
-	logger := testenv.NewLogger(t)
 	db, err := usage.CloneM3BillingValidationDatabase(t, "m3_subscription_lifecycle")
 	require.NoError(t, err)
 
@@ -221,7 +126,6 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	}
 
 	stripe := &m3StripeWebhookClient{}
-	provisioner := &m3OpenRouterProvisioner{db: db, disableCalls: nil, refreshCalls: nil}
 	service, metrics := usage.NewM3StripeWebhookService(t, db, stripe)
 	mux := goahttp.NewMuxer()
 	usage.Attach(mux, service)
@@ -277,25 +181,14 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	deleted("event_subscription_loss", "subscription_initial")
 	require.EqualValues(t, 1, metrics.SubscriptionLosses())
 	require.True(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.Equal(t, []string{"billing_inactive"}, keyState(openrouter.KeyTypeChat).DisableCauses)
 	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
-
-	reconciler := activities.NewReconcilePaygOpenRouterChatKey(logger, db, provisioner)
-	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
-		OrganizationID: m3OrganizationID,
-		DesiredState:   openrouter.KeyDesiredStateDisabled,
-	}))
-	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.disableCalls)
-	require.Empty(t, provisioner.refreshCalls)
 	require.EqualValues(t, 70, keyState(openrouter.KeyTypeInternal).MonthlyCredits)
 
 	secondAnchor := time.Date(2026, time.October, 2, 0, 0, 0, 0, time.UTC)
 	checkout("event_recheckout", "subscription_replacement", secondAnchor)
-	require.True(t, keyState(openrouter.KeyTypeChat).Disabled, "recheckout commits before the durable wake-up is consumed")
-	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
-		OrganizationID: m3OrganizationID,
-		DesiredState:   openrouter.KeyDesiredStateEnabled,
-	}))
 	require.False(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.Empty(t, keyState(openrouter.KeyTypeChat).DisableCauses)
 	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
 	require.EqualValues(t, 100, keyState(openrouter.KeyTypeChat).MonthlyCredits)
 	require.EqualValues(t, 70, keyState(openrouter.KeyTypeInternal).MonthlyCredits)
@@ -305,10 +198,6 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	deleted("event_stale_subscription_loss", "subscription_initial")
 	serve("exact replay")
 	require.EqualValues(t, 1, metrics.SubscriptionLosses(), "stale and replayed deletions do not repeat the metric")
-	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{
-		OrganizationID: m3OrganizationID,
-		DesiredState:   openrouter.KeyDesiredStateDisabled,
-	}))
 
 	metadata, err := usagerepo.New(db).GetBillingMetadata(t.Context(), m3OrganizationID)
 	require.NoError(t, err)
@@ -320,9 +209,8 @@ func TestM3SubscriptionLossRecheckoutAndStaleReplayLifecycle(t *testing.T) {
 	require.Equal(t, "payg", organization.GramAccountType)
 	require.True(t, organization.Whitelisted)
 	require.False(t, keyState(openrouter.KeyTypeChat).Disabled)
+	require.Empty(t, keyState(openrouter.KeyTypeChat).DisableCauses)
 	require.False(t, keyState(openrouter.KeyTypeInternal).Disabled)
-	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.disableCalls)
-	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat}, provisioner.refreshCalls)
 
 	receipts, err := usagerepo.New(db).CountStripeWebhookReceiptsFixture(t.Context(), m3OrganizationID)
 	require.NoError(t, err)

--- a/server/internal/usage/payg_openrouter_chat_key_repair.go
+++ b/server/internal/usage/payg_openrouter_chat_key_repair.go
@@ -1,0 +1,155 @@
+package usage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	"github.com/speakeasy-api/gram/server/internal/usage/repo"
+)
+
+type paygOpenRouterChatKeyRepairer interface {
+	AddAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause) (openrouter.DisableCauseChange, error)
+	RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error)
+	ReconcileAPIKeyDisabledWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType) error
+}
+
+// RepairPaygOpenRouterChatKey projects committed self-serve billing state onto
+// the existing chat key. intent only fences stale asynchronous deliveries.
+func RepairPaygOpenRouterChatKey(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, provisioner openrouter.Provisioner, organizationID string, intent openrouter.KeyDesiredState) error {
+	if organizationID == "" {
+		return errors.New("organization ID is required")
+	}
+	if err := intent.Validate(); err != nil {
+		return fmt.Errorf("invalid PAYG OpenRouter chat key desired state %q", intent)
+	}
+
+	conn, err := db.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection for PAYG OpenRouter chat key repair: %w", err)
+	}
+	defer conn.Release()
+
+	queries := repo.New(conn)
+	lock := repo.AcquireOpenRouterBillingSessionLockParams{
+		OrganizationID: organizationID,
+		KeyType:        string(openrouter.KeyTypeChat),
+	}
+	if err := queries.AcquireOpenRouterBillingSessionLock(ctx, lock); err != nil {
+		return fmt.Errorf("lock PAYG OpenRouter chat key repair: %w", err)
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		unlocked, unlockErr := queries.ReleaseOpenRouterBillingSessionLock(cleanupCtx, repo.ReleaseOpenRouterBillingSessionLockParams(lock))
+		if unlockErr != nil {
+			logger.ErrorContext(cleanupCtx, "failed to unlock PAYG OpenRouter chat key repair", attr.SlogError(unlockErr))
+		} else if !unlocked {
+			logger.ErrorContext(cleanupCtx, "PAYG OpenRouter chat key repair lock was not held")
+		}
+	}()
+
+	projection, err := queries.GetPaygOpenRouterChatLifecycleProjection(ctx, organizationID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read PAYG OpenRouter chat key lifecycle projection: %w", err)
+	}
+	hasSubscription := projection.StripeSubscriptionID.Valid && projection.StripeSubscriptionID.String != ""
+
+	switch {
+	case projection.GramAccountType == string(billing.TierPayg) && hasSubscription:
+		if intent != openrouter.KeyDesiredStateEnabled {
+			return nil
+		}
+		return repairPaidOpenRouterChatKey(ctx, conn, queries, provisioner, organizationID)
+	case projection.GramAccountType == string(billing.TierBase) && !hasSubscription:
+		if intent != openrouter.KeyDesiredStateDisabled {
+			return nil
+		}
+		return repairUnpaidOpenRouterChatKey(ctx, conn, provisioner, organizationID)
+	case projection.GramAccountType != string(billing.TierPayg) && projection.GramAccountType != string(billing.TierBase):
+		return nil
+	default:
+		return fmt.Errorf("inconsistent PAYG OpenRouter chat key billing projection: account_type=%q has_subscription=%t", projection.GramAccountType, hasSubscription)
+	}
+}
+
+func repairPaidOpenRouterChatKey(ctx context.Context, conn *pgxpool.Conn, queries *repo.Queries, provisioner openrouter.Provisioner, organizationID string) error {
+	key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{OrganizationID: organizationID, KeyType: string(openrouter.KeyTypeChat)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read PAYG OpenRouter chat key: %w", err)
+	case key.DisableCauses == nil:
+		return errors.New("PAYG OpenRouter chat key disable causes are unclassified")
+	}
+	limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
+	if !ok || limit <= 0 {
+		return errors.New("PAYG OpenRouter chat key credit policy is unavailable")
+	}
+	repairer, ok := provisioner.(paygOpenRouterChatKeyRepairer)
+	if !ok {
+		if reconciler, supported := provisioner.(openrouter.DisableStateReconciler); supported {
+			if err := reconciler.ReconcileAPIKeyDisabled(ctx, organizationID, openrouter.KeyTypeChat); err != nil {
+				return fmt.Errorf("reconcile committed PAYG OpenRouter chat key: %w", err)
+			}
+			return nil
+		}
+		return errors.New("OpenRouter key provisioner cannot repair committed PAYG lifecycle state")
+	}
+	if _, _, err := repairer.RemoveAPIKeyDisableCauseWithDB(ctx, conn, organizationID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive, &limit); err != nil {
+		return fmt.Errorf("remove inactive PAYG billing cause: %w", err)
+	}
+	rows, err := queries.RecoverPaygOpenRouterChatKey(ctx, repo.RecoverPaygOpenRouterChatKeyParams{MonthlyCredits: int64(limit), OrganizationID: organizationID, KeyHash: key.KeyHash})
+	if err != nil {
+		return fmt.Errorf("refresh committed PAYG OpenRouter chat key cap: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("refresh committed PAYG OpenRouter chat key cap: updated %d rows", rows)
+	}
+	if err := repairer.ReconcileAPIKeyDisabledWithDB(ctx, conn, organizationID, openrouter.KeyTypeChat); err != nil {
+		return fmt.Errorf("reconcile committed PAYG OpenRouter chat key: %w", err)
+	}
+	return nil
+}
+
+func repairUnpaidOpenRouterChatKey(ctx context.Context, conn *pgxpool.Conn, provisioner openrouter.Provisioner, organizationID string) error {
+	key, err := openrouterrepo.New(conn).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{OrganizationID: organizationID, KeyType: string(openrouter.KeyTypeChat)})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read unpaid OpenRouter chat key: %w", err)
+	case key.DisableCauses == nil:
+		return errors.New("unpaid OpenRouter chat key disable causes are unclassified")
+	}
+	repairer, ok := provisioner.(paygOpenRouterChatKeyRepairer)
+	if !ok {
+		if reconciler, supported := provisioner.(openrouter.DisableStateReconciler); supported {
+			if err := reconciler.ReconcileAPIKeyDisabled(ctx, organizationID, openrouter.KeyTypeChat); err != nil {
+				return fmt.Errorf("reconcile committed unpaid OpenRouter chat key: %w", err)
+			}
+			return nil
+		}
+		return errors.New("OpenRouter key provisioner cannot repair committed PAYG lifecycle state")
+	}
+	if _, err := repairer.AddAPIKeyDisableCauseWithDB(ctx, conn, organizationID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive); err != nil {
+		return fmt.Errorf("add inactive PAYG billing cause: %w", err)
+	}
+	if err := repairer.ReconcileAPIKeyDisabledWithDB(ctx, conn, organizationID, openrouter.KeyTypeChat); err != nil {
+		return fmt.Errorf("reconcile committed unpaid OpenRouter chat key: %w", err)
+	}
+	return nil
+}

--- a/server/internal/usage/payg_openrouter_chat_key_repair.go
+++ b/server/internal/usage/payg_openrouter_chat_key_repair.go
@@ -37,7 +37,6 @@ func RepairPaygOpenRouterChatKey(ctx context.Context, logger *slog.Logger, db *p
 	if err != nil {
 		return fmt.Errorf("acquire connection for PAYG OpenRouter chat key repair: %w", err)
 	}
-	defer conn.Release()
 
 	queries := repo.New(conn)
 	lock := repo.AcquireOpenRouterBillingSessionLockParams{
@@ -45,16 +44,28 @@ func RepairPaygOpenRouterChatKey(ctx context.Context, logger *slog.Logger, db *p
 		KeyType:        string(openrouter.KeyTypeChat),
 	}
 	if err := queries.AcquireOpenRouterBillingSessionLock(ctx, lock); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		closeErr := conn.Hijack().Close(cleanupCtx)
+		cancel()
+		if closeErr != nil {
+			logger.ErrorContext(ctx, "close connection after PAYG OpenRouter chat key repair lock failure", attr.SlogError(closeErr))
+		}
 		return fmt.Errorf("lock PAYG OpenRouter chat key repair: %w", err)
 	}
 	defer func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		unlocked, unlockErr := queries.ReleaseOpenRouterBillingSessionLock(cleanupCtx, repo.ReleaseOpenRouterBillingSessionLockParams(lock))
-		if unlockErr != nil {
-			logger.ErrorContext(cleanupCtx, "failed to unlock PAYG OpenRouter chat key repair", attr.SlogError(unlockErr))
-		} else if !unlocked {
-			logger.ErrorContext(cleanupCtx, "PAYG OpenRouter chat key repair lock was not held")
+		if unlockErr == nil && unlocked {
+			conn.Release()
+			return
+		}
+		if unlockErr == nil {
+			unlockErr = errors.New("lock was not held by this session")
+		}
+		logger.ErrorContext(cleanupCtx, "failed to unlock PAYG OpenRouter chat key repair", attr.SlogError(unlockErr))
+		if closeErr := conn.Hijack().Close(cleanupCtx); closeErr != nil {
+			logger.ErrorContext(cleanupCtx, "close connection with unreleased PAYG OpenRouter chat key repair lock", attr.SlogError(closeErr))
 		}
 	}()
 

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -113,7 +113,11 @@ FROM latest_months
 ORDER BY period_start;
 
 -- name: ListMaterializedOpenRouterInferenceKeys :many
-SELECT key_type, monthly_credits, (CASE WHEN disable_causes IS NULL THEN disabled ELSE cardinality(disable_causes) > 0 END)::boolean AS disabled
+SELECT key_type
+  , monthly_credits
+  , (CASE WHEN disable_causes IS NULL THEN disabled ELSE cardinality(disable_causes) > 0 END)::boolean AS disabled
+  , disable_causes
+  , (disable_causes IS NOT NULL)::boolean AS disable_causes_classified
 FROM openrouter_api_keys
 WHERE organization_id = @organization_id
   AND key_type = ANY(@key_types::text[])

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -400,6 +400,42 @@ WHERE organization_id = @organization_id
   AND key_type = 'chat'
   AND deleted IS FALSE;
 
+-- name: RecoverPaygOpenRouterChatKey :execrows
+UPDATE openrouter_api_keys
+SET disable_causes = ARRAY(
+      SELECT cause
+      FROM unnest(array_remove(disable_causes, 'billing_inactive')) AS causes(cause)
+      GROUP BY cause
+      ORDER BY CASE cause
+        WHEN 'admin_lock' THEN 1
+        WHEN 'trial_demotion' THEN 2
+        WHEN 'billing_inactive' THEN 3
+        ELSE 4
+      END, cause
+    ),
+    disabled = cardinality(array_remove(disable_causes, 'billing_inactive')) > 0,
+    monthly_credits = @monthly_credits,
+    updated_at = CASE
+      WHEN 'billing_inactive' = ANY(disable_causes) OR monthly_credits != @monthly_credits
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = @organization_id
+  AND key_type = 'chat'
+  AND key_hash = @key_hash
+  AND disable_causes IS NOT NULL
+  AND deleted IS FALSE;
+
+-- name: SetOpenRouterKeyLifecycleFixture :execrows
+-- Test-only fixture for Stripe lifecycle tests.
+UPDATE openrouter_api_keys
+SET disabled = @disabled,
+    disable_causes = @disable_causes,
+    monthly_credits = @monthly_credits
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE;
+
 -- name: CreateStripeBillingMetadataFixture :exec
 -- Test-only fixture for webhook tests that need a Stripe customer association.
 INSERT INTO billing_metadata (organization_id, stripe_customer_id)

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -443,16 +443,6 @@ WHERE organization_id = @organization_id
   AND disable_causes IS NOT NULL
   AND deleted IS FALSE;
 
--- name: SetOpenRouterKeyLifecycleFixture :execrows
--- Test-only fixture for Stripe lifecycle tests.
-UPDATE openrouter_api_keys
-SET disabled = @disabled,
-    disable_causes = @disable_causes,
-    monthly_credits = @monthly_credits
-WHERE organization_id = @organization_id
-  AND key_type = @key_type
-  AND deleted IS FALSE;
-
 -- name: CreateStripeBillingMetadataFixture :exec
 -- Test-only fixture for webhook tests that need a Stripe customer association.
 INSERT INTO billing_metadata (organization_id, stripe_customer_id)

--- a/server/internal/usage/queries.sql
+++ b/server/internal/usage/queries.sql
@@ -296,12 +296,10 @@ WITH inserted AS (
 )
 SELECT EXISTS (SELECT 1 FROM inserted) AS inserted;
 
--- name: StripeWebhookReceiptExists :one
-SELECT EXISTS (
-    SELECT 1
-    FROM stripe_webhook_receipts
-    WHERE stripe_event_id = @stripe_event_id
-) AS received;
+-- name: GetStripeWebhookReceipt :one
+SELECT organization_id, event_type
+FROM stripe_webhook_receipts
+WHERE stripe_event_id = @stripe_event_id;
 
 -- name: AcquireStripeSubscriptionActivationLock :exec
 -- Serializes distinct Stripe events that refer to the same subscription.
@@ -313,6 +311,25 @@ SELECT pg_advisory_xact_lock(hashtextextended(@stripe_subscription_id, 0));
 SELECT pg_advisory_xact_lock(
     hashtextextended('openrouter-' || @key_type::text || '-billing:' || @organization_id::text, 0)
 );
+
+-- name: AcquireOpenRouterBillingSessionLock :exec
+SELECT pg_advisory_lock(
+    hashtextextended('openrouter-' || @key_type::text || '-billing:' || @organization_id::text, 0)
+);
+
+-- name: ReleaseOpenRouterBillingSessionLock :one
+SELECT pg_advisory_unlock(
+    hashtextextended('openrouter-' || @key_type::text || '-billing:' || @organization_id::text, 0)
+) AS unlocked;
+
+-- name: GetPaygOpenRouterChatLifecycleProjection :one
+SELECT
+    organization_metadata.gram_account_type
+  , billing_metadata.stripe_subscription_id
+FROM organization_metadata
+LEFT JOIN billing_metadata
+  ON billing_metadata.organization_id = organization_metadata.id
+WHERE organization_metadata.id = @organization_id;
 
 -- name: GetPaygActivationState :one
 SELECT

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -1178,7 +1178,11 @@ func (q *Queries) ListFinalizedBillingCycleStarts(ctx context.Context, organizat
 }
 
 const listMaterializedOpenRouterInferenceKeys = `-- name: ListMaterializedOpenRouterInferenceKeys :many
-SELECT key_type, monthly_credits, (CASE WHEN disable_causes IS NULL THEN disabled ELSE cardinality(disable_causes) > 0 END)::boolean AS disabled
+SELECT key_type
+  , monthly_credits
+  , (CASE WHEN disable_causes IS NULL THEN disabled ELSE cardinality(disable_causes) > 0 END)::boolean AS disabled
+  , disable_causes
+  , (disable_causes IS NOT NULL)::boolean AS disable_causes_classified
 FROM openrouter_api_keys
 WHERE organization_id = $1
   AND key_type = ANY($2::text[])
@@ -1192,9 +1196,11 @@ type ListMaterializedOpenRouterInferenceKeysParams struct {
 }
 
 type ListMaterializedOpenRouterInferenceKeysRow struct {
-	KeyType        string
-	MonthlyCredits int64
-	Disabled       bool
+	KeyType                 string
+	MonthlyCredits          int64
+	Disabled                bool
+	DisableCauses           []string
+	DisableCausesClassified bool
 }
 
 func (q *Queries) ListMaterializedOpenRouterInferenceKeys(ctx context.Context, arg ListMaterializedOpenRouterInferenceKeysParams) ([]ListMaterializedOpenRouterInferenceKeysRow, error) {
@@ -1206,7 +1212,13 @@ func (q *Queries) ListMaterializedOpenRouterInferenceKeys(ctx context.Context, a
 	var items []ListMaterializedOpenRouterInferenceKeysRow
 	for rows.Next() {
 		var i ListMaterializedOpenRouterInferenceKeysRow
-		if err := rows.Scan(&i.KeyType, &i.MonthlyCredits, &i.Disabled); err != nil {
+		if err := rows.Scan(
+			&i.KeyType,
+			&i.MonthlyCredits,
+			&i.Disabled,
+			&i.DisableCauses,
+			&i.DisableCausesClassified,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -1990,39 +1990,6 @@ func (q *Queries) SetOpenRouterAPIKeysCreatedAtFixture(ctx context.Context, arg 
 	return err
 }
 
-const setOpenRouterKeyLifecycleFixture = `-- name: SetOpenRouterKeyLifecycleFixture :execrows
-UPDATE openrouter_api_keys
-SET disabled = $1,
-    disable_causes = $2,
-    monthly_credits = $3
-WHERE organization_id = $4
-  AND key_type = $5
-  AND deleted IS FALSE
-`
-
-type SetOpenRouterKeyLifecycleFixtureParams struct {
-	Disabled       bool
-	DisableCauses  []string
-	MonthlyCredits int64
-	OrganizationID string
-	KeyType        string
-}
-
-// Test-only fixture for Stripe lifecycle tests.
-func (q *Queries) SetOpenRouterKeyLifecycleFixture(ctx context.Context, arg SetOpenRouterKeyLifecycleFixtureParams) (int64, error) {
-	result, err := q.db.Exec(ctx, setOpenRouterKeyLifecycleFixture,
-		arg.Disabled,
-		arg.DisableCauses,
-		arg.MonthlyCredits,
-		arg.OrganizationID,
-		arg.KeyType,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const setStripeCheckoutSessionFixture = `-- name: SetStripeCheckoutSessionFixture :exec
 UPDATE billing_metadata
 SET stripe_checkout_session_id = $1

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -1839,6 +1839,47 @@ func (q *Queries) PrepareStripeCheckoutIntent(ctx context.Context, arg PrepareSt
 	return i, err
 }
 
+const recoverPaygOpenRouterChatKey = `-- name: RecoverPaygOpenRouterChatKey :execrows
+UPDATE openrouter_api_keys
+SET disable_causes = ARRAY(
+      SELECT cause
+      FROM unnest(array_remove(disable_causes, 'billing_inactive')) AS causes(cause)
+      GROUP BY cause
+      ORDER BY CASE cause
+        WHEN 'admin_lock' THEN 1
+        WHEN 'trial_demotion' THEN 2
+        WHEN 'billing_inactive' THEN 3
+        ELSE 4
+      END, cause
+    ),
+    disabled = cardinality(array_remove(disable_causes, 'billing_inactive')) > 0,
+    monthly_credits = $1,
+    updated_at = CASE
+      WHEN 'billing_inactive' = ANY(disable_causes) OR monthly_credits != $1
+        THEN GREATEST(clock_timestamp(), updated_at + INTERVAL '1 microsecond')
+      ELSE updated_at
+    END
+WHERE organization_id = $2
+  AND key_type = 'chat'
+  AND key_hash = $3
+  AND disable_causes IS NOT NULL
+  AND deleted IS FALSE
+`
+
+type RecoverPaygOpenRouterChatKeyParams struct {
+	MonthlyCredits int64
+	OrganizationID string
+	KeyHash        string
+}
+
+func (q *Queries) RecoverPaygOpenRouterChatKey(ctx context.Context, arg RecoverPaygOpenRouterChatKeyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recoverPaygOpenRouterChatKey, arg.MonthlyCredits, arg.OrganizationID, arg.KeyHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const setOpenRouterAPIKeyCreatedAtFixture = `-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
 UPDATE openrouter_api_keys
 SET created_at = $1
@@ -1873,6 +1914,39 @@ type SetOpenRouterAPIKeysCreatedAtFixtureParams struct {
 func (q *Queries) SetOpenRouterAPIKeysCreatedAtFixture(ctx context.Context, arg SetOpenRouterAPIKeysCreatedAtFixtureParams) error {
 	_, err := q.db.Exec(ctx, setOpenRouterAPIKeysCreatedAtFixture, arg.CreatedAt, arg.OrganizationID)
 	return err
+}
+
+const setOpenRouterKeyLifecycleFixture = `-- name: SetOpenRouterKeyLifecycleFixture :execrows
+UPDATE openrouter_api_keys
+SET disabled = $1,
+    disable_causes = $2,
+    monthly_credits = $3
+WHERE organization_id = $4
+  AND key_type = $5
+  AND deleted IS FALSE
+`
+
+type SetOpenRouterKeyLifecycleFixtureParams struct {
+	Disabled       bool
+	DisableCauses  []string
+	MonthlyCredits int64
+	OrganizationID string
+	KeyType        string
+}
+
+// Test-only fixture for Stripe lifecycle tests.
+func (q *Queries) SetOpenRouterKeyLifecycleFixture(ctx context.Context, arg SetOpenRouterKeyLifecycleFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setOpenRouterKeyLifecycleFixture,
+		arg.Disabled,
+		arg.DisableCauses,
+		arg.MonthlyCredits,
+		arg.OrganizationID,
+		arg.KeyType,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const setStripeCheckoutSessionFixture = `-- name: SetStripeCheckoutSessionFixture :exec

--- a/server/internal/usage/repo/queries.sql.go
+++ b/server/internal/usage/repo/queries.sql.go
@@ -30,6 +30,22 @@ func (q *Queries) AcquireOpenRouterBillingLock(ctx context.Context, arg AcquireO
 	return err
 }
 
+const acquireOpenRouterBillingSessionLock = `-- name: AcquireOpenRouterBillingSessionLock :exec
+SELECT pg_advisory_lock(
+    hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
+)
+`
+
+type AcquireOpenRouterBillingSessionLockParams struct {
+	KeyType        string
+	OrganizationID string
+}
+
+func (q *Queries) AcquireOpenRouterBillingSessionLock(ctx context.Context, arg AcquireOpenRouterBillingSessionLockParams) error {
+	_, err := q.db.Exec(ctx, acquireOpenRouterBillingSessionLock, arg.KeyType, arg.OrganizationID)
+	return err
+}
+
 const acquireStripeSubscriptionActivationLock = `-- name: AcquireStripeSubscriptionActivationLock :exec
 SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
 `
@@ -964,6 +980,46 @@ func (q *Queries) GetPaygInvoiceIdentity(ctx context.Context, organizationID str
 	return i, err
 }
 
+const getPaygOpenRouterChatLifecycleProjection = `-- name: GetPaygOpenRouterChatLifecycleProjection :one
+SELECT
+    organization_metadata.gram_account_type
+  , billing_metadata.stripe_subscription_id
+FROM organization_metadata
+LEFT JOIN billing_metadata
+  ON billing_metadata.organization_id = organization_metadata.id
+WHERE organization_metadata.id = $1
+`
+
+type GetPaygOpenRouterChatLifecycleProjectionRow struct {
+	GramAccountType      string
+	StripeSubscriptionID pgtype.Text
+}
+
+func (q *Queries) GetPaygOpenRouterChatLifecycleProjection(ctx context.Context, organizationID string) (GetPaygOpenRouterChatLifecycleProjectionRow, error) {
+	row := q.db.QueryRow(ctx, getPaygOpenRouterChatLifecycleProjection, organizationID)
+	var i GetPaygOpenRouterChatLifecycleProjectionRow
+	err := row.Scan(&i.GramAccountType, &i.StripeSubscriptionID)
+	return i, err
+}
+
+const getStripeWebhookReceipt = `-- name: GetStripeWebhookReceipt :one
+SELECT organization_id, event_type
+FROM stripe_webhook_receipts
+WHERE stripe_event_id = $1
+`
+
+type GetStripeWebhookReceiptRow struct {
+	OrganizationID string
+	EventType      string
+}
+
+func (q *Queries) GetStripeWebhookReceipt(ctx context.Context, stripeEventID string) (GetStripeWebhookReceiptRow, error) {
+	row := q.db.QueryRow(ctx, getStripeWebhookReceipt, stripeEventID)
+	var i GetStripeWebhookReceiptRow
+	err := row.Scan(&i.OrganizationID, &i.EventType)
+	return i, err
+}
+
 const getTUMMeterReportTotals = `-- name: GetTUMMeterReportTotals :one
 SELECT
     COALESCE(SUM(delta_tokens) FILTER (WHERE delivery_state = 'confirmed'), 0)::bigint AS confirmed_tokens
@@ -1880,6 +1936,24 @@ func (q *Queries) RecoverPaygOpenRouterChatKey(ctx context.Context, arg RecoverP
 	return result.RowsAffected(), nil
 }
 
+const releaseOpenRouterBillingSessionLock = `-- name: ReleaseOpenRouterBillingSessionLock :one
+SELECT pg_advisory_unlock(
+    hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)
+) AS unlocked
+`
+
+type ReleaseOpenRouterBillingSessionLockParams struct {
+	KeyType        string
+	OrganizationID string
+}
+
+func (q *Queries) ReleaseOpenRouterBillingSessionLock(ctx context.Context, arg ReleaseOpenRouterBillingSessionLockParams) (bool, error) {
+	row := q.db.QueryRow(ctx, releaseOpenRouterBillingSessionLock, arg.KeyType, arg.OrganizationID)
+	var unlocked bool
+	err := row.Scan(&unlocked)
+	return unlocked, err
+}
+
 const setOpenRouterAPIKeyCreatedAtFixture = `-- name: SetOpenRouterAPIKeyCreatedAtFixture :exec
 UPDATE openrouter_api_keys
 SET created_at = $1
@@ -2022,21 +2096,6 @@ func (q *Queries) StoreStripeCustomer(ctx context.Context, arg StoreStripeCustom
 		&i.UpdatedAt,
 	)
 	return i, err
-}
-
-const stripeWebhookReceiptExists = `-- name: StripeWebhookReceiptExists :one
-SELECT EXISTS (
-    SELECT 1
-    FROM stripe_webhook_receipts
-    WHERE stripe_event_id = $1
-) AS received
-`
-
-func (q *Queries) StripeWebhookReceiptExists(ctx context.Context, stripeEventID string) (bool, error) {
-	row := q.db.QueryRow(ctx, stripeWebhookReceiptExists, stripeEventID)
-	var received bool
-	err := row.Scan(&received)
-	return received, err
 }
 
 const tryInsertStripeWebhookReceipt = `-- name: TryInsertStripeWebhookReceipt :one

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -445,7 +445,7 @@ func recoverPaygOpenRouterChatKeyTx(ctx context.Context, tx pgx.Tx, organization
 	disableCauses := slices.DeleteFunc(slices.Clone(key.DisableCauses), func(cause string) bool {
 		return cause == string(openrouter.DisableCauseBillingInactive)
 	})
-	stateChanged := len(disableCauses) != len(key.DisableCauses) || key.MonthlyCredits != int64(limit) || key.Disabled != (len(disableCauses) > 0)
+	stateChanged := key.MonthlyCredits != int64(limit) || key.Disabled != (len(disableCauses) > 0)
 	rows, err := repo.New(tx).RecoverPaygOpenRouterChatKey(ctx, repo.RecoverPaygOpenRouterChatKeyParams{
 		MonthlyCredits: int64(limit),
 		OrganizationID: organizationID,

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -156,6 +156,9 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
+	// Resolve routing identity without taking a row lock. The lifecycle handler
+	// validates the customer and subscription again from GetPaygActivationState
+	// after all canonical advisory locks have been acquired.
 	organizationID, err := queries.GetBillingMetadataOrganizationByStripeCustomerID(ctx, pgtype.Text{String: event.CustomerID, Valid: true})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
@@ -165,14 +168,6 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve Stripe webhook customer").LogError(ctx, logger)
 	}
 
-	if event.Type == "checkout.session.completed" && checkoutEligible {
-		// Serialize Stripe activation with legacy billing-metadata writes. Without
-		// this shared lock, a writer can read the old anchor, wait on the row lock,
-		// and overwrite the newly activated Stripe anchor after the webhook commits.
-		if err := queries.LockBillingMetadataOrganization(ctx, organizationID); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to lock billing metadata organization").LogError(ctx, logger)
-		}
-	}
 	if event.Type == "checkout.session.completed" && checkoutEligible {
 		trialQueries := trialsrepo.New(tx)
 		_, err := trialQueries.LockTrialLifecycleForRearm(ctx, organizationID)
@@ -187,20 +182,21 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
-	// Trial demotion locks the trial row before it takes the platform-key
-	// locks. Checkout must use the same order so a conversion racing the hourly
-	// sweep cannot deadlock on the inverse trials-row/key-lock sequence.
-	switch {
-	case event.Type == "checkout.session.completed" && checkoutEligible:
+	// Lifecycle transactions use one deployment-safe order even when replacement
+	// checkout and prior-subscription deletion hold different subscription locks:
+	// trial row when applicable, every OpenRouter key advisory lock, then billing
+	// and key rows. Trial demotion follows the same trial/key prefix.
+	if (event.Type == "checkout.session.completed" && checkoutEligible) || event.Type == "customer.subscription.deleted" {
 		if err := acquireOpenRouterBillingLocks(ctx, queries, organizationID); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to lock OpenRouter billing state").LogError(ctx, logger)
 		}
-	case event.Type == "customer.subscription.deleted":
-		if err := queries.AcquireOpenRouterBillingLock(ctx, repo.AcquireOpenRouterBillingLockParams{
-			KeyType:        string(openrouter.KeyTypeChat),
-			OrganizationID: organizationID,
-		}); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to lock OpenRouter chat billing state").LogError(ctx, logger)
+	}
+
+	if event.Type == "checkout.session.completed" && checkoutEligible {
+		// Serialize Stripe activation with legacy billing-metadata writes only after
+		// OpenRouter locks. This keeps all lifecycle paths advisory-before-row ordered.
+		if err := queries.LockBillingMetadataOrganization(ctx, organizationID); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to lock billing metadata organization").LogError(ctx, logger)
 		}
 	}
 

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -432,27 +433,31 @@ func removeOpenRouterDisableCauseTx(ctx context.Context, tx pgx.Tx, organization
 	return nil
 }
 
-func recoverPaygOpenRouterChatKeyTx(ctx context.Context, tx pgx.Tx, organizationID string) error {
+func recoverPaygOpenRouterChatKeyTx(ctx context.Context, tx pgx.Tx, organizationID string) (bool, error) {
 	key, err := getClassifiedOpenRouterKeyTx(ctx, tx, organizationID, openrouter.KeyTypeChat)
 	if err != nil || key == nil {
-		return err
+		return false, err
 	}
 	limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
 	if !ok || limit <= 0 {
-		return errors.New("PAYG OpenRouter chat key credit policy is unavailable")
+		return false, errors.New("PAYG OpenRouter chat key credit policy is unavailable")
 	}
+	disableCauses := slices.DeleteFunc(slices.Clone(key.DisableCauses), func(cause string) bool {
+		return cause == string(openrouter.DisableCauseBillingInactive)
+	})
+	stateChanged := len(disableCauses) != len(key.DisableCauses) || key.MonthlyCredits != int64(limit) || key.Disabled != (len(disableCauses) > 0)
 	rows, err := repo.New(tx).RecoverPaygOpenRouterChatKey(ctx, repo.RecoverPaygOpenRouterChatKeyParams{
 		MonthlyCredits: int64(limit),
 		OrganizationID: organizationID,
 		KeyHash:        key.KeyHash,
 	})
 	if err != nil {
-		return fmt.Errorf("persist OpenRouter chat key PAYG recovery: %w", err)
+		return false, fmt.Errorf("persist OpenRouter chat key PAYG recovery: %w", err)
 	}
 	if rows != 1 {
-		return fmt.Errorf("OpenRouter chat key changed while recovering PAYG billing: updated %d rows", rows)
+		return false, fmt.Errorf("OpenRouter chat key changed while recovering PAYG billing: updated %d rows", rows)
 	}
-	return nil
+	return stateChanged, nil
 }
 
 func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent) (stripeWebhookResult, error) {
@@ -630,17 +635,21 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		newlyEnabled = append(newlyEnabled, productfeatures.TrialRuntimeFeatures...)
 	}
 
-	reconcileKeyTypes := []openrouter.KeyType{openrouter.KeyTypeChat}
+	reconcileKeyTypes := []openrouter.KeyType(nil)
 	if convertedDemotedTrial {
-		reconcileKeyTypes = append([]openrouter.KeyType(nil), openrouter.AllKeyTypes...)
+		reconcileKeyTypes = append(reconcileKeyTypes, openrouter.AllKeyTypes...)
 		for _, keyType := range openrouter.AllKeyTypes {
 			if err := removeOpenRouterDisableCauseTx(ctx, tx, organizationID, keyType, openrouter.DisableCauseTrialDemotion); err != nil {
 				return stripeWebhookResult{}, fmt.Errorf("replace demoted trial OpenRouter %s key lifecycle: %w", keyType, err)
 			}
 		}
 	}
-	if err := recoverPaygOpenRouterChatKeyTx(ctx, tx, organizationID); err != nil {
+	chatStateChanged, err := recoverPaygOpenRouterChatKeyTx(ctx, tx, organizationID)
+	if err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("recover PAYG OpenRouter chat key billing: %w", err)
+	}
+	if chatStateChanged && !convertedDemotedTrial {
+		reconcileKeyTypes = append(reconcileKeyTypes, openrouter.KeyTypeChat)
 	}
 
 	anchorDay := conv.SafeInt32(checkout.BillingCycleAnchor.UTC().Day())

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -87,13 +87,27 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		logger.WarnContext(ctx, "skipping Stripe webhook event without a customer")
 		return nil
 	}
-	received, err := repo.New(s.db).StripeWebhookReceiptExists(ctx, event.ID)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to check Stripe webhook receipt").LogError(ctx, logger)
-	}
-	if received {
-		logger.InfoContext(ctx, "skipping duplicate Stripe webhook event")
+	receipt, err := repo.New(s.db).GetStripeWebhookReceipt(ctx, event.ID)
+	if err == nil {
+		if receipt.EventType != event.Type {
+			return oops.E(oops.CodeUnexpected, nil, "Stripe webhook receipt type does not match replayed event").LogError(ctx, logger)
+		}
+		logger.InfoContext(ctx, "repairing duplicate Stripe lifecycle event from committed state")
+		switch event.Type {
+		case "checkout.session.completed":
+			err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateEnabled)
+		case "customer.subscription.deleted":
+			err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateDisabled)
+		default:
+			return nil
+		}
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to repair replayed Stripe lifecycle event").LogError(ctx, logger)
+		}
 		return nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return oops.E(oops.CodeUnexpected, err, "failed to check Stripe webhook receipt").LogError(ctx, logger)
 	}
 	if event.Type == "invoice.created" {
 		_, err := repo.New(s.db).GetBillingMetadataOrganizationByStripeCustomerID(ctx, pgtype.Text{String: event.CustomerID, Valid: true})

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -14,18 +14,23 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
 )
 
-const maxStripeWebhookBodyBytes = 1 << 20
+const (
+	maxStripeWebhookBodyBytes       = 1 << 20
+	stripeLifecycleReconcileTimeout = 10 * time.Second
+)
 
 var acceptedStripeWebhookEvents = map[string]struct{}{
 	"checkout.session.completed":    {},
@@ -36,6 +41,7 @@ var acceptedStripeWebhookEvents = map[string]struct{}{
 
 type stripeWebhookResult struct {
 	newlyEnabledFeatures []productfeatures.Feature
+	reconcileKeyTypes    []openrouter.KeyType
 	invoicePaymentFailed bool
 	subscriptionLost     bool
 }
@@ -154,17 +160,33 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 	if event.Type == "checkout.session.completed" && checkoutEligible {
-		if _, err := trialsrepo.New(tx).MarkTrialConverted(ctx, organizationID); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to mark enterprise trial converted").LogError(ctx, logger)
+		trialQueries := trialsrepo.New(tx)
+		_, err := trialQueries.LockTrialLifecycleForRearm(ctx, organizationID)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+		case err != nil:
+			return oops.E(oops.CodeUnexpected, err, "failed to lock enterprise trial lifecycle").LogError(ctx, logger)
+		default:
+			if _, err := trialQueries.MarkTrialConverted(ctx, organizationID); err != nil {
+				return oops.E(oops.CodeUnexpected, err, "failed to mark enterprise trial converted").LogError(ctx, logger)
+			}
 		}
 	}
 
 	// Trial demotion locks the trial row before it takes the platform-key
 	// locks. Checkout must use the same order so a conversion racing the hourly
 	// sweep cannot deadlock on the inverse trials-row/key-lock sequence.
-	if (event.Type == "checkout.session.completed" && checkoutEligible) || event.Type == "customer.subscription.deleted" {
+	switch {
+	case event.Type == "checkout.session.completed" && checkoutEligible:
 		if err := acquireOpenRouterBillingLocks(ctx, queries, organizationID); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "failed to lock OpenRouter billing state").LogError(ctx, logger)
+		}
+	case event.Type == "customer.subscription.deleted":
+		if err := queries.AcquireOpenRouterBillingLock(ctx, repo.AcquireOpenRouterBillingLockParams{
+			KeyType:        string(openrouter.KeyTypeChat),
+			OrganizationID: organizationID,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to lock OpenRouter chat billing state").LogError(ctx, logger)
 		}
 	}
 
@@ -204,6 +226,16 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 	}
 	if result.subscriptionLost && s.stripeMetrics != nil {
 		s.stripeMetrics.RecordSubscriptionLost(ctx)
+	}
+	if reconciler, ok := s.openRouter.(openrouter.DisableStateReconciler); ok {
+		for _, keyType := range result.reconcileKeyTypes {
+			reconcileCtx, cancel := context.WithTimeout(ctx, stripeLifecycleReconcileTimeout)
+			err := reconciler.ReconcileAPIKeyDisabled(reconcileCtx, organizationID, keyType)
+			cancel()
+			if err != nil {
+				return oops.E(oops.CodeUnexpected, err, "failed to reconcile committed OpenRouter lifecycle state").LogError(ctx, logger)
+			}
+		}
 	}
 
 	return nil
@@ -290,11 +322,93 @@ func (s *Service) serviceStripeWebhookHandler(ctx context.Context, logger *slog.
 		}
 	case "invoice.payment_failed":
 		logger.InfoContext(ctx, "received Stripe invoice payment failure")
-		return stripeWebhookResult{newlyEnabledFeatures: nil, invoicePaymentFailed: true, subscriptionLost: false}, nil
+		return stripeWebhookResult{newlyEnabledFeatures: nil, reconcileKeyTypes: nil, invoicePaymentFailed: true, subscriptionLost: false}, nil
 	case "customer.subscription.deleted":
 		return s.deactivatePaygSubscription(ctx, tx, organizationID, event)
 	}
-	return stripeWebhookResult{newlyEnabledFeatures: nil, invoicePaymentFailed: false, subscriptionLost: false}, nil
+	return stripeWebhookResult{newlyEnabledFeatures: nil, reconcileKeyTypes: nil, invoicePaymentFailed: false, subscriptionLost: false}, nil
+}
+
+func getClassifiedOpenRouterKeyTx(ctx context.Context, tx pgx.Tx, organizationID string, keyType openrouter.KeyType) (*openrouterrepo.OpenrouterApiKey, error) {
+	key, err := openrouterrepo.New(tx).GetOpenRouterAPIKey(ctx, openrouterrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("read OpenRouter %s key lifecycle: %w", keyType, err)
+	case key.DisableCauses == nil:
+		return nil, fmt.Errorf("OpenRouter %s key lifecycle causes are unclassified", keyType)
+	default:
+		return &key, nil
+	}
+}
+
+func addOpenRouterDisableCauseTx(ctx context.Context, tx pgx.Tx, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) error {
+	key, err := getClassifiedOpenRouterKeyTx(ctx, tx, organizationID, keyType)
+	if err != nil || key == nil {
+		return err
+	}
+	_, err = openrouterrepo.New(tx).AddOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.AddOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID: organizationID,
+		KeyType:        string(keyType),
+		KeyHash:        key.KeyHash,
+		DisableCause:   string(cause),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("OpenRouter %s key changed while adding %s lifecycle cause", keyType, cause)
+	}
+	if err != nil {
+		return fmt.Errorf("persist OpenRouter %s key %s lifecycle cause: %w", keyType, cause, err)
+	}
+	return nil
+}
+
+func removeOpenRouterDisableCauseTx(ctx context.Context, tx pgx.Tx, organizationID string, keyType openrouter.KeyType, cause openrouter.DisableCause) error {
+	key, err := getClassifiedOpenRouterKeyTx(ctx, tx, organizationID, keyType)
+	if err != nil || key == nil {
+		return err
+	}
+	_, err = openrouterrepo.New(tx).RemoveOpenRouterAPIKeyDisableCause(ctx, openrouterrepo.RemoveOpenRouterAPIKeyDisableCauseParams{
+		OrganizationID:       organizationID,
+		KeyType:              string(keyType),
+		KeyHash:              key.KeyHash,
+		DisableCause:         string(cause),
+		MonthlyCredits:       key.MonthlyCredits,
+		UpdateMonthlyCredits: false,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("OpenRouter %s key changed while removing %s lifecycle cause", keyType, cause)
+	}
+	if err != nil {
+		return fmt.Errorf("persist OpenRouter %s key %s lifecycle cause removal: %w", keyType, cause, err)
+	}
+	return nil
+}
+
+func recoverPaygOpenRouterChatKeyTx(ctx context.Context, tx pgx.Tx, organizationID string) error {
+	key, err := getClassifiedOpenRouterKeyTx(ctx, tx, organizationID, openrouter.KeyTypeChat)
+	if err != nil || key == nil {
+		return err
+	}
+	limit, ok := openrouter.AccountTypeCreditLimit(billing.TierPayg)
+	if !ok || limit <= 0 {
+		return errors.New("PAYG OpenRouter chat key credit policy is unavailable")
+	}
+	rows, err := repo.New(tx).RecoverPaygOpenRouterChatKey(ctx, repo.RecoverPaygOpenRouterChatKeyParams{
+		MonthlyCredits: int64(limit),
+		OrganizationID: organizationID,
+		KeyHash:        key.KeyHash,
+	})
+	if err != nil {
+		return fmt.Errorf("persist OpenRouter chat key PAYG recovery: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf("OpenRouter chat key changed while recovering PAYG billing: updated %d rows", rows)
+	}
+	return nil
 }
 
 func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent) (stripeWebhookResult, error) {
@@ -307,7 +421,7 @@ func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, org
 	if !state.StripeCustomerID.Valid || state.StripeCustomerID.String != event.CustomerID ||
 		state.GramAccountType != "payg" ||
 		!state.StripeSubscriptionID.Valid || state.StripeSubscriptionID.String != event.ObjectID {
-		return stripeWebhookResult{newlyEnabledFeatures: nil, invoicePaymentFailed: false, subscriptionLost: false}, nil
+		return stripeWebhookResult{newlyEnabledFeatures: nil, reconcileKeyTypes: nil, invoicePaymentFailed: false, subscriptionLost: false}, nil
 	}
 
 	billingRows, err := q.DeactivatePaygBillingMetadata(ctx, repo.DeactivatePaygBillingMetadataParams{
@@ -329,8 +443,8 @@ func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, org
 	if organizationRows != 1 {
 		return stripeWebhookResult{}, fmt.Errorf("deactivate PAYG organization: expected one row, updated %d", organizationRows)
 	}
-	if err := q.DisablePaygOpenRouterChatKey(ctx, organizationID); err != nil {
-		return stripeWebhookResult{}, fmt.Errorf("disable PAYG OpenRouter chat key: %w", err)
+	if err := addOpenRouterDisableCauseTx(ctx, tx, organizationID, openrouter.KeyTypeChat, openrouter.DisableCauseBillingInactive); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("record inactive PAYG billing for OpenRouter chat key: %w", err)
 	}
 
 	if s.auditLogger == nil {
@@ -355,7 +469,12 @@ func (s *Service) deactivatePaygSubscription(ctx context.Context, tx pgx.Tx, org
 		return stripeWebhookResult{}, fmt.Errorf("log PAYG organization deactivation: %w", err)
 	}
 
-	return stripeWebhookResult{newlyEnabledFeatures: nil, invoicePaymentFailed: false, subscriptionLost: true}, nil
+	return stripeWebhookResult{
+		newlyEnabledFeatures: nil,
+		reconcileKeyTypes:    []openrouter.KeyType{openrouter.KeyTypeChat},
+		invoicePaymentFailed: false,
+		subscriptionLost:     true,
+	}, nil
 }
 
 func (s *Service) recordStripeInvoice(ctx context.Context, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, invoice *stripeclient.InvoiceState) (bool, error) {
@@ -447,6 +566,7 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	}
 
 	newlyEnabled := []productfeatures.Feature(nil)
+	convertedDemotedTrial := false
 	trial, err := trialsrepo.New(tx).GetTrial(ctx, organizationID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		newlyEnabled, err = productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
@@ -456,10 +576,26 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	} else if err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("read trial state for PAYG activation: %w", err)
 	} else if trial.DemotedAt.Valid {
+		if !trial.ConvertedAt.Valid {
+			return stripeWebhookResult{}, errors.New("demoted enterprise trial is not durably converted")
+		}
+		convertedDemotedTrial = true
 		if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, organizationID, true); err != nil {
 			return stripeWebhookResult{}, fmt.Errorf("restore demoted trial runtime features: %w", err)
 		}
 		newlyEnabled = append(newlyEnabled, productfeatures.TrialRuntimeFeatures...)
+	}
+
+	reconcileKeyTypes := []openrouter.KeyType{openrouter.KeyTypeChat}
+	if convertedDemotedTrial {
+		reconcileKeyTypes = append([]openrouter.KeyType(nil), openrouter.AllKeyTypes...)
+		for _, keyType := range openrouter.AllKeyTypes {
+			if err := removeOpenRouterDisableCauseTx(ctx, tx, organizationID, keyType, openrouter.DisableCauseTrialDemotion); err != nil {
+				return stripeWebhookResult{}, fmt.Errorf("replace demoted trial OpenRouter %s key lifecycle: %w", keyType, err)
+			}
+		}
+	} else if err := recoverPaygOpenRouterChatKeyTx(ctx, tx, organizationID); err != nil {
+		return stripeWebhookResult{}, fmt.Errorf("recover PAYG OpenRouter chat key billing: %w", err)
 	}
 
 	anchorDay := conv.SafeInt32(checkout.BillingCycleAnchor.UTC().Day())
@@ -470,7 +606,12 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		state.BillingCycleAnchorDay == anchorDay &&
 		state.GramAccountType == "payg" && state.Whitelisted
 	if alreadyActivated {
-		return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled, invoicePaymentFailed: false, subscriptionLost: false}, nil
+		return stripeWebhookResult{
+			newlyEnabledFeatures: newlyEnabled,
+			reconcileKeyTypes:    reconcileKeyTypes,
+			invoicePaymentFailed: false,
+			subscriptionLost:     false,
+		}, nil
 	}
 
 	if _, err := q.ActivatePaygBillingMetadata(ctx, repo.ActivatePaygBillingMetadataParams{
@@ -508,5 +649,10 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 		return stripeWebhookResult{}, fmt.Errorf("log PAYG organization activation: %w", err)
 	}
 
-	return stripeWebhookResult{newlyEnabledFeatures: newlyEnabled, invoicePaymentFailed: false, subscriptionLost: false}, nil
+	return stripeWebhookResult{
+		newlyEnabledFeatures: newlyEnabled,
+		reconcileKeyTypes:    reconcileKeyTypes,
+		invoicePaymentFailed: false,
+		subscriptionLost:     false,
+	}, nil
 }

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -95,7 +95,7 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		logger.InfoContext(ctx, "repairing duplicate Stripe lifecycle event from committed state")
 		switch event.Type {
 		case "checkout.session.completed":
-			err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateEnabled)
+			err = s.repairReplayedPaygCheckout(ctx, logger, receipt.OrganizationID)
 		case "customer.subscription.deleted":
 			err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateDisabled)
 		default:
@@ -252,6 +252,32 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
+	return nil
+}
+
+func (s *Service) repairReplayedPaygCheckout(ctx context.Context, logger *slog.Logger, organizationID string) error {
+	if err := RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, organizationID, openrouter.KeyDesiredStateEnabled); err != nil {
+		return err
+	}
+
+	reconciler, ok := s.openRouter.(openrouter.DisableStateReconciler)
+	if !ok {
+		return errors.New("OpenRouter key provisioner cannot reconcile replayed PAYG checkout lifecycle state")
+	}
+	for index, keyType := range openrouter.AllKeyTypes {
+		if index == 0 {
+			if keyType != openrouter.KeyTypeChat {
+				return errors.New("OpenRouter key reconciliation order must start with chat")
+			}
+			continue
+		}
+		reconcileCtx, cancel := context.WithTimeout(ctx, stripeLifecycleReconcileTimeout)
+		err := reconciler.ReconcileAPIKeyDisabled(reconcileCtx, organizationID, keyType)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("reconcile replayed PAYG checkout OpenRouter %s key: %w", keyType, err)
+		}
+	}
 	return nil
 }
 

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -594,7 +594,8 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 				return stripeWebhookResult{}, fmt.Errorf("replace demoted trial OpenRouter %s key lifecycle: %w", keyType, err)
 			}
 		}
-	} else if err := recoverPaygOpenRouterChatKeyTx(ctx, tx, organizationID); err != nil {
+	}
+	if err := recoverPaygOpenRouterChatKeyTx(ctx, tx, organizationID); err != nil {
 		return stripeWebhookResult{}, fmt.Errorf("recover PAYG OpenRouter chat key billing: %w", err)
 	}
 

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -445,7 +445,7 @@ func recoverPaygOpenRouterChatKeyTx(ctx context.Context, tx pgx.Tx, organization
 	disableCauses := slices.DeleteFunc(slices.Clone(key.DisableCauses), func(cause string) bool {
 		return cause == string(openrouter.DisableCauseBillingInactive)
 	})
-	stateChanged := key.MonthlyCredits != int64(limit) || key.Disabled != (len(disableCauses) > 0)
+	stateChanged := key.MonthlyCredits != int64(limit) || openrouter.EffectiveDisabled(key.Disabled, key.DisableCauses) != (len(disableCauses) > 0)
 	rows, err := repo.New(tx).RecoverPaygOpenRouterChatKey(ctx, repo.RecoverPaygOpenRouterChatKeyParams{
 		MonthlyCredits: int64(limit),
 		OrganizationID: organizationID,

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -89,22 +89,7 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 	}
 	receipt, err := repo.New(s.db).GetStripeWebhookReceipt(ctx, event.ID)
 	if err == nil {
-		if receipt.EventType != event.Type {
-			return oops.E(oops.CodeUnexpected, nil, "Stripe webhook receipt type does not match replayed event").LogError(ctx, logger)
-		}
-		logger.InfoContext(ctx, "repairing duplicate Stripe lifecycle event from committed state")
-		switch event.Type {
-		case "checkout.session.completed":
-			err = s.repairReplayedPaygCheckout(ctx, logger, receipt.OrganizationID)
-		case "customer.subscription.deleted":
-			err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateDisabled)
-		default:
-			return nil
-		}
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to repair replayed Stripe lifecycle event").LogError(ctx, logger)
-		}
-		return nil
+		return s.repairCommittedStripeLifecycleEvent(ctx, logger, receipt)
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
 		return oops.E(oops.CodeUnexpected, err, "failed to check Stripe webhook receipt").LogError(ctx, logger)
@@ -209,8 +194,14 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		return oops.E(oops.CodeUnexpected, err, "failed to record Stripe webhook receipt").LogError(ctx, logger)
 	}
 	if !inserted {
-		logger.InfoContext(ctx, "skipping duplicate Stripe webhook event")
-		return nil
+		receipt, err := queries.GetStripeWebhookReceipt(ctx, event.ID)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to load committed Stripe webhook receipt after insert conflict").LogError(ctx, logger)
+		}
+		if err := tx.Rollback(ctx); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "failed to end duplicate Stripe webhook transaction").LogError(ctx, logger)
+		}
+		return s.repairCommittedStripeLifecycleEvent(ctx, logger, receipt)
 	}
 	if !checkoutEligible {
 		if err := tx.Commit(ctx); err != nil {
@@ -248,6 +239,23 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 		}
 	}
 
+	return nil
+}
+
+func (s *Service) repairCommittedStripeLifecycleEvent(ctx context.Context, logger *slog.Logger, receipt repo.GetStripeWebhookReceiptRow) error {
+	logger.InfoContext(ctx, "repairing duplicate Stripe lifecycle event from committed state")
+	var err error
+	switch receipt.EventType {
+	case "checkout.session.completed":
+		err = s.repairReplayedPaygCheckout(ctx, logger, receipt.OrganizationID)
+	case "customer.subscription.deleted":
+		err = RepairPaygOpenRouterChatKey(ctx, logger, s.db, s.openRouter, receipt.OrganizationID, openrouter.KeyDesiredStateDisabled)
+	default:
+		return nil
+	}
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to repair replayed Stripe lifecycle event").LogError(ctx, logger)
+	}
 	return nil
 }
 

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -46,6 +46,7 @@ type fakeStripeWebhookClient struct {
 	checkoutError error
 	invoice       *stripeclient.InvoiceState
 	invoiceError  error
+	checkoutCalls atomic.Int32
 	invoiceCalls  atomic.Int32
 	verifyCalls   atomic.Int32
 }
@@ -61,6 +62,7 @@ func (f *fakeStripeWebhookClient) CreateCheckoutSession(context.Context, stripec
 }
 
 func (f *fakeStripeWebhookClient) GetCheckoutSession(context.Context, string) (*stripeclient.CheckoutSessionState, error) {
+	f.checkoutCalls.Add(1)
 	return f.checkout, f.checkoutError
 }
 
@@ -200,6 +202,7 @@ func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebh
 		db:            db,
 		stripeClient:  client,
 		stripeHandler: handler,
+		openRouter:    openrouter.NewDevelopment("test-key"),
 	}, db
 }
 
@@ -1479,6 +1482,66 @@ func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
 	require.Equal(t, 1, paygSchedulingIntentCount(t, service.db))
 }
 
+func TestStripeCheckoutExactReplayRepairsPostCommitOpenRouterFailure(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_repair_replay", "subscription_repair_replay", "active")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"billing_inactive"}, 17)
+
+	var patches atomic.Int32
+	var failPatches atomic.Bool
+	failPatches.Store(true)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		patches.Add(1)
+		if failPatches.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 100.0, "hash": "hash_placeholder_chat"},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "first").Code)
+	failedPatchAttempts := patches.Load()
+	require.Positive(t, failedPatchAttempts)
+	failPatches.Store(false)
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	require.EqualValues(t, 1, client.checkoutCalls.Load())
+	client.checkoutError = errors.New("exact replay must not fetch Stripe checkout state")
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "exact replay").Code)
+	require.Greater(t, patches.Load(), failedPatchAttempts)
+	require.EqualValues(t, 1, client.checkoutCalls.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	require.Empty(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
+}
+
 func TestStripeCheckoutAuditFailureRollsBackActivationAndSchedulingIntent(t *testing.T) {
 	t.Parallel()
 
@@ -1700,6 +1763,120 @@ func TestStripeSubscriptionDeletionPostCommitReconcileFailurePreservesDurableInt
 	require.True(t, sawCommittedIntent.Load())
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
+}
+
+func TestStripeSubscriptionDeletionExactReplayRepairsPostCommitOpenRouterFailure(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	metrics := configurePaygSubscriptionDeletion(t, service, "event_deletion_repair_replay", "subscription_current", "subscription_current")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
+
+	var patches atomic.Int32
+	var failPatches atomic.Bool
+	failPatches.Store(true)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		patches.Add(1)
+		if failPatches.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 321.0, "hash": "hash_placeholder_chat"},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "first").Code)
+	failedPatchAttempts := patches.Load()
+	require.Positive(t, failedPatchAttempts)
+	failPatches.Store(false)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "exact replay").Code)
+	require.Greater(t, patches.Load(), failedPatchAttempts)
+	require.EqualValues(t, 1, metrics.subscriptionLosses.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.True(t, chat.Disabled)
+	require.Equal(t, []string{"billing_inactive"}, chat.DisableCauses)
+}
+
+func TestStripeSubscriptionDeletionReplayCannotOverrideLaterConversion(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	metrics := configurePaygSubscriptionDeletion(t, service, "event_loss_before_conversion", "subscription_old", "subscription_old")
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	deletedEvent := client.verify
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 73)
+
+	var patches atomic.Int32
+	var failPatches atomic.Bool
+	failPatches.Store(true)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		patches.Add(1)
+		if failPatches.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 100.0, "hash": "hash_placeholder_chat"},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "loss").Code)
+	require.Positive(t, patches.Load())
+	failPatches.Store(false)
+
+	configurePaygCheckout(t, service, "event_conversion_after_loss", "subscription_replacement", "active")
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "conversion").Code)
+	patchesAfterConversion := patches.Load()
+	client.verify = deletedEvent
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "stale exact loss replay").Code)
+	require.Equal(t, patchesAfterConversion, patches.Load())
+
+	require.EqualValues(t, 1, metrics.subscriptionLosses.Load())
+	require.Equal(t, 2, stripeWebhookReceiptCount(t, db))
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "subscription_replacement", metadata.StripeSubscriptionID.String)
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	require.Empty(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
 }
 
 func TestStripeSubscriptionDeletionDeactivatesCurrentPaygBillingAtomically(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1604,24 +1604,29 @@ func TestStripeSubscriptionDeletionLocksOnlyChatLifecycle(t *testing.T) {
 	configurePaygSubscriptionDeletion(t, service, "event_chat_lock_only", "subscription_current", "subscription_current")
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
 
-	lockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold the unrelated advisory lock while deletion proceeds
+	internalLockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold the unrelated advisory lock while deletion proceeds
 	require.NoError(t, err)
-	require.NoError(t, repo.New(lockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+	t.Cleanup(func() { _ = internalLockTx.Rollback(context.Background()) })
+	require.NoError(t, repo.New(internalLockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
 		KeyType:        string(openrouter.KeyTypeInternal),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+
+	chatLockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test uses the relevant advisory lock to synchronize with the webhook backend
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = chatLockTx.Rollback(context.Background()) })
+	chatHolderPID := postgresBackendPID(t, chatLockTx)
+	require.NoError(t, repo.New(chatLockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeChat),
 		OrganizationID: stripeWebhookOrganizationID,
 	}))
 
 	response := make(chan int, 1)
 	go func() { response <- serveStripeWebhook(service, "deactivate").Code }()
-	select {
-	case status := <-response:
-		require.Equal(t, http.StatusOK, status)
-		require.NoError(t, lockTx.Rollback(t.Context()))
-	case <-time.After(time.Second):
-		require.NoError(t, lockTx.Rollback(t.Context()))
-		status := <-response
-		require.Failf(t, "subscription deletion waited for Security inference lock", "status after releasing unrelated lock: %d", status)
-	}
+	waitForStripeWebhookBlockedByPID(t, db, chatHolderPID)
+	require.NoError(t, chatLockTx.Rollback(t.Context()))
+	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
+	require.NoError(t, internalLockTx.Rollback(t.Context()))
 }
 
 func TestStripeSubscriptionDeletionRejectsUnclassifiedKeyAndRollsBackAtomically(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -356,7 +356,7 @@ func createOpenRouterKeyFixture(t *testing.T, db *pgxpool.Pool, keyType openrout
 func setOpenRouterKeyLifecycleFixture(t *testing.T, db *pgxpool.Pool, keyType openrouter.KeyType, disabled bool, causes []string, credits int64) {
 	t.Helper()
 
-	rows, err := repo.New(db).SetOpenRouterKeyLifecycleFixture(t.Context(), repo.SetOpenRouterKeyLifecycleFixtureParams{
+	rows, err := testrepo.New(db).SetOpenRouterKeyLifecycleFixture(t.Context(), testrepo.SetOpenRouterKeyLifecycleFixtureParams{
 		Disabled:       disabled,
 		DisableCauses:  causes,
 		MonthlyCredits: credits,

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1593,17 +1593,27 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"billing_inactive"}, 17)
 
 	var patches atomic.Int32
+	var firstPatchMu sync.Mutex
 	var firstPatch map[string]any
-	handlerErrors := make(chan error, 3)
+	var handlerErrorsMu sync.Mutex
+	var handlerErrors []error
+	recordHandlerError := func(err error) {
+		handlerErrorsMu.Lock()
+		defer handlerErrorsMu.Unlock()
+		handlerErrors = append(handlerErrors, err)
+	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
-			handlerErrors <- fmt.Errorf("unexpected OpenRouter method %s", r.Method)
+			recordHandlerError(fmt.Errorf("unexpected OpenRouter method %s", r.Method))
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 		if patches.Add(1) == 1 {
-			if err := json.NewDecoder(r.Body).Decode(&firstPatch); err != nil {
-				handlerErrors <- fmt.Errorf("decode OpenRouter PATCH: %w", err)
+			firstPatchMu.Lock()
+			err := json.NewDecoder(r.Body).Decode(&firstPatch)
+			firstPatchMu.Unlock()
+			if err != nil {
+				recordHandlerError(fmt.Errorf("decode OpenRouter PATCH: %w", err))
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
@@ -1612,7 +1622,7 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{"limit": 100.0, "hash": "hash_placeholder_chat"},
 		}); err != nil {
-			handlerErrors <- fmt.Errorf("encode OpenRouter response: %w", err)
+			recordHandlerError(fmt.Errorf("encode OpenRouter response: %w", err))
 		}
 	}))
 	t.Cleanup(upstream.Close)
@@ -1631,7 +1641,10 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	require.Positive(t, patchesAfterFirst)
 	limit, ok := openrouter.AccountTypeCreditLimit("payg")
 	require.True(t, ok)
-	require.EqualValues(t, limit, firstPatch["limit"], "true recovery must PATCH the current PAYG cap")
+	firstPatchMu.Lock()
+	patchedLimit := firstPatch["limit"]
+	firstPatchMu.Unlock()
+	require.EqualValues(t, limit, patchedLimit, "true recovery must PATCH the current PAYG cap")
 	cacheAfterFirst := featureCache.snapshot()
 	keyAfterFirst := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
 
@@ -1648,8 +1661,11 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 		}, nil
 	}
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "second").Code)
-	if len(handlerErrors) > 0 {
-		require.NoError(t, <-handlerErrors)
+	handlerErrorsMu.Lock()
+	collectedHandlerErrors := slices.Clone(handlerErrors)
+	handlerErrorsMu.Unlock()
+	for _, handlerErr := range collectedHandlerErrors {
+		require.NoError(t, handlerErr)
 	}
 
 	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
@@ -1664,6 +1680,41 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	require.Zero(t, metrics.invoicePaymentFailures.Load())
 	require.Zero(t, metrics.subscriptionLosses.Load())
 	require.Equal(t, keyAfterFirst, openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat))
+}
+
+func TestStripeCheckoutLayeredBillingRecoveryDoesNotReconcileUnchangedAccess(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_layered_recovery", "subscription_layered_recovery", "past_due")
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, int64(limit))
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "billing_inactive", "unknown_policy"}, int64(limit))
+
+	var patches atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		patches.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "layered recovery").Code)
+	require.Zero(t, patches.Load(), "removing billing_inactive must not PATCH while another cause keeps access disabled")
+	key := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.True(t, key.Disabled)
+	require.Equal(t, []string{"admin_lock", "unknown_policy"}, key.DisableCauses)
+	require.Equal(t, int64(limit), key.MonthlyCredits)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 }
 
 func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1491,15 +1491,35 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 23)
 	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive"}, 17)
-	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion", "security_hold"}, 23)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion"}, 23)
 
 	var chatPatches atomic.Int32
 	var internalPatches atomic.Int32
+	var internalSecurityUpstream struct {
+		sync.Mutex
+		disabled     bool
+		monthlyLimit float64
+		limitReset   string
+		patchPaths   []string
+	}
+	internalSecurityUpstream.disabled = true
+	internalSecurityUpstream.monthlyLimit = 23
+	internalSecurityUpstream.limitReset = "monthly"
 	var failInternal atomic.Bool
 	failInternal.Store(true)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		var patch struct {
+			Limit      *float64 `json:"limit"`
+			LimitReset string   `json:"limit_reset"`
+			Disabled   *bool    `json:"disabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			http.Error(w, "invalid patch", http.StatusBadRequest)
 			return
 		}
 
@@ -1509,10 +1529,22 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 			chatPatches.Add(1)
 		case "hash_placeholder_internal":
 			internalPatches.Add(1)
+			internalSecurityUpstream.Lock()
+			internalSecurityUpstream.patchPaths = append(internalSecurityUpstream.patchPaths, r.URL.Path)
+			internalSecurityUpstream.Unlock()
 			if failInternal.Load() {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			internalSecurityUpstream.Lock()
+			if patch.Disabled != nil {
+				internalSecurityUpstream.disabled = *patch.Disabled
+			}
+			if patch.Limit != nil {
+				internalSecurityUpstream.monthlyLimit = *patch.Limit
+				internalSecurityUpstream.limitReset = patch.LimitReset
+			}
+			internalSecurityUpstream.Unlock()
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -1549,8 +1581,8 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 	require.True(t, ok)
 	require.EqualValues(t, limit, chat.MonthlyCredits)
 	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
-	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
-	require.True(t, internal.Disabled)
+	require.Empty(t, internal.DisableCauses)
+	require.False(t, internal.Disabled)
 	require.EqualValues(t, 23, internal.MonthlyCredits)
 
 	failInternal.Store(false)
@@ -1571,9 +1603,20 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 	require.True(t, chat.Disabled)
 	require.EqualValues(t, limit, chat.MonthlyCredits)
 	internal = openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
-	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
-	require.True(t, internal.Disabled)
+	require.Empty(t, internal.DisableCauses)
+	require.False(t, internal.Disabled)
 	require.EqualValues(t, 23, internal.MonthlyCredits)
+
+	internalSecurityUpstream.Lock()
+	defer internalSecurityUpstream.Unlock()
+	require.False(t, internalSecurityUpstream.disabled)
+	require.EqualValues(t, 23, internalSecurityUpstream.monthlyLimit)
+	require.Equal(t, "monthly", internalSecurityUpstream.limitReset)
+	require.NotEqualValues(t, limit, internalSecurityUpstream.monthlyLimit)
+	require.NotEmpty(t, internalSecurityUpstream.patchPaths)
+	for _, path := range internalSecurityUpstream.patchPaths {
+		require.Equal(t, "/v1/keys/hash_placeholder_internal", path)
+	}
 }
 
 func TestStripeCheckoutExactReplayRepairsPostCommitOpenRouterFailure(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1096,23 +1096,44 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NotContains(t, string(record.AfterSnapshot), "subscription_activation")
 }
 
-func waitForStripeWebhookLockWait(t *testing.T, db *pgxpool.Pool) {
+func postgresBackendPID(t *testing.T, tx pgx.Tx) int32 {
+	t.Helper()
+
+	var pid int32
+	err := tx.QueryRow(t.Context(), `SELECT pg_backend_pid()`).Scan(&pid) //nolint:glint // notestingrawsql: backend identity is a PostgreSQL test synchronization primitive unavailable through application SQLc queries
+	require.NoError(t, err)
+	return pid
+}
+
+func waitForStripeWebhookBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID int32) {
 	t.Helper()
 
 	require.Eventually(t, func() bool {
 		var waiting bool
-		err := db.QueryRow(t.Context(), `
+		err := db.QueryRow( //nolint:glint // notestingrawsql: pg_blocking_pids is a PostgreSQL test synchronization primitive unavailable to SQLc generation
+			t.Context(), `
 SELECT EXISTS (
   SELECT 1
-  FROM pg_locks AS locks
-  JOIN pg_stat_activity AS activity ON activity.pid = locks.pid
+  FROM pg_stat_activity AS activity
   WHERE activity.datname = current_database()
-    AND locks.granted IS FALSE
+    AND $1 = ANY(pg_blocking_pids(activity.pid))
 )
-`).Scan(&waiting) //nolint:glint // notestingrawsql: pg_locks is a PostgreSQL catalog view unavailable to SQLc generation
+`, holderPID).Scan(&waiting)
 		require.NoError(t, err)
 		return waiting
 	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func receiveStripeWebhookStatus(t *testing.T, response <-chan int) int {
+	t.Helper()
+
+	select {
+	case status := <-response:
+		return status
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for Stripe webhook response")
+		return 0
+	}
 }
 
 func TestStripeCheckoutLocksConvertedTrialBeforeOpenRouterKeys(t *testing.T) {
@@ -1124,17 +1145,18 @@ func TestStripeCheckoutLocksConvertedTrialBeforeOpenRouterKeys(t *testing.T) {
 	_, err := trialsrepo.New(db).MarkTrialConverted(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 
-	trialTx, err := db.Begin(t.Context())
+	trialTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold a trial-row transaction open while the webhook blocks
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = trialTx.Rollback(context.Background()) })
+	trialHolderPID := postgresBackendPID(t, trialTx)
 	_, err = trialsrepo.New(trialTx).LockTrialLifecycleForRearm(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 
 	response := make(chan int, 1)
 	go func() { response <- serveStripeWebhook(service, "convert").Code }()
-	waitForStripeWebhookLockWait(t, db)
+	waitForStripeWebhookBlockedByPID(t, db, trialHolderPID)
 
-	probeTx, err := db.Begin(t.Context())
+	probeTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the probe transaction proves the chat advisory lock remains available
 	require.NoError(t, err)
 	probeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
@@ -1144,7 +1166,7 @@ func TestStripeCheckoutLocksConvertedTrialBeforeOpenRouterKeys(t *testing.T) {
 	}))
 	require.NoError(t, probeTx.Rollback(t.Context()))
 	require.NoError(t, trialTx.Rollback(t.Context()))
-	require.Equal(t, http.StatusOK, <-response)
+	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
 }
 
 func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
@@ -1154,9 +1176,10 @@ func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
 	configurePaygCheckout(t, service, "event_key_lock_order", "subscription_key_lock_order", "active")
 	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat, openrouter.KeyTypeInternal}, openrouter.AllKeyTypes)
 
-	chatTx, err := db.Begin(t.Context())
+	chatTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold the first advisory lock while the webhook blocks
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = chatTx.Rollback(context.Background()) })
+	chatHolderPID := postgresBackendPID(t, chatTx)
 	require.NoError(t, repo.New(chatTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
 		KeyType:        string(openrouter.KeyTypeChat),
 		OrganizationID: stripeWebhookOrganizationID,
@@ -1164,9 +1187,9 @@ func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
 
 	response := make(chan int, 1)
 	go func() { response <- serveStripeWebhook(service, "activate").Code }()
-	waitForStripeWebhookLockWait(t, db)
+	waitForStripeWebhookBlockedByPID(t, db, chatHolderPID)
 
-	probeTx, err := db.Begin(t.Context())
+	probeTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the probe transaction proves the internal advisory lock remains available
 	require.NoError(t, err)
 	probeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
@@ -1176,10 +1199,10 @@ func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
 	}))
 	require.NoError(t, probeTx.Rollback(t.Context()))
 	require.NoError(t, chatTx.Rollback(t.Context()))
-	require.Equal(t, http.StatusOK, <-response)
+	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
 }
 
-func TestStripeCheckoutConversionReplacesOnlyTrialDemotionCauses(t *testing.T) {
+func TestStripeCheckoutConversionReplacesTrialAndBillingCausesIndependently(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
@@ -1187,7 +1210,7 @@ func TestStripeCheckoutConversionReplacesOnlyTrialDemotionCauses(t *testing.T) {
 	createDemotedEnterpriseTrialFixture(t, db)
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 41)
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 59)
-	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive"}, 41)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive", "policy_hold"}, 41)
 	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"admin_lock", "trial_demotion"}, 59)
 
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "convert").Code)
@@ -1195,11 +1218,93 @@ func TestStripeCheckoutConversionReplacesOnlyTrialDemotionCauses(t *testing.T) {
 	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
 
 	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
-	require.Equal(t, []string{"admin_lock", "billing_inactive"}, chat.DisableCauses)
+	require.Equal(t, []string{"admin_lock", "policy_hold"}, chat.DisableCauses)
 	require.True(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
 	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
 	require.Equal(t, []string{"admin_lock"}, internal.DisableCauses)
 	require.True(t, internal.Disabled)
+}
+
+func TestStripeCheckoutConversionRecoversBillingWithoutAdminLock(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_conversion_billing_only", "subscription_conversion_billing_only", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 23)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"trial_demotion", "billing_inactive"}, 17)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion", "security_hold"}, 23)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "convert").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Empty(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+	require.EqualValues(t, 23, internal.MonthlyCredits)
+}
+
+func TestStripeCheckoutConversionRefreshesCurrentPaygCapWhenBillingCauseIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_conversion_cap_refresh", "subscription_conversion_cap_refresh", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 29)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 31)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion"}, 29)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion"}, 31)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "convert").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Empty(t, internal.DisableCauses)
+	require.False(t, internal.Disabled)
+	require.EqualValues(t, 31, internal.MonthlyCredits)
+}
+
+func TestStripeCheckoutConvertedTrialAuditFailureRollsBackLifecycleAndReceipt(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_conversion_rollback", "subscription_conversion_rollback", "active")
+	service.auditLogger = nil
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 37)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 43)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive"}, 37)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion"}, 43)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "convert").Code)
+
+	trial, err := trialsrepo.New(db).GetTrial(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, trial.ConvertedAt.Valid)
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "trial_demotion", "billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	require.EqualValues(t, 37, chat.MonthlyCredits)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"trial_demotion"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+	require.EqualValues(t, 43, internal.MonthlyCredits)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
 }
 
 func TestStripeCheckoutRecoveryRemovesOnlyBillingCauseAndRefreshesCurrentPaygCap(t *testing.T) {
@@ -1499,7 +1604,7 @@ func TestStripeSubscriptionDeletionLocksOnlyChatLifecycle(t *testing.T) {
 	configurePaygSubscriptionDeletion(t, service, "event_chat_lock_only", "subscription_current", "subscription_current")
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
 
-	lockTx, err := db.Begin(t.Context())
+	lockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold the unrelated advisory lock while deletion proceeds
 	require.NoError(t, err)
 	require.NoError(t, repo.New(lockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
 		KeyType:        string(openrouter.KeyTypeInternal),

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1610,7 +1610,7 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 	internalSecurityUpstream.Lock()
 	defer internalSecurityUpstream.Unlock()
 	require.False(t, internalSecurityUpstream.disabled)
-	require.EqualValues(t, 23, internalSecurityUpstream.monthlyLimit)
+	require.InDelta(t, 23, internalSecurityUpstream.monthlyLimit, 0)
 	require.Equal(t, "monthly", internalSecurityUpstream.limitReset)
 	require.NotEqualValues(t, limit, internalSecurityUpstream.monthlyLimit)
 	require.NotEmpty(t, internalSecurityUpstream.patchPaths)

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
@@ -341,6 +343,43 @@ func createOpenRouterKeyFixture(t *testing.T, db *pgxpool.Pool, keyType openrout
 		KeyHash:        "hash_placeholder_" + string(keyType),
 		MonthlyCredits: credits,
 	})
+	require.NoError(t, err)
+}
+
+func setOpenRouterKeyLifecycleFixture(t *testing.T, db *pgxpool.Pool, keyType openrouter.KeyType, disabled bool, causes []string, credits int64) {
+	t.Helper()
+
+	rows, err := repo.New(db).SetOpenRouterKeyLifecycleFixture(t.Context(), repo.SetOpenRouterKeyLifecycleFixtureParams{
+		Disabled:       disabled,
+		DisableCauses:  causes,
+		MonthlyCredits: credits,
+		OrganizationID: stripeWebhookOrganizationID,
+		KeyType:        string(keyType),
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+func openRouterKeyLifecycleFixture(t *testing.T, db *pgxpool.Pool, keyType openrouter.KeyType) openrouterrepo.OpenrouterApiKey {
+	t.Helper()
+
+	key, err := openrouterrepo.New(db).GetOpenRouterAPIKey(t.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		KeyType:        string(keyType),
+	})
+	require.NoError(t, err)
+	return key
+}
+
+func createDemotedEnterpriseTrialFixture(t *testing.T, db *pgxpool.Pool) {
+	t.Helper()
+
+	require.NoError(t, trialsrepo.New(db).CreateTrial(t.Context(), trialsrepo.CreateTrialParams{
+		OrganizationID: stripeWebhookOrganizationID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(-time.Hour), Valid: true},
+	}))
+	_, err := trialsrepo.New(db).MarkTrialDemoted(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 }
 
@@ -1057,6 +1096,148 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.NotContains(t, string(record.AfterSnapshot), "subscription_activation")
 }
 
+func waitForStripeWebhookLockWait(t *testing.T, db *pgxpool.Pool) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRow(t.Context(), `
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_locks AS locks
+  JOIN pg_stat_activity AS activity ON activity.pid = locks.pid
+  WHERE activity.datname = current_database()
+    AND locks.granted IS FALSE
+)
+`).Scan(&waiting) //nolint:glint // notestingrawsql: pg_locks is a PostgreSQL catalog view unavailable to SQLc generation
+		require.NoError(t, err)
+		return waiting
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestStripeCheckoutLocksConvertedTrialBeforeOpenRouterKeys(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_trial_lock_order", "subscription_trial_lock_order", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	_, err := trialsrepo.New(db).MarkTrialConverted(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+
+	trialTx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = trialTx.Rollback(context.Background()) })
+	_, err = trialsrepo.New(trialTx).LockTrialLifecycleForRearm(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+
+	response := make(chan int, 1)
+	go func() { response <- serveStripeWebhook(service, "convert").Code }()
+	waitForStripeWebhookLockWait(t, db)
+
+	probeTx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	probeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	require.NoError(t, repo.New(probeTx).AcquireOpenRouterBillingLock(probeCtx, repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeChat),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+	require.NoError(t, probeTx.Rollback(t.Context()))
+	require.NoError(t, trialTx.Rollback(t.Context()))
+	require.Equal(t, http.StatusOK, <-response)
+}
+
+func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_key_lock_order", "subscription_key_lock_order", "active")
+	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat, openrouter.KeyTypeInternal}, openrouter.AllKeyTypes)
+
+	chatTx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = chatTx.Rollback(context.Background()) })
+	require.NoError(t, repo.New(chatTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeChat),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+
+	response := make(chan int, 1)
+	go func() { response <- serveStripeWebhook(service, "activate").Code }()
+	waitForStripeWebhookLockWait(t, db)
+
+	probeTx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	probeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	require.NoError(t, repo.New(probeTx).AcquireOpenRouterBillingLock(probeCtx, repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeInternal),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+	require.NoError(t, probeTx.Rollback(t.Context()))
+	require.NoError(t, chatTx.Rollback(t.Context()))
+	require.Equal(t, http.StatusOK, <-response)
+}
+
+func TestStripeCheckoutConversionReplacesOnlyTrialDemotionCauses(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_lifecycle_conversion", "subscription_lifecycle_conversion", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 41)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 59)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive"}, 41)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"admin_lock", "trial_demotion"}, 59)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "convert").Code)
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "duplicate_convert").Code)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"admin_lock"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+}
+
+func TestStripeCheckoutRecoveryRemovesOnlyBillingCauseAndRefreshesCurrentPaygCap(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_billing_recovery", "subscription_billing_recovery", "active")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 7)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "billing_inactive"}, 7)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "recover").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+}
+
+func TestStripeCheckoutRecoveryRefreshesCurrentPaygCapWhenBillingCauseIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_billing_refresh", "subscription_billing_refresh", "active")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 13)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, []string{}, 13)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "refresh").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Empty(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+}
+
 func TestStripeCheckoutCompletionRestoresDemotedTrialRuntimeFeatures(t *testing.T) {
 	t.Parallel()
 
@@ -1198,6 +1379,8 @@ func TestStripeCheckoutAuditFailureRollsBackActivationAndSchedulingIntent(t *tes
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
 	featureCache := configurePaygCheckout(t, service, "event_audit_failure", "subscription_audit_failure", "active")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 7)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "billing_inactive"}, 7)
 	service.auditLogger = nil
 
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
@@ -1210,6 +1393,10 @@ func TestStripeCheckoutAuditFailureRollsBackActivationAndSchedulingIntent(t *tes
 	require.NotEqual(t, "payg", organization.GramAccountType)
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
 	require.Zero(t, paygSchedulingIntentCount(t, db))
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	require.EqualValues(t, 7, chat.MonthlyCredits)
 	require.Empty(t, featureCache.snapshot())
 	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
@@ -1287,6 +1474,122 @@ func TestStripeCheckoutTerminalStateIsDurableNoop(t *testing.T) {
 	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.False(t, metadata.StripeSubscriptionID.Valid)
+}
+
+func TestStripeSubscriptionDeletionAddsOnlyBillingInactiveCause(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, service, "event_billing_loss_cause", "subscription_current", "subscription_current")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock"}, 321)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "deactivate").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	require.EqualValues(t, 321, chat.MonthlyCredits)
+}
+
+func TestStripeSubscriptionDeletionLocksOnlyChatLifecycle(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, service, "event_chat_lock_only", "subscription_current", "subscription_current")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
+
+	lockTx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	require.NoError(t, repo.New(lockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeInternal),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+
+	response := make(chan int, 1)
+	go func() { response <- serveStripeWebhook(service, "deactivate").Code }()
+	select {
+	case status := <-response:
+		require.Equal(t, http.StatusOK, status)
+		require.NoError(t, lockTx.Rollback(t.Context()))
+	case <-time.After(time.Second):
+		require.NoError(t, lockTx.Rollback(t.Context()))
+		status := <-response
+		require.Failf(t, "subscription deletion waited for Security inference lock", "status after releasing unrelated lock: %d", status)
+	}
+}
+
+func TestStripeSubscriptionDeletionRejectsUnclassifiedKeyAndRollsBackAtomically(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, service, "event_unclassified_key", "subscription_current", "subscription_current")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, nil, 321)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "deactivate").Code)
+
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "subscription_current", metadata.StripeSubscriptionID.String)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "payg", organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Nil(t, chat.DisableCauses)
+	require.False(t, chat.Disabled)
+	require.EqualValues(t, 321, chat.MonthlyCredits)
+	require.Zero(t, stripeWebhookReceiptCount(t, db))
+	require.Zero(t, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
+}
+
+func TestStripeSubscriptionDeletionPostCommitReconcileFailurePreservesDurableIntent(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, service, "event_postcommit_failure", "subscription_current", "subscription_current")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
+	var sawCommittedIntent atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chat, keyErr := openrouterrepo.New(db).GetOpenRouterAPIKey(r.Context(), openrouterrepo.GetOpenRouterAPIKeyParams{
+			OrganizationID: stripeWebhookOrganizationID,
+			KeyType:        string(openrouter.KeyTypeChat),
+		})
+		receipts, receiptErr := repo.New(db).CountStripeWebhookReceiptsFixture(r.Context(), stripeWebhookOrganizationID)
+		if r.Method == http.MethodPatch && keyErr == nil && receiptErr == nil && chat.Disabled && slices.Equal(chat.DisableCauses, []string{"billing_inactive"}) && receipts == 1 {
+			sawCommittedIntent.Store(true)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t),
+		tracerProvider,
+		guardianPolicy,
+		db,
+		"test",
+		"provisioning_key_placeholder",
+		nil,
+		nil,
+		nil,
+		testenv.NewEncryptionClient(t),
+		option,
+	)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "deactivate").Code)
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	require.True(t, sawCommittedIntent.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
 }
 
 func TestStripeSubscriptionDeletionDeactivatesCurrentPaygBillingAtomically(t *testing.T) {
@@ -1512,6 +1815,7 @@ func TestStripeSubscriptionDeletionAuditFailureRollsBackDomainAndReceipt(t *test
 	metrics := configurePaygSubscriptionDeletion(t, service, "event_deactivation_failure", "subscription_failure", "subscription_failure")
 	service.auditLogger = nil
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 100)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock"}, 100)
 	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "failure").Code)
 
 	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
@@ -1527,7 +1831,9 @@ func TestStripeSubscriptionDeletionAuditFailureRollsBackDomainAndReceipt(t *test
 		KeyType:        string(openrouter.KeyTypeChat),
 	})
 	require.NoError(t, err)
-	require.False(t, chatKey.Disabled)
+	require.True(t, chatKey.Disabled)
+	require.Equal(t, []string{"admin_lock"}, chatKey.DisableCauses)
+	require.EqualValues(t, 100, chatKey.MonthlyCredits)
 	require.Zero(t, stripeWebhookReceiptCount(t, db))
 	require.Equal(t, 0, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
 	require.Zero(t, metrics.subscriptionLosses.Load())

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -207,8 +207,12 @@ func newStripeWebhookService(t *testing.T, customerID string, handler stripeWebh
 }
 
 func serveStripeWebhook(service *Service, body string) *httptest.ResponseRecorder {
+	return serveStripeWebhookWithContext(context.Background(), service, body)
+}
+
+func serveStripeWebhookWithContext(ctx context.Context, service *Service, body string) *httptest.ResponseRecorder {
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "/rpc/stripe.webhook", strings.NewReader(body))
+	request := httptest.NewRequest(http.MethodPost, "/rpc/stripe.webhook", strings.NewReader(body)).WithContext(ctx)
 	request.Header.Set("Stripe-Signature", "signature_placeholder")
 	oops.ErrHandle(service.logger, service.handleStripeWebhook).ServeHTTP(recorder, request)
 	return recorder
@@ -1108,23 +1112,32 @@ func postgresBackendPID(t *testing.T, tx pgx.Tx) int32 {
 	return pid
 }
 
-func waitForStripeWebhookBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID int32) {
+func waitForStripeWebhookWaitersBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID int32, count int) []int32 {
 	t.Helper()
 
+	var waiterPIDs []int32
 	require.Eventually(t, func() bool {
-		var waiting bool
-		err := db.QueryRow( //nolint:glint // notestingrawsql: pg_blocking_pids is a PostgreSQL test synchronization primitive unavailable to SQLc generation
+		rows, err := db.Query( //nolint:glint // notestingrawsql: pg_blocking_pids is a PostgreSQL test synchronization primitive unavailable to SQLc generation
 			t.Context(), `
-SELECT EXISTS (
-  SELECT 1
-  FROM pg_stat_activity AS activity
-  WHERE activity.datname = current_database()
-    AND $1 = ANY(pg_blocking_pids(activity.pid))
-)
-`, holderPID).Scan(&waiting)
+SELECT activity.pid
+FROM pg_stat_activity AS activity
+WHERE activity.datname = current_database()
+  AND $1 = ANY(pg_blocking_pids(activity.pid))
+ORDER BY activity.pid
+`, holderPID)
+		if err != nil {
+			return false
+		}
+		waiterPIDs, err = pgx.CollectRows(rows, pgx.RowTo[int32])
 		require.NoError(t, err)
-		return waiting
+		return len(waiterPIDs) == count
 	}, 2*time.Second, 10*time.Millisecond)
+	return waiterPIDs
+}
+
+func waitForStripeWebhookBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID int32) {
+	t.Helper()
+	waitForStripeWebhookWaitersBlockedByPID(t, db, holderPID, 1)
 }
 
 func receiveStripeWebhookStatus(t *testing.T, response <-chan int) int {
@@ -1203,6 +1216,100 @@ func TestStripeCheckoutAcquiresOpenRouterLocksInAllKeyTypesOrder(t *testing.T) {
 	require.NoError(t, probeTx.Rollback(t.Context()))
 	require.NoError(t, chatTx.Rollback(t.Context()))
 	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
+}
+
+func TestStripeSubscriptionDeletionAcquiresEveryOpenRouterLockInOrder(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, service, "event_deletion_key_order", "subscription_key_order", "subscription_key_order")
+	service.stripeHandler = service.serviceStripeWebhookHandler
+	require.Equal(t, []openrouter.KeyType{openrouter.KeyTypeChat, openrouter.KeyTypeInternal}, openrouter.AllKeyTypes)
+
+	internalTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the targeted backend holds the second canonical advisory lock
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = internalTx.Rollback(context.Background()) })
+	internalHolderPID := postgresBackendPID(t, internalTx)
+	require.NoError(t, repo.New(internalTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeInternal),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+
+	requestCtx, cancelRequest := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelRequest()
+	response := make(chan int, 1)
+	go func() { response <- serveStripeWebhookWithContext(requestCtx, service, "delete").Code }()
+	waitForStripeWebhookBlockedByPID(t, db, internalHolderPID)
+
+	probeTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the probe proves deletion retained the first lock while waiting for the second
+	require.NoError(t, err)
+	probeCtx, cancelProbe := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	probeErr := repo.New(probeTx).AcquireOpenRouterBillingLock(probeCtx, repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeChat),
+		OrganizationID: stripeWebhookOrganizationID,
+	})
+	cancelProbe()
+	_ = probeTx.Rollback(t.Context())
+	require.ErrorIs(t, probeErr, context.DeadlineExceeded)
+
+	require.NoError(t, internalTx.Rollback(t.Context()))
+	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
+}
+
+func TestReplacementCheckoutAndPriorSubscriptionDeletionAcquireOpenRouterBeforeBilling(t *testing.T) {
+	t.Parallel()
+
+	deletionService, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygSubscriptionDeletion(t, deletionService, "event_prior_deletion", "subscription_prior", "subscription_prior")
+	deletionService.stripeHandler = deletionService.serviceStripeWebhookHandler
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 100)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 100)
+
+	checkoutService := *deletionService
+	checkoutService.stripeClient = &fakeStripeWebhookClient{}
+	configurePaygCheckout(t, &checkoutService, "event_replacement_checkout", "subscription_replacement", "active")
+
+	holderTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test queues both lifecycle transactions behind one targeted backend
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = holderTx.Rollback(context.Background()) })
+	holderPID := postgresBackendPID(t, holderTx)
+	require.NoError(t, repo.New(holderTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
+		KeyType:        string(openrouter.KeyTypeChat),
+		OrganizationID: stripeWebhookOrganizationID,
+	}))
+
+	requestCtx, cancelRequests := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelRequests()
+	deletionResponse := make(chan int, 1)
+	go func() {
+		deletionResponse <- serveStripeWebhookWithContext(requestCtx, deletionService, "delete prior").Code
+	}()
+	deletionWaiter := waitForStripeWebhookWaitersBlockedByPID(t, db, holderPID, 1)
+
+	checkoutResponse := make(chan int, 1)
+	go func() {
+		checkoutResponse <- serveStripeWebhookWithContext(requestCtx, &checkoutService, "replace").Code
+	}()
+	waiters := waitForStripeWebhookWaitersBlockedByPID(t, db, holderPID, 2)
+	require.Contains(t, waiters, deletionWaiter[0])
+
+	probeTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: availability of the canonical next lock is the ordering assertion
+	require.NoError(t, err)
+	probeCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	probeErr := repo.New(probeTx).LockBillingMetadataOrganization(probeCtx, stripeWebhookOrganizationID)
+	cancel()
+	_ = probeTx.Rollback(t.Context())
+
+	require.NoError(t, holderTx.Rollback(t.Context()))
+	deletionStatus := receiveStripeWebhookStatus(t, deletionResponse)
+	checkoutStatus := receiveStripeWebhookStatus(t, checkoutResponse)
+	require.NoError(t, probeErr, "billing lock must remain available while both lifecycle transactions wait for OpenRouter")
+	require.Equal(t, http.StatusOK, deletionStatus)
+	require.Equal(t, http.StatusOK, checkoutStatus)
+
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "subscription_replacement", metadata.StripeSubscriptionID.String)
 }
 
 func TestStripeCheckoutConversionReplacesTrialAndBillingCausesIndependently(t *testing.T) {
@@ -1797,38 +1904,6 @@ func TestStripeSubscriptionDeletionAddsOnlyBillingInactiveCause(t *testing.T) {
 	require.EqualValues(t, 321, chat.MonthlyCredits)
 }
 
-func TestStripeSubscriptionDeletionLocksOnlyChatLifecycle(t *testing.T) {
-	t.Parallel()
-
-	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	configurePaygSubscriptionDeletion(t, service, "event_chat_lock_only", "subscription_current", "subscription_current")
-	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
-
-	internalLockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test must hold the unrelated advisory lock while deletion proceeds
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = internalLockTx.Rollback(context.Background()) })
-	require.NoError(t, repo.New(internalLockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
-		KeyType:        string(openrouter.KeyTypeInternal),
-		OrganizationID: stripeWebhookOrganizationID,
-	}))
-
-	chatLockTx, err := db.Begin(t.Context()) //nolint:glint // notestingrawsql: the test uses the relevant advisory lock to synchronize with the webhook backend
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = chatLockTx.Rollback(context.Background()) })
-	chatHolderPID := postgresBackendPID(t, chatLockTx)
-	require.NoError(t, repo.New(chatLockTx).AcquireOpenRouterBillingLock(t.Context(), repo.AcquireOpenRouterBillingLockParams{
-		KeyType:        string(openrouter.KeyTypeChat),
-		OrganizationID: stripeWebhookOrganizationID,
-	}))
-
-	response := make(chan int, 1)
-	go func() { response <- serveStripeWebhook(service, "deactivate").Code }()
-	waitForStripeWebhookBlockedByPID(t, db, chatHolderPID)
-	require.NoError(t, chatLockTx.Rollback(t.Context()))
-	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, response))
-	require.NoError(t, internalLockTx.Rollback(t.Context()))
-}
-
 func TestStripeSubscriptionDeletionRejectsUnclassifiedKeyAndRollsBackAtomically(t *testing.T) {
 	t.Parallel()
 
@@ -2014,6 +2089,69 @@ func TestStripeSubscriptionDeletionReplayCannotOverrideLaterConversion(t *testin
 	require.EqualValues(t, limit, chat.MonthlyCredits)
 	require.Empty(t, chat.DisableCauses)
 	require.False(t, chat.Disabled)
+}
+
+func TestConvertedDemotedTrialSubscriptionLossWinsBeforeDelayedActivationReconcile(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_converted_before_loss", "subscription_converted_before_loss", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 41)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 59)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion"}, 41)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion", "security_hold"}, 59)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "convert").Code)
+	trial, err := trialsrepo.New(db).GetTrial(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.True(t, trial.ConvertedAt.Valid)
+	require.True(t, trial.DemotedAt.Valid)
+
+	configurePaygSubscriptionDeletion(t, service, "event_loss_before_activation_wakeup", "subscription_converted_before_loss", "subscription_converted_before_loss")
+	service.stripeHandler = service.serviceStripeWebhookHandler
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "lose subscription").Code)
+
+	var patches atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patches.Add(1)
+		}
+		hash := strings.TrimPrefix(r.URL.Path, "/v1/keys/")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"hash": hash, "limit": 100.0}})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	production := openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+	require.NoError(t, RepairPaygOpenRouterChatKey(
+		t.Context(), testenv.NewLogger(t), db, production, stripeWebhookOrganizationID, openrouter.KeyDesiredStateEnabled,
+	))
+
+	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.False(t, metadata.StripeSubscriptionID.Valid)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "free", organization.GramAccountType)
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock", "billing_inactive"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	paygLimit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, paygLimit, chat.MonthlyCredits)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+	require.EqualValues(t, 59, internal.MonthlyCredits)
+	require.Zero(t, patches.Load(), "delayed activation must not patch over committed subscription loss")
 }
 
 func TestStripeSubscriptionDeletionDeactivatesCurrentPaygBillingAtomically(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1586,8 +1586,54 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	t.Parallel()
 
 	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	configurePaygCheckout(t, service, "event_first", "subscription_replay", "past_due")
+	featureCache := configurePaygCheckout(t, service, "event_first", "subscription_replay", "past_due")
+	metrics := &captureStripeWebhookMetrics{}
+	service.stripeMetrics = metrics
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"billing_inactive"}, 17)
+
+	var patches atomic.Int32
+	var firstPatch map[string]any
+	handlerErrors := make(chan error, 3)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			handlerErrors <- fmt.Errorf("unexpected OpenRouter method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if patches.Add(1) == 1 {
+			if err := json.NewDecoder(r.Body).Decode(&firstPatch); err != nil {
+				handlerErrors <- fmt.Errorf("decode OpenRouter PATCH: %w", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 100.0, "hash": "hash_placeholder_chat"},
+		}); err != nil {
+			handlerErrors <- fmt.Errorf("encode OpenRouter response: %w", err)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "first").Code)
+	patchesAfterFirst := patches.Load()
+	require.Positive(t, patchesAfterFirst)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, firstPatch["limit"], "true recovery must PATCH the current PAYG cap")
+	cacheAfterFirst := featureCache.snapshot()
+	keyAfterFirst := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
 
 	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
 	require.True(t, ok)
@@ -1602,12 +1648,22 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 		}, nil
 	}
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "second").Code)
+	if len(handlerErrors) > 0 {
+		require.NoError(t, <-handlerErrors)
+	}
 
 	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
-	require.Equal(t, 2, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 2, stripeWebhookReceiptCount(t, db), "the distinct event receipt remains durable")
 	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, count)
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
+	require.Equal(t, patchesAfterFirst, patches.Load(), "unchanged active checkout must not PATCH OpenRouter again")
+	require.Equal(t, cacheAfterFirst, featureCache.snapshot())
+	require.EqualValues(t, 2, client.checkoutCalls.Load(), "a distinct event must verify current Stripe state")
+	require.Zero(t, metrics.invoicePaymentFailures.Load())
+	require.Zero(t, metrics.subscriptionLosses.Load())
+	require.Equal(t, keyAfterFirst, openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat))
 }
 
 func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1482,6 +1482,100 @@ func TestStripeCheckoutExactReplaySkipsCurrentStateRetrieval(t *testing.T) {
 	require.Equal(t, 1, paygSchedulingIntentCount(t, service.db))
 }
 
+func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommitFailure(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_internal_repair_replay", "subscription_internal_repair_replay", "active")
+	createDemotedEnterpriseTrialFixture(t, db)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 23)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "trial_demotion", "billing_inactive"}, 17)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal, true, []string{"trial_demotion", "security_hold"}, 23)
+
+	var chatPatches atomic.Int32
+	var internalPatches atomic.Int32
+	var failInternal atomic.Bool
+	failInternal.Store(true)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		keyHash := strings.TrimPrefix(r.URL.Path, "/v1/keys/")
+		switch keyHash {
+		case "hash_placeholder_chat":
+			chatPatches.Add(1)
+		case "hash_placeholder_internal":
+			internalPatches.Add(1)
+			if failInternal.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 100.0, "hash": keyHash},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "first").Code)
+	failedInternalPatchAttempts := internalPatches.Load()
+	require.Positive(t, failedInternalPatchAttempts)
+	require.Positive(t, chatPatches.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
+	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
+
+	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	internal := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+	require.EqualValues(t, 23, internal.MonthlyCredits)
+
+	failInternal.Store(false)
+	client, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	require.EqualValues(t, 1, client.checkoutCalls.Load())
+	client.checkoutError = errors.New("exact replay must not fetch Stripe checkout state")
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "exact replay").Code)
+	require.Greater(t, internalPatches.Load(), failedInternalPatchAttempts)
+	require.EqualValues(t, 1, client.checkoutCalls.Load())
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
+	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
+
+	chat = openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.Equal(t, []string{"admin_lock"}, chat.DisableCauses)
+	require.True(t, chat.Disabled)
+	require.EqualValues(t, limit, chat.MonthlyCredits)
+	internal = openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeInternal)
+	require.Equal(t, []string{"security_hold"}, internal.DisableCauses)
+	require.True(t, internal.Disabled)
+	require.EqualValues(t, 23, internal.MonthlyCredits)
+}
+
 func TestStripeCheckoutExactReplayRepairsPostCommitOpenRouterFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -365,6 +366,20 @@ func setOpenRouterKeyLifecycleFixture(t *testing.T, db *pgxpool.Pool, keyType op
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, rows)
+}
+
+func stripeLifecycleOpenRouterProvisioner(t *testing.T, db *pgxpool.Pool, baseURL string) openrouter.Provisioner {
+	t.Helper()
+
+	option, err := openrouter.WithTestBaseURL(baseURL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	return openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
 }
 
 func openRouterKeyLifecycleFixture(t *testing.T, db *pgxpool.Pool, keyType openrouter.KeyType) openrouterrepo.OpenrouterApiKey {
@@ -1140,13 +1155,33 @@ func waitForStripeWebhookBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID 
 	waitForStripeWebhookWaitersBlockedByPID(t, db, holderPID, 1)
 }
 
+func waitForStripeReceiptInsertBlockedByPID(t *testing.T, db *pgxpool.Pool, holderPID int32) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		var blocked bool
+		err := db.QueryRow( //nolint:glint // notestingrawsql: pg_blocking_pids is a PostgreSQL test synchronization primitive unavailable to SQLc generation
+			t.Context(), `
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_stat_activity AS activity
+  WHERE activity.datname = current_database()
+    AND $1 = ANY(pg_blocking_pids(activity.pid))
+    AND activity.query LIKE '%INSERT INTO stripe_webhook_receipts%'
+)
+`, holderPID).Scan(&blocked)
+		require.NoError(t, err)
+		return blocked
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
 func receiveStripeWebhookStatus(t *testing.T, response <-chan int) int {
 	t.Helper()
 
 	select {
 	case status := <-response:
 		return status
-	case <-time.After(2 * time.Second):
+	case <-time.After(15 * time.Second):
 		require.FailNow(t, "timed out waiting for Stripe webhook response")
 		return 0
 	}
@@ -1724,6 +1759,141 @@ func TestStripeCheckoutConvertedDemotedTrialExactReplayRepairsInternalPostCommit
 	for _, path := range internalSecurityUpstream.patchPaths {
 		require.Equal(t, "/v1/keys/hash_placeholder_internal", path)
 	}
+}
+
+func TestStripeCheckoutLostReceiptInsertRepairsWinnerPostCommitFailure(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_lost_insert_repair", "subscription_lost_insert_repair", "active")
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 17)
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"billing_inactive"}, 17)
+
+	const duplicateOrganizationID = "org_duplicate_placeholder"
+	require.NoError(t, orgrepo.New(db).CreateOrganizationMetadata(t.Context(), orgrepo.CreateOrganizationMetadataParams{
+		ID: duplicateOrganizationID, Name: "Duplicate Placeholder Organization", Slug: "duplicate-placeholder-organization",
+	}))
+	require.NoError(t, repo.New(db).CreateStripeBillingMetadataFixture(t.Context(), repo.CreateStripeBillingMetadataFixtureParams{
+		OrganizationID:   duplicateOrganizationID,
+		StripeCustomerID: pgtype.Text{String: "customer_duplicate_placeholder", Valid: true},
+	}))
+
+	failingUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(failingUpstream.Close)
+	service.openRouter = stripeLifecycleOpenRouterProvisioner(t, db, failingUpstream.URL)
+
+	var repairedPatches atomic.Int32
+	var repairedUpstream struct {
+		sync.Mutex
+		disabled *bool
+		limit    *float64
+	}
+	repairingUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var patch struct {
+			Limit    *float64 `json:"limit"`
+			Disabled *bool    `json:"disabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			http.Error(w, "invalid patch", http.StatusBadRequest)
+			return
+		}
+		repairedUpstream.Lock()
+		repairedUpstream.disabled = patch.Disabled
+		repairedUpstream.limit = patch.Limit
+		repairedUpstream.Unlock()
+		repairedPatches.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": 100.0, "hash": "hash_placeholder_chat"},
+		})
+	}))
+	t.Cleanup(repairingUpstream.Close)
+
+	winnerEntered := make(chan int32, 1)
+	releaseWinner := make(chan struct{})
+	originalHandler := service.stripeHandler
+	service.stripeHandler = func(ctx context.Context, logger *slog.Logger, tx pgx.Tx, organizationID string, event *stripeclient.WebhookEvent, checkout *stripeclient.CheckoutSessionState, invoice *stripeclient.InvoiceState) (stripeWebhookResult, error) {
+		result, err := originalHandler(ctx, logger, tx, organizationID, event, checkout, invoice)
+		if err != nil {
+			return stripeWebhookResult{}, err
+		}
+		var pid int32
+		if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil { //nolint:glint // notestingrawsql: backend identity synchronizes the real PostgreSQL conflict
+			return stripeWebhookResult{}, fmt.Errorf("read winner backend PID: %w", err)
+		}
+		select {
+		case winnerEntered <- pid:
+		default:
+			return stripeWebhookResult{}, errors.New("winner backend was already reported")
+		}
+		select {
+		case <-releaseWinner:
+			return result, nil
+		case <-ctx.Done():
+			return stripeWebhookResult{}, ctx.Err()
+		}
+	}
+
+	duplicateClient := &fakeStripeWebhookClient{
+		verify: func(_ []byte, _ string) (*stripeclient.WebhookEvent, error) {
+			return &stripeclient.WebhookEvent{
+				ID: "event_lost_insert_repair", Type: "invoice.payment_failed", ObjectID: "invoice_duplicate_placeholder",
+				CustomerID: "customer_duplicate_placeholder",
+			}, nil
+		},
+		checkout: nil, checkoutError: nil, invoice: nil, invoiceError: nil,
+		checkoutCalls: atomic.Int32{}, invoiceCalls: atomic.Int32{}, verifyCalls: atomic.Int32{},
+	}
+	duplicate := *service
+	duplicate.stripeClient = duplicateClient
+	duplicate.openRouter = stripeLifecycleOpenRouterProvisioner(t, db, repairingUpstream.URL)
+
+	winnerResponse := make(chan int, 1)
+	go func() { winnerResponse <- serveStripeWebhook(service, "winner").Code }()
+	var winnerPID int32
+	select {
+	case winnerPID = <-winnerEntered:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "timed out waiting for winner transaction")
+	}
+
+	duplicateResponse := make(chan int, 1)
+	go func() { duplicateResponse <- serveStripeWebhook(&duplicate, "duplicate").Code }()
+	waitForStripeReceiptInsertBlockedByPID(t, db, winnerPID)
+	close(releaseWinner)
+
+	require.Equal(t, http.StatusInternalServerError, receiveStripeWebhookStatus(t, winnerResponse))
+	require.Equal(t, http.StatusOK, receiveStripeWebhookStatus(t, duplicateResponse))
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+	require.Equal(t, 1, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygActivated))
+	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
+	count, err := audittest.AuditLogCountByAction(t.Context(), db, audit.ActionOrganizationPaygActivated)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+	winnerClient, ok := service.stripeClient.(*fakeStripeWebhookClient)
+	require.True(t, ok)
+	require.EqualValues(t, 1, winnerClient.checkoutCalls.Load())
+	require.Zero(t, duplicateClient.checkoutCalls.Load())
+	require.EqualValues(t, 1, repairedPatches.Load())
+
+	repairedUpstream.Lock()
+	defer repairedUpstream.Unlock()
+	require.NotNil(t, repairedUpstream.disabled)
+	require.False(t, *repairedUpstream.disabled)
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	require.NotNil(t, repairedUpstream.limit)
+	require.InDelta(t, limit, *repairedUpstream.limit, 0)
 }
 
 func TestStripeCheckoutExactReplayRepairsPostCommitOpenRouterFailure(t *testing.T) {

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1692,22 +1692,44 @@ func TestStripeCheckoutFinalBillingCauseRecoveryReconcilesStaleDisabledMirror(t 
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, int64(limit))
 	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, []string{"billing_inactive"}, int64(limit))
 
-	patches := make(chan map[string]any, 10)
+	type openRouterPatch struct {
+		Limit      *float64 `json:"limit"`
+		LimitReset *string  `json:"limit_reset"`
+		Disabled   *bool    `json:"disabled"`
+	}
+	var recorder struct {
+		sync.Mutex
+		paths   []string
+		patches []openRouterPatch
+		errors  []error
+	}
+	recordHandlerError := func(err error) {
+		recorder.Lock()
+		defer recorder.Unlock()
+		recorder.errors = append(recorder.errors, err)
+	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
+			recordHandlerError(fmt.Errorf("unexpected OpenRouter method %s", r.Method))
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		var patch map[string]any
+		var patch openRouterPatch
 		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			recordHandlerError(fmt.Errorf("decode OpenRouter PATCH: %w", err))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		patches <- patch
+		recorder.Lock()
+		recorder.paths = append(recorder.paths, r.URL.Path)
+		recorder.patches = append(recorder.patches, patch)
+		recorder.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		if err := json.NewEncoder(w).Encode(map[string]any{
 			"data": map[string]any{"limit": float64(limit), "hash": "hash_placeholder_chat"},
-		})
+		}); err != nil {
+			recordHandlerError(fmt.Errorf("encode OpenRouter response: %w", err))
+		}
 	}))
 	t.Cleanup(upstream.Close)
 	option, err := openrouter.WithTestBaseURL(upstream.URL)
@@ -1721,8 +1743,22 @@ func TestStripeCheckoutFinalBillingCauseRecoveryReconcilesStaleDisabledMirror(t 
 	)
 
 	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "final cause recovery").Code)
+	recorder.Lock()
+	paths := slices.Clone(recorder.paths)
+	patches := slices.Clone(recorder.patches)
+	handlerErrors := slices.Clone(recorder.errors)
+	recorder.Unlock()
+	for _, handlerErr := range handlerErrors {
+		require.NoError(t, handlerErr)
+	}
+	require.Equal(t, []string{"/v1/keys/hash_placeholder_chat"}, paths)
 	require.Len(t, patches, 1, "removing the final cause must schedule postcommit reconciliation")
-	require.Equal(t, false, (<-patches)["disabled"])
+	require.NotNil(t, patches[0].Disabled)
+	require.False(t, *patches[0].Disabled)
+	require.NotNil(t, patches[0].Limit)
+	require.InDelta(t, limit, *patches[0].Limit, 0)
+	require.NotNil(t, patches[0].LimitReset)
+	require.Equal(t, "monthly", *patches[0].LimitReset)
 	key := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
 	require.False(t, key.Disabled)
 	require.Empty(t, key.DisableCauses)

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1682,6 +1682,54 @@ func TestStripeCheckoutDomainReplayIsNoop(t *testing.T) {
 	require.Equal(t, keyAfterFirst, openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat))
 }
 
+func TestStripeCheckoutFinalBillingCauseRecoveryReconcilesStaleDisabledMirror(t *testing.T) {
+	t.Parallel()
+
+	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
+	configurePaygCheckout(t, service, "event_final_cause_recovery", "subscription_final_cause_recovery", "past_due")
+	limit, ok := openrouter.AccountTypeCreditLimit("payg")
+	require.True(t, ok)
+	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, int64(limit))
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, []string{"billing_inactive"}, int64(limit))
+
+	patches := make(chan map[string]any, 10)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var patch map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		patches <- patch
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": float64(limit), "hash": "hash_placeholder_chat"},
+		})
+	}))
+	t.Cleanup(upstream.Close)
+	option, err := openrouter.WithTestBaseURL(upstream.URL)
+	require.NoError(t, err)
+	tracerProvider := testenv.NewTracerProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+	service.openRouter = openrouter.New(
+		testenv.NewLogger(t), tracerProvider, guardianPolicy, db, "test", "provisioning_key_placeholder",
+		nil, nil, nil, testenv.NewEncryptionClient(t), option,
+	)
+
+	require.Equal(t, http.StatusOK, serveStripeWebhook(service, "final cause recovery").Code)
+	require.Len(t, patches, 1, "removing the final cause must schedule postcommit reconciliation")
+	require.Equal(t, false, (<-patches)["disabled"])
+	key := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
+	require.False(t, key.Disabled)
+	require.Empty(t, key.DisableCauses)
+	require.Equal(t, int64(limit), key.MonthlyCredits)
+	require.Equal(t, 1, stripeWebhookReceiptCount(t, db))
+}
+
 func TestStripeCheckoutLayeredBillingRecoveryDoesNotReconcileUnchangedAccess(t *testing.T) {
 	t.Parallel()
 
@@ -1690,7 +1738,7 @@ func TestStripeCheckoutLayeredBillingRecoveryDoesNotReconcileUnchangedAccess(t *
 	limit, ok := openrouter.AccountTypeCreditLimit("payg")
 	require.True(t, ok)
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, int64(limit))
-	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, true, []string{"admin_lock", "billing_inactive", "unknown_policy"}, int64(limit))
+	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, []string{"admin_lock", "billing_inactive", "unknown_policy"}, int64(limit))
 
 	var patches atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
<!-- stack-narrative:start -->
## Why this PR exists

After writers become cause-aware, platform administrators need to understand why a key is unavailable. A single “Disabled” label hides whether the restriction came from an administrator, trial lifecycle, billing lifecycle, or several causes at once.

## What changes in this layer

This PR shows every active cause in both the dashboard platform-admin key view and the standalone organization Billing UI. The platform-admin view offers only actions the administrator owns: admins may add or remove `admin_lock`, while automatic and unknown causes remain intact. The standalone Billing UI remains read-only for disable causes and keeps its existing key-limit editing unchanged. Both surfaces distinguish classified empty cause sets from legacy unclassified rows, preserve effective Enabled/Disabled state, and display unknown future causes.

## How it advances the stack

The safer lifecycle model becomes understandable and operable without creating a shortcut around automatic policy.
<!-- stack-narrative:end -->

---

## Detailed scope, rollout, and verification

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the platform admin OpenRouter key table so disable causes drive status and row actions, preventing the UI from suggesting re-enabling keys that were disabled automatically.

**Behavior**
- Displays each key's disable causes as labels, keeps unknown causes as-is, and shows "Unclassified legacy state" when causes were never recorded.
- Shows "Disable key" only for keys without an `admin_lock` cause, "Remove admin lock" only for keys with one, and no actions for legacy unclassified rows.
- Treats a key as enabled only when its cause list is non-empty or it has explicit `disabled: false` with no causes.
- Locks all row triggers during any key mutation and marks the affected row as in progress.
- Restores focus to the `MoreActions` trigger on close, deferring until the action's loading and disabled states clear.

<sup>Written for commit e108d67cca64bdaddcc758225dcd3b3e3779dd4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



