### PR TITLE
fix(telemetry): Attribute MCP tool drilldown by server, not by session

### DIFF
--- a/server/internal/telemetry/mcp_drilldown_test.go
+++ b/server/internal/telemetry/mcp_drilldown_test.go
@@ -1,6 +1,9 @@
 package telemetry_test
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -266,4 +269,235 @@ func TestMCPDrilldownTraceIDsAreStable(t *testing.T) {
 	require.Len(t, first, 1)
 	require.Equal(t, first[0].TraceID, second[0].TraceID)
 	require.Equal(t, telemetryRepo.MCPOutcomeUnauthorized, first[0].Outcome)
+}
+
+// hookToolEventParams describes a hook-observed tool event for testing.
+type hookToolEventParams struct {
+	projectID    string
+	traceID      string
+	timestamp    time.Time
+	mcpServerURL string
+	toolName     string
+	hookSource   string
+	hasResult    bool
+	hasError     bool
+}
+
+// insertHookToolEvent inserts a hook-observed tool event into telemetry_logs.
+// This simulates traffic observed by an agent hook where multiple MCP server
+// calls can share the same trace_id (session).
+func insertHookToolEvent(t *testing.T, ctx context.Context, ti *testInstance, p hookToolEventParams) {
+	t.Helper()
+
+	// Generate a unique tool call ID for each event, which is how hook events
+	// distinguish individual tool calls within a session.
+	toolCallID := uuid.New().String()
+
+	attrs := map[string]any{
+		"gram.event.source":   "hook",
+		"gram.tool.name":      p.toolName,
+		"gram.mcp.server_url": p.mcpServerURL,
+		"gram.hook.source":    p.hookSource,
+		"gen_ai.tool.call.id": toolCallID,
+	}
+	if p.hasResult {
+		attrs["gen_ai.tool.call.result"] = `"ok"`
+	}
+	if p.hasError {
+		attrs["gram.hook.error"] = "tool call failed"
+	}
+	attrsJSON, err := json.Marshal(attrs)
+	require.NoError(t, err)
+
+	spanID := uuid.New().String()[:16]
+	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+		ID:                   uuid.New().String(),
+		TimeUnixNano:         p.timestamp.UnixNano(),
+		ObservedTimeUnixNano: p.timestamp.UnixNano(),
+		SeverityText:         nil,
+		Body:                 "hook tool event",
+		TraceID:              &p.traceID,
+		SpanID:               &spanID,
+		Attributes:           string(attrsJSON),
+		ResourceAttributes:   "{}",
+		GramProjectID:        p.projectID,
+		GramDeploymentID:     nil,
+		GramFunctionID:       nil,
+		GramURN:              "hooks:" + p.toolName,
+		ServiceName:          "gram-hooks",
+		ServiceVersion:       nil,
+		GramChatID:           nil,
+	})
+	require.NoError(t, err)
+}
+
+// TestGetMCPToolOutcomeBreakdown_HookObservedMultiServerSession verifies that
+// when a single session (shared trace_id) calls multiple MCP servers through
+// hook-observed traffic, filtering by one server only shows tools from that
+// server. This directly tests the bug scenario from the customer report.
+func TestGetMCPToolOutcomeBreakdown_HookObservedMultiServerSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	// All events share the same trace_id to simulate a single session
+	// that calls multiple MCP servers.
+	sharedTraceID := strings.ReplaceAll(uuid.New().String(), "-", "")
+
+	// Session calls multiple MCP servers:
+	// - Datadog: 2 calls (get_logs, search_metrics)
+	// - Linear: 2 calls (get_issues, create_issue)
+	// - GitHub: 1 call (list_repos)
+	for _, event := range []struct {
+		mcpServerURL string
+		toolName     string
+		hasResult    bool
+		hasError     bool
+	}{
+		{"https://api.speakeasy.com/mcp/datadog", "mcp__datadog__get_logs", true, false},
+		{"https://api.speakeasy.com/mcp/datadog", "mcp__datadog__search_metrics", true, false},
+		{"https://api.speakeasy.com/mcp/linear", "mcp__linear__get_issues", true, false},
+		{"https://api.speakeasy.com/mcp/linear", "mcp__linear__create_issue", false, true},
+		{"https://api.speakeasy.com/mcp/github", "mcp__github__list_repos", true, false},
+	} {
+		insertHookToolEvent(t, ctx, ti, hookToolEventParams{
+			projectID:    projectID,
+			traceID:      sharedTraceID,
+			timestamp:    now.Add(-10 * time.Minute),
+			mcpServerURL: event.mcpServerURL,
+			toolName:     event.toolName,
+			hookSource:   "claude-code",
+			hasResult:    event.hasResult,
+			hasError:     event.hasError,
+		})
+	}
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// When drilling into "datadog", we should ONLY see datadog tools.
+	rows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs:       []string{projectID},
+			MCPServerURLSuffixes: []string{"/mcp/datadog"},
+			TimeStart:            now.Add(-time.Hour).UnixNano(),
+			TimeEnd:              now.UnixNano(),
+		},
+	})
+	require.NoError(t, err)
+
+	counts := toolOutcomeCounts(rows)
+
+	// Verify datadog tools are present
+	require.Contains(t, counts, "mcp__datadog__get_logs", "datadog's get_logs should appear")
+	require.Contains(t, counts, "mcp__datadog__search_metrics", "datadog's search_metrics should appear")
+
+	// Verify tools from OTHER servers (linear, github) are NOT present
+	_, hasLinearTool := counts["mcp__linear__get_issues"]
+	require.False(t, hasLinearTool, "linear's get_issues should NOT appear when filtering for datadog")
+	_, hasLinearTool2 := counts["mcp__linear__create_issue"]
+	require.False(t, hasLinearTool2, "linear's create_issue should NOT appear when filtering for datadog")
+	_, hasGithubTool := counts["mcp__github__list_repos"]
+	require.False(t, hasGithubTool, "github's list_repos should NOT appear when filtering for datadog")
+
+	// When drilling into "linear", we should only see linear tools
+	linearRows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs:       []string{projectID},
+			MCPServerURLSuffixes: []string{"/mcp/linear"},
+			TimeStart:            now.Add(-time.Hour).UnixNano(),
+			TimeEnd:              now.UnixNano(),
+		},
+	})
+	require.NoError(t, err)
+
+	linearCounts := toolOutcomeCounts(linearRows)
+	require.Contains(t, linearCounts, "mcp__linear__get_issues", "linear's get_issues should appear")
+	require.Contains(t, linearCounts, "mcp__linear__create_issue", "linear's create_issue should appear")
+	_, hasDatadogTool := linearCounts["mcp__datadog__get_logs"]
+	require.False(t, hasDatadogTool, "datadog's tools should NOT appear when filtering for linear")
+}
+
+// TestGetMCPToolOutcomeBreakdown_FiltersToSpecificServer verifies that when
+// drilling down into a specific MCP server, only tools from that server appear
+// in the breakdown — not tools from other servers that happened to be called
+// in the same session or trace. This was the bug reported by Fermatcommerce:
+// when drilling into Datadog, tools from Linear, GitHub, and Speakeasy-Slack
+// were appearing because attribution was by session rather than by server.
+func TestGetMCPToolOutcomeBreakdown_FiltersToSpecificServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	now := time.Now().UTC()
+
+	// Insert events for multiple servers. Each hosted tool call gets its own
+	// trace_id (via insertHostedToolEvent), so this tests the per-trace
+	// attribution for direct hosted MCP traffic.
+	for _, event := range []struct {
+		toolsetSlug string
+		toolName    string
+		statusCode  int
+	}{
+		// Server A: datadog with 3 calls
+		{"datadog", "get_logs", 200},
+		{"datadog", "search_metrics", 200},
+		{"datadog", "get_logs", 500},
+		// Server B: linear with 2 calls
+		{"linear", "get_issues", 200},
+		{"linear", "create_issue", 200},
+		// Server C: github with 1 call
+		{"github", "list_repos", 200},
+	} {
+		insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{
+			projectID:   projectID,
+			timestamp:   now.Add(-10 * time.Minute),
+			toolsetSlug: event.toolsetSlug,
+			toolName:    event.toolName,
+			userEmail:   "alice@example.com",
+			statusCode:  event.statusCode,
+		})
+	}
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	// When drilling into "datadog", we should ONLY see datadog tools.
+	rows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs: []string{projectID},
+			ToolsetSlugs:   []string{"datadog"},
+			TimeStart:      now.Add(-time.Hour).UnixNano(),
+			TimeEnd:        now.UnixNano(),
+		},
+	})
+	require.NoError(t, err)
+
+	counts := toolOutcomeCounts(rows)
+
+	// Verify datadog tools are present with correct counts
+	require.Equal(t, map[string]uint64{
+		telemetryRepo.MCPOutcomeSuccess:     1,
+		telemetryRepo.MCPOutcomeServerError: 1,
+	}, counts["get_logs"], "get_logs should have 1 success and 1 server_error")
+	require.Equal(t, map[string]uint64{
+		telemetryRepo.MCPOutcomeSuccess: 1,
+	}, counts["search_metrics"], "search_metrics should have 1 success")
+
+	// Verify tools from OTHER servers (linear, github) are NOT present
+	_, hasLinearTool := counts["get_issues"]
+	require.False(t, hasLinearTool, "linear's get_issues should NOT appear when filtering for datadog")
+	_, hasLinearTool2 := counts["create_issue"]
+	require.False(t, hasLinearTool2, "linear's create_issue should NOT appear when filtering for datadog")
+	_, hasGithubTool := counts["list_repos"]
+	require.False(t, hasGithubTool, "github's list_repos should NOT appear when filtering for datadog")
+
+	// Total should be exactly 3 datadog calls
+	totalCalls := uint64(0)
+	for _, tool := range counts {
+		for _, count := range tool {
+			totalCalls += count
+		}
+	}
+	require.Equal(t, uint64(3), totalCalls, "should see exactly 3 datadog calls, not calls from other servers")
 }

--- a/server/internal/telemetry/repo/mcp_diagnostics.go
+++ b/server/internal/telemetry/repo/mcp_diagnostics.go
@@ -146,30 +146,41 @@ func unionSource(directSQL string, directArgs []any, hookSQL string, hookArgs []
 }
 
 // mcpOutcomeDirectSource classifies calls that reached a hosted MCP server
-// directly. Aggregate aliases carry the "g_" prefix for the reason the tool
-// usage CTE documents: an alias that shadows a trace_summaries column is merged
-// into the enclosing aggregate and fails with ILLEGAL_AGGREGATION.
+// directly. It queries telemetry_logs directly and filters by toolset_slug at
+// the row level to ensure correct per-tool attribution when a trace contains
+// calls to multiple MCP servers.
+//
+// The query groups by trace_id to deduplicate multiple log rows for the same
+// call, but the toolset_slug filter is applied before grouping so only rows
+// matching the specified server are included.
 func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
-	grouped := sq.Select(
-		"trace_id",
-		"min(start_time_unix_nano) AS event_time_ns",
-		"max(toolset_slug) AS g_toolset_slug",
-		"any(tool_name) AS g_tool_name",
-		"ifNull(anyIfMerge(http_status_code), 0) AS g_http_status_code",
-	).
-		From("trace_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
-		GroupBy("trace_id").
-		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
-		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
-		Having("any(event_source) != 'hook'").
-		Having("g_toolset_slug != ''")
-	if len(arg.ToolsetSlugs) > 0 {
-		grouped = grouped.Having(squirrel.Eq{"g_toolset_slug": arg.ToolsetSlugs})
-	}
-	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
+	httpStatusCode := "toInt32OrZero(toString(attributes.http.response.status_code))"
 
-	groupedSQL, groupedArgs, err := grouped.ToSql()
+	sb := sq.Select(
+		"trace_id",
+		"min(time_unix_nano) AS event_time_ns",
+		"max(toolset_slug) AS g_toolset_slug",
+		"max(tool_name) AS g_tool_name",
+		"max("+httpStatusCode+") AS g_http_status_code",
+	).
+		From("telemetry_logs").
+		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
+		Where("trace_id IS NOT NULL").
+		Where("trace_id != ''").
+		Where("toolset_slug != ''").
+		Where("event_source != 'hook'")
+
+	if len(arg.ToolsetSlugs) > 0 {
+		sb = sb.Where(squirrel.Eq{"toolset_slug": arg.ToolsetSlugs})
+	}
+
+	sb = sb.GroupBy("trace_id").
+		Having("min(time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(time_unix_nano) <= ?", arg.TimeEnd)
+
+	sb = withTraceWindowScanBounds(sb, "time_unix_nano", arg.TimeStart, arg.TimeEnd)
+
+	groupedSQL, groupedArgs, err := sb.ToSql()
 	if err != nil {
 		return "", nil, fmt.Errorf("build direct mcp outcome source: %w", err)
 	}
@@ -196,29 +207,52 @@ FROM (%s)`, MCPClientUnattributed, outcome, groupedSQL), groupedArgs, nil
 // observed them. This is the only lane that can name a client today, and it
 // names the reporting integration — self-reported evidence, never a metric
 // dimension a caller can filter on.
+//
+// It queries telemetry_logs directly and filters by mcp_server_url at the row
+// level to ensure correct per-tool attribution when a trace (session) contains
+// calls to multiple MCP servers. Grouping uses a tool call dedup identifier
+// (gen_ai.tool.call.id or tool_use_id) to distinguish individual tool calls
+// within a trace.
 func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
-	grouped := sq.Select(
-		"trace_id",
-		"min(start_time_unix_nano) AS event_time_ns",
-		"any(hook_source) AS g_hook_source",
-		"any(tool_name) AS g_tool_name",
-		"max(mcp_server_url) AS g_mcp_server_url",
-		"max(has_result) AS g_has_result",
-		"max(has_error) AS g_has_error",
-	).
-		From("trace_summaries").
-		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
-		GroupBy("trace_id").
-		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
-		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
-		Having("any(event_source) = 'hook'").
-		Having("g_mcp_server_url != ''")
-	if len(arg.MCPServerURLSuffixes) > 0 {
-		grouped = grouped.Having("arrayExists(suffix -> endsWith(g_mcp_server_url, suffix), ?)", arg.MCPServerURLSuffixes)
-	}
-	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
+	mcpServerURL := "toString(attributes.gram.mcp.server_url)"
+	hasResult := "if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)"
+	hasError := "if(toString(attributes.gram.hook.error) != '', 1, 0)"
+	// Tool call dedup identifier: prefer tool_use_id, then gen_ai.tool.call.id,
+	// fallback to row id. This mirrors the session schema's tool_call_dedup_id.
+	toolCallDedupID := "multiIf(" +
+		"toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), " +
+		"toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), " +
+		"toString(id))"
 
-	groupedSQL, groupedArgs, err := grouped.ToSql()
+	sb := sq.Select(
+		"trace_id",
+		"min(time_unix_nano) AS event_time_ns",
+		"max(hook_source) AS g_hook_source",
+		"max(tool_name) AS g_tool_name",
+		"max("+mcpServerURL+") AS g_mcp_server_url",
+		"max("+hasResult+") AS g_has_result",
+		"max("+hasError+") AS g_has_error",
+	).
+		From("telemetry_logs").
+		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
+		Where("trace_id IS NOT NULL").
+		Where("trace_id != ''").
+		Where("event_source = 'hook'").
+		Where(mcpServerURL + " != ''")
+
+	if len(arg.MCPServerURLSuffixes) > 0 {
+		sb = sb.Where("arrayExists(suffix -> endsWith("+mcpServerURL+", suffix), ?)", arg.MCPServerURLSuffixes)
+	}
+
+	// Group by both trace_id and tool_call_dedup_id to distinguish individual
+	// tool calls within a session that may call the same server multiple times.
+	sb = sb.GroupBy("trace_id", toolCallDedupID).
+		Having("min(time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(time_unix_nano) <= ?", arg.TimeEnd)
+
+	sb = withTraceWindowScanBounds(sb, "time_unix_nano", arg.TimeStart, arg.TimeEnd)
+
+	groupedSQL, groupedArgs, err := sb.ToSql()
 	if err != nil {
 		return "", nil, fmt.Errorf("build hook mcp outcome source: %w", err)
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the bug where Platform MCP analytics attributed tool usage by session rather than by the selected server. When drilling down into a specific MCP server (e.g., Datadog), tools from other servers (Linear, GitHub, etc.) that happened to be called in the same session were incorrectly appearing in the breakdown.

## Problem

As reported by a customer when drilling into the Datadog MCP server analytics, tools from Linear, GitHub, and speakeasy-slack were appearing in the breakdown. This happened because:

1. `mcpOutcomeDirectSource` and `mcpOutcomeHookSource` were querying `trace_summaries` (which aggregates data by `trace_id`)
2. The filtering by `toolset_slug`/`mcp_server_url` happened at the trace level using HAVING clauses
3. This meant if ANY call in a trace touched server X, ALL tools from that trace were included
4. The `any(tool_name)` aggregation picked an arbitrary tool from the whole trace

## Solution

- Query `telemetry_logs` directly instead of `trace_summaries` to access per-row granularity
- Filter by `toolset_slug`/`mcp_server_url` at the row level (WHERE clause) before any grouping
- For hook-observed traffic, group by `tool_call_dedup_id` (combining `tool_use_id`, `gen_ai.tool.call.id`, or row id) to distinguish individual tool calls within a session

## Testing

Added two new tests:
- `TestGetMCPToolOutcomeBreakdown_FiltersToSpecificServer`: Verifies hosted MCP traffic filters correctly when multiple servers have events
- `TestGetMCPToolOutcomeBreakdown_HookObservedMultiServerSession`: Verifies hook-observed traffic with shared `trace_id` (session) filters correctly by server

All existing MCP drilldown tests continue to pass (397 tests in the telemetry package).

## Related

Resolves [AGE-3357](https://linear.app/speakeasy/issue/AGE-3357/feat-add-tool-and-skill-user-attribution-tracking)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3357](https://linear.app/speakeasy/issue/AGE-3357/feat-add-tool-and-skill-user-attribution-tracking)

<div><a href="https://cursor.com/agents/bc-b10c5a34-d4d2-4016-986f-aeb398263158?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b10c5a34-d4d2-4016-986f-aeb398263158&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP tool drilldown so filtering by a specific server shows only that server's tools, not tools from other servers called in the same session. The old query used `trace_summaries` and filtered at the trace level; it now queries `telemetry_logs` and filters at the row level.

**Bug Fixes**
- Hosted traffic filters by `toolset_slug` in the `WHERE` clause before grouping.
- Hook-observed traffic filters by `mcp_server_url` and groups by tool call dedup ID to separate calls within a session.
- Adds tests for hosted and hook-observed multi-server scenarios.

Resolves AGE-3357.

<sup>Written for commit ff55aefd73abfda42fe69f1bef7a5cf68e9d27b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

