### PR TITLE
feat: convert enterprise trials manually (AGE-3131)

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -74114,6 +74114,29 @@ components:
         - coverage_bucket
         - first_seen_at
         - last_seen_at
+    MarkEnterpriseTrialConvertedRequestBody:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Organization ID.
+          minLength: 1
+      required:
+        - id
+    MarkEnterpriseTrialConvertedResult:
+      type: object
+      properties:
+        converted_at:
+          type: string
+          description: The time at which the enterprise trial was recorded as converted.
+          format: date-time
+        organization_id:
+          type: string
+          description: The converted organization ID.
+      description: Privacy-minimal result of recording an enterprise trial conversion.
+      required:
+        - organization_id
+        - converted_at
     MarkRiskResultsFalsePositiveRequestBody:
       type: object
       properties:

--- a/client/dashboard/src/lib/audit-actions.test.ts
+++ b/client/dashboard/src/lib/audit-actions.test.ts
@@ -55,6 +55,12 @@ describe("AUDIT_ACTIONS", () => {
     }
   });
 
+  it("describes enterprise conversion against its organization subject", () => {
+    expect(staticActionPhrase("organization:enterprise_trial_converted")).toBe(
+      "converted enterprise trial for",
+    );
+  });
+
   it("rejects actions it doesn't know", () => {
     expect(isAuditAction("risk_policy:delete")).toBe(true);
     expect(isAuditAction("not_a_resource:not_a_verb")).toBe(false);

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -106,6 +106,7 @@ export const AUDIT_ACTIONS = [
   "organization:enterprise_trial_demoted",
   "organization:enterprise_trial_extended",
   "organization:enterprise_trial_rearmed",
+  "organization:enterprise_trial_converted",
   "organization:hooks_fail_open_disabled",
   "organization:hooks_fail_open_enabled",
   "organization:payg_activated",
@@ -467,6 +468,8 @@ export function staticActionPhrase(action: AuditAction): string {
       return "extended enterprise trial";
     case "organization:enterprise_trial_rearmed":
       return "restarted enterprise trial";
+    case "organization:enterprise_trial_converted":
+      return "converted enterprise trial";
     case "organization:payg_activated":
       return "activated pay-as-you-go billing for";
     case "organization:payg_deactivated":

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -469,7 +469,7 @@ export function staticActionPhrase(action: AuditAction): string {
     case "organization:enterprise_trial_rearmed":
       return "restarted enterprise trial";
     case "organization:enterprise_trial_converted":
-      return "converted enterprise trial";
+      return "converted enterprise trial for";
     case "organization:payg_activated":
       return "activated pay-as-you-go billing for";
     case "organization:payg_deactivated":

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -769,4 +769,27 @@ var _ = Service("admin", func() {
 		HTTP(func() { POST("/admin/organization.resumeStripeSubscription"); Response(StatusOK) })
 		Meta("openapi:operationId", "adminResumeStripeSubscription")
 	})
+
+	Method("markEnterpriseTrialConverted", func() {
+		Description("Records that an organization's enterprise trial converted to a signed contract.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+			Required("id")
+			Meta("openapi:typename", "MarkEnterpriseTrialConvertedRequestBody")
+
+			Attribute("id", String, "Organization ID.", func() {
+				MinLength(1)
+			})
+		})
+
+		Result(AdminOrganization)
+
+		HTTP(func() {
+			POST("/admin/trial.convert")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminMarkEnterpriseTrialConverted")
+	})
 })

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -12,6 +12,17 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
+var MarkEnterpriseTrialConvertedResult = Type("MarkEnterpriseTrialConvertedResult", func() {
+	Description("Privacy-minimal result of recording an enterprise trial conversion.")
+	Required("organization_id", "converted_at")
+
+	Attribute("organization_id", String, "The converted organization ID.")
+	Attribute("converted_at", String, func() {
+		Description("The time at which the enterprise trial was recorded as converted.")
+		Format(FormatDateTime)
+	})
+})
+
 var AdminOrganization = Type("AdminOrganization", func() {
 	Description("Organization details surfaced to admin operators.")
 	Required("id", "name", "slug", "account_type", "whitelisted", "member_count", "created_at", "updated_at")
@@ -783,7 +794,7 @@ var _ = Service("admin", func() {
 			})
 		})
 
-		Result(AdminOrganization)
+		Result(MarkEnterpriseTrialConvertedResult)
 
 		HTTP(func() {
 			POST("/admin/trial.convert")

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -15,59 +15,61 @@ import (
 
 // Client is the "admin" service client.
 type Client struct {
-	LoginEndpoint                       goa.Endpoint
-	CallbackEndpoint                    goa.Endpoint
-	LogoutEndpoint                      goa.Endpoint
-	GetProjectEndpoint                  goa.Endpoint
-	UpdateOrganizationEndpoint          goa.Endpoint
-	BulkUpdateAccountTypeEndpoint       goa.Endpoint
-	DisableOrganizationEndpoint         goa.Endpoint
-	EnableOrganizationEndpoint          goa.Endpoint
-	GetOrganizationEndpoint             goa.Endpoint
-	ListOrganizationMembersEndpoint     goa.Endpoint
-	ListOrganizationProjectsEndpoint    goa.Endpoint
-	ListOrganizationActivityEndpoint    goa.Endpoint
-	ListOrganizationsEndpoint           goa.Endpoint
-	ExtendTrialEndpoint                 goa.Endpoint
-	CreateOrganizationEndpoint          goa.Endpoint
-	RearmTrialEndpoint                  goa.Endpoint
-	GetOrganizationStatsEndpoint        goa.Endpoint
-	GetInferenceKeysEndpoint            goa.Endpoint
-	SetInferenceKeyMonthlyLimitEndpoint goa.Endpoint
-	GetInferenceSpendHistoryEndpoint    goa.Endpoint
-	GetPaygBillingSummaryEndpoint       goa.Endpoint
-	GetStripeSubscriptionEndpoint       goa.Endpoint
-	CancelStripeSubscriptionEndpoint    goa.Endpoint
-	ResumeStripeSubscriptionEndpoint    goa.Endpoint
+	LoginEndpoint                        goa.Endpoint
+	CallbackEndpoint                     goa.Endpoint
+	LogoutEndpoint                       goa.Endpoint
+	GetProjectEndpoint                   goa.Endpoint
+	UpdateOrganizationEndpoint           goa.Endpoint
+	BulkUpdateAccountTypeEndpoint        goa.Endpoint
+	DisableOrganizationEndpoint          goa.Endpoint
+	EnableOrganizationEndpoint           goa.Endpoint
+	GetOrganizationEndpoint              goa.Endpoint
+	ListOrganizationMembersEndpoint      goa.Endpoint
+	ListOrganizationProjectsEndpoint     goa.Endpoint
+	ListOrganizationActivityEndpoint     goa.Endpoint
+	ListOrganizationsEndpoint            goa.Endpoint
+	ExtendTrialEndpoint                  goa.Endpoint
+	CreateOrganizationEndpoint           goa.Endpoint
+	RearmTrialEndpoint                   goa.Endpoint
+	GetOrganizationStatsEndpoint         goa.Endpoint
+	GetInferenceKeysEndpoint             goa.Endpoint
+	SetInferenceKeyMonthlyLimitEndpoint  goa.Endpoint
+	GetInferenceSpendHistoryEndpoint     goa.Endpoint
+	GetPaygBillingSummaryEndpoint        goa.Endpoint
+	GetStripeSubscriptionEndpoint        goa.Endpoint
+	CancelStripeSubscriptionEndpoint     goa.Endpoint
+	ResumeStripeSubscriptionEndpoint     goa.Endpoint
+	MarkEnterpriseTrialConvertedEndpoint goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizationActivity, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, setInferenceKeyMonthlyLimit, getInferenceSpendHistory, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, bulkUpdateAccountType, disableOrganization, enableOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizationActivity, listOrganizations, extendTrial, createOrganization, rearmTrial, getOrganizationStats, getInferenceKeys, setInferenceKeyMonthlyLimit, getInferenceSpendHistory, getPaygBillingSummary, getStripeSubscription, cancelStripeSubscription, resumeStripeSubscription, markEnterpriseTrialConverted goa.Endpoint) *Client {
 	return &Client{
-		LoginEndpoint:                       login,
-		CallbackEndpoint:                    callback,
-		LogoutEndpoint:                      logout,
-		GetProjectEndpoint:                  getProject,
-		UpdateOrganizationEndpoint:          updateOrganization,
-		BulkUpdateAccountTypeEndpoint:       bulkUpdateAccountType,
-		DisableOrganizationEndpoint:         disableOrganization,
-		EnableOrganizationEndpoint:          enableOrganization,
-		GetOrganizationEndpoint:             getOrganization,
-		ListOrganizationMembersEndpoint:     listOrganizationMembers,
-		ListOrganizationProjectsEndpoint:    listOrganizationProjects,
-		ListOrganizationActivityEndpoint:    listOrganizationActivity,
-		ListOrganizationsEndpoint:           listOrganizations,
-		ExtendTrialEndpoint:                 extendTrial,
-		CreateOrganizationEndpoint:          createOrganization,
-		RearmTrialEndpoint:                  rearmTrial,
-		GetOrganizationStatsEndpoint:        getOrganizationStats,
-		GetInferenceKeysEndpoint:            getInferenceKeys,
-		SetInferenceKeyMonthlyLimitEndpoint: setInferenceKeyMonthlyLimit,
-		GetInferenceSpendHistoryEndpoint:    getInferenceSpendHistory,
-		GetPaygBillingSummaryEndpoint:       getPaygBillingSummary,
-		GetStripeSubscriptionEndpoint:       getStripeSubscription,
-		CancelStripeSubscriptionEndpoint:    cancelStripeSubscription,
-		ResumeStripeSubscriptionEndpoint:    resumeStripeSubscription,
+		LoginEndpoint:                        login,
+		CallbackEndpoint:                     callback,
+		LogoutEndpoint:                       logout,
+		GetProjectEndpoint:                   getProject,
+		UpdateOrganizationEndpoint:           updateOrganization,
+		BulkUpdateAccountTypeEndpoint:        bulkUpdateAccountType,
+		DisableOrganizationEndpoint:          disableOrganization,
+		EnableOrganizationEndpoint:           enableOrganization,
+		GetOrganizationEndpoint:              getOrganization,
+		ListOrganizationMembersEndpoint:      listOrganizationMembers,
+		ListOrganizationProjectsEndpoint:     listOrganizationProjects,
+		ListOrganizationActivityEndpoint:     listOrganizationActivity,
+		ListOrganizationsEndpoint:            listOrganizations,
+		ExtendTrialEndpoint:                  extendTrial,
+		CreateOrganizationEndpoint:           createOrganization,
+		RearmTrialEndpoint:                   rearmTrial,
+		GetOrganizationStatsEndpoint:         getOrganizationStats,
+		GetInferenceKeysEndpoint:             getInferenceKeys,
+		SetInferenceKeyMonthlyLimitEndpoint:  setInferenceKeyMonthlyLimit,
+		GetInferenceSpendHistoryEndpoint:     getInferenceSpendHistory,
+		GetPaygBillingSummaryEndpoint:        getPaygBillingSummary,
+		GetStripeSubscriptionEndpoint:        getStripeSubscription,
+		CancelStripeSubscriptionEndpoint:     cancelStripeSubscription,
+		ResumeStripeSubscriptionEndpoint:     resumeStripeSubscription,
+		MarkEnterpriseTrialConvertedEndpoint: markEnterpriseTrialConverted,
 	}
 }
 
@@ -610,4 +612,27 @@ func (c *Client) ResumeStripeSubscription(ctx context.Context, p *ResumeStripeSu
 		return
 	}
 	return ires.(*AdminStripeSubscription), nil
+}
+
+// MarkEnterpriseTrialConverted calls the "markEnterpriseTrialConverted"
+// endpoint of the "admin" service.
+// MarkEnterpriseTrialConverted may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) MarkEnterpriseTrialConverted(ctx context.Context, p *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error) {
+	var ires any
+	ires, err = c.MarkEnterpriseTrialConvertedEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminOrganization), nil
 }

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -628,11 +628,11 @@ func (c *Client) ResumeStripeSubscription(ctx context.Context, p *ResumeStripeSu
 //   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
 //   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
 //   - error: internal error
-func (c *Client) MarkEnterpriseTrialConverted(ctx context.Context, p *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error) {
+func (c *Client) MarkEnterpriseTrialConverted(ctx context.Context, p *MarkEnterpriseTrialConvertedPayload) (res *MarkEnterpriseTrialConvertedResult, err error) {
 	var ires any
 	ires, err = c.MarkEnterpriseTrialConvertedEndpoint(ctx, p)
 	if err != nil {
 		return
 	}
-	return ires.(*AdminOrganization), nil
+	return ires.(*MarkEnterpriseTrialConvertedResult), nil
 }

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -16,30 +16,31 @@ import (
 
 // Endpoints wraps the "admin" service endpoints.
 type Endpoints struct {
-	Login                       goa.Endpoint
-	Callback                    goa.Endpoint
-	Logout                      goa.Endpoint
-	GetProject                  goa.Endpoint
-	UpdateOrganization          goa.Endpoint
-	BulkUpdateAccountType       goa.Endpoint
-	DisableOrganization         goa.Endpoint
-	EnableOrganization          goa.Endpoint
-	GetOrganization             goa.Endpoint
-	ListOrganizationMembers     goa.Endpoint
-	ListOrganizationProjects    goa.Endpoint
-	ListOrganizationActivity    goa.Endpoint
-	ListOrganizations           goa.Endpoint
-	ExtendTrial                 goa.Endpoint
-	CreateOrganization          goa.Endpoint
-	RearmTrial                  goa.Endpoint
-	GetOrganizationStats        goa.Endpoint
-	GetInferenceKeys            goa.Endpoint
-	SetInferenceKeyMonthlyLimit goa.Endpoint
-	GetInferenceSpendHistory    goa.Endpoint
-	GetPaygBillingSummary       goa.Endpoint
-	GetStripeSubscription       goa.Endpoint
-	CancelStripeSubscription    goa.Endpoint
-	ResumeStripeSubscription    goa.Endpoint
+	Login                        goa.Endpoint
+	Callback                     goa.Endpoint
+	Logout                       goa.Endpoint
+	GetProject                   goa.Endpoint
+	UpdateOrganization           goa.Endpoint
+	BulkUpdateAccountType        goa.Endpoint
+	DisableOrganization          goa.Endpoint
+	EnableOrganization           goa.Endpoint
+	GetOrganization              goa.Endpoint
+	ListOrganizationMembers      goa.Endpoint
+	ListOrganizationProjects     goa.Endpoint
+	ListOrganizationActivity     goa.Endpoint
+	ListOrganizations            goa.Endpoint
+	ExtendTrial                  goa.Endpoint
+	CreateOrganization           goa.Endpoint
+	RearmTrial                   goa.Endpoint
+	GetOrganizationStats         goa.Endpoint
+	GetInferenceKeys             goa.Endpoint
+	SetInferenceKeyMonthlyLimit  goa.Endpoint
+	GetInferenceSpendHistory     goa.Endpoint
+	GetPaygBillingSummary        goa.Endpoint
+	GetStripeSubscription        goa.Endpoint
+	CancelStripeSubscription     goa.Endpoint
+	ResumeStripeSubscription     goa.Endpoint
+	MarkEnterpriseTrialConverted goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -47,30 +48,31 @@ func NewEndpoints(s Service) *Endpoints {
 	// Casting service to Auther interface
 	a := s.(Auther)
 	return &Endpoints{
-		Login:                       NewLoginEndpoint(s),
-		Callback:                    NewCallbackEndpoint(s),
-		Logout:                      NewLogoutEndpoint(s),
-		GetProject:                  NewGetProjectEndpoint(s, a.APIKeyAuth),
-		UpdateOrganization:          NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
-		BulkUpdateAccountType:       NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
-		DisableOrganization:         NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
-		EnableOrganization:          NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
-		GetOrganization:             NewGetOrganizationEndpoint(s, a.APIKeyAuth),
-		ListOrganizationMembers:     NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
-		ListOrganizationProjects:    NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
-		ListOrganizationActivity:    NewListOrganizationActivityEndpoint(s, a.APIKeyAuth),
-		ListOrganizations:           NewListOrganizationsEndpoint(s, a.APIKeyAuth),
-		ExtendTrial:                 NewExtendTrialEndpoint(s, a.APIKeyAuth),
-		CreateOrganization:          NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
-		RearmTrial:                  NewRearmTrialEndpoint(s, a.APIKeyAuth),
-		GetOrganizationStats:        NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
-		GetInferenceKeys:            NewGetInferenceKeysEndpoint(s, a.APIKeyAuth),
-		SetInferenceKeyMonthlyLimit: NewSetInferenceKeyMonthlyLimitEndpoint(s, a.APIKeyAuth),
-		GetInferenceSpendHistory:    NewGetInferenceSpendHistoryEndpoint(s, a.APIKeyAuth),
-		GetPaygBillingSummary:       NewGetPaygBillingSummaryEndpoint(s, a.APIKeyAuth),
-		GetStripeSubscription:       NewGetStripeSubscriptionEndpoint(s, a.APIKeyAuth),
-		CancelStripeSubscription:    NewCancelStripeSubscriptionEndpoint(s, a.APIKeyAuth),
-		ResumeStripeSubscription:    NewResumeStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		Login:                        NewLoginEndpoint(s),
+		Callback:                     NewCallbackEndpoint(s),
+		Logout:                       NewLogoutEndpoint(s),
+		GetProject:                   NewGetProjectEndpoint(s, a.APIKeyAuth),
+		UpdateOrganization:           NewUpdateOrganizationEndpoint(s, a.APIKeyAuth),
+		BulkUpdateAccountType:        NewBulkUpdateAccountTypeEndpoint(s, a.APIKeyAuth),
+		DisableOrganization:          NewDisableOrganizationEndpoint(s, a.APIKeyAuth),
+		EnableOrganization:           NewEnableOrganizationEndpoint(s, a.APIKeyAuth),
+		GetOrganization:              NewGetOrganizationEndpoint(s, a.APIKeyAuth),
+		ListOrganizationMembers:      NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
+		ListOrganizationProjects:     NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
+		ListOrganizationActivity:     NewListOrganizationActivityEndpoint(s, a.APIKeyAuth),
+		ListOrganizations:            NewListOrganizationsEndpoint(s, a.APIKeyAuth),
+		ExtendTrial:                  NewExtendTrialEndpoint(s, a.APIKeyAuth),
+		CreateOrganization:           NewCreateOrganizationEndpoint(s, a.APIKeyAuth),
+		RearmTrial:                   NewRearmTrialEndpoint(s, a.APIKeyAuth),
+		GetOrganizationStats:         NewGetOrganizationStatsEndpoint(s, a.APIKeyAuth),
+		GetInferenceKeys:             NewGetInferenceKeysEndpoint(s, a.APIKeyAuth),
+		SetInferenceKeyMonthlyLimit:  NewSetInferenceKeyMonthlyLimitEndpoint(s, a.APIKeyAuth),
+		GetInferenceSpendHistory:     NewGetInferenceSpendHistoryEndpoint(s, a.APIKeyAuth),
+		GetPaygBillingSummary:        NewGetPaygBillingSummaryEndpoint(s, a.APIKeyAuth),
+		GetStripeSubscription:        NewGetStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		CancelStripeSubscription:     NewCancelStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		ResumeStripeSubscription:     NewResumeStripeSubscriptionEndpoint(s, a.APIKeyAuth),
+		MarkEnterpriseTrialConverted: NewMarkEnterpriseTrialConvertedEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -100,6 +102,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.GetStripeSubscription = m(e.GetStripeSubscription)
 	e.CancelStripeSubscription = m(e.CancelStripeSubscription)
 	e.ResumeStripeSubscription = m(e.ResumeStripeSubscription)
+	e.MarkEnterpriseTrialConverted = m(e.MarkEnterpriseTrialConverted)
 }
 
 // NewLoginEndpoint returns an endpoint function that calls the method "login"
@@ -609,5 +612,28 @@ func NewResumeStripeSubscriptionEndpoint(s Service, authAPIKeyFn security.AuthAP
 			return nil, err
 		}
 		return s.ResumeStripeSubscription(ctx, p)
+	}
+}
+
+// NewMarkEnterpriseTrialConvertedEndpoint returns an endpoint function that
+// calls the method "markEnterpriseTrialConverted" of service "admin".
+func NewMarkEnterpriseTrialConvertedEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*MarkEnterpriseTrialConvertedPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.MarkEnterpriseTrialConverted(ctx, p)
 	}
 }

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -89,7 +89,7 @@ type Service interface {
 	ResumeStripeSubscription(context.Context, *ResumeStripeSubscriptionPayload) (res *AdminStripeSubscription, err error)
 	// Records that an organization's enterprise trial converted to a signed
 	// contract.
-	MarkEnterpriseTrialConverted(context.Context, *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error)
+	MarkEnterpriseTrialConverted(context.Context, *MarkEnterpriseTrialConvertedPayload) (res *MarkEnterpriseTrialConvertedResult, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -591,6 +591,15 @@ type MarkEnterpriseTrialConvertedPayload struct {
 	AdminSessionToken *string
 	// Organization ID.
 	ID string
+}
+
+// MarkEnterpriseTrialConvertedResult is the result type of the admin service
+// markEnterpriseTrialConverted method.
+type MarkEnterpriseTrialConvertedResult struct {
+	// The converted organization ID.
+	OrganizationID string
+	// The time at which the enterprise trial was recorded as converted.
+	ConvertedAt string
 }
 
 // RearmTrialPayload is the payload type of the admin service rearmTrial method.

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -87,6 +87,9 @@ type Service interface {
 	// Removes a scheduled period-end cancellation from an organization's PAYG
 	// subscription.
 	ResumeStripeSubscription(context.Context, *ResumeStripeSubscriptionPayload) (res *AdminStripeSubscription, err error)
+	// Records that an organization's enterprise trial converted to a signed
+	// contract.
+	MarkEnterpriseTrialConverted(context.Context, *MarkEnterpriseTrialConvertedPayload) (res *AdminOrganization, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -109,7 +112,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [24]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizationActivity", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "setInferenceKeyMonthlyLimit", "getInferenceSpendHistory", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription"}
+var MethodNames = [25]string{"login", "callback", "logout", "getProject", "updateOrganization", "bulkUpdateAccountType", "disableOrganization", "enableOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizationActivity", "listOrganizations", "extendTrial", "createOrganization", "rearmTrial", "getOrganizationStats", "getInferenceKeys", "setInferenceKeyMonthlyLimit", "getInferenceSpendHistory", "getPaygBillingSummary", "getStripeSubscription", "cancelStripeSubscription", "resumeStripeSubscription", "markEnterpriseTrialConverted"}
 
 // AdminBulkUpdateAccountTypeResult is the result type of the admin service
 // bulkUpdateAccountType method.
@@ -580,6 +583,14 @@ type LoginResult struct {
 type LogoutPayload struct {
 	// The session cookie value to clear for logging out
 	SessionID *string
+}
+
+// MarkEnterpriseTrialConvertedPayload is the payload type of the admin service
+// markEnterpriseTrialConverted method.
+type MarkEnterpriseTrialConvertedPayload struct {
+	AdminSessionToken *string
+	// Organization ID.
+	ID string
 }
 
 // RearmTrialPayload is the payload type of the admin service rearmTrial method.

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -768,3 +768,34 @@ func BuildResumeStripeSubscriptionPayload(adminResumeStripeSubscriptionBody stri
 
 	return v, nil
 }
+
+// BuildMarkEnterpriseTrialConvertedPayload builds the payload for the admin
+// markEnterpriseTrialConverted endpoint from CLI flags.
+func BuildMarkEnterpriseTrialConvertedPayload(adminMarkEnterpriseTrialConvertedBody string, adminMarkEnterpriseTrialConvertedAdminSessionToken string) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+	var err error
+	var body MarkEnterpriseTrialConvertedRequestBody
+	{
+		err = json.Unmarshal([]byte(adminMarkEnterpriseTrialConvertedBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"id\": \"aa\"\n   }'")
+		}
+		if utf8.RuneCountInString(body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", body.ID, utf8.RuneCountInString(body.ID), 1, true))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminMarkEnterpriseTrialConvertedAdminSessionToken != "" {
+			adminSessionToken = &adminMarkEnterpriseTrialConvertedAdminSessionToken
+		}
+	}
+	v := &admin.MarkEnterpriseTrialConvertedPayload{
+		ID: body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -111,6 +111,10 @@ type Client struct {
 	// the resumeStripeSubscription endpoint.
 	ResumeStripeSubscriptionDoer goahttp.Doer
 
+	// MarkEnterpriseTrialConverted Doer is the HTTP client used to make requests
+	// to the markEnterpriseTrialConverted endpoint.
+	MarkEnterpriseTrialConvertedDoer goahttp.Doer
+
 	// RestoreResponseBody controls whether the response bodies are reset after
 	// decoding so they can be read again.
 	RestoreResponseBody bool
@@ -131,35 +135,36 @@ func NewClient(
 	restoreBody bool,
 ) *Client {
 	return &Client{
-		LoginDoer:                       doer,
-		CallbackDoer:                    doer,
-		LogoutDoer:                      doer,
-		GetProjectDoer:                  doer,
-		UpdateOrganizationDoer:          doer,
-		BulkUpdateAccountTypeDoer:       doer,
-		DisableOrganizationDoer:         doer,
-		EnableOrganizationDoer:          doer,
-		GetOrganizationDoer:             doer,
-		ListOrganizationMembersDoer:     doer,
-		ListOrganizationProjectsDoer:    doer,
-		ListOrganizationActivityDoer:    doer,
-		ListOrganizationsDoer:           doer,
-		ExtendTrialDoer:                 doer,
-		CreateOrganizationDoer:          doer,
-		RearmTrialDoer:                  doer,
-		GetOrganizationStatsDoer:        doer,
-		GetInferenceKeysDoer:            doer,
-		SetInferenceKeyMonthlyLimitDoer: doer,
-		GetInferenceSpendHistoryDoer:    doer,
-		GetPaygBillingSummaryDoer:       doer,
-		GetStripeSubscriptionDoer:       doer,
-		CancelStripeSubscriptionDoer:    doer,
-		ResumeStripeSubscriptionDoer:    doer,
-		RestoreResponseBody:             restoreBody,
-		scheme:                          scheme,
-		host:                            host,
-		decoder:                         dec,
-		encoder:                         enc,
+		LoginDoer:                        doer,
+		CallbackDoer:                     doer,
+		LogoutDoer:                       doer,
+		GetProjectDoer:                   doer,
+		UpdateOrganizationDoer:           doer,
+		BulkUpdateAccountTypeDoer:        doer,
+		DisableOrganizationDoer:          doer,
+		EnableOrganizationDoer:           doer,
+		GetOrganizationDoer:              doer,
+		ListOrganizationMembersDoer:      doer,
+		ListOrganizationProjectsDoer:     doer,
+		ListOrganizationActivityDoer:     doer,
+		ListOrganizationsDoer:            doer,
+		ExtendTrialDoer:                  doer,
+		CreateOrganizationDoer:           doer,
+		RearmTrialDoer:                   doer,
+		GetOrganizationStatsDoer:         doer,
+		GetInferenceKeysDoer:             doer,
+		SetInferenceKeyMonthlyLimitDoer:  doer,
+		GetInferenceSpendHistoryDoer:     doer,
+		GetPaygBillingSummaryDoer:        doer,
+		GetStripeSubscriptionDoer:        doer,
+		CancelStripeSubscriptionDoer:     doer,
+		ResumeStripeSubscriptionDoer:     doer,
+		MarkEnterpriseTrialConvertedDoer: doer,
+		RestoreResponseBody:              restoreBody,
+		scheme:                           scheme,
+		host:                             host,
+		decoder:                          dec,
+		encoder:                          enc,
 	}
 }
 
@@ -734,6 +739,30 @@ func (c *Client) ResumeStripeSubscription() goa.Endpoint {
 		resp, err := c.ResumeStripeSubscriptionDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "resumeStripeSubscription", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// MarkEnterpriseTrialConverted returns an endpoint that makes HTTP requests to
+// the admin service markEnterpriseTrialConverted server.
+func (c *Client) MarkEnterpriseTrialConverted() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeMarkEnterpriseTrialConvertedRequest(c.encoder)
+		decodeResponse = DecodeMarkEnterpriseTrialConvertedResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildMarkEnterpriseTrialConvertedRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.MarkEnterpriseTrialConvertedDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "markEnterpriseTrialConverted", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -5792,7 +5792,7 @@ func DecodeMarkEnterpriseTrialConvertedResponse(decoder func(*http.Response) goa
 			if err != nil {
 				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
 			}
-			res := NewMarkEnterpriseTrialConvertedAdminOrganizationOK(&body)
+			res := NewMarkEnterpriseTrialConvertedResultOK(&body)
 			return res, nil
 		case http.StatusUnauthorized:
 			var (

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -5713,6 +5713,241 @@ func DecodeResumeStripeSubscriptionResponse(decoder func(*http.Response) goahttp
 	}
 }
 
+// BuildMarkEnterpriseTrialConvertedRequest instantiates a HTTP request object
+// with method and path set to call the "admin" service
+// "markEnterpriseTrialConverted" endpoint
+func (c *Client) BuildMarkEnterpriseTrialConvertedRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: MarkEnterpriseTrialConvertedAdminPath()}
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "markEnterpriseTrialConverted", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeMarkEnterpriseTrialConvertedRequest returns an encoder for requests
+// sent to the admin markEnterpriseTrialConverted server.
+func EncodeMarkEnterpriseTrialConvertedRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.MarkEnterpriseTrialConvertedPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "markEnterpriseTrialConverted", "*admin.MarkEnterpriseTrialConvertedPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		body := NewMarkEnterpriseTrialConvertedRequestBody(p)
+		if err := encoder(req).Encode(&body); err != nil {
+			return goahttp.ErrEncodingError("admin", "markEnterpriseTrialConverted", err)
+		}
+		return nil
+	}
+}
+
+// DecodeMarkEnterpriseTrialConvertedResponse returns a decoder for responses
+// returned by the admin markEnterpriseTrialConverted endpoint. restoreBody
+// controls whether the response body should be restored after having been read.
+// DecodeMarkEnterpriseTrialConvertedResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeMarkEnterpriseTrialConvertedResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body MarkEnterpriseTrialConvertedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			res := NewMarkEnterpriseTrialConvertedAdminOrganizationOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body MarkEnterpriseTrialConvertedUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body MarkEnterpriseTrialConvertedForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body MarkEnterpriseTrialConvertedBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body MarkEnterpriseTrialConvertedNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body MarkEnterpriseTrialConvertedConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body MarkEnterpriseTrialConvertedInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body MarkEnterpriseTrialConvertedInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+				}
+				err = ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+				}
+				return nil, NewMarkEnterpriseTrialConvertedInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body MarkEnterpriseTrialConvertedUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+				}
+				err = ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+				}
+				return nil, NewMarkEnterpriseTrialConvertedUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "markEnterpriseTrialConverted", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body MarkEnterpriseTrialConvertedGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "markEnterpriseTrialConverted", err)
+			}
+			err = ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "markEnterpriseTrialConverted", err)
+			}
+			return nil, NewMarkEnterpriseTrialConvertedGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "markEnterpriseTrialConverted", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember
 // builds a value of type *admin.AdminOrganizationMember from a value of type
 // *AdminOrganizationMemberResponseBody.

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -126,3 +126,8 @@ func CancelStripeSubscriptionAdminPath() string {
 func ResumeStripeSubscriptionAdminPath() string {
 	return "/admin/organization.resumeStripeSubscription"
 }
+
+// MarkEnterpriseTrialConvertedAdminPath returns the URL path to the admin service markEnterpriseTrialConverted HTTP endpoint.
+func MarkEnterpriseTrialConvertedAdminPath() string {
+	return "/admin/trial.convert"
+}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -513,37 +513,10 @@ type ResumeStripeSubscriptionResponseBody struct {
 // MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
 // "markEnterpriseTrialConverted" endpoint HTTP response body.
 type MarkEnterpriseTrialConvertedResponseBody struct {
-	// The ID of the organization
-	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// The name of the organization
-	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// The slug of the organization
-	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
-	// Gram account type (e.g. free, pro, payg, enterprise).
-	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
-	// WorkOS organization ID, if linked.
-	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
-	// Whether the organization is whitelisted for full access.
-	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
-	// The time at which the organization was disabled, if any.
-	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
-	// Lifecycle state of the organization's enterprise trial.
-	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
-	// The trial tier. Absent when the organization never trialled.
-	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
-	// The time at which the enterprise trial ends. Absent when the organization
-	// never trialled.
-	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
-	// The time at which the trial converted to a paid plan, if any.
-	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
-	// The time at which the organization was demoted after its trial, if any.
-	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
-	// Number of active members in the organization.
-	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
-	// The creation date of the organization.
-	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
-	// The last update date of the organization.
-	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+	// The converted organization ID.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
+	// The time at which the enterprise trial was recorded as converted.
+	ConvertedAt *string `form:"converted_at,omitempty" json:"converted_at,omitempty" xml:"converted_at,omitempty"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -9428,25 +9401,12 @@ func NewResumeStripeSubscriptionGatewayError(body *ResumeStripeSubscriptionGatew
 	return v
 }
 
-// NewMarkEnterpriseTrialConvertedAdminOrganizationOK builds a "admin" service
+// NewMarkEnterpriseTrialConvertedResultOK builds a "admin" service
 // "markEnterpriseTrialConverted" endpoint result from a HTTP "OK" response.
-func NewMarkEnterpriseTrialConvertedAdminOrganizationOK(body *MarkEnterpriseTrialConvertedResponseBody) *admin.AdminOrganization {
-	v := &admin.AdminOrganization{
-		ID:               *body.ID,
-		Name:             *body.Name,
-		Slug:             *body.Slug,
-		AccountType:      *body.AccountType,
-		WorkosID:         body.WorkosID,
-		Whitelisted:      *body.Whitelisted,
-		DisabledAt:       body.DisabledAt,
-		TrialState:       body.TrialState,
-		TrialTier:        body.TrialTier,
-		TrialEndsAt:      body.TrialEndsAt,
-		TrialConvertedAt: body.TrialConvertedAt,
-		TrialDemotedAt:   body.TrialDemotedAt,
-		MemberCount:      *body.MemberCount,
-		CreatedAt:        *body.CreatedAt,
-		UpdatedAt:        *body.UpdatedAt,
+func NewMarkEnterpriseTrialConvertedResultOK(body *MarkEnterpriseTrialConvertedResponseBody) *admin.MarkEnterpriseTrialConvertedResult {
+	v := &admin.MarkEnterpriseTrialConvertedResult{
+		OrganizationID: *body.OrganizationID,
+		ConvertedAt:    *body.ConvertedAt,
 	}
 
 	return v
@@ -10310,52 +10270,14 @@ func ValidateResumeStripeSubscriptionResponseBody(body *ResumeStripeSubscription
 // ValidateMarkEnterpriseTrialConvertedResponseBody runs the validations
 // defined on MarkEnterpriseTrialConvertedResponseBody
 func ValidateMarkEnterpriseTrialConvertedResponseBody(body *MarkEnterpriseTrialConvertedResponseBody) (err error) {
-	if body.ID == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	if body.OrganizationID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "body"))
 	}
-	if body.Name == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	if body.ConvertedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("converted_at", "body"))
 	}
-	if body.Slug == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
-	}
-	if body.AccountType == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
-	}
-	if body.Whitelisted == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
-	}
-	if body.MemberCount == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
-	}
-	if body.CreatedAt == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
-	}
-	if body.UpdatedAt == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
-	}
-	if body.DisabledAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
-	}
-	if body.TrialState != nil {
-		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
-		}
-	}
-	if body.TrialEndsAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
-	}
-	if body.TrialConvertedAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_converted_at", *body.TrialConvertedAt, goa.FormatDateTime))
-	}
-	if body.TrialDemotedAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_demoted_at", *body.TrialDemotedAt, goa.FormatDateTime))
-	}
-	if body.CreatedAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
-	}
-	if body.UpdatedAt != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	if body.ConvertedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.converted_at", *body.ConvertedAt, goa.FormatDateTime))
 	}
 	return
 }

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -93,6 +93,13 @@ type ResumeStripeSubscriptionRequestBody struct {
 	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
 }
 
+// MarkEnterpriseTrialConvertedRequestBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP request body.
+type MarkEnterpriseTrialConvertedRequestBody struct {
+	// Organization ID.
+	ID string `form:"id" json:"id" xml:"id"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -501,6 +508,42 @@ type ResumeStripeSubscriptionResponseBody struct {
 	CancelAt           *string `form:"cancel_at,omitempty" json:"cancel_at,omitempty" xml:"cancel_at,omitempty"`
 	CanceledAt         *string `form:"canceled_at,omitempty" json:"canceled_at,omitempty" xml:"canceled_at,omitempty"`
 	PaymentFailed      *bool   `form:"payment_failed,omitempty" json:"payment_failed,omitempty" xml:"payment_failed,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP response body.
+type MarkEnterpriseTrialConvertedResponseBody struct {
+	// The ID of the organization
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// The name of the organization
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, payg, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted *bool `form:"whitelisted,omitempty" json:"whitelisted,omitempty" xml:"whitelisted,omitempty"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The trial tier. Absent when the organization never trialled.
+	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// The time at which the trial converted to a paid plan, if any.
+	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
+	// The time at which the organization was demoted after its trial, if any.
+	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount *int `form:"member_count,omitempty" json:"member_count,omitempty" xml:"member_count,omitempty"`
+	// The creation date of the organization.
+	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
+	// The last update date of the organization.
+	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -4948,6 +4991,196 @@ type ResumeStripeSubscriptionGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// MarkEnterpriseTrialConvertedUnauthorizedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unauthorized" error.
+type MarkEnterpriseTrialConvertedUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedForbiddenResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "forbidden" error.
+type MarkEnterpriseTrialConvertedForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedBadRequestResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "bad_request" error.
+type MarkEnterpriseTrialConvertedBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedNotFoundResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "not_found" error.
+type MarkEnterpriseTrialConvertedNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedConflictResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "conflict" error.
+type MarkEnterpriseTrialConvertedConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unsupported_media" error.
+type MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedInvalidResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "invalid" error.
+type MarkEnterpriseTrialConvertedInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedInvariantViolationResponseBody is the type of
+// the "admin" service "markEnterpriseTrialConverted" endpoint HTTP response
+// body for the "invariant_violation" error.
+type MarkEnterpriseTrialConvertedInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedUnexpectedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unexpected" error.
+type MarkEnterpriseTrialConvertedUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// MarkEnterpriseTrialConvertedGatewayErrorResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "gateway_error" error.
+type MarkEnterpriseTrialConvertedGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -5168,6 +5401,16 @@ func NewCancelStripeSubscriptionRequestBody(p *admin.CancelStripeSubscriptionPay
 func NewResumeStripeSubscriptionRequestBody(p *admin.ResumeStripeSubscriptionPayload) *ResumeStripeSubscriptionRequestBody {
 	body := &ResumeStripeSubscriptionRequestBody{
 		OrganizationID: p.OrganizationID,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedRequestBody builds the HTTP request body from
+// the payload of the "markEnterpriseTrialConverted" endpoint of the "admin"
+// service.
+func NewMarkEnterpriseTrialConvertedRequestBody(p *admin.MarkEnterpriseTrialConvertedPayload) *MarkEnterpriseTrialConvertedRequestBody {
+	body := &MarkEnterpriseTrialConvertedRequestBody{
+		ID: p.ID,
 	}
 	return body
 }
@@ -9185,6 +9428,180 @@ func NewResumeStripeSubscriptionGatewayError(body *ResumeStripeSubscriptionGatew
 	return v
 }
 
+// NewMarkEnterpriseTrialConvertedAdminOrganizationOK builds a "admin" service
+// "markEnterpriseTrialConverted" endpoint result from a HTTP "OK" response.
+func NewMarkEnterpriseTrialConvertedAdminOrganizationOK(body *MarkEnterpriseTrialConvertedResponseBody) *admin.AdminOrganization {
+	v := &admin.AdminOrganization{
+		ID:               *body.ID,
+		Name:             *body.Name,
+		Slug:             *body.Slug,
+		AccountType:      *body.AccountType,
+		WorkosID:         body.WorkosID,
+		Whitelisted:      *body.Whitelisted,
+		DisabledAt:       body.DisabledAt,
+		TrialState:       body.TrialState,
+		TrialTier:        body.TrialTier,
+		TrialEndsAt:      body.TrialEndsAt,
+		TrialConvertedAt: body.TrialConvertedAt,
+		TrialDemotedAt:   body.TrialDemotedAt,
+		MemberCount:      *body.MemberCount,
+		CreatedAt:        *body.CreatedAt,
+		UpdatedAt:        *body.UpdatedAt,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnauthorized builds a admin service
+// markEnterpriseTrialConverted endpoint unauthorized error.
+func NewMarkEnterpriseTrialConvertedUnauthorized(body *MarkEnterpriseTrialConvertedUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedForbidden builds a admin service
+// markEnterpriseTrialConverted endpoint forbidden error.
+func NewMarkEnterpriseTrialConvertedForbidden(body *MarkEnterpriseTrialConvertedForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedBadRequest builds a admin service
+// markEnterpriseTrialConverted endpoint bad_request error.
+func NewMarkEnterpriseTrialConvertedBadRequest(body *MarkEnterpriseTrialConvertedBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedNotFound builds a admin service
+// markEnterpriseTrialConverted endpoint not_found error.
+func NewMarkEnterpriseTrialConvertedNotFound(body *MarkEnterpriseTrialConvertedNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedConflict builds a admin service
+// markEnterpriseTrialConverted endpoint conflict error.
+func NewMarkEnterpriseTrialConvertedConflict(body *MarkEnterpriseTrialConvertedConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnsupportedMedia builds a admin service
+// markEnterpriseTrialConverted endpoint unsupported_media error.
+func NewMarkEnterpriseTrialConvertedUnsupportedMedia(body *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedInvalid builds a admin service
+// markEnterpriseTrialConverted endpoint invalid error.
+func NewMarkEnterpriseTrialConvertedInvalid(body *MarkEnterpriseTrialConvertedInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedInvariantViolation builds a admin service
+// markEnterpriseTrialConverted endpoint invariant_violation error.
+func NewMarkEnterpriseTrialConvertedInvariantViolation(body *MarkEnterpriseTrialConvertedInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedUnexpected builds a admin service
+// markEnterpriseTrialConverted endpoint unexpected error.
+func NewMarkEnterpriseTrialConvertedUnexpected(body *MarkEnterpriseTrialConvertedUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewMarkEnterpriseTrialConvertedGatewayError builds a admin service
+// markEnterpriseTrialConverted endpoint gateway_error error.
+func NewMarkEnterpriseTrialConvertedGatewayError(body *MarkEnterpriseTrialConvertedGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // ValidateGetProjectResponseBody runs the validations defined on
 // GetProjectResponseBody
 func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
@@ -9886,6 +10303,59 @@ func ValidateResumeStripeSubscriptionResponseBody(body *ResumeStripeSubscription
 	}
 	if body.CanceledAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.canceled_at", *body.CanceledAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedResponseBody runs the validations
+// defined on MarkEnterpriseTrialConvertedResponseBody
+func ValidateMarkEnterpriseTrialConvertedResponseBody(body *MarkEnterpriseTrialConvertedResponseBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.Whitelisted == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("whitelisted", "body"))
+	}
+	if body.MemberCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("member_count", "body"))
+	}
+	if body.CreatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
+	}
+	if body.UpdatedAt == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
+	}
+	if body.DisabledAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.disabled_at", *body.DisabledAt, goa.FormatDateTime))
+	}
+	if body.TrialState != nil {
+		if !(*body.TrialState == "none" || *body.TrialState == "running" || *body.TrialState == "ending_soon" || *body.TrialState == "expired" || *body.TrialState == "demoted" || *body.TrialState == "converted") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.trial_state", *body.TrialState, []any{"none", "running", "ending_soon", "expired", "demoted", "converted"}))
+		}
+	}
+	if body.TrialEndsAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_ends_at", *body.TrialEndsAt, goa.FormatDateTime))
+	}
+	if body.TrialConvertedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_converted_at", *body.TrialConvertedAt, goa.FormatDateTime))
+	}
+	if body.TrialDemotedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.trial_demoted_at", *body.TrialDemotedAt, goa.FormatDateTime))
+	}
+	if body.CreatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.created_at", *body.CreatedAt, goa.FormatDateTime))
+	}
+	if body.UpdatedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
 	}
 	return
 }
@@ -15647,6 +16117,250 @@ func ValidateResumeStripeSubscriptionUnexpectedResponseBody(body *ResumeStripeSu
 // ValidateResumeStripeSubscriptionGatewayErrorResponseBody runs the
 // validations defined on resumeStripeSubscription_gateway_error_response_body
 func ValidateResumeStripeSubscriptionGatewayErrorResponseBody(body *ResumeStripeSubscriptionGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_unauthorized_response_body
+func ValidateMarkEnterpriseTrialConvertedUnauthorizedResponseBody(body *MarkEnterpriseTrialConvertedUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_forbidden_response_body
+func ValidateMarkEnterpriseTrialConvertedForbiddenResponseBody(body *MarkEnterpriseTrialConvertedForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_bad_request_response_body
+func ValidateMarkEnterpriseTrialConvertedBadRequestResponseBody(body *MarkEnterpriseTrialConvertedBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_not_found_response_body
+func ValidateMarkEnterpriseTrialConvertedNotFoundResponseBody(body *MarkEnterpriseTrialConvertedNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedConflictResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_conflict_response_body
+func ValidateMarkEnterpriseTrialConvertedConflictResponseBody(body *MarkEnterpriseTrialConvertedConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_unsupported_media_response_body
+func ValidateMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(body *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedInvalidResponseBody runs the validations
+// defined on markEnterpriseTrialConverted_invalid_response_body
+func ValidateMarkEnterpriseTrialConvertedInvalidResponseBody(body *MarkEnterpriseTrialConvertedInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_invariant_violation_response_body
+func ValidateMarkEnterpriseTrialConvertedInvariantViolationResponseBody(body *MarkEnterpriseTrialConvertedInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody runs the
+// validations defined on markEnterpriseTrialConverted_unexpected_response_body
+func ValidateMarkEnterpriseTrialConvertedUnexpectedResponseBody(body *MarkEnterpriseTrialConvertedUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody runs the
+// validations defined on
+// markEnterpriseTrialConverted_gateway_error_response_body
+func ValidateMarkEnterpriseTrialConvertedGatewayErrorResponseBody(body *MarkEnterpriseTrialConvertedGatewayErrorResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -5052,7 +5052,7 @@ func EncodeResumeStripeSubscriptionError(encoder func(context.Context, http.Resp
 // returned by the admin markEnterpriseTrialConverted endpoint.
 func EncodeMarkEnterpriseTrialConvertedResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
 	return func(ctx context.Context, w http.ResponseWriter, v any) error {
-		res, _ := v.(*admin.AdminOrganization)
+		res, _ := v.(*admin.MarkEnterpriseTrialConvertedResult)
 		enc := encoder(ctx, w)
 		body := NewMarkEnterpriseTrialConvertedResponseBody(res)
 		w.WriteHeader(http.StatusOK)

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -5048,6 +5048,219 @@ func EncodeResumeStripeSubscriptionError(encoder func(context.Context, http.Resp
 	}
 }
 
+// EncodeMarkEnterpriseTrialConvertedResponse returns an encoder for responses
+// returned by the admin markEnterpriseTrialConverted endpoint.
+func EncodeMarkEnterpriseTrialConvertedResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminOrganization)
+		enc := encoder(ctx, w)
+		body := NewMarkEnterpriseTrialConvertedResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeMarkEnterpriseTrialConvertedRequest returns a decoder for requests
+// sent to the admin markEnterpriseTrialConverted endpoint.
+func DecodeMarkEnterpriseTrialConvertedRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+	return func(r *http.Request) (*admin.MarkEnterpriseTrialConvertedPayload, error) {
+		var payload *admin.MarkEnterpriseTrialConvertedPayload
+		var (
+			body MarkEnterpriseTrialConvertedRequestBody
+			err  error
+		)
+		err = decoder(r).Decode(&body)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return payload, goa.MissingPayloadError()
+			}
+			var gerr *goa.ServiceError
+			if errors.As(err, &gerr) {
+				return payload, gerr
+			}
+			return payload, goa.DecodePayloadError(err.Error())
+		}
+		err = ValidateMarkEnterpriseTrialConvertedRequestBody(&body)
+		if err != nil {
+			return payload, err
+		}
+
+		var (
+			adminSessionToken *string
+		)
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		payload = NewMarkEnterpriseTrialConvertedPayload(&body, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeMarkEnterpriseTrialConvertedError returns an encoder for errors
+// returned by the markEnterpriseTrialConverted admin endpoint.
+func EncodeMarkEnterpriseTrialConvertedError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody
 // builds a value of type *AdminOrganizationMemberResponseBody from a value of
 // type *admin.AdminOrganizationMember.

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -126,3 +126,8 @@ func CancelStripeSubscriptionAdminPath() string {
 func ResumeStripeSubscriptionAdminPath() string {
 	return "/admin/organization.resumeStripeSubscription"
 }
+
+// MarkEnterpriseTrialConvertedAdminPath returns the URL path to the admin service markEnterpriseTrialConverted HTTP endpoint.
+func MarkEnterpriseTrialConvertedAdminPath() string {
+	return "/admin/trial.convert"
+}

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -18,31 +18,32 @@ import (
 
 // Server lists the admin service endpoint HTTP handlers.
 type Server struct {
-	Mounts                      []*MountPoint
-	Login                       http.Handler
-	Callback                    http.Handler
-	Logout                      http.Handler
-	GetProject                  http.Handler
-	UpdateOrganization          http.Handler
-	BulkUpdateAccountType       http.Handler
-	DisableOrganization         http.Handler
-	EnableOrganization          http.Handler
-	GetOrganization             http.Handler
-	ListOrganizationMembers     http.Handler
-	ListOrganizationProjects    http.Handler
-	ListOrganizationActivity    http.Handler
-	ListOrganizations           http.Handler
-	ExtendTrial                 http.Handler
-	CreateOrganization          http.Handler
-	RearmTrial                  http.Handler
-	GetOrganizationStats        http.Handler
-	GetInferenceKeys            http.Handler
-	SetInferenceKeyMonthlyLimit http.Handler
-	GetInferenceSpendHistory    http.Handler
-	GetPaygBillingSummary       http.Handler
-	GetStripeSubscription       http.Handler
-	CancelStripeSubscription    http.Handler
-	ResumeStripeSubscription    http.Handler
+	Mounts                       []*MountPoint
+	Login                        http.Handler
+	Callback                     http.Handler
+	Logout                       http.Handler
+	GetProject                   http.Handler
+	UpdateOrganization           http.Handler
+	BulkUpdateAccountType        http.Handler
+	DisableOrganization          http.Handler
+	EnableOrganization           http.Handler
+	GetOrganization              http.Handler
+	ListOrganizationMembers      http.Handler
+	ListOrganizationProjects     http.Handler
+	ListOrganizationActivity     http.Handler
+	ListOrganizations            http.Handler
+	ExtendTrial                  http.Handler
+	CreateOrganization           http.Handler
+	RearmTrial                   http.Handler
+	GetOrganizationStats         http.Handler
+	GetInferenceKeys             http.Handler
+	SetInferenceKeyMonthlyLimit  http.Handler
+	GetInferenceSpendHistory     http.Handler
+	GetPaygBillingSummary        http.Handler
+	GetStripeSubscription        http.Handler
+	CancelStripeSubscription     http.Handler
+	ResumeStripeSubscription     http.Handler
+	MarkEnterpriseTrialConverted http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -96,31 +97,33 @@ func New(
 			{"GetStripeSubscription", "GET", "/admin/organization.stripeSubscription"},
 			{"CancelStripeSubscription", "POST", "/admin/organization.cancelStripeSubscription"},
 			{"ResumeStripeSubscription", "POST", "/admin/organization.resumeStripeSubscription"},
+			{"MarkEnterpriseTrialConverted", "POST", "/admin/trial.convert"},
 		},
-		Login:                       NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
-		Callback:                    NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
-		Logout:                      NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
-		GetProject:                  NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
-		UpdateOrganization:          NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
-		BulkUpdateAccountType:       NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
-		DisableOrganization:         NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
-		EnableOrganization:          NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
-		GetOrganization:             NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationMembers:     NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationProjects:    NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizationActivity:    NewListOrganizationActivityHandler(e.ListOrganizationActivity, mux, decoder, encoder, errhandler, formatter),
-		ListOrganizations:           NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
-		ExtendTrial:                 NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
-		CreateOrganization:          NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
-		RearmTrial:                  NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
-		GetOrganizationStats:        NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
-		GetInferenceKeys:            NewGetInferenceKeysHandler(e.GetInferenceKeys, mux, decoder, encoder, errhandler, formatter),
-		SetInferenceKeyMonthlyLimit: NewSetInferenceKeyMonthlyLimitHandler(e.SetInferenceKeyMonthlyLimit, mux, decoder, encoder, errhandler, formatter),
-		GetInferenceSpendHistory:    NewGetInferenceSpendHistoryHandler(e.GetInferenceSpendHistory, mux, decoder, encoder, errhandler, formatter),
-		GetPaygBillingSummary:       NewGetPaygBillingSummaryHandler(e.GetPaygBillingSummary, mux, decoder, encoder, errhandler, formatter),
-		GetStripeSubscription:       NewGetStripeSubscriptionHandler(e.GetStripeSubscription, mux, decoder, encoder, errhandler, formatter),
-		CancelStripeSubscription:    NewCancelStripeSubscriptionHandler(e.CancelStripeSubscription, mux, decoder, encoder, errhandler, formatter),
-		ResumeStripeSubscription:    NewResumeStripeSubscriptionHandler(e.ResumeStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		Login:                        NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
+		Callback:                     NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
+		Logout:                       NewLogoutHandler(e.Logout, mux, decoder, encoder, errhandler, formatter),
+		GetProject:                   NewGetProjectHandler(e.GetProject, mux, decoder, encoder, errhandler, formatter),
+		UpdateOrganization:           NewUpdateOrganizationHandler(e.UpdateOrganization, mux, decoder, encoder, errhandler, formatter),
+		BulkUpdateAccountType:        NewBulkUpdateAccountTypeHandler(e.BulkUpdateAccountType, mux, decoder, encoder, errhandler, formatter),
+		DisableOrganization:          NewDisableOrganizationHandler(e.DisableOrganization, mux, decoder, encoder, errhandler, formatter),
+		EnableOrganization:           NewEnableOrganizationHandler(e.EnableOrganization, mux, decoder, encoder, errhandler, formatter),
+		GetOrganization:              NewGetOrganizationHandler(e.GetOrganization, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationMembers:      NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationProjects:     NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizationActivity:     NewListOrganizationActivityHandler(e.ListOrganizationActivity, mux, decoder, encoder, errhandler, formatter),
+		ListOrganizations:            NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
+		ExtendTrial:                  NewExtendTrialHandler(e.ExtendTrial, mux, decoder, encoder, errhandler, formatter),
+		CreateOrganization:           NewCreateOrganizationHandler(e.CreateOrganization, mux, decoder, encoder, errhandler, formatter),
+		RearmTrial:                   NewRearmTrialHandler(e.RearmTrial, mux, decoder, encoder, errhandler, formatter),
+		GetOrganizationStats:         NewGetOrganizationStatsHandler(e.GetOrganizationStats, mux, decoder, encoder, errhandler, formatter),
+		GetInferenceKeys:             NewGetInferenceKeysHandler(e.GetInferenceKeys, mux, decoder, encoder, errhandler, formatter),
+		SetInferenceKeyMonthlyLimit:  NewSetInferenceKeyMonthlyLimitHandler(e.SetInferenceKeyMonthlyLimit, mux, decoder, encoder, errhandler, formatter),
+		GetInferenceSpendHistory:     NewGetInferenceSpendHistoryHandler(e.GetInferenceSpendHistory, mux, decoder, encoder, errhandler, formatter),
+		GetPaygBillingSummary:        NewGetPaygBillingSummaryHandler(e.GetPaygBillingSummary, mux, decoder, encoder, errhandler, formatter),
+		GetStripeSubscription:        NewGetStripeSubscriptionHandler(e.GetStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		CancelStripeSubscription:     NewCancelStripeSubscriptionHandler(e.CancelStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		ResumeStripeSubscription:     NewResumeStripeSubscriptionHandler(e.ResumeStripeSubscription, mux, decoder, encoder, errhandler, formatter),
+		MarkEnterpriseTrialConverted: NewMarkEnterpriseTrialConvertedHandler(e.MarkEnterpriseTrialConverted, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -153,6 +156,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.GetStripeSubscription = m(s.GetStripeSubscription)
 	s.CancelStripeSubscription = m(s.CancelStripeSubscription)
 	s.ResumeStripeSubscription = m(s.ResumeStripeSubscription)
+	s.MarkEnterpriseTrialConverted = m(s.MarkEnterpriseTrialConverted)
 }
 
 // MethodNames returns the methods served.
@@ -184,6 +188,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountGetStripeSubscriptionHandler(mux, h.GetStripeSubscription)
 	MountCancelStripeSubscriptionHandler(mux, h.CancelStripeSubscription)
 	MountResumeStripeSubscriptionHandler(mux, h.ResumeStripeSubscription)
+	MountMarkEnterpriseTrialConvertedHandler(mux, h.MarkEnterpriseTrialConverted)
 }
 
 // Mount configures the mux to serve the admin endpoints.
@@ -1447,6 +1452,60 @@ func NewResumeStripeSubscriptionHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "resumeStripeSubscription")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountMarkEnterpriseTrialConvertedHandler configures the mux to serve the
+// "admin" service "markEnterpriseTrialConverted" endpoint.
+func MountMarkEnterpriseTrialConvertedHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("POST", "/admin/trial.convert", f)
+}
+
+// NewMarkEnterpriseTrialConvertedHandler creates a HTTP handler which loads
+// the HTTP request and calls the "admin" service
+// "markEnterpriseTrialConverted" endpoint.
+func NewMarkEnterpriseTrialConvertedHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeMarkEnterpriseTrialConvertedRequest(mux, decoder)
+		encodeResponse = EncodeMarkEnterpriseTrialConvertedResponse(encoder)
+		encodeError    = EncodeMarkEnterpriseTrialConvertedError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "markEnterpriseTrialConverted")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -522,37 +522,10 @@ type ResumeStripeSubscriptionResponseBody struct {
 // MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
 // "markEnterpriseTrialConverted" endpoint HTTP response body.
 type MarkEnterpriseTrialConvertedResponseBody struct {
-	// The ID of the organization
-	ID string `form:"id" json:"id" xml:"id"`
-	// The name of the organization
-	Name string `form:"name" json:"name" xml:"name"`
-	// The slug of the organization
-	Slug string `form:"slug" json:"slug" xml:"slug"`
-	// Gram account type (e.g. free, pro, payg, enterprise).
-	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
-	// WorkOS organization ID, if linked.
-	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
-	// Whether the organization is whitelisted for full access.
-	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
-	// The time at which the organization was disabled, if any.
-	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
-	// Lifecycle state of the organization's enterprise trial.
-	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
-	// The trial tier. Absent when the organization never trialled.
-	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
-	// The time at which the enterprise trial ends. Absent when the organization
-	// never trialled.
-	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
-	// The time at which the trial converted to a paid plan, if any.
-	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
-	// The time at which the organization was demoted after its trial, if any.
-	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
-	// Number of active members in the organization.
-	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
-	// The creation date of the organization.
-	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
-	// The last update date of the organization.
-	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+	// The converted organization ID.
+	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
+	// The time at which the enterprise trial was recorded as converted.
+	ConvertedAt string `form:"converted_at" json:"converted_at" xml:"converted_at"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -5720,23 +5693,10 @@ func NewResumeStripeSubscriptionResponseBody(res *admin.AdminStripeSubscription)
 // NewMarkEnterpriseTrialConvertedResponseBody builds the HTTP response body
 // from the result of the "markEnterpriseTrialConverted" endpoint of the
 // "admin" service.
-func NewMarkEnterpriseTrialConvertedResponseBody(res *admin.AdminOrganization) *MarkEnterpriseTrialConvertedResponseBody {
+func NewMarkEnterpriseTrialConvertedResponseBody(res *admin.MarkEnterpriseTrialConvertedResult) *MarkEnterpriseTrialConvertedResponseBody {
 	body := &MarkEnterpriseTrialConvertedResponseBody{
-		ID:               res.ID,
-		Name:             res.Name,
-		Slug:             res.Slug,
-		AccountType:      res.AccountType,
-		WorkosID:         res.WorkosID,
-		Whitelisted:      res.Whitelisted,
-		DisabledAt:       res.DisabledAt,
-		TrialState:       res.TrialState,
-		TrialTier:        res.TrialTier,
-		TrialEndsAt:      res.TrialEndsAt,
-		TrialConvertedAt: res.TrialConvertedAt,
-		TrialDemotedAt:   res.TrialDemotedAt,
-		MemberCount:      res.MemberCount,
-		CreatedAt:        res.CreatedAt,
-		UpdatedAt:        res.UpdatedAt,
+		OrganizationID: res.OrganizationID,
+		ConvertedAt:    res.ConvertedAt,
 	}
 	return body
 }

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -94,6 +94,13 @@ type ResumeStripeSubscriptionRequestBody struct {
 	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
 }
 
+// MarkEnterpriseTrialConvertedRequestBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP request body.
+type MarkEnterpriseTrialConvertedRequestBody struct {
+	// Organization ID.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+}
+
 // GetProjectResponseBody is the type of the "admin" service "getProject"
 // endpoint HTTP response body.
 type GetProjectResponseBody struct {
@@ -510,6 +517,42 @@ type ResumeStripeSubscriptionResponseBody struct {
 	CancelAt           *string `form:"cancel_at,omitempty" json:"cancel_at,omitempty" xml:"cancel_at,omitempty"`
 	CanceledAt         *string `form:"canceled_at,omitempty" json:"canceled_at,omitempty" xml:"canceled_at,omitempty"`
 	PaymentFailed      bool    `form:"payment_failed" json:"payment_failed" xml:"payment_failed"`
+}
+
+// MarkEnterpriseTrialConvertedResponseBody is the type of the "admin" service
+// "markEnterpriseTrialConverted" endpoint HTTP response body.
+type MarkEnterpriseTrialConvertedResponseBody struct {
+	// The ID of the organization
+	ID string `form:"id" json:"id" xml:"id"`
+	// The name of the organization
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, payg, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// WorkOS organization ID, if linked.
+	WorkosID *string `form:"workos_id,omitempty" json:"workos_id,omitempty" xml:"workos_id,omitempty"`
+	// Whether the organization is whitelisted for full access.
+	Whitelisted bool `form:"whitelisted" json:"whitelisted" xml:"whitelisted"`
+	// The time at which the organization was disabled, if any.
+	DisabledAt *string `form:"disabled_at,omitempty" json:"disabled_at,omitempty" xml:"disabled_at,omitempty"`
+	// Lifecycle state of the organization's enterprise trial.
+	TrialState *string `form:"trial_state,omitempty" json:"trial_state,omitempty" xml:"trial_state,omitempty"`
+	// The trial tier. Absent when the organization never trialled.
+	TrialTier *string `form:"trial_tier,omitempty" json:"trial_tier,omitempty" xml:"trial_tier,omitempty"`
+	// The time at which the enterprise trial ends. Absent when the organization
+	// never trialled.
+	TrialEndsAt *string `form:"trial_ends_at,omitempty" json:"trial_ends_at,omitempty" xml:"trial_ends_at,omitempty"`
+	// The time at which the trial converted to a paid plan, if any.
+	TrialConvertedAt *string `form:"trial_converted_at,omitempty" json:"trial_converted_at,omitempty" xml:"trial_converted_at,omitempty"`
+	// The time at which the organization was demoted after its trial, if any.
+	TrialDemotedAt *string `form:"trial_demoted_at,omitempty" json:"trial_demoted_at,omitempty" xml:"trial_demoted_at,omitempty"`
+	// Number of active members in the organization.
+	MemberCount int `form:"member_count" json:"member_count" xml:"member_count"`
+	// The creation date of the organization.
+	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
+	// The last update date of the organization.
+	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
 }
 
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
@@ -4957,6 +5000,196 @@ type ResumeStripeSubscriptionGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// MarkEnterpriseTrialConvertedUnauthorizedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unauthorized" error.
+type MarkEnterpriseTrialConvertedUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedForbiddenResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "forbidden" error.
+type MarkEnterpriseTrialConvertedForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedBadRequestResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "bad_request" error.
+type MarkEnterpriseTrialConvertedBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedNotFoundResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "not_found" error.
+type MarkEnterpriseTrialConvertedNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedConflictResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "conflict" error.
+type MarkEnterpriseTrialConvertedConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unsupported_media" error.
+type MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedInvalidResponseBody is the type of the "admin"
+// service "markEnterpriseTrialConverted" endpoint HTTP response body for the
+// "invalid" error.
+type MarkEnterpriseTrialConvertedInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedInvariantViolationResponseBody is the type of
+// the "admin" service "markEnterpriseTrialConverted" endpoint HTTP response
+// body for the "invariant_violation" error.
+type MarkEnterpriseTrialConvertedInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedUnexpectedResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "unexpected" error.
+type MarkEnterpriseTrialConvertedUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// MarkEnterpriseTrialConvertedGatewayErrorResponseBody is the type of the
+// "admin" service "markEnterpriseTrialConverted" endpoint HTTP response body
+// for the "gateway_error" error.
+type MarkEnterpriseTrialConvertedGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -5480,6 +5713,30 @@ func NewResumeStripeSubscriptionResponseBody(res *admin.AdminStripeSubscription)
 		CancelAt:           res.CancelAt,
 		CanceledAt:         res.CanceledAt,
 		PaymentFailed:      res.PaymentFailed,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedResponseBody builds the HTTP response body
+// from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedResponseBody(res *admin.AdminOrganization) *MarkEnterpriseTrialConvertedResponseBody {
+	body := &MarkEnterpriseTrialConvertedResponseBody{
+		ID:               res.ID,
+		Name:             res.Name,
+		Slug:             res.Slug,
+		AccountType:      res.AccountType,
+		WorkosID:         res.WorkosID,
+		Whitelisted:      res.Whitelisted,
+		DisabledAt:       res.DisabledAt,
+		TrialState:       res.TrialState,
+		TrialTier:        res.TrialTier,
+		TrialEndsAt:      res.TrialEndsAt,
+		TrialConvertedAt: res.TrialConvertedAt,
+		TrialDemotedAt:   res.TrialDemotedAt,
+		MemberCount:      res.MemberCount,
+		CreatedAt:        res.CreatedAt,
+		UpdatedAt:        res.UpdatedAt,
 	}
 	return body
 }
@@ -8967,6 +9224,156 @@ func NewResumeStripeSubscriptionGatewayErrorResponseBody(res *goa.ServiceError) 
 	return body
 }
 
+// NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnauthorizedResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnauthorizedResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedForbiddenResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedForbiddenResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedForbiddenResponseBody {
+	body := &MarkEnterpriseTrialConvertedForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedBadRequestResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedBadRequestResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedBadRequestResponseBody {
+	body := &MarkEnterpriseTrialConvertedBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedNotFoundResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedNotFoundResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedNotFoundResponseBody {
+	body := &MarkEnterpriseTrialConvertedNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedConflictResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedConflictResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedConflictResponseBody {
+	body := &MarkEnterpriseTrialConvertedConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnsupportedMediaResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedInvalidResponseBody builds the HTTP response
+// body from the result of the "markEnterpriseTrialConverted" endpoint of the
+// "admin" service.
+func NewMarkEnterpriseTrialConvertedInvalidResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedInvalidResponseBody {
+	body := &MarkEnterpriseTrialConvertedInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody builds the
+// HTTP response body from the result of the "markEnterpriseTrialConverted"
+// endpoint of the "admin" service.
+func NewMarkEnterpriseTrialConvertedInvariantViolationResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedInvariantViolationResponseBody {
+	body := &MarkEnterpriseTrialConvertedInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedUnexpectedResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedUnexpectedResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedUnexpectedResponseBody {
+	body := &MarkEnterpriseTrialConvertedUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody builds the HTTP
+// response body from the result of the "markEnterpriseTrialConverted" endpoint
+// of the "admin" service.
+func NewMarkEnterpriseTrialConvertedGatewayErrorResponseBody(res *goa.ServiceError) *MarkEnterpriseTrialConvertedGatewayErrorResponseBody {
+	body := &MarkEnterpriseTrialConvertedGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewLoginPayload builds a admin service login endpoint payload.
 func NewLoginPayload(returnTo *string, prompt *string) *admin.LoginPayload {
 	v := &admin.LoginPayload{}
@@ -9234,6 +9641,17 @@ func NewResumeStripeSubscriptionPayload(body *ResumeStripeSubscriptionRequestBod
 	return v
 }
 
+// NewMarkEnterpriseTrialConvertedPayload builds a admin service
+// markEnterpriseTrialConverted endpoint payload.
+func NewMarkEnterpriseTrialConvertedPayload(body *MarkEnterpriseTrialConvertedRequestBody, adminSessionToken *string) *admin.MarkEnterpriseTrialConvertedPayload {
+	v := &admin.MarkEnterpriseTrialConvertedPayload{
+		ID: *body.ID,
+	}
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
 // ValidateUpdateOrganizationRequestBody runs the validations defined on
 // UpdateOrganizationRequestBody
 func ValidateUpdateOrganizationRequestBody(body *UpdateOrganizationRequestBody) (err error) {
@@ -9416,6 +9834,20 @@ func ValidateCancelStripeSubscriptionRequestBody(body *CancelStripeSubscriptionR
 func ValidateResumeStripeSubscriptionRequestBody(body *ResumeStripeSubscriptionRequestBody) (err error) {
 	if body.OrganizationID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "body"))
+	}
+	return
+}
+
+// ValidateMarkEnterpriseTrialConvertedRequestBody runs the validations defined
+// on MarkEnterpriseTrialConvertedRequestBody
+func ValidateMarkEnterpriseTrialConvertedRequestBody(body *MarkEnterpriseTrialConvertedRequestBody) (err error) {
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.ID != nil {
+		if utf8.RuneCountInString(*body.ID) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.id", *body.ID, utf8.RuneCountInString(*body.ID), 1, true))
+		}
 	}
 	return
 }

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -114,7 +114,7 @@ func UsageCommands() []string {
 		"assistant-memories (list-assistant-memories|get-assistant-memory|delete-assistant-memory)",
 		"assistants (list-assistants|get-assistant|create-assistant|update-assistant|delete-assistant|send-message|interrupt-turn|get-managed-assistant|ensure-managed-assistant)",
 		"auditlogs (list|list-facets)",
-		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organization-activity|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|set-inference-key-monthly-limit|get-inference-spend-history|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription)",
+		"admin (login|callback|logout|get-project|update-organization|bulk-update-account-type|disable-organization|enable-organization|get-organization|list-organization-members|list-organization-projects|list-organization-activity|list-organizations|extend-trial|create-organization|rearm-trial|get-organization-stats|get-inference-keys|set-inference-key-monthly-limit|get-inference-spend-history|get-payg-billing-summary|get-stripe-subscription|cancel-stripe-subscription|resume-stripe-subscription|mark-enterprise-trial-converted)",
 		"auth (callback|login|switch-scopes|enter-demo|logout|register|info)",
 		"business-memories (list-business-memories|list-business-memory-content-scopes|search-business-memories)",
 		"chat (list-chats|get-assistant-session-summary|get-work-units-trend|load-chat|generate-title|credit-usage|delete-chat|set-pinned|summarize|summarize-tool-call|submit-feedback|list-sources|list-session-links)",
@@ -718,6 +718,10 @@ func ParseEndpoint(
 		adminResumeStripeSubscriptionFlags                 = flag.NewFlagSet("resume-stripe-subscription", flag.ExitOnError)
 		adminResumeStripeSubscriptionBodyFlag              = adminResumeStripeSubscriptionFlags.String("body", "REQUIRED", "")
 		adminResumeStripeSubscriptionAdminSessionTokenFlag = adminResumeStripeSubscriptionFlags.String("admin-session-token", "", "")
+
+		adminMarkEnterpriseTrialConvertedFlags                 = flag.NewFlagSet("mark-enterprise-trial-converted", flag.ExitOnError)
+		adminMarkEnterpriseTrialConvertedBodyFlag              = adminMarkEnterpriseTrialConvertedFlags.String("body", "REQUIRED", "")
+		adminMarkEnterpriseTrialConvertedAdminSessionTokenFlag = adminMarkEnterpriseTrialConvertedFlags.String("admin-session-token", "", "")
 
 		authFlags = flag.NewFlagSet("auth", flag.ContinueOnError)
 
@@ -3908,6 +3912,7 @@ func ParseEndpoint(
 	adminGetStripeSubscriptionFlags.Usage = adminGetStripeSubscriptionUsage
 	adminCancelStripeSubscriptionFlags.Usage = adminCancelStripeSubscriptionUsage
 	adminResumeStripeSubscriptionFlags.Usage = adminResumeStripeSubscriptionUsage
+	adminMarkEnterpriseTrialConvertedFlags.Usage = adminMarkEnterpriseTrialConvertedUsage
 
 	authFlags.Usage = authUsage
 	authCallbackFlags.Usage = authCallbackUsage
@@ -5113,6 +5118,9 @@ func ParseEndpoint(
 
 			case "resume-stripe-subscription":
 				epf = adminResumeStripeSubscriptionFlags
+
+			case "mark-enterprise-trial-converted":
+				epf = adminMarkEnterpriseTrialConvertedFlags
 
 			}
 
@@ -7393,6 +7401,9 @@ func ParseEndpoint(
 			case "resume-stripe-subscription":
 				endpoint = c.ResumeStripeSubscription()
 				data, err = adminc.BuildResumeStripeSubscriptionPayload(*adminResumeStripeSubscriptionBodyFlag, *adminResumeStripeSubscriptionAdminSessionTokenFlag)
+			case "mark-enterprise-trial-converted":
+				endpoint = c.MarkEnterpriseTrialConverted()
+				data, err = adminc.BuildMarkEnterpriseTrialConvertedPayload(*adminMarkEnterpriseTrialConvertedBodyFlag, *adminMarkEnterpriseTrialConvertedAdminSessionTokenFlag)
 			}
 		case "auth":
 			c := authc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -11137,6 +11148,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    get-stripe-subscription: Returns the live Stripe subscription and payment state for an organization.`)
 	fmt.Fprintln(os.Stderr, `    cancel-stripe-subscription: Schedules an organization's PAYG subscription to cancel at period end.`)
 	fmt.Fprintln(os.Stderr, `    resume-stripe-subscription: Removes a scheduled period-end cancellation from an organization's PAYG subscription.`)
+	fmt.Fprintln(os.Stderr, `    mark-enterprise-trial-converted: Records that an organization's enterprise trial converted to a signed contract.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin COMMAND --help\n", os.Args[0])
@@ -11645,6 +11657,26 @@ func adminResumeStripeSubscriptionUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin resume-stripe-subscription --body '{\n      \"organization_id\": \"abc123\"\n   }' --admin-session-token \"abc123\"")
+}
+
+func adminMarkEnterpriseTrialConvertedUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin mark-enterprise-trial-converted", os.Args[0])
+	fmt.Fprint(os.Stderr, " -body JSON")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Records that an organization's enterprise trial converted to a signed contract.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -body JSON: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin mark-enterprise-trial-converted --body '{\n      \"id\": \"aa\"\n   }' --admin-session-token \"abc123\"")
 }
 
 // authUsage displays the usage of the auth command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1848,6 +1848,82 @@ paths:
                                 $ref: '#/components/schemas/Error'
             security:
                 - admin_auth_header_Authorization: []
+    /admin/trial.convert:
+        post:
+            tags:
+                - admin
+            summary: markEnterpriseTrialConverted admin
+            description: Records that an organization's enterprise trial converted to a signed contract.
+            operationId: adminMarkEnterpriseTrialConverted
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/MarkEnterpriseTrialConvertedRequestBody'
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminOrganization'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/trial.extend:
         post:
             tags:
@@ -75584,6 +75660,15 @@ components:
                 - coverage_bucket
                 - first_seen_at
                 - last_seen_at
+        MarkEnterpriseTrialConvertedRequestBody:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization ID.
+                    minLength: 1
+            required:
+                - id
         MarkRiskResultsFalsePositiveRequestBody:
             type: object
             properties:

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1867,7 +1867,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/AdminOrganization'
+                                $ref: '#/components/schemas/MarkEnterpriseTrialConvertedResult'
                 "400":
                     description: 'bad_request: request is invalid'
                     content:
@@ -75669,6 +75669,20 @@ components:
                     minLength: 1
             required:
                 - id
+        MarkEnterpriseTrialConvertedResult:
+            type: object
+            properties:
+                converted_at:
+                    type: string
+                    description: The time at which the enterprise trial was recorded as converted.
+                    format: date-time
+                organization_id:
+                    type: string
+                    description: The converted organization ID.
+            description: Privacy-minimal result of recording an enterprise trial conversion.
+            required:
+                - organization_id
+                - converted_at
         MarkRiskResultsFalsePositiveRequestBody:
             type: object
             properties:

--- a/server/internal/admin/bulkupdateaccounttype_test.go
+++ b/server/internal/admin/bulkupdateaccounttype_test.go
@@ -33,6 +33,20 @@ func postBulk(t *testing.T, ctx context.Context, svc *Service, body string) (*ge
 	return svc.BulkUpdateAccountType(ctx, payload)
 }
 
+func TestBulkUpdateAccountType_RejectsEnterpriseTrialBatchAtomically(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
+	trialID, ordinaryID := "org_bulk_enterprise_trial", "org_bulk_ordinary"
+	seedOrg(t, ctx, conn, orgFixture{id: trialID, name: trialID, slug: trialID, accountType: "free"})
+	seedTrial(t, ctx, conn, trialFixture{orgID: trialID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
+	seedOrg(t, ctx, conn, orgFixture{id: ordinaryID, name: ordinaryID, slug: ordinaryID, accountType: "free"})
+
+	_, err := svc.BulkUpdateAccountType(ctx, &gen.BulkUpdateAccountTypePayload{Ids: []string{ordinaryID, trialID}, AccountType: "enterprise"})
+	require.ErrorContains(t, err, "enterprise trial")
+	require.Equal(t, "free", readOrgState(t, ctx, conn, trialID).GramAccountType)
+	require.Equal(t, "free", readOrgState(t, ctx, conn, ordinaryID).GramAccountType, "batch must not partially update before conflict")
+}
+
 func TestBulkUpdateAccountType_WritesOnlyTheListedIDs(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/bulkupdateaccounttype_test.go
+++ b/server/internal/admin/bulkupdateaccounttype_test.go
@@ -33,18 +33,48 @@ func postBulk(t *testing.T, ctx context.Context, svc *Service, body string) (*ge
 	return svc.BulkUpdateAccountType(ctx, payload)
 }
 
-func TestBulkUpdateAccountType_RejectsEnterpriseTrialBatchAtomically(t *testing.T) {
+func TestBulkUpdateAccountType_RejectsAnyEnterpriseTrialBatchAtomically(t *testing.T) {
+	t.Parallel()
+	convertedAt := time.Now().UTC().Add(-time.Hour)
+	for _, tc := range []struct {
+		name        string
+		convertedAt *time.Time
+	}{
+		{name: "unconverted enterprise trial"},
+		{name: "converted enterprise trial", convertedAt: &convertedAt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, svc, conn := newTestAdminService(t)
+			suffix := strings.ReplaceAll(tc.name, " ", "_")
+			trialID, ordinaryID, bystanderID := "org_bulk_trial_"+suffix, "org_bulk_ordinary_"+suffix, "org_bulk_bystander_"+suffix
+			seedOrg(t, ctx, conn, orgFixture{id: trialID, name: trialID, slug: trialID, accountType: "free"})
+			seedTrial(t, ctx, conn, trialFixture{orgID: trialID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour), convertedAt: tc.convertedAt})
+			seedOrg(t, ctx, conn, orgFixture{id: ordinaryID, name: ordinaryID, slug: ordinaryID, accountType: "free"})
+			seedOrg(t, ctx, conn, orgFixture{id: bystanderID, name: bystanderID, slug: bystanderID, accountType: "pro"})
+			trialBefore, ordinaryBefore, bystanderBefore := readOrgState(t, ctx, conn, trialID), readOrgState(t, ctx, conn, ordinaryID), readOrgState(t, ctx, conn, bystanderID)
+
+			result, err := svc.BulkUpdateAccountType(ctx, &gen.BulkUpdateAccountTypePayload{Ids: []string{ordinaryID, trialID}, AccountType: "enterprise"})
+			require.Nil(t, result)
+			require.ErrorContains(t, err, "enterprise trial")
+			require.Equal(t, trialBefore, readOrgState(t, ctx, conn, trialID))
+			require.Equal(t, ordinaryBefore, readOrgState(t, ctx, conn, ordinaryID), "batch must not partially update before conflict")
+			require.Equal(t, bystanderBefore, readOrgState(t, ctx, conn, bystanderID), "organization outside the batch must remain untouched")
+		})
+	}
+}
+
+func TestBulkUpdateAccountType_AllowsNonEnterpriseTargetForEnterpriseTrial(t *testing.T) {
 	t.Parallel()
 	ctx, svc, conn := newTestAdminService(t)
-	trialID, ordinaryID := "org_bulk_enterprise_trial", "org_bulk_ordinary"
-	seedOrg(t, ctx, conn, orgFixture{id: trialID, name: trialID, slug: trialID, accountType: "free"})
-	seedTrial(t, ctx, conn, trialFixture{orgID: trialID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
-	seedOrg(t, ctx, conn, orgFixture{id: ordinaryID, name: ordinaryID, slug: ordinaryID, accountType: "free"})
+	orgID := "org_bulk_trial_nonenterprise_target"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free"})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
 
-	_, err := svc.BulkUpdateAccountType(ctx, &gen.BulkUpdateAccountTypePayload{Ids: []string{ordinaryID, trialID}, AccountType: "enterprise"})
-	require.ErrorContains(t, err, "enterprise trial")
-	require.Equal(t, "free", readOrgState(t, ctx, conn, trialID).GramAccountType)
-	require.Equal(t, "free", readOrgState(t, ctx, conn, ordinaryID).GramAccountType, "batch must not partially update before conflict")
+	result, err := svc.BulkUpdateAccountType(ctx, &gen.BulkUpdateAccountTypePayload{Ids: []string{orgID}, AccountType: "pro"})
+	require.NoError(t, err)
+	require.Equal(t, []string{orgID}, result.UpdatedIds)
+	require.Equal(t, "pro", readOrgState(t, ctx, conn, orgID).GramAccountType)
 }
 
 func TestBulkUpdateAccountType_WritesOnlyTheListedIDs(t *testing.T) {

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -243,10 +245,18 @@ func enterpriseTrialConversionResult(organizationID string, convertedAt pgtype.T
 
 func enterpriseTrialConversionAuditActor(ctx context.Context) (urn.Principal, *string) {
 	actor, displayName, operatorEmail := adminActor(ctx)
-	if displayName != nil && operatorEmail != nil && *displayName == *operatorEmail {
-		displayName = nil
+	if displayName == nil {
+		return actor, nil
 	}
-	return actor, displayName
+
+	normalized := strings.TrimSpace(*displayName)
+	if operatorEmail != nil && strings.EqualFold(normalized, strings.TrimSpace(*operatorEmail)) {
+		return actor, nil
+	}
+	if address, err := mail.ParseAddress(normalized); err == nil && strings.Contains(address.Address, "@") {
+		return actor, nil
+	}
+	return actor, &normalized
 }
 
 func pgTimePtr(value pgtype.Timestamptz) *time.Time {

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -172,18 +172,20 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 	beforeKeys := make([]audit.OrganizationEnterpriseTrialConversionKeySnapshot, 0, len(keyChanges))
 	afterKeys := make([]audit.OrganizationEnterpriseTrialConversionKeySnapshot, 0, len(keyChanges))
 	for _, change := range keyChanges {
-		beforeKeys = append(beforeKeys, conversionKeyAuditSnapshot(change.Before))
-		afterKeys = append(afterKeys, conversionKeyAuditSnapshot(change.After))
+		accessChanged := openrouter.EffectiveDisabled(change.Before.Disabled, change.Before.DisableCauses) != openrouter.EffectiveDisabled(change.After.Disabled, change.After.DisableCauses)
+		beforeKeys = append(beforeKeys, conversionKeyAuditSnapshot(change.Before, accessChanged))
+		afterKeys = append(afterKeys, conversionKeyAuditSnapshot(change.After, accessChanged))
 	}
+	snapshotTime := time.Now().UTC()
 	before := audit.OrganizationEnterpriseTrialConversionSnapshot{
 		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: organization.AccountType, Whitelisted: organization.Whitelisted, Disabled: organization.DisabledAt.Valid},
-		Trial:        conversionTrialAuditSnapshot(trial.Tier, trial.EndsAt, trial.ConvertedAt, trial.DemotedAt), Keys: beforeKeys,
+		Trial:        conversionTrialAuditSnapshot(trial.Tier, trial.EndsAt, trial.ConvertedAt, trial.DemotedAt, snapshotTime), Keys: beforeKeys,
 	}
 	after := audit.OrganizationEnterpriseTrialConversionSnapshot{
 		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: "enterprise", Whitelisted: true, Disabled: organization.DisabledAt.Valid},
-		Trial:        conversionTrialAuditSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt), Keys: afterKeys,
+		Trial:        conversionTrialAuditSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt, snapshotTime), Keys: afterKeys,
 	}
-	actor, actorDisplayName := enterpriseTrialConversionAuditActor()
+	actor, actorDisplayName := enterpriseTrialConversionAuditActor(ctx)
 	if err := s.audit.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
 		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil, Before: before, After: after,
 	}); err != nil {
@@ -216,25 +218,35 @@ func (s *Service) reconcileConvertedTrialKeys(ctx context.Context, organizationI
 	return nil
 }
 
-func conversionTrialAuditSnapshot(tier string, endsAt, convertedAt, demotedAt pgtype.Timestamptz) audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot {
-	return audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot{Tier: tier, EndsAt: pgTimePtr(endsAt), ConvertedAt: pgTimePtr(convertedAt), DemotedAt: pgTimePtr(demotedAt)}
+func conversionTrialAuditSnapshot(tier string, endsAt, convertedAt, demotedAt pgtype.Timestamptz, now time.Time) audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot {
+	status := "running"
+	switch {
+	case convertedAt.Valid:
+		status = "converted"
+	case demotedAt.Valid:
+		status = "demoted"
+	case !endsAt.Time.After(now):
+		status = "expired"
+	case !endsAt.Time.After(now.Add(7 * 24 * time.Hour)):
+		status = "ending_soon"
+	}
+	return audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot{Status: status, Tier: tier, EndsAt: pgTimePtr(endsAt), ConvertedAt: pgTimePtr(convertedAt), DemotedAt: pgTimePtr(demotedAt)}
 }
 
-func conversionKeyAuditSnapshot(state openrouter.EnterpriseTrialConversionKeyState) audit.OrganizationEnterpriseTrialConversionKeySnapshot {
-	return audit.OrganizationEnterpriseTrialConversionKeySnapshot{KeyType: string(state.KeyType), DisableCauses: state.DisableCauses, StoredDisabled: state.Disabled, EffectiveDisabled: openrouter.EffectiveDisabled(state.Disabled, state.DisableCauses), MonthlyCredits: state.MonthlyCredits}
+func conversionKeyAuditSnapshot(state openrouter.EnterpriseTrialConversionKeyState, accessChanged bool) audit.OrganizationEnterpriseTrialConversionKeySnapshot {
+	return audit.OrganizationEnterpriseTrialConversionKeySnapshot{KeyType: string(state.KeyType), StoredDisabled: state.Disabled, EffectiveDisabled: openrouter.EffectiveDisabled(state.Disabled, state.DisableCauses), KeyAccessChanged: accessChanged, MonthlyCredits: state.MonthlyCredits}
 }
 
 func enterpriseTrialConversionResult(organizationID string, convertedAt pgtype.Timestamptz) *gen.MarkEnterpriseTrialConvertedResult {
 	return &gen.MarkEnterpriseTrialConvertedResult{OrganizationID: organizationID, ConvertedAt: convertedAt.Time.Format(time.RFC3339)}
 }
 
-// enterpriseTrialConversionAuditActor deliberately uses the established system
-// principal. Every identifier available in the admin auth context is either an
-// external identity or a bearer credential and must not enter audit storage or
-// its transactional outbox payload.
-func enterpriseTrialConversionAuditActor() (urn.Principal, *string) {
-	label := "Platform administrator"
-	return urn.NewPrincipal(urn.PrincipalTypeUser, "system"), &label
+func enterpriseTrialConversionAuditActor(ctx context.Context) (urn.Principal, *string) {
+	actor, displayName, operatorEmail := adminActor(ctx)
+	if displayName != nil && operatorEmail != nil && *displayName == *operatorEmail {
+		displayName = nil
+	}
+	return actor, displayName
 }
 
 func pgTimePtr(value pgtype.Timestamptz) *time.Time {

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -13,16 +13,18 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // MarkEnterpriseTrialConverted atomically records an enterprise contract and
 // its complete local access policy before reconciling provider state.
-func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.AdminOrganization, error) {
+func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.MarkEnterpriseTrialConvertedResult, error) {
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -70,7 +72,7 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		if err := s.reconcileConvertedTrialKeys(ctx, payload.ID); err != nil {
 			return nil, err
 		}
-		return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion retry")
+		return enterpriseTrialConversionResult(payload.ID, trial.ConvertedAt), nil
 	}
 
 	demotedAccess := organization.AccountType == "free" && !organization.Whitelisted
@@ -103,7 +105,7 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 	if err != nil || rows != 1 {
 		return nil, oops.E(oops.CodeUnexpected, err, "mark enterprise trial converted").LogError(ctx, logger)
 	}
-	restored, err := trialsRepo.New(tx).RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{OrganizationID: payload.ID, AccountType: "enterprise"})
+	_, err = trialsRepo.New(tx).RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{OrganizationID: payload.ID, AccountType: "enterprise"})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "restore organization after enterprise trial conversion").LogError(ctx, logger)
 	}
@@ -129,9 +131,9 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: "enterprise", Whitelisted: true, Disabled: organization.DisabledAt.Valid},
 		Trial:        conversionTrialAuditSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt), Keys: afterKeys,
 	}
-	actor, actorDisplayName, _ := adminActor(ctx)
+	actor, actorDisplayName := enterpriseTrialConversionAuditActor(ctx)
 	if err := s.audit.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
-		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil, OrganizationName: restored.Name, OrganizationSlug: restored.Slug, Before: before, After: after,
+		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil, Before: before, After: after,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log enterprise trial conversion").LogError(ctx, logger)
 	}
@@ -146,7 +148,7 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 	if err := s.reconcileConvertedTrialKeys(ctx, payload.ID); err != nil {
 		return nil, err
 	}
-	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion")
+	return enterpriseTrialConversionResult(payload.ID, convertedTrial.ConvertedAt), nil
 }
 
 func (s *Service) reconcileConvertedTrialKeys(ctx context.Context, organizationID string) error {
@@ -163,7 +165,20 @@ func conversionTrialAuditSnapshot(tier string, endsAt, convertedAt, demotedAt pg
 }
 
 func conversionKeyAuditSnapshot(state openrouter.EnterpriseTrialConversionKeyState) audit.OrganizationEnterpriseTrialConversionKeySnapshot {
-	return audit.OrganizationEnterpriseTrialConversionKeySnapshot{KeyType: string(state.KeyType), DisableCauses: state.DisableCauses, EffectiveDisabled: openrouter.EffectiveDisabled(state.Disabled, state.DisableCauses), MonthlyCredits: state.MonthlyCredits}
+	return audit.OrganizationEnterpriseTrialConversionKeySnapshot{KeyType: string(state.KeyType), DisableCauses: state.DisableCauses, StoredDisabled: state.Disabled, EffectiveDisabled: openrouter.EffectiveDisabled(state.Disabled, state.DisableCauses), MonthlyCredits: state.MonthlyCredits}
+}
+
+func enterpriseTrialConversionResult(organizationID string, convertedAt pgtype.Timestamptz) *gen.MarkEnterpriseTrialConvertedResult {
+	return &gen.MarkEnterpriseTrialConvertedResult{OrganizationID: organizationID, ConvertedAt: convertedAt.Time.Format(time.RFC3339)}
+}
+
+func enterpriseTrialConversionAuditActor(ctx context.Context) (urn.Principal, *string) {
+	label := "Platform administrator"
+	authCtx, ok := contextvalues.GetAdminAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.SessionID == "" {
+		return urn.NewPrincipal(urn.PrincipalTypeUser, "system"), &label
+	}
+	return urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.SessionID), &label
 }
 
 func pgTimePtr(value pgtype.Timestamptz) *time.Time {

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -13,7 +13,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/billing"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -25,6 +24,13 @@ import (
 // MarkEnterpriseTrialConverted atomically records an enterprise contract and
 // its complete local access policy before reconciling provider state.
 func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.MarkEnterpriseTrialConvertedResult, error) {
+	return s.markEnterpriseTrialConverted(ctx, payload.ID)
+}
+
+// markEnterpriseTrialConverted is the single transaction coordinator shared by
+// both admin mutation surfaces. Callers must not start a transaction around it.
+func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organizationID string) (*gen.MarkEnterpriseTrialConvertedResult, error) {
+	payload := &gen.MarkEnterpriseTrialConvertedPayload{ID: organizationID, AdminSessionToken: nil}
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -41,11 +47,6 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		return nil, oops.E(oops.CodeUnexpected, err, "lock enterprise trial conversion lifecycle").LogError(ctx, logger)
 	}
 
-	if trial.Tier != "enterprise" {
-		_ = tx.Rollback(ctx)
-		return nil, oops.E(oops.CodeConflict, nil, "organization has no enterprise trial to convert")
-	}
-
 	// The lifecycle row is always first, followed by every key advisory lock in
 	// canonical order, before any organization or key row is read.
 	for _, keyType := range openrouter.AllKeyTypes {
@@ -54,7 +55,20 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		}
 	}
 
-	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
+	queries := repo.New(tx)
+	if _, err := queries.LockOrganizationMetadata(ctx, payload.ID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.E(oops.CodeNotFound, err, "organization not found")
+		}
+		return nil, oops.E(oops.CodeUnexpected, err, "lock organization metadata for enterprise trial conversion").LogError(ctx, logger)
+	}
+
+	if trial.Tier != "enterprise" {
+		_ = tx.Rollback(ctx)
+		return nil, oops.E(oops.CodeConflict, nil, "organization has no enterprise trial to convert")
+	}
+
+	organization, err := queries.AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "read organization for enterprise trial conversion").LogError(ctx, logger)
 	}
@@ -69,6 +83,9 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 			return nil, oops.E(oops.CodeUnexpected, err, "close enterprise trial conversion retry transaction").LogError(ctx, logger)
 		}
 		s.updateTrialFeatureCache(ctx, payload.ID)
+		if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
+			logger.WarnContext(ctx, "failed to stop enterprise trial notifications on conversion retry", attr.SlogError(err))
+		}
 		if err := s.reconcileConvertedTrialKeys(ctx, payload.ID); err != nil {
 			return nil, err
 		}
@@ -131,7 +148,7 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: "enterprise", Whitelisted: true, Disabled: organization.DisabledAt.Valid},
 		Trial:        conversionTrialAuditSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt), Keys: afterKeys,
 	}
-	actor, actorDisplayName := enterpriseTrialConversionAuditActor(ctx)
+	actor, actorDisplayName := enterpriseTrialConversionAuditActor()
 	if err := s.audit.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
 		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil, Before: before, After: after,
 	}); err != nil {
@@ -172,13 +189,13 @@ func enterpriseTrialConversionResult(organizationID string, convertedAt pgtype.T
 	return &gen.MarkEnterpriseTrialConvertedResult{OrganizationID: organizationID, ConvertedAt: convertedAt.Time.Format(time.RFC3339)}
 }
 
-func enterpriseTrialConversionAuditActor(ctx context.Context) (urn.Principal, *string) {
+// enterpriseTrialConversionAuditActor deliberately uses the established system
+// principal. Every identifier available in the admin auth context is either an
+// external identity or a bearer credential and must not enter audit storage or
+// its transactional outbox payload.
+func enterpriseTrialConversionAuditActor() (urn.Principal, *string) {
 	label := "Platform administrator"
-	authCtx, ok := contextvalues.GetAdminAuthContext(ctx)
-	if !ok || authCtx == nil || authCtx.SessionID == "" {
-		return urn.NewPrincipal(urn.PrincipalTypeUser, "system"), &label
-	}
-	return urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.SessionID), &label
+	return urn.NewPrincipal(urn.PrincipalTypeUser, "system"), &label
 }
 
 func pgTimePtr(value pgtype.Timestamptz) *time.Time {

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -26,7 +26,7 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
-	trial, err := trialsRepo.New(tx).LockTrialLifecycleForRearm(ctx, payload.ID)
+	trial, err := trialsRepo.New(tx).LockTrialLifecycle(ctx, payload.ID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		_ = tx.Rollback(ctx)

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -209,7 +209,7 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 
 func (s *Service) reconcileConvertedTrialKeys(ctx context.Context, organizationID string) error {
 	for _, keyType := range openrouter.AllKeyTypes {
-		if err := s.openRouter.ReconcileAPIKeyDisabled(ctx, organizationID, keyType); err != nil {
+		if err := s.openRouter.ReconcileAPIKeyConversionPolicy(ctx, organizationID, keyType); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "reconcile openrouter %s key after enterprise trial conversion", keyType).LogError(ctx, s.logger)
 		}
 	}

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -44,12 +45,15 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 		}
 	}
 	defer releaseFeatures()
-	refreshFeatureCache := func() {
+	refreshFeatureCache := func() error {
+		cacheCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
 		for _, feature := range productfeatures.TrialRuntimeFeatures {
-			if cacheErr := s.productFeatures.UpdateFeatureCacheUnderLock(ctx, lockConn, payload.ID, feature); cacheErr != nil {
-				logger.WarnContext(ctx, "failed to refresh enterprise runtime feature cache", attr.SlogError(cacheErr), attr.SlogProductFeatureName(string(feature)))
+			if cacheErr := s.productFeatures.UpdateFeatureCacheUnderLock(cacheCtx, lockConn, payload.ID, feature); cacheErr != nil {
+				return fmt.Errorf("refresh %s cache: %w", feature, cacheErr)
 			}
 		}
+		return nil
 	}
 
 	tx, err := lockConn.Begin(ctx)
@@ -109,7 +113,10 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 		if err := tx.Rollback(ctx); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "close enterprise trial conversion retry transaction").LogError(ctx, logger)
 		}
-		refreshFeatureCache()
+		if err := refreshFeatureCache(); err != nil {
+			releaseFeatures()
+			return nil, oops.E(oops.CodeUnexpected, err, "refresh enterprise runtime feature cache after conversion retry").LogError(ctx, logger)
+		}
 		releaseFeatures()
 		if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
 			logger.WarnContext(ctx, "failed to stop enterprise trial notifications on conversion retry", attr.SlogError(err))
@@ -186,7 +193,10 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 		return nil, oops.E(oops.CodeUnexpected, err, "commit enterprise trial conversion").LogError(ctx, logger)
 	}
 
-	refreshFeatureCache()
+	if err := refreshFeatureCache(); err != nil {
+		releaseFeatures()
+		return nil, oops.E(oops.CodeUnexpected, err, "refresh enterprise runtime feature cache after conversion").LogError(ctx, logger)
+	}
 	releaseFeatures()
 	if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
 		logger.WarnContext(ctx, "failed to stop enterprise trial notifications after conversion", attr.SlogError(err))

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -27,8 +27,8 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 	return s.markEnterpriseTrialConverted(ctx, payload.ID)
 }
 
-// markEnterpriseTrialConverted is the single transaction coordinator shared by
-// both admin mutation surfaces. Callers must not start a transaction around it.
+// markEnterpriseTrialConverted is the dedicated operation's transaction
+// coordinator. Generic organization updates must never call it.
 func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organizationID string) (*gen.MarkEnterpriseTrialConvertedResult, error) {
 	payload := &gen.MarkEnterpriseTrialConvertedPayload{ID: organizationID, AdminSessionToken: nil}
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -32,7 +32,27 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organizationID string) (*gen.MarkEnterpriseTrialConvertedResult, error) {
 	payload := &gen.MarkEnterpriseTrialConvertedPayload{ID: organizationID, AdminSessionToken: nil}
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
-	tx, err := s.db.Begin(ctx)
+	lockConn, releaseFeatureLocks, err := s.productFeatures.AcquireFeatureCacheLocks(ctx, payload.ID, productfeatures.TrialRuntimeFeatures)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "lock enterprise runtime features").LogError(ctx, logger)
+	}
+	featureLocksReleased := false
+	releaseFeatures := func() {
+		if !featureLocksReleased {
+			releaseFeatureLocks()
+			featureLocksReleased = true
+		}
+	}
+	defer releaseFeatures()
+	refreshFeatureCache := func() {
+		for _, feature := range productfeatures.TrialRuntimeFeatures {
+			if cacheErr := s.productFeatures.UpdateFeatureCacheUnderLock(ctx, lockConn, payload.ID, feature); cacheErr != nil {
+				logger.WarnContext(ctx, "failed to refresh enterprise runtime feature cache", attr.SlogError(cacheErr), attr.SlogProductFeatureName(string(feature)))
+			}
+		}
+	}
+
+	tx, err := lockConn.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "begin enterprise trial conversion transaction").LogError(ctx, logger)
 	}
@@ -42,16 +62,23 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		_ = tx.Rollback(ctx)
+		releaseFeatures()
 		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization without enterprise trial", "organization has no enterprise trial to convert")
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "lock enterprise trial conversion lifecycle").LogError(ctx, logger)
 	}
 
-	// The lifecycle row is always first, followed by every key advisory lock in
-	// canonical order, before any organization or key row is read.
+	// Inside the feature-lock envelope, the lifecycle row is first, followed
+	// by every billing lock and then every provisioning lock in canonical key
+	// order, before any organization or key row is read.
 	for _, keyType := range openrouter.AllKeyTypes {
 		if err := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, tx, payload.ID, keyType); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter %s key for enterprise trial conversion", keyType).LogError(ctx, logger)
+		}
+	}
+	for _, keyType := range openrouter.AllKeyTypes {
+		if err := openrouter.AcquireAPIKeyProvisioningTransactionLock(ctx, tx, payload.ID, keyType); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter %s key provisioning for enterprise trial conversion", keyType).LogError(ctx, logger)
 		}
 	}
 
@@ -82,7 +109,8 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 		if err := tx.Rollback(ctx); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "close enterprise trial conversion retry transaction").LogError(ctx, logger)
 		}
-		s.updateTrialFeatureCache(ctx, payload.ID)
+		refreshFeatureCache()
+		releaseFeatures()
 		if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
 			logger.WarnContext(ctx, "failed to stop enterprise trial notifications on conversion retry", attr.SlogError(err))
 		}
@@ -158,7 +186,8 @@ func (s *Service) markEnterpriseTrialConverted(ctx context.Context, organization
 		return nil, oops.E(oops.CodeUnexpected, err, "commit enterprise trial conversion").LogError(ctx, logger)
 	}
 
-	s.updateTrialFeatureCache(ctx, payload.ID)
+	refreshFeatureCache()
+	releaseFeatures()
 	if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
 		logger.WarnContext(ctx, "failed to stop enterprise trial notifications after conversion", attr.SlogError(err))
 	}

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -3,21 +3,25 @@ package admin
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	"github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
-// MarkEnterpriseTrialConverted owns the eligibility and idempotency boundary
-// for manual enterprise conversion. The business transition intentionally stays
-// disabled until its lifecycle, organization, key, audit, and outbox writes can
-// commit atomically.
+// MarkEnterpriseTrialConverted atomically records an enterprise contract and
+// its complete local access policy before reconciling provider state.
 func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.AdminOrganization, error) {
 	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
 	tx, err := s.db.Begin(ctx)
@@ -40,6 +44,14 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		return nil, oops.E(oops.CodeConflict, nil, "organization has no enterprise trial to convert")
 	}
 
+	// The lifecycle row is always first, followed by every key advisory lock in
+	// canonical order, before any organization or key row is read.
+	for _, keyType := range openrouter.AllKeyTypes {
+		if err := openrouter.AcquireAPIKeyBillingTransactionLock(ctx, tx, payload.ID, keyType); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "lock openrouter %s key for enterprise trial conversion", keyType).LogError(ctx, logger)
+		}
+	}
+
 	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "read organization for enterprise trial conversion").LogError(ctx, logger)
@@ -54,16 +66,110 @@ func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen
 		if err := tx.Rollback(ctx); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "close enterprise trial conversion retry transaction").LogError(ctx, logger)
 		}
-		return adminOrganizationFromGetRow(organization), nil
+		s.updateTrialFeatureCache(ctx, payload.ID)
+		if err := s.reconcileConvertedTrialKeys(ctx, payload.ID); err != nil {
+			return nil, err
+		}
+		return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion retry")
 	}
 
-	demotedAccess := trial.DemotedAt.Valid && organization.AccountType == "free" && !organization.Whitelisted
-	runningAccess := !trial.DemotedAt.Valid && organization.AccountType == "enterprise" && organization.Whitelisted
+	demotedAccess := organization.AccountType == "free" && !organization.Whitelisted
+	runningAccess := organization.AccountType == "enterprise" && organization.Whitelisted
 	if !demotedAccess && !runningAccess {
 		_ = tx.Rollback(ctx)
 		return nil, oops.E(oops.CodeConflict, nil, "enterprise trial has incompatible organization access")
 	}
 
-	_ = tx.Rollback(ctx)
-	return nil, oops.E(oops.CodeUnexpected, nil, "enterprise trial conversion business transition is not implemented")
+	enterpriseFloor, ok := openrouter.DefaultCreditLimit(payload.ID, billing.TierEnterprise, false)
+	if !ok || enterpriseFloor <= 0 {
+		return nil, oops.E(oops.CodeUnexpected, nil, "enterprise tier has no OpenRouter credit policy").LogError(ctx, logger)
+	}
+
+	keyChanges := make([]openrouter.EnterpriseTrialConversionKeyChange, 0, len(openrouter.AllKeyTypes))
+	for _, keyType := range openrouter.AllKeyTypes {
+		change, prepareErr := s.openRouter.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, payload.ID, keyType, int64(enterpriseFloor))
+		switch {
+		case errors.Is(prepareErr, ErrOpenRouterUnavailable):
+			return nil, oops.E(oops.CodeInvalid, prepareErr, "this server cannot update model provider key lifecycle state")
+		case prepareErr != nil:
+			return nil, oops.E(oops.CodeUnexpected, prepareErr, "prepare openrouter %s key for enterprise trial conversion", keyType).LogError(ctx, logger)
+		}
+		if change.Exists {
+			keyChanges = append(keyChanges, change)
+		}
+	}
+
+	rows, err := trialsRepo.New(tx).MarkTrialConverted(ctx, payload.ID)
+	if err != nil || rows != 1 {
+		return nil, oops.E(oops.CodeUnexpected, err, "mark enterprise trial converted").LogError(ctx, logger)
+	}
+	restored, err := trialsRepo.New(tx).RestoreOrganizationFromTrial(ctx, trialsRepo.RestoreOrganizationFromTrialParams{OrganizationID: payload.ID, AccountType: "enterprise"})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "restore organization after enterprise trial conversion").LogError(ctx, logger)
+	}
+	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, payload.ID, true); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "restore enterprise runtime features").LogError(ctx, logger)
+	}
+	convertedTrial, err := trialsRepo.New(tx).GetTrial(ctx, payload.ID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "read converted enterprise trial").LogError(ctx, logger)
+	}
+
+	beforeKeys := make([]audit.OrganizationEnterpriseTrialConversionKeySnapshot, 0, len(keyChanges))
+	afterKeys := make([]audit.OrganizationEnterpriseTrialConversionKeySnapshot, 0, len(keyChanges))
+	for _, change := range keyChanges {
+		beforeKeys = append(beforeKeys, conversionKeyAuditSnapshot(change.Before))
+		afterKeys = append(afterKeys, conversionKeyAuditSnapshot(change.After))
+	}
+	before := audit.OrganizationEnterpriseTrialConversionSnapshot{
+		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: organization.AccountType, Whitelisted: organization.Whitelisted, Disabled: organization.DisabledAt.Valid},
+		Trial:        conversionTrialAuditSnapshot(trial.Tier, trial.EndsAt, trial.ConvertedAt, trial.DemotedAt), Keys: beforeKeys,
+	}
+	after := audit.OrganizationEnterpriseTrialConversionSnapshot{
+		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: "enterprise", Whitelisted: true, Disabled: organization.DisabledAt.Valid},
+		Trial:        conversionTrialAuditSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt), Keys: afterKeys,
+	}
+	actor, actorDisplayName, _ := adminActor(ctx)
+	if err := s.audit.LogOrganizationEnterpriseTrialConverted(ctx, tx, audit.LogOrganizationEnterpriseTrialConvertedEvent{
+		OrganizationID: payload.ID, Actor: actor, ActorDisplayName: actorDisplayName, ActorSlug: nil, OrganizationName: restored.Name, OrganizationSlug: restored.Slug, Before: before, After: after,
+	}); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "log enterprise trial conversion").LogError(ctx, logger)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit enterprise trial conversion").LogError(ctx, logger)
+	}
+
+	s.updateTrialFeatureCache(ctx, payload.ID)
+	if err := s.trial.TrialInactive(ctx, payload.ID); err != nil {
+		logger.WarnContext(ctx, "failed to stop enterprise trial notifications after conversion", attr.SlogError(err))
+	}
+	if err := s.reconcileConvertedTrialKeys(ctx, payload.ID); err != nil {
+		return nil, err
+	}
+	return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion")
+}
+
+func (s *Service) reconcileConvertedTrialKeys(ctx context.Context, organizationID string) error {
+	for _, keyType := range openrouter.AllKeyTypes {
+		if err := s.openRouter.ReconcileAPIKeyDisabled(ctx, organizationID, keyType); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "reconcile openrouter %s key after enterprise trial conversion", keyType).LogError(ctx, s.logger)
+		}
+	}
+	return nil
+}
+
+func conversionTrialAuditSnapshot(tier string, endsAt, convertedAt, demotedAt pgtype.Timestamptz) audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot {
+	return audit.OrganizationEnterpriseTrialConversionLifecycleSnapshot{Tier: tier, EndsAt: pgTimePtr(endsAt), ConvertedAt: pgTimePtr(convertedAt), DemotedAt: pgTimePtr(demotedAt)}
+}
+
+func conversionKeyAuditSnapshot(state openrouter.EnterpriseTrialConversionKeyState) audit.OrganizationEnterpriseTrialConversionKeySnapshot {
+	return audit.OrganizationEnterpriseTrialConversionKeySnapshot{KeyType: string(state.KeyType), DisableCauses: state.DisableCauses, EffectiveDisabled: openrouter.EffectiveDisabled(state.Disabled, state.DisableCauses), MonthlyCredits: state.MonthlyCredits}
+}
+
+func pgTimePtr(value pgtype.Timestamptz) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Time
+	return &result
 }

--- a/server/internal/admin/converttrial.go
+++ b/server/internal/admin/converttrial.go
@@ -1,0 +1,69 @@
+package admin
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/admin/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// MarkEnterpriseTrialConverted owns the eligibility and idempotency boundary
+// for manual enterprise conversion. The business transition intentionally stays
+// disabled until its lifecycle, organization, key, audit, and outbox writes can
+// commit atomically.
+func (s *Service) MarkEnterpriseTrialConverted(ctx context.Context, payload *gen.MarkEnterpriseTrialConvertedPayload) (*gen.AdminOrganization, error) {
+	logger := s.logger.With(attr.SlogOrganizationID(payload.ID))
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin enterprise trial conversion transaction").LogError(ctx, logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	trial, err := trialsRepo.New(tx).LockTrialLifecycleForRearm(ctx, payload.ID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		_ = tx.Rollback(ctx)
+		return nil, s.rejectTrialChange(ctx, logger, payload.ID, "look up organization without enterprise trial", "organization has no enterprise trial to convert")
+	case err != nil:
+		return nil, oops.E(oops.CodeUnexpected, err, "lock enterprise trial conversion lifecycle").LogError(ctx, logger)
+	}
+
+	if trial.Tier != "enterprise" {
+		_ = tx.Rollback(ctx)
+		return nil, oops.E(oops.CodeConflict, nil, "organization has no enterprise trial to convert")
+	}
+
+	organization, err := repo.New(tx).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "read organization for enterprise trial conversion").LogError(ctx, logger)
+	}
+
+	if trial.ConvertedAt.Valid {
+		if organization.AccountType != "enterprise" || !organization.Whitelisted {
+			_ = tx.Rollback(ctx)
+			return nil, oops.E(oops.CodeConflict, nil, "converted enterprise trial has incompatible organization access")
+		}
+
+		if err := tx.Rollback(ctx); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "close enterprise trial conversion retry transaction").LogError(ctx, logger)
+		}
+		return adminOrganizationFromGetRow(organization), nil
+	}
+
+	demotedAccess := trial.DemotedAt.Valid && organization.AccountType == "free" && !organization.Whitelisted
+	runningAccess := !trial.DemotedAt.Valid && organization.AccountType == "enterprise" && organization.Whitelisted
+	if !demotedAccess && !runningAccess {
+		_ = tx.Rollback(ctx)
+		return nil, oops.E(oops.CodeConflict, nil, "enterprise trial has incompatible organization access")
+	}
+
+	_ = tx.Rollback(ctx)
+	return nil, oops.E(oops.CodeUnexpected, nil, "enterprise trial conversion business transition is not implemented")
+}

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -32,15 +32,32 @@ func TestEnterpriseTrialConversionAuditActor_FallsBackWithoutSafeInternalID(t *t
 	require.Nil(t, display)
 }
 
-func TestEnterpriseTrialConversionAuditActor_DoesNotUseEmailAsDisplayName(t *testing.T) {
+func TestEnterpriseTrialConversionAuditActor_UsesOnlySafeHumanDisplayNames(t *testing.T) {
 	t.Parallel()
-	ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{
-		OIDCSubject: "staff-subject",
-		Email:       "staff@example.test",
-	})
-	actor, display := enterpriseTrialConversionAuditActor(ctx)
-	require.Equal(t, "staff-subject", actor.ID)
-	require.Nil(t, display)
+	tests := []struct {
+		name        string
+		authName    string
+		email       string
+		wantDisplay *string
+	}{
+		{name: "email fallback", email: "staff@example.test"},
+		{name: "email with different casing and surrounding whitespace", authName: "  Staff@Example.Test  ", email: "staff@example.test"},
+		{name: "arbitrary email-shaped name", authName: "alias@other.example", email: "staff@example.test"},
+		{name: "valid human name is normalized", authName: "  Staff Operator  ", email: "staff@example.test", wantDisplay: new("Staff Operator")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{
+				OIDCSubject: "staff-subject",
+				Name:        tt.authName,
+				Email:       tt.email,
+			})
+			actor, display := enterpriseTrialConversionAuditActor(ctx)
+			require.Equal(t, "staff-subject", actor.ID)
+			require.Equal(t, tt.wantDisplay, display)
+		})
+	}
 }
 
 func TestConversionTrialAuditSnapshot_CanonicalStatus(t *testing.T) {

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -26,14 +26,10 @@ import (
 
 func TestEnterpriseTrialConversionAuditActor_FallsBackWithoutSafeInternalID(t *testing.T) {
 	t.Parallel()
-	actor, display := enterpriseTrialConversionAuditActor(t.Context())
+	actor, display := enterpriseTrialConversionAuditActor()
 	require.Equal(t, "system", actor.ID)
 	require.Equal(t, "Platform administrator", *display)
 
-	ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{OIDCSubject: "external-subject-must-not-be-actor", Email: "external@privacy.invalid", Name: "External Name"})
-	actor, display = enterpriseTrialConversionAuditActor(ctx)
-	require.Equal(t, "system", actor.ID)
-	require.Equal(t, "Platform administrator", *display)
 }
 
 func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *testing.T) {
@@ -41,6 +37,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	ctx, svc, conn, provisioner := newRearmService(t)
 	const (
 		orgID            = "org_convert_audit"
+		sessionSentinel  = "bearer-session-token-privacy-sentinel"
 		emailSentinel    = "conversion-operator@privacy.invalid"
 		oidcSentinel     = "external-oidc-subject-privacy-sentinel"
 		workosSentinel   = "external-workos-privacy-sentinel"
@@ -48,7 +45,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 		promptSentinel   = "prompt-privacy-sentinel"
 		spendSentinel    = "spend-privacy-sentinel"
 	)
-	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: "internal-session-conversion-audit", Email: emailSentinel, OIDCSubject: oidcSentinel, Name: emailSentinel, HD: "privacy.invalid"})
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: sessionSentinel, Email: emailSentinel, OIDCSubject: oidcSentinel, Name: emailSentinel, HD: "privacy.invalid"})
 	endsAt := time.Now().UTC().Add(7 * 24 * time.Hour)
 	demotedAt := time.Now().UTC().Add(-time.Hour)
 	workosID := workosSentinel
@@ -72,7 +69,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	require.NotEmpty(t, response["converted_at"])
 	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
-	require.Equal(t, "internal-session-conversion-audit", record.ActorID)
+	require.Equal(t, "system", record.ActorID)
 	require.Equal(t, "Platform administrator", record.ActorDisplay)
 	require.Empty(t, record.ActorSlug)
 	var metadata map[string]any
@@ -140,7 +137,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	})
 	require.NoError(t, err)
 	for surface, data := range map[string][]byte{"audit row": fullAuditRow, "outbox envelope": envelope, "endpoint response": responseJSON} {
-		for _, forbidden := range []string{emailSentinel, oidcSentinel, workosSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
+		for _, forbidden := range []string{sessionSentinel, emailSentinel, oidcSentinel, workosSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
 			require.NotContains(t, string(data), forbidden, "%s leaked %s", surface, forbidden)
 		}
 	}
@@ -233,6 +230,8 @@ func TestMarkEnterpriseTrialConverted_PostCommitFailureRetryConverges(t *testing
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
 	}
 	provisioner.failOn, provisioner.failAfter, provisioner.failWith = openrouter.KeyTypeInternal, 1, errors.New("provider unavailable")
+	notifier := &fakeTrialNotifier{inactiveErr: errors.New("notification cleanup unavailable")}
+	svc.trial = notifier
 
 	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 	requireOopsCode(t, err, oops.CodeUnexpected)
@@ -241,10 +240,13 @@ func TestMarkEnterpriseTrialConverted_PostCommitFailureRetryConverges(t *testing
 	require.NoError(t, err)
 	require.EqualValues(t, 1, count)
 
+	require.Equal(t, []string{orgID}, notifier.inactive)
 	provisioner.failWith = nil
+	notifier.inactiveErr = nil
 	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 	require.NoError(t, err)
 	count, err = audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, count)
+	require.Equal(t, []string{orgID, orgID}, notifier.inactive, "valid retries must reattempt transient TrialInactive cleanup")
 }

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -1,0 +1,135 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_audit"
+	endsAt := time.Now().UTC().Add(7 * 24 * time.Hour)
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Conversion Fixture", slug: "conversion-fixture", accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: true, DisableCauses: []string{"trial_demotion", "billing_inactive", "admin_lock"}}))
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
+	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(record.Metadata, &metadata))
+	require.Equal(t, "platform_admin", metadata["conversion_source"])
+	for _, payload := range [][]byte{record.BeforeSnapshot, record.AfterSnapshot} {
+		var snapshot map[string]any
+		require.NoError(t, json.Unmarshal(payload, &snapshot))
+		require.Contains(t, snapshot, "organization")
+		require.Contains(t, snapshot, "trial")
+		require.Len(t, snapshot["keys"], len(openrouter.AllKeyTypes))
+		text := string(payload)
+		require.NotContains(t, text, "hash-")
+		require.NotContains(t, text, "sk-test")
+		require.NotContains(t, text, "cipher")
+	}
+}
+
+func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackEverything(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_audit_rollback"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 7, disabled: true})
+	beforeOrg, beforeTrial, beforeKey := readOrgState(t, ctx, conn, orgID), readTrial(t, ctx, conn, orgID), readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	require.NoError(t, audittest.RejectAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted))
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+	require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+	require.Equal(t, beforeKey, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat))
+	require.Empty(t, provisioner.reconcileAttempts)
+}
+
+func TestMarkEnterpriseTrialConverted_OutboxFailureRollsBackEverything(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_outbox_rollback"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 7, disabled: true})
+	beforeOrg, beforeTrial, beforeKey := readOrgState(t, ctx, conn, orgID), readTrial(t, ctx, conn, orgID), readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	err := testrepo.New(conn).RejectPublishOutboxWritesFixture(ctx)
+	require.NoError(t, err)
+
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+	require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+	require.Equal(t, beforeKey, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat))
+	count, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Zero(t, count)
+	require.Empty(t, provisioner.reconcileAttempts)
+}
+
+func TestMarkEnterpriseTrialConverted_UnclassifiedKeyRollsBack(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_null_key"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 7})
+	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: false, DisableCauses: nil}))
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.False(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	require.Empty(t, provisioner.reconcileAttempts)
+}
+
+func TestMarkEnterpriseTrialConverted_PostCommitFailureRetryConverges(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_convert_retry"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+	provisioner.failOn, provisioner.failAfter, provisioner.failWith = openrouter.KeyTypeInternal, 1, errors.New("provider unavailable")
+
+	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid, "provider failure occurs after commit")
+	count, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+
+	provisioner.failWith = nil
+	_, err = svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	require.NoError(t, err)
+	count, err = audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+}

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -7,47 +7,162 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
+func TestEnterpriseTrialConversionAuditActor_FallsBackWithoutSafeInternalID(t *testing.T) {
+	t.Parallel()
+	actor, display := enterpriseTrialConversionAuditActor(t.Context())
+	require.Equal(t, "system", actor.ID)
+	require.Equal(t, "Platform administrator", *display)
+
+	ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{OIDCSubject: "external-subject-must-not-be-actor", Email: "external@privacy.invalid", Name: "External Name"})
+	actor, display = enterpriseTrialConversionAuditActor(ctx)
+	require.Equal(t, "system", actor.ID)
+	require.Equal(t, "Platform administrator", *display)
+}
+
 func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *testing.T) {
 	t.Parallel()
 	ctx, svc, conn, provisioner := newRearmService(t)
-	orgID := "org_convert_audit"
+	const (
+		orgID            = "org_convert_audit"
+		emailSentinel    = "conversion-operator@privacy.invalid"
+		oidcSentinel     = "external-oidc-subject-privacy-sentinel"
+		workosSentinel   = "external-workos-privacy-sentinel"
+		providerSentinel = "provider-payload-privacy-sentinel"
+		promptSentinel   = "prompt-privacy-sentinel"
+		spendSentinel    = "spend-privacy-sentinel"
+	)
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: "internal-session-conversion-audit", Email: emailSentinel, OIDCSubject: oidcSentinel, Name: emailSentinel, HD: "privacy.invalid"})
 	endsAt := time.Now().UTC().Add(7 * 24 * time.Hour)
 	demotedAt := time.Now().UTC().Add(-time.Hour)
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: "Conversion Fixture", slug: "conversion-fixture", accountType: "free", whitelisted: false})
+	workosID := workosSentinel
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: promptSentinel, slug: spendSentinel, accountType: "free", workosID: &workosID, whitelisted: false})
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
 	for _, keyType := range openrouter.AllKeyTypes {
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
 	}
 	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: true, DisableCauses: []string{"trial_demotion", "billing_inactive", "admin_lock"}}))
+	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyProviderPayloadFixture(ctx, testrepo.SetOpenRouterAPIKeyProviderPayloadFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), ProviderPayload: conv.ToPGText(providerSentinel)}))
 
-	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 	require.NoError(t, err)
 	require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
+	responseJSON, err := json.Marshal(srv.NewMarkEnterpriseTrialConvertedResponseBody(result))
+	require.NoError(t, err)
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(responseJSON, &response))
+	require.ElementsMatch(t, []string{"organization_id", "converted_at"}, mapKeys(response))
+	require.Equal(t, orgID, response["organization_id"])
+	require.NotEmpty(t, response["converted_at"])
 	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
+	require.Equal(t, "internal-session-conversion-audit", record.ActorID)
+	require.Equal(t, "Platform administrator", record.ActorDisplay)
+	require.Empty(t, record.ActorSlug)
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(record.Metadata, &metadata))
-	require.Equal(t, "platform_admin", metadata["conversion_source"])
-	for _, payload := range [][]byte{record.BeforeSnapshot, record.AfterSnapshot} {
-		var snapshot map[string]any
-		require.NoError(t, json.Unmarshal(payload, &snapshot))
-		require.Contains(t, snapshot, "organization")
-		require.Contains(t, snapshot, "trial")
-		require.Len(t, snapshot["keys"], len(openrouter.AllKeyTypes))
-		text := string(payload)
-		require.NotContains(t, text, "hash-")
-		require.NotContains(t, text, "sk-test")
-		require.NotContains(t, text, "cipher")
+	require.Equal(t, map[string]any{"conversion_source": "platform_admin"}, metadata)
+	for _, raw := range [][]byte{record.BeforeSnapshot, record.AfterSnapshot} {
+		var snapshot struct {
+			Organization map[string]any   `json:"organization"`
+			Trial        map[string]any   `json:"trial"`
+			Keys         []map[string]any `json:"keys"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &snapshot))
+		require.ElementsMatch(t, []string{"account_type", "whitelisted", "disabled"}, mapKeys(snapshot.Organization))
+		require.ElementsMatch(t, []string{"tier", "ends_at", "converted_at", "demoted_at"}, mapKeys(snapshot.Trial))
+		require.Len(t, snapshot.Keys, len(openrouter.AllKeyTypes))
+		for _, key := range snapshot.Keys {
+			require.ElementsMatch(t, []string{"key_type", "disable_causes", "stored_disabled", "effective_disabled", "monthly_credits"}, mapKeys(key))
+		}
 	}
+
+	var before, after struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(record.BeforeSnapshot, &before))
+	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
+	chatBefore := keyAuditSnapshotByType(t, before.Keys, openrouter.KeyTypeChat)
+	chatAfter := keyAuditSnapshotByType(t, after.Keys, openrouter.KeyTypeChat)
+	internalBefore := keyAuditSnapshotByType(t, before.Keys, openrouter.KeyTypeInternal)
+	internalAfter := keyAuditSnapshotByType(t, after.Keys, openrouter.KeyTypeInternal)
+	require.Equal(t, true, chatBefore["stored_disabled"])
+	require.Equal(t, true, chatBefore["effective_disabled"])
+	require.ElementsMatch(t, []any{"trial_demotion", "billing_inactive", "admin_lock"}, chatBefore["disable_causes"])
+	require.Equal(t, true, chatAfter["stored_disabled"])
+	require.Equal(t, true, chatAfter["effective_disabled"])
+	require.Equal(t, []any{"admin_lock"}, chatAfter["disable_causes"])
+	require.Equal(t, true, internalBefore["stored_disabled"])
+	require.Equal(t, true, internalBefore["effective_disabled"])
+	require.Equal(t, false, internalAfter["stored_disabled"])
+	require.Equal(t, false, internalAfter["effective_disabled"])
+	require.Empty(t, internalAfter["disable_causes"])
+	floor, ok := openrouter.DefaultCreditLimit(orgID, "enterprise", false)
+	require.True(t, ok)
+	require.EqualValues(t, floor, chatAfter["monthly_credits"])
+	require.EqualValues(t, floor, internalAfter["monthly_credits"])
+
+	envelope, err := audittestrepo.New(conn).GetLatestOutboxPayloadByOrg(ctx, audittestrepo.GetLatestOutboxPayloadByOrgParams{OrganizationID: orgID, EventType: string(events.OrganizationEnterpriseTrialV1.EventType())})
+	require.NoError(t, err)
+	var event webhooksv1.Event
+	require.NoError(t, proto.Unmarshal(envelope, &event))
+	var payload events.AuditLogCreatedPayloadV1
+	require.NoError(t, json.Unmarshal(event.GetPayload(), &payload))
+	require.Equal(t, record.ActorID, payload.ActorID)
+	require.Equal(t, audit.SpeakeasyTeamActorLabel, payload.ActorDisplayName)
+	require.Equal(t, string(audit.ActionOrganizationEnterpriseTrialConverted), payload.Action)
+	require.NotEmpty(t, payload.BeforeSnapshot)
+	require.NotEmpty(t, payload.AfterSnapshot)
+	require.NotEmpty(t, payload.Metadata)
+
+	fullAuditRow, err := json.Marshal(map[string]any{
+		"action": record.Action, "organization_id": record.OrganizationID, "project_id": record.ProjectID,
+		"actor_id": record.ActorID, "actor_type": record.ActorType, "actor_display_name": record.ActorDisplayName, "actor_slug": record.ActorSlug,
+		"subject_id": record.SubjectID, "subject_type": record.SubjectType, "subject_display": record.SubjectDisplay, "subject_slug": record.SubjectSlug,
+		"metadata": json.RawMessage(record.Metadata), "before_snapshot": json.RawMessage(record.BeforeSnapshot), "after_snapshot": json.RawMessage(record.AfterSnapshot),
+		"acting_surface": record.ActingSurface, "acting_client_id": record.ActingClientID,
+	})
+	require.NoError(t, err)
+	for surface, data := range map[string][]byte{"audit row": fullAuditRow, "outbox envelope": envelope, "endpoint response": responseJSON} {
+		for _, forbidden := range []string{emailSentinel, oidcSentinel, workosSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
+			require.NotContains(t, string(data), forbidden, "%s leaked %s", surface, forbidden)
+		}
+	}
+}
+
+func keyAuditSnapshotByType(t *testing.T, keys []map[string]any, keyType openrouter.KeyType) map[string]any {
+	t.Helper()
+	for _, key := range keys {
+		if key["key_type"] == string(keyType) {
+			return key
+		}
+	}
+	require.FailNow(t, "missing key audit snapshot", string(keyType))
+	return nil
+}
+
+func mapKeys(value map[string]any) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func TestMarkEnterpriseTrialConverted_AuditFailureRollsBackEverything(t *testing.T) {

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -26,10 +27,48 @@ import (
 
 func TestEnterpriseTrialConversionAuditActor_FallsBackWithoutSafeInternalID(t *testing.T) {
 	t.Parallel()
-	actor, display := enterpriseTrialConversionAuditActor()
+	actor, display := enterpriseTrialConversionAuditActor(t.Context())
 	require.Equal(t, "system", actor.ID)
-	require.Equal(t, "Platform administrator", *display)
+	require.Nil(t, display)
+}
 
+func TestEnterpriseTrialConversionAuditActor_DoesNotUseEmailAsDisplayName(t *testing.T) {
+	t.Parallel()
+	ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{
+		OIDCSubject: "staff-subject",
+		Email:       "staff@example.test",
+	})
+	actor, display := enterpriseTrialConversionAuditActor(ctx)
+	require.Equal(t, "staff-subject", actor.ID)
+	require.Nil(t, display)
+}
+
+func TestConversionTrialAuditSnapshot_CanonicalStatus(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	valid := func(value time.Time) pgtype.Timestamptz {
+		return pgtype.Timestamptz{Time: value, Valid: true}
+	}
+	tests := []struct {
+		name        string
+		endsAt      time.Time
+		convertedAt pgtype.Timestamptz
+		demotedAt   pgtype.Timestamptz
+		want        string
+	}{
+		{name: "running", endsAt: now.Add(8 * 24 * time.Hour), want: "running"},
+		{name: "ending soon", endsAt: now.Add(24 * time.Hour), want: "ending_soon"},
+		{name: "expired undemoted", endsAt: now.Add(-time.Hour), want: "expired"},
+		{name: "demoted takes precedence over dates", endsAt: now.Add(-time.Hour), demotedAt: valid(now.Add(-2 * time.Hour)), want: "demoted"},
+		{name: "converted takes precedence over demotion", endsAt: now.Add(-time.Hour), convertedAt: valid(now), demotedAt: valid(now.Add(-2 * time.Hour)), want: "converted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			snapshot := conversionTrialAuditSnapshot("enterprise", valid(tt.endsAt), tt.convertedAt, tt.demotedAt, now)
+			require.Equal(t, tt.want, snapshot.Status)
+		})
+	}
 }
 
 func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *testing.T) {
@@ -39,6 +78,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 		orgID            = "org_convert_audit"
 		sessionSentinel  = "bearer-session-token-privacy-sentinel"
 		emailSentinel    = "conversion-operator@privacy.invalid"
+		operatorName     = "Conversion Operator"
 		oidcSentinel     = "external-oidc-subject-privacy-sentinel"
 		workosSentinel   = "external-workos-privacy-sentinel"
 		nameSentinel     = "organization-name-privacy-sentinel"
@@ -47,7 +87,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 		promptSentinel   = "prompt-privacy-sentinel"
 		spendSentinel    = "313131.313131"
 	)
-	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: sessionSentinel, Email: emailSentinel, OIDCSubject: oidcSentinel, Name: emailSentinel, HD: "privacy.invalid"})
+	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: sessionSentinel, Email: emailSentinel, OIDCSubject: oidcSentinel, Name: operatorName, HD: "privacy.invalid"})
 	endsAt := time.Now().UTC().Add(7 * 24 * time.Hour)
 	demotedAt := time.Now().UTC().Add(-time.Hour)
 	workosID := workosSentinel
@@ -76,12 +116,12 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	require.NotEmpty(t, response["converted_at"])
 	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
-	require.Equal(t, "system", record.ActorID)
-	require.Equal(t, "Platform administrator", record.ActorDisplay)
+	require.Equal(t, oidcSentinel, record.ActorID)
+	require.Equal(t, operatorName, record.ActorDisplay)
 	require.Empty(t, record.ActorSlug)
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(record.Metadata, &metadata))
-	require.Equal(t, map[string]any{"conversion_source": "platform_admin"}, metadata)
+	require.Equal(t, map[string]any{"conversion_source": "admin"}, metadata)
 	for _, raw := range [][]byte{record.BeforeSnapshot, record.AfterSnapshot} {
 		var snapshot struct {
 			Organization map[string]any   `json:"organization"`
@@ -90,33 +130,38 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 		}
 		require.NoError(t, json.Unmarshal(raw, &snapshot))
 		require.ElementsMatch(t, []string{"account_type", "whitelisted", "disabled"}, mapKeys(snapshot.Organization))
-		require.ElementsMatch(t, []string{"tier", "ends_at", "converted_at", "demoted_at"}, mapKeys(snapshot.Trial))
+		require.ElementsMatch(t, []string{"status", "tier", "ends_at", "converted_at", "demoted_at"}, mapKeys(snapshot.Trial))
 		require.Len(t, snapshot.Keys, len(openrouter.AllKeyTypes))
 		for _, key := range snapshot.Keys {
-			require.ElementsMatch(t, []string{"key_type", "disable_causes", "stored_disabled", "effective_disabled", "monthly_credits"}, mapKeys(key))
+			require.ElementsMatch(t, []string{"key_type", "stored_disabled", "effective_disabled", "key_access_changed", "monthly_credits"}, mapKeys(key))
+			require.NotContains(t, key, "disable_causes")
 		}
 	}
 
 	var before, after struct {
-		Keys []map[string]any `json:"keys"`
+		Trial map[string]any   `json:"trial"`
+		Keys  []map[string]any `json:"keys"`
 	}
 	require.NoError(t, json.Unmarshal(record.BeforeSnapshot, &before))
 	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
+	require.Equal(t, "demoted", before.Trial["status"])
+	require.Equal(t, "converted", after.Trial["status"])
 	chatBefore := keyAuditSnapshotByType(t, before.Keys, openrouter.KeyTypeChat)
 	chatAfter := keyAuditSnapshotByType(t, after.Keys, openrouter.KeyTypeChat)
 	internalBefore := keyAuditSnapshotByType(t, before.Keys, openrouter.KeyTypeInternal)
 	internalAfter := keyAuditSnapshotByType(t, after.Keys, openrouter.KeyTypeInternal)
 	require.Equal(t, true, chatBefore["stored_disabled"])
 	require.Equal(t, true, chatBefore["effective_disabled"])
-	require.ElementsMatch(t, []any{"trial_demotion", "billing_inactive", "admin_lock"}, chatBefore["disable_causes"])
+	require.Equal(t, false, chatBefore["key_access_changed"])
 	require.Equal(t, true, chatAfter["stored_disabled"])
 	require.Equal(t, true, chatAfter["effective_disabled"])
-	require.Equal(t, []any{"admin_lock"}, chatAfter["disable_causes"])
+	require.Equal(t, false, chatAfter["key_access_changed"])
 	require.Equal(t, true, internalBefore["stored_disabled"])
 	require.Equal(t, true, internalBefore["effective_disabled"])
+	require.Equal(t, true, internalBefore["key_access_changed"])
 	require.Equal(t, false, internalAfter["stored_disabled"])
 	require.Equal(t, false, internalAfter["effective_disabled"])
-	require.Empty(t, internalAfter["disable_causes"])
+	require.Equal(t, true, internalAfter["key_access_changed"])
 	floor, ok := openrouter.DefaultCreditLimit(orgID, "enterprise", false)
 	require.True(t, ok)
 	require.EqualValues(t, floor, chatAfter["monthly_credits"])
@@ -144,7 +189,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	})
 	require.NoError(t, err)
 	for surface, data := range map[string][]byte{"audit row": fullAuditRow, "outbox envelope": envelope, "endpoint response": responseJSON} {
-		for _, forbidden := range []string{sessionSentinel, emailSentinel, oidcSentinel, workosSentinel, nameSentinel, slugSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
+		for _, forbidden := range []string{sessionSentinel, emailSentinel, workosSentinel, nameSentinel, slugSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
 			require.NotContains(t, string(data), forbidden, "%s leaked %s", surface, forbidden)
 		}
 	}

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -65,7 +65,8 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	payloadSessionToken := sessionSentinel
 	result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID, AdminSessionToken: &payloadSessionToken})
 	require.NoError(t, err)
-	require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
+	require.Empty(t, provisioner.reconcileAttempts, "conversion must not use disabled-only reconciliation")
+	require.Equal(t, openrouter.AllKeyTypes, provisioner.conversionPolicyAttempts)
 	responseJSON, err := json.Marshal(srv.NewMarkEnterpriseTrialConvertedResponseBody(result))
 	require.NoError(t, err)
 	var response map[string]any
@@ -255,4 +256,6 @@ func TestMarkEnterpriseTrialConverted_PostCommitFailureRetryConverges(t *testing
 	require.NoError(t, err)
 	require.EqualValues(t, 1, count)
 	require.Equal(t, []string{orgID, orgID}, notifier.inactive, "valid retries must reattempt transient TrialInactive cleanup")
+	require.Empty(t, provisioner.reconcileAttempts, "conversion must not use disabled-only reconciliation")
+	require.Equal(t, append(append([]openrouter.KeyType{}, openrouter.AllKeyTypes...), openrouter.AllKeyTypes...), provisioner.conversionPolicyAttempts, "valid retry must repeat complete conversion-policy reconciliation")
 }

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -41,15 +41,20 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 		emailSentinel    = "conversion-operator@privacy.invalid"
 		oidcSentinel     = "external-oidc-subject-privacy-sentinel"
 		workosSentinel   = "external-workos-privacy-sentinel"
+		nameSentinel     = "organization-name-privacy-sentinel"
+		slugSentinel     = "organization-slug-privacy-sentinel"
 		providerSentinel = "provider-payload-privacy-sentinel"
 		promptSentinel   = "prompt-privacy-sentinel"
-		spendSentinel    = "spend-privacy-sentinel"
+		spendSentinel    = "313131.313131"
 	)
 	ctx = contextvalues.SetAdminAuthContext(ctx, &contextvalues.AdminAuthContext{SessionID: sessionSentinel, Email: emailSentinel, OIDCSubject: oidcSentinel, Name: emailSentinel, HD: "privacy.invalid"})
 	endsAt := time.Now().UTC().Add(7 * 24 * time.Hour)
 	demotedAt := time.Now().UTC().Add(-time.Hour)
 	workosID := workosSentinel
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: promptSentinel, slug: spendSentinel, accountType: "free", workosID: &workosID, whitelisted: false})
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: nameSentinel, slug: slugSentinel, accountType: "free", workosID: &workosID, whitelisted: false})
+	projectID := seedProject(t, ctx, conn, orgID, "conversion-privacy")
+	require.NoError(t, testrepo.New(conn).SeedPromptTemplatePrivacyFixture(ctx, testrepo.SeedPromptTemplatePrivacyFixtureParams{ProjectID: projectID, Prompt: promptSentinel}))
+	require.NoError(t, testrepo.New(conn).SeedOpenRouterSpendPrivacyFixture(ctx, testrepo.SeedOpenRouterSpendPrivacyFixtureParams{OrganizationID: orgID, SpendUsd: spendSentinel}))
 	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: endsAt, demotedAt: &demotedAt})
 	for _, keyType := range openrouter.AllKeyTypes {
 		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
@@ -57,7 +62,8 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: true, DisableCauses: []string{"trial_demotion", "billing_inactive", "admin_lock"}}))
 	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyProviderPayloadFixture(ctx, testrepo.SetOpenRouterAPIKeyProviderPayloadFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), ProviderPayload: conv.ToPGText(providerSentinel)}))
 
-	result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+	payloadSessionToken := sessionSentinel
+	result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID, AdminSessionToken: &payloadSessionToken})
 	require.NoError(t, err)
 	require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
 	responseJSON, err := json.Marshal(srv.NewMarkEnterpriseTrialConvertedResponseBody(result))
@@ -137,7 +143,7 @@ func TestMarkEnterpriseTrialConverted_AuditSnapshotsAreCompleteAndPrivate(t *tes
 	})
 	require.NoError(t, err)
 	for surface, data := range map[string][]byte{"audit row": fullAuditRow, "outbox envelope": envelope, "endpoint response": responseJSON} {
-		for _, forbidden := range []string{sessionSentinel, emailSentinel, oidcSentinel, workosSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
+		for _, forbidden := range []string{sessionSentinel, emailSentinel, oidcSentinel, workosSentinel, nameSentinel, slugSentinel, providerSentinel, promptSentinel, spendSentinel, "hash-", "sk-test"} {
 			require.NotContains(t, string(data), forbidden, "%s leaked %s", surface, forbidden)
 		}
 	}

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -16,9 +16,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
@@ -168,4 +172,144 @@ func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t 
 	}
 	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
 	require.True(t, after.Organization.Whitelisted, "audit snapshot must describe conversion state under the organization lock")
+}
+
+func TestMarkEnterpriseTrialConverted_MissingKeyWaitsForProvisioningAndReReads(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_convert_missing_key_race"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeInternal, monthlyCredits: 7, disabled: true})
+
+	provisioning := testenv.BeginTx(t, ctx, conn)
+	keys := orrepo.New(provisioning)
+	require.NoError(t, keys.LockOpenRouterKeyProvisioning(ctx, orrepo.LockOpenRouterKeyProvisioningParams{
+		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat),
+	}))
+
+	converted := make(chan error, 1)
+	go func() {
+		_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- err
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelWait()
+	requireAdminCondition(t, waitCtx, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%LockOpenRouterKeyProvisioning%")
+	}, "conversion did not wait for in-flight first-time key provisioning")
+
+	ciphertext, err := testenv.NewEncryptionClient(t).Encrypt([]byte("sk-test-racing-provisioner"))
+	require.NoError(t, err)
+	_, err = keys.CreateOpenRouterAPIKey(ctx, orrepo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(openrouter.KeyTypeChat),
+		KeyEncrypted:   conv.ToPGText(ciphertext),
+		KeyHash:        "hash-racing-provisioner",
+		MonthlyCredits: 7,
+	})
+	require.NoError(t, err)
+	require.NoError(t, provisioning.Commit(ctx))
+
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion did not resume after provisioning committed")
+	}
+
+	key := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+	floor, ok := openrouter.DefaultCreditLimit(orgID, "enterprise", false)
+	require.True(t, ok)
+	require.GreaterOrEqual(t, key.MonthlyCredits, int64(floor), "conversion must re-read and promote the newly provisioned key")
+}
+
+func TestMarkEnterpriseTrialConverted_SerializesRuntimeFeatureWritesThroughCacheRefresh(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_convert_feature_race"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+
+	keyBlocker, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer keyBlocker.Release()
+	internalLock := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
+	require.NoError(t, activitiesrepo.New(keyBlocker).AcquireOpenRouterKeyBillingLock(ctx, internalLock))
+	defer func() {
+		_, _ = activitiesrepo.New(keyBlocker).ReleaseOpenRouterKeyBillingLock(context.WithoutCancel(ctx), activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalLock))
+	}()
+
+	converted := make(chan error, 1)
+	go func() {
+		_, callErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- callErr
+	}()
+	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelWait()
+	requireAdminCondition(t, waitCtx, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%AcquireOpenRouterBillingLock%")
+	}, "conversion did not reach the key lock after acquiring feature locks")
+
+	featureWriter, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer featureWriter.Release()
+	feature := productfeatures.FeatureLogs
+	written := make(chan error, 1)
+	go func() {
+		q := featurerepo.New(featureWriter)
+		params := featurerepo.AcquireFeatureCacheLockParams{OrganizationID: orgID, FeatureName: string(feature)}
+		if lockErr := q.AcquireFeatureCacheLock(ctx, params); lockErr != nil {
+			written <- lockErr
+			return
+		}
+		defer q.ReleaseFeatureCacheLock(context.WithoutCancel(ctx), featurerepo.ReleaseFeatureCacheLockParams(params)) //nolint:errcheck
+		tx, txErr := featureWriter.Begin(ctx)
+		if txErr == nil {
+			_, txErr = featurerepo.New(tx).DeleteFeature(ctx, featurerepo.DeleteFeatureParams{OrganizationID: orgID, FeatureName: string(feature)})
+		}
+		if txErr == nil {
+			txErr = tx.Commit(ctx)
+		} else if tx != nil {
+			_ = tx.Rollback(ctx)
+		}
+		if txErr == nil {
+			txErr = svc.productFeatures.UpdateFeatureCacheUnderLock(ctx, featureWriter, orgID, feature)
+		}
+		written <- txErr
+	}()
+
+	featureWait, cancelFeatureWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelFeatureWait()
+	requireAdminCondition(t, featureWait, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%AcquireFeatureCacheLock%")
+	}, "overlapping feature disable was not serialized behind conversion")
+
+	unlocked, err := activitiesrepo.New(keyBlocker).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalLock))
+	require.NoError(t, err)
+	require.True(t, unlocked)
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion did not finish")
+	}
+	select {
+	case err = <-written:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "queued feature disable did not finish")
+	}
+	enabled, err := featurerepo.New(conn).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{OrganizationID: orgID, FeatureName: string(feature)})
+	require.NoError(t, err)
+	require.False(t, enabled, "later-completed disable must not be overwritten by conversion")
+	cached, err := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+	require.NoError(t, err)
+	require.False(t, cached, "later-completed disable must own the final cache value")
 }

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -1,0 +1,117 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_convert_lock_order"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+
+	lifecycleBlocker := testenv.BeginTx(t, ctx, conn)
+	_, err := trialsRepo.New(lifecycleBlocker).LockTrialLifecycle(ctx, orgID)
+	require.NoError(t, err)
+	converted := make(chan error, 1)
+	go func() {
+		_, callErr := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- callErr
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelWait()
+	requireAdminCondition(t, waitCtx, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%SELECT tier, ends_at, converted_at, demoted_at%")
+	}, "conversion did not block on the lifecycle row")
+
+	probe, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer probe.Release()
+	for _, keyType := range openrouter.AllKeyTypes {
+		acquired, lockErr := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(ctx, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{OrganizationID: orgID, KeyType: string(keyType)})
+		require.NoError(t, lockErr)
+		require.Truef(t, acquired, "%s advisory lock was taken before lifecycle lock", keyType)
+		unlocked, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(keyType)})
+		require.NoError(t, unlockErr)
+		require.True(t, unlocked)
+	}
+
+	internalLock, err := conn.Acquire(ctx)
+	require.NoError(t, err)
+	defer internalLock.Release()
+	internalParams := activitiesrepo.AcquireOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeInternal)}
+	require.NoError(t, activitiesrepo.New(internalLock).AcquireOpenRouterKeyBillingLock(ctx, internalParams))
+	require.NoError(t, lifecycleBlocker.Commit(ctx))
+
+	chatWait, cancelChat := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelChat()
+	requireAdminCondition(t, chatWait, conn, func(check context.Context) (bool, error) {
+		acquired, lockErr := testrepo.New(probe).TryAcquireOpenRouterKeyBillingLockFixture(check, testrepo.TryAcquireOpenRouterKeyBillingLockFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+		if lockErr != nil {
+			return false, fmt.Errorf("probe chat advisory lock: %w", lockErr)
+		}
+		if !acquired {
+			return true, nil
+		}
+		_, unlockErr := activitiesrepo.New(probe).ReleaseOpenRouterKeyBillingLock(check, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+		if unlockErr != nil {
+			return false, fmt.Errorf("release chat advisory lock probe: %w", unlockErr)
+		}
+		return false, nil
+	}, "chat advisory lock was not acquired before internal")
+
+	contender := testenv.BeginTx(t, ctx, conn)
+	contenderDone := make(chan error, 1)
+	go func() {
+		_, contenderErr := trialsRepo.New(contender).LockTrialLifecycle(ctx, orgID)
+		contenderDone <- contenderErr
+	}()
+	contenderWait, cancelContender := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelContender()
+	requireAdminCondition(t, contenderWait, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%SELECT tier, ends_at, converted_at, demoted_at%")
+	}, "concurrent lifecycle contender was not blocked by conversion")
+
+	rowProbe := testenv.BeginTx(t, ctx, conn)
+	_, err = testrepo.New(rowProbe).LockOrganizationMetadataForUpdateNowaitFixture(ctx, orgID)
+	require.NoError(t, err, "organization row was read before every advisory lock")
+	causesByKey, err := testrepo.New(rowProbe).ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture(ctx, orgID)
+	require.NoError(t, err, "key rows were read before every advisory lock")
+	require.Len(t, causesByKey, len(openrouter.AllKeyTypes))
+	require.NoError(t, rowProbe.Rollback(ctx))
+
+	unlocked, err := activitiesrepo.New(internalLock).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
+	require.NoError(t, err)
+	require.True(t, unlocked)
+	select {
+	case err = <-converted:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion did not finish")
+	}
+	select {
+	case err = <-contenderDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "lifecycle contender did not resume")
+	}
+	require.NoError(t, contender.Rollback(ctx))
+}

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -2,13 +2,19 @@ package admin
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -98,9 +104,41 @@ func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t 
 	require.Len(t, causesByKey, len(openrouter.AllKeyTypes))
 	require.NoError(t, rowProbe.Rollback(ctx))
 
+	keyBlocker := testenv.BeginTx(t, ctx, conn)
+	_, err = testrepo.New(keyBlocker).LockOpenRouterAPIKeyForUpdateFixture(ctx, testrepo.LockOpenRouterAPIKeyForUpdateFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+	require.NoError(t, err)
+
 	unlocked, err := activitiesrepo.New(internalLock).ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(internalParams))
 	require.NoError(t, err)
 	require.True(t, unlocked)
+
+	orgLockWait, cancelOrgLock := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelOrgLock()
+	requireAdminCondition(t, orgLockWait, conn, func(check context.Context) (bool, error) {
+		_, lockErr := testrepo.New(probe).LockOrganizationMetadataForUpdateNowaitFixture(check, orgID)
+		if lockErr == nil {
+			return false, nil
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(lockErr, &pgErr) && pgErr.Code == pgerrcode.LockNotAvailable {
+			return true, nil
+		}
+		return false, fmt.Errorf("probe conversion organization lock: %w", lockErr)
+	}, "conversion did not lock organization row after advisory locks")
+
+	updateDone := make(chan error, 1)
+	whitelisted := false
+	go func() {
+		_, updateErr := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, Whitelisted: &whitelisted})
+		updateDone <- updateErr
+	}()
+	updateWait, cancelUpdate := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelUpdate()
+	requireAdminCondition(t, updateWait, conn, func(check context.Context) (bool, error) {
+		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%UPDATE organization_metadata%")
+	}, "concurrent organization update was not blocked by conversion snapshot lock")
+
+	require.NoError(t, keyBlocker.Rollback(ctx))
 	select {
 	case err = <-converted:
 		require.NoError(t, err)
@@ -114,4 +152,20 @@ func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t 
 		require.FailNow(t, "lifecycle contender did not resume")
 	}
 	require.NoError(t, contender.Rollback(ctx))
+	select {
+	case err = <-updateDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "concurrent organization update did not resume")
+	}
+	require.False(t, readOrgState(t, ctx, conn, orgID).Whitelisted, "queued update must apply after conversion rather than be lost")
+	record, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	var after struct {
+		Organization struct {
+			Whitelisted bool `json:"whitelisted"`
+		} `json:"organization"`
+	}
+	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
+	require.True(t, after.Organization.Whitelisted, "audit snapshot must describe conversion state under the organization lock")
 }

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -403,16 +403,10 @@ func TestMarkEnterpriseTrialConverted_SerializesRuntimeFeatureWritesThroughCache
 			written <- lockErr
 			return
 		}
-		defer q.ReleaseFeatureCacheLock(context.WithoutCancel(ctx), featurerepo.ReleaseFeatureCacheLockParams(params)) //nolint:errcheck
-		tx, txErr := featureWriter.Begin(ctx)
-		if txErr == nil {
-			_, txErr = featurerepo.New(tx).DeleteFeature(ctx, featurerepo.DeleteFeatureParams{OrganizationID: orgID, FeatureName: string(feature)})
-		}
-		if txErr == nil {
-			txErr = tx.Commit(ctx)
-		} else if tx != nil {
-			_ = tx.Rollback(ctx)
-		}
+		defer func() {
+			_, _ = q.ReleaseFeatureCacheLock(context.WithoutCancel(ctx), featurerepo.ReleaseFeatureCacheLockParams(params))
+		}()
+		_, txErr := q.DeleteFeature(ctx, featurerepo.DeleteFeatureParams{OrganizationID: orgID, FeatureName: string(feature)})
 		if txErr == nil {
 			txErr = svc.productFeatures.UpdateFeatureCacheUnderLock(ctx, featureWriter, orgID, feature)
 		}

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
@@ -25,6 +28,36 @@ import (
 	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
+
+type cancelOnRedisSetHook struct {
+	cancel func()
+	once   sync.Once
+	called chan struct{}
+}
+
+func (h *cancelOnRedisSetHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+func (h *cancelOnRedisSetHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if cmd.Name() == "set" {
+			h.once.Do(func() {
+				h.cancel()
+				close(h.called)
+			})
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (h *cancelOnRedisSetHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		return next(ctx, cmds)
+	}
+}
 
 func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t *testing.T) {
 	t.Parallel()
@@ -172,6 +205,107 @@ func TestMarkEnterpriseTrialConverted_LocksLifecycleThenAllKeysBeforeRowReads(t 
 	}
 	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
 	require.True(t, after.Organization.Whitelisted, "audit snapshot must describe conversion state under the organization lock")
+}
+
+func TestMarkEnterpriseTrialConverted_CancellationDuringPostCommitCacheRefreshDoesNotLeaveStaleCache(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_convert_cache_cancel"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		key := productfeatures.FeatureCacheKey(orgID, feature) + ":"
+		require.NoError(t, redisClient.Del(ctx, key).Err())
+	}
+	requestCtx, cancelRequest := context.WithCancel(ctx)
+	hook := &cancelOnRedisSetHook{cancel: cancelRequest, called: make(chan struct{})}
+	redisClient.AddHook(hook)
+	svc.productFeatures = productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, redisClient)
+
+	converted := make(chan error, 1)
+	go func() {
+		_, callErr := svc.MarkEnterpriseTrialConverted(requestCtx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		converted <- callErr
+	}()
+
+	select {
+	case <-hook.called:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion never attempted its post-commit cache refresh")
+	}
+	select {
+	case <-converted:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion did not return after request cancellation")
+	}
+
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		key := productfeatures.FeatureCacheKey(orgID, feature) + ":"
+		exists, existsErr := redisClient.Exists(ctx, key).Result()
+		require.NoError(t, existsErr)
+		require.Equalf(t, int64(1), exists, "%s cache entry was not safely refreshed after durable commit", feature)
+		enabled, cacheErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, cacheErr)
+		require.Truef(t, enabled, "%s cache entry did not match committed state", feature)
+	}
+}
+
+func TestMarkEnterpriseTrialConverted_RetryCancellationDuringCacheRefreshDoesNotLeaveStaleCache(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newProductionRearmService(t)
+	const orgID = "org_convert_retry_cache_cancel"
+	convertedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: convertedAt, convertedAt: &convertedAt})
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		_, err := featurerepo.New(conn).EnableFeature(ctx, featurerepo.EnableFeatureParams{OrganizationID: orgID, FeatureName: string(feature)})
+		require.NoError(t, err)
+	}
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		key := productfeatures.FeatureCacheKey(orgID, feature) + ":"
+		require.NoError(t, redisClient.Del(ctx, key).Err())
+	}
+	requestCtx, cancelRequest := context.WithCancel(ctx)
+	hook := &cancelOnRedisSetHook{cancel: cancelRequest, called: make(chan struct{})}
+	redisClient.AddHook(hook)
+	svc.productFeatures = productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, redisClient)
+
+	retried := make(chan error, 1)
+	go func() {
+		_, callErr := svc.MarkEnterpriseTrialConverted(requestCtx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+		retried <- callErr
+	}()
+
+	select {
+	case <-hook.called:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion retry never attempted its cache refresh")
+	}
+	select {
+	case <-retried:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "conversion retry did not return after request cancellation")
+	}
+
+	for _, feature := range productfeatures.TrialRuntimeFeatures {
+		key := productfeatures.FeatureCacheKey(orgID, feature) + ":"
+		exists, existsErr := redisClient.Exists(ctx, key).Result()
+		require.NoError(t, existsErr)
+		require.Equalf(t, int64(1), exists, "%s cache entry was not safely refreshed on retry", feature)
+		enabled, cacheErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
+		require.NoError(t, cacheErr)
+		require.Truef(t, enabled, "%s retry cache entry did not match durable state", feature)
+	}
 }
 
 func TestMarkEnterpriseTrialConverted_MissingKeyWaitsForProvisioningAndReReads(t *testing.T) {

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -136,6 +136,7 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	demotedAt := now.Add(-24 * time.Hour)
 	convertedAt := now.Add(-time.Hour)
+	disabledAt := now.Add(-2 * time.Hour)
 
 	tests := []struct {
 		name           string
@@ -145,6 +146,8 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 		trialTier      string
 		convertedAt    *time.Time
 		demotedAt      *time.Time
+		endsAt         time.Time
+		disabledAt     *time.Time
 		seedKey        bool
 		wantCode       oops.Code
 		wantHTTPStatus int
@@ -154,8 +157,11 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 		{name: "absent organization is private not found", wantCode: oops.CodeNotFound, wantHTTPStatus: http.StatusNotFound},
 		{name: "existing organization without trial is a conflict", seedOrg: true, accountType: "enterprise", seedKey: true, wantCode: oops.CodeConflict},
 		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", seedKey: true, wantCode: oops.CodeConflict},
-		{name: "running unconverted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", seedKey: true, wantConverted: true},
-		{name: "running undemoted trial normalizes drifted free access", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", seedKey: true, wantConverted: true},
+		{name: "running unconverted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", endsAt: now.Add(8 * 24 * time.Hour), seedKey: true, wantConverted: true},
+		{name: "ending-soon unconverted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", endsAt: now.Add(24 * time.Hour), seedKey: true, wantConverted: true},
+		{name: "expired undemoted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", endsAt: now.Add(-time.Hour), seedKey: true, wantConverted: true},
+		{name: "running undemoted trial normalizes drifted free access", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", endsAt: now.Add(8 * 24 * time.Hour), seedKey: true, wantConverted: true},
+		{name: "disabled organization converts without being enabled", seedOrg: true, accountType: "enterprise", disabledAt: &disabledAt, seedTrial: true, trialTier: "enterprise", endsAt: now.Add(8 * 24 * time.Hour), seedKey: true, wantConverted: true},
 		{name: "demoted unconverted enterprise trial converts", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantConverted: true},
 		{name: "demoted trial preserves already restored enterprise access", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantConverted: true},
 		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantValidRetry: true},
@@ -169,10 +175,14 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 			ctx, svc, conn, provisioner := newRearmService(t)
 			orgID := "org_convert_boundary_" + string(rune('a'+i))
 			if tc.seedOrg {
-				seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: tc.accountType, whitelisted: tc.accountType == "enterprise"})
+				seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: tc.accountType, whitelisted: tc.accountType == "enterprise", disabledAt: tc.disabledAt})
 			}
 			if tc.seedTrial {
-				seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tc.trialTier, endsAt: now.Add(7 * 24 * time.Hour), convertedAt: tc.convertedAt, demotedAt: tc.demotedAt})
+				endsAt := tc.endsAt
+				if endsAt.IsZero() {
+					endsAt = now.Add(7 * 24 * time.Hour)
+				}
+				seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tc.trialTier, endsAt: endsAt, convertedAt: tc.convertedAt, demotedAt: tc.demotedAt})
 			}
 			if tc.seedKey {
 				require.True(t, tc.seedOrg, "an OpenRouter key requires an organization")
@@ -217,6 +227,10 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 					org := readOrgState(t, ctx, conn, orgID)
 					require.Equal(t, "enterprise", org.GramAccountType)
 					require.True(t, org.Whitelisted)
+					if tc.disabledAt != nil {
+						require.True(t, org.DisabledAt.Valid)
+						require.True(t, tc.disabledAt.Equal(org.DisabledAt.Time))
+					}
 				} else {
 					require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
 				}

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -52,7 +52,9 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 		{name: "existing organization without trial is a conflict", seedOrg: true, accountType: "enterprise", seedKey: true, wantCode: oops.CodeConflict},
 		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", seedKey: true, wantCode: oops.CodeConflict},
 		{name: "running unconverted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", seedKey: true, wantConverted: true},
+		{name: "running undemoted trial normalizes drifted free access", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", seedKey: true, wantConverted: true},
 		{name: "demoted unconverted enterprise trial converts", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantConverted: true},
+		{name: "demoted trial preserves already restored enterprise access", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantConverted: true},
 		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantValidRetry: true},
 		{name: "converted trial with free organization is incompatible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantCode: oops.CodeConflict},
 	}
@@ -96,9 +98,8 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 			result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
 			if tc.wantValidRetry || tc.wantConverted {
 				require.NoError(t, err)
-				require.Equal(t, orgID, result.ID)
-				require.Equal(t, "enterprise", result.AccountType)
-				require.True(t, result.Whitelisted)
+				require.Equal(t, orgID, result.OrganizationID)
+				require.NotEmpty(t, result.ConvertedAt)
 			} else {
 				requireOopsCode(t, err, tc.wantCode)
 				if tc.wantHTTPStatus != 0 {

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -1,9 +1,11 @@
 package admin
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
@@ -11,6 +13,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	orrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *testing.T) {
@@ -37,16 +42,19 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 		trialTier      string
 		convertedAt    *time.Time
 		demotedAt      *time.Time
+		seedKey        bool
 		wantCode       oops.Code
+		wantHTTPStatus int
 		wantNotImpl    bool
 		wantValidRetry bool
 	}{
-		{name: "organization without trial", seedOrg: true, accountType: "enterprise", wantCode: oops.CodeConflict},
-		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", wantCode: oops.CodeConflict},
-		{name: "running unconverted enterprise trial is eligible", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", wantCode: oops.CodeUnexpected, wantNotImpl: true},
-		{name: "demoted unconverted enterprise trial is eligible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, wantCode: oops.CodeUnexpected, wantNotImpl: true},
-		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, wantValidRetry: true},
-		{name: "converted trial with free organization is incompatible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, wantCode: oops.CodeConflict},
+		{name: "absent organization is private not found", wantCode: oops.CodeNotFound, wantHTTPStatus: http.StatusNotFound},
+		{name: "existing organization without trial is a conflict", seedOrg: true, accountType: "enterprise", seedKey: true, wantCode: oops.CodeConflict},
+		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", seedKey: true, wantCode: oops.CodeConflict},
+		{name: "running unconverted enterprise trial is eligible", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", seedKey: true, wantCode: oops.CodeUnexpected, wantNotImpl: true},
+		{name: "demoted unconverted enterprise trial is eligible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantCode: oops.CodeUnexpected, wantNotImpl: true},
+		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantValidRetry: true},
+		{name: "converted trial with free organization is incompatible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantCode: oops.CodeConflict},
 	}
 
 	for i, tc := range tests {
@@ -61,15 +69,26 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 			if tc.seedTrial {
 				seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tc.trialTier, endsAt: now.Add(7 * 24 * time.Hour), convertedAt: tc.convertedAt, demotedAt: tc.demotedAt})
 			}
+			if tc.seedKey {
+				require.True(t, tc.seedOrg, "an OpenRouter key requires an organization")
+				seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 73, disabled: true})
+			}
 
 			beforeAudit, err := audittest.AuditLogCount(ctx, conn)
 			require.NoError(t, err)
 			beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
 			require.NoError(t, err)
-			beforeOrg := readOrgState(t, ctx, conn, orgID)
+			var beforeOrg any
+			if tc.seedOrg {
+				beforeOrg = readOrgState(t, ctx, conn, orgID)
+			}
 			var beforeTrial any
 			if tc.seedTrial {
 				beforeTrial = readTrial(t, ctx, conn, orgID)
+			}
+			var beforeKey any
+			if tc.seedKey {
+				beforeKey = readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
 			}
 
 			result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
@@ -78,14 +97,31 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 				require.Equal(t, orgID, result.ID)
 			} else {
 				requireOopsCode(t, err, tc.wantCode)
+				if tc.wantHTTPStatus != 0 {
+					var publicErr *oops.ShareableError
+					require.ErrorAs(t, err, &publicErr)
+					require.Equal(t, tc.wantHTTPStatus, publicErr.HTTPStatus(ctx))
+				}
 				if tc.wantNotImpl {
 					require.ErrorContains(t, err, "not implemented")
 				}
 			}
 
-			require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+			if tc.seedOrg {
+				require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+			} else {
+				_, orgErr := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: orgID})
+				requireOopsCode(t, orgErr, oops.CodeNotFound)
+				_, trialErr := trialsRepo.New(conn).GetTrial(ctx, orgID)
+				require.ErrorIs(t, trialErr, pgx.ErrNoRows)
+				_, keyErr := orrepo.New(conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat)})
+				require.ErrorIs(t, keyErr, pgx.ErrNoRows)
+			}
 			if tc.seedTrial {
 				require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+			}
+			if tc.seedKey {
+				require.Equal(t, beforeKey, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat), "complete persisted key state must remain unchanged")
 			}
 			afterAudit, err := audittest.AuditLogCount(ctx, conn)
 			require.NoError(t, err)

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -27,22 +29,60 @@ func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *t
 	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: new(string)}))
 }
 
-func TestUpdateOrganization_EnterpriseTrialDelegatesToAtomicConversion(t *testing.T) {
+func TestUpdateOrganization_RejectsEnterpriseTrialConversionAndRetryWithoutSideEffects(t *testing.T) {
 	t.Parallel()
-	ctx, svc, conn, _ := newRearmService(t)
-	orgID := "org_update_conversion_delegate"
-	demotedAt := time.Now().UTC().Add(-time.Hour)
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
-	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
-	for _, keyType := range openrouter.AllKeyTypes {
-		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	convertedAt := time.Now().UTC().Add(-time.Hour)
+	tests := []struct {
+		name        string
+		accountType string
+		whitelisted bool
+		convertedAt *time.Time
+	}{
+		{name: "unconverted eligible trial", accountType: "free", whitelisted: false},
+		{name: "compatible converted trial retry", accountType: "enterprise", whitelisted: true, convertedAt: &convertedAt},
 	}
-	enterprise, whitelisted := "enterprise", true
-	result, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &enterprise, Whitelisted: &whitelisted})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, svc, conn, provisioner := newRearmService(t)
+			orgID := "org_update_conversion_reject_" + strings.ReplaceAll(tc.name, " ", "_")
+			seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: tc.accountType, whitelisted: tc.whitelisted})
+			seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour), convertedAt: tc.convertedAt})
+			beforeOrg := readOrgState(t, ctx, conn, orgID)
+			beforeTrial := readTrial(t, ctx, conn, orgID)
+			beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+			require.NoError(t, err)
+
+			enterprise, whitelisted := "enterprise", true
+			result, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &enterprise, Whitelisted: &whitelisted})
+			require.Nil(t, result)
+			requireOopsCode(t, err, oops.CodeConflict)
+			require.ErrorContains(t, err, "MarkEnterpriseTrialConverted")
+			require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+			require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+			require.Empty(t, provisioner.reconcileAttempts)
+			auditCount, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+			require.NoError(t, err)
+			require.Zero(t, auditCount)
+			afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+			require.NoError(t, err)
+			require.Equal(t, beforeOutbox, afterOutbox)
+		})
+	}
+}
+
+func TestUpdateOrganization_AllowsUnrelatedEnterpriseTrialAdministration(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_update_trial_unrelated"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
+	pro := "pro"
+	result, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &pro})
 	require.NoError(t, err)
-	require.Equal(t, "enterprise", result.AccountType)
-	require.True(t, result.Whitelisted)
-	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	require.Equal(t, "pro", result.AccountType)
+	require.False(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+	require.Empty(t, provisioner.reconcileAttempts)
 }
 
 func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testing.T) {

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -27,6 +27,24 @@ func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *t
 	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: new(string)}))
 }
 
+func TestUpdateOrganization_EnterpriseTrialDelegatesToAtomicConversion(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, _ := newRearmService(t)
+	orgID := "org_update_conversion_delegate"
+	demotedAt := time.Now().UTC().Add(-time.Hour)
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: demotedAt, demotedAt: &demotedAt})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+	enterprise, whitelisted := "enterprise", true
+	result, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &enterprise, Whitelisted: &whitelisted})
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", result.AccountType)
+	require.True(t, result.Whitelisted)
+	require.True(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
+}
+
 func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -45,14 +45,14 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 		seedKey        bool
 		wantCode       oops.Code
 		wantHTTPStatus int
-		wantNotImpl    bool
+		wantConverted  bool
 		wantValidRetry bool
 	}{
 		{name: "absent organization is private not found", wantCode: oops.CodeNotFound, wantHTTPStatus: http.StatusNotFound},
 		{name: "existing organization without trial is a conflict", seedOrg: true, accountType: "enterprise", seedKey: true, wantCode: oops.CodeConflict},
 		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", seedKey: true, wantCode: oops.CodeConflict},
-		{name: "running unconverted enterprise trial is eligible", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", seedKey: true, wantCode: oops.CodeUnexpected, wantNotImpl: true},
-		{name: "demoted unconverted enterprise trial is eligible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantCode: oops.CodeUnexpected, wantNotImpl: true},
+		{name: "running unconverted enterprise trial converts", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", seedKey: true, wantConverted: true},
+		{name: "demoted unconverted enterprise trial converts", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, seedKey: true, wantConverted: true},
 		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantValidRetry: true},
 		{name: "converted trial with free organization is incompatible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, seedKey: true, wantCode: oops.CodeConflict},
 	}
@@ -82,19 +82,23 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 			if tc.seedOrg {
 				beforeOrg = readOrgState(t, ctx, conn, orgID)
 			}
-			var beforeTrial any
+			var beforeTrial *trialsRepo.Trial
 			if tc.seedTrial {
-				beforeTrial = readTrial(t, ctx, conn, orgID)
+				trial := readTrial(t, ctx, conn, orgID)
+				beforeTrial = &trial
 			}
-			var beforeKey any
+			var beforeKey *orrepo.OpenrouterApiKey
 			if tc.seedKey {
-				beforeKey = readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+				key := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+				beforeKey = &key
 			}
 
 			result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
-			if tc.wantValidRetry {
+			if tc.wantValidRetry || tc.wantConverted {
 				require.NoError(t, err)
 				require.Equal(t, orgID, result.ID)
+				require.Equal(t, "enterprise", result.AccountType)
+				require.True(t, result.Whitelisted)
 			} else {
 				requireOopsCode(t, err, tc.wantCode)
 				if tc.wantHTTPStatus != 0 {
@@ -102,13 +106,16 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 					require.ErrorAs(t, err, &publicErr)
 					require.Equal(t, tc.wantHTTPStatus, publicErr.HTTPStatus(ctx))
 				}
-				if tc.wantNotImpl {
-					require.ErrorContains(t, err, "not implemented")
-				}
 			}
 
 			if tc.seedOrg {
-				require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+				if tc.wantConverted {
+					org := readOrgState(t, ctx, conn, orgID)
+					require.Equal(t, "enterprise", org.GramAccountType)
+					require.True(t, org.Whitelisted)
+				} else {
+					require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+				}
 			} else {
 				_, orgErr := svc.GetOrganization(ctx, &gen.GetOrganizationPayload{IDOrSlug: orgID})
 				requireOopsCode(t, orgErr, oops.CodeNotFound)
@@ -118,18 +125,48 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 				require.ErrorIs(t, keyErr, pgx.ErrNoRows)
 			}
 			if tc.seedTrial {
-				require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+				if tc.wantConverted {
+					trial := readTrial(t, ctx, conn, orgID)
+					require.True(t, trial.ConvertedAt.Valid)
+					require.Equal(t, beforeTrial.EndsAt, trial.EndsAt)
+					require.Equal(t, beforeTrial.DemotedAt, trial.DemotedAt)
+				} else {
+					require.Equal(t, *beforeTrial, readTrial(t, ctx, conn, orgID))
+				}
 			}
 			if tc.seedKey {
-				require.Equal(t, beforeKey, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat), "complete persisted key state must remain unchanged")
+				if tc.wantConverted {
+					key := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+					floor, ok := openrouter.DefaultCreditLimit(orgID, "enterprise", false)
+					require.True(t, ok)
+					require.GreaterOrEqual(t, key.MonthlyCredits, int64(floor))
+					require.Empty(t, key.DisableCauses)
+					require.False(t, key.Disabled)
+				} else {
+					afterKey := readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat)
+					afterKey.UpdatedAt = beforeKey.UpdatedAt
+					require.Equal(t, *beforeKey, afterKey, "retry reconciliation may only refresh bookkeeping timestamps")
+				}
 			}
 			afterAudit, err := audittest.AuditLogCount(ctx, conn)
 			require.NoError(t, err)
-			require.Equal(t, beforeAudit, afterAudit)
+			if tc.wantConverted {
+				require.Equal(t, beforeAudit+1, afterAudit)
+			} else {
+				require.Equal(t, beforeAudit, afterAudit)
+			}
 			afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
 			require.NoError(t, err)
-			require.Equal(t, beforeOutbox, afterOutbox)
-			require.Empty(t, provisioner.revivals, "eligibility boundary must not perform provider HTTP")
+			if tc.wantConverted {
+				require.Equal(t, beforeOutbox+1, afterOutbox)
+			} else {
+				require.Equal(t, beforeOutbox, afterOutbox)
+			}
+			if tc.wantConverted || tc.wantValidRetry {
+				require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
+			} else {
+				require.Empty(t, provisioner.revivals, "rejected conversion must not perform provider HTTP")
+			}
 		})
 	}
 }

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -267,7 +267,8 @@ func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testi
 				require.Equal(t, beforeOutbox, afterOutbox)
 			}
 			if tc.wantConverted || tc.wantValidRetry {
-				require.Equal(t, openrouter.AllKeyTypes, provisioner.reconcileAttempts)
+				require.Empty(t, provisioner.reconcileAttempts, "conversion must not use disabled-only reconciliation")
+				require.Equal(t, openrouter.AllKeyTypes, provisioner.conversionPolicyAttempts)
 			} else {
 				require.Empty(t, provisioner.revivals, "rejected conversion must not perform provider HTTP")
 			}

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -39,7 +39,9 @@ func TestUpdateOrganization_RejectsEnterpriseTrialConversionAndRetryWithoutSideE
 		convertedAt *time.Time
 	}{
 		{name: "unconverted eligible trial", accountType: "free", whitelisted: false},
+		{name: "unconverted incompatible staged trial", accountType: "free", whitelisted: true},
 		{name: "compatible converted trial retry", accountType: "enterprise", whitelisted: true, convertedAt: &convertedAt},
+		{name: "incompatible converted trial", accountType: "free", whitelisted: false, convertedAt: &convertedAt},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -69,6 +71,49 @@ func TestUpdateOrganization_RejectsEnterpriseTrialConversionAndRetryWithoutSideE
 			require.Equal(t, beforeOutbox, afterOutbox)
 		})
 	}
+}
+
+func TestUpdateOrganization_StagedWhitelistCannotBypassDedicatedConversion(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn, provisioner := newRearmService(t)
+	orgID := "org_update_staged_bypass"
+	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "free", whitelisted: false})
+	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
+	for _, keyType := range openrouter.AllKeyTypes {
+		seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: keyType, monthlyCredits: 7, disabled: true})
+	}
+
+	whitelisted := true
+	first, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, Whitelisted: &whitelisted})
+	require.NoError(t, err)
+	require.True(t, first.Whitelisted)
+	trialBefore := readTrial(t, ctx, conn, orgID)
+	keysBefore := make(map[openrouter.KeyType]orrepo.OpenrouterApiKey, len(openrouter.AllKeyTypes))
+	for _, keyType := range openrouter.AllKeyTypes {
+		keysBefore[keyType] = readOpenRouterKey(t, ctx, conn, orgID, keyType)
+	}
+	outboxBefore, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+
+	enterprise := "enterprise"
+	second, err := svc.UpdateOrganization(ctx, &gen.UpdateOrganizationPayload{ID: orgID, AccountType: &enterprise})
+	require.Nil(t, second)
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.ErrorContains(t, err, "MarkEnterpriseTrialConverted")
+	state := readOrgState(t, ctx, conn, orgID)
+	require.Equal(t, "free", state.GramAccountType)
+	require.True(t, state.Whitelisted, "the allowed first request remains, but the enterprise account-type write must not occur")
+	require.Equal(t, trialBefore, readTrial(t, ctx, conn, orgID))
+	for _, keyType := range openrouter.AllKeyTypes {
+		require.Equal(t, keysBefore[keyType], readOpenRouterKey(t, ctx, conn, orgID, keyType))
+	}
+	require.Empty(t, provisioner.reconcileAttempts)
+	auditCount, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	require.Zero(t, auditCount)
+	outboxAfter, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+	require.NoError(t, err)
+	require.Equal(t, outboxBefore, outboxAfter)
 }
 
 func TestUpdateOrganization_AllowsUnrelatedEnterpriseTrialAdministration(t *testing.T) {

--- a/server/internal/admin/converttrial_test.go
+++ b/server/internal/admin/converttrial_test.go
@@ -1,0 +1,99 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func TestMarkEnterpriseTrialConvertedRequestBody_RequiresOrganizationIDOnly(t *testing.T) {
+	t.Parallel()
+
+	id := "org_convert_validate"
+	require.NoError(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: &id}))
+	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{}))
+	require.Error(t, srv.ValidateMarkEnterpriseTrialConvertedRequestBody(&srv.MarkEnterpriseTrialConvertedRequestBody{ID: new(string)}))
+}
+
+func TestMarkEnterpriseTrialConverted_EligibilityAndIdempotencyBoundary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	demotedAt := now.Add(-24 * time.Hour)
+	convertedAt := now.Add(-time.Hour)
+
+	tests := []struct {
+		name           string
+		seedOrg        bool
+		accountType    string
+		seedTrial      bool
+		trialTier      string
+		convertedAt    *time.Time
+		demotedAt      *time.Time
+		wantCode       oops.Code
+		wantNotImpl    bool
+		wantValidRetry bool
+	}{
+		{name: "organization without trial", seedOrg: true, accountType: "enterprise", wantCode: oops.CodeConflict},
+		{name: "stored trial tier is not enterprise", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "free", wantCode: oops.CodeConflict},
+		{name: "running unconverted enterprise trial is eligible", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", wantCode: oops.CodeUnexpected, wantNotImpl: true},
+		{name: "demoted unconverted enterprise trial is eligible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", demotedAt: &demotedAt, wantCode: oops.CodeUnexpected, wantNotImpl: true},
+		{name: "converted enterprise organization is a valid retry", seedOrg: true, accountType: "enterprise", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, wantValidRetry: true},
+		{name: "converted trial with free organization is incompatible", seedOrg: true, accountType: "free", seedTrial: true, trialTier: "enterprise", convertedAt: &convertedAt, wantCode: oops.CodeConflict},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, svc, conn, provisioner := newRearmService(t)
+			orgID := "org_convert_boundary_" + string(rune('a'+i))
+			if tc.seedOrg {
+				seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: tc.accountType, whitelisted: tc.accountType == "enterprise"})
+			}
+			if tc.seedTrial {
+				seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: tc.trialTier, endsAt: now.Add(7 * 24 * time.Hour), convertedAt: tc.convertedAt, demotedAt: tc.demotedAt})
+			}
+
+			beforeAudit, err := audittest.AuditLogCount(ctx, conn)
+			require.NoError(t, err)
+			beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+			require.NoError(t, err)
+			beforeOrg := readOrgState(t, ctx, conn, orgID)
+			var beforeTrial any
+			if tc.seedTrial {
+				beforeTrial = readTrial(t, ctx, conn, orgID)
+			}
+
+			result, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
+			if tc.wantValidRetry {
+				require.NoError(t, err)
+				require.Equal(t, orgID, result.ID)
+			} else {
+				requireOopsCode(t, err, tc.wantCode)
+				if tc.wantNotImpl {
+					require.ErrorContains(t, err, "not implemented")
+				}
+			}
+
+			require.Equal(t, beforeOrg, readOrgState(t, ctx, conn, orgID))
+			if tc.seedTrial {
+				require.Equal(t, beforeTrial, readTrial(t, ctx, conn, orgID))
+			}
+			afterAudit, err := audittest.AuditLogCount(ctx, conn)
+			require.NoError(t, err)
+			require.Equal(t, beforeAudit, afterAudit)
+			afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
+			require.NoError(t, err)
+			require.Equal(t, beforeOutbox, afterOutbox)
+			require.Empty(t, provisioner.revivals, "eligibility boundary must not perform provider HTTP")
+		})
+	}
+}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -1154,7 +1154,7 @@ func (s *Service) RearmTrial(ctx context.Context, payload *gen.RearmTrialPayload
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	trials := trialsRepo.New(tx)
-	lockedTrial, err := trials.LockTrialLifecycleForRearm(ctx, payload.ID)
+	lockedTrial, err := trials.LockTrialLifecycle(ctx, payload.ID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		_ = tx.Rollback(ctx)

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -95,6 +95,7 @@ type TrialKeyReviver interface {
 	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error)
 	PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, enterpriseFloor int64) (openrouter.EnterpriseTrialConversionKeyChange, error)
 	ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error
+	ReconcileAPIKeyConversionPolicy(ctx context.Context, orgID string, keyType openrouter.KeyType) error
 }
 
 type OpenRouterSpendCapScheduler interface {
@@ -147,6 +148,10 @@ func (TrialKeysUnavailable) PrepareEnterpriseTrialConversionKeyWithDB(context.Co
 }
 
 func (TrialKeysUnavailable) ReconcileAPIKeyDisabled(context.Context, string, openrouter.KeyType) error {
+	return ErrOpenRouterUnavailable
+}
+
+func (TrialKeysUnavailable) ReconcileAPIKeyConversionPolicy(context.Context, string, openrouter.KeyType) error {
 	return ErrOpenRouterUnavailable
 }
 

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -824,11 +824,16 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 	if payload.AccountType != nil && *payload.AccountType == "enterprise" {
 		trial, trialErr := trialsRepo.New(s.db).GetTrial(ctx, payload.ID)
 		switch {
-		case trialErr == nil && trial.Tier == "enterprise" && !trial.ConvertedAt.Valid:
-			if _, err := s.markEnterpriseTrialConverted(ctx, payload.ID); err != nil {
-				return nil, err
+		case trialErr == nil && trial.Tier == "enterprise":
+			organization, orgErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
+			if orgErr != nil {
+				return nil, oops.E(oops.CodeUnexpected, orgErr, "check organization before enterprise trial update").LogError(ctx, s.logger)
 			}
-			return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion")
+			compatibleConvertedRetry := trial.ConvertedAt.Valid && organization.AccountType == "enterprise" && organization.Whitelisted
+			eligibleUnconverted := !trial.ConvertedAt.Valid && ((organization.AccountType == "free" && !organization.Whitelisted) || (organization.AccountType == "enterprise" && organization.Whitelisted))
+			if compatibleConvertedRetry || eligibleUnconverted {
+				return nil, oops.E(oops.CodeConflict, nil, "enterprise trial conversion and retries require MarkEnterpriseTrialConverted")
+			}
 		case trialErr != nil && !errors.Is(trialErr, pgx.ErrNoRows):
 			return nil, oops.E(oops.CodeUnexpected, trialErr, "check enterprise trial before organization update").LogError(ctx, s.logger)
 		}

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -821,6 +821,19 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 		return nil, oops.E(oops.CodeInvalid, nil, "account_type must be one of %s, got %q", strings.Join(constants.AccountTypes, ", "), *payload.AccountType)
 	}
 
+	if payload.AccountType != nil && *payload.AccountType == "enterprise" {
+		trial, trialErr := trialsRepo.New(s.db).GetTrial(ctx, payload.ID)
+		switch {
+		case trialErr == nil && trial.Tier == "enterprise" && !trial.ConvertedAt.Valid:
+			if _, err := s.markEnterpriseTrialConverted(ctx, payload.ID); err != nil {
+				return nil, err
+			}
+			return s.readOrganizationAfterWrite(ctx, payload.ID, "fetch organization after enterprise trial conversion")
+		case trialErr != nil && !errors.Is(trialErr, pgx.ErrNoRows):
+			return nil, oops.E(oops.CodeUnexpected, trialErr, "check enterprise trial before organization update").LogError(ctx, s.logger)
+		}
+	}
+
 	queries := repo.New(s.db)
 	if err := queries.AdminUpdateOrganization(ctx, repo.AdminUpdateOrganizationParams{
 		ID:          payload.ID,
@@ -846,12 +859,27 @@ func (s *Service) BulkUpdateAccountType(ctx context.Context, payload *gen.BulkUp
 		return nil, oops.E(oops.CodeInvalid, nil, "account_type must be one of %s, got %q", strings.Join(constants.AccountTypes, ", "), payload.AccountType)
 	}
 
-	updated, err := repo.New(s.db).AdminBulkUpdateAccountType(ctx, repo.AdminBulkUpdateAccountTypeParams{
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "begin bulk account type update").LogError(ctx, s.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+	queries := repo.New(tx)
+	if trialID, lockErr := queries.LockUnconvertedEnterpriseTrialInOrganizations(ctx, payload.Ids); lockErr == nil {
+		return nil, oops.E(oops.CodeConflict, nil, "organization %s has an unconverted enterprise trial; use atomic enterprise conversion", trialID)
+	} else if !errors.Is(lockErr, pgx.ErrNoRows) {
+		return nil, oops.E(oops.CodeUnexpected, lockErr, "check enterprise trials before bulk account type update").LogError(ctx, s.logger)
+	}
+
+	updated, err := queries.AdminBulkUpdateAccountType(ctx, repo.AdminBulkUpdateAccountTypeParams{
 		AccountType: payload.AccountType,
 		Ids:         payload.Ids,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "bulk update account type").LogError(ctx, s.logger)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "commit bulk account type update").LogError(ctx, s.logger)
 	}
 
 	written := make(map[string]struct{}, len(updated))

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -862,10 +862,12 @@ func (s *Service) BulkUpdateAccountType(ctx context.Context, payload *gen.BulkUp
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 	queries := repo.New(tx)
-	if trialID, lockErr := queries.LockUnconvertedEnterpriseTrialInOrganizations(ctx, payload.Ids); lockErr == nil {
-		return nil, oops.E(oops.CodeConflict, nil, "organization %s has an unconverted enterprise trial; use atomic enterprise conversion", trialID)
-	} else if !errors.Is(lockErr, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, lockErr, "check enterprise trials before bulk account type update").LogError(ctx, s.logger)
+	if payload.AccountType == "enterprise" {
+		if trialID, lockErr := queries.LockEnterpriseTrialInOrganizations(ctx, payload.Ids); lockErr == nil {
+			return nil, oops.E(oops.CodeConflict, nil, "organization %s has an enterprise trial; use atomic enterprise conversion", trialID)
+		} else if !errors.Is(lockErr, pgx.ErrNoRows) {
+			return nil, oops.E(oops.CodeUnexpected, lockErr, "check enterprise trials before bulk account type update").LogError(ctx, s.logger)
+		}
 	}
 
 	updated, err := queries.AdminBulkUpdateAccountType(ctx, repo.AdminBulkUpdateAccountTypeParams{

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -93,6 +93,7 @@ type TrialKeyReviver interface {
 	ReinstateAPIKeyLimit(ctx context.Context, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
 	ReinstateAPIKeyLimitWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, limit *int) (int, error)
 	RemoveAPIKeyDisableCauseWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, cause openrouter.DisableCause, limit *int) (int, openrouter.DisableCauseChange, error)
+	PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, enterpriseFloor int64) (openrouter.EnterpriseTrialConversionKeyChange, error)
 	ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error
 }
 
@@ -139,6 +140,10 @@ func (TrialKeysUnavailable) ReinstateAPIKeyLimitWithDB(context.Context, openrout
 
 func (TrialKeysUnavailable) RemoveAPIKeyDisableCauseWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, openrouter.DisableCause, *int) (int, openrouter.DisableCauseChange, error) {
 	return 0, openrouter.DisableCauseChange{}, ErrOpenRouterUnavailable
+}
+
+func (TrialKeysUnavailable) PrepareEnterpriseTrialConversionKeyWithDB(context.Context, openrouter.DBTX, string, openrouter.KeyType, int64) (openrouter.EnterpriseTrialConversionKeyChange, error) {
+	return openrouter.EnterpriseTrialConversionKeyChange{}, ErrOpenRouterUnavailable
 }
 
 func (TrialKeysUnavailable) ReconcileAPIKeyDisabled(context.Context, string, openrouter.KeyType) error {

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -825,15 +825,7 @@ func (s *Service) UpdateOrganization(ctx context.Context, payload *gen.UpdateOrg
 		trial, trialErr := trialsRepo.New(s.db).GetTrial(ctx, payload.ID)
 		switch {
 		case trialErr == nil && trial.Tier == "enterprise":
-			organization, orgErr := repo.New(s.db).AdminGetOrganization(ctx, repo.AdminGetOrganizationParams{ID: payload.ID, AllowSlug: false})
-			if orgErr != nil {
-				return nil, oops.E(oops.CodeUnexpected, orgErr, "check organization before enterprise trial update").LogError(ctx, s.logger)
-			}
-			compatibleConvertedRetry := trial.ConvertedAt.Valid && organization.AccountType == "enterprise" && organization.Whitelisted
-			eligibleUnconverted := !trial.ConvertedAt.Valid && ((organization.AccountType == "free" && !organization.Whitelisted) || (organization.AccountType == "enterprise" && organization.Whitelisted))
-			if compatibleConvertedRetry || eligibleUnconverted {
-				return nil, oops.E(oops.CodeConflict, nil, "enterprise trial conversion and retries require MarkEnterpriseTrialConverted")
-			}
+			return nil, oops.E(oops.CodeConflict, nil, "enterprise trial conversion and retries require MarkEnterpriseTrialConverted")
 		case trialErr != nil && !errors.Is(trialErr, pgx.ErrNoRows):
 			return nil, oops.E(oops.CodeUnexpected, trialErr, "check enterprise trial before organization update").LogError(ctx, s.logger)
 		}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -116,6 +116,14 @@ WHERE id = sqlc.arg('id_or_slug')::text
 ORDER BY (id = sqlc.arg('id_or_slug')::text) DESC
 LIMIT 1;
 
+-- name: LockOrganizationMetadata :one
+-- Conversion locks this row only after lifecycle and key advisory locks, before
+-- reading eligibility or snapshot data that a concurrent admin update can change.
+SELECT id
+FROM organization_metadata
+WHERE id = @id
+FOR UPDATE;
+
 -- name: AdminListOrganizations :many
 -- Two paging modes share this query. A caller that supplies no sort key gets the
 -- cursor walk it always had: the sort ladder collapses to all-NULL and the
@@ -314,6 +322,16 @@ SET
     whitelisted = COALESCE(sqlc.narg('whitelisted')::boolean, whitelisted),
     updated_at = clock_timestamp()
 WHERE id = @id;
+
+-- name: LockUnconvertedEnterpriseTrialInOrganizations :one
+SELECT organization_id
+FROM trials
+WHERE organization_id = ANY(@ids::text[])
+  AND tier = 'enterprise'
+  AND converted_at IS NULL
+ORDER BY organization_id
+LIMIT 1
+FOR UPDATE;
 
 -- name: AdminBulkUpdateAccountType :many
 -- One statement rather than a loop, so every id is matched against one snapshot.

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -323,12 +323,11 @@ SET
     updated_at = clock_timestamp()
 WHERE id = @id;
 
--- name: LockUnconvertedEnterpriseTrialInOrganizations :one
+-- name: LockEnterpriseTrialInOrganizations :one
 SELECT organization_id
 FROM trials
 WHERE organization_id = ANY(@ids::text[])
   AND tier = 'enterprise'
-  AND converted_at IS NULL
 ORDER BY organization_id
 LIMIT 1
 FOR UPDATE;

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -55,9 +55,10 @@ type keyRevival struct {
 type rearmProvisioner struct {
 	conn *pgxpool.Pool
 
-	mu                sync.Mutex
-	revivals          []keyRevival
-	reconcileAttempts []openrouter.KeyType
+	mu                       sync.Mutex
+	revivals                 []keyRevival
+	reconcileAttempts        []openrouter.KeyType
+	conversionPolicyAttempts []openrouter.KeyType
 
 	failOn openrouter.KeyType
 	// failAfter is how a test reaches the post-commit recap.
@@ -123,6 +124,17 @@ func (p *rearmProvisioner) ReconcileAPIKeyDisabled(ctx context.Context, orgID st
 	p.mu.Lock()
 	p.reconcileAttempts = append(p.reconcileAttempts, keyType)
 	p.mu.Unlock()
+	return p.reconcileAPIKey(ctx, orgID, keyType)
+}
+
+func (p *rearmProvisioner) ReconcileAPIKeyConversionPolicy(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
+	p.mu.Lock()
+	p.conversionPolicyAttempts = append(p.conversionPolicyAttempts, keyType)
+	p.mu.Unlock()
+	return p.reconcileAPIKey(ctx, orgID, keyType)
+}
+
+func (p *rearmProvisioner) reconcileAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
 	row, err := orrepo.New(p.conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -55,8 +55,9 @@ type keyRevival struct {
 type rearmProvisioner struct {
 	conn *pgxpool.Pool
 
-	mu       sync.Mutex
-	revivals []keyRevival
+	mu                sync.Mutex
+	revivals          []keyRevival
+	reconcileAttempts []openrouter.KeyType
 
 	failOn openrouter.KeyType
 	// failAfter is how a test reaches the post-commit recap.
@@ -109,7 +110,19 @@ func (p *rearmProvisioner) RemoveAPIKeyDisableCauseWithDB(ctx context.Context, d
 	return keyLimit, change, nil
 }
 
+func (p *rearmProvisioner) PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db openrouter.DBTX, orgID string, keyType openrouter.KeyType, floor int64) (openrouter.EnterpriseTrialConversionKeyChange, error) {
+	change, err := new(openrouter.OpenRouter).PrepareEnterpriseTrialConversionKeyWithDB(ctx, db, orgID, keyType, floor)
+	if err != nil {
+		return openrouter.EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare enterprise conversion key: %w", err)
+	}
+	return change, nil
+
+}
+
 func (p *rearmProvisioner) ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
+	p.mu.Lock()
+	p.reconcileAttempts = append(p.reconcileAttempts, keyType)
+	p.mu.Unlock()
 	row, err := orrepo.New(p.conn).GetOpenRouterAPIKey(ctx, orrepo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -829,7 +829,7 @@ func TestRearmTrial_LocksLifecycleBeforeAllKeyLocksAndRows(t *testing.T) {
 	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
 
 	rowLock := testenv.BeginTx(t, ctx, conn)
-	_, err := trialsRepo.New(rowLock).LockTrialLifecycleForRearm(ctx, orgID)
+	_, err := trialsRepo.New(rowLock).LockTrialLifecycle(ctx, orgID)
 	require.NoError(t, err)
 
 	rearmed := make(chan error, 1)

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -846,3 +846,37 @@ func (q *Queries) GetProjectBySlug(ctx context.Context, slug string) (GetProject
 	err := row.Scan(&i.ID, &i.Slug)
 	return i, err
 }
+
+const lockOrganizationMetadata = `-- name: LockOrganizationMetadata :one
+SELECT id
+FROM organization_metadata
+WHERE id = $1
+FOR UPDATE
+`
+
+// Conversion locks this row only after lifecycle and key advisory locks, before
+// reading eligibility or snapshot data that a concurrent admin update can change.
+func (q *Queries) LockOrganizationMetadata(ctx context.Context, id string) (string, error) {
+	row := q.db.QueryRow(ctx, lockOrganizationMetadata, id)
+	var id_2 string
+	err := row.Scan(&id_2)
+	return id_2, err
+}
+
+const lockUnconvertedEnterpriseTrialInOrganizations = `-- name: LockUnconvertedEnterpriseTrialInOrganizations :one
+SELECT organization_id
+FROM trials
+WHERE organization_id = ANY($1::text[])
+  AND tier = 'enterprise'
+  AND converted_at IS NULL
+ORDER BY organization_id
+LIMIT 1
+FOR UPDATE
+`
+
+func (q *Queries) LockUnconvertedEnterpriseTrialInOrganizations(ctx context.Context, ids []string) (string, error) {
+	row := q.db.QueryRow(ctx, lockUnconvertedEnterpriseTrialInOrganizations, ids)
+	var organization_id string
+	err := row.Scan(&organization_id)
+	return organization_id, err
+}

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -847,6 +847,23 @@ func (q *Queries) GetProjectBySlug(ctx context.Context, slug string) (GetProject
 	return i, err
 }
 
+const lockEnterpriseTrialInOrganizations = `-- name: LockEnterpriseTrialInOrganizations :one
+SELECT organization_id
+FROM trials
+WHERE organization_id = ANY($1::text[])
+  AND tier = 'enterprise'
+ORDER BY organization_id
+LIMIT 1
+FOR UPDATE
+`
+
+func (q *Queries) LockEnterpriseTrialInOrganizations(ctx context.Context, ids []string) (string, error) {
+	row := q.db.QueryRow(ctx, lockEnterpriseTrialInOrganizations, ids)
+	var organization_id string
+	err := row.Scan(&organization_id)
+	return organization_id, err
+}
+
 const lockOrganizationMetadata = `-- name: LockOrganizationMetadata :one
 SELECT id
 FROM organization_metadata
@@ -861,22 +878,4 @@ func (q *Queries) LockOrganizationMetadata(ctx context.Context, id string) (stri
 	var id_2 string
 	err := row.Scan(&id_2)
 	return id_2, err
-}
-
-const lockUnconvertedEnterpriseTrialInOrganizations = `-- name: LockUnconvertedEnterpriseTrialInOrganizations :one
-SELECT organization_id
-FROM trials
-WHERE organization_id = ANY($1::text[])
-  AND tier = 'enterprise'
-  AND converted_at IS NULL
-ORDER BY organization_id
-LIMIT 1
-FOR UPDATE
-`
-
-func (q *Queries) LockUnconvertedEnterpriseTrialInOrganizations(ctx context.Context, ids []string) (string, error) {
-	row := q.db.QueryRow(ctx, lockUnconvertedEnterpriseTrialInOrganizations, ids)
-	var organization_id string
-	err := row.Scan(&organization_id)
-	return organization_id, err
 }

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -27,9 +27,10 @@ const (
 
 	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
 
-	ActionOrganizationEnterpriseTrialDemoted  Action = "organization:enterprise_trial_demoted"
-	ActionOrganizationEnterpriseTrialRearmed  Action = "organization:enterprise_trial_rearmed"
-	ActionOrganizationEnterpriseTrialExtended Action = "organization:enterprise_trial_extended"
+	ActionOrganizationEnterpriseTrialDemoted   Action = "organization:enterprise_trial_demoted"
+	ActionOrganizationEnterpriseTrialRearmed   Action = "organization:enterprise_trial_rearmed"
+	ActionOrganizationEnterpriseTrialExtended  Action = "organization:enterprise_trial_extended"
+	ActionOrganizationEnterpriseTrialConverted Action = "organization:enterprise_trial_converted"
 
 	ActionOrganizationPaygActivated   Action = "organization:payg_activated"
 	ActionOrganizationPaygDeactivated Action = "organization:payg_deactivated"
@@ -382,6 +383,68 @@ func (l *Logger) LogOrganizationEnterpriseTrialArmed(ctx context.Context, dbtx r
 // LogOrganizationEnterpriseTrialRearmedEvent records an operator putting a
 // demoted trial back on. AccountType carries the restored tier so a reader can
 // compare it with the demotion entry, which is the only record of the old one.
+type OrganizationEnterpriseTrialConversionOrganizationSnapshot struct {
+	AccountType string `json:"account_type"`
+	Whitelisted bool   `json:"whitelisted"`
+	Disabled    bool   `json:"disabled"`
+}
+
+type OrganizationEnterpriseTrialConversionLifecycleSnapshot struct {
+	Tier        string     `json:"tier"`
+	EndsAt      *time.Time `json:"ends_at"`
+	ConvertedAt *time.Time `json:"converted_at"`
+	DemotedAt   *time.Time `json:"demoted_at"`
+}
+
+type OrganizationEnterpriseTrialConversionKeySnapshot struct {
+	KeyType           string   `json:"key_type"`
+	DisableCauses     []string `json:"disable_causes"`
+	EffectiveDisabled bool     `json:"effective_disabled"`
+	MonthlyCredits    int64    `json:"monthly_credits"`
+}
+
+type OrganizationEnterpriseTrialConversionSnapshot struct {
+	Organization OrganizationEnterpriseTrialConversionOrganizationSnapshot `json:"organization"`
+	Trial        OrganizationEnterpriseTrialConversionLifecycleSnapshot    `json:"trial"`
+	Keys         []OrganizationEnterpriseTrialConversionKeySnapshot        `json:"keys"`
+}
+
+type LogOrganizationEnterpriseTrialConvertedEvent struct {
+	OrganizationID   string
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+	OrganizationName string
+	OrganizationSlug string
+	Before           OrganizationEnterpriseTrialConversionSnapshot
+	After            OrganizationEnterpriseTrialConversionSnapshot
+}
+
+func (l *Logger) LogOrganizationEnterpriseTrialConverted(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialConvertedEvent) error {
+	action := ActionOrganizationEnterpriseTrialConverted
+	metadata, err := marshalAuditPayload(map[string]any{"conversion_source": "platform_admin"})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+	beforeSnapshot, err := marshalAuditPayload(event.Before)
+	if err != nil {
+		return fmt.Errorf("marshal %s before snapshot: %w", action, err)
+	}
+	afterSnapshot, err := marshalAuditPayload(event.After)
+	if err != nil {
+		return fmt.Errorf("marshal %s after snapshot: %w", action, err)
+	}
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID, ProjectID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ActorID: event.Actor.ID, ActorType: string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName), ActorSlug: conv.PtrToPGTextEmpty(event.ActorSlug),
+		Action: string(action), SubjectID: event.OrganizationID, SubjectType: "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName), SubjectSlug: conv.ToPGTextEmpty(event.OrganizationSlug),
+		Metadata: metadata, BeforeSnapshot: beforeSnapshot, AfterSnapshot: afterSnapshot,
+	}
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
+}
+
 type LogOrganizationEnterpriseTrialRearmedEvent struct {
 	OrganizationID string
 

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -399,6 +399,7 @@ type OrganizationEnterpriseTrialConversionLifecycleSnapshot struct {
 type OrganizationEnterpriseTrialConversionKeySnapshot struct {
 	KeyType           string   `json:"key_type"`
 	DisableCauses     []string `json:"disable_causes"`
+	StoredDisabled    bool     `json:"stored_disabled"`
 	EffectiveDisabled bool     `json:"effective_disabled"`
 	MonthlyCredits    int64    `json:"monthly_credits"`
 }
@@ -414,8 +415,6 @@ type LogOrganizationEnterpriseTrialConvertedEvent struct {
 	Actor            urn.Principal
 	ActorDisplayName *string
 	ActorSlug        *string
-	OrganizationName string
-	OrganizationSlug string
 	Before           OrganizationEnterpriseTrialConversionSnapshot
 	After            OrganizationEnterpriseTrialConversionSnapshot
 }
@@ -439,7 +438,7 @@ func (l *Logger) LogOrganizationEnterpriseTrialConverted(ctx context.Context, db
 		ActorID: event.Actor.ID, ActorType: string(event.Actor.Type),
 		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName), ActorSlug: conv.PtrToPGTextEmpty(event.ActorSlug),
 		Action: string(action), SubjectID: event.OrganizationID, SubjectType: "organization",
-		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName), SubjectSlug: conv.ToPGTextEmpty(event.OrganizationSlug),
+		SubjectDisplayName: conv.ToPGText("Organization"), SubjectSlug: conv.ToPGTextEmpty(""),
 		Metadata: metadata, BeforeSnapshot: beforeSnapshot, AfterSnapshot: afterSnapshot,
 	}
 	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -390,6 +390,7 @@ type OrganizationEnterpriseTrialConversionOrganizationSnapshot struct {
 }
 
 type OrganizationEnterpriseTrialConversionLifecycleSnapshot struct {
+	Status      string     `json:"status"`
 	Tier        string     `json:"tier"`
 	EndsAt      *time.Time `json:"ends_at"`
 	ConvertedAt *time.Time `json:"converted_at"`
@@ -397,11 +398,11 @@ type OrganizationEnterpriseTrialConversionLifecycleSnapshot struct {
 }
 
 type OrganizationEnterpriseTrialConversionKeySnapshot struct {
-	KeyType           string   `json:"key_type"`
-	DisableCauses     []string `json:"disable_causes"`
-	StoredDisabled    bool     `json:"stored_disabled"`
-	EffectiveDisabled bool     `json:"effective_disabled"`
-	MonthlyCredits    int64    `json:"monthly_credits"`
+	KeyType           string `json:"key_type"`
+	StoredDisabled    bool   `json:"stored_disabled"`
+	EffectiveDisabled bool   `json:"effective_disabled"`
+	KeyAccessChanged  bool   `json:"key_access_changed"`
+	MonthlyCredits    int64  `json:"monthly_credits"`
 }
 
 type OrganizationEnterpriseTrialConversionSnapshot struct {
@@ -421,7 +422,7 @@ type LogOrganizationEnterpriseTrialConvertedEvent struct {
 
 func (l *Logger) LogOrganizationEnterpriseTrialConverted(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialConvertedEvent) error {
 	action := ActionOrganizationEnterpriseTrialConverted
-	metadata, err := marshalAuditPayload(map[string]any{"conversion_source": "platform_admin"})
+	metadata, err := marshalAuditPayload(map[string]any{"conversion_source": "admin"})
 	if err != nil {
 		return fmt.Errorf("marshal %s metadata: %w", action, err)
 	}

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -86,7 +86,7 @@ func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTria
 			d.logger.InfoContext(ctx, "expired trial changed before demotion", attr.SlogOrganizationID(args.OrganizationID))
 			return nil
 		}
-		if _, lockErr := tx.LockTrialLifecycleForRearm(ctx, args.OrganizationID); lockErr != nil {
+		if _, lockErr := tx.LockTrialLifecycle(ctx, args.OrganizationID); lockErr != nil {
 			return fmt.Errorf("lock no-op trial demotion lifecycle: %w", lockErr)
 		}
 		for _, keyType := range openrouter.AllKeyTypes {

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -521,7 +521,7 @@ func TestDemoteExpiredTrials_LocksLifecycleBeforeAllKeysAndRows(t *testing.T) {
 	}
 
 	rowLock := testenv.BeginTx(t, ctx, ti.conn)
-	_, err := trialsrepo.New(rowLock).LockTrialLifecycleForRearm(ctx, orgID)
+	_, err := trialsrepo.New(rowLock).LockTrialLifecycle(ctx, orgID)
 	require.NoError(t, err)
 
 	demoted := make(chan error, 1)

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -50,7 +50,7 @@ var (
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
 	OrganizationBillingV1                  = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_billing_event_v1", "Emitted when the organization's billing state changes")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
-	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed")
+	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed, extended, demoted, re-armed, or converted")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -2036,7 +2036,7 @@ webhooks:
                 required: true
     audit_log.organization_enterprise_trial_event_v1:
         post:
-            description: Emitted when the organization's enterprise trial is armed, extended, demoted, or re-armed
+            description: Emitted when the organization's enterprise trial is armed, extended, demoted, re-armed, or converted
             operationId: audit_log.organization_enterprise_trial_event_v1
             requestBody:
                 content:

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -180,19 +180,25 @@ func (c *Client) SetRemoteSessionAutoRefreshEnabled(ctx context.Context, organiz
 // the feature flag from a code path that bypasses this client.
 func (c *Client) UpdateFeatureCache(ctx context.Context, organizationID string, feature Feature, _ bool) {
 	if err := c.withFeatureCacheLock(ctx, organizationID, feature, func(conn *pgxpool.Conn) error {
-		enabled, err := repo.New(conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
-			OrganizationID: organizationID, FeatureName: string(feature),
-		})
-		if err != nil {
-			return fmt.Errorf("reload feature cache state: %w", err)
-		}
-		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
-		return nil
+		return c.UpdateFeatureCacheUnderLock(ctx, conn, organizationID, feature)
 	}); err != nil {
 		c.logger.WarnContext(ctx, "failed to refresh feature flag cache",
 			attr.SlogError(err), attr.SlogOrganizationID(organizationID), attr.SlogProductFeatureName(string(feature)),
 		)
 	}
+}
+
+// UpdateFeatureCacheUnderLock refreshes one cache entry using the connection
+// that holds its feature lock. Callers must already hold that lock.
+func (c *Client) UpdateFeatureCacheUnderLock(ctx context.Context, conn *pgxpool.Conn, organizationID string, feature Feature) error {
+	enabled, err := repo.New(conn).IsFeatureEnabled(ctx, repo.IsFeatureEnabledParams{
+		OrganizationID: organizationID, FeatureName: string(feature),
+	})
+	if err != nil {
+		return fmt.Errorf("reload feature cache state: %w", err)
+	}
+	c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+	return nil
 }
 
 func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool, message string) {
@@ -236,6 +242,13 @@ func (c *Client) withFeatureCacheLocks(ctx context.Context, organizationID strin
 	}
 	defer release()
 	return fn(conn)
+}
+
+// AcquireFeatureCacheLocks acquires the same canonical, sorted advisory locks
+// used by feature mutations. The caller must begin its transaction on the
+// returned connection and hold the locks through commit and cache refresh.
+func (c *Client) AcquireFeatureCacheLocks(ctx context.Context, organizationID string, features []Feature) (*pgxpool.Conn, func(), error) {
+	return c.acquireFeatureCacheLocks(ctx, organizationID, features)
 }
 
 func (c *Client) acquireFeatureCacheLocks(ctx context.Context, organizationID string, features []Feature) (*pgxpool.Conn, func(), error) {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -197,11 +197,13 @@ func (c *Client) UpdateFeatureCacheUnderLock(ctx context.Context, conn *pgxpool.
 	if err != nil {
 		return fmt.Errorf("reload feature cache state: %w", err)
 	}
-	c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+	if err := c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache"); err != nil {
+		return fmt.Errorf("store feature cache state: %w", err)
+	}
 	return nil
 }
 
-func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool, message string) {
+func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, feature Feature, enabled bool, message string) error {
 	cacheEntry := FeatureCache{
 		OrganizationID: organizationID,
 		Feature:        feature,
@@ -213,7 +215,9 @@ func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, f
 			attr.SlogOrganizationID(organizationID),
 			attr.SlogProductFeatureName(string(feature)),
 		)
+		return err
 	}
+	return nil
 }
 
 func setFeatureEnabled(ctx context.Context, queries *repo.Queries, organizationID string, feature Feature, enabled bool) error {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -79,7 +79,7 @@ func (c *Client) IsFeatureEnabled(ctx context.Context, organizationID string, fe
 		}
 
 		enabled = res
-		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to cache feature flag state")
+		_ = c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to cache feature flag state")
 		return nil
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func (c *Client) SetFeatureEnabled(ctx context.Context, organizationID string, f
 		if err := setFeatureEnabled(ctx, repo.New(conn), organizationID, feature, enabled); err != nil {
 			return err
 		}
-		c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
+		_ = c.storeFeatureCache(ctx, organizationID, feature, enabled, "failed to update feature flag cache")
 		return nil
 	})
 }
@@ -169,8 +169,8 @@ func (c *Client) SetRemoteSessionAutoRefreshEnabled(ctx context.Context, organiz
 			return fmt.Errorf("commit remote session auto-refresh update: %w", err)
 		}
 
-		c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefreshEnforced, false, "failed to update feature flag cache")
-		c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefresh, enabled, "failed to update feature flag cache")
+		_ = c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefreshEnforced, false, "failed to update feature flag cache")
+		_ = c.storeFeatureCache(ctx, organizationID, FeatureRemoteSessionAutoRefresh, enabled, "failed to update feature flag cache")
 		return nil
 	})
 }
@@ -215,7 +215,7 @@ func (c *Client) storeFeatureCache(ctx context.Context, organizationID string, f
 			attr.SlogOrganizationID(organizationID),
 			attr.SlogProductFeatureName(string(feature)),
 		)
-		return err
+		return fmt.Errorf("store feature cache entry: %w", err)
 	}
 	return nil
 }

--- a/server/internal/productfeatures/client_cache_test.go
+++ b/server/internal/productfeatures/client_cache_test.go
@@ -1,0 +1,55 @@
+package productfeatures_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type failRedisSetHook struct{}
+
+func (failRedisSetHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+func (failRedisSetHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if cmd.Name() == "set" {
+			return errors.New("injected redis set failure")
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (failRedisSetHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		return next(ctx, cmds)
+	}
+}
+
+func TestUpdateFeatureCacheUnderLockReturnsStoreFailure(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "featurecachefailure")
+	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	redisClient.AddHook(failRedisSetHook{})
+	client := productfeatures.NewClient(testenv.NewLogger(t), testenv.NewTracerProvider(t), conn, redisClient)
+
+	lockConn, release, err := client.AcquireFeatureCacheLocks(ctx, "org_cache_store_failure", []productfeatures.Feature{productfeatures.FeatureLogs})
+	require.NoError(t, err)
+	defer release()
+
+	err = client.UpdateFeatureCacheUnderLock(ctx, lockConn, "org_cache_store_failure", productfeatures.FeatureLogs)
+	require.ErrorContains(t, err, "store feature cache state")
+}

--- a/server/internal/productfeatures/impl.go
+++ b/server/internal/productfeatures/impl.go
@@ -192,7 +192,7 @@ func (s *Service) SetProductFeature(ctx context.Context, payload *gen.SetProduct
 		return oops.E(oops.CodeUnexpected, err, "commit feature flag change").LogError(ctx, s.logger, attr.SlogOrganizationID(orgID))
 	}
 
-	s.featureClient.storeFeatureCache(ctx, orgID, Feature(payload.FeatureName), payload.Enabled, "failed to cache feature flag state")
+	_ = s.featureClient.storeFeatureCache(ctx, orgID, Feature(payload.FeatureName), payload.Enabled, "failed to cache feature flag state")
 
 	return nil
 }
@@ -270,7 +270,7 @@ func (s *Service) SetRemoteSessionAutoRefreshPolicy(ctx context.Context, payload
 		{feature: FeatureRemoteSessionAutoRefresh, enabled: visible},
 		{feature: FeatureRemoteSessionAutoRefreshEnforced, enabled: enforced},
 	} {
-		s.featureClient.storeFeatureCache(ctx, orgID, state.feature, state.enabled, "failed to cache remote session refresh policy")
+		_ = s.featureClient.storeFeatureCache(ctx, orgID, state.feature, state.enabled, "failed to cache remote session refresh policy")
 	}
 
 	return nil

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -697,6 +697,14 @@ WHERE organization_id = @organization_id
   AND key_type = @key_type
 FOR UPDATE;
 
+-- name: SeedOpenRouterSpendPrivacyFixture :exec
+INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
+VALUES (@organization_id, 'chat', CURRENT_DATE, sqlc.arg('spend_usd')::text::numeric);
+
+-- name: SeedPromptTemplatePrivacyFixture :exec
+INSERT INTO prompt_templates (tool_urn, project_id, history_id, name, prompt, kind)
+VALUES ('tools:privacy-fixture', @project_id, generate_uuidv7(), 'Privacy fixture', @prompt, 'prompt');
+
 -- name: LockOrganizationMetadataForUpdateNowaitFixture :one
 -- Test-only lock probe: fails instead of waiting if a lifecycle handler read the organization row too early.
 SELECT id

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -602,6 +602,13 @@ SET key_hash = @key_hash
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 
+-- name: SetOpenRouterAPIKeyProviderPayloadFixture :exec
+-- Test-only privacy sentinel in the deprecated plaintext provider payload column.
+UPDATE openrouter_api_keys
+SET key = @provider_payload
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
 -- name: GetOpenRouterAPIKeyStateFixture :one
 -- Test-only fixture: observes guarded-mutation state, including soft-deleted rows.
 SELECT key_hash, monthly_credits, disabled, disable_causes, deleted
@@ -689,6 +696,13 @@ FROM openrouter_api_keys
 WHERE organization_id = @organization_id
   AND key_type = @key_type
 FOR UPDATE;
+
+-- name: LockOrganizationMetadataForUpdateNowaitFixture :one
+-- Test-only lock probe: fails instead of waiting if a lifecycle handler read the organization row too early.
+SELECT id
+FROM organization_metadata
+WHERE id = @organization_id
+FOR UPDATE NOWAIT;
 
 -- name: ListOpenRouterAPIKeyDisableCausesForUpdateNowaitFixture :many
 -- Test-only lock-order probe: fails immediately if any matching key row is locked.

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -162,6 +162,10 @@ EXECUTE FUNCTION fail_admin_key_audit();
 -- name: DisableOpenRouterAdminDisableAuditFailureFixture :exec
 ALTER TABLE audit_logs DISABLE TRIGGER fail_admin_key_audit;
 
+-- name: RejectPublishOutboxWritesFixture :exec
+-- Test-only failure injection proving audit callers roll back when enqueueing fails.
+ALTER TABLE publish_outbox ADD CONSTRAINT reject_publish_outbox_writes_fixture CHECK (false) NOT VALID;
+
 -- name: CountOutboxEntriesByEventType :one
 -- Counts enqueued webhook events of a given type. The event type lives in a
 -- Pub/Sub message attribute rather than a column now, because the outbox row

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -598,6 +598,13 @@ SET key_hash = @key_hash
 WHERE organization_id = @organization_id
   AND key_type = @key_type;
 
+-- name: GetOpenRouterAPIKeyStateFixture :one
+-- Test-only fixture: observes guarded-mutation state, including soft-deleted rows.
+SELECT key_hash, monthly_credits, disabled, disable_causes, deleted
+FROM openrouter_api_keys
+WHERE organization_id = @organization_id
+  AND key_type = @key_type;
+
 -- name: SeedTrialArmAuditFixture :one
 -- Test-only fixture: records the immutable audit operation for a trial generation.
 INSERT INTO audit_logs (organization_id, actor_id, actor_type, action, subject_id, subject_type)

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1634,6 +1634,21 @@ func (q *Queries) LockOpenRouterAPIKeyForUpdateFixture(ctx context.Context, arg 
 	return column_1, err
 }
 
+const lockOrganizationMetadataForUpdateNowaitFixture = `-- name: LockOrganizationMetadataForUpdateNowaitFixture :one
+SELECT id
+FROM organization_metadata
+WHERE id = $1
+FOR UPDATE NOWAIT
+`
+
+// Test-only lock probe: fails instead of waiting if a lifecycle handler read the organization row too early.
+func (q *Queries) LockOrganizationMetadataForUpdateNowaitFixture(ctx context.Context, organizationID string) (string, error) {
+	row := q.db.QueryRow(ctx, lockOrganizationMetadataForUpdateNowaitFixture, organizationID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const pauseDeviceIntegrationSyncsFixture = `-- name: PauseDeviceIntegrationSyncsFixture :exec
 UPDATE device_integration_syncs s
 SET auto_paused_at = clock_timestamp(),
@@ -2193,6 +2208,25 @@ type SetOpenRouterAPIKeyHashFixtureParams struct {
 // Test-only fixture: simulates key rotation between an upstream response and CAS.
 func (q *Queries) SetOpenRouterAPIKeyHashFixture(ctx context.Context, arg SetOpenRouterAPIKeyHashFixtureParams) error {
 	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyHashFixture, arg.KeyHash, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
+const setOpenRouterAPIKeyProviderPayloadFixture = `-- name: SetOpenRouterAPIKeyProviderPayloadFixture :exec
+UPDATE openrouter_api_keys
+SET key = $1
+WHERE organization_id = $2
+  AND key_type = $3
+`
+
+type SetOpenRouterAPIKeyProviderPayloadFixtureParams struct {
+	ProviderPayload pgtype.Text
+	OrganizationID  string
+	KeyType         string
+}
+
+// Test-only privacy sentinel in the deprecated plaintext provider payload column.
+func (q *Queries) SetOpenRouterAPIKeyProviderPayloadFixture(ctx context.Context, arg SetOpenRouterAPIKeyProviderPayloadFixtureParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterAPIKeyProviderPayloadFixture, arg.ProviderPayload, arg.OrganizationID, arg.KeyType)
 	return err
 }
 

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1696,6 +1696,16 @@ func (q *Queries) RedemoteTrialLifecycleFixture(ctx context.Context, organizatio
 	return err
 }
 
+const rejectPublishOutboxWritesFixture = `-- name: RejectPublishOutboxWritesFixture :exec
+ALTER TABLE publish_outbox ADD CONSTRAINT reject_publish_outbox_writes_fixture CHECK (false) NOT VALID
+`
+
+// Test-only failure injection proving audit callers roll back when enqueueing fails.
+func (q *Queries) RejectPublishOutboxWritesFixture(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, rejectPublishOutboxWritesFixture)
+	return err
+}
+
 const scrubDeploymentFunctionMachineSpecs = `-- name: ScrubDeploymentFunctionMachineSpecs :exec
 UPDATE deployments_functions SET memory_mib = NULL, scale = NULL WHERE deployment_id = $1
 `

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -609,6 +609,40 @@ func (q *Queries) GetLatestTrialArmAuditIDFixture(ctx context.Context, organizat
 	return id, err
 }
 
+const getOpenRouterAPIKeyStateFixture = `-- name: GetOpenRouterAPIKeyStateFixture :one
+SELECT key_hash, monthly_credits, disabled, disable_causes, deleted
+FROM openrouter_api_keys
+WHERE organization_id = $1
+  AND key_type = $2
+`
+
+type GetOpenRouterAPIKeyStateFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+type GetOpenRouterAPIKeyStateFixtureRow struct {
+	KeyHash        string
+	MonthlyCredits int64
+	Disabled       bool
+	DisableCauses  []string
+	Deleted        bool
+}
+
+// Test-only fixture: observes guarded-mutation state, including soft-deleted rows.
+func (q *Queries) GetOpenRouterAPIKeyStateFixture(ctx context.Context, arg GetOpenRouterAPIKeyStateFixtureParams) (GetOpenRouterAPIKeyStateFixtureRow, error) {
+	row := q.db.QueryRow(ctx, getOpenRouterAPIKeyStateFixture, arg.OrganizationID, arg.KeyType)
+	var i GetOpenRouterAPIKeyStateFixtureRow
+	err := row.Scan(
+		&i.KeyHash,
+		&i.MonthlyCredits,
+		&i.Disabled,
+		&i.DisableCauses,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getOrganizationMetadataStateFixture = `-- name: GetOrganizationMetadataStateFixture :one
 SELECT disabled_at, workos_last_event_id, whitelisted, gram_account_type, created_at, updated_at
 FROM organization_metadata

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1826,6 +1826,21 @@ func (q *Queries) SeedCapturedAgentChatMessageFixture(ctx context.Context, arg S
 	return id, err
 }
 
+const seedOpenRouterSpendPrivacyFixture = `-- name: SeedOpenRouterSpendPrivacyFixture :exec
+INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
+VALUES ($1, 'chat', CURRENT_DATE, $2::text::numeric)
+`
+
+type SeedOpenRouterSpendPrivacyFixtureParams struct {
+	OrganizationID string
+	SpendUsd       string
+}
+
+func (q *Queries) SeedOpenRouterSpendPrivacyFixture(ctx context.Context, arg SeedOpenRouterSpendPrivacyFixtureParams) error {
+	_, err := q.db.Exec(ctx, seedOpenRouterSpendPrivacyFixture, arg.OrganizationID, arg.SpendUsd)
+	return err
+}
+
 const seedOpenRouterSpendRangeFixture = `-- name: SeedOpenRouterSpendRangeFixture :exec
 INSERT INTO openrouter_spend_daily (organization_id, key_type, day, spend_usd)
 SELECT
@@ -1877,6 +1892,21 @@ func (q *Queries) SeedOutboxEntry(ctx context.Context, arg SeedOutboxEntryParams
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const seedPromptTemplatePrivacyFixture = `-- name: SeedPromptTemplatePrivacyFixture :exec
+INSERT INTO prompt_templates (tool_urn, project_id, history_id, name, prompt, kind)
+VALUES ('tools:privacy-fixture', $1, generate_uuidv7(), 'Privacy fixture', $2, 'prompt')
+`
+
+type SeedPromptTemplatePrivacyFixtureParams struct {
+	ProjectID uuid.UUID
+	Prompt    string
+}
+
+func (q *Queries) SeedPromptTemplatePrivacyFixture(ctx context.Context, arg SeedPromptTemplatePrivacyFixtureParams) error {
+	_, err := q.db.Exec(ctx, seedPromptTemplatePrivacyFixture, arg.ProjectID, arg.Prompt)
+	return err
 }
 
 const seedPublishOutboxRow = `-- name: SeedPublishOutboxRow :one

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -62,11 +62,19 @@ func emptyEnterpriseTrialConversionKeyState() EnterpriseTrialConversionKeyState 
 	return EnterpriseTrialConversionKeyState{KeyType: "", MonthlyCredits: 0, Disabled: false, DisableCauses: nil}
 }
 
+var errEnterpriseTrialConversionKeyChangedConcurrently = errors.New("OpenRouter API key changed concurrently")
+
 // PrepareEnterpriseTrialConversionKeyWithDB atomically prepares one classified
 // local key for enterprise conversion. The caller owns the transaction and must
 // already hold lifecycle and per-key advisory locks; this method acquires none
 // and never contacts OpenRouter. Missing and deleted keys are safe no-ops.
 func (o *OpenRouter) PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, enterpriseFloor int64) (EnterpriseTrialConversionKeyChange, error) {
+	return o.prepareEnterpriseTrialConversionKeyWithDB(ctx, db, orgID, keyType, enterpriseFloor, nil)
+}
+
+// beforeMutationTestHook is nil in production. Deterministic tests use the
+// narrow seam to prove each CAS guard without introducing race-based tests.
+func (o *OpenRouter) prepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, enterpriseFloor int64, beforeMutationTestHook func(context.Context, DBTX) error) (EnterpriseTrialConversionKeyChange, error) {
 	keyType = keyType.OrDefault()
 	if err := keyType.Validate(); err != nil {
 		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", err)
@@ -75,18 +83,40 @@ func (o *OpenRouter) PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Conte
 		return EnterpriseTrialConversionKeyChange{}, errors.New("prepare OpenRouter API key for enterprise trial conversion: enterprise floor cannot be negative")
 	}
 
-	row, err := repo.New(db).PrepareEnterpriseTrialConversionKey(ctx, repo.PrepareEnterpriseTrialConversionKeyParams{
-		OrganizationID:  orgID,
-		KeyType:         string(keyType),
-		EnterpriseFloor: enterpriseFloor,
-	})
+	queries := repo.New(db)
+	snapshot, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(keyType)})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		return EnterpriseTrialConversionKeyChange{Exists: false, Changed: false, Before: emptyEnterpriseTrialConversionKeyState(), After: emptyEnterpriseTrialConversionKeyState()}, nil
 	case err != nil:
-		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", err)
-	case !row.Classified:
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("read OpenRouter API key for enterprise trial conversion: %w", err)
+	case snapshot.DisableCauses == nil:
 		return EnterpriseTrialConversionKeyChange{}, errors.New("prepare OpenRouter API key for enterprise trial conversion: disable causes are unclassified")
+	}
+
+	if beforeMutationTestHook != nil {
+		if err := beforeMutationTestHook(ctx, db); err != nil {
+			return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key test hook: %w", err)
+		}
+	}
+
+	row, err := queries.PrepareEnterpriseTrialConversionKey(ctx, repo.PrepareEnterpriseTrialConversionKeyParams{
+		OrganizationID:  orgID,
+		KeyType:         string(keyType),
+		EnterpriseFloor: enterpriseFloor,
+		ExpectedKeyHash: snapshot.KeyHash,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", errEnterpriseTrialConversionKeyChangedConcurrently)
+	}
+	if err != nil {
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", err)
+	}
+	if row.BeforeKeyHash != snapshot.KeyHash || !row.AfterKeyHash.Valid || row.AfterKeyHash.String != row.BeforeKeyHash {
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", errEnterpriseTrialConversionKeyChangedConcurrently)
+	}
+	if !row.AfterMonthlyCredits.Valid || !row.AfterDisabled.Valid || row.AfterDisableCauses == nil {
+		return EnterpriseTrialConversionKeyChange{}, errors.New("prepare OpenRouter API key for enterprise trial conversion: guarded mutation returned no updated state")
 	}
 
 	before := EnterpriseTrialConversionKeyState{

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -151,6 +151,27 @@ func AcquireAPIKeyBillingTransactionLock(ctx context.Context, db DBTX, orgID str
 	return nil
 }
 
+// AcquireAPIKeyProvisioningTransactionLock serializes missing-row decisions
+// with first-time provisioning. Lifecycle operations acquire their lifecycle
+// row first, then every billing lock in AllKeyTypes order, then every
+// provisioning lock in AllKeyTypes order, before reading key rows. A first-time
+// provisioner acquires only its provisioning lock before re-reading the row.
+// This single order prevents stale inserts without introducing a lock cycle.
+func AcquireAPIKeyProvisioningTransactionLock(ctx context.Context, db DBTX, orgID string, keyType KeyType) error {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return fmt.Errorf("acquire OpenRouter API key provisioning transaction lock: %w", err)
+	}
+
+	if err := repo.New(db).LockOpenRouterKeyProvisioning(ctx, repo.LockOpenRouterKeyProvisioningParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	}); err != nil {
+		return fmt.Errorf("acquire OpenRouter %s key provisioning transaction lock: %w", keyType, err)
+	}
+	return nil
+}
+
 // EffectiveDisabled preserves legacy access for rows that have not been
 // classified yet. Once disable_causes is non-NULL, the cause set is
 // authoritative even if the rollout mirror has drifted.

--- a/server/internal/thirdparty/openrouter/disable_causes.go
+++ b/server/internal/thirdparty/openrouter/disable_causes.go
@@ -2,7 +2,11 @@ package openrouter
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 )
@@ -38,6 +42,65 @@ type DisableCauseChange struct {
 
 func unchangedDisableCauseChange() DisableCauseChange {
 	return DisableCauseChange{CauseChanged: false, KeyAccessChanged: false}
+}
+
+type EnterpriseTrialConversionKeyState struct {
+	KeyType        KeyType
+	MonthlyCredits int64
+	Disabled       bool
+	DisableCauses  []string
+}
+
+type EnterpriseTrialConversionKeyChange struct {
+	Exists  bool
+	Changed bool
+	Before  EnterpriseTrialConversionKeyState
+	After   EnterpriseTrialConversionKeyState
+}
+
+func emptyEnterpriseTrialConversionKeyState() EnterpriseTrialConversionKeyState {
+	return EnterpriseTrialConversionKeyState{KeyType: "", MonthlyCredits: 0, Disabled: false, DisableCauses: nil}
+}
+
+// PrepareEnterpriseTrialConversionKeyWithDB atomically prepares one classified
+// local key for enterprise conversion. The caller owns the transaction and must
+// already hold lifecycle and per-key advisory locks; this method acquires none
+// and never contacts OpenRouter. Missing and deleted keys are safe no-ops.
+func (o *OpenRouter) PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, enterpriseFloor int64) (EnterpriseTrialConversionKeyChange, error) {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", err)
+	}
+	if enterpriseFloor < 0 {
+		return EnterpriseTrialConversionKeyChange{}, errors.New("prepare OpenRouter API key for enterprise trial conversion: enterprise floor cannot be negative")
+	}
+
+	row, err := repo.New(db).PrepareEnterpriseTrialConversionKey(ctx, repo.PrepareEnterpriseTrialConversionKeyParams{
+		OrganizationID:  orgID,
+		KeyType:         string(keyType),
+		EnterpriseFloor: enterpriseFloor,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return EnterpriseTrialConversionKeyChange{Exists: false, Changed: false, Before: emptyEnterpriseTrialConversionKeyState(), After: emptyEnterpriseTrialConversionKeyState()}, nil
+	case err != nil:
+		return EnterpriseTrialConversionKeyChange{}, fmt.Errorf("prepare OpenRouter API key for enterprise trial conversion: %w", err)
+	case !row.Classified:
+		return EnterpriseTrialConversionKeyChange{}, errors.New("prepare OpenRouter API key for enterprise trial conversion: disable causes are unclassified")
+	}
+
+	before := EnterpriseTrialConversionKeyState{
+		KeyType: keyType, MonthlyCredits: row.BeforeMonthlyCredits, Disabled: row.BeforeDisabled, DisableCauses: row.BeforeDisableCauses,
+	}
+	after := EnterpriseTrialConversionKeyState{
+		KeyType: keyType, MonthlyCredits: row.AfterMonthlyCredits.Int64, Disabled: row.AfterDisabled.Bool, DisableCauses: row.AfterDisableCauses,
+	}
+	return EnterpriseTrialConversionKeyChange{
+		Exists:  true,
+		Changed: before.MonthlyCredits != after.MonthlyCredits || before.Disabled != after.Disabled || !slices.Equal(before.DisableCauses, after.DisableCauses),
+		Before:  before,
+		After:   after,
+	}, nil
 }
 
 // AcquireAPIKeyBillingTransactionLock serializes a caller-owned business

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -25,6 +25,7 @@ import (
 type disableTestUpstream struct {
 	server    *httptest.Server
 	mu        sync.Mutex
+	requests  int
 	patches   []string
 	onPatch   func()
 	patchHash string
@@ -38,6 +39,13 @@ func (u *disableTestUpstream) recorded() []string {
 	defer u.mu.Unlock()
 
 	return append([]string(nil), u.patches...)
+}
+
+func (u *disableTestUpstream) requestCount() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.requests
 }
 
 // interceptPatch runs fn while a patch is in flight.
@@ -73,6 +81,9 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 
 	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil, onPatch: nil, patchHash: "hash-1"}
 	upstream.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstream.mu.Lock()
+		upstream.requests++
+		upstream.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.Method {

--- a/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
+++ b/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
@@ -1,0 +1,126 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+)
+
+func TestPrepareEnterpriseTrialConversionKeyWithDB(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		keyType        KeyType
+		beforeCauses   []string
+		beforeDisabled bool
+		beforeCredits  int64
+		floor          int64
+		wantCauses     []string
+		wantDisabled   bool
+		wantCredits    int64
+		wantChanged    bool
+	}{
+		{name: "chat removes trial and billing while preserving layered causes", keyType: KeyTypeChat, beforeCauses: []string{"admin_lock", "trial_demotion", "billing_inactive", "unknown_policy"}, beforeDisabled: true, beforeCredits: 10, floor: 50, wantCauses: []string{"admin_lock", "unknown_policy"}, wantDisabled: true, wantCredits: 50, wantChanged: true},
+		{name: "internal removes only trial and preserves billing", keyType: KeyTypeInternal, beforeCauses: []string{"trial_demotion", "billing_inactive"}, beforeDisabled: true, beforeCredits: 10, floor: 50, wantCauses: []string{"billing_inactive"}, wantDisabled: true, wantCredits: 50, wantChanged: true},
+		{name: "chat billing absent", keyType: KeyTypeChat, beforeCauses: []string{"trial_demotion"}, beforeDisabled: true, beforeCredits: 50, floor: 50, wantCauses: []string{}, wantDisabled: false, wantCredits: 50, wantChanged: true},
+		{name: "chat removes billing independently when trial is absent", keyType: KeyTypeChat, beforeCauses: []string{"billing_inactive"}, beforeDisabled: true, beforeCredits: 50, floor: 50, wantCauses: []string{}, wantDisabled: false, wantCredits: 50, wantChanged: true},
+		{name: "internal billing absent", keyType: KeyTypeInternal, beforeCauses: []string{"admin_lock"}, beforeDisabled: false, beforeCredits: 75, floor: 50, wantCauses: []string{"admin_lock"}, wantDisabled: true, wantCredits: 75, wantChanged: true},
+		{name: "classified empty below floor repairs stale disabled", keyType: KeyTypeChat, beforeCauses: []string{}, beforeDisabled: true, beforeCredits: 10, floor: 50, wantCauses: []string{}, wantDisabled: false, wantCredits: 50, wantChanged: true},
+		{name: "classified empty equal floor no change", keyType: KeyTypeInternal, beforeCauses: []string{}, beforeDisabled: false, beforeCredits: 50, floor: 50, wantCauses: []string{}, wantDisabled: false, wantCredits: 50, wantChanged: false},
+		{name: "classified unknown above floor preserved", keyType: KeyTypeChat, beforeCauses: []string{"security_hold"}, beforeDisabled: true, beforeCredits: 75, floor: 50, wantCauses: []string{"security_hold"}, wantDisabled: true, wantCredits: 75, wantChanged: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			created, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
+				OrganizationID: orgID, KeyType: string(tt.keyType), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: tt.beforeCredits,
+			})
+			require.NoError(t, err)
+			require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+				OrganizationID: orgID, KeyType: string(tt.keyType), Disabled: tt.beforeDisabled, DisableCauses: tt.beforeCauses,
+			}))
+
+			tx := testenv.BeginTx(t, ctx, provisioner.db)
+			change, err := provisioner.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, tt.keyType, tt.floor)
+			require.NoError(t, err)
+			require.NoError(t, tx.Commit(ctx))
+
+			require.True(t, change.Exists)
+			require.Equal(t, tt.wantChanged, change.Changed)
+			require.Equal(t, EnterpriseTrialConversionKeyState{KeyType: tt.keyType, MonthlyCredits: tt.beforeCredits, Disabled: tt.beforeDisabled, DisableCauses: tt.beforeCauses}, change.Before)
+			require.Equal(t, EnterpriseTrialConversionKeyState{KeyType: tt.keyType, MonthlyCredits: tt.wantCredits, Disabled: tt.wantDisabled, DisableCauses: tt.wantCauses}, change.After)
+
+			after, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(tt.keyType)})
+			require.NoError(t, err)
+			require.Equal(t, created.KeyHash, after.KeyHash, "local preparation must preserve key identity")
+			require.Equal(t, tt.wantCauses, after.DisableCauses)
+			require.Equal(t, tt.wantDisabled, after.Disabled)
+			require.Equal(t, tt.wantCredits, after.MonthlyCredits)
+			require.Zero(t, upstream.requestCount(), "local preparation must not contact OpenRouter")
+		})
+	}
+}
+
+func TestPrepareEnterpriseTrialConversionKeyWithDBMissingAndDeletedAreNoOps(t *testing.T) {
+	t.Parallel()
+
+	for _, deleted := range []bool{false, true} {
+		t.Run(map[bool]string{false: "missing", true: "deleted"}[deleted], func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			if deleted {
+				_, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: 5})
+				require.NoError(t, err)
+				require.NoError(t, testrepo.New(provisioner.db).SoftDeleteOpenRouterAPIKeyFixture(ctx, testrepo.SoftDeleteOpenRouterAPIKeyFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)}))
+			}
+
+			tx := testenv.BeginTx(t, ctx, provisioner.db)
+			change, err := provisioner.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, KeyTypeChat, 50)
+			require.NoError(t, err)
+			require.NoError(t, tx.Commit(ctx))
+			require.Equal(t, EnterpriseTrialConversionKeyChange{}, change)
+			require.Zero(t, upstream.requestCount())
+		})
+	}
+}
+
+func TestPrepareEnterpriseTrialConversionKeyWithDBNullFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+	_, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: 5})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil}))
+
+	tx := testenv.BeginTx(t, ctx, provisioner.db)
+	_, err = provisioner.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, KeyTypeChat, 50)
+	require.ErrorContains(t, err, "disable causes are unclassified")
+	inTransaction, err := repo.New(tx).GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Nil(t, inTransaction.DisableCauses)
+	require.True(t, inTransaction.Disabled)
+	require.EqualValues(t, 5, inTransaction.MonthlyCredits, "unclassified preparation must perform no write even before rollback")
+	require.NoError(t, tx.Rollback(ctx))
+
+	after, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.Nil(t, after.DisableCauses)
+	require.True(t, after.Disabled)
+	require.EqualValues(t, 5, after.MonthlyCredits)
+	require.Zero(t, upstream.requestCount())
+}

--- a/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
+++ b/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
@@ -1,6 +1,7 @@
 package openrouter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -47,9 +48,20 @@ func TestPrepareEnterpriseTrialConversionKeyWithDB(t *testing.T) {
 				OrganizationID: orgID, KeyType: string(tt.keyType), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: tt.beforeCredits,
 			})
 			require.NoError(t, err)
-			require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+			testQueries := testrepo.New(provisioner.db)
+			require.NoError(t, testQueries.SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
 				OrganizationID: orgID, KeyType: string(tt.keyType), Disabled: tt.beforeDisabled, DisableCauses: tt.beforeCauses,
 			}))
+
+			siblingType := KeyTypeInternal
+			if tt.keyType == KeyTypeInternal {
+				siblingType = KeyTypeChat
+			}
+			sibling, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(siblingType), KeyEncrypted: pgtype.Text{String: "sibling-ciphertext", Valid: true}, KeyHash: "sibling-hash-" + orgID, MonthlyCredits: 17})
+			require.NoError(t, err)
+			decoyOrgID := orgID + "-decoy"
+			decoy, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: decoyOrgID, KeyType: string(tt.keyType), KeyEncrypted: pgtype.Text{String: "decoy-ciphertext", Valid: true}, KeyHash: "decoy-hash-" + orgID, MonthlyCredits: 23})
+			require.NoError(t, err)
 
 			tx := testenv.BeginTx(t, ctx, provisioner.db)
 			change, err := provisioner.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, tt.keyType, tt.floor)
@@ -67,6 +79,12 @@ func TestPrepareEnterpriseTrialConversionKeyWithDB(t *testing.T) {
 			require.Equal(t, tt.wantCauses, after.DisableCauses)
 			require.Equal(t, tt.wantDisabled, after.Disabled)
 			require.Equal(t, tt.wantCredits, after.MonthlyCredits)
+			siblingAfter, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(siblingType)})
+			require.NoError(t, err)
+			require.Equal(t, sibling, siblingAfter, "conversion preparation must not touch the sibling key")
+			decoyAfter, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: decoyOrgID, KeyType: string(tt.keyType)})
+			require.NoError(t, err)
+			require.Equal(t, decoy, decoyAfter, "conversion preparation must not touch another organization")
 			require.Zero(t, upstream.requestCount(), "local preparation must not contact OpenRouter")
 		})
 	}
@@ -92,6 +110,71 @@ func TestPrepareEnterpriseTrialConversionKeyWithDBMissingAndDeletedAreNoOps(t *t
 			require.NoError(t, err)
 			require.NoError(t, tx.Commit(ctx))
 			require.Equal(t, EnterpriseTrialConversionKeyChange{}, change)
+			require.Zero(t, upstream.requestCount())
+		})
+	}
+}
+
+func TestPrepareEnterpriseTrialConversionKeyWithDBConcurrentGuardFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		hook        func(context.Context, DBTX, string) error
+		wantHash    func(string) string
+		wantCauses  []string
+		wantDeleted bool
+	}{
+		{
+			name: "stale snapshot after key hash replacement",
+			hook: func(ctx context.Context, db DBTX, orgID string) error {
+				return testrepo.New(db).SetOpenRouterAPIKeyHashFixture(ctx, testrepo.SetOpenRouterAPIKeyHashFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyHash: "replacement-hash-" + orgID})
+			},
+			wantHash:   func(orgID string) string { return "replacement-hash-" + orgID },
+			wantCauses: []string{"trial_demotion"},
+		},
+		{
+			name: "current causes become unclassified",
+			hook: func(ctx context.Context, db DBTX, orgID string) error {
+				return testrepo.New(db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil})
+			},
+			wantHash:   func(orgID string) string { return "hash-" + orgID },
+			wantCauses: nil,
+		},
+		{
+			name: "current row becomes soft deleted",
+			hook: func(ctx context.Context, db DBTX, orgID string) error {
+				return testrepo.New(db).SoftDeleteOpenRouterAPIKeyFixture(ctx, testrepo.SoftDeleteOpenRouterAPIKeyFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			},
+			wantHash:    func(orgID string) string { return "hash-" + orgID },
+			wantCauses:  []string{"trial_demotion"},
+			wantDeleted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			_, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: 5})
+			require.NoError(t, err)
+			require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: []string{"trial_demotion"}}))
+
+			tx := testenv.BeginTx(t, ctx, provisioner.db)
+			_, err = provisioner.prepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, KeyTypeChat, 50, func(ctx context.Context, db DBTX) error {
+				return tt.hook(ctx, db, orgID)
+			})
+			require.ErrorIs(t, err, errEnterpriseTrialConversionKeyChangedConcurrently)
+
+			current, err := testrepo.New(tx).GetOpenRouterAPIKeyStateFixture(ctx, testrepo.GetOpenRouterAPIKeyStateFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHash(orgID), current.KeyHash)
+			require.EqualValues(t, 5, current.MonthlyCredits, "guard failure must not raise credits")
+			require.True(t, current.Disabled)
+			require.Equal(t, tt.wantCauses, current.DisableCauses, "guard failure must not remove causes")
+			require.Equal(t, tt.wantDeleted, current.Deleted)
 			require.Zero(t, upstream.requestCount())
 		})
 	}

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -62,6 +62,10 @@ func (o *Development) ReconcileAPIKeyDisabled(context.Context, string, KeyType) 
 	return nil
 }
 
+func (o *Development) ReconcileAPIKeyConversionPolicy(context.Context, string, KeyType) error {
+	return nil
+}
+
 func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	return nil
 }

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -54,6 +54,10 @@ func (o *Development) RemoveAPIKeyDisableCauseWithDB(context.Context, DBTX, stri
 	return 0, unchangedDisableCauseChange(), nil
 }
 
+func (o *Development) PrepareEnterpriseTrialConversionKeyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, floor int64) (EnterpriseTrialConversionKeyChange, error) {
+	return new(OpenRouter).PrepareEnterpriseTrialConversionKeyWithDB(ctx, db, orgID, keyType, floor)
+}
+
 func (o *Development) ReconcileAPIKeyDisabled(context.Context, string, KeyType) error {
 	return nil
 }

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -968,6 +968,19 @@ func (o *OpenRouter) removeAPIKeyDisableCauseWithDB(ctx context.Context, db DBTX
 	return keyLimit, DisableCauseChange{CauseChanged: true, KeyAccessChanged: accessChanged}, nil
 }
 
+// ReconcileAPIKeyConversionPolicy projects both the persisted monthly limit and
+// effective disabled state from committed local state. It serializes with key
+// replacement and billing mutations so retries always reconcile one current key.
+func (o *OpenRouter) ReconcileAPIKeyConversionPolicy(ctx context.Context, orgID string, keyType KeyType) error {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return fmt.Errorf("reconcile OpenRouter API key conversion policy: %w", err)
+	}
+	return o.withOpenRouterKeyBillingLock(ctx, orgID, keyType, func(conn *pgxpool.Conn) error {
+		return o.reconcileAPIKeyPolicyWithDB(ctx, conn, orgID, keyType, true)
+	})
+}
+
 // ReconcileAPIKeyDisabled serializes reconciliation with key replacement and
 // every compliant billing mutation before reading committed desired state.
 func (o *OpenRouter) ReconcileAPIKeyDisabled(ctx context.Context, orgID string, keyType KeyType) error {
@@ -990,6 +1003,10 @@ func (o *OpenRouter) ReconcileAPIKeyDisabledWithDB(ctx context.Context, db DBTX,
 		return fmt.Errorf("reconcile OpenRouter API key disabled state: %w", err)
 	}
 
+	return o.reconcileAPIKeyPolicyWithDB(ctx, db, orgID, keyType, false)
+}
+
+func (o *OpenRouter) reconcileAPIKeyPolicyWithDB(ctx context.Context, db DBTX, orgID string, keyType KeyType, includeLimitWhileDisabled bool) error {
 	key, err := repo.New(db).GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(keyType),
@@ -1005,7 +1022,7 @@ func (o *OpenRouter) ReconcileAPIKeyDisabledWithDB(ctx context.Context, db DBTX,
 
 	disabled := EffectiveDisabled(key.Disabled, key.DisableCauses)
 	patch := updateKeyRequest{Disabled: &disabled, Limit: nil, LimitReset: ""}
-	if !disabled && key.MonthlyCredits > 0 {
+	if (!disabled || includeLimitWhileDisabled) && key.MonthlyCredits > 0 {
 		creditLimit := float64(key.MonthlyCredits)
 		patch.Limit = &creditLimit
 		patch.LimitReset = "monthly"

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -515,10 +515,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	txRepo := o.repo.WithTx(dbtx)
-	if err := txRepo.LockOpenRouterKeyProvisioning(ctx, repo.LockOpenRouterKeyProvisioningParams{
-		OrganizationID: orgID,
-		KeyType:        string(keyType),
-	}); err != nil {
+	if err := AcquireAPIKeyProvisioningTransactionLock(ctx, dbtx, orgID, keyType); err != nil {
 		return "", oops.E(oops.CodeUnexpected, err, "error locking openrouter key provisioning").LogError(ctx, o.logger)
 	}
 

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -48,7 +48,7 @@ WHERE organization_id = @organization_id
 -- Local-only conversion preparation. The caller owns the transaction and has
 -- already acquired lifecycle and per-key advisory locks in canonical order.
 WITH existing AS MATERIALIZED (
-  SELECT keys.key_type, keys.monthly_credits, keys.disabled, keys.disable_causes
+  SELECT keys.key_type, keys.key_hash, keys.monthly_credits, keys.disabled, keys.disable_causes
   FROM openrouter_api_keys AS keys
   WHERE keys.organization_id = @organization_id
     AND keys.key_type = @key_type
@@ -56,6 +56,7 @@ WITH existing AS MATERIALIZED (
 ), desired AS (
   SELECT
     key_type,
+    key_hash,
     GREATEST(monthly_credits, @enterprise_floor::bigint) AS monthly_credits,
     CASE
       WHEN key_type = 'chat' THEN array_remove(array_remove(disable_causes, 'trial_demotion'), 'billing_inactive')
@@ -77,16 +78,19 @@ WITH existing AS MATERIALIZED (
   FROM desired
   WHERE keys.organization_id = @organization_id
     AND keys.key_type = @key_type
+    AND keys.key_hash = desired.key_hash
+    AND keys.key_hash = @expected_key_hash
     AND keys.deleted IS FALSE
-    AND desired.disable_causes IS NOT NULL
-  RETURNING keys.monthly_credits, keys.disabled, keys.disable_causes
+    AND keys.disable_causes IS NOT NULL
+  RETURNING keys.key_hash, keys.monthly_credits, keys.disabled, keys.disable_causes
 )
 SELECT
   existing.key_type,
-  (existing.disable_causes IS NOT NULL)::boolean AS classified,
+  existing.key_hash AS before_key_hash,
   existing.monthly_credits AS before_monthly_credits,
   existing.disabled AS before_disabled,
   existing.disable_causes AS before_disable_causes,
+  updated.key_hash AS after_key_hash,
   updated.monthly_credits AS after_monthly_credits,
   updated.disabled AS after_disabled,
   updated.disable_causes AS after_disable_causes

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -44,6 +44,55 @@ WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE;
 
+-- name: PrepareEnterpriseTrialConversionKey :one
+-- Local-only conversion preparation. The caller owns the transaction and has
+-- already acquired lifecycle and per-key advisory locks in canonical order.
+WITH existing AS MATERIALIZED (
+  SELECT keys.key_type, keys.monthly_credits, keys.disabled, keys.disable_causes
+  FROM openrouter_api_keys AS keys
+  WHERE keys.organization_id = @organization_id
+    AND keys.key_type = @key_type
+    AND keys.deleted IS FALSE
+), desired AS (
+  SELECT
+    key_type,
+    GREATEST(monthly_credits, @enterprise_floor::bigint) AS monthly_credits,
+    CASE
+      WHEN key_type = 'chat' THEN array_remove(array_remove(disable_causes, 'trial_demotion'), 'billing_inactive')
+      ELSE array_remove(disable_causes, 'trial_demotion')
+    END AS disable_causes
+  FROM existing
+), updated AS (
+  UPDATE openrouter_api_keys AS keys
+  SET monthly_credits = desired.monthly_credits,
+      disable_causes = desired.disable_causes,
+      disabled = cardinality(desired.disable_causes) > 0,
+      updated_at = CASE
+        WHEN keys.monthly_credits IS DISTINCT FROM desired.monthly_credits
+          OR keys.disable_causes IS DISTINCT FROM desired.disable_causes
+          OR keys.disabled IS DISTINCT FROM (cardinality(desired.disable_causes) > 0)
+          THEN GREATEST(clock_timestamp(), keys.updated_at + INTERVAL '1 microsecond')
+        ELSE keys.updated_at
+      END
+  FROM desired
+  WHERE keys.organization_id = @organization_id
+    AND keys.key_type = @key_type
+    AND keys.deleted IS FALSE
+    AND desired.disable_causes IS NOT NULL
+  RETURNING keys.monthly_credits, keys.disabled, keys.disable_causes
+)
+SELECT
+  existing.key_type,
+  (existing.disable_causes IS NOT NULL)::boolean AS classified,
+  existing.monthly_credits AS before_monthly_credits,
+  existing.disabled AS before_disabled,
+  existing.disable_causes AS before_disable_causes,
+  updated.monthly_credits AS after_monthly_credits,
+  updated.disabled AS after_disabled,
+  updated.disable_causes AS after_disable_causes
+FROM existing
+LEFT JOIN updated ON TRUE;
+
 -- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
 SET monthly_credits = @monthly_credits, key_hash = @key_hash,

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -175,6 +175,51 @@ func TestDevelopmentReconcileAPIKeyDisabledIsSafe(t *testing.T) {
 	require.NoError(t, NewDevelopment("local-key").ReconcileAPIKeyDisabled(t.Context(), "org-local", KeyTypeChat))
 }
 
+func TestReconcileAPIKeyConversionPolicyPinsLimitAndEffectiveDisabledState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		disableCauses []string
+		wantDisabled  bool
+	}{
+		{name: "enabled", disableCauses: []string{}, wantDisabled: false},
+		{name: "admin lock", disableCauses: []string{"admin_lock"}, wantDisabled: true},
+		{name: "billing inactive", disableCauses: []string{"billing_inactive"}, wantDisabled: true},
+		{name: "combined", disableCauses: []string{"admin_lock", "billing_inactive"}, wantDisabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			orgID := "org-" + uuid.NewString()[:8]
+			provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+			_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+			require.NoError(t, err)
+			require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+				OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: false, DisableCauses: tt.disableCauses,
+			}))
+			key, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			patchesBefore := len(upstream.recorded())
+
+			require.NoError(t, provisioner.ReconcileAPIKeyConversionPolicy(ctx, orgID, KeyTypeChat))
+			require.NoError(t, provisioner.ReconcileAPIKeyConversionPolicy(ctx, orgID, KeyTypeChat), "idempotent retry must repeat complete reconciliation")
+
+			patches := upstream.recorded()[patchesBefore:]
+			require.Len(t, patches, 2)
+			wantPatch := fmt.Sprintf(`{"disabled":%t,"limit":%d,"limit_reset":"monthly"}`, tt.wantDisabled, key.MonthlyCredits)
+			require.JSONEq(t, wantPatch, patches[0])
+			require.JSONEq(t, wantPatch, patches[1])
+			after, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+			require.NoError(t, err)
+			require.Equal(t, tt.disableCauses, after.DisableCauses, "reconciliation must preserve every disable cause")
+		})
+	}
+}
+
 func TestDisableCauseWithDBUsesCallerLockedConnection(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -267,7 +267,7 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 
 const prepareEnterpriseTrialConversionKey = `-- name: PrepareEnterpriseTrialConversionKey :one
 WITH existing AS MATERIALIZED (
-  SELECT keys.key_type, keys.monthly_credits, keys.disabled, keys.disable_causes
+  SELECT keys.key_type, keys.key_hash, keys.monthly_credits, keys.disabled, keys.disable_causes
   FROM openrouter_api_keys AS keys
   WHERE keys.organization_id = $1
     AND keys.key_type = $2
@@ -275,6 +275,7 @@ WITH existing AS MATERIALIZED (
 ), desired AS (
   SELECT
     key_type,
+    key_hash,
     GREATEST(monthly_credits, $3::bigint) AS monthly_credits,
     CASE
       WHEN key_type = 'chat' THEN array_remove(array_remove(disable_causes, 'trial_demotion'), 'billing_inactive')
@@ -296,16 +297,19 @@ WITH existing AS MATERIALIZED (
   FROM desired
   WHERE keys.organization_id = $1
     AND keys.key_type = $2
+    AND keys.key_hash = desired.key_hash
+    AND keys.key_hash = $4
     AND keys.deleted IS FALSE
-    AND desired.disable_causes IS NOT NULL
-  RETURNING keys.monthly_credits, keys.disabled, keys.disable_causes
+    AND keys.disable_causes IS NOT NULL
+  RETURNING keys.key_hash, keys.monthly_credits, keys.disabled, keys.disable_causes
 )
 SELECT
   existing.key_type,
-  (existing.disable_causes IS NOT NULL)::boolean AS classified,
+  existing.key_hash AS before_key_hash,
   existing.monthly_credits AS before_monthly_credits,
   existing.disabled AS before_disabled,
   existing.disable_causes AS before_disable_causes,
+  updated.key_hash AS after_key_hash,
   updated.monthly_credits AS after_monthly_credits,
   updated.disabled AS after_disabled,
   updated.disable_causes AS after_disable_causes
@@ -317,14 +321,16 @@ type PrepareEnterpriseTrialConversionKeyParams struct {
 	OrganizationID  string
 	KeyType         string
 	EnterpriseFloor int64
+	ExpectedKeyHash string
 }
 
 type PrepareEnterpriseTrialConversionKeyRow struct {
 	KeyType              string
-	Classified           bool
+	BeforeKeyHash        string
 	BeforeMonthlyCredits int64
 	BeforeDisabled       bool
 	BeforeDisableCauses  []string
+	AfterKeyHash         pgtype.Text
 	AfterMonthlyCredits  pgtype.Int8
 	AfterDisabled        pgtype.Bool
 	AfterDisableCauses   []string
@@ -333,14 +339,20 @@ type PrepareEnterpriseTrialConversionKeyRow struct {
 // Local-only conversion preparation. The caller owns the transaction and has
 // already acquired lifecycle and per-key advisory locks in canonical order.
 func (q *Queries) PrepareEnterpriseTrialConversionKey(ctx context.Context, arg PrepareEnterpriseTrialConversionKeyParams) (PrepareEnterpriseTrialConversionKeyRow, error) {
-	row := q.db.QueryRow(ctx, prepareEnterpriseTrialConversionKey, arg.OrganizationID, arg.KeyType, arg.EnterpriseFloor)
+	row := q.db.QueryRow(ctx, prepareEnterpriseTrialConversionKey,
+		arg.OrganizationID,
+		arg.KeyType,
+		arg.EnterpriseFloor,
+		arg.ExpectedKeyHash,
+	)
 	var i PrepareEnterpriseTrialConversionKeyRow
 	err := row.Scan(
 		&i.KeyType,
-		&i.Classified,
+		&i.BeforeKeyHash,
 		&i.BeforeMonthlyCredits,
 		&i.BeforeDisabled,
 		&i.BeforeDisableCauses,
+		&i.AfterKeyHash,
 		&i.AfterMonthlyCredits,
 		&i.AfterDisabled,
 		&i.AfterDisableCauses,

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -265,6 +265,89 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 	return err
 }
 
+const prepareEnterpriseTrialConversionKey = `-- name: PrepareEnterpriseTrialConversionKey :one
+WITH existing AS MATERIALIZED (
+  SELECT keys.key_type, keys.monthly_credits, keys.disabled, keys.disable_causes
+  FROM openrouter_api_keys AS keys
+  WHERE keys.organization_id = $1
+    AND keys.key_type = $2
+    AND keys.deleted IS FALSE
+), desired AS (
+  SELECT
+    key_type,
+    GREATEST(monthly_credits, $3::bigint) AS monthly_credits,
+    CASE
+      WHEN key_type = 'chat' THEN array_remove(array_remove(disable_causes, 'trial_demotion'), 'billing_inactive')
+      ELSE array_remove(disable_causes, 'trial_demotion')
+    END AS disable_causes
+  FROM existing
+), updated AS (
+  UPDATE openrouter_api_keys AS keys
+  SET monthly_credits = desired.monthly_credits,
+      disable_causes = desired.disable_causes,
+      disabled = cardinality(desired.disable_causes) > 0,
+      updated_at = CASE
+        WHEN keys.monthly_credits IS DISTINCT FROM desired.monthly_credits
+          OR keys.disable_causes IS DISTINCT FROM desired.disable_causes
+          OR keys.disabled IS DISTINCT FROM (cardinality(desired.disable_causes) > 0)
+          THEN GREATEST(clock_timestamp(), keys.updated_at + INTERVAL '1 microsecond')
+        ELSE keys.updated_at
+      END
+  FROM desired
+  WHERE keys.organization_id = $1
+    AND keys.key_type = $2
+    AND keys.deleted IS FALSE
+    AND desired.disable_causes IS NOT NULL
+  RETURNING keys.monthly_credits, keys.disabled, keys.disable_causes
+)
+SELECT
+  existing.key_type,
+  (existing.disable_causes IS NOT NULL)::boolean AS classified,
+  existing.monthly_credits AS before_monthly_credits,
+  existing.disabled AS before_disabled,
+  existing.disable_causes AS before_disable_causes,
+  updated.monthly_credits AS after_monthly_credits,
+  updated.disabled AS after_disabled,
+  updated.disable_causes AS after_disable_causes
+FROM existing
+LEFT JOIN updated ON TRUE
+`
+
+type PrepareEnterpriseTrialConversionKeyParams struct {
+	OrganizationID  string
+	KeyType         string
+	EnterpriseFloor int64
+}
+
+type PrepareEnterpriseTrialConversionKeyRow struct {
+	KeyType              string
+	Classified           bool
+	BeforeMonthlyCredits int64
+	BeforeDisabled       bool
+	BeforeDisableCauses  []string
+	AfterMonthlyCredits  pgtype.Int8
+	AfterDisabled        pgtype.Bool
+	AfterDisableCauses   []string
+}
+
+// Local-only conversion preparation. The caller owns the transaction and has
+// already acquired lifecycle and per-key advisory locks in canonical order.
+func (q *Queries) PrepareEnterpriseTrialConversionKey(ctx context.Context, arg PrepareEnterpriseTrialConversionKeyParams) (PrepareEnterpriseTrialConversionKeyRow, error) {
+	row := q.db.QueryRow(ctx, prepareEnterpriseTrialConversionKey, arg.OrganizationID, arg.KeyType, arg.EnterpriseFloor)
+	var i PrepareEnterpriseTrialConversionKeyRow
+	err := row.Scan(
+		&i.KeyType,
+		&i.Classified,
+		&i.BeforeMonthlyCredits,
+		&i.BeforeDisabled,
+		&i.BeforeDisableCauses,
+		&i.AfterMonthlyCredits,
+		&i.AfterDisabled,
+		&i.AfterDisableCauses,
+	)
+	return i, err
+}
+
 const releaseOpenRouterKeyBillingLock = `-- name: ReleaseOpenRouterKeyBillingLock :one
 SELECT pg_advisory_unlock(
     hashtextextended('openrouter-' || $1::text || '-billing:' || $2::text, 0)

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -141,7 +141,7 @@ FROM previous
 WHERE trials.organization_id = previous.organization_id
 RETURNING previous.ends_at AS previous_ends_at, trials.ends_at;
 
--- name: LockTrialLifecycleForRearm :one
+-- name: LockTrialLifecycle :one
 -- Lifecycle operations lock this row before taking OpenRouter advisory locks.
 SELECT tier, ends_at, converted_at, demoted_at
 FROM trials

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -284,14 +284,14 @@ func (q *Queries) ListExpiredTrials(ctx context.Context) ([]string, error) {
 	return items, nil
 }
 
-const lockTrialLifecycleForRearm = `-- name: LockTrialLifecycleForRearm :one
+const lockTrialLifecycle = `-- name: LockTrialLifecycle :one
 SELECT tier, ends_at, converted_at, demoted_at
 FROM trials
 WHERE organization_id = $1
 FOR UPDATE
 `
 
-type LockTrialLifecycleForRearmRow struct {
+type LockTrialLifecycleRow struct {
 	Tier        string
 	EndsAt      pgtype.Timestamptz
 	ConvertedAt pgtype.Timestamptz
@@ -299,9 +299,9 @@ type LockTrialLifecycleForRearmRow struct {
 }
 
 // Lifecycle operations lock this row before taking OpenRouter advisory locks.
-func (q *Queries) LockTrialLifecycleForRearm(ctx context.Context, organizationID string) (LockTrialLifecycleForRearmRow, error) {
-	row := q.db.QueryRow(ctx, lockTrialLifecycleForRearm, organizationID)
-	var i LockTrialLifecycleForRearmRow
+func (q *Queries) LockTrialLifecycle(ctx context.Context, organizationID string) (LockTrialLifecycleRow, error) {
+	row := q.db.QueryRow(ctx, lockTrialLifecycle, organizationID)
+	var i LockTrialLifecycleRow
 	err := row.Scan(
 		&i.Tier,
 		&i.EndsAt,

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -156,7 +156,7 @@ func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) er
 
 	if event.Type == "checkout.session.completed" && checkoutEligible {
 		trialQueries := trialsrepo.New(tx)
-		_, err := trialQueries.LockTrialLifecycleForRearm(ctx, organizationID)
+		_, err := trialQueries.LockTrialLifecycle(ctx, organizationID)
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
 		case err != nil:

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1200,7 +1200,7 @@ func TestStripeCheckoutLocksConvertedTrialBeforeOpenRouterKeys(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = trialTx.Rollback(context.Background()) })
 	trialHolderPID := postgresBackendPID(t, trialTx)
-	_, err = trialsrepo.New(trialTx).LockTrialLifecycleForRearm(t.Context(), stripeWebhookOrganizationID)
+	_, err = trialsrepo.New(trialTx).LockTrialLifecycle(t.Context(), stripeWebhookOrganizationID)
 	require.NoError(t, err)
 
 	response := make(chan int, 1)


### PR DESCRIPTION
<!-- stack-narrative:start -->
## Why this PR exists

With cause ownership established, a platform administrator can safely record an enterprise trial as converted without reopening keys that remain restricted by an admin lock or billing state.

## What changes in this layer

This PR adds `MarkEnterpriseTrialConverted` as the single manual conversion and retry boundary. It restores enterprise organization and feature state, removes the trial-owned restriction, applies current enterprise key policy, and records one durable audit event. Conversion is serialized against lifecycle, provisioning, key-policy, and feature writes; local state commits before provider reconciliation.

## How it advances the stack

The backend now has a durable, idempotent conversion operation whose privacy-minimal response is separate from the canonical organization read model.
<!-- stack-narrative:end -->

---

## Detailed scope, rollout, and verification

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `markEnterpriseTrialConverted` admin endpoint so a platform admin can record a signed enterprise contract by setting `converted_at`. Previously nothing distinguished a contracted enterprise from a trial under `account_type = enterprise`, so the demotion sweeper could demote a signed customer; converted trials keep access, and demoted trials regain full enterprise access.

**Transition behavior**
- Accepts only an organization ID; converts running, ending-soon, expired, and demoted unconverted enterprise trials and returns success idempotently for already converted orgs.
- Preserves `ends_at` and keeps `demoted_at` and `disabled_at` as history while normalizing the org to enterprise account type, admission, and product features.
- Writes one `organization:enterprise_trial_converted` audit event with the staff actor; snapshots exclude key secrets and PII; retries emit no duplicates and can repair a failed trial-email enqueue.
- Rejects eligible trial conversions from generic `updateOrganization` and bulk account-type updates so the transition cannot be bypassed.

**Key and access safety**
- Reconciles every OpenRouter key type to the enterprise credit floor with `GREATEST`, never lowering a higher authorized cap.
- Removes only `trial_demotion` (plus the chat-only `billing_inactive` cause) and preserves `admin_lock` and unknown causes.
- Requires OpenRouter upstream updates to finish before `converted_at` is committed; a failed update leaves the org unconverted and retries converge state.
- Depends on AGE-3219's independent disable-cause model so an admin-disabled key can never be re-enabled by conversion.

<sup>Written for commit d642855698990e3355b6dcfa45047aadef73a0c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


