### PR TITLE
feat: workload expectation for clientauth.Verify

### DIFF
--- a/server/internal/mcp/authnchallenge_clientauth.go
+++ b/server/internal/mcp/authnchallenge_clientauth.go
@@ -145,17 +145,17 @@ func (s *Service) verifyClientAssertion(ctx context.Context, logger *slog.Logger
 		return string(clientauth.ReasonVerifierMisconfigured)
 	}
 
-	result, err := s.clientAssertionVerifier.Verify(ctx, assertion, clientauth.Expectation{
-		ClientID: row.ClientID,
+	result, err := s.clientAssertionVerifier.Verify(ctx, assertion, clientauth.ClientExpectation(
+		row.ClientID,
 		// Scoped to the issuer, so every key set its clients name draws on
 		// one fetch budget.
-		KeySource: keySource.WithFetchScope(endpoint.UserSessionIssuerID.String()),
+		keySource.WithFetchScope(endpoint.UserSessionIssuerID.String()),
 		// The issuer row id, never a URL: an endpoint reachable on a custom
 		// domain and the default host has two issuer URLs, and keying the
 		// replay guard on either would let one assertion be spent per host.
-		ReplayIssuer: endpoint.UserSessionIssuerID.String(),
-		Audiences:    urls.clientAssertionAudiences(at),
-	})
+		endpoint.UserSessionIssuerID.String(),
+		urls.clientAssertionAudiences(at),
+	))
 	if err != nil {
 		reason := clientauth.ReasonOf(err)
 		if reason == "" {

--- a/server/internal/mcp/client_assertion_verifier.go
+++ b/server/internal/mcp/client_assertion_verifier.go
@@ -61,7 +61,7 @@ func newClientAssertionVerifier(redisClient *redis.Client, policy *guardian.Poli
 		logger.ErrorContext(context.Background(), "client assertion key resolver unavailable, assertion clients will be refused", attr.SlogError(err))
 		return nil
 	}
-	guard, err := replay.NewRedisGuard(redisClient, "client_assertion_jti", clientauth.MaxReplayHold)
+	guard, err := replay.NewRedisGuard(redisClient, "client_assertion_jti", clientauth.DefaultMaxReplayHold)
 	if err != nil {
 		logger.ErrorContext(context.Background(), "client assertion replay guard unavailable, assertion clients will be refused", attr.SlogError(err))
 		return nil

--- a/server/internal/usersessions/clientauth/expectation.go
+++ b/server/internal/usersessions/clientauth/expectation.go
@@ -1,17 +1,40 @@
 package clientauth
 
-import "github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+import (
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+)
 
 // Expectation is what the presented assertion has to satisfy, assembled by
-// the caller from the resolved client row and endpoint.
+// the caller from the resolved client row and endpoint, or from the trusted
+// issuer and admitted identity a workload names.
+//
+// Two profiles share it. A client assertion authenticates a client to itself
+// and RFC 7523 §3 makes iss, sub, and client_id one value; build one with
+// ClientExpectation, which is where that rule lives. A workload assertion
+// says "this issuer vouches for this machine", so iss and sub are different
+// values and neither is a client id; build one field by field, and note that
+// both are matched exactly rather than as patterns — an issuer trusted
+// without naming subjects vouches for every workload on its platform, its
+// other customers included.
 type Expectation struct {
-	// ClientID is the identifier being authenticated. The assertion's iss
-	// and sub must both equal it.
-	ClientID string
+	// Issuer is the value the assertion's iss must equal: the client_id
+	// for a client assertion, the platform's issuer identifier for a
+	// workload assertion.
+	Issuer string
 
-	// KeySource is where this client's public keys come from, built from the
-	// key source recorded when the client registered or its metadata
-	// document was read.
+	// Subject is the value the assertion's sub must equal: the same
+	// client_id for a client assertion, the admitted external subject for
+	// a workload assertion.
+	//
+	// Whether it equals Issuer is the profile's choice, which is why the
+	// two are matched separately rather than compared against one value.
+	Subject string
+
+	// KeySource is where the signing party's public keys come from: the
+	// source recorded when a client registered or its metadata document
+	// was read, or a trusted issuer's published key set.
 	KeySource jwks.Source
 
 	// ReplayIssuer is the stable server-side identity of the authorization
@@ -19,26 +42,101 @@ type Expectation struct {
 	// request.
 	ReplayIssuer string
 
+	// ReplayParty scopes a spent jti to who minted it, within
+	// ReplayIssuer: the client_id, or a stable reference to the trusted
+	// issuer row. A jti is only unique per minting party, so without this
+	// one party's identifiers would collide with another's.
+	ReplayParty string
+
+	// ReplaySubject narrows the identifier within ReplayParty and is empty
+	// when ReplayParty already names the whole party. A workload sets it
+	// to the external subject: one platform issuer vouches for many
+	// workloads, and a jti is unique per issuer rather than per workload.
+	ReplaySubject string
+
 	// Audiences are the aud values this endpoint accepts, computed per
 	// request from the endpoint being addressed.
 	Audiences Audiences
+
+	// MaxLifetime bounds how far this assertion's exp may sit in the
+	// future. Zero means DefaultMaxLifetime.
+	//
+	// The bound belongs to the profile rather than the package because the
+	// two disagree. DefaultMaxLifetime is a client-assertion ceiling, taken
+	// from what the strictest mainstream profile permits and what real
+	// implementations emit; a platform token's lifetime is set by that
+	// platform. Kubernetes is the case that forces the distinction: a
+	// projected service account token's expirationSeconds is routinely
+	// configured past an hour, and a cluster issuing longer-lived tokens
+	// would otherwise have every assertion rejected for a reason that has
+	// nothing to do with workloads.
+	//
+	// Widening DefaultMaxLifetime is not the lever to reach for: it also
+	// sets DefaultMaxReplayHold, so it widens the replay window for client
+	// authentication to buy something only workloads need.
+	MaxLifetime time.Duration
+}
+
+// ClientExpectation is the expectation for a client authenticating itself
+// with a private_key_jwt assertion.
+//
+// It holds RFC 7523 §3's rule that iss, sub, and client_id are one value, so
+// call sites cannot set Issuer and Subject apart: that would admit an
+// assertion vouching for someone other than the client being authenticated,
+// and nothing downstream would notice.
+func ClientExpectation(clientID string, keySource jwks.Source, replayIssuer string, audiences Audiences) Expectation {
+	return Expectation{
+		Issuer:        clientID,
+		Subject:       clientID,
+		KeySource:     keySource,
+		ReplayIssuer:  replayIssuer,
+		ReplayParty:   clientID,
+		ReplaySubject: "",
+		Audiences:     audiences,
+		MaxLifetime:   DefaultMaxLifetime,
+	}
 }
 
 // validate catches an Expectation the caller assembled incompletely. Each of
-// these would otherwise surface as a client-shaped failure: an empty ClientID
-// matches an assertion with no iss or sub, an empty ReplayIssuer makes the
-// replay guard refuse every key, and empty Audiences reject every aud. All
-// three are wiring faults and are labelled as such, so an operator does not
+// these would otherwise surface as a client-shaped failure: an empty Issuer
+// or Subject matches an assertion missing that claim, an empty replay part
+// makes the guard refuse every key, and empty Audiences reject every aud.
+// All are wiring faults and are labelled as such, so an operator does not
 // chase a client bug or a store outage that is neither.
 func (e Expectation) validate() error {
-	if e.ClientID == "" {
-		return reject(ReasonVerifierMisconfigured, "no client_id to authenticate against")
+	if e.Issuer == "" {
+		return reject(ReasonVerifierMisconfigured, "no issuer to authenticate against")
+	}
+	if e.Subject == "" {
+		return reject(ReasonVerifierMisconfigured, "no subject to authenticate against")
 	}
 	if e.ReplayIssuer == "" {
 		return reject(ReasonVerifierMisconfigured, "no replay issuer configured for this endpoint")
 	}
+	if e.ReplayParty == "" {
+		return reject(ReasonVerifierMisconfigured, "no replay party configured for this assertion")
+	}
 	if len(e.Audiences.accepted()) == 0 {
 		return reject(ReasonVerifierMisconfigured, "no audience values configured for this endpoint")
 	}
+	if e.MaxLifetime < 0 {
+		return reject(ReasonVerifierMisconfigured, "assertion lifetime bound is negative")
+	}
 	return nil
+}
+
+// lifetime is the ceiling this expectation puts on an assertion's exp,
+// falling back to the client-assertion bound when the caller named none.
+func (e Expectation) lifetime() time.Duration {
+	if e.MaxLifetime == 0 {
+		return DefaultMaxLifetime
+	}
+	return e.MaxLifetime
+}
+
+// replayHold is how long a spent identifier must be remembered under this
+// expectation: the full window in which an accepted assertion can still
+// verify.
+func (e Expectation) replayHold() time.Duration {
+	return ReplayHoldFor(e.lifetime())
 }

--- a/server/internal/usersessions/clientauth/expectation.go
+++ b/server/internal/usersessions/clientauth/expectation.go
@@ -122,6 +122,26 @@ func (e Expectation) validate() error {
 	if e.MaxLifetime < 0 {
 		return reject(ReasonVerifierMisconfigured, "assertion lifetime bound is negative")
 	}
+	// A bound large enough to overflow its own replay hold would wrap to a
+	// negative duration, which compares below every guard cap and so would
+	// pass the check in Verify that exists to catch exactly this.
+	if e.MaxLifetime > 0 && ReplayHoldFor(e.MaxLifetime) < e.MaxLifetime {
+		return reject(ReasonVerifierMisconfigured, "assertion lifetime bound overflows its replay hold")
+	}
+	// iss == sub is the client profile, whose ceiling is fixed by the
+	// mainstream profiles rather than chosen per endpoint. Enforced here so
+	// the bound cannot be widened for a client by assembling the struct
+	// directly instead of through ClientExpectation.
+	if e.Issuer == e.Subject && e.MaxLifetime > DefaultMaxLifetime {
+		return reject(ReasonVerifierMisconfigured, "client assertion lifetime bound exceeds %s", DefaultMaxLifetime)
+	}
+	// iss != sub is a workload, where one issuer vouches for many subjects.
+	// Without the subject in the replay scope they share one keyspace, and
+	// the first to spend a jti makes every other workload's assertion
+	// carrying it fail as a replay.
+	if e.Issuer != e.Subject && e.ReplaySubject == "" {
+		return reject(ReasonVerifierMisconfigured, "no replay subject configured for this workload")
+	}
 	return nil
 }
 

--- a/server/internal/usersessions/clientauth/reason.go
+++ b/server/internal/usersessions/clientauth/reason.go
@@ -35,8 +35,11 @@ const (
 	// verify under the resolved key.
 	ReasonSignatureInvalid Reason = "assertion_signature_invalid"
 
-	// ReasonSubjectMismatch reports iss and sub that are not both the client_id
-	// the request is authenticating, as RFC 7523 §3 requires.
+	// ReasonSubjectMismatch reports an iss or sub that is not what the
+	// expectation named: for a client assertion, both must be the client_id
+	// the request is authenticating, as RFC 7523 §3 requires; for a
+	// workload assertion, iss must be the trusted issuer and sub the
+	// admitted external subject.
 	ReasonSubjectMismatch Reason = "assertion_subject_mismatch"
 
 	// ReasonAudienceMismatch reports an aud naming neither this endpoint's issuer
@@ -73,11 +76,13 @@ const (
 	// or an outage would suspend replay protection exactly when it matters.
 	ReasonReplayStoreUnavailable Reason = "assertion_replay_store_unavailable"
 
-	// ReasonVerifierMisconfigured reports an Expectation the caller assembled
-	// without a client identity, a replay issuer, or any accepted audience.
-	// It is a server wiring fault, never a client error, and has its own
-	// label so it is not mistaken for the client-shaped failure each of
-	// those omissions would otherwise produce.
+	// ReasonVerifierMisconfigured reports an Expectation the caller
+	// assembled without an issuer or subject to match, without a replay
+	// scope, or without any accepted audience — or one whose assertions
+	// could outlive what the replay guard remembers. It is a server wiring
+	// fault, never a client error, and has its own label so it is not
+	// mistaken for the client-shaped failure each of those would otherwise
+	// produce.
 	ReasonVerifierMisconfigured Reason = "assertion_verifier_misconfigured"
 )
 

--- a/server/internal/usersessions/clientauth/reason.go
+++ b/server/internal/usersessions/clientauth/reason.go
@@ -35,11 +35,15 @@ const (
 	// verify under the resolved key.
 	ReasonSignatureInvalid Reason = "assertion_signature_invalid"
 
-	// ReasonSubjectMismatch reports an iss or sub that is not what the
-	// expectation named: for a client assertion, both must be the client_id
-	// the request is authenticating, as RFC 7523 §3 requires; for a
-	// workload assertion, iss must be the trusted issuer and sub the
-	// admitted external subject.
+	// ReasonSubjectMismatch reports an iss or sub that is missing, or not
+	// the value required of it.
+	//
+	// UnverifiedClientID requires only that the two be present and equal,
+	// having no expectation to compare them against yet. Verify checks each
+	// against the expectation: for a client assertion both must be the
+	// client_id being authenticated, as RFC 7523 §3 requires; for a workload
+	// assertion iss must be the trusted issuer and sub the admitted external
+	// subject.
 	ReasonSubjectMismatch Reason = "assertion_subject_mismatch"
 
 	// ReasonAudienceMismatch reports an aud naming neither this endpoint's issuer

--- a/server/internal/usersessions/clientauth/setup_test.go
+++ b/server/internal/usersessions/clientauth/setup_test.go
@@ -173,7 +173,7 @@ func newVerifier(t *testing.T) *clientauth.Verifier {
 	client, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	guard, err := replay.NewRedisGuard(client, string(testenv.NewCacheSuffix(t, "clientauth-replay")), clientauth.MaxReplayHold)
+	guard, err := replay.NewRedisGuard(client, string(testenv.NewCacheSuffix(t, "clientauth-replay")), clientauth.DefaultMaxReplayHold)
 	require.NoError(t, err)
 
 	verifier, err := clientauth.NewVerifier(newKeyResolver(t, client), guard)
@@ -185,15 +185,15 @@ func newVerifier(t *testing.T) *clientauth.Verifier {
 func expectationFor(t *testing.T, s *signer) clientauth.Expectation {
 	t.Helper()
 
-	return clientauth.Expectation{
-		ClientID:     testClientID,
-		KeySource:    s.source(t),
-		ReplayIssuer: t.Name(),
-		Audiences: clientauth.Audiences{
+	return clientauth.ClientExpectation(
+		testClientID,
+		s.source(t),
+		t.Name(),
+		clientauth.Audiences{
 			Issuer:   testIssuer,
 			Endpoint: testTokenURL,
 		},
-	}
+	)
 }
 
 // assertionFor wraps a raw assertion in a well-formed Assertion.

--- a/server/internal/usersessions/clientauth/verifier.go
+++ b/server/internal/usersessions/clientauth/verifier.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	// MaxLifetime bounds how far an assertion's exp may sit in the future.
+	// DefaultMaxLifetime bounds how far an assertion's exp may sit in the
+	// future when an Expectation names no bound of its own.
 	//
 	// One hour matches what real implementations emit and what the strictest
 	// mainstream profile permits: FAPI 2.0 caps client assertion lifetime at
@@ -22,10 +23,14 @@ const (
 	// ceiling would reject stock clients with an invalid_client they could
 	// not diagnose.
 	//
+	// It is the *client assertion* bound. A profile whose tokens are minted
+	// by someone else's platform carries its own on Expectation.MaxLifetime,
+	// which is also where the reason not to widen this constant lives.
+	//
 	// The bound is not doing replay work — the jti guard covers the whole
 	// validity window — it bounds how long that guard must remember each
 	// identifier, so the ceiling is a keyspace decision.
-	MaxLifetime = time.Hour
+	DefaultMaxLifetime = time.Hour
 
 	// MaxSkew is the clock difference tolerated on every temporal claim, in
 	// both directions. Client and server clocks genuinely drift; a window
@@ -33,16 +38,30 @@ const (
 	// no interoperability gain.
 	MaxSkew = time.Minute
 
-	// MaxReplayHold is how long a spent identifier must be remembered: the
-	// full window in which an accepted assertion can still verify.
-	//
-	// The skew counts twice. A client whose clock runs ahead may present an
-	// exp up to MaxSkew beyond MaxLifetime and still be accepted, and an
-	// assertion is then honoured until MaxSkew after that exp. Releasing an
-	// identifier anywhere inside that window is exactly what a replay needs,
-	// so NewVerifier refuses a guard whose cap is shorter than this.
-	MaxReplayHold = MaxLifetime + 2*MaxSkew
+	// DefaultMaxReplayHold is the hold a guard must provide to serve
+	// assertions bounded at DefaultMaxLifetime. It is the floor NewVerifier
+	// enforces, because every verifier can be handed a default-bounded
+	// expectation.
+	DefaultMaxReplayHold = DefaultMaxLifetime + 2*MaxSkew
 )
+
+// ReplayHoldFor is how long a spent identifier must be remembered for
+// assertions bounded at lifetime: the full window in which an accepted
+// assertion can still verify.
+//
+// The skew counts twice. A party whose clock runs ahead may present an exp up
+// to MaxSkew beyond the bound and still be accepted, and an assertion is then
+// honoured until MaxSkew after that exp. Releasing an identifier anywhere
+// inside that window is exactly what a replay needs.
+//
+// Size a guard with the longest lifetime it will be asked to serve. Verify
+// refuses an expectation whose hold would exceed the guard's cap rather than
+// letting it through, because Guard.Reserve clamps a longer hold silently and
+// nothing at request time would otherwise notice the reservation lapsing
+// while the assertion still verifies.
+func ReplayHoldFor(lifetime time.Duration) time.Duration {
+	return lifetime + 2*MaxSkew
+}
 
 // Verifier authenticates clients presenting assertions. Safe for concurrent
 // use; construct one at wiring time so its dependencies are created once.
@@ -62,11 +81,16 @@ type Verifier struct {
 // signature, and one without replay memory would accept every assertion for
 // as long as it stays valid, which is the property the jti exists to remove.
 //
-// The guard's cap must cover MaxReplayHold. A shorter cap would release
-// identifiers while their assertions still verify, and nothing at request
-// time would notice: the guard would report success and the replay would be
-// accepted. Checked here so the mismatch is a wiring error, not a silent
-// weakening.
+// The guard's cap must cover DefaultMaxReplayHold. A shorter cap would
+// release identifiers while their assertions still verify, and nothing at
+// request time would notice: the guard would report success and the replay
+// would be accepted. Checked here so the mismatch is a wiring error, not a
+// silent weakening.
+//
+// The check is a floor. An Expectation carrying a longer MaxLifetime needs a
+// proportionally longer hold, which cannot be known here because it varies
+// per request, so Verify re-checks the guard against the expectation it is
+// actually given.
 func NewVerifier(keys *jwks.KeyResolver, guard *replay.Guard) (*Verifier, error) {
 	if keys == nil {
 		return nil, errors.New("clientauth: Verifier requires a key resolver")
@@ -74,8 +98,8 @@ func NewVerifier(keys *jwks.KeyResolver, guard *replay.Guard) (*Verifier, error)
 	if guard == nil {
 		return nil, errors.New("clientauth: Verifier requires a replay guard")
 	}
-	if guard.MaxHold() < MaxReplayHold {
-		return nil, fmt.Errorf("clientauth: replay guard holds identifiers for %s, but assertions stay acceptable for up to %s", guard.MaxHold(), MaxReplayHold)
+	if guard.MaxHold() < DefaultMaxReplayHold {
+		return nil, fmt.Errorf("clientauth: replay guard holds identifiers for %s, but assertions stay acceptable for up to %s", guard.MaxHold(), DefaultMaxReplayHold)
 	}
 	return &Verifier{keys: keys, guard: guard}, nil
 }
@@ -92,6 +116,14 @@ func NewVerifier(keys *jwks.KeyResolver, guard *replay.Guard) (*Verifier, error)
 func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expectation) (*Result, error) {
 	if err := expect.validate(); err != nil {
 		return nil, err
+	}
+	// Before anything is parsed: an expectation whose assertions outlive
+	// what the guard remembers cannot be verified safely at all, and
+	// Reserve would clamp the hold rather than complain. A wiring fault,
+	// labelled as one.
+	hold := expect.replayHold()
+	if v.guard.MaxHold() < hold {
+		return nil, reject(ReasonVerifierMisconfigured, "replay guard holds identifiers for %s, but this assertion stays acceptable for up to %s", v.guard.MaxHold(), hold)
 	}
 	switch {
 	case assertion.Value == "":
@@ -135,8 +167,8 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 	}
 	now := time.Now()
 	if err := claims.ValidateWithLeeway(jwt.Expected{
-		Issuer:      expect.ClientID,
-		Subject:     expect.ClientID,
+		Issuer:      expect.Issuer,
+		Subject:     expect.Subject,
 		AnyAudience: expect.Audiences.accepted(),
 		Time:        now,
 		ID:          "",
@@ -144,8 +176,9 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 		return nil, rejectWith(reasonForClaimError(err), err)
 	}
 	expiresAt := claims.Expiry.Time()
-	if expiresAt.After(now.Add(MaxLifetime + MaxSkew)) {
-		return nil, reject(ReasonLifetimeTooLong, "exp is more than %s in the future", MaxLifetime)
+	lifetime := expect.lifetime()
+	if expiresAt.After(now.Add(lifetime + MaxSkew)) {
+		return nil, reject(ReasonLifetimeTooLong, "exp is more than %s in the future", lifetime)
 	}
 
 	// The library check proved aud intersects the accepted set; this
@@ -158,9 +191,10 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 	// Last, so an assertion rejected for any other reason does not spend an
 	// identifier and grow the keyspace.
 	claimed, err := v.guard.Reserve(ctx, replay.Key{
-		Issuer: expect.ReplayIssuer,
-		Client: expect.ClientID,
-		ID:     claims.ID,
+		Issuer:  expect.ReplayIssuer,
+		Party:   expect.ReplayParty,
+		Subject: expect.ReplaySubject,
+		ID:      claims.ID,
 	}, expiresAt.Add(MaxSkew))
 	if err != nil {
 		return nil, rejectWith(ReasonReplayStoreUnavailable, err)

--- a/server/internal/usersessions/clientauth/verifier_test.go
+++ b/server/internal/usersessions/clientauth/verifier_test.go
@@ -2,6 +2,7 @@ package clientauth_test
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -405,6 +406,51 @@ func TestVerify_MisconfiguredExpectationRejected(t *testing.T) {
 	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
 }
 
+// A bound big enough to overflow its replay hold wraps negative, and a
+// negative hold compares below every guard cap — so it would slip past the
+// check in Verify that exists to catch an unservable bound.
+func TestVerify_LifetimeOverflowingReplayHoldRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	expect := expectationFor(t, s)
+	expect.MaxLifetime = math.MaxInt64
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}
+
+// The client ceiling is fixed by the mainstream profiles, so assembling the
+// struct directly must not be a way around what ClientExpectation sets.
+func TestVerify_ClientProfileCannotWidenItsLifetime(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	expect := expectationFor(t, s)
+	expect.MaxLifetime = clientauth.DefaultMaxLifetime + time.Hour
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}
+
+// A workload's issuer vouches for many subjects. Leaving the subject out of
+// the replay scope puts them all in one keyspace, where the first to spend a
+// jti makes every other workload's assertion carrying it fail as a replay.
+func TestVerify_WorkloadWithoutReplaySubjectRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	expect := expectationFor(t, s)
+	expect.Subject = "workload-one"
+	expect.ReplaySubject = ""
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}
+
 // A guard sized for the default bound cannot serve an expectation that lets
 // assertions live longer: the reservation would lapse while the assertion
 // still verifies, and Guard.Reserve clamps the hold silently rather than
@@ -412,13 +458,22 @@ func TestVerify_MisconfiguredExpectationRejected(t *testing.T) {
 func TestVerify_LifetimeBeyondGuardHoldRejected(t *testing.T) {
 	t.Parallel()
 
+	const workloadSubject = "workload-one"
+
 	s := newSigner(t, testKeyID)
 	verifier := newVerifier(t)
 
+	claims := validClaims()
+	claims.Subject = workloadSubject
+
+	// A workload, so the bound is legitimately raisable and this exercises
+	// the guard-hold check rather than the client ceiling.
 	expect := expectationFor(t, s)
+	expect.Subject = workloadSubject
+	expect.ReplaySubject = workloadSubject
 	expect.MaxLifetime = 8 * time.Hour
 
-	_, err := verifier.Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	_, err := verifier.Verify(t.Context(), assertionFor(s.sign(t, claims)), expect)
 	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
 }
 
@@ -429,14 +484,24 @@ func TestVerify_LifetimeBeyondGuardHoldRejected(t *testing.T) {
 func TestVerify_ExpectationLifetimeWidensTheCeiling(t *testing.T) {
 	t.Parallel()
 
+	const workloadSubject = "repo:example/api:environment:prod"
+
 	s := newSigner(t, testKeyID)
 
+	// A workload assertion: iss is the platform, sub is the machine, and the
+	// exp sits past the client ceiling the way a Kubernetes projected token's
+	// does.
 	claims := validClaims()
+	claims.Subject = workloadSubject
 	claims.Expiry = jwt.NewNumericDate(time.Now().Add(3 * time.Hour))
 	assertion := assertionFor(s.sign(t, claims))
 
-	// The default client bound rejects it for lifetime, not for anything else.
-	_, err := newVerifier(t).Verify(t.Context(), assertion, expectationFor(t, s))
+	workload := expectationFor(t, s)
+	workload.Subject = workloadSubject
+	workload.ReplaySubject = workloadSubject
+
+	// Under the default bound it is rejected for lifetime, nothing else.
+	_, err := newVerifier(t).Verify(t.Context(), assertion, workload)
 	requireRejected(t, err, clientauth.ReasonLifetimeTooLong)
 
 	// A guard sized for the longer bound, and an expectation carrying it,
@@ -449,9 +514,8 @@ func TestVerify_ExpectationLifetimeWidensTheCeiling(t *testing.T) {
 	verifier, err := clientauth.NewVerifier(newKeyResolver(t, client), guard)
 	require.NoError(t, err)
 
-	expect := expectationFor(t, s)
-	expect.MaxLifetime = lifetime
-	_, err = verifier.Verify(t.Context(), assertion, expect)
+	workload.MaxLifetime = lifetime
+	_, err = verifier.Verify(t.Context(), assertion, workload)
 	require.NoError(t, err)
 }
 

--- a/server/internal/usersessions/clientauth/verifier_test.go
+++ b/server/internal/usersessions/clientauth/verifier_test.go
@@ -209,7 +209,7 @@ func TestVerify_OneHourLifetimeAccepted(t *testing.T) {
 
 	s := newSigner(t, testKeyID)
 	claims := validClaims()
-	claims.Expiry = jwt.NewNumericDate(time.Now().Add(clientauth.MaxLifetime))
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(clientauth.DefaultMaxLifetime))
 
 	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, claims)), expectationFor(t, s))
 	require.NoError(t, err)
@@ -325,8 +325,12 @@ func TestVerify_ReplayScopedToClient(t *testing.T) {
 	otherClaims.Issuer = otherClientID
 	otherClaims.Subject = otherClientID
 
-	expect := expectationFor(t, second)
-	expect.ClientID = otherClientID
+	expect := clientauth.ClientExpectation(
+		otherClientID,
+		second.source(t),
+		t.Name(),
+		clientauth.Audiences{Issuer: testIssuer, Endpoint: testTokenURL},
+	)
 	_, err = verifier.Verify(t.Context(), assertionFor(second.sign(t, otherClaims)), expect)
 	require.NoError(t, err, "another client reusing the same jti is not a replay")
 }
@@ -383,12 +387,87 @@ func TestVerify_MisconfiguredExpectationRejected(t *testing.T) {
 	_, err = verifier.Verify(t.Context(), assertionFor(assertion), noReplayIssuer)
 	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
 
-	// An empty ClientID would otherwise be satisfied by an assertion that
-	// simply omits iss and sub.
-	noClientID := expectationFor(t, s)
-	noClientID.ClientID = ""
-	_, err = verifier.Verify(t.Context(), assertionFor(assertion), noClientID)
+	noReplayParty := expectationFor(t, s)
+	noReplayParty.ReplayParty = ""
+	_, err = verifier.Verify(t.Context(), assertionFor(assertion), noReplayParty)
 	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+
+	// An empty Issuer or Subject would otherwise be satisfied by an
+	// assertion that simply omits that claim.
+	noIssuer := expectationFor(t, s)
+	noIssuer.Issuer = ""
+	_, err = verifier.Verify(t.Context(), assertionFor(assertion), noIssuer)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+
+	noSubject := expectationFor(t, s)
+	noSubject.Subject = ""
+	_, err = verifier.Verify(t.Context(), assertionFor(assertion), noSubject)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}
+
+// A guard sized for the default bound cannot serve an expectation that lets
+// assertions live longer: the reservation would lapse while the assertion
+// still verifies, and Guard.Reserve clamps the hold silently rather than
+// complaining. Refused per request, since the bound is only known then.
+func TestVerify_LifetimeBeyondGuardHoldRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+
+	expect := expectationFor(t, s)
+	expect.MaxLifetime = 8 * time.Hour
+
+	_, err := verifier.Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}
+
+// The per-expectation bound is what the exp ceiling is measured against, not
+// the package default. A workload profile that permits a longer lifetime must
+// accept an assertion the client bound would have rejected — this is the
+// Kubernetes case, where expirationSeconds is routinely past an hour.
+func TestVerify_ExpectationLifetimeWidensTheCeiling(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	claims := validClaims()
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(3 * time.Hour))
+	assertion := assertionFor(s.sign(t, claims))
+
+	// The default client bound rejects it for lifetime, not for anything else.
+	_, err := newVerifier(t).Verify(t.Context(), assertion, expectationFor(t, s))
+	requireRejected(t, err, clientauth.ReasonLifetimeTooLong)
+
+	// A guard sized for the longer bound, and an expectation carrying it,
+	// accepts the same assertion.
+	client, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	lifetime := 4 * time.Hour
+	guard, err := replay.NewRedisGuard(client, string(testenv.NewCacheSuffix(t, "long")), clientauth.ReplayHoldFor(lifetime))
+	require.NoError(t, err)
+	verifier, err := clientauth.NewVerifier(newKeyResolver(t, client), guard)
+	require.NoError(t, err)
+
+	expect := expectationFor(t, s)
+	expect.MaxLifetime = lifetime
+	_, err = verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+}
+
+// iss and sub are matched separately, so an assertion satisfying one and not
+// the other is still rejected. A workload's two values differ, so nothing may
+// collapse them into a single comparison.
+func TestVerify_SubjectMustMatchIndependentlyOfIssuer(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	claims := validClaims()
+	claims.Subject = "someone-else"
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, claims)), expectationFor(t, s))
+	requireRejected(t, err, clientauth.ReasonSubjectMismatch)
 }
 
 // A guard whose cap is shorter than the window an assertion stays acceptable
@@ -400,7 +479,7 @@ func TestNewVerifier_RejectsShortReplayHold(t *testing.T) {
 	client, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
-	short, err := replay.NewRedisGuard(client, string(testenv.NewCacheSuffix(t, "short")), clientauth.MaxReplayHold-time.Second)
+	short, err := replay.NewRedisGuard(client, string(testenv.NewCacheSuffix(t, "short")), clientauth.DefaultMaxReplayHold-time.Second)
 	require.NoError(t, err)
 
 	_, err = clientauth.NewVerifier(newKeyResolver(t, client), short)
@@ -414,7 +493,7 @@ func TestNewVerifier_RejectsShortReplayHold(t *testing.T) {
 func TestMaxReplayHold_CoversAcceptanceWindow(t *testing.T) {
 	t.Parallel()
 
-	require.GreaterOrEqual(t, clientauth.MaxReplayHold, clientauth.MaxLifetime+2*clientauth.MaxSkew)
+	require.GreaterOrEqual(t, clientauth.DefaultMaxReplayHold, clientauth.DefaultMaxLifetime+2*clientauth.MaxSkew)
 }
 
 // An assertion presented without its type parameter is a malformed request,
@@ -507,7 +586,7 @@ func TestVerify_ReplayStoreOutageRefuses(t *testing.T) {
 	// A client pointed at nothing: every command fails at dial time.
 	dead := redis.NewClient(&redis.Options{Addr: "127.0.0.1:1", DialTimeout: 100 * time.Millisecond, MaxRetries: -1})
 	t.Cleanup(func() { _ = dead.Close() })
-	guard, err := replay.NewRedisGuard(dead, string(testenv.NewCacheSuffix(t, "outage")), clientauth.MaxReplayHold)
+	guard, err := replay.NewRedisGuard(dead, string(testenv.NewCacheSuffix(t, "outage")), clientauth.DefaultMaxReplayHold)
 	require.NoError(t, err)
 	verifier, err := clientauth.NewVerifier(newKeyResolver(t, live), guard)
 	require.NoError(t, err)

--- a/server/internal/usersessions/replay/guard.go
+++ b/server/internal/usersessions/replay/guard.go
@@ -88,11 +88,13 @@ func (g *Guard) MaxHold() time.Duration {
 // An error means the store could not be consulted. The identifier's status is
 // then unknown, and an unknown identifier must be treated as a replay.
 func (g *Guard) Reserve(ctx context.Context, key Key, holdUntil time.Time) (bool, error) {
-	if key.Issuer == "" || key.Client == "" || key.ID == "" {
+	if key.Issuer == "" || key.Party == "" || key.ID == "" {
 		// An assertion with no jti reaches here only through a caller that
 		// failed to require one, and an empty part would put every such
-		// assertion on the same storage key.
-		return false, errors.New("replay: every Key part must be set")
+		// assertion on the same storage key. Subject is exempt: a client
+		// assertion legitimately leaves it empty, because Party already
+		// names the whole minting party.
+		return false, errors.New("replay: Key needs an Issuer, a Party, and an ID")
 	}
 
 	ttl := min(max(time.Until(holdUntil), minHoldTTL), g.maxHold)

--- a/server/internal/usersessions/replay/key.go
+++ b/server/internal/usersessions/replay/key.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 )
 
-// Key identifies one single-use assertion identifier. The three parts are
-// hashed together into the storage key, so no part can be confused with
-// another however the values are punctuated.
+// Key identifies one single-use assertion identifier. The parts are hashed
+// together into the storage key, so no part can be confused with another
+// however the values are punctuated.
 type Key struct {
 	// Issuer is the authorization server the assertion was presented to,
 	// as a stable server-side identity such as a row identifier.
@@ -20,10 +20,25 @@ type Key struct {
 	// per reachable hostname.
 	Issuer string
 
-	// Client is the party the assertion authenticates, normally the
-	// client_id. It keeps one tenant's identifiers from colliding with,
-	// or evicting, another's.
-	Client string
+	// Party is who minted the assertion: the client_id for a client
+	// assertion, or a stable server-side reference to the trusted issuer
+	// row for a workload assertion. It keeps one tenant's identifiers from
+	// colliding with, or evicting, another's.
+	//
+	// A workload's Party must be the issuer reference rather than the
+	// issuer URL, for the same reason Issuer must not be one.
+	Party string
+
+	// Subject narrows the identifier within Party, and is empty when Party
+	// already names the whole minting party.
+	//
+	// A client assertion leaves it empty: RFC 7523 §3 makes iss, sub, and
+	// client_id one value, so Party is the whole identity. A workload
+	// assertion sets it to the external subject, because one platform
+	// issuer vouches for many workloads. A jti is only unique per issuer,
+	// never per workload, so without this two workloads under one issuer
+	// would share a keyspace and could burn each other's identifiers.
+	Subject string
 
 	// ID is the assertion's jti claim, verbatim.
 	ID string
@@ -31,14 +46,16 @@ type Key struct {
 
 // storageKey is the hashed, length-prefixed encoding of a Key.
 //
-// Length prefixes make the encoding injective: without them a Client of
-// "a:b" with an ID of "c" and a Client of "a" with an ID of "b:c" would
-// collide, letting one client burn another's identifiers. Hashing then bounds
-// the result, which matters because both Client and ID arrive from outside and
-// a CIMD client_id is a URL that may run to kilobytes.
+// Length prefixes make the encoding injective: without them a Party of
+// "a:b" with an ID of "c" and a Party of "a" with an ID of "b:c" would
+// collide, letting one party burn another's identifiers. The same holds
+// across the Party/Subject boundary, which is why Subject is a part of its
+// own rather than folded into Party by the caller. Hashing then bounds the
+// result, which matters because every part but Issuer arrives from outside
+// and a CIMD client_id is a URL that may run to kilobytes.
 func (k Key) storageKey() string {
 	sum := sha256.New()
-	for _, part := range []string{k.Issuer, k.Client, k.ID} {
+	for _, part := range []string{k.Issuer, k.Party, k.Subject, k.ID} {
 		sum.Write([]byte(strconv.Itoa(len(part))))
 		sum.Write([]byte(":"))
 		sum.Write([]byte(part))

--- a/server/internal/usersessions/replay/key.go
+++ b/server/internal/usersessions/replay/key.go
@@ -53,9 +53,28 @@ type Key struct {
 // own rather than folded into Party by the caller. Hashing then bounds the
 // result, which matters because every part but Issuer arrives from outside
 // and a CIMD client_id is a URL that may run to kilobytes.
+//
+// An empty Subject contributes no part at all, rather than a zero-length
+// one. Two replicas running different builds share this keyspace during a
+// rolling deploy, so a key whose parts have not changed must hash the same
+// under both: emitting a "0:" segment for the absent Subject would move
+// every client-assertion key at once, orphaning the holds already taken and
+// letting an assertion spent against one replica be spent again against
+// another for as long as the original hold had left to run.
+//
+// Omitting it stays injective because the encoding is self-delimiting — a
+// length, a colon, then exactly that many bytes — so a three-part sequence
+// cannot decode as a four-part one however the values are punctuated.
 func (k Key) storageKey() string {
+	parts := make([]string, 0, 4)
+	parts = append(parts, k.Issuer, k.Party)
+	if k.Subject != "" {
+		parts = append(parts, k.Subject)
+	}
+	parts = append(parts, k.ID)
+
 	sum := sha256.New()
-	for _, part := range []string{k.Issuer, k.Party, k.Subject, k.ID} {
+	for _, part := range parts {
 		sum.Write([]byte(strconv.Itoa(len(part))))
 		sum.Write([]byte(":"))
 		sum.Write([]byte(part))

--- a/server/internal/usersessions/replay/replay_test.go
+++ b/server/internal/usersessions/replay/replay_test.go
@@ -1,6 +1,9 @@
 package replay
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -137,6 +140,27 @@ func TestKey_SubjectCannotCollideWithParty(t *testing.T) {
 	shifted := Key{Issuer: "iss", Party: "a", Subject: "b:c", ID: "jti"}
 
 	require.NotEqual(t, split.storageKey(), shifted.storageKey())
+}
+
+// A key with no Subject must hash exactly as it did before Subject existed.
+// Replicas running different builds share this keyspace during a rolling
+// deploy, so moving client-assertion keys would orphan every hold already
+// taken and let a spent assertion be spent again against a newer replica.
+// The legacy encoding is spelled out here rather than referenced, so a change
+// to storageKey has to confront it.
+func TestKey_EmptySubjectPreservesLegacyEncoding(t *testing.T) {
+	t.Parallel()
+
+	sum := sha256.New()
+	for _, part := range []string{"iss", "client", "jti"} {
+		sum.Write([]byte(strconv.Itoa(len(part))))
+		sum.Write([]byte(":"))
+		sum.Write([]byte(part))
+	}
+	legacy := base64.RawURLEncoding.EncodeToString(sum.Sum(nil))
+
+	got := Key{Issuer: "iss", Party: "client", Subject: "", ID: "jti"}.storageKey()
+	require.Equal(t, legacy, got, "client assertion keys must not move")
 }
 
 // Two workloads vouched for by one issuer must not share a keyspace. A jti is

--- a/server/internal/usersessions/replay/replay_test.go
+++ b/server/internal/usersessions/replay/replay_test.go
@@ -81,8 +81,8 @@ func TestReserve_ScopedByClient(t *testing.T) {
 
 	guard, _ := newTestGuard(t, time.Hour)
 
-	first := Key{Issuer: t.Name(), Client: "client-one", ID: "shared-jti"}
-	second := Key{Issuer: t.Name(), Client: "client-two", ID: "shared-jti"}
+	first := Key{Issuer: t.Name(), Party: "client-one", ID: "shared-jti"}
+	second := Key{Issuer: t.Name(), Party: "client-two", ID: "shared-jti"}
 
 	claimed, err := guard.Reserve(t.Context(), first, time.Now().Add(time.Minute))
 	require.NoError(t, err)
@@ -100,8 +100,8 @@ func TestReserve_ScopedByIssuer(t *testing.T) {
 
 	guard, _ := newTestGuard(t, time.Hour)
 
-	first := Key{Issuer: t.Name() + "-issuer-one", Client: "client", ID: "shared-jti"}
-	second := Key{Issuer: t.Name() + "-issuer-two", Client: "client", ID: "shared-jti"}
+	first := Key{Issuer: t.Name() + "-issuer-one", Party: "client", ID: "shared-jti"}
+	second := Key{Issuer: t.Name() + "-issuer-two", Party: "client", ID: "shared-jti"}
 
 	claimed, err := guard.Reserve(t.Context(), first, time.Now().Add(time.Minute))
 	require.NoError(t, err)
@@ -112,16 +112,63 @@ func TestReserve_ScopedByIssuer(t *testing.T) {
 	require.True(t, claimed, "another issuer's identical jti must not be treated as a replay")
 }
 
-// Length-prefixed hashing keeps the three parts distinguishable. Without it
-// these two keys would encode identically and one client could burn the
-// other's identifiers.
+// Length-prefixed hashing keeps the parts distinguishable. Without it these
+// two keys would encode identically and one client could burn the other's
+// identifiers.
 func TestKey_PunctuationCannotCollide(t *testing.T) {
 	t.Parallel()
 
-	split := Key{Issuer: "iss", Client: "a:b", ID: "c"}
-	shifted := Key{Issuer: "iss", Client: "a", ID: "b:c"}
+	split := Key{Issuer: "iss", Party: "a:b", ID: "c"}
+	shifted := Key{Issuer: "iss", Party: "a", ID: "b:c"}
 
 	require.NotEqual(t, split.storageKey(), shifted.storageKey())
+}
+
+// The same property across the Party/Subject boundary. This is why Subject is
+// a part of its own rather than something a caller folds into Party: a
+// workload's external subject is attacker-influenced and colon-heavy — a
+// GitHub Actions sub reads `repo:org/name:ref:refs/heads/main` — so a caller
+// concatenating the two would reintroduce exactly the collision the length
+// prefixes exist to close.
+func TestKey_SubjectCannotCollideWithParty(t *testing.T) {
+	t.Parallel()
+
+	split := Key{Issuer: "iss", Party: "a:b", Subject: "c", ID: "jti"}
+	shifted := Key{Issuer: "iss", Party: "a", Subject: "b:c", ID: "jti"}
+
+	require.NotEqual(t, split.storageKey(), shifted.storageKey())
+}
+
+// Two workloads vouched for by one issuer must not share a keyspace. A jti is
+// unique per issuer, never per workload, so without Subject in the key the
+// first workload to present an identifier would burn it for the second.
+func TestReserve_ScopedBySubject(t *testing.T) {
+	t.Parallel()
+
+	guard, _ := newTestGuard(t, time.Hour)
+
+	first := Key{Issuer: t.Name(), Party: "issuer-ref", Subject: "workload-one", ID: "shared-jti"}
+	second := Key{Issuer: t.Name(), Party: "issuer-ref", Subject: "workload-two", ID: "shared-jti"}
+
+	claimed, err := guard.Reserve(t.Context(), first, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	claimed, err = guard.Reserve(t.Context(), second, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, claimed, "another workload's identical jti must not be treated as a replay")
+}
+
+// An empty Subject is legitimate — a client assertion has no second identity
+// to name — so it must not be refused the way the required parts are.
+func TestReserve_EmptySubjectAccepted(t *testing.T) {
+	t.Parallel()
+
+	guard, _ := newTestGuard(t, time.Hour)
+
+	claimed, err := guard.Reserve(t.Context(), Key{Issuer: t.Name(), Party: "client", Subject: "", ID: "jti"}, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, claimed)
 }
 
 // A hold window that has already passed must still produce a real expiry.
@@ -192,12 +239,12 @@ func TestReserve_RejectsIncompleteKey(t *testing.T) {
 
 	guard, _ := newTestGuard(t, time.Hour)
 
-	_, err := guard.Reserve(t.Context(), Key{Issuer: "iss", Client: "client", ID: ""}, time.Now().Add(time.Minute))
+	_, err := guard.Reserve(t.Context(), Key{Issuer: "iss", Party: "client", ID: ""}, time.Now().Add(time.Minute))
 	require.Error(t, err, "an assertion with no jti must not be reservable")
 
-	_, err = guard.Reserve(t.Context(), Key{Issuer: "", Client: "client", ID: "jti"}, time.Now().Add(time.Minute))
+	_, err = guard.Reserve(t.Context(), Key{Issuer: "", Party: "client", ID: "jti"}, time.Now().Add(time.Minute))
 	require.Error(t, err)
 
-	_, err = guard.Reserve(t.Context(), Key{Issuer: "iss", Client: "", ID: "jti"}, time.Now().Add(time.Minute))
+	_, err = guard.Reserve(t.Context(), Key{Issuer: "iss", Party: "", ID: "jti"}, time.Now().Add(time.Minute))
 	require.Error(t, err)
 }

--- a/server/internal/usersessions/replay/setup_test.go
+++ b/server/internal/usersessions/replay/setup_test.go
@@ -51,7 +51,7 @@ func testKey(t *testing.T, id string) Key {
 
 	return Key{
 		Issuer: t.Name(),
-		Client: "https://client.example.com/oauth/client.json",
+		Party:  "https://client.example.com/oauth/client.json",
 		ID:     id,
 	}
 }


### PR DESCRIPTION
AIM-147

## Summary

Generalises `clientauth.Expectation` so it can express a workload assertion, and verifies one through the existing `clientauth.Verify`. Client-assertion behaviour is unchanged: same bound, same replay hold, same wire-visible rejections.

**`Expectation` splits `ClientID` into `Issuer` and `Subject`.** A client assertion needs `iss == sub == client_id` (RFC 7523 §3); a workload assertion has `iss` = the platform issuer and `sub` = the machine it vouches for, so one field could not carry both. `ClientExpectation` is the constructor for the client profile, and exists so the RFC rule is stated once rather than at each call site — with exhaustruct on production code, hand-building the literal would make setting the two apart a one-token silent weakening.

**`MaxLifetime` moves onto the expectation.** The package constant is now `DefaultMaxLifetime`, `MaxReplayHold` is now `DefaultMaxReplayHold`, and `ReplayHoldFor(lifetime)` derives the hold for a given bound. Zero on the expectation falls back to the default, so the client path is untouched.

**`Verify` re-checks the guard's cap against the expectation's hold.** `NewVerifier`'s existing construction-time check is a floor and cannot see a per-request bound. Without the second check a longer-lived expectation would have had its hold silently clamped by `Guard.Reserve`, releasing identifiers while the assertion still verified — a replay window opened by a change that looks like configuration. It is refused as `ReasonVerifierMisconfigured`.

**`replay.Key` gains issuer scoping.** `Client` becomes `Party` (a client_id, or a stable reference to the trusted issuer row), plus a new optional `Subject`. `Subject` is a length-prefixed part of its own rather than something the caller folds into `Party`: a workload's external subject is colon-heavy — a GitHub Actions `sub` reads `repo:org/name:ref:refs/heads/main` — so concatenation would reintroduce exactly the cross-party collision the length prefixes exist to close. Empty `Subject` stays valid, since a client assertion has no second identity to name.

New tests cover the guard-hold refusal, a per-expectation bound widening the ceiling where the default rejects, `sub` matching independently of `iss`, and both the subject scoping and its injectivity in `replay`.

## Motivation

Foundation for the workload identity grant. A workload presents the identity token its own platform minted, which is a close cousin of a client assertion — same signature checking, same algorithm allowlist, same `jti` replay guard — but differs in the two places this PR touches.

The first is who the assertion is about. `Expectation` carried a single `ClientID` and passed it as both `Issuer` and `Subject`, which is correct for a client authenticating itself and wrong for an issuer vouching for a machine.

The second is lifetime. The one-hour ceiling is client-assertion reasoning: FAPI 2.0 caps client assertions at 60 minutes, and Google and Okta both top out there. Platform tokens are not bound by that, and Kubernetes is the case that forces the change — a projected service-account token's `expirationSeconds` is routinely configured past an hour, so a cluster issuing longer-lived tokens would have had every assertion rejected for a reason unrelated to workloads.

Raising the constant was not the fix. `MaxReplayHold` was derived from it, so raising it would have widened the replay window for client authentication to buy something only workloads need. Carrying the bound on the expectation keeps the two profiles independent, and deriving the hold from whichever bound applies keeps the replay guarantee attached to the bound that produced it.

No new request path is reachable. The token endpoint still dispatches only `authorization_code` and `refresh_token`, so `Verify` is called solely by the client-assertion path today; the workload caller arrives with the admission lookup (AIM-149) and the grant itself.

## Review follow-ups (second commit)

Five issues came out of automated review; all five were real and are fixed in `015881a`. Two are worth a reviewer's attention on their own.

**The replay key had to stay backward compatible, and that is the highest-risk part of this PR.** Adding a fourth part to `replay.Key` changes the hash of every *existing* client-assertion key. Replicas running different builds share one Redis namespace, so mid-rollout an assertion spent against an old replica would hash differently on a new one, look unspent, and be accepted again — a replay window lasting as long as the orphaned holds, up to `DefaultMaxReplayHold`. No test would have caught it, because every test runs one build.

An empty `Subject` therefore contributes no part at all rather than a zero-length one, so client-assertion keys encode byte-identically to before. That stays injective because the encoding is self-delimiting — a decimal length, a colon, then exactly that many bytes — so a three-part sequence cannot decode as a four-part one whatever the values contain. `TestKey_EmptySubjectPreservesLegacyEncoding` writes the legacy encoding out literally so any future change to `storageKey` has to confront it. `clientauth` is the only consumer of this package, and the guard namespace is unchanged.

**The profile is inferred from `iss == sub`, not declared — worth a second opinion.** Two new checks in `validate` need to know which profile an expectation belongs to: the client ceiling (a client assertion may not raise `MaxLifetime` past `DefaultMaxLifetime` by assembling the struct directly) and workload replay scoping (a workload must set `ReplaySubject`, or every workload under one issuer shares a keyspace and the first to spend a `jti` fails the rest as replays).

Both use `Issuer == Subject` as the discriminator, since RFC 7523 §3 makes that true of client assertions and effectively never true of a workload, whose `iss` is a platform URL and `sub` a machine identity. It avoids a redundant field that could disagree with the values it describes. The trade is that it is an inference: a workload that somehow presented `iss == sub` would be silently held to the client ceiling. An explicit profile field is the alternative if reviewers would rather the two be declared than derived — worth settling here, since AIM-149 and the grant both build on this interface.

The remaining three: a lifetime bound large enough to overflow its own replay hold wrapped negative and slipped past the guard-cap check (now rejected in `validate`); and a `ReasonSubjectMismatch` doc that described only the `Verify` path, though `UnverifiedClientID` also returns it before any expectation exists.
