### PR TITLE
feat: enforce AI access on MCP tool calls

### DIFF
--- a/.changeset/internal-ai-access-mcp-enforcement.md
+++ b/.changeset/internal-ai-access-mcp-enforcement.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Authenticated hosted and private MCP tool calls now honor the internal AI-access kill switch alongside the customer-managed MCP tool-call kill switch. Both checks use the authenticated user and canonical MCP server identity in one fail-closed evaluation, while MCP-specific operator messages retain precedence when both switches match.

--- a/server/internal/killswitches/mcptoolexecution/checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint.go
@@ -20,6 +20,10 @@ import (
 // per-call serving path.
 const DefaultEvaluationTimeout = time.Second
 
+func mcpEvaluationDefinitionKeys() []killswitches.DefinitionKey {
+	return []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}
+}
+
 type evaluator interface {
 	Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult
 }
@@ -38,8 +42,8 @@ type Checkpoint struct {
 	flags         feature.Provider
 }
 
-// NewCheckpoint builds the private MCP tool-execution checkpoint
-// from the registered adapters and authoritative PostgreSQL evaluator.
+// NewCheckpoint builds the private dual-definition MCP checkpoint from the
+// registered adapters and authoritative PostgreSQL evaluator.
 func NewCheckpoint(db *pgxpool.Pool, timeout time.Duration, meterProvider metric.MeterProvider, logger *slog.Logger, flags feature.Provider) (*Checkpoint, error) {
 	registry, err := NewRegistry(db)
 	if err != nil {
@@ -148,7 +152,7 @@ func (c *Checkpoint) evaluate(ctx context.Context, organizationID, mcpServerID s
 
 	result := c.evaluator.Evaluate(ctx, killswitches.EvaluationRequest{
 		OrganizationID:      organization,
-		DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution},
+		DefinitionKeys:      mcpEvaluationDefinitionKeys(),
 		PrincipalCandidates: derivation.principalResult.Candidates(),
 		ResourceKind:        ResourceKindMCPServer,
 		ResourceKey:         resourceKey,

--- a/server/internal/killswitches/mcptoolexecution/checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint.go
@@ -20,8 +20,10 @@ import (
 // per-call serving path.
 const DefaultEvaluationTimeout = time.Second
 
+var mcpEvaluationDefinitions = [...]killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}
+
 func mcpEvaluationDefinitionKeys() []killswitches.DefinitionKey {
-	return []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}
+	return mcpEvaluationDefinitions[:]
 }
 
 type evaluator interface {

--- a/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
@@ -19,20 +19,24 @@ import (
 type countingEvaluator struct {
 	delegate evaluator
 	calls    int
+	requests []killswitches.EvaluationRequest
 }
 
 func (e *countingEvaluator) Evaluate(ctx context.Context, request killswitches.EvaluationRequest) killswitches.EvaluationResult {
 	e.calls++
+	e.requests = append(e.requests, request)
 	return e.delegate.Evaluate(ctx, request)
 }
 
 type fixedEvaluator struct {
-	result killswitches.EvaluationResult
-	calls  int
+	result   killswitches.EvaluationResult
+	calls    int
+	requests []killswitches.EvaluationRequest
 }
 
-func (e *fixedEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+func (e *fixedEvaluator) Evaluate(_ context.Context, request killswitches.EvaluationRequest) killswitches.EvaluationResult {
 	e.calls++
+	e.requests = append(e.requests, request)
 	return e.result
 }
 
@@ -40,6 +44,11 @@ func enforcedRollout(organizationID string) *feature.InMemory {
 	flags := &feature.InMemory{}
 	flags.SetFlag(feature.FlagMCPKillswitchEnforce, organizationID, true)
 	return flags
+}
+
+func TestMCPEvaluationDefinitionCandidates(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, mcpEvaluationDefinitionKeys())
 }
 
 func TestCheckpointEvaluatesEveryCoveredCallWithRealEvaluator(t *testing.T) {
@@ -239,4 +248,6 @@ func TestCheckpointReturnsEvaluatorInfrastructureFailureWithoutMatch(t *testing.
 	_, hasNote := disposition.ExternalNote()
 	require.False(t, hasNote)
 	require.Equal(t, 1, evaluation.calls)
+	require.Len(t, evaluation.requests, 1)
+	require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, evaluation.requests[0].DefinitionKeys)
 }

--- a/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
@@ -81,7 +81,10 @@ func TestPrivateCheckpointDualDefinitionMatrixAndNextCall(t *testing.T) {
 	// The MCP match was activated first and is less specific than the newer,
 	// selected AI match. Definition candidate order must still choose MCP.
 	requireNote("MCP-specific note.")
-	require.Equal(t, 4, counted.calls)
+
+	deletePrescription(t, conn, orgID, mcpID)
+	requireNote("Newer selected AI note.")
+	require.Equal(t, 5, counted.calls)
 	for _, request := range counted.requests {
 		require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, request.DefinitionKeys)
 	}

--- a/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
@@ -1,0 +1,133 @@
+package mcptoolexecution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestPrivateCheckpointDualDefinitionMatrixAndNextCall(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_mcp_dual_matrix")
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	realEvaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
+	require.NoError(t, err)
+	counted := &countingEvaluator{delegate: realEvaluator}
+	checkpoint, err := newCheckpoint(registry, counted, time.Second)
+	require.NoError(t, err)
+
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "dual-matrix", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	ctx := testIdentityContext(t, mcpidentity.KindUserSession, userID)
+
+	evaluate := func() killswitches.TransportDisposition {
+		t.Helper()
+		disposition, evalErr := checkpoint.Evaluate(ctx, orgID, serverID.String())
+		require.NoError(t, evalErr)
+		return disposition
+	}
+	requireNote := func(want string) {
+		t.Helper()
+		disposition := evaluate()
+		require.Equal(t, killswitches.TransportDispositionMatchedDenial, disposition.Kind())
+		note, ok := disposition.ExternalNote()
+		require.True(t, ok)
+		require.Equal(t, want, note)
+	}
+
+	// No match is not cached: the AI-only prescription is authoritative on the
+	// immediately following call.
+	require.Equal(t, killswitches.TransportDispositionContinue, evaluate().Kind())
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:            uuid.New(),
+		DefinitionKey: DefinitionKeyAIAccess,
+		PrincipalKey:  userID,
+		Scope:         "selected",
+		Resources:     []string{serverID.String()},
+		ExternalNote:  "AI-only note.",
+	})
+	requireNote("AI-only note.")
+
+	clearPrescriptions(t, conn, orgID)
+	mcpID := uuid.New()
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           mcpID,
+		PrincipalKey: userID,
+		Scope:        "all",
+		ExternalNote: "MCP-specific note.",
+	})
+	requireNote("MCP-specific note.")
+
+	aiID := uuid.New()
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:            aiID,
+		DefinitionKey: DefinitionKeyAIAccess,
+		PrincipalKey:  userID,
+		Scope:         "selected",
+		Resources:     []string{serverID.String()},
+		ExternalNote:  "Newer selected AI note.",
+	})
+	// The MCP match was activated first and is less specific than the newer,
+	// selected AI match. Definition candidate order must still choose MCP.
+	requireNote("MCP-specific note.")
+	require.Equal(t, 4, counted.calls)
+	for _, request := range counted.requests {
+		require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, request.DefinitionKeys)
+	}
+}
+
+func TestEvaluatorHasNoImplicitCapabilityHierarchy(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_mcp_no_hierarchy")
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	evaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
+	require.NoError(t, err)
+
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "no-hierarchy", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:            uuid.New(),
+		DefinitionKey: DefinitionKeyAIAccess,
+		PrincipalKey:  userID,
+		Scope:         "all",
+		ExternalNote:  "AI only.",
+	})
+
+	request := killswitches.EvaluationRequest{
+		OrganizationID:      killswitches.OrganizationID(orgID),
+		DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution},
+		PrincipalCandidates: []killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(userID)}},
+		ResourceKind:        ResourceKindMCPServer,
+		ResourceKey:         killswitches.ResourceKey(serverID.String()),
+	}
+	require.Equal(t, killswitches.EvaluationResultNoMatch, evaluator.Evaluate(t.Context(), request).Kind())
+	request.DefinitionKeys = []killswitches.DefinitionKey{DefinitionKeyAIAccess}
+	require.Equal(t, killswitches.EvaluationResultMatch, evaluator.Evaluate(t.Context(), request).Kind())
+
+	clearPrescriptions(t, conn, orgID)
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           uuid.New(),
+		PrincipalKey: userID,
+		Scope:        "all",
+		ExternalNote: "MCP only.",
+	})
+	require.Equal(t, killswitches.EvaluationResultNoMatch, evaluator.Evaluate(t.Context(), request).Kind())
+	request.DefinitionKeys = []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution}
+	require.Equal(t, killswitches.EvaluationResultMatch, evaluator.Evaluate(t.Context(), request).Kind())
+}

--- a/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
@@ -87,6 +87,56 @@ func TestPrivateCheckpointDualDefinitionMatrixAndNextCall(t *testing.T) {
 	}
 }
 
+func TestAIAccessLifecyclePersistsExactMCPIdentity(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_ai_access_lifecycle")
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	lifecycle, err := killswitches.NewLifecycleService(conn, registry, NewCustomerLifecycleValidator(), nil)
+	require.NoError(t, err)
+	facade, err := killswitches.NewFacade(lifecycle)
+	require.NoError(t, err)
+
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "ai-lifecycle", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+
+	activated, err := lifecycle.ActivatePrescription(t.Context(), killswitches.ActivatePrescriptionRequest{
+		MutationContext: killswitches.MutationContext{
+			OrganizationID:   killswitches.OrganizationID(orgID),
+			ActorUserID:      userID,
+			ActorDisplayName: "Test operator",
+			OperationID:      uuid.New(),
+		},
+		Definition:     DefinitionKeyAIAccess,
+		PrincipalKind:  PrincipalKindUser,
+		PrincipalInput: userID,
+		ResourceKind:   ResourceKindMCPServer,
+		Desired: killswitches.DesiredVersionInput{
+			ResourceScope:          killswitches.ResourceScopeSelected,
+			SelectedResourceInputs: []string{serverID.String()},
+			StartMode:              killswitches.StartModeNow,
+			InternalNote:           "test incident context",
+			ExternalNote:           "AI access paused.",
+		},
+	})
+	require.NoError(t, err)
+
+	persisted, err := facade.GetPrescription(t.Context(), killswitches.GetPrescriptionRequest{
+		OrganizationID: killswitches.OrganizationID(orgID),
+		PrescriptionID: activated.PrescriptionID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, DefinitionKeyAIAccess, persisted.Definition)
+	require.Equal(t, PrincipalKindUser, persisted.PrincipalKind)
+	require.Equal(t, killswitches.PrincipalKey(userID), persisted.PrincipalKey)
+	require.Equal(t, ResourceKindMCPServer, persisted.ResourceKind)
+	require.Equal(t, []killswitches.ResourceKey{killswitches.ResourceKey(serverID.String())}, persisted.SelectedResourceKeys)
+}
+
 func TestEvaluatorHasNoImplicitCapabilityHierarchy(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/dual_evaluation_test.go
@@ -21,7 +21,7 @@ func TestPrivateCheckpointDualDefinitionMatrixAndNextCall(t *testing.T) {
 	realEvaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
 	require.NoError(t, err)
 	counted := &countingEvaluator{delegate: realEvaluator}
-	checkpoint, err := newCheckpoint(registry, counted, time.Second)
+	checkpoint, err := newCheckpoint(registry, counted, time.Second, enforcedRollout(orgID))
 	require.NoError(t, err)
 
 	userID := "user_" + uuid.NewString()

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -13,12 +13,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-// TestMCPToolExecutionEvaluationAcrossProjects proves the end-to-end
-// adapter-to-evaluator slice with real database state: authoritative
-// candidates from provenance, canonical server keys from fronting IDs, and
-// selected-one, selected-many (cross-project), and dynamic all-server
-// matching — including a server created after the all-server activation,
-// without materializing the organization's server list.
+// TestHostedCheckpoint_ReevaluatesAndFailsClosed proves hosted MCP performs
+// one dual-definition evaluation on every covered call and preserves
+// fail-closed non-match language for infrastructure failures.
 func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	t.Parallel()
 
@@ -32,19 +29,22 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	recorder := &coverageRecorder{}
 	checkpoint, err := NewHostedCheckpoint(conn, testenv.NewMeterProvider(t), testenv.NewLogger(t), recorder, enforcedRollout(orgID))
 	require.NoError(t, err)
+	counted := &countingEvaluator{delegate: checkpoint.evaluator}
+	checkpoint.evaluator = counted
 	ctx := testIdentityContext(t, mcpidentity.KindUserSession, userID)
 
 	disposition, err := checkpoint.Evaluate(ctx, orgID, source)
 	require.NoError(t, err)
 	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
 
-	note := "Exact operator note."
+	note := "AI access paused exactly."
 	insertPrescription(t, conn, orgID, prescriptionFixture{
-		ID:           uuid.New(),
-		PrincipalKey: userID,
-		Scope:        "selected",
-		Resources:    []string{serverID.String()},
-		ExternalNote: note,
+		ID:            uuid.New(),
+		DefinitionKey: DefinitionKeyAIAccess,
+		PrincipalKey:  userID,
+		Scope:         "selected",
+		Resources:     []string{serverID.String()},
+		ExternalNote:  note,
 	})
 
 	disposition, err = checkpoint.Evaluate(ctx, orgID, source)
@@ -53,6 +53,10 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	gotNote, ok := disposition.ExternalNote()
 	require.True(t, ok)
 	require.Equal(t, note, gotNote)
+	require.Equal(t, 2, counted.calls)
+	for _, request := range counted.requests {
+		require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, request.DefinitionKeys)
+	}
 	require.Len(t, recorder.observations, 2)
 	for _, observation := range recorder.observations {
 		require.Equal(t, coverageObservation{

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -38,8 +38,9 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
 
 	note := "AI access paused exactly."
+	aiID := uuid.New()
 	insertPrescription(t, conn, orgID, prescriptionFixture{
-		ID:            uuid.New(),
+		ID:            aiID,
 		DefinitionKey: DefinitionKeyAIAccess,
 		PrincipalKey:  userID,
 		Scope:         "selected",
@@ -53,11 +54,27 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	gotNote, ok := disposition.ExternalNote()
 	require.True(t, ok)
 	require.Equal(t, note, gotNote)
-	require.Equal(t, 2, counted.calls)
+	deletePrescription(t, conn, orgID, aiID)
+	mcpNote := "MCP tool calls paused exactly."
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID:           uuid.New(),
+		PrincipalKey: userID,
+		Scope:        "selected",
+		Resources:    []string{serverID.String()},
+		ExternalNote: mcpNote,
+	})
+	disposition, err = checkpoint.Evaluate(ctx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionMatchedDenial, disposition.Kind())
+	gotNote, ok = disposition.ExternalNote()
+	require.True(t, ok)
+	require.Equal(t, mcpNote, gotNote)
+
+	require.Equal(t, 3, counted.calls)
 	for _, request := range counted.requests {
 		require.Equal(t, []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution, DefinitionKeyAIAccess}, request.DefinitionKeys)
 	}
-	require.Len(t, recorder.observations, 2)
+	require.Len(t, recorder.observations, 3)
 	for _, observation := range recorder.observations {
 		require.Equal(t, coverageObservation{
 			surface:  mcpmetrics.KillswitchSurfaceHosted,

--- a/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
@@ -18,12 +18,12 @@ import (
 
 const hostedEvaluatorTimeout = 2 * time.Second
 
-// HostedCheckpoint authoritatively evaluates the M2 kill switch before hosted
-// tools/call configuration or execution work begins.
+// HostedCheckpoint authoritatively evaluates the ordered MCP and AI-access
+// kill switches before hosted tools/call configuration or execution work begins.
 type HostedCheckpoint struct {
 	principal     killswitches.PrincipalAdapter
 	resource      killswitches.ResourceAdapter
-	evaluator     *killswitches.Evaluator
+	evaluator     evaluator
 	transport     killswitches.TransportAdapter
 	failurePolicy killswitches.FailurePolicy
 	recorder      IdentityCoverageRecorder
@@ -119,7 +119,7 @@ func (c *HostedCheckpoint) evaluate(ctx context.Context, organizationID string, 
 
 	result := c.evaluator.Evaluate(evaluationCtx, killswitches.EvaluationRequest{
 		OrganizationID:      organization,
-		DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyMCPToolExecution},
+		DefinitionKeys:      mcpEvaluationDefinitionKeys(),
 		PrincipalCandidates: derivation.principalResult.Candidates(),
 		ResourceKind:        ResourceKindMCPServer,
 		ResourceKey:         resourceKey,

--- a/server/internal/killswitches/mcptoolexecution/registration.go
+++ b/server/internal/killswitches/mcptoolexecution/registration.go
@@ -1,13 +1,12 @@
-// Package mcptoolexecution registers the M2 `mcp_tool_execution` kill-switch
-// contracts: the fail-closed definition, the authoritative concrete-user
-// principal adapter, the canonical organization-owned `mcp_server` resource
-// adapter, and the coverage inventory for the hosted and private-proxy MCP
-// tools/call surfaces.
+// Package mcptoolexecution registers the MCP kill-switch contracts: the
+// fail-closed `mcp_tool_execution` and internal `ai_access` definitions, the
+// authoritative concrete-user principal adapter, the canonical
+// organization-owned `mcp_server` resource adapter, and the coverage inventory
+// for the hosted and private-proxy MCP tools/call surfaces.
 //
-// Registration declares the contracts consumed by the hosted dispatch
-// checkpoint. Private forwarding enforcement ships separately, and production
-// prescriptions must not be enabled until every covered checkpoint has reached
-// the fleet.
+// Registration declares the contracts consumed by both MCP checkpoints. The
+// internal ai_access definition is not exposed through customer management or
+// used to claim coverage for planned non-MCP surfaces.
 package mcptoolexecution
 
 import (
@@ -23,6 +22,10 @@ const (
 	// DefinitionKeyMCPToolExecution is the M2 capability governing MCP
 	// tools/call execution.
 	DefinitionKeyMCPToolExecution killswitches.DefinitionKey = "mcp_tool_execution"
+
+	// DefinitionKeyAIAccess is the internal broad AI-access capability. Its
+	// currently verified coverage is limited to authenticated MCP tools/call.
+	DefinitionKeyAIAccess killswitches.DefinitionKey = "ai_access"
 
 	// PrincipalKindUser is the concrete Gram user principal namespace; keys
 	// are user IDs of authoritative active organization members.
@@ -52,31 +55,47 @@ const (
 	TransportAdapterPrivateProxyJSONRPC killswitches.TransportAdapterKey = "mcp_private_proxy_jsonrpc"
 
 	// DefaultExternalNote is the editable customer-safe starting value for
-	// new prescriptions. It never leaks framework vocabulary.
+	// new MCP tool-execution prescriptions. It never leaks framework vocabulary.
 	DefaultExternalNote = "MCP tool calls are currently paused by your organization's administrator."
+
+	// DefaultAIAccessExternalNote is the separate customer-safe starting value
+	// for internal AI-access prescriptions.
+	DefaultAIAccessExternalNote = "AI access is currently paused by your organization's administrator."
 
 	// EnforcementOwner is the team accountable for the enforcement
 	// checkpoints of this definition.
 	EnforcementOwner = "devices-observability"
 )
 
-// NewRegistration assembles the complete code-owned mcp_tool_execution
-// registration. The database is used by the adapters at evaluation and
+// NewRegistration assembles the complete code-owned MCP registration. The database is used by the adapters at evaluation and
 // validation time only; fixture validation during registry construction is
 // pure.
 func NewRegistration(db *pgxpool.Pool) killswitches.Registration {
 	return killswitches.Registration{
-		Definitions: []killswitches.Definition{{
-			Key:                 DefinitionKeyMCPToolExecution,
-			PrincipalKinds:      []killswitches.PrincipalKind{PrincipalKindUser},
-			ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer},
-			FailurePolicy:       killswitches.FailurePolicyFailClosed,
-			DefaultExternalNote: DefaultExternalNote,
-			EnforcementOwner:    EnforcementOwner,
-			IdentityContract:    IdentityContractKeyAuthenticatedUserMCPServer,
-			Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall},
-			TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC},
-		}},
+		Definitions: []killswitches.Definition{
+			{
+				Key:                 DefinitionKeyMCPToolExecution,
+				PrincipalKinds:      []killswitches.PrincipalKind{PrincipalKindUser},
+				ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer},
+				FailurePolicy:       killswitches.FailurePolicyFailClosed,
+				DefaultExternalNote: DefaultExternalNote,
+				EnforcementOwner:    EnforcementOwner,
+				IdentityContract:    IdentityContractKeyAuthenticatedUserMCPServer,
+				Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall},
+				TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC},
+			},
+			{
+				Key:                 DefinitionKeyAIAccess,
+				PrincipalKinds:      []killswitches.PrincipalKind{PrincipalKindUser},
+				ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer},
+				FailurePolicy:       killswitches.FailurePolicyFailClosed,
+				DefaultExternalNote: DefaultAIAccessExternalNote,
+				EnforcementOwner:    EnforcementOwner,
+				IdentityContract:    IdentityContractKeyAuthenticatedUserMCPServer,
+				Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall},
+				TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC},
+			},
+		},
 		IdentityContracts: []killswitches.IdentityContract{{
 			Key:            IdentityContractKeyAuthenticatedUserMCPServer,
 			PrincipalKinds: []killswitches.PrincipalKind{PrincipalKindUser},
@@ -113,8 +132,32 @@ func NewRegistration(db *pgxpool.Pool) killswitches.Registration {
 				Surface:          SurfacePrivateProxyToolsCall,
 				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
 				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route, validated as a live server in a live project of the organization. The remote or tunneled backend ID is never the key, so hosted and private routes to one server share one canonical resource.",
-				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on private proxied or remote MCP tools/call forwarding. Registration does not deploy this checkpoint; the forwarding wiring ships separately (DNO-980).",
+				Checkpoint:       "After trusted authentication, tenant resolution, and acting-user validation on private proxied or remote MCP tools/call forwarding.",
 				ProtectedWork:    "Tool-level authorization-dependent forwarding work and any upstream request; per-server connection configuration may already be loaded.",
+				FailurePolicy:    killswitches.FailurePolicyFailClosed,
+				TransportAdapter: TransportAdapterPrivateProxyJSONRPC,
+				EnforcementOwner: EnforcementOwner,
+				IdentityContract: IdentityContractKeyAuthenticatedUserMCPServer,
+			},
+			{
+				Definition:       DefinitionKeyAIAccess,
+				Surface:          SurfaceHostedToolsCall,
+				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
+				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route and validated as a live server in a live project of the organization.",
+				Checkpoint:       "The shared MCP checkpoint after trusted authentication, tenant resolution, and acting-user validation on hosted MCP tools/call dispatch.",
+				ProtectedWork:    "The same hosted MCP tools/call work protected by mcp_tool_execution; no non-MCP AI surface is claimed.",
+				FailurePolicy:    killswitches.FailurePolicyFailClosed,
+				TransportAdapter: TransportAdapterHostedJSONRPC,
+				EnforcementOwner: EnforcementOwner,
+				IdentityContract: IdentityContractKeyAuthenticatedUserMCPServer,
+			},
+			{
+				Definition:       DefinitionKeyAIAccess,
+				Surface:          SurfacePrivateProxyToolsCall,
+				PrincipalSource:  "Validated user-session provenance (mcpidentity), revalidated as an active organization member on every covered call.",
+				ResourceSource:   "Fronting mcp_servers.id resolved from the mcp_endpoint route and validated as a live server in a live project of the organization.",
+				Checkpoint:       "The shared MCP checkpoint after trusted authentication, tenant resolution, and acting-user validation on private proxied or remote MCP tools/call forwarding.",
+				ProtectedWork:    "The same private MCP tools/call work protected by mcp_tool_execution; no non-MCP AI surface is claimed.",
 				FailurePolicy:    killswitches.FailurePolicyFailClosed,
 				TransportAdapter: TransportAdapterPrivateProxyJSONRPC,
 				EnforcementOwner: EnforcementOwner,
@@ -124,17 +167,17 @@ func NewRegistration(db *pgxpool.Pool) killswitches.Registration {
 	}
 }
 
-// NewRegistry builds and validates the finalized mcp_tool_execution registry.
+// NewRegistry builds and validates the finalized MCP registry.
 func NewRegistry(db *pgxpool.Pool) (*killswitches.Registry, error) {
 	registry, err := killswitches.BuildRegistry(NewRegistration(db))
 	if err != nil {
-		return nil, fmt.Errorf("build mcp_tool_execution registry: %w", err)
+		return nil, fmt.Errorf("build MCP kill-switch registry: %w", err)
 	}
 	return registry, nil
 }
 
 // ExcludedMCPSurface documents an MCP serving mode that deliberately produces
-// no supported principal or resource under mcp_tool_execution M2.
+// no supported principal or resource for either registered MCP definition.
 type ExcludedMCPSurface struct {
 	// Name identifies the serving mode.
 	Name string

--- a/server/internal/killswitches/mcptoolexecution/registration_test.go
+++ b/server/internal/killswitches/mcptoolexecution/registration_test.go
@@ -18,6 +18,7 @@ func TestMCPToolExecutionRegistration(t *testing.T) {
 
 	registry, err := NewRegistry(nil)
 	require.NoError(t, err)
+	require.Len(t, registry.Definitions(), 2)
 
 	definition, ok := registry.Definition(DefinitionKeyMCPToolExecution)
 	require.True(t, ok)
@@ -27,8 +28,20 @@ func TestMCPToolExecutionRegistration(t *testing.T) {
 	require.Equal(t, IdentityContractKeyAuthenticatedUserMCPServer, definition.IdentityContract)
 	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, definition.Surfaces)
 	require.ElementsMatch(t, []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC}, definition.TransportAdapters)
-	require.NotEmpty(t, definition.DefaultExternalNote)
-	require.NotEmpty(t, definition.EnforcementOwner)
+	require.Equal(t, DefaultExternalNote, definition.DefaultExternalNote)
+	require.Equal(t, EnforcementOwner, definition.EnforcementOwner)
+
+	aiDefinition, ok := registry.Definition(DefinitionKeyAIAccess)
+	require.True(t, ok)
+	require.Equal(t, killswitches.FailurePolicyFailClosed, aiDefinition.FailurePolicy)
+	require.Equal(t, []killswitches.PrincipalKind{PrincipalKindUser}, aiDefinition.PrincipalKinds)
+	require.Equal(t, []killswitches.ResourceKind{ResourceKindMCPServer}, aiDefinition.ResourceKinds)
+	require.Equal(t, IdentityContractKeyAuthenticatedUserMCPServer, aiDefinition.IdentityContract)
+	require.Equal(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, aiDefinition.Surfaces)
+	require.Equal(t, []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC}, aiDefinition.TransportAdapters)
+	require.Equal(t, DefaultAIAccessExternalNote, aiDefinition.DefaultExternalNote)
+	require.NotEqual(t, definition.DefaultExternalNote, aiDefinition.DefaultExternalNote)
+	require.Equal(t, EnforcementOwner, aiDefinition.EnforcementOwner)
 
 	adapter, ok := registry.PrincipalAdapter(PrincipalKindUser)
 	require.True(t, ok)
@@ -48,9 +61,10 @@ func TestMCPCoverageInventory(t *testing.T) {
 	require.NoError(t, err)
 
 	inventory := registry.CoverageInventory()
-	require.Len(t, inventory, 2)
+	require.Len(t, inventory, 4)
+	coverageByDefinition := map[killswitches.DefinitionKey][]killswitches.Surface{}
 	for _, contract := range inventory {
-		require.Equal(t, DefinitionKeyMCPToolExecution, contract.Definition)
+		coverageByDefinition[contract.Definition] = append(coverageByDefinition[contract.Definition], contract.Surface)
 		require.Equal(t, killswitches.FailurePolicyFailClosed, contract.FailurePolicy)
 		require.Equal(t, IdentityContractKeyAuthenticatedUserMCPServer, contract.IdentityContract)
 		require.NotEmpty(t, contract.PrincipalSource)
@@ -58,6 +72,8 @@ func TestMCPCoverageInventory(t *testing.T) {
 		require.NotEmpty(t, contract.Checkpoint)
 		require.NotEmpty(t, contract.ProtectedWork)
 	}
+	require.Equal(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, coverageByDefinition[DefinitionKeyMCPToolExecution])
+	require.Equal(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, coverageByDefinition[DefinitionKeyAIAccess])
 
 	hosted, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfaceHostedToolsCall)
 	require.True(t, ok)
@@ -67,6 +83,17 @@ func TestMCPCoverageInventory(t *testing.T) {
 	proxy, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfacePrivateProxyToolsCall)
 	require.True(t, ok)
 	require.Equal(t, TransportAdapterPrivateProxyJSONRPC, proxy.TransportAdapter)
+
+	aiHosted, ok := registry.Coverage(DefinitionKeyAIAccess, SurfaceHostedToolsCall)
+	require.True(t, ok)
+	require.Equal(t, TransportAdapterHostedJSONRPC, aiHosted.TransportAdapter)
+	aiProxy, ok := registry.Coverage(DefinitionKeyAIAccess, SurfacePrivateProxyToolsCall)
+	require.True(t, ok)
+	require.Equal(t, TransportAdapterPrivateProxyJSONRPC, aiProxy.TransportAdapter)
+	for _, excludedSurface := range []killswitches.Surface{"killswitch_management", "audit_read", "platform_break_glass", "hooks", "litellm", "hosted_inference", "assistant_runtime"} {
+		_, covered := registry.Coverage(DefinitionKeyAIAccess, excludedSurface)
+		require.False(t, covered, string(excludedSurface))
+	}
 
 	excluded := ExcludedMCPSurfaces()
 	names := make([]string, 0, len(excluded))

--- a/server/internal/killswitches/mcptoolexecution/setup_test.go
+++ b/server/internal/killswitches/mcptoolexecution/setup_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
@@ -120,22 +121,27 @@ func clearPrescriptions(t *testing.T, conn *pgxpool.Pool, organizationID string)
 }
 
 type prescriptionFixture struct {
-	ID           uuid.UUID
-	PrincipalKey string
-	Scope        string
-	Resources    []string
-	ExternalNote string
+	ID            uuid.UUID
+	DefinitionKey killswitches.DefinitionKey
+	PrincipalKey  string
+	Scope         string
+	Resources     []string
+	ExternalNote  string
 }
 
-// insertPrescription creates an immediately active mcp_tool_execution
-// prescription with the concrete user principal and mcp_server resource kind.
+// insertPrescription creates an immediately active prescription with the
+// concrete user principal and mcp_server resource kind.
 func insertPrescription(t *testing.T, conn *pgxpool.Pool, organizationID string, fixture prescriptionFixture) {
 	t.Helper()
 
+	definitionKey := fixture.DefinitionKey
+	if definitionKey == "" {
+		definitionKey = DefinitionKeyMCPToolExecution
+	}
 	err := testrepo.New(conn).InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
 		PrescriptionID: fixture.ID,
 		OrganizationID: organizationID,
-		DefinitionKey:  string(DefinitionKeyMCPToolExecution),
+		DefinitionKey:  string(definitionKey),
 		PrincipalKind:  string(PrincipalKindUser),
 		PrincipalKey:   fixture.PrincipalKey,
 		ResourceKind:   string(ResourceKindMCPServer),

--- a/server/internal/killswitches/mcptoolexecution/setup_test.go
+++ b/server/internal/killswitches/mcptoolexecution/setup_test.go
@@ -120,6 +120,12 @@ func clearPrescriptions(t *testing.T, conn *pgxpool.Pool, organizationID string)
 	}
 }
 
+func deletePrescription(t *testing.T, conn *pgxpool.Pool, organizationID string, prescriptionID uuid.UUID) {
+	t.Helper()
+	_, err := conn.Exec(t.Context(), "DELETE FROM killswitch_prescriptions WHERE organization_id = $1 AND id = $2", organizationID, prescriptionID)
+	require.NoError(t, err)
+}
+
 type prescriptionFixture struct {
 	ID            uuid.UUID
 	DefinitionKey killswitches.DefinitionKey

--- a/server/internal/mcp/killswitch_acceptance_test.go
+++ b/server/internal/mcp/killswitch_acceptance_test.go
@@ -24,9 +24,11 @@ import (
 
 	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
 	gen "github.com/speakeasy-api/gram/server/gen/killswitches"
+	platformgen "github.com/speakeasy-api/gram/server/gen/platform_killswitches"
 	usersessionsgen "github.com/speakeasy-api/gram/server/gen/user_sessions"
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	authrepo "github.com/speakeasy-api/gram/server/internal/auth/repo"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -42,12 +44,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
-	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsrepo "github.com/speakeasy-api/gram/server/internal/tools/repo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
@@ -397,6 +399,13 @@ func requireGoaError(t *testing.T, err error, name string) {
 	require.Equal(t, name, named.GoaErrorName())
 }
 
+func requireUnavailableError(t *testing.T, err error) {
+	t.Helper()
+	var unavailable *oops.ShareableError
+	require.ErrorAs(t, err, &unavailable)
+	require.Equal(t, oops.CodeUnavailable, unavailable.Code)
+}
+
 func databaseNow(t *testing.T, db *pgxpool.Pool) time.Time {
 	t.Helper()
 	now, err := killswitchrepo.New(db).GetKillswitchDatabaseTime(t.Context())
@@ -498,19 +507,20 @@ func requireHistoryEvent(t *testing.T, event *gen.KillswitchHistoryEvent, versio
 }
 
 type expectedLifecycleEvent struct {
-	action      audit.Action
-	version     int64
-	state       string
-	operation   string
-	operationID uuid.UUID
-	actorID     string
+	action        audit.Action
+	version       int64
+	state         string
+	operation     string
+	operationID   uuid.UUID
+	actorID       string
+	actingSurface string
 }
 
 func requireLifecycleEvents(t *testing.T, f *killswitchAcceptanceFixture, prescriptionID string, expected []expectedLifecycleEvent) {
 	t.Helper()
 	//nolint:glint // notestingrawsql: bounded read-only acceptance assertion
 	rows, err := f.ti.conn.Query(t.Context(), `
-		SELECT action, actor_id, subject_type, coalesce(after_snapshot, 'null'::jsonb), coalesce(metadata, 'null'::jsonb)
+		SELECT action, actor_id, subject_type, coalesce(after_snapshot, 'null'::jsonb), coalesce(metadata, 'null'::jsonb), coalesce(acting_surface, '')
 		FROM audit_logs
 		WHERE organization_id = $1 AND subject_id = $2
 		ORDER BY seq
@@ -521,9 +531,9 @@ func requireLifecycleEvents(t *testing.T, f *killswitchAcceptanceFixture, prescr
 	var got int
 	for rows.Next() {
 		require.Less(t, got, len(expected))
-		var action, actorID, subjectType string
+		var action, actorID, subjectType, actingSurface string
 		var snapshotJSON, metadataJSON []byte
-		require.NoError(t, rows.Scan(&action, &actorID, &subjectType, &snapshotJSON, &metadataJSON))
+		require.NoError(t, rows.Scan(&action, &actorID, &subjectType, &snapshotJSON, &metadataJSON, &actingSurface))
 		want := expected[got]
 		require.Equal(t, string(want.action), action)
 		wantActorID := want.actorID
@@ -532,6 +542,9 @@ func requireLifecycleEvents(t *testing.T, f *killswitchAcceptanceFixture, prescr
 		}
 		require.Equal(t, wantActorID, actorID)
 		require.Equal(t, "killswitch_prescription", subjectType)
+		if want.actingSurface != "" {
+			require.Equal(t, want.actingSurface, actingSurface)
+		}
 		var snapshot audit.KillswitchVersionSnapshot
 		require.NoError(t, json.Unmarshal(snapshotJSON, &snapshot))
 		require.Equal(t, audit.KillswitchVersionSnapshot{Version: want.version, State: want.state}, snapshot)
@@ -708,6 +721,8 @@ func TestKillswitchAcceptanceAIAccessProductionComposition(t *testing.T) {
 	t.Parallel()
 
 	ctx, f := newKillswitchAcceptanceFixture(t)
+	require.NoError(t, authrepo.New(f.ti.conn).SetUserAdminFixture(ctx, authrepo.SetUserAdminFixtureParams{Admin: true, UserID: f.auth.UserID}))
+	platform := killswitches.NewPlatformService(f.ti.logger, f.ti.tracerProvider, f.ti.conn, f.ti.sessionManager, f.ti.authzEngine, f.management.GenericService())
 
 	hosted := f.newHostedTarget(t, ctx, "ai-hosted")
 	var hostedProtectedCalls atomic.Int32
@@ -736,19 +751,35 @@ func TestKillswitchAcceptanceAIAccessProductionComposition(t *testing.T) {
 		{target: remote, toolName: "ping", successToken: remote.successToken, protectedCalls: remote.upstream.calls.Load},
 		{target: tunnel, toolName: "ping", successToken: tunnel.successToken, protectedCalls: tunnel.upstream.calls.Load},
 	}
-	resourceKeys := make([]string, 0, len(targets))
 	for i := range targets {
 		targets[i].sessionID = f.initialize(t, targets[i].target)
 		requireSuccessfulToolCall(t, f.call(t, targets[i].target, makeToolsCallBody(targets[i].toolName), targets[i].sessionID), targets[i].successToken)
-		resourceKeys = append(resourceKeys, targets[i].target.server.ID.String())
 	}
+	scope := selectedServers(hosted.server.ID, remote.server.ID, tunnel.server.ID)
+	resourceKeys := scope.ServerIds
 
-	require.NoError(t, testrepo.New(f.ti.conn).InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
-		PrescriptionID: uuid.New(), OrganizationID: f.auth.ActiveOrganizationID,
-		DefinitionKey: string(mcptoolexecution.DefinitionKeyAIAccess), PrincipalKind: string(mcptoolexecution.PrincipalKindUser), PrincipalKey: f.auth.UserID,
-		ResourceKind: string(mcptoolexecution.ResourceKindMCPServer), ResourceScope: "selected", ResourceKeys: resourceKeys,
-		InternalNote: "internal AI access acceptance fixture", ExternalNote: acceptanceAIExternalNote,
-	}))
+	aiActivateOperation := uuid.New()
+	aiActivatePayload := &platformgen.ActivatePrescriptionPayload{
+		OrganizationID: f.auth.ActiveOrganizationID, OperationID: aiActivateOperation.String(),
+		Definition: new(string(mcptoolexecution.DefinitionKeyAIAccess)), PrincipalKind: new(string(mcptoolexecution.PrincipalKindUser)), PrincipalInput: new(f.auth.UserID),
+		ResourceKind: new(string(mcptoolexecution.ResourceKindMCPServer)), ResourceScope: string(killswitches.ResourceScopeSelected), SelectedResourceInputs: resourceKeys, StartMode: string(killswitches.StartModeNow),
+		InternalNote: acceptanceInternalNote, ExternalNote: acceptanceAIExternalNote,
+	}
+	aiPrescription, err := platform.ActivatePrescription(ctx, aiActivatePayload)
+	require.NoError(t, err)
+	require.False(t, aiPrescription.Replayed)
+	require.Equal(t, int64(1), aiPrescription.Version)
+	require.Equal(t, string(killswitches.PrescriptionStateActive), aiPrescription.State)
+
+	listed, err := platform.ListPrescriptions(ctx, &platformgen.ListPrescriptionsPayload{OrganizationID: f.auth.ActiveOrganizationID})
+	require.NoError(t, err)
+	require.Len(t, listed.Prescriptions, 1)
+	require.Equal(t, aiPrescription.PrescriptionID, listed.Prescriptions[0].ID)
+	aiDetail, err := platform.GetPrescription(ctx, &platformgen.GetPrescriptionPayload{OrganizationID: f.auth.ActiveOrganizationID, PrescriptionID: aiPrescription.PrescriptionID})
+	require.NoError(t, err)
+	require.Equal(t, string(mcptoolexecution.DefinitionKeyAIAccess), aiDetail.Definition)
+	require.Equal(t, acceptanceInternalNote, aiDetail.InternalNote)
+	require.Equal(t, acceptanceAIExternalNote, aiDetail.ExternalNote)
 
 	protectedBaselines := make([]int32, len(targets))
 	for i, target := range targets {
@@ -757,11 +788,58 @@ func TestKillswitchAcceptanceAIAccessProductionComposition(t *testing.T) {
 		require.Equal(t, protectedBaselines[i], target.protectedCalls(), target.target.name)
 	}
 
+	f.ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, f.auth.ActiveOrganizationID, false)
+	replayedActivation, err := platform.ActivatePrescription(ctx, aiActivatePayload)
+	require.NoError(t, err)
+	require.True(t, replayedActivation.Replayed)
+	freshActivation := *aiActivatePayload
+	freshActivation.OperationID = uuid.NewString()
+	_, err = platform.ActivatePrescription(ctx, &freshActivation)
+	requireUnavailableError(t, err)
+
+	_, err = platform.ChangePrescription(ctx, &platformgen.ChangePrescriptionPayload{
+		OrganizationID: f.auth.ActiveOrganizationID, OperationID: uuid.NewString(), PrescriptionID: aiPrescription.PrescriptionID, ExpectedVersion: 1,
+		ResourceScope: string(killswitches.ResourceScopeSelected), SelectedResourceInputs: resourceKeys, StartMode: string(killswitches.StartModeNow), InternalNote: acceptanceInternalNote, ExternalNote: "fresh change while rollout is off",
+	})
+	requireUnavailableError(t, err)
+
+	aiDeactivateOperation := uuid.New()
+	aiDeactivatePayload := &platformgen.DeactivatePrescriptionPayload{
+		OrganizationID: f.auth.ActiveOrganizationID, OperationID: aiDeactivateOperation.String(), PrescriptionID: aiPrescription.PrescriptionID, ExpectedVersion: 1,
+	}
+	deactivated, err := platform.DeactivatePrescription(ctx, aiDeactivatePayload)
+	require.NoError(t, err)
+	require.False(t, deactivated.Replayed)
+	require.Equal(t, int64(2), deactivated.Version)
+	require.Equal(t, string(killswitches.PrescriptionStateInactive), deactivated.State)
+	replayedDeactivation, err := platform.DeactivatePrescription(ctx, aiDeactivatePayload)
+	require.NoError(t, err)
+	require.True(t, replayedDeactivation.Replayed)
+
+	aiDetail, err = platform.GetPrescription(ctx, &platformgen.GetPrescriptionPayload{OrganizationID: f.auth.ActiveOrganizationID, PrescriptionID: aiPrescription.PrescriptionID})
+	require.NoError(t, err)
+	require.Equal(t, string(killswitches.PrescriptionStateInactive), aiDetail.State)
+	require.Equal(t, acceptanceInternalNote, aiDetail.InternalNote)
+	listed, err = platform.ListPrescriptions(ctx, &platformgen.ListPrescriptionsPayload{OrganizationID: f.auth.ActiveOrganizationID})
+	require.NoError(t, err)
+	require.Len(t, listed.Prescriptions, 1)
+	require.Equal(t, string(killswitches.PrescriptionStateInactive), listed.Prescriptions[0].State)
+	requireLifecycleEvents(t, f, aiPrescription.PrescriptionID, []expectedLifecycleEvent{
+		{action: audit.ActionKillswitchActivate, version: 1, state: "active", operation: "activate", operationID: aiActivateOperation, actingSurface: string(audit.SurfacePlatformBreakGlass)},
+		{action: audit.ActionKillswitchDeactivate, version: 2, state: "inactive", operation: "deactivate", operationID: aiDeactivateOperation, actingSurface: string(audit.SurfacePlatformBreakGlass)},
+	})
+
+	f.ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, f.auth.ActiveOrganizationID, true)
+	for i, target := range targets {
+		requireSuccessfulToolCall(t, f.call(t, target.target, makeToolsCallBody(target.toolName), target.sessionID), target.successToken)
+		protectedBaselines[i] = target.protectedCalls()
+	}
+
 	capabilities, err := f.management.ListCapabilities(ctx, &gen.ListCapabilitiesPayload{})
 	require.NoError(t, err)
 	require.Equal(t, []*gen.KillswitchCapability{{Key: killswitchapi.CapabilityMCPToolCalls, Label: "MCP tool calls"}}, capabilities.Capabilities)
 	operationID := uuid.New()
-	mcpPrescription := f.create(t, ctx, operationID, selectedServers(hosted.server.ID, remote.server.ID, tunnel.server.ID), scheduleNow(), acceptanceExternalNote)
+	mcpPrescription := f.create(t, ctx, operationID, scope, scheduleNow(), acceptanceExternalNote)
 	requireLifecycleEvents(t, f, mcpPrescription.ID, []expectedLifecycleEvent{{
 		action: audit.ActionKillswitchActivate, version: 1, state: "active", operation: "activate", operationID: operationID,
 	}})

--- a/server/internal/mcp/killswitch_acceptance_test.go
+++ b/server/internal/mcp/killswitch_acceptance_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsrepo "github.com/speakeasy-api/gram/server/internal/tools/repo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
@@ -57,8 +58,9 @@ import (
 )
 
 const (
-	acceptanceExternalNote = "Tool calls paused exactly. <b>plain text</b>\nPlain text only."
-	acceptanceInternalNote = "INTERNAL-ONLY incident context"
+	acceptanceExternalNote   = "Tool calls paused exactly. <b>plain text</b>\nPlain text only."
+	acceptanceAIExternalNote = "AI access paused exactly."
+	acceptanceInternalNote   = "INTERNAL-ONLY incident context"
 )
 
 type killswitchAcceptanceFixture struct {
@@ -699,6 +701,74 @@ func TestKillswitchAcceptancePrivateRemoteAndTunnelProductionComposition(t *test
 			requireUserSessionActive(t, f, target)
 			requireUserSessionActive(t, f, other)
 		})
+	}
+}
+
+func TestKillswitchAcceptanceAIAccessProductionComposition(t *testing.T) {
+	t.Parallel()
+
+	ctx, f := newKillswitchAcceptanceFixture(t)
+
+	hosted := f.newHostedTarget(t, ctx, "ai-hosted")
+	var hostedProtectedCalls atomic.Int32
+	hostedSentinel := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hostedProtectedCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":"hosted-ai-ok"}`))
+	}))
+	t.Cleanup(hostedSentinel.Close)
+	f.addHostedSentinelTool(t, ctx, hosted.toolset, "ai_sentinel", hostedSentinel.URL)
+
+	remote := f.newPrivateTarget(t, ctx, "remote")
+	tunnel := f.newPrivateTarget(t, ctx, "tunnel")
+	require.NotEqual(t, remote.backendID, remote.server.ID)
+	require.NotEqual(t, tunnel.backendID, tunnel.server.ID)
+
+	type coveredTarget struct {
+		target         killswitchAcceptanceTarget
+		sessionID      string
+		toolName       string
+		successToken   string
+		protectedCalls func() int32
+	}
+	targets := []coveredTarget{
+		{target: hosted, toolName: "ai_sentinel", successToken: "hosted-ai-ok", protectedCalls: hostedProtectedCalls.Load},
+		{target: remote, toolName: "ping", successToken: remote.successToken, protectedCalls: remote.upstream.calls.Load},
+		{target: tunnel, toolName: "ping", successToken: tunnel.successToken, protectedCalls: tunnel.upstream.calls.Load},
+	}
+	resourceKeys := make([]string, 0, len(targets))
+	for i := range targets {
+		targets[i].sessionID = f.initialize(t, targets[i].target)
+		requireSuccessfulToolCall(t, f.call(t, targets[i].target, makeToolsCallBody(targets[i].toolName), targets[i].sessionID), targets[i].successToken)
+		resourceKeys = append(resourceKeys, targets[i].target.server.ID.String())
+	}
+
+	require.NoError(t, testrepo.New(f.ti.conn).InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
+		PrescriptionID: uuid.New(), OrganizationID: f.auth.ActiveOrganizationID,
+		DefinitionKey: string(mcptoolexecution.DefinitionKeyAIAccess), PrincipalKind: string(mcptoolexecution.PrincipalKindUser), PrincipalKey: f.auth.UserID,
+		ResourceKind: string(mcptoolexecution.ResourceKindMCPServer), ResourceScope: "selected", ResourceKeys: resourceKeys,
+		InternalNote: "internal AI access acceptance fixture", ExternalNote: acceptanceAIExternalNote,
+	}))
+
+	protectedBaselines := make([]int32, len(targets))
+	for i, target := range targets {
+		protectedBaselines[i] = target.protectedCalls()
+		requireKillswitchDenied(t, f.call(t, target.target, makeToolsCallBody(target.toolName), target.sessionID), acceptanceAIExternalNote)
+		require.Equal(t, protectedBaselines[i], target.protectedCalls(), target.target.name)
+	}
+
+	capabilities, err := f.management.ListCapabilities(ctx, &gen.ListCapabilitiesPayload{})
+	require.NoError(t, err)
+	require.Equal(t, []*gen.KillswitchCapability{{Key: killswitchapi.CapabilityMCPToolCalls, Label: "MCP tool calls"}}, capabilities.Capabilities)
+	operationID := uuid.New()
+	mcpPrescription := f.create(t, ctx, operationID, selectedServers(hosted.server.ID, remote.server.ID, tunnel.server.ID), scheduleNow(), acceptanceExternalNote)
+	requireLifecycleEvents(t, f, mcpPrescription.ID, []expectedLifecycleEvent{{
+		action: audit.ActionKillswitchActivate, version: 1, state: "active", operation: "activate", operationID: operationID,
+	}})
+
+	for i, target := range targets {
+		requireKillswitchDenied(t, f.call(t, target.target, makeToolsCallBody(target.toolName), target.sessionID), acceptanceExternalNote)
+		require.Equal(t, protectedBaselines[i], target.protectedCalls(), target.target.name)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Register internal `ai_access` with explicit fail-closed authenticated-user and canonical MCP-server contracts for verified hosted and private MCP `tools/call` surfaces.
- Evaluate `mcp_tool_execution` and `ai_access` together on every covered call, preserving MCP-specific denial precedence without introducing a capability hierarchy or broader product coverage claims.

Closes [DNO-988](https://linear.app/speakeasy/issue/DNO-988/feat-register-ai-access-and-dual-mcp-evaluation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the internal `ai_access` kill switch on authenticated hosted and private MCP `tools/call` calls alongside the existing `mcp_tool_execution` switch, so broad AI shutdowns are explicit rather than inferred from MCP definitions. Previously only `mcp_tool_execution` was evaluated; now both are checked in one ordered, fail-closed evaluation, and either match denies the call. When both match, the MCP-specific operator message is returned.

Closes [DNO-988](https://linear.app/speakeasy/issue/DNO-988/feat-register-ai-access-and-dual-mcp-evaluation).

**Evaluation behavior**
- Hosted and private checkpoints share one evaluation that checks both `mcp_tool_execution` and `ai_access` using the authenticated user and canonical MCP server identity.
- Either match denies the call; neither match continues.
- Both matches return the `mcp_tool_execution` note regardless of which prescription is more specific or newer.
- `ai_access` has its own fail-closed definition, defaults, and coverage metadata, with verified coverage limited to hosted and private MCP `tools/call`.
- An `ai_access` prescription never matches an MCP-only evaluation and vice versa, so no capability hierarchy is introduced.
- Customer management surfaces are unchanged: `ai_access` stays out of customer capabilities and management/audit APIs, while platform break-glass is its lifecycle surface.
- Prescriptions persist with the exact MCP identity: user principal, MCP server resource kind, and selected resource keys.

<sup>Written for commit 5ccf5484b233f8065632ea381c65abc450fe07e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

