### PR TITLE
fix: refresh support session on tab focus

### DIFF
--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -116,7 +116,7 @@ export const useSessionData = (): {
     refetch,
     status,
   } = useSessionInfo(undefined, undefined, {
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
     retry: false,
     throwOnError: false,
   });

--- a/client/dashboard/src/contexts/AuthProvider.test.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.test.tsx
@@ -1,3 +1,4 @@
+import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -43,6 +44,7 @@ vi.mock("@/contexts/Auth", async (importOriginal) => ({
   useSessionData: () => mocks.sessionData() as unknown,
 }));
 
+import { useSession } from "./Auth";
 import { AuthProvider } from "./AuthProvider";
 import { nullTelemetry, TelemetryStateProvider } from "./Telemetry";
 
@@ -91,6 +93,10 @@ const LocationProbe = () => {
   );
 };
 
+const SessionProbe = () => (
+  <div data-testid="session">{useSession().session ?? "none"}</div>
+);
+
 function renderGate(initialPath: string | string[] = "/") {
   const initialEntries = Array.isArray(initialPath)
     ? initialPath
@@ -105,6 +111,7 @@ function renderGate(initialPath: string | string[] = "/") {
         <LocationProbe />
         <AuthProvider>
           <div data-testid="app" />
+          <SessionProbe />
         </AuthProvider>
       </MemoryRouter>
     </TelemetryStateProvider>,
@@ -172,6 +179,35 @@ describe("AuthProvider organization telemetry group", () => {
     renderGate();
 
     expect(registeredOrgGroups()).toEqual([]);
+  });
+
+  it("retains cached authentication after a transient focus refetch error", () => {
+    mocks.sessionData.mockReturnValue({
+      ...gatedSession({ activeOrganizationId: undefined }),
+      error: new Error("temporary network failure"),
+      status: "error",
+    });
+
+    renderGate();
+
+    expect(screen.getByTestId("session").textContent).toBe("session-token");
+  });
+
+  it("drops cached authentication after an unauthorized focus refetch", () => {
+    const error = new GramError("unauthorized", {
+      response: new Response(null, { status: 401 }),
+      request: new Request("https://app.getgram.ai/rpc/auth.info"),
+      body: "",
+    });
+    mocks.sessionData.mockReturnValue({
+      ...gatedSession({ activeOrganizationId: undefined }),
+      error,
+      status: "error",
+    });
+
+    renderGate();
+
+    expect(screen.getByTestId("session").textContent).toBe("");
   });
 
   it("lets authenticated users stay on /guide until the guide route resolves", () => {

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import BookDemo from "@/pages/demo/BookDemo";
 import SwitchOrg from "@/pages/demo/SwitchOrg";
 import { getTrialLifecycleFromDates } from "@/lib/trial-status";
+import { isGramSessionUnauthorizedError } from "@/lib/route-errors";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useIsPlatformAdminRef } from "@/contexts/Sdk";
@@ -127,7 +128,7 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     ? encodeURIComponent(location.pathname + location.search + location.hash)
     : undefined;
 
-  if (error || !session || !session.session) {
+  if (isGramSessionUnauthorizedError(error) || !session || !session.session) {
     if (portableRedirect) {
       return <Navigate to={`/login?redirect=${portableRedirect}`} replace />;
     }


### PR DESCRIPTION
## Summary

- refetch `auth.info` when a dashboard tab regains focus so support-session state updates across tabs
- retain cached authentication after transient focus-refetch failures while still clearing unauthorized sessions

## Testing

- `aube run -F dashboard test -- src/contexts/AuthProvider.test.tsx`
- `aube run -F dashboard type-check`
