### PR TITLE
feat: polish gateway UX across listing, overview, and team access

### DIFF
--- a/.changeset/gateway-listing-ux-polish.md
+++ b/.changeset/gateway-listing-ux-polish.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Polish the gateway UX on the MCP listing and detail pages: gateway cards show their member servers' logos and a status dot consistent with server rows, the listing copy and table columns account for gateways, member management (reorder, add, remove) moves onto the Overview tab and the separate Members tab is removed (its URL redirects to overview), detail-page tab switches scroll back to the top, the gateway sidebar URL truncates instead of wrapping mid-token, absent MCP metadata no longer replays 404 requests on every remount, and team-access rows (gateways and MCP servers alike) click through to the Access page's pre-filled grant dialog — "No access" cells deep-link the specific missing scope. Clickable table rows across the dashboard now highlight more strongly on hover.

--- a/client/dashboard/src/components/gateway-sidebar-nav.tsx
+++ b/client/dashboard/src/components/gateway-sidebar-nav.tsx
@@ -79,8 +79,9 @@ export function GatewaySidebarNav(): React.JSX.Element | null {
             rows.length > 0
               ? `Fronting ${rows.length} MCP ${rows.length === 1 ? "server" : "servers"}.`
               : "Add MCP servers for this gateway to front.",
+          // Member management lives on the Overview tab.
           ready: rows.length > 0,
-          href: gatewayTabHref(routes, id, "members"),
+          href: gatewayTabHref(routes, id, "overview"),
         },
         {
           key: "authentication",
@@ -101,13 +102,6 @@ export function GatewaySidebarNav(): React.JSX.Element | null {
       Icon: LayoutDashboard,
       href: gatewayTabHref(routes, id, "overview"),
       active: activeTab === "overview",
-    },
-    {
-      key: "members",
-      title: "Members",
-      Icon: Network,
-      href: gatewayTabHref(routes, id, "members"),
-      active: activeTab === "members",
     },
     {
       key: "inspect",
@@ -163,11 +157,12 @@ export function GatewaySidebarNav(): React.JSX.Element | null {
       {mcpUrl && (
         <div className="flex flex-col gap-1">
           <DetailSidebarInfoLabel>URL</DetailSidebarInfoLabel>
-          <div className="flex items-start gap-1">
+          <div className="flex min-w-0 items-start gap-1">
             <Text
               variant="small"
               muted
-              className="line-clamp-2 font-mono text-xs break-all"
+              className="truncate font-mono text-xs"
+              title={mcpUrl}
             >
               {mcpUrl.replace(/^https?:\/\//, "")}
             </Text>

--- a/client/dashboard/src/components/mcp/GatewayCard.tsx
+++ b/client/dashboard/src/components/mcp/GatewayCard.tsx
@@ -2,9 +2,62 @@ import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Text } from "@/components/ui/Text";
+import { SourceMcpIcon } from "@/components/sources/SourceCard";
 import { useRoutes } from "@/routes";
 import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
+import { useMetaMcpMembers } from "@gram/client/react-query/metaMcpMembers.js";
 import { ArrowRight, Network } from "lucide-react";
+import { GatewayStatusIndicator } from "./MCPStatusIndicator";
+
+// The gateway's cargo is its member servers, so the icon rail shows their
+// logos (up to four, then a +N tile) instead of a generic glyph.
+function GatewayMemberIcons({
+  metaMcpServerId,
+}: {
+  metaMcpServerId: string;
+}): JSX.Element {
+  const { data } = useMetaMcpMembers({ metaMcpServerId }, undefined, {
+    throwOnError: false,
+    staleTime: 60 * 1000,
+  });
+  const members = data?.members ?? [];
+
+  if (members.length === 0) {
+    return <Network className="text-muted-foreground h-8 w-8" />;
+  }
+  const only = members[0];
+  if (members.length === 1 && only) {
+    return (
+      <SourceMcpIcon
+        mcpServerId={only.mcpServerId}
+        className="h-8 w-8 object-contain"
+      />
+    );
+  }
+
+  const overflow = members.length > 4 ? members.length - 3 : 0;
+  const shown = members.slice(0, overflow > 0 ? 3 : 4);
+  return (
+    <div className="grid grid-cols-2 gap-1.5">
+      {shown.map((member) => (
+        <SourceMcpIcon
+          key={member.id}
+          mcpServerId={member.mcpServerId}
+          className="h-6 w-6 object-contain"
+        />
+      ))}
+      {overflow > 0 && (
+        <Text
+          muted
+          as="div"
+          className="flex h-6 w-6 items-center justify-center font-mono text-[10px]"
+        >
+          +{overflow}
+        </Text>
+      )}
+    </div>
+  );
+}
 
 // GatewayCard renders a meta MCP server (Gateway Endpoint) inside the /mcp
 // listing grid, alongside MCPCard (toolsets) and MCPServerCard (mcp_servers).
@@ -24,7 +77,7 @@ export function GatewayCard({
     <Card.Entity
       className="focus-visible:ring-ring cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       onClick={() => routes.mcp.gateway.overview.goTo(gateway.id)}
-      icon={<Network className="text-muted-foreground h-8 w-8" />}
+      icon={<GatewayMemberIcons metaMcpServerId={gateway.id} />}
     >
       <div className="mb-2 flex items-start justify-between gap-2">
         <Text
@@ -65,11 +118,10 @@ export function GatewayCard({
           <Badge variant="neutral">
             <Badge.Text>Gateway</Badge.Text>
           </Badge>
-          <Text muted className="text-xs">
-            {gateway.userSessionIssuerId
-              ? "Requires sign-in"
-              : "Open to anyone with the URL"}
-          </Text>
+          <GatewayStatusIndicator
+            visibility={gateway.visibility}
+            requiresSignIn={!!gateway.userSessionIssuerId}
+          />
         </div>
         <div className="text-muted-foreground group-hover:text-primary flex items-center gap-1 text-sm transition-colors">
           <span>Open</span>

--- a/client/dashboard/src/components/mcp/GatewayTableRow.tsx
+++ b/client/dashboard/src/components/mcp/GatewayTableRow.tsx
@@ -4,6 +4,7 @@ import { useRoutes } from "@/routes";
 import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
 import { Network } from "lucide-react";
 import { Badge } from "../ui/Badge";
+import { GatewayStatusIndicator } from "./MCPStatusIndicator";
 
 // GatewayTableRow renders a meta MCP server (Gateway Endpoint) in the /mcp
 // listing table view. Mirrors MCPServerTableRow.
@@ -35,12 +36,13 @@ export function GatewayTableRow({
         </Text>
       </td>
 
-      {/* Visibility column slot: gateways have no visibility setting, so this
-          reports the closest equivalent — whether callers must sign in. */}
+      {/* Visibility column slot */}
       <td className="px-3 py-3">
-        <Text small muted>
-          {gateway.userSessionIssuerId ? "Requires sign-in" : "Open"}
-        </Text>
+        <GatewayStatusIndicator
+          visibility={gateway.visibility}
+          requiresSignIn={!!gateway.userSessionIssuerId}
+          size="sm"
+        />
       </td>
 
       {/* URL column slot */}

--- a/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
+++ b/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
@@ -1,5 +1,6 @@
 import { Text } from "@/components/ui/Text";
 import { cn } from "@/lib/utils";
+import type { MetaMcpServerVisibility } from "@gram/client/models/components/metamcpserver.js";
 
 interface MCPStatusIndicatorProps {
   mcpEnabled: boolean | undefined;
@@ -8,15 +9,23 @@ interface MCPStatusIndicatorProps {
   className?: string;
 }
 
+interface StatusConfig {
+  color: string;
+  pulseColor: string;
+  label: string;
+  animate: boolean;
+}
+
 function getStatusConfig(
   mcpEnabled: boolean | undefined,
   mcpIsPublic: boolean | undefined,
-) {
+): StatusConfig {
   if (!mcpEnabled) {
     return {
       color: "bg-destructive",
       pulseColor: "bg-destructive/60",
       label: "Disabled",
+      animate: false,
     };
   }
   if (!mcpIsPublic) {
@@ -24,28 +33,63 @@ function getStatusConfig(
       color: "bg-muted-foreground/60",
       pulseColor: "bg-muted-foreground/40",
       label: "Private",
+      animate: true,
     };
   }
   return {
     color: "bg-success-default",
     pulseColor: "bg-success-default",
     label: "Public",
+    animate: true,
   };
 }
 
-export function MCPStatusIndicator({
-  mcpEnabled,
-  mcpIsPublic,
+// A gateway's closest equivalent of server visibility: whether it serves at
+// all, and whether callers must sign in first.
+function getGatewayStatusConfig(
+  visibility: MetaMcpServerVisibility,
+  requiresSignIn: boolean,
+): StatusConfig {
+  if (visibility === "disabled") {
+    return {
+      color: "bg-destructive",
+      pulseColor: "bg-destructive/60",
+      label: "Disabled",
+      animate: false,
+    };
+  }
+  if (requiresSignIn) {
+    return {
+      color: "bg-muted-foreground/60",
+      pulseColor: "bg-muted-foreground/40",
+      label: "Sign-in required",
+      animate: true,
+    };
+  }
+  // "Anonymous" matches the gateway overview's Authentication tile wording.
+  return {
+    color: "bg-success-default",
+    pulseColor: "bg-success-default",
+    label: "Anonymous",
+    animate: true,
+  };
+}
+
+function StatusDotLabel({
+  status,
   size = "md",
   className,
-}: MCPStatusIndicatorProps): JSX.Element {
-  const status = getStatusConfig(mcpEnabled, mcpIsPublic);
+}: {
+  status: StatusConfig;
+  size?: "sm" | "md";
+  className?: string;
+}): JSX.Element {
   const dotSize = size === "sm" ? "h-2 w-2" : "h-2.5 w-2.5";
 
   return (
     <div className={cn("flex items-center gap-2", className)}>
       <div className={cn("relative flex", dotSize)}>
-        {mcpEnabled && (
+        {status.animate && (
           <span
             className={cn(
               "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
@@ -65,5 +109,40 @@ export function MCPStatusIndicator({
         {status.label}
       </Text>
     </div>
+  );
+}
+
+export function MCPStatusIndicator({
+  mcpEnabled,
+  mcpIsPublic,
+  size = "md",
+  className,
+}: MCPStatusIndicatorProps): JSX.Element {
+  return (
+    <StatusDotLabel
+      status={getStatusConfig(mcpEnabled, mcpIsPublic)}
+      size={size}
+      className={className}
+    />
+  );
+}
+
+export function GatewayStatusIndicator({
+  visibility,
+  requiresSignIn,
+  size = "md",
+  className,
+}: {
+  visibility: MetaMcpServerVisibility;
+  requiresSignIn: boolean;
+  size?: "sm" | "md";
+  className?: string;
+}): JSX.Element {
+  return (
+    <StatusDotLabel
+      status={getGatewayStatusConfig(visibility, requiresSignIn)}
+      size={size}
+      className={className}
+    />
   );
 }

--- a/client/dashboard/src/components/page-layout.tsx
+++ b/client/dashboard/src/components/page-layout.tsx
@@ -44,6 +44,8 @@ function PageBody({
   return (
     // Nest the max-width container inside another div so that the entire page area remains scrollable
     <div
+      // Anchor for useTabScrollReset: the one scroll container a page owns.
+      data-page-scroll=""
       className={cn(
         // flex-1 + min-h-0 ensures this pane occupies exactly the remaining
         // space in PageLayout's flex column (after PageHeader). Using h-full

--- a/client/dashboard/src/components/sources/SourceCard.tsx
+++ b/client/dashboard/src/components/sources/SourceCard.tsx
@@ -120,7 +120,11 @@ export function SourceMcpIcon({
 }): JSX.Element {
   const { data } = useGetMcpMetadata({ mcpServerId }, undefined, {
     enabled: !!mcpServerId,
+    // 404 is the normal "no metadata set" answer; don't re-request it on every
+    // remount or each navigation replays a console error per server.
     retry: false,
+    retryOnMount: false,
+    staleTime: 5 * 60 * 1000,
     throwOnError: false,
   });
   const logoAssetId = data?.metadata?.logoAssetId;

--- a/client/dashboard/src/components/ui/Table/index.tsx
+++ b/client/dashboard/src/components/ui/Table/index.tsx
@@ -616,9 +616,13 @@ const RowContainer = forwardRef<HTMLTableRowElement, RowContainerProps>(
         ref={ref}
         {...rest}
         className={cn(
-          "-z-0 [grid-column:1/-1] grid max-w-full [grid-template-columns:subgrid] border-b transition-colors last:border-none hover:bg-muted/50 data-[state=selected]:bg-muted",
+          // Hovers use the accent token, not muted: in dark mode muted equals
+          // the card surface, so a muted hover paints invisibly.
+          "-z-0 [grid-column:1/-1] grid max-w-full [grid-template-columns:subgrid] border-b transition-colors last:border-none hover:bg-accent/50 data-[state=selected]:bg-muted",
+          // Clickable rows highlight at full accent so the hover reads as an
+          // affordance, not just a scan aid.
           isClickable &&
-            "cursor-pointer focus-visible:bg-muted/50 focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none",
+            "cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none",
           className,
         )}
         onClick={onClick}

--- a/client/dashboard/src/hooks/useTabScrollReset.ts
+++ b/client/dashboard/src/hooks/useTabScrollReset.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { useLocation } from "react-router";
 
 /**
@@ -12,7 +12,9 @@ export function useTabScrollReset(
 ): React.RefObject<HTMLDivElement | null> {
   const ref = useRef<HTMLDivElement>(null);
   const { hash } = useLocation();
-  useEffect(() => {
+  // Layout effect: resetting after paint would flash the old offset for a
+  // frame when the incoming tab is tall enough to keep it.
+  useLayoutEffect(() => {
     // In-page anchors (e.g. settings section hashes) win over the reset.
     if (hash) return;
     ref.current?.closest("[data-page-scroll]")?.scrollTo({ top: 0 });

--- a/client/dashboard/src/hooks/useTabScrollReset.ts
+++ b/client/dashboard/src/hooks/useTabScrollReset.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * Detail pages render all their tab routes inside one persistent Page.Body, so
+ * switching tabs would otherwise land mid-page at the previous tab's scroll
+ * offset. Attach the returned ref to the tab content wrapper; the nearest
+ * page scroll container resets to the top whenever the tab changes.
+ */
+export function useTabScrollReset(
+  activeTab: string | undefined,
+): React.RefObject<HTMLDivElement | null> {
+  const ref = useRef<HTMLDivElement>(null);
+  const { hash } = useLocation();
+  useEffect(() => {
+    // In-page anchors (e.g. settings section hashes) win over the reset.
+    if (hash) return;
+    ref.current?.closest("[data-page-scroll]")?.scrollTo({ top: 0 });
+  }, [activeTab, hash]);
+  return ref;
+}

--- a/client/dashboard/src/pages/access/GrantAccessDialog.tsx
+++ b/client/dashboard/src/pages/access/GrantAccessDialog.tsx
@@ -113,10 +113,12 @@ export function GrantAccessDialog({
       <Dialog.Content className="sm:max-w-md">
         <Dialog.Header>
           <Dialog.Title>Grant Access</Dialog.Title>
+          {/* Opened from access-request emails and from server team-access
+              rows alike, so the copy names the permission without assuming a
+              request. */}
           <Dialog.Description>
-            This member requested the{" "}
+            Assign a role that includes the{" "}
             <span className="font-mono text-xs">{scope}</span> permission.
-            Assign a role that includes it.
           </Dialog.Description>
         </Dialog.Header>
 

--- a/client/dashboard/src/pages/catalog/Catalog.tsx
+++ b/client/dashboard/src/pages/catalog/Catalog.tsx
@@ -96,14 +96,14 @@ function CatalogInner() {
     if (attachFailures > 0) {
       toast.error(
         attachFailures === 1
-          ? "An installed server could not be added to the gateway. Add it from the gateway's Members tab."
-          : `${attachFailures} installed servers could not be added to the gateway. Add them from the gateway's Members tab.`,
+          ? "An installed server could not be added to the gateway. Add it from the gateway's overview."
+          : `${attachFailures} installed servers could not be added to the gateway. Add them from the gateway's overview.`,
       );
     }
     // Redirect only when everything worked; otherwise stay so the dialog's
     // per-server results (and the toast above) remain visible.
     if (result.status === "succeeded" && attachFailures === 0) {
-      void navigate(routes.mcp.gateway.members.href(attachToGatewayId));
+      void navigate(routes.mcp.gateway.overview.href(attachToGatewayId));
     }
   };
 

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -396,7 +396,7 @@ function MCPOverview() {
       invalidateAllMcpEndpoints(queryClient, { refetchType: "all" }),
     ]);
     toast.success(`Gateway "${gateway.name}" created`);
-    routes.mcp.gateway.members.goTo(gateway.id);
+    routes.mcp.gateway.overview.goTo(gateway.id);
   };
 
   const newMcpServerButton = (
@@ -538,6 +538,8 @@ function MCPOverview() {
           Sources exposed as MCP servers. These include all types of sources
           such as OpenAPI, functions, third-party servers from the catalog, and
           custom remote MCPs imported by URL.
+          {gatewaysEnabled &&
+            " Gateways front a set of these servers behind a single URL."}
         </Page.Section.Description>
         <Page.Section.Body>
           {showFilters && (
@@ -623,7 +625,9 @@ function MCPOverview() {
                 { label: "Name" },
                 { label: "Visibility" },
                 { label: "URL" },
-                { label: "Tools" },
+                // Kind-dependent cargo: tool chips for toolsets, the kind badge
+                // for mcp_servers, member count for gateways.
+                { label: "Contents" },
               ]}
             >
               {isLoading ? (

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -53,6 +53,7 @@ import {
   isUserSessionIssuerWired,
   mustConvertOAuthBeforePrivate,
 } from "./toolsetAuthSurface";
+import { useTabScrollReset } from "@/hooks/useTabScrollReset";
 import { useRoutes } from "@/routes";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { useExportMcpMetadataMutation } from "@gram/client/react-query/exportMcpMetadata.js";
@@ -277,6 +278,7 @@ function MCPDetailPageContent({
   const location = useLocation();
 
   const activeTab = activeTabFromPath(location.pathname, toolsetSlug);
+  const tabContentRef = useTabScrollReset(activeTab ?? undefined);
 
   if (!activeTab) {
     const initialTab = initialTabFromHash(window.location.hash);
@@ -297,7 +299,10 @@ function MCPDetailPageContent({
       </Page.Header>
       <Page.Body fullWidth className="gap-0">
         {/* Name, status, URL, and Playground live in the sidebar header now */}
-        <div className="mx-auto w-full max-w-[1270px] flex-1">
+        <div
+          ref={tabContentRef}
+          className="mx-auto w-full max-w-[1270px] flex-1"
+        >
           {renderMcpDetailTabContent(activeTab, toolset)}
         </div>
       </Page.Body>

--- a/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/Button";
 import { Column, Table } from "@/components/ui/Table";
 import { SkeletonTable } from "@/components/ui/Skeleton";
 import { useMemo, useState, ReactElement } from "react";
+import { useNavigate } from "react-router";
 
 function getInitials(name: string) {
   return name
@@ -187,9 +188,12 @@ function ToolRow({ tool }: { tool: Tool }) {
 function AccessBadge({
   level,
   onClick,
+  onGrant,
 }: {
   level: AccessLevel;
   onClick?: () => void;
+  /** Deep-link to grant this scope; renders "No access" as a click target. */
+  onGrant?: () => void;
 }) {
   switch (level) {
     case "full":
@@ -206,7 +210,16 @@ function AccessBadge({
       );
     case "tools":
       return (
-        <button type="button" onClick={onClick} className="cursor-pointer">
+        <button
+          type="button"
+          // The row underneath navigates to the grant flow; this button only
+          // opens the tool drill-down sheet.
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick?.();
+          }}
+          className="cursor-pointer"
+        >
           <Badge
             variant="neutral"
             className="hover:bg-accent transition-colors"
@@ -216,8 +229,22 @@ function AccessBadge({
         </button>
       );
     case "none":
+      if (!onGrant) {
+        return (
+          <span className="text-muted-foreground/50 text-sm">No access</span>
+        );
+      }
       return (
-        <span className="text-muted-foreground/50 text-sm">No access</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onGrant();
+          }}
+          className="text-muted-foreground/50 hover:text-foreground cursor-pointer text-sm underline-offset-2 hover:underline"
+        >
+          No access
+        </button>
       );
   }
 }
@@ -253,10 +280,22 @@ export function MCPTeamAccessTab({
   tools?: Tool[];
 }): ReactElement | null {
   const orgRoutes = useOrgRoutes();
+  const navigate = useNavigate();
   const { data: membersData, isLoading: membersLoading } = useMembers();
   const { data: rolesData, isLoading: rolesLoading } = useRoles();
 
   const [sheetData, setSheetData] = useState<ToolDetailSheet | null>(null);
+
+  // Deep-links into the Access page's pre-filled grant dialog (the same one
+  // access-request emails open), scoped to this member and this server.
+  const goToGrantAccess = (row: MemberAccess, scope: string) => {
+    const params = new URLSearchParams({
+      grant_user: row.member.id,
+      scope,
+      resource_id: resourceId,
+    });
+    void navigate(`${orgRoutes.access.roles.href()}?${params.toString()}`);
+  };
 
   const memberAccess = useMemo((): MemberAccess[] => {
     const members = membersData?.members ?? [];
@@ -371,6 +410,7 @@ export function MCPTeamAccessTab({
               ? () => openToolSheet(row, "mcp:read", "Read")
               : undefined
           }
+          onGrant={() => goToGrantAccess(row, "mcp:read")}
         />
       ),
     },
@@ -386,6 +426,7 @@ export function MCPTeamAccessTab({
               ? () => openToolSheet(row, "mcp:write", "Write")
               : undefined
           }
+          onGrant={() => goToGrantAccess(row, "mcp:write")}
         />
       ),
     },
@@ -401,6 +442,7 @@ export function MCPTeamAccessTab({
               ? () => openToolSheet(row, "mcp:connect", "Connect")
               : undefined
           }
+          onGrant={() => goToGrantAccess(row, "mcp:connect")}
         />
       ),
     },
@@ -429,6 +471,9 @@ export function MCPTeamAccessTab({
               columns={columns}
               data={memberAccess}
               rowKey={(row) => row.member.id}
+              // Row click lands on the Access page's grant dialog for this
+              // member and server; connect is the "can use this server" scope.
+              onRowClick={(row) => goToGrantAccess(row, "mcp:connect")}
             />
           )}
           <Table.Row>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayDetails.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayDetails.tsx
@@ -1,6 +1,7 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { ClientsAndSessionsTab } from "@/components/sessions/ClientsAndSessionsTab";
+import { useTabScrollReset } from "@/hooks/useTabScrollReset";
 import { useRoutes } from "@/routes";
 import { useGetMetaMcpServer } from "@gram/client/react-query/getMetaMcpServer.js";
 import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
@@ -13,7 +14,6 @@ import {
 } from "./GatewayDetailsRouting";
 import { MCPTeamAccessTab } from "@/pages/mcp/MCPTeamAccessTab";
 import { GatewayInspectTab } from "./GatewayInspectTab";
-import { GatewayMembersTab } from "./GatewayMembersTab";
 import { GatewayOverviewTab } from "./GatewayOverviewTab";
 import { GatewaySettingsTab } from "./GatewaySettingsTab";
 
@@ -23,6 +23,7 @@ export default function GatewayDetails(): JSX.Element {
   const routes = useRoutes();
   const id = gatewayId ?? "";
   const activeTab = activeTabFromPath(location.pathname, id);
+  const tabContentRef = useTabScrollReset(activeTab);
 
   const {
     data: metaMcpServer,
@@ -61,12 +62,6 @@ export default function GatewayDetails(): JSX.Element {
             endpoints={endpoints}
             isLoadingEndpoints={isLoadingEndpoints}
           />
-        );
-      case "members":
-        return (
-          <RequireScope scope="mcp:read" level="page">
-            <GatewayMembersTab metaMcpServer={metaMcpServer} />
-          </RequireScope>
         );
       case "inspect":
         return (
@@ -121,7 +116,10 @@ export default function GatewayDetails(): JSX.Element {
       </Page.Header>
 
       <Page.Body fullWidth className="gap-0">
-        <div className="mx-auto w-full max-w-[1270px] flex-1">
+        <div
+          ref={tabContentRef}
+          className="mx-auto w-full max-w-[1270px] flex-1"
+        >
           {renderTabContent()}
         </div>
       </Page.Body>

--- a/client/dashboard/src/pages/mcp/gateway/GatewayDetailsRouting.test.ts
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayDetailsRouting.test.ts
@@ -12,7 +12,6 @@ const BASE = `/acme/projects/demo/mcp/gateway/${ID}`;
 // tab fails here instead of quietly shrinking the expectations.
 const TABS = [
   "overview",
-  "members",
   "inspect",
   "team-access",
   "sessions",
@@ -31,6 +30,8 @@ describe("activeTabFromPath", () => {
   it("returns undefined for the bare detail path and unknown tabs", () => {
     expect(activeTabFromPath(BASE, ID)).toBeUndefined();
     expect(activeTabFromPath(`${BASE}/performance`, ID)).toBeUndefined();
+    // The legacy members URL redirects to overview via the unknown-tab path.
+    expect(activeTabFromPath(`${BASE}/members`, ID)).toBeUndefined();
   });
 
   it("requires the mcp/gateway prefix, so a lookalike path misses", () => {
@@ -42,10 +43,10 @@ describe("activeTabFromPath", () => {
   it("matches a url-encoded id segment", () => {
     expect(
       activeTabFromPath(
-        `/acme/projects/demo/mcp/gateway/${encodeURIComponent("a b")}/members`,
+        `/acme/projects/demo/mcp/gateway/${encodeURIComponent("a b")}/inspect`,
         "a b",
       ),
-    ).toBe("members");
+    ).toBe("inspect");
   });
 
   it("returns undefined without an id", () => {

--- a/client/dashboard/src/pages/mcp/gateway/GatewayDetailsRouting.ts
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayDetailsRouting.ts
@@ -1,8 +1,9 @@
 import type { useRoutes } from "@/routes";
 
+// "members" is not a tab: member management lives on the Overview tab, and the
+// legacy /members URL falls through the unknown-tab redirect to overview.
 const VALID_TABS = [
   "overview",
-  "members",
   "inspect",
   "team-access",
   "sessions",
@@ -72,8 +73,6 @@ export function gatewayTabHref(
   switch (tab) {
     case "overview":
       return routes.mcp.gateway.overview.href(gatewayId);
-    case "members":
-      return routes.mcp.gateway.members.href(gatewayId);
     case "inspect":
       return routes.mcp.gateway.inspect.href(gatewayId);
     case "team-access":

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
@@ -276,7 +276,11 @@ export function GatewayMembersSection({
             render: (row) => {
               const index = indexByMemberId.get(row.member.id) ?? 0;
               return (
-                <RequireScope scope="mcp:write" level="component">
+                <RequireScope
+                  scope="mcp:write"
+                  resourceId={metaMcpServer.id}
+                  level="component"
+                >
                   <div className="flex items-center gap-1">
                     <Button
                       variant="tertiary"
@@ -333,7 +337,11 @@ export function GatewayMembersSection({
       header: "",
       width: "64px",
       render: (row) => (
-        <RequireScope scope="mcp:write" level="component">
+        <RequireScope
+          scope="mcp:write"
+          resourceId={metaMcpServer.id}
+          level="component"
+        >
           <Button
             variant="destructive-secondary"
             size="sm"
@@ -364,7 +372,11 @@ export function GatewayMembersSection({
           upstream health lands with the proxied runtime.
         </Page.Section.Description>
         <Page.Section.CTA>
-          <RequireScope scope="mcp:write" level="component">
+          <RequireScope
+            scope="mcp:write"
+            resourceId={metaMcpServer.id}
+            level="component"
+          >
             <Button size="sm" onClick={() => setAddOpen(true)}>
               <Button.LeftIcon>
                 <Plus />
@@ -386,7 +398,11 @@ export function GatewayMembersSection({
                       No members yet. A gateway with no members exposes its four
                       tools but has nothing to route to.
                     </Text>
-                    <RequireScope scope="mcp:write" level="component">
+                    <RequireScope
+                      scope="mcp:write"
+                      resourceId={metaMcpServer.id}
+                      level="component"
+                    >
                       <Button
                         variant="secondary"
                         size="sm"

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
@@ -31,7 +31,6 @@ import {
   Cable,
   Globe,
   Loader2,
-  Network,
   Plus,
   Server,
   Trash2,
@@ -185,66 +184,8 @@ function MemberNameCell({ row }: { row: MemberRow }): JSX.Element {
   );
 }
 
-/** Read-only members table shared by the Overview tab. */
-export function MembersStatusTable({
-  rows,
-  isLoading,
-}: {
-  rows: MemberRow[];
-  isLoading: boolean;
-}): JSX.Element {
-  const columns: Column<MemberRow>[] = [
-    {
-      key: "server",
-      header: "Server",
-      render: (row) => <MemberNameCell row={row} />,
-    },
-    {
-      key: "backend",
-      header: "Backend",
-      render: (row) => <BackendKindTag row={row} />,
-      width: "140px",
-    },
-    {
-      key: "status",
-      header: "Status",
-      render: (row) => (
-        <MemberStatusBadge classification={row.classification} />
-      ),
-      width: "140px",
-    },
-  ];
-
-  if (isLoading) {
-    return <SkeletonTable />;
-  }
-
-  return (
-    <Table columns={columns}>
-      <Table.Header columns={columns} />
-      {rows.length === 0 ? (
-        <Table.NoResultsMessage>
-          <div className="flex flex-col items-center gap-2 px-4 py-10 text-center">
-            <Network className="text-muted-foreground/50 size-8" aria-hidden />
-            <Text className="font-medium">No members yet</Text>
-            <Text muted small>
-              Front your first MCP server through this gateway from the Members
-              tab.
-            </Text>
-          </div>
-        </Table.NoResultsMessage>
-      ) : (
-        <Table.Body
-          columns={columns}
-          data={rows}
-          rowKey={(row) => row.member.id}
-        />
-      )}
-    </Table>
-  );
-}
-
-export function GatewayMembersTab({
+/** Member management (list, reorder, add, remove) rendered on the Overview tab. */
+export function GatewayMembersSection({
   metaMcpServer,
 }: {
   metaMcpServer: MetaMcpServer;
@@ -412,10 +353,15 @@ export function GatewayMembersTab({
   return (
     <>
       <Page.Section>
-        <Page.Section.Title>Members</Page.Section.Title>
+        {/* Section heading under the Overview page title: no eyebrow, smaller
+            serif. */}
+        <Page.Section.Title area="" className="text-display-xs">
+          Members
+        </Page.Section.Title>
         <Page.Section.Description>
           The MCP servers this gateway fronts, in the order agents see them in
-          list_servers.
+          list_servers. Status reflects what the backend can attest; live
+          upstream health lands with the proxied runtime.
         </Page.Section.Description>
         <Page.Section.CTA>
           <RequireScope scope="mcp:write" level="component">

--- a/client/dashboard/src/pages/mcp/gateway/GatewayOverviewTab.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayOverviewTab.tsx
@@ -4,15 +4,12 @@ import {
   StatTileSkeleton,
 } from "@/components/chart/stat-tile";
 import { Page } from "@/components/page-layout";
-import { Button } from "@/components/ui/Button";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Text } from "@/components/ui/Text";
 import { useResolvedMcpServerUrl } from "@/hooks/useToolsetUrl";
-import { useRoutes } from "@/routes";
 import type { McpEndpoint } from "@gram/client/models/components/mcpendpoint.js";
 import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
-import { ArrowRight } from "lucide-react";
-import { MembersStatusTable } from "./GatewayMembersTab";
+import { GatewayMembersSection } from "./GatewayMembersSection";
 import { useGatewayMemberRows } from "./useGatewayMemberRows";
 
 export function GatewayOverviewTab({
@@ -24,7 +21,6 @@ export function GatewayOverviewTab({
   endpoints: McpEndpoint[];
   isLoadingEndpoints: boolean;
 }): JSX.Element {
-  const routes = useRoutes();
   const { mcpUrl } = useResolvedMcpServerUrl(endpoints, isLoadingEndpoints);
   const { rows, isLoading } = useGatewayMemberRows(metaMcpServer.id);
 
@@ -110,30 +106,7 @@ export function GatewayOverviewTab({
         </Page.Section.Body>
       </Page.Section>
 
-      <Page.Section>
-        <Page.Section.Title area="" className="text-display-xs">
-          Members
-        </Page.Section.Title>
-        <Page.Section.CTA>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={() => routes.mcp.gateway.members.goTo(metaMcpServer.id)}
-          >
-            <Button.Text>Manage members</Button.Text>
-            <Button.RightIcon>
-              <ArrowRight className="size-4" />
-            </Button.RightIcon>
-          </Button>
-        </Page.Section.CTA>
-        <Page.Section.Description>
-          The order agents see in list_servers. Status reflects what the backend
-          can attest; live upstream health lands with the proxied runtime.
-        </Page.Section.Description>
-        <Page.Section.Body>
-          <MembersStatusTable rows={rows} isLoading={isLoading} />
-        </Page.Section.Body>
-      </Page.Section>
+      <GatewayMembersSection metaMcpServer={metaMcpServer} />
     </>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -2,6 +2,7 @@ import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { cn } from "@/lib/utils";
 import { useRBAC } from "@/hooks/useRBAC";
+import { useTabScrollReset } from "@/hooks/useTabScrollReset";
 import { getMcpServerArgs } from "@/lib/sources";
 import { useRoutes } from "@/routes";
 import type {
@@ -51,6 +52,7 @@ export default function MCPServerDetails(): JSX.Element {
   const routes = useRoutes();
   const idOrSlug = mcpServerSlug ?? "";
   const activeTab = activeTabFromPath(location.pathname, idOrSlug);
+  const tabContentRef = useTabScrollReset(activeTab);
   const legacyAuthenticationPath = isLegacyAuthenticationTabPath(
     location.pathname,
     idOrSlug,
@@ -213,7 +215,10 @@ export default function MCPServerDetails(): JSX.Element {
       </Page.Header>
 
       <Page.Body fullWidth className="gap-0">
-        <div className="mx-auto w-full max-w-[1270px] flex-1">
+        <div
+          ref={tabContentRef}
+          className="mx-auto w-full max-w-[1270px] flex-1"
+        >
           {renderTabContent()}
         </div>
       </Page.Body>

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -529,6 +529,9 @@ const ROUTE_STRUCTURE = {
             title: "Gateway Overview",
             url: "overview",
           },
+          // Legacy URL: member management moved onto the Overview tab, and
+          // GatewayDetails redirects unknown tab segments there. Kept so old
+          // links keep resolving to the gateway page.
           members: {
             title: "Gateway Members",
             url: "members",


### PR DESCRIPTION
## Summary

A UX pass over the gateway (meta MCP) surfaces in the dashboard, plus two fixes that reach every MCP server page.

**MCP listing**

- Gateway cards render their member servers' logos in the icon rail (up to four, then a `+N` tile) instead of the generic network glyph, so a gateway's composition is scannable from the list.
- Gateways get the same status-dot treatment as server rows — `Disabled` / `Sign-in required` / `Anonymous` — in both grid and table views, replacing bare text. `Anonymous` matches the overview's Authentication tile wording.
- The page description mentions gateways (when the rollout flag is on), and the table's `Tools` column is renamed `Contents` since it holds tool chips, kind badges, or member counts depending on row kind.

**Gateway detail**

- The separate Members tab is removed; member management (reorder, add, remove, the add-member sheet) moves onto the Overview tab, replacing the read-only members table that duplicated it. The legacy `/members` URL still resolves and redirects to overview, and the catalog `attachToGateway` flow, post-create navigation, and sidebar readiness links now point at overview.
- The gateway sidebar URL truncates with a tooltip instead of wrapping mid-token.

**Shared fixes**

- Detail-page tab switches (gateway, MCP server, toolset) reset the scroll container to the top via a new `useTabScrollReset` hook — previously the next tab opened at the prior tab's scroll offset. In-page anchor hashes (settings sections) still win.
- Team-access rows click through to the Access page's pre-filled grant dialog (`?grant_user=&scope=&resource_id=`, the same deep link access-request emails use) with `mcp:connect`; `No access` cells deep-link the specific missing scope. The grant dialog copy no longer assumes an access request. Applies to gateways and regular MCP servers alike since the tab is shared.
- Clickable table rows highlight on hover using the accent token. The previous muted-token hover was invisible in dark mode, where `--muted` equals the card surface; accent is identical to muted in light mode, so light is unchanged.
- `SourceMcpIcon`'s metadata lookup no longer refetches known-404 responses on every remount, removing a stream of repeated console errors on member-heavy pages.

## Motivation

Gateways recently opened to mainstream MCP clients, but their dashboard surfaces still read as scaffolding: identical placeholder cards, a listing page whose copy ignored them, a Members tab duplicating the overview's members table, tab switches landing mid-page, and a team-access matrix that showed access but offered no path to grant it. This pass makes the listing scannable, collapses the redundant tab, and turns team access into a working entry point to role assignment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyfJJfEQHLB7BDNZsfW4ZC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes gateway UX across the MCP listing and detail pages, and fixes shared issues affecting every MCP server page. The listing now makes gateways scannable, member management collapses onto Overview, and team access becomes a working entry point to role assignment.

**New Features**
- Gateway cards show member server logos in an icon rail (up to four, then a +N tile) and a status dot that matches server rows.
- Member management (reorder, add, remove) moves from the removed Members tab onto the Overview tab; the legacy `/members` URL redirects to overview.
- Team-access rows and "No access" cells deep-link to the Access page's pre-filled grant dialog, scoped to the missing permission.

**Bug Fixes**
- Detail-page tab switches reset the page scroll to the top before paint, so the old offset never flashes; anchor hashes still win.
- Member-management controls are gated by `mcp:write` scoped to the gateway itself, so write access elsewhere no longer grants member control.
- Clickable table row hovers use the accent token so they're visible in dark mode.
- `SourceMcpIcon` stops refetching known-404 metadata on every remount, removing repeated console errors.

<sup>Written for commit 6d6c0bc29a674b5740c94315267312e46d65f886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

