### PR TITLE
mig: support curated MCP killswitch management

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4316,6 +4316,12 @@ ON audit_logs (organization_id, seq DESC);
 CREATE INDEX IF NOT EXISTS audit_logs_organization_id_project_id_seq_idx
 ON audit_logs (organization_id, project_id, seq DESC);
 
+CREATE INDEX IF NOT EXISTS audit_logs_organization_subject_action_seq_idx
+ON audit_logs (organization_id, subject_type, subject_id, action, seq DESC);
+
+CREATE INDEX IF NOT EXISTS audit_logs_organization_subject_seq_idx
+ON audit_logs (organization_id, subject_id, seq DESC);
+
 -- Remote MCP servers are upstream MCP endpoints that Gram proxies requests to.
 -- See https://modelcontextprotocol.io/registry/remote-servers
 CREATE TABLE IF NOT EXISTS remote_mcp_servers (
@@ -7716,6 +7722,8 @@ CREATE TABLE IF NOT EXISTS killswitch_prescriptions (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS killswitch_prescriptions_organization_id_id_key ON killswitch_prescriptions (organization_id, id);
 CREATE INDEX IF NOT EXISTS killswitch_prescriptions_evaluator_idx ON killswitch_prescriptions (organization_id, definition_key, principal_kind, principal_key, resource_kind, id);
+-- Customer list pages use fixed contract dimensions and descending keyset order.
+CREATE INDEX IF NOT EXISTS killswitch_prescriptions_customer_list_idx ON killswitch_prescriptions (organization_id, definition_key, principal_kind, resource_kind, created_at DESC, id DESC);
 
 CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   organization_id TEXT NOT NULL,
@@ -7723,7 +7731,8 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   version BIGINT NOT NULL,
   state TEXT NOT NULL,
   resource_scope TEXT NOT NULL,
-  starts_at timestamptz NOT NULL,
+  -- NULL means the prescription starts immediately; a value is an explicit schedule.
+  starts_at timestamptz,
   expires_at timestamptz,
   activated_at timestamptz,
   superseded_at timestamptz,
@@ -7735,7 +7744,7 @@ CREATE TABLE IF NOT EXISTS killswitch_prescription_versions (
   CONSTRAINT killswitch_prescription_versions_version_check CHECK (version > 0),
   CONSTRAINT killswitch_prescription_versions_state_check CHECK (state <> ''),
   CONSTRAINT killswitch_prescription_versions_resource_scope_check CHECK (resource_scope IN ('all', 'selected')),
-  CONSTRAINT killswitch_prescription_versions_interval_check CHECK (expires_at IS NULL OR expires_at > starts_at),
+  CONSTRAINT killswitch_prescription_versions_interval_check CHECK (expires_at IS NULL OR starts_at IS NULL OR expires_at > starts_at),
   CONSTRAINT killswitch_prescription_versions_external_note_check CHECK (char_length(external_note) BETWEEN 1 AND 500),
   CONSTRAINT killswitch_prescription_versions_internal_note_check CHECK (char_length(internal_note) BETWEEN 1 AND 4000)
 );

--- a/server/migrations/20260829131739_dno-983-killswitch-review-fixes.sql
+++ b/server/migrations/20260829131739_dno-983-killswitch-review-fixes.sql
@@ -1,0 +1,11 @@
+-- atlas:txmode none
+
+-- Create index "audit_logs_organization_subject_action_seq_idx" to table: "audit_logs"
+CREATE INDEX CONCURRENTLY "audit_logs_organization_subject_action_seq_idx" ON "audit_logs" ("organization_id", "subject_type", "subject_id", "action", "seq" DESC);
+-- Create index "audit_logs_organization_subject_seq_idx" to table: "audit_logs"
+CREATE INDEX CONCURRENTLY "audit_logs_organization_subject_seq_idx" ON "audit_logs" ("organization_id", "subject_id", "seq" DESC);
+-- Modify "killswitch_prescription_versions" table
+ALTER TABLE "killswitch_prescription_versions" DROP CONSTRAINT "killswitch_prescription_versions_interval_check", ADD CONSTRAINT "killswitch_prescription_versions_interval_check" CHECK ((expires_at IS NULL) OR (starts_at IS NULL) OR (expires_at > starts_at)) NOT VALID, ALTER COLUMN "starts_at" DROP NOT NULL;
+ALTER TABLE "killswitch_prescription_versions" VALIDATE CONSTRAINT "killswitch_prescription_versions_interval_check";
+-- Create index "killswitch_prescriptions_customer_list_idx" to table: "killswitch_prescriptions"
+CREATE INDEX CONCURRENTLY "killswitch_prescriptions_customer_list_idx" ON "killswitch_prescriptions" ("organization_id", "definition_key", "principal_kind", "resource_kind", "created_at" DESC, "id" DESC);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
+h1:aDZPWXwSZmFWJs3QkjC/f4rkgW6eysYfLJaylXHcxoI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -375,3 +375,4 @@ h1:CeutMp9ldAyEX+6NLEY+U9wyxRqy7KOm7j2fchCz3nM=
 20260828101442_data_export_routes_single_destination.sql h1:Tz5KBmcarW1pNl/D4MR7TA5m/+PnZn5IDk8bQkeniVQ=
 20260828145942_dno-974-durable-killswitch-prescriptions.sql h1:qPmCeNHQURcvp4RrbtPz9t+vs8iyLy0B5LPcEgO2ejY=
 20260828181110_dno-978-killswitch-expiry-discovery-index.sql h1:O4HoCdj2hCOhQHKbtzOJIza01sNlC+1mD+frDob19f8=
+20260829131739_dno-983-killswitch-review-fixes.sql h1:t5J2SbzQwB8YWbJ6hz1wpMvbzxGn9URFT+lJe+9x1MQ=


### PR DESCRIPTION
## Summary

Adds persisted requested start-mode metadata plus supporting list and audit-history indexes for curated MCP killswitch management. This is split from #5855 so the schema can deploy before the API logic.

## Technical details

The migration creates both indexes concurrently and validates the new start-mode check without holding an access-exclusive lock for the validation scan.
