### PR TITLE
mig: version meter readings by producer time

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260830194012_drop-billing-meter-readings-for-recreation.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260830194012_drop-billing-meter-readings-for-recreation.down.sql
@@ -1,0 +1,22 @@
+-- reverse: drop "billing_meter_readings" table
+CREATE TABLE `billing_meter_readings` (
+  `id` UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+  `organization_id` String COMMENT 'Organization that owns the workload.',
+  `project_id` UUID COMMENT 'Project that owns the workload.',
+  `meter_id` LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+  `operation_id` String COMMENT 'Domain operation that produced the reading.',
+  `unit` LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+  `value` Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'ClickHouse ingestion time and ReplacingMergeTree version.',
+  `corrects_reading_id` Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+  `reading_kind` LowCardinality(String) MATERIALIZED if(corrects_reading_id IS NULL, 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+  `attributes` Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+  `tokenizer_codec` LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+  INDEX `idx_billing_meter_readings_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1,
+  CONSTRAINT `identity_valid` CHECK ((id != toUUID('00000000-0000-0000-0000-000000000000')) AND (project_id != toUUID('00000000-0000-0000-0000-000000000000')) AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id))),
+  CONSTRAINT `value_kind_valid` CHECK (((corrects_reading_id IS NULL) AND (value > 0)) OR ((corrects_reading_id IS NOT NULL) AND (value != 0))),
+  CONSTRAINT `correction_id_valid` CHECK ((corrects_reading_id IS NULL) OR ((corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000')) AND (corrects_reading_id != id))),
+  CONSTRAINT `measurement_valid` CHECK ((unit = 'stokens') AND (tokenizer_codec = 'tiktoken_o200k_base'))
+) ENGINE = ReplacingMergeTree(inserted_at)
+PRIMARY KEY (`organization_id`, `meter_id`, `project_id`) ORDER BY (`organization_id`, `meter_id`, `project_id`, `id`) PARTITION BY (cityHash64(toString(id)) % 64) SETTINGS index_granularity = 8192 COMMENT 'Raw immutable s-token usage ledger with stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/local/golang_migrate/20260830194012_drop-billing-meter-readings-for-recreation.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260830194012_drop-billing-meter-readings-for-recreation.up.sql
@@ -1,0 +1,2 @@
+-- drop "billing_meter_readings" table
+DROP TABLE `billing_meter_readings`;

--- a/server/clickhouse/local/golang_migrate/20260830194031_create-billing-meter-readings-with-produced-version.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260830194031_create-billing-meter-readings-with-produced-version.down.sql
@@ -1,0 +1,2 @@
+-- reverse: create "billing_meter_readings" table
+DROP TABLE `billing_meter_readings`;

--- a/server/clickhouse/local/golang_migrate/20260830194031_create-billing-meter-readings-with-produced-version.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260830194031_create-billing-meter-readings-with-produced-version.up.sql
@@ -1,0 +1,23 @@
+-- create "billing_meter_readings" table
+CREATE TABLE `billing_meter_readings` (
+  `id` UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+  `organization_id` String COMMENT 'Organization that owns the workload.',
+  `project_id` UUID COMMENT 'Project that owns the workload.',
+  `meter_id` LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+  `operation_id` String COMMENT 'Domain operation that produced the reading.',
+  `unit` LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+  `value` Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed and the timestamp used for billing periods.',
+  `produced_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the producer created this reading variant and the ReplacingMergeTree version.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row for delivery-lag diagnostics.',
+  `corrects_reading_id` Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+  `reading_kind` LowCardinality(String) MATERIALIZED if(corrects_reading_id IS NULL, 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+  `attributes` Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+  `tokenizer_codec` LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+  INDEX `idx_billing_meter_readings_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1,
+  CONSTRAINT `identity_valid` CHECK ((id != toUUID('00000000-0000-0000-0000-000000000000')) AND (project_id != toUUID('00000000-0000-0000-0000-000000000000')) AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id))),
+  CONSTRAINT `value_kind_valid` CHECK (((corrects_reading_id IS NULL) AND (value > 0)) OR ((corrects_reading_id IS NOT NULL) AND (value != 0))),
+  CONSTRAINT `correction_id_valid` CHECK ((corrects_reading_id IS NULL) OR ((corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000')) AND (corrects_reading_id != id))),
+  CONSTRAINT `measurement_valid` CHECK ((unit = 'stokens') AND (tokenizer_codec = 'tiktoken_o200k_base'))
+) ENGINE = ReplacingMergeTree(produced_at)
+PRIMARY KEY (`organization_id`, `meter_id`, `project_id`) ORDER BY (`organization_id`, `meter_id`, `project_id`, `id`) PARTITION BY (cityHash64(toString(id)) % 64) SETTINGS index_granularity = 8192 COMMENT 'Raw s-token usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:5xIpaQ7Q8fdToRy0Oo/pKMul9rY3feKkJPdKQWhjIJg=
+h1:cy0aZtbtIM9sc7a3YF0ZFKUyJjoNUbJMww3/A5A5xKQ=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -92,3 +92,5 @@ h1:5xIpaQ7Q8fdToRy0Oo/pKMul9rY3feKkJPdKQWhjIJg=
 20260821180408_add-risk-findings-event-kind.up.sql h1:QkhOhO7Q4cfBVkbhvAatxmHdTbZtDm9MQ7+78USDRFQ=
 20260824192251_otel-event-feed-tables.up.sql h1:n3KFSIcdJXiqHRQQCAjkrD5Ux0dAsqJ1Ar9R7rM31qI=
 20260825112511_billing-meter-readings.up.sql h1:27Ts5n4EmmxCSfPKF89JmZBaixYgLQ0xvqoE/4yAGOM=
+20260830194012_drop-billing-meter-readings-for-recreation.up.sql h1:BaYerdiYBJFHERzcT2RjXIpGcOKOOue8RhqS6B0IPuU=
+20260830194031_create-billing-meter-readings-with-produced-version.up.sql h1:P/yMjAzN6cJJ/krXI3/Eqk7PEGEYdgNJIa8kpETP8t8=

--- a/server/clickhouse/migrations/20260830194007_drop-billing-meter-readings-for-recreation.sql
+++ b/server/clickhouse/migrations/20260830194007_drop-billing-meter-readings-for-recreation.sql
@@ -1,2 +1,4 @@
+-- atlas:nolint destructive
+
 -- Drop "billing_meter_readings" table
 DROP TABLE `billing_meter_readings`;

--- a/server/clickhouse/migrations/20260830194007_drop-billing-meter-readings-for-recreation.sql
+++ b/server/clickhouse/migrations/20260830194007_drop-billing-meter-readings-for-recreation.sql
@@ -1,0 +1,2 @@
+-- Drop "billing_meter_readings" table
+DROP TABLE `billing_meter_readings`;

--- a/server/clickhouse/migrations/20260830194025_create-billing-meter-readings-with-produced-version.sql
+++ b/server/clickhouse/migrations/20260830194025_create-billing-meter-readings-with-produced-version.sql
@@ -1,0 +1,23 @@
+-- Create "billing_meter_readings" table
+CREATE TABLE `billing_meter_readings` (
+  `id` UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
+  `organization_id` String COMMENT 'Organization that owns the workload.',
+  `project_id` UUID COMMENT 'Project that owns the workload.',
+  `meter_id` LowCardinality(String) COMMENT 'Registered workload meter identifier.',
+  `operation_id` String COMMENT 'Domain operation that produced the reading.',
+  `unit` LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+  `value` Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed and the timestamp used for billing periods.',
+  `produced_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the producer created this reading variant and the ReplacingMergeTree version.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row for delivery-lag diagnostics.',
+  `corrects_reading_id` Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
+  `reading_kind` LowCardinality(String) MATERIALIZED if(corrects_reading_id IS NULL, 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+  `attributes` Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
+  `tokenizer_codec` LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
+  INDEX `idx_billing_meter_readings_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1,
+  CONSTRAINT `identity_valid` CHECK ((id != toUUID('00000000-0000-0000-0000-000000000000')) AND (project_id != toUUID('00000000-0000-0000-0000-000000000000')) AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id))),
+  CONSTRAINT `value_kind_valid` CHECK (((corrects_reading_id IS NULL) AND (value > 0)) OR ((corrects_reading_id IS NOT NULL) AND (value != 0))),
+  CONSTRAINT `correction_id_valid` CHECK ((corrects_reading_id IS NULL) OR ((corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000')) AND (corrects_reading_id != id))),
+  CONSTRAINT `measurement_valid` CHECK ((unit = 'stokens') AND (tokenizer_codec = 'tiktoken_o200k_base'))
+) ENGINE = ReplacingMergeTree(produced_at)
+PRIMARY KEY (`organization_id`, `meter_id`, `project_id`) ORDER BY (`organization_id`, `meter_id`, `project_id`, `id`) PARTITION BY (cityHash64(toString(id)) % 64) SETTINGS index_granularity = 8192 COMMENT 'Raw s-token usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nogJJfQQOr2FQOyJAAxJFMYI3e65NheDm1oh5Ji6Loo=
+h1:/Sd8KSe7b8SJnys7g2cSIF5isSpK6KywCB5rbzHcFas=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -97,5 +97,5 @@ h1:nogJJfQQOr2FQOyJAAxJFMYI3e65NheDm1oh5Ji6Loo=
 20260821180402_add-risk-findings-event-kind.sql h1:1NyIucg2KfdbPn1PqiPfLpzMf62hgy7Zogmk0uuZzu0=
 20260824192245_otel-event-feed-tables.sql h1:fC4u4OnBq3d3Dwcq7VmWp4J8YwSSNXUKfhA55C04ZkQ=
 20260825112504_billing-meter-readings.sql h1:tQBQtUvTVevKBYdP539VUMePWX/XYBS9FWYQvsDvZ0M=
-20260830194007_drop-billing-meter-readings-for-recreation.sql h1:nm1C57TcNZCCedrGc+RzYtkTm21lPcfgLS6DOEJoeMs=
-20260830194025_create-billing-meter-readings-with-produced-version.sql h1:oN3jZAm5UWrykndJDoPyMgP9MX64nJsW0ek8/vm1qB0=
+20260830194007_drop-billing-meter-readings-for-recreation.sql h1:wkU35/YZ9frc0FklFIGxr6SU4to66HvkIV35wxbklxs=
+20260830194025_create-billing-meter-readings-with-produced-version.sql h1:8zElCaRtJdH7pqsg9gKO469BADjfzEWyebYiNrRQFzA=

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:M4tHi9jHBtmcZtIR3cr05p4sMRVrpl9gYWBBQqKfg7k=
+h1:nogJJfQQOr2FQOyJAAxJFMYI3e65NheDm1oh5Ji6Loo=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -97,3 +97,5 @@ h1:M4tHi9jHBtmcZtIR3cr05p4sMRVrpl9gYWBBQqKfg7k=
 20260821180402_add-risk-findings-event-kind.sql h1:1NyIucg2KfdbPn1PqiPfLpzMf62hgy7Zogmk0uuZzu0=
 20260824192245_otel-event-feed-tables.sql h1:fC4u4OnBq3d3Dwcq7VmWp4J8YwSSNXUKfhA55C04ZkQ=
 20260825112504_billing-meter-readings.sql h1:tQBQtUvTVevKBYdP539VUMePWX/XYBS9FWYQvsDvZ0M=
+20260830194007_drop-billing-meter-readings-for-recreation.sql h1:nm1C57TcNZCCedrGc+RzYtkTm21lPcfgLS6DOEJoeMs=
+20260830194025_create-billing-meter-readings-with-produced-version.sql h1:oN3jZAm5UWrykndJDoPyMgP9MX64nJsW0ek8/vm1qB0=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1152,7 +1152,7 @@ SELECT
     groupUniqArrayArray(arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)'))) AS groups,
     -- Attribution values only exist meaningfully on api_request rows; the If
     -- guard keeps other rows from contributing an all-empty tuple.
-    groupUniqArrayIf(tuple(toString(attributes.query_source), toString(attributes.skill.name), toString(attributes.agent.name), toString(attributes.mcp_server.name), toString(attributes.mcp_tool.name)), is_claude_api_request) AS attribution_tuples
+    groupUniqArrayIf((toString(attributes.query_source), toString(attributes.skill.name), toString(attributes.agent.name), toString(attributes.mcp_server.name), toString(attributes.mcp_tool.name)), is_claude_api_request) AS attribution_tuples
 FROM telemetry_logs
 WHERE time_unix_nano >= chat_session_cutoff_unix_nano
   AND chat_id != ''
@@ -1199,12 +1199,12 @@ CREATE TABLE IF NOT EXISTS billing_meter_readings (
     produced_at DateTime64(9, 'UTC') COMMENT 'UTC time when the producer created this reading variant and the ReplacingMergeTree version.',
     inserted_at DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row for delivery-lag diagnostics.',
     corrects_reading_id Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
-    reading_kind LowCardinality(String) MATERIALIZED if(isNull(corrects_reading_id), 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
+    reading_kind LowCardinality(String) MATERIALIZED if(corrects_reading_id IS NULL, 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
     attributes Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
     tokenizer_codec LowCardinality(String) MATERIALIZED attributes['codec'] COMMENT 'Tokenizer codec promoted from attributes for billing analysis.',
     CONSTRAINT identity_valid CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id)),
-    CONSTRAINT value_kind_valid CHECK (isNull(corrects_reading_id) AND value > 0) OR (isNotNull(corrects_reading_id) AND value != 0),
-    CONSTRAINT correction_id_valid CHECK isNull(corrects_reading_id) OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
+    CONSTRAINT value_kind_valid CHECK (corrects_reading_id IS NULL AND value > 0) OR (corrects_reading_id IS NOT NULL AND value != 0),
+    CONSTRAINT correction_id_valid CHECK corrects_reading_id IS NULL OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
     CONSTRAINT measurement_valid CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
     INDEX idx_billing_meter_readings_occurred_at occurred_at TYPE minmax GRANULARITY 1
 ) ENGINE = ReplacingMergeTree(produced_at)

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1181,9 +1181,12 @@ GROUP BY gram_project_id, attribute_key;
 
 -- Raw usage ledger only. Meter definitions, pricing, billability, aggregation,
 -- finalized billing-cycle records, and reconciliation live in transactional models.
--- Outbox and Pub/Sub delivery is at least once. Producers keep each deterministic
--- id's payload stable. Readers must use FINAL or equivalent id deduplication
--- before summing. Adjustments use distinct ids and never update originals.
+-- Outbox and Pub/Sub delivery is at least once and may reorder variants sharing
+-- a deterministic id. produced_at is the replacement version, so newer producer
+-- state wins across delivery batches. Equal producer times deliberately use
+-- ClickHouse latest-insert tie-breaking to refresh mutable enrichment. Readers
+-- must use FINAL or equivalent id deduplication before summing. Adjustments use
+-- distinct ids and never update originals.
 CREATE TABLE IF NOT EXISTS billing_meter_readings (
     id UUID COMMENT 'Deterministic reading UUID stable across redelivery.',
     organization_id String COMMENT 'Organization that owns the workload.',
@@ -1192,8 +1195,9 @@ CREATE TABLE IF NOT EXISTS billing_meter_readings (
     operation_id String COMMENT 'Domain operation that produced the reading.',
     unit LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
     value Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
-    occurred_at DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed.',
-    inserted_at DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'ClickHouse ingestion time and ReplacingMergeTree version.',
+    occurred_at DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed and the timestamp used for billing periods.',
+    produced_at DateTime64(9, 'UTC') COMMENT 'UTC time when the producer created this reading variant and the ReplacingMergeTree version.',
+    inserted_at DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row for delivery-lag diagnostics.',
     corrects_reading_id Nullable(UUID) COMMENT 'Original reading corrected by this immutable adjustment.',
     reading_kind LowCardinality(String) MATERIALIZED if(isNull(corrects_reading_id), 'usage', 'adjustment') COMMENT 'Derived row kind based on whether the reading corrects an earlier reading.',
     attributes Map(String, String) COMMENT 'Additional producer-supplied reading dimensions.',
@@ -1203,12 +1207,12 @@ CREATE TABLE IF NOT EXISTS billing_meter_readings (
     CONSTRAINT correction_id_valid CHECK isNull(corrects_reading_id) OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
     CONSTRAINT measurement_valid CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
     INDEX idx_billing_meter_readings_occurred_at occurred_at TYPE minmax GRANULARITY 1
-) ENGINE = ReplacingMergeTree(inserted_at)
+) ENGINE = ReplacingMergeTree(produced_at)
 PARTITION BY cityHash64(toString(id)) % 64
 PRIMARY KEY (organization_id, meter_id, project_id)
 ORDER BY (organization_id, meter_id, project_id, id)
 SETTINGS index_granularity = 8192
-COMMENT 'Raw immutable s-token usage ledger with stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
+COMMENT 'Raw s-token usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
 
 CREATE TABLE IF NOT EXISTS authz_challenges (
     -- Identity

--- a/server/internal/metering/ch_writer.go
+++ b/server/internal/metering/ch_writer.go
@@ -47,7 +47,7 @@ func (w *MeterReadingCHWriter) HandleBatch(ctx context.Context, messages []*mete
 
 	insertedAt := time.Now().UTC()
 	rows := make([]chrepo.ReadingRow, 0, len(messages))
-	seen := make(map[uuid.UUID]struct{}, len(messages))
+	received := make(map[uuid.UUID]int, len(messages))
 
 	for _, message := range messages {
 		row, reason := meterReadingRow(message, insertedAt)
@@ -62,10 +62,14 @@ func (w *MeterReadingCHWriter) HandleBatch(ctx context.Context, messages []*mete
 			)
 			continue
 		}
-		if _, duplicate := seen[row.ID]; duplicate {
+		if priorIndex, duplicate := received[row.ID]; duplicate {
+			if !row.ProducedAt.After(rows[priorIndex].ProducedAt) {
+				continue
+			}
+			rows[priorIndex] = row
 			continue
 		}
-		seen[row.ID] = struct{}{}
+		received[row.ID] = len(rows)
 		rows = append(rows, row)
 	}
 
@@ -175,6 +179,7 @@ func meterReadingRow(message *meteringv1.MeterReading, insertedAt time.Time) (ch
 		Unit:              string(definition.unit),
 		Value:             message.GetValue(),
 		OccurredAt:        occurredAt,
+		ProducedAt:        producedAt,
 		InsertedAt:        insertedAt,
 		CorrectsReadingID: correctsReadingID,
 		Attributes:        attributes,

--- a/server/internal/metering/ch_writer.go
+++ b/server/internal/metering/ch_writer.go
@@ -63,7 +63,7 @@ func (w *MeterReadingCHWriter) HandleBatch(ctx context.Context, messages []*mete
 			continue
 		}
 		if priorIndex, duplicate := received[row.ID]; duplicate {
-			if !row.ProducedAt.After(rows[priorIndex].ProducedAt) {
+			if row.ProducedAt.Before(rows[priorIndex].ProducedAt) {
 				continue
 			}
 			rows[priorIndex] = row

--- a/server/internal/metering/ch_writer_test.go
+++ b/server/internal/metering/ch_writer_test.go
@@ -89,6 +89,10 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 		Attributes:  nil,
 	}
 	valid, reading := usageMessage(t, input)
+	updatedInput := input
+	updatedInput.ProducedAt = now.Add(time.Second)
+	updatedInput.Attributes = map[string]string{"revision": "native-promotion"}
+	updated, _ := usageMessage(t, updatedInput)
 	cloned := proto.Clone(valid)
 	invalid, ok := cloned.(*meteringv1.MeterReading)
 	require.True(t, ok)
@@ -96,11 +100,13 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 	capture := &captureReadingInserter{rows: nil, err: nil}
 	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture, true)
 
-	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{nil, invalid, valid, valid}, nil))
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{nil, invalid, valid, updated, valid}, nil))
 	require.Len(t, capture.rows, 1)
 	require.Equal(t, reading.ID(), capture.rows[0].ID)
 	require.Equal(t, input.Value, capture.rows[0].Value)
 	require.Equal(t, string(metering.MeasurementTiktokenO200kBase), capture.rows[0].Attributes["codec"])
+	require.Equal(t, "native-promotion", capture.rows[0].Attributes["revision"])
+	require.Equal(t, updatedInput.ProducedAt, capture.rows[0].ProducedAt)
 }
 
 func TestMeterReadingCHWriterPropagatesInsertFailure(t *testing.T) {
@@ -128,7 +134,7 @@ func TestMeterReadingCHWriterRedeliveryConvergesAndPreservesAdjustment(t *testin
 	definition := metering.AgentSessionStorage()
 	scope := metering.ProjectScope("org-"+uuid.NewString(), uuid.New())
 	now := time.Now().UTC()
-	usageInput := metering.UsageInput{
+	staleInput := metering.UsageInput{
 		Meter:       definition,
 		Scope:       scope,
 		OperationID: "chat_message:" + uuid.NewString(),
@@ -136,30 +142,58 @@ func TestMeterReadingCHWriterRedeliveryConvergesAndPreservesAdjustment(t *testin
 		OccurredAt:  now,
 		ProducedAt:  now,
 		Source:      "test",
-		Attributes:  nil,
+		Attributes:  map[string]string{"attribution": "stale"},
 	}
-	usageEvent, usage := usageMessage(t, usageInput)
+	staleEvent, usage := usageMessage(t, staleInput)
+	newerInput := staleInput
+	newerInput.ProducedAt = now.Add(time.Second)
+	newerInput.Attributes = map[string]string{"attribution": "newer"}
+	newerEvent, newerUsage := usageMessage(t, newerInput)
+	require.Equal(t, usage.ID(), newerUsage.ID())
+	equalVersionInput := newerInput
+	equalVersionInput.Attributes = map[string]string{"attribution": "refreshed"}
+	equalVersionEvent, equalVersionUsage := usageMessage(t, equalVersionInput)
+	require.Equal(t, usage.ID(), equalVersionUsage.ID())
 	adjustmentEvent, _ := adjustmentMessage(t, metering.AdjustmentInput{
 		Meter:             definition,
 		Scope:             scope,
-		OperationID:       usageInput.OperationID + ":adjustment",
+		OperationID:       staleInput.OperationID + ":adjustment",
 		Value:             -5,
 		OccurredAt:        now,
-		ProducedAt:        now.Add(time.Second),
+		ProducedAt:        now.Add(2 * time.Second),
 		CorrectsReadingID: usage.ID(),
 		Reason:            "source_reconciliation",
 		Source:            "test",
 		Attributes:        nil,
 	})
 	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), chrepo.New(conn), true)
-	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{usageEvent}, nil))
-	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{usageEvent}, nil))
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{newerEvent}, nil))
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{staleEvent}, nil))
+
+	projectID, ok := scope.ProjectID()
+	require.True(t, ok)
+	var storedProducedAt time.Time
+	var attributes map[string]string
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT produced_at, attributes
+		FROM billing_meter_readings FINAL
+		WHERE organization_id = ? AND project_id = ? AND meter_id = ? AND id = ?
+	`, scope.OrganizationID(), projectID, string(metering.MeterAgentSessionStorage), usage.ID()).Scan(&storedProducedAt, &attributes))
+	require.Equal(t, newerInput.ProducedAt, storedProducedAt)
+	require.Equal(t, "newer", attributes["attribution"])
+
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{equalVersionEvent}, nil))
 	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{adjustmentEvent}, nil))
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT produced_at, attributes
+		FROM billing_meter_readings FINAL
+		WHERE organization_id = ? AND project_id = ? AND meter_id = ? AND id = ?
+	`, scope.OrganizationID(), projectID, string(metering.MeterAgentSessionStorage), usage.ID()).Scan(&storedProducedAt, &attributes))
+	require.Equal(t, equalVersionInput.ProducedAt, storedProducedAt)
+	require.Equal(t, "refreshed", attributes["attribution"])
 
 	var count uint64
 	var net int64
-	projectID, ok := scope.ProjectID()
-	require.True(t, ok)
 	require.NoError(t, conn.QueryRow(t.Context(), `
 		SELECT count(), sum(value)
 		FROM billing_meter_readings FINAL

--- a/server/internal/metering/ch_writer_test.go
+++ b/server/internal/metering/ch_writer_test.go
@@ -93,6 +93,9 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 	updatedInput.ProducedAt = now.Add(time.Second)
 	updatedInput.Attributes = map[string]string{"revision": "native-promotion"}
 	updated, _ := usageMessage(t, updatedInput)
+	refreshedInput := updatedInput
+	refreshedInput.Attributes = map[string]string{"revision": "refreshed"}
+	refreshed, _ := usageMessage(t, refreshedInput)
 	cloned := proto.Clone(valid)
 	invalid, ok := cloned.(*meteringv1.MeterReading)
 	require.True(t, ok)
@@ -100,12 +103,12 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 	capture := &captureReadingInserter{rows: nil, err: nil}
 	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture, true)
 
-	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{nil, invalid, valid, updated, valid}, nil))
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{nil, invalid, valid, updated, valid, refreshed}, nil))
 	require.Len(t, capture.rows, 1)
 	require.Equal(t, reading.ID(), capture.rows[0].ID)
 	require.Equal(t, input.Value, capture.rows[0].Value)
 	require.Equal(t, string(metering.MeasurementTiktokenO200kBase), capture.rows[0].Attributes["codec"])
-	require.Equal(t, "native-promotion", capture.rows[0].Attributes["revision"])
+	require.Equal(t, "refreshed", capture.rows[0].Attributes["revision"])
 	require.Equal(t, updatedInput.ProducedAt, capture.rows[0].ProducedAt)
 }
 

--- a/server/internal/metering/chrepo/queries.go
+++ b/server/internal/metering/chrepo/queries.go
@@ -39,7 +39,10 @@ type ReadingRow struct {
 	// OccurredAt is the UTC work-execution time.
 	OccurredAt time.Time `ch:"occurred_at"`
 
-	// InsertedAt is the UTC ingestion time shared by the received batch.
+	// ProducedAt is the UTC source-production time used as the replacement version.
+	ProducedAt time.Time `ch:"produced_at"`
+
+	// InsertedAt is the UTC ClickHouse ingestion time used for delivery diagnostics.
 	InsertedAt time.Time `ch:"inserted_at"`
 
 	// CorrectsReadingID identifies the original reading for a compensation.
@@ -74,6 +77,7 @@ func (q *Queries) InsertReadings(ctx context.Context, rows []ReadingRow) error {
 		"unit",
 		"value",
 		"occurred_at",
+		"produced_at",
 		"inserted_at",
 		"corrects_reading_id",
 		"attributes",
@@ -92,6 +96,7 @@ func (q *Queries) InsertReadings(ctx context.Context, rows []ReadingRow) error {
 			row.Unit,
 			row.Value,
 			row.OccurredAt.Format("2006-01-02 15:04:05.999999999"),
+			row.ProducedAt.Format("2006-01-02 15:04:05.999999999"),
 			row.InsertedAt.Format("2006-01-02 15:04:05.999999999"),
 			correctsReadingID,
 			row.Attributes,

--- a/server/internal/metering/chrepo/queries_test.go
+++ b/server/internal/metering/chrepo/queries_test.go
@@ -18,7 +18,9 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	projectID := uuid.New()
 	readingID := uuid.New()
 	correctionID := uuid.New()
-	firstInsertedAt := time.Now().UTC().Add(-2 * time.Second)
+	producedAt := time.Now().UTC().Add(-3 * time.Second)
+	adjustmentProducedAt := producedAt.Add(time.Second)
+	firstInsertedAt := producedAt.Add(2 * time.Second)
 	secondInsertedAt := firstInsertedAt.Add(time.Second)
 	firstOccurredAt := time.Date(2026, time.January, 15, 1, 2, 3, 4, time.UTC)
 	secondOccurredAt := time.Date(2026, time.February, 15, 1, 2, 3, 4, time.UTC)
@@ -32,6 +34,7 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 		Unit:              "stokens",
 		Value:             10,
 		OccurredAt:        firstOccurredAt,
+		ProducedAt:        producedAt,
 		InsertedAt:        firstInsertedAt,
 		CorrectsReadingID: nil,
 		Attributes:        map[string]string{"codec": "tiktoken_o200k_base", "source": "first"},
@@ -49,6 +52,7 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 		Unit:              "stokens",
 		Value:             -4,
 		OccurredAt:        secondOccurredAt,
+		ProducedAt:        adjustmentProducedAt,
 		InsertedAt:        secondInsertedAt,
 		CorrectsReadingID: &readingID,
 		Attributes:        map[string]string{"codec": "tiktoken_o200k_base"},
@@ -59,13 +63,14 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	require.NoError(t, queries.InsertReadings(t.Context(), []chrepo.ReadingRow{redelivery, correction}))
 
 	var (
-		operationID, unit, corrects string
-		value                       int64
-		occurredAt, insertedAt      time.Time
-		attributes                  map[string]string
+		operationID, unit, corrects  string
+		value                        int64
+		occurredAt, storedProducedAt time.Time
+		storedInsertedAt             time.Time
+		attributes                   map[string]string
 	)
 	err := conn.QueryRow(t.Context(), `
-		SELECT operation_id, toString(unit), value, occurred_at, inserted_at,
+		SELECT operation_id, toString(unit), value, occurred_at, produced_at, inserted_at,
 		       ifNull(toString(corrects_reading_id), ''), attributes
 		FROM billing_meter_readings FINAL
 		WHERE organization_id = ? AND project_id = ? AND meter_id = ? AND id = ?
@@ -74,7 +79,8 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 		&unit,
 		&value,
 		&occurredAt,
-		&insertedAt,
+		&storedProducedAt,
+		&storedInsertedAt,
 		&corrects,
 		&attributes,
 	)
@@ -83,7 +89,8 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	require.Equal(t, "stokens", unit)
 	require.Equal(t, int64(10), value)
 	require.Equal(t, secondOccurredAt, occurredAt)
-	require.Equal(t, secondInsertedAt, insertedAt)
+	require.Equal(t, producedAt, storedProducedAt)
+	require.Equal(t, secondInsertedAt, storedInsertedAt)
 	require.Empty(t, corrects)
 	require.Equal(t, "redelivery", attributes["source"])
 


### PR DESCRIPTION
> [!CAUTION]
> This migration drops and recreates `billing_meter_readings`, permanently deleting any existing rows. Merge only while the ClickHouse metering writer remains disabled. The accompanying `isNull`/`IS NULL` and `tuple(...)`/`(...)` schema edits are behavior-preserving ClickHouse 26.2 canonicalization changes required for Atlas drift checks; they do not add a separate production migration.

## Summary

- Recreate `billing_meter_readings` with distinct `occurred_at`, `produced_at`, and `inserted_at` timestamps.
- Use `produced_at` as the `ReplacingMergeTree` version while retaining `occurred_at` for billing periods and `inserted_at` for delivery-lag diagnostics.
- Persist both producer and ClickHouse receipt times, order same-batch variants by producer time, and cover cross-batch reordering, equal-version refreshes, and adjustments against real ClickHouse.

## Motivation

Pub/Sub delivery order is independent of producer-time ordering. Versioning same-ID variants by receipt time lets an older variant delivered in a later batch replace newer attribution under `FINAL`; versioning by `produced_at` makes convergence follow producer order instead.

The table is not used in production and is intended to start empty, so the generated migration deliberately drops and recreates it rather than carrying incompatible receipt-time versions forward. Equal producer timestamps remain equal replacement versions, allowing ClickHouse's latest-insert tie-breaking to refresh mutable enrichment.
