### PR TITLE
fix: improve billing inference cap empty state

### DIFF
--- a/client/dashboard/src/components/billing/inference-caps-section.test.tsx
+++ b/client/dashboard/src/components/billing/inference-caps-section.test.tsx
@@ -442,9 +442,11 @@ describe("InferenceCapsSection", () => {
       expect(securityField()).toBeNull();
       expect(
         screen.getByText(
-          "No Gram-managed inference keys are available to configure yet.",
+          "There are no Speakeasy-managed inference keys available to configure yet.",
         ),
       ).toBeTruthy();
+      expect(screen.getByText("No keys available")).toBeTruthy();
+      expect(container.querySelector(".border-dashed")).not.toBeNull();
       expect(container.querySelector(".skeleton")).toBeNull();
       expect(mocks.mutation).not.toHaveBeenCalled();
     });
@@ -1399,7 +1401,7 @@ describe("InferenceCapsSection", () => {
         if (count === 0) {
           expect(
             screen.getByText(
-              "No Gram-managed inference keys are available to configure yet.",
+              "There are no Speakeasy-managed inference keys available to configure yet.",
             ),
           ).toBeTruthy();
         }
@@ -1465,7 +1467,7 @@ describe("InferenceCapsSection", () => {
         if (count === 0) {
           expect(
             screen.getByText(
-              "No Gram-managed inference keys are available to configure yet.",
+              "There are no Speakeasy-managed inference keys available to configure yet.",
             ),
           ).toBeTruthy();
         }

--- a/client/dashboard/src/components/billing/inference-caps-section.tsx
+++ b/client/dashboard/src/components/billing/inference-caps-section.tsx
@@ -1,4 +1,5 @@
 import { InferenceCapControl } from "@/components/billing/inference-cap-control";
+import { InlineEmptyState } from "@/components/inline-empty-state";
 import { useInferenceCapsMode } from "@/components/billing/inference-caps-mode";
 import {
   INFERENCE_CAPS_ANCHOR,
@@ -52,8 +53,9 @@ const NOT_BILLING_NOTE =
 
 // The endpoint answers with the Gram-managed inference keys that have been
 // materialized for this organization, which can be none of them.
+const NO_CAPS_HEADING = "No keys available";
 const NO_CAPS_NOTE =
-  "No Gram-managed inference keys are available to configure yet.";
+  "There are no Speakeasy-managed inference keys available to configure yet.";
 
 /** The same note for a Stripe trial, which knows when billing takes over. */
 function stripeTrialNote(convertsOn: Date | null | undefined): string {
@@ -187,9 +189,9 @@ export function InferenceCapsSection(): JSX.Element | null {
         <Page.Section.Title area="">Inference caps</Page.Section.Title>
         <Page.Section.Description>
           Limit what this organization can spend each month on the inference
-          Gram runs for it. Each cap is enforced on its own. Caps follow the
-          calendar month rather than your billing cycle, so the spend they meter
-          isn't an invoice figure.
+          Speakeasy runs for it. Each cap is enforced on its own. Caps follow
+          the calendar month rather than your billing cycle, so the spend they
+          meter isn't an invoice figure.
         </Page.Section.Description>
         <Page.Section.Body>
           {mode === "product-trial" ? (
@@ -326,9 +328,11 @@ function InferenceCaps({
           </Text>
         )}
         {caps.length === 0 ? (
-          <Text muted small>
-            {NO_CAPS_NOTE}
-          </Text>
+          <InlineEmptyState
+            icon="key-round"
+            heading={NO_CAPS_HEADING}
+            description={NO_CAPS_NOTE}
+          />
         ) : (
           caps.map((cap) => (
             <InferenceCapControl

--- a/client/dashboard/src/components/billing/inference-caps.ts
+++ b/client/dashboard/src/components/billing/inference-caps.ts
@@ -37,7 +37,7 @@ const CAP_COPY: Record<InferenceSpendCapKeyType, CapCopy> = {
     name: "Security inference",
     slug: "security",
     paused:
-      "The automated analysis Gram runs over this organization's traffic, including security scanning, is paused for the rest of the month. Raise the cap to start it again.",
+      "The automated analysis Speakeasy runs over this organization's traffic, including security scanning, is paused for the rest of the month. Raise the cap to start it again.",
   },
   chat: {
     name: "Other inference",


### PR DESCRIPTION
## Summary
- update pay-as-you-go billing copy to use the Speakeasy brand
- show a structured empty state when no inference keys can be configured
- cover the empty-state presentation in the inference caps tests

## Testing
- `aube run -F dashboard test -- src/components/billing/inference-caps-section.test.tsx`
- `aube run -F dashboard type-check`
- `aube exec oxfmt -- --check client/dashboard/src/components/billing/inference-caps-section.tsx client/dashboard/src/components/billing/inference-caps.ts client/dashboard/src/components/billing/inference-caps-section.test.tsx`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates billing inference cap copy to use the Speakeasy brand and shows a structured empty state with a heading and icon when no inference keys are available. Also refreshes the existing fallback text and updates tests to cover the new empty-state presentation.

<sup>Written for commit fe16df3d07b6fbd370d67334ff920c5f8af64781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

