### PR TITLE
chore: temporarily disable ClickHouse metering writes

### DIFF
--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -574,7 +574,7 @@ func newStreamsCommand() *cli.Command {
 				mustReceive(rg, &webhooksv1.Event{}, &webhooksv1.SvixRelay{}, webhookEventHandler)
 
 				mustReceive(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, chConn))
-				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
+				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, meteringchrepo.New(chConn), false), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
 
 				mustReceive(rg, &otelv1.InboundLogRecord{}, &otelv1.InboundLogRecordTransformer{}, otelsvc.NewLogTransformHandler(
 					logger,

--- a/server/internal/metering/ch_writer.go
+++ b/server/internal/metering/ch_writer.go
@@ -23,22 +23,28 @@ type ReadingInserter interface {
 
 // MeterReadingCHWriter validates Pub/Sub readings and writes them to ClickHouse.
 type MeterReadingCHWriter struct {
-	logger   *slog.Logger
-	inserter ReadingInserter
+	logger        *slog.Logger
+	inserter      ReadingInserter
+	writesEnabled bool
 }
 
 // NewMeterReadingCHWriter creates a ClickHouse workload reading subscriber.
-func NewMeterReadingCHWriter(logger *slog.Logger, inserter ReadingInserter) *MeterReadingCHWriter {
+func NewMeterReadingCHWriter(logger *slog.Logger, inserter ReadingInserter, writesEnabled bool) *MeterReadingCHWriter {
 	return &MeterReadingCHWriter{
-		logger:   logger.With(attr.SlogComponent("meter-reading-ch-writer")),
-		inserter: inserter,
+		logger:        logger.With(attr.SlogComponent("meter-reading-ch-writer")),
+		inserter:      inserter,
+		writesEnabled: writesEnabled,
 	}
 }
 
 var _ streams.BatchHandler[*meteringv1.MeterReading] = (*MeterReadingCHWriter)(nil)
 
-// HandleBatch acknowledges malformed poison messages and retries ClickHouse failures.
+// HandleBatch acknowledges messages without insertion when ClickHouse writes are disabled.
 func (w *MeterReadingCHWriter) HandleBatch(ctx context.Context, messages []*meteringv1.MeterReading, _ []gcp.MessageMetadata) error {
+	if !w.writesEnabled {
+		return nil
+	}
+
 	insertedAt := time.Now().UTC()
 	rows := make([]chrepo.ReadingRow, 0, len(messages))
 	seen := make(map[uuid.UUID]struct{}, len(messages))

--- a/server/internal/metering/ch_writer_test.go
+++ b/server/internal/metering/ch_writer_test.go
@@ -94,7 +94,7 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 	require.True(t, ok)
 	invalid.SetId("not-a-uuid")
 	capture := &captureReadingInserter{rows: nil, err: nil}
-	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture)
+	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture, true)
 
 	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{nil, invalid, valid, valid}, nil))
 	require.Len(t, capture.rows, 1)
@@ -117,7 +117,7 @@ func TestMeterReadingCHWriterPropagatesInsertFailure(t *testing.T) {
 		Attributes:  nil,
 	})
 	capture := &captureReadingInserter{rows: nil, err: errors.New("clickhouse unavailable")}
-	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture)
+	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), capture, true)
 	require.Error(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{message}, nil))
 }
 
@@ -151,7 +151,7 @@ func TestMeterReadingCHWriterRedeliveryConvergesAndPreservesAdjustment(t *testin
 		Source:            "test",
 		Attributes:        nil,
 	})
-	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), chrepo.New(conn))
+	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), chrepo.New(conn), true)
 	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{usageEvent}, nil))
 	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{usageEvent}, nil))
 	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{adjustmentEvent}, nil))

--- a/server/internal/metering/pipeline_test.go
+++ b/server/internal/metering/pipeline_test.go
@@ -120,7 +120,7 @@ func TestChatStorageReadingPipelineToClickHouse(t *testing.T) {
 
 	clickhouseConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
-	chWriter := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), meteringchrepo.New(clickhouseConn))
+	chWriter := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), meteringchrepo.New(clickhouseConn), true)
 	require.NoError(t, chWriter.HandleBatch(ctx, []*meteringv1.MeterReading{message}, nil))
 	require.NoError(t, chWriter.HandleBatch(ctx, []*meteringv1.MeterReading{message}, nil))
 


### PR DESCRIPTION
## Summary

- Acknowledge metering subscriber batches without writing them to ClickHouse.
- Preserve the existing writer path behind a disabled switch so ingestion can be restored after maintenance.

## Motivation

The metering ClickHouse table needs to be recreated. Acknowledging incoming batches prevents writes and retry pressure while that maintenance is in progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disables ClickHouse metering writes while the metering table is recreated, so incoming batches are acknowledged without being written and no retry pressure builds up.

- Keeps the existing writer path behind a disabled switch so ingestion can be restored after maintenance.

<sup>Written for commit b08188e241aba5357357a9615e3508691fb760ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

