### PR TITLE
feat: enforce MCP network access modes

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1279,6 +1279,11 @@ func newStartCommand() *cli.Command {
 			hooksArtifactRoutes := middleware.NewRecovery(logger)(hooksArtifactServer.Routes())
 
 			mux := goahttp.NewMuxer()
+			// Stamp the serving-policy contract and strip private-ingress authority
+			// at the outermost public-listener boundary, before short-circuit
+			// handlers, tracing, or logging.
+			mux.Use(middleware.NetworkServingPolicyVersion)
+			mux.Use(middleware.StripPrivateIngressHeaders)
 			mux.Use(func(h http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodGet && r.URL.Path == "/healthz" {

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -83,6 +83,18 @@ type EndpointRef struct {
 	// challenge before it existed.
 	MetaMcpServerID uuid.NullUUID `json:"meta_mcp_server_id,omitzero"`
 
+	// IsPublic snapshots whether the endpoint admitted an anonymous subject at
+	// mint time. New states always set it; nil preserves compatibility only for
+	// states minted before this field existed, which expire within the challenge
+	// TTL. Re-entry rejects a visibility change before consent or token minting.
+	IsPublic *bool `json:"is_public,omitempty"`
+
+	// ToolsetID pins direct-toolset endpoints. It is also populated on bridged
+	// server-backed endpoints for attribution, but server/meta IDs remain the
+	// primary backend identity. Missing alongside both server IDs denotes a
+	// pre-field legacy cached state.
+	ToolsetID uuid.NullUUID `json:"toolset_id,omitzero"`
+
 	// Path of a toolset-backed endpoint. Set for /mcp and toolset-backed
 	// /x/mcp challenges.
 	McpSlug string `json:"mcp_slug"`
@@ -194,6 +206,10 @@ type UserSessionGrant struct {
 	CodeChallenge       string             `json:"code_challenge"`
 	CodeChallengeMethod string             `json:"code_challenge_method"`
 	Subject             urn.SessionSubject `json:"subject"`
+	// Endpoint pins new authorization codes to the exact endpoint authority
+	// consented by the subject. Nil is accepted only for grants minted before
+	// this field landed; authorization-code TTL bounds that compatibility window.
+	Endpoint *EndpointRef `json:"endpoint,omitempty"`
 	// DesiredSessionDurationHours is the subject's consent-screen session
 	// length choice. Token minting clamps it to the issuer maximum. Zero means
 	// "no explicit choice" and the mint uses that maximum. Keep the JSON key

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -705,7 +705,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		return oops.E(oops.CodeUnexpected, err, "generate authorization code").LogError(ctx, logger)
 	}
 
-	grantEndpoint := endpoint.EndpointRef(challengeState.mintOriginOr(s.serverURL.String()))
+	grantEndpoint := endpoint.EndpointRef(challengeState.mintOriginOr(s.BaseURLForRequest(r)))
 	grant := UserSessionGrant{
 		Code:                        code,
 		FlowID:                      challengeState.FlowID,

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -361,7 +361,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogError(ctx, logger)
 	}
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
-	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
+	if err := endpoint.ValidateChallenge(challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").LogError(ctx, logger)
 	}
 
@@ -705,6 +705,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		return oops.E(oops.CodeUnexpected, err, "generate authorization code").LogError(ctx, logger)
 	}
 
+	grantEndpoint := endpoint.EndpointRef(challengeState.mintOriginOr(s.serverURL.String()))
 	grant := UserSessionGrant{
 		Code:                        code,
 		FlowID:                      challengeState.FlowID,
@@ -715,6 +716,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		CodeChallenge:               challengeState.CodeChallenge,
 		CodeChallengeMethod:         challengeState.CodeChallengeMethod,
 		Subject:                     subject,
+		Endpoint:                    &grantEndpoint,
 		DesiredSessionDurationHours: desiredSessionDurationHours(r.PostForm.Get("session_duration_hours")),
 		ToolSelection:               toolSelection,
 		CreatedAt:                   time.Now(),
@@ -749,7 +751,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 // resolution. Shared by the preflight Get and the post-consume revalidation
 // so both read the same rules.
 func validateConsentChallenge(endpoint *ResolvedMcpEndpoint, challengeState *AuthnChallengeState, csrfToken string) *oops.ShareableError {
-	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
+	if err := endpoint.ValidateChallenge(challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server")
 	}
 	if challengeState.CSRFToken == "" || subtle.ConstantTimeCompare([]byte(csrfToken), []byte(challengeState.CSRFToken)) != 1 {

--- a/server/internal/mcp/authnchallenge_consent_action.go
+++ b/server/internal/mcp/authnchallenge_consent_action.go
@@ -67,7 +67,7 @@ func (s *Service) ServeConsentAction(w http.ResponseWriter, r *http.Request, end
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogError(ctx, logger)
 	}
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
-	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
+	if err := endpoint.ValidateChallenge(challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").LogError(ctx, logger)
 	}
 	if challengeState.CSRFToken == "" || subtle.ConstantTimeCompare([]byte(r.PostForm.Get("csrf_token")), []byte(challengeState.CSRFToken)) != 1 {

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -139,7 +139,7 @@ func (s *Service) ServeConsentMCP(w http.ResponseWriter, r *http.Request, endpoi
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state not found or expired").LogWarn(ctx, logger)
 	}
 	logger = logger.With(attr.SlogOAuthFlowID(challengeState.FlowID))
-	if err := endpoint.ValidateRef(challengeState.Endpoint); err != nil {
+	if err := endpoint.ValidateChallenge(challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge state does not match this MCP server").LogWarn(ctx, logger)
 	}
 	if challengeState.CSRFToken == "" || subtle.ConstantTimeCompare([]byte(csrfToken), []byte(challengeState.CSRFToken)) != 1 {

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -81,9 +81,9 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
 		return err
 	}
-	if endpoint.UserSessionIssuerID != challengeState.UserSessionIssuerID {
+	if err := endpoint.ValidateChallenge(challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
-		return oops.E(oops.CodeUnauthorized, errToolsetEndpointMismatch, "authn challenge issuer changed while the flow was in progress").LogError(ctx, logger)
+		return oops.E(oops.CodeUnauthorized, err, "authn challenge endpoint authority changed while the flow was in progress").LogError(ctx, logger)
 	}
 
 	logger = endpoint.LogWith(logger)

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -81,6 +81,10 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
 		return err
 	}
+	if endpoint.UserSessionIssuerID != challengeState.UserSessionIssuerID {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
+		return oops.E(oops.CodeUnauthorized, errToolsetEndpointMismatch, "authn challenge issuer changed while the flow was in progress").LogError(ctx, logger)
+	}
 
 	logger = endpoint.LogWith(logger)
 	// issuerID is unchanged (same issuer the ref resolved to); re-point mcpSlug

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -300,6 +300,17 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 	// key minted at /authorize and carried through the grant.
 	logger = logger.With(attr.SlogOAuthFlowID(grant.FlowID))
 
+	// New grants are bound to the exact endpoint authority consented by the
+	// subject. A nil snapshot denotes only a grant minted before this field
+	// landed; the authorization-code TTL bounds that compatibility window.
+	if grant.Endpoint != nil {
+		if err := endpoint.ValidateGrant(*grant.Endpoint, grant.UserSessionIssuerID, baseURL); err != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_endpoint_mismatch")
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "authorization code is bound to a different MCP endpoint or origin")
+		}
+	}
+
 	if grant.ClientID != clientRow.ClientID {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_client_mismatch")
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -280,11 +280,12 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		return writeTokenOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
-	// Atomic GETDEL: single-use authorization code. If two clients race to
-	// redeem the same code, exactly one wins the GETDEL; the other gets
-	// ErrCacheMiss and is rejected as invalid_grant (RFC 6749 §4.1.2 / §10.5).
+	// Inspect the endpoint binding before consuming the code so presenting it on
+	// another endpoint cannot burn the legitimate client's grant. Once that
+	// authority matches, GETDEL atomically elects one redemption winner; client,
+	// redirect, and PKCE misuse intentionally burn the single-use code.
 	grantKey := "userSessionGrant:" + endpoint.UserSessionIssuerID.String() + ":" + req.Code
-	grant, err := s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
+	grant, err := s.userSessionGrantCache.Get(ctx, grantKey)
 	if err != nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_not_found_or_expired")
 		// Deliberately NOT counted as a flow failure: a missing/expired code is
@@ -307,7 +308,22 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		if err := endpoint.ValidateGrant(*grant.Endpoint, grant.UserSessionIssuerID, baseURL); err != nil {
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_endpoint_mismatch")
 			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
-			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "authorization code is bound to a different MCP endpoint or origin")
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
+		}
+	}
+
+	grant, err = s.userSessionGrantCache.GetAndDelete(ctx, grantKey)
+	if err != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_already_redeemed")
+		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
+	}
+	// Recheck the consumed value so this remains safe if a future writer ever
+	// replaces grants under an existing key between the peek and GETDEL.
+	if grant.Endpoint != nil {
+		if err := endpoint.ValidateGrant(*grant.Endpoint, grant.UserSessionIssuerID, baseURL); err != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "code_endpoint_mismatch")
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 		}
 	}
 
@@ -351,6 +367,7 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		}
 		toolSelection = encoded
 	}
+
 	minted, err := s.mintSession(ctx, endpoint, clientRow, usersessions_repo.New(s.db), mintSessionParams{
 		AuthorizationExpiresAt: nil,
 		BaseURL:                baseURL,

--- a/server/internal/mcp/authnchallenge_token_test.go
+++ b/server/internal/mcp/authnchallenge_token_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -95,6 +97,70 @@ func TestHandleTokenCode_ResourceIndicator(t *testing.T) {
 	w = redeem("")
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "access_token")
+}
+
+func TestHandleTokenAuthorizationCodeIsSingleUse(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	code, verifier := seedAuthorizationCode(t, ctx, ti, toolset, client)
+
+	first := postForm(t, ti, toolset.McpSlug.String, "token", codeGrantForm(client, code, verifier))
+	require.Equal(t, http.StatusOK, first.Code, first.Body.String())
+	second := postForm(t, ti, toolset.McpSlug.String, "token", codeGrantForm(client, code, verifier))
+	require.Equal(t, http.StatusBadRequest, second.Code)
+	require.Contains(t, second.Body.String(), "invalid_grant")
+}
+
+func TestHandleTokenWrongEndpointDoesNotBurnAuthorizationCode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, issuer, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	correct, err := ti.service.LoadResolvedMcpEndpointBySlug(ctx, ti.logger, toolset.McpSlug.String, "mcp")
+	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	other := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "sibling-"+uuid.NewString()[:8])
+	other, err = toolsets_repo.New(ti.conn).UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true}, Slug: other.Slug, ProjectID: other.ProjectID,
+	})
+	require.NoError(t, err)
+
+	verifier := "verifier-" + uuid.NewString()
+	sum := sha256.Sum256([]byte(verifier))
+	code := "code-" + uuid.NewString()
+	grantCache := cache.NewTypedObjectCache[mcp.UserSessionGrant](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	ref := correct.EndpointRef(ti.serverURL.String())
+	require.NoError(t, grantCache.Store(ctx, mcp.UserSessionGrant{
+		Code: code, UserSessionIssuerID: issuer.ID, UserSessionClientID: client.ID,
+		ClientID: client.ClientID, RedirectURI: client.RedirectUris[0],
+		CodeChallenge: base64.RawURLEncoding.EncodeToString(sum[:]), CodeChallengeMethod: "S256",
+		Subject: urn.NewUserSubject("endpoint-user-" + uuid.NewString()), Endpoint: &ref, CreatedAt: time.Now(),
+	}))
+
+	wrong := postForm(t, ti, other.McpSlug.String, "token", codeGrantForm(client, code, verifier))
+	require.Equal(t, http.StatusBadRequest, wrong.Code)
+	require.Contains(t, wrong.Body.String(), "invalid_grant")
+	legitimate := postForm(t, ti, toolset.McpSlug.String, "token", codeGrantForm(client, code, verifier))
+	require.Equal(t, http.StatusOK, legitimate.Code, legitimate.Body.String())
+}
+
+func TestHandleTokenBadPKCEBurnsAuthorizationCode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	code, verifier := seedAuthorizationCode(t, ctx, ti, toolset, client)
+
+	bad := postForm(t, ti, toolset.McpSlug.String, "token", codeGrantForm(client, code, "wrong-verifier"))
+	require.Equal(t, http.StatusBadRequest, bad.Code)
+	require.Contains(t, bad.Body.String(), "invalid_grant")
+	legitimate := postForm(t, ti, toolset.McpSlug.String, "token", codeGrantForm(client, code, verifier))
+	require.Equal(t, http.StatusBadRequest, legitimate.Code)
+	require.Contains(t, legitimate.Body.String(), "invalid_grant")
 }
 
 // TestHandleTokenRefresh_ResourceIndicator asserts the same check on the

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -202,10 +202,6 @@ func (e *ResolvedMcpEndpoint) ConsentURL(baseURL, stateID string) (string, error
 // rebuild the consent redirect without re-deriving the origin.
 func (e *ResolvedMcpEndpoint) EndpointRef(baseURL string) EndpointRef {
 	isPublic := e.IsPublic
-	toolsetID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
-	if !e.McpServerID.Valid && !e.MetaMcpServerID.Valid {
-		toolsetID = e.ToolsetID
-	}
 	return EndpointRef{
 		BaseURL:         baseURL,
 		RouteBase:       e.RouteBase,
@@ -213,7 +209,7 @@ func (e *ResolvedMcpEndpoint) EndpointRef(baseURL string) EndpointRef {
 		CustomDomainID:  e.CustomDomainID,
 		McpServerID:     e.McpServerID,
 		MetaMcpServerID: e.MetaMcpServerID,
-		ToolsetID:       toolsetID,
+		ToolsetID:       e.ToolsetID,
 		IsPublic:        &isPublic,
 	}
 }
@@ -310,19 +306,18 @@ func (e *ResolvedMcpEndpoint) ValidateRef(ref EndpointRef) error {
 	if ref.IsPublic != nil && e.IsPublic != *ref.IsPublic {
 		return errToolsetEndpointMismatch
 	}
-	// Modern states pin their primary backend identity. Server/meta-backed
-	// endpoints are identified by those rows even when a server delegates to a
-	// toolset; only direct-toolset endpoints pin ToolsetID. States carrying no
+	// Modern states pin the owning server/meta row and, when present, the
+	// delegated toolset. A legacy direct-toolset ref can intentionally survive a
+	// migration to a server-backed endpoint only when slug, issuer, visibility,
+	// route, domain, and the exact toolset all still match. States carrying no
 	// backend ID retain TTL-bounded compatibility with pre-field cached values.
-	switch {
-	case ref.McpServerID.Valid || ref.MetaMcpServerID.Valid:
+	if ref.McpServerID.Valid || ref.MetaMcpServerID.Valid {
 		if e.McpServerID != ref.McpServerID || e.MetaMcpServerID != ref.MetaMcpServerID {
 			return errToolsetEndpointMismatch
 		}
-	case ref.ToolsetID.Valid:
-		if e.McpServerID.Valid || e.MetaMcpServerID.Valid || e.ToolsetID != ref.ToolsetID {
-			return errToolsetEndpointMismatch
-		}
+	}
+	if ref.ToolsetID.Valid && e.ToolsetID != ref.ToolsetID {
+		return errToolsetEndpointMismatch
 	}
 	// The route surface is part of the endpoint's identity: the same slug can
 	// resolve on both /mcp and /x/mcp, and the RFC 9207 `iss` on every

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -21,11 +21,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	metamcp_visibility "github.com/speakeasy-api/gram/server/internal/metamcp/visibility"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projects_repo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -199,6 +201,11 @@ func (e *ResolvedMcpEndpoint) ConsentURL(baseURL, stateID string) (string, error
 // resume the challenge from a global URL (HandleIDPCallback) can
 // rebuild the consent redirect without re-deriving the origin.
 func (e *ResolvedMcpEndpoint) EndpointRef(baseURL string) EndpointRef {
+	isPublic := e.IsPublic
+	toolsetID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+	if !e.McpServerID.Valid && !e.MetaMcpServerID.Valid {
+		toolsetID = e.ToolsetID
+	}
 	return EndpointRef{
 		BaseURL:         baseURL,
 		RouteBase:       e.RouteBase,
@@ -206,6 +213,8 @@ func (e *ResolvedMcpEndpoint) EndpointRef(baseURL string) EndpointRef {
 		CustomDomainID:  e.CustomDomainID,
 		McpServerID:     e.McpServerID,
 		MetaMcpServerID: e.MetaMcpServerID,
+		ToolsetID:       toolsetID,
+		IsPublic:        &isPublic,
 	}
 }
 
@@ -274,12 +283,46 @@ func (e *ResolvedMcpEndpoint) RootURL(baseURL string) (string, error) {
 // here so a future model with multiple addresses per endpoint can
 // expand the check to "the stored ref is in the endpoint's address
 // set" without churning callers.
+func (e *ResolvedMcpEndpoint) ValidateChallenge(ref EndpointRef, issuerID uuid.UUID) error {
+	if e.UserSessionIssuerID != issuerID {
+		return errToolsetEndpointMismatch
+	}
+	return e.ValidateRef(ref)
+}
+
+func (e *ResolvedMcpEndpoint) ValidateGrant(ref EndpointRef, issuerID uuid.UUID, baseURL string) error {
+	if err := e.ValidateChallenge(ref, issuerID); err != nil {
+		return err
+	}
+	if ref.BaseURL != "" && ref.BaseURL != baseURL {
+		return errToolsetEndpointMismatch
+	}
+	return nil
+}
+
 func (e *ResolvedMcpEndpoint) ValidateRef(ref EndpointRef) error {
 	if e.Slug != ref.McpSlug {
 		return errToolsetEndpointMismatch
 	}
 	if e.CustomDomainID != ref.CustomDomainID {
 		return errToolsetEndpointMismatch
+	}
+	if ref.IsPublic != nil && e.IsPublic != *ref.IsPublic {
+		return errToolsetEndpointMismatch
+	}
+	// Modern states pin their primary backend identity. Server/meta-backed
+	// endpoints are identified by those rows even when a server delegates to a
+	// toolset; only direct-toolset endpoints pin ToolsetID. States carrying no
+	// backend ID retain TTL-bounded compatibility with pre-field cached values.
+	switch {
+	case ref.McpServerID.Valid || ref.MetaMcpServerID.Valid:
+		if e.McpServerID != ref.McpServerID || e.MetaMcpServerID != ref.MetaMcpServerID {
+			return errToolsetEndpointMismatch
+		}
+	case ref.ToolsetID.Valid:
+		if e.McpServerID.Valid || e.MetaMcpServerID.Valid || e.ToolsetID != ref.ToolsetID {
+			return errToolsetEndpointMismatch
+		}
 	}
 	// The route surface is part of the endpoint's identity: the same slug can
 	// resolve on both /mcp and /x/mcp, and the RFC 9207 `iss` on every
@@ -458,8 +501,12 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		// A tunnel flipped to public visibility mid-OAuth-flow has no OAuth
 		// surface: reject the cached-ref resumption (e.g. /mcp/idp_callback)
 		// so a visibility change closes in-flight flows.
-		if !mcpServer.UserSessionIssuerID.Valid || isTunneledPublic(&mcpServer) {
+		if mcpServer.Visibility == mcpservers.VisibilityDisabled || !mcpServer.UserSessionIssuerID.Valid || isTunneledPublic(&mcpServer) {
 			return nil, oops.E(oops.CodeNotFound, nil, "not found")
+		}
+		mode, err := networkaccess.Effective(mcpServer.NetworkAccessMode)
+		if err != nil || !mode.Allows(networkaccess.SurfacePublic) {
+			return nil, oops.E(oops.CodeNotFound, mcpendpoints.ErrPolicyDenied, "not found")
 		}
 		// Guard against an mcp_endpoint that has been re-pointed mid-flow
 		// at a different mcp_server: the cached challenge belongs to the
@@ -577,6 +624,10 @@ func (s *Service) buildResolvedMetaMcpEndpointByRef(ctx context.Context, ref End
 		// A gateway disabled mid-flow closes in-flight challenges, matching
 		// the generic-server branch's visibility check.
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")
+	}
+	mode, err := networkaccess.Effective(metaServer.NetworkAccessMode)
+	if err != nil || !mode.Allows(networkaccess.SurfacePublic) {
+		return nil, oops.E(oops.CodeNotFound, mcpendpoints.ErrPolicyDenied, "not found")
 	}
 
 	routeBase := ref.RouteBase

--- a/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
+++ b/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
@@ -7,6 +7,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateGrantRejectsOriginChange(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:                "my-server",
+		RouteBase:           "mcp",
+		UserSessionIssuerID: issuerID,
+	}
+	err := endpoint.ValidateGrant(EndpointRef{
+		McpSlug: "my-server",
+		BaseURL: "https://custom.example.com",
+	}, issuerID, "https://platform.example.com")
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}
+
+func TestValidateGrantAllowsLegacyMissingOrigin(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:                "my-server",
+		RouteBase:           "mcp",
+		UserSessionIssuerID: issuerID,
+	}
+	require.NoError(t, endpoint.ValidateGrant(EndpointRef{McpSlug: "my-server"}, issuerID, "https://platform.example.com"))
+}
+
+func TestValidateChallengeRejectsIssuerChange(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:                "my-server",
+		RouteBase:           "mcp",
+		UserSessionIssuerID: uuid.New(),
+	}
+	err := endpoint.ValidateChallenge(EndpointRef{McpSlug: "my-server"}, uuid.New())
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}
+
 func TestValidateRef_Matches(t *testing.T) {
 	t.Parallel()
 
@@ -24,6 +64,49 @@ func TestValidateRef_Matches(t *testing.T) {
 // the RFC 9207 `iss` is built from the resolved endpoint's RouteBase, so a
 // cross-surface resume would emit an issuer differing from the one the client
 // recorded at mint time.
+func TestValidateRefRejectsVisibilityChange(t *testing.T) {
+	t.Parallel()
+
+	wasPublic := true
+	endpoint := &ResolvedMcpEndpoint{Slug: "my-server", RouteBase: "mcp", IsPublic: false}
+	err := endpoint.ValidateRef(EndpointRef{McpSlug: "my-server", IsPublic: &wasPublic})
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}
+
+func TestValidateRefAllowsLegacyMissingVisibility(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{Slug: "my-server", RouteBase: "mcp", IsPublic: false}
+	require.NoError(t, endpoint.ValidateRef(EndpointRef{McpSlug: "my-server"}))
+}
+
+func TestValidateRefAllowsLegacyMissingBackendIDs(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:        "my-server",
+		RouteBase:   "mcp",
+		McpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+	}
+	require.NoError(t, endpoint.ValidateRef(EndpointRef{McpSlug: "my-server"}))
+}
+
+func TestValidateRefRejectsBackendSwap(t *testing.T) {
+	t.Parallel()
+
+	serverID := uuid.New()
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:        "my-server",
+		RouteBase:   "mcp",
+		McpServerID: uuid.NullUUID{UUID: serverID, Valid: true},
+	}
+	err := endpoint.ValidateRef(EndpointRef{
+		McpSlug:     "my-server",
+		McpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+	})
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}
+
 func TestValidateRef_RejectsCrossSurfaceResume(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
+++ b/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
@@ -91,6 +91,24 @@ func TestValidateRefAllowsLegacyMissingBackendIDs(t *testing.T) {
 	require.NoError(t, endpoint.ValidateRef(EndpointRef{McpSlug: "my-server"}))
 }
 
+func TestEndpointRefPinsBridgedToolset(t *testing.T) {
+	t.Parallel()
+
+	toolsetID := uuid.New()
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:        "my-server",
+		RouteBase:   "x/mcp",
+		McpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		ToolsetID:   uuid.NullUUID{UUID: toolsetID, Valid: true},
+	}
+	ref := endpoint.EndpointRef("https://platform.example.com")
+	require.Equal(t, endpoint.McpServerID, ref.McpServerID)
+	require.Equal(t, endpoint.ToolsetID, ref.ToolsetID)
+
+	endpoint.ToolsetID = uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	require.ErrorIs(t, endpoint.ValidateRef(ref), errToolsetEndpointMismatch)
+}
+
 func TestValidateRefRejectsBackendSwap(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -548,13 +548,8 @@ func TestServePublic_McpEndpoint_UnknownVisibility_DoesNotServe(t *testing.T) {
 	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }
 
-// TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint
-// regression-guards the platform-only resolution semantic: a
-// custom-domain-scoped mcp_endpoint must not resolve for a request
-// arriving on the platform domain, even when the slug matches and no
-// legacy toolset claims the slug. Asymmetric to the toolsets fallback
-// path, which DOES allow platform requests to resolve custom-domain
-// toolsets (see loadToolset docstring).
+// A private-only endpoint owns its slug on the public surface and must not
+// fall through to an unrelated legacy toolset with the same slug.
 func TestServePublic_PrivateOnlyEndpointDoesNotFallBackToLegacyToolset(t *testing.T) {
 	t.Parallel()
 
@@ -607,6 +602,13 @@ func TestLoadResolvedMcpEndpointPrivateOnlyDoesNotFallBack(t *testing.T) {
 	require.Equal(t, oops.CodeNotFound, shareErr.Code)
 }
 
+// TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint
+// regression-guards the platform-only resolution semantic: a
+// custom-domain-scoped mcp_endpoint must not resolve for a request
+// arriving on the platform domain, even when the slug matches and no
+// legacy toolset claims the slug. Asymmetric to the toolsets fallback
+// path, which DOES allow platform requests to resolve custom-domain
+// toolsets (see loadToolset docstring).
 func TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -36,9 +36,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -496,8 +498,7 @@ func TestServePublic_McpEndpoint_IssuerGated_NoAuth_EmitsChallenge(t *testing.T)
 // endpoint-authority rule (AIS-633): a disabled mcp_server behind a live
 // mcp_endpoint is a terminal not-found. Even when a public toolset carries
 // the same slug via toolsets.mcp_slug, the endpoint row owns the address and
-// the disabled server must not resurrect through its toolset. (This reverses
-// the pre-AIS-633 fallback behavior, where the same setup served the toolset.)
+// the disabled server must not resurrect through its toolset.
 func TestServePublic_McpEndpoint_DisabledMcpServer_DoesNotFallBack(t *testing.T) {
 	t.Parallel()
 
@@ -509,9 +510,8 @@ func TestServePublic_McpEndpoint_DisabledMcpServer_DoesNotFallBack(t *testing.T)
 	require.NotNil(t, authCtx.ProjectID)
 
 	// A separate (disabled) wrapper is the mcp_endpoint's backend; a second
-	// public toolset shares the slug via createPublicMCPToolset (which sets
-	// both Slug and McpSlug to the same value) and would have served the
-	// request under the old fallback.
+	// public toolset shares the slug via createPublicMCPToolset and must not
+	// shadow the authoritative disabled endpoint.
 	sharedSlug := "shared-" + uuid.NewString()[:8]
 	disabledToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "disabled-"+uuid.NewString()[:8])
 	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
@@ -555,6 +555,58 @@ func TestServePublic_McpEndpoint_UnknownVisibility_DoesNotServe(t *testing.T) {
 // legacy toolset claims the slug. Asymmetric to the toolsets fallback
 // path, which DOES allow platform requests to resolve custom-domain
 // toolsets (see loadToolset docstring).
+func TestServePublic_PrivateOnlyEndpointDoesNotFallBackToLegacyToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sharedSlug := "private-only-shared-" + uuid.NewString()[:8]
+	privateToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "private-backend-"+uuid.NewString()[:8])
+	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
+	server := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, privateToolset.ID, sharedSlug, "public", uuid.NullUUID{}, uuid.Nil)
+	rows, err := testrepo.New(ti.conn).SetMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMCPServerNetworkAccessModeFixtureParams{
+		NetworkAccessMode: pgtype.Text{String: string(networkaccess.ModePrivateOnly), Valid: true},
+		ID:                server.ID,
+		ProjectID:         *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	_, err = servePublicHTTP(t, ctx, ti, sharedSlug, makeInitializeBody(), "", nil)
+	require.Error(t, err)
+	var shareErr *oops.ShareableError
+	require.ErrorAs(t, err, &shareErr)
+	require.Equal(t, oops.CodeNotFound, shareErr.Code)
+}
+
+func TestLoadResolvedMcpEndpointPrivateOnlyDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	sharedSlug := "oauth-private-only-" + uuid.NewString()[:8]
+	endpointToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "oauth-endpoint-"+uuid.NewString()[:8])
+	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	server := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, endpointToolset.ID, sharedSlug, "public", uuid.NullUUID{}, issuerID)
+	rows, err := testrepo.New(ti.conn).SetMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMCPServerNetworkAccessModeFixtureParams{
+		NetworkAccessMode: pgtype.Text{String: string(networkaccess.ModePrivateOnly), Valid: true},
+		ID:                server.ID, ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	_, err = ti.service.LoadResolvedMcpEndpointBySlug(ctx, ti.logger, sharedSlug, "mcp")
+	require.Error(t, err)
+	var shareErr *oops.ShareableError
+	require.ErrorAs(t, err, &shareErr)
+	require.Equal(t, oops.CodeNotFound, shareErr.Code)
+}
+
 func TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -80,7 +80,18 @@ func TestWellKnownPrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
 	toolsetsRepo := toolsetsrepo.New(ti.conn)
 	sharedSlug := "wellknown-private-only-" + uuid.NewString()[:8]
 	endpointToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "endpoint-"+uuid.NewString()[:8])
-	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
+	legacy := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug: sharedSlug, IsPublic: true,
+	})
+	_, err := toolsetsRepo.UpdateToolset(ctx, toolsetsrepo.UpdateToolsetParams{
+		Name: legacy.Toolset.Name, Description: legacy.Toolset.Description,
+		DefaultEnvironmentSlug: legacy.Toolset.DefaultEnvironmentSlug,
+		McpSlug:                pgtype.Text{String: sharedSlug, Valid: true},
+		McpIsPublic:            true, McpEnabled: true,
+		CustomDomainID: uuid.NullUUID{}, ToolSelectionMode: "",
+		Slug: legacy.Toolset.Slug, ProjectID: legacy.Toolset.ProjectID,
+	})
+	require.NoError(t, err)
 	server := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, endpointToolset.ID, sharedSlug, "public", uuid.NullUUID{}, uuid.Nil)
 	rows, err := testrepo.New(ti.conn).SetMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMCPServerNetworkAccessModeFixtureParams{
 		NetworkAccessMode: pgtype.Text{String: string(networkaccess.ModePrivateOnly), Valid: true},

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	"github.com/speakeasy-api/gram/server/internal/requestorigin"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -67,6 +69,34 @@ func TestHandleGetAuthorizationServer_MissingSlug(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "mcp slug must be provided")
 	require.Empty(t, w.Body.String())
+}
+
+func TestWellKnownPrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	sharedSlug := "wellknown-private-only-" + uuid.NewString()[:8]
+	endpointToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "endpoint-"+uuid.NewString()[:8])
+	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
+	server := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, endpointToolset.ID, sharedSlug, "public", uuid.NullUUID{}, uuid.Nil)
+	rows, err := testrepo.New(ti.conn).SetMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMCPServerNetworkAccessModeFixtureParams{
+		NetworkAccessMode: pgtype.Text{String: string(networkaccess.ModePrivateOnly), Valid: true},
+		ID:                server.ID, ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	for _, handler := range []func(http.ResponseWriter, *http.Request) error{
+		ti.service.HandleGetAuthorizationServer,
+		ti.service.HandleGetProtectedResource,
+	} {
+		w, err := runMCPWellKnown(t, ctx, handler, sharedSlug)
+		require.Error(t, err)
+		require.Empty(t, w.Body.String())
+	}
 }
 
 func TestHandleGetAuthorizationServer_NotFound(t *testing.T) {

--- a/server/internal/mcpendpoints/metamcpbackend_test.go
+++ b/server/internal/mcpendpoints/metamcpbackend_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/metamcp/visibility"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -22,6 +23,12 @@ import (
 // seedMetaMcpServer inserts a meta_mcp_servers row in the given project so
 // backend tests have a valid meta_mcp_server_id FK.
 func seedMetaMcpServer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	return seedMetaMcpServerWithMode(t, ctx, ti, projectID, networkaccess.ModePublicOnly)
+}
+
+func seedMetaMcpServerWithMode(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, mode networkaccess.Mode) uuid.UUID {
 	t.Helper()
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -33,6 +40,7 @@ func seedMetaMcpServer(t *testing.T, ctx context.Context, ti *testInstance, proj
 		Name:                "endpoint-backed meta",
 		UserSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		Visibility:          visibility.Private,
+		NetworkAccessMode:   networkaccess.Storage(mode),
 	})
 	require.NoError(t, err)
 

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -176,7 +176,15 @@ func Resolve(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, input R
 	if modeErr != nil {
 		return deniedResult(&endpoint, &server, nil, networkaccess.ModePrivateOnly), nil
 	}
-	if server.Visibility == mcpservers.VisibilityDisabled || !mode.Allows(input.Surface) {
+	switch server.Visibility {
+	case mcpservers.VisibilityPublic, mcpservers.VisibilityPrivate:
+		// Known serving states continue to network-surface policy below.
+	default:
+		// Disabled and unrecognized values fail closed. An endpoint row owns
+		// its address, so this is an authoritative denial rather than a miss.
+		return deniedResult(&endpoint, &server, nil, mode), nil
+	}
+	if !mode.Allows(input.Surface) {
 		return deniedResult(&endpoint, &server, nil, mode), nil
 	}
 	return ResolutionResult{Endpoint: &endpoint, Server: &server, MetaServer: nil, Mode: mode, Found: true, Allowed: true}, nil

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -16,53 +16,129 @@ import (
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	metamcp_visibility "github.com/speakeasy-api/gram/server/internal/metamcp/visibility"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	projects_repo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/requestorigin"
 )
 
-// ErrEndpointUnavailable marks an address that resolved to an mcp_endpoints
-// row whose backend cannot serve: disabled visibility, or a dangling backend
-// FK. The endpoint row makes the address authoritative, so this outcome is a
-// terminal not-found on every surface — unlike a plain address miss, it must
-// never fall back to the legacy toolsets.mcp_slug lookup, which would let a
-// disabled server resurrect the same slug through its toolset (AIS-633).
-var ErrEndpointUnavailable = errors.New("mcp endpoint unavailable")
+type NamespaceKind string
 
-// IsAddressMiss reports whether a resolution error is a true address miss —
-// the only outcome that may fall back to a legacy toolsets.mcp_slug lookup.
-func IsAddressMiss(err error) bool {
-	var shareErr *oops.ShareableError
-	return errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound && !errors.Is(err, ErrEndpointUnavailable)
+const (
+	NamespacePlatform     NamespaceKind = "platform"
+	NamespaceCustomDomain NamespaceKind = "custom_domain"
+)
+
+// ResolutionInput is the complete addressing and policy authority for one MCP
+// endpoint lookup. Callers may use FromContext for public/custom-domain
+// requests. Private-listener callers must provide the ingress-pinned namespace
+// and expected organization explicitly once that listener lands.
+type ResolutionInput struct {
+	Slug                 string
+	NamespaceKind        NamespaceKind
+	CustomDomainID       uuid.NullUUID
+	ExpectedOrganization string
+	Surface              networkaccess.Surface
 }
 
-// BySlugAndCustomDomain walks the public addressing chain shared by the /mcp
-// and /x/mcp slug handlers, the install-page handlers, and the .well-known
-// routes: it scopes the lookup to the request's customdomains.Context, loads
-// the mcp_endpoint by (slug, custom domain), then loads whichever backend the
-// endpoint addresses. Exactly one of the returned server and metaServer is
-// non-nil, matching the endpoint table's backend-exclusivity check. Disabled
-// backends of either kind and missing rows all surface as oops.CodeNotFound to
-// avoid leaking existence to unauthenticated callers. logger should already
-// carry the slug attribute.
-//
-// Callers that want to fall back to a legacy lookup (e.g. /mcp's existing
-// toolsets.mcp_slug path) may do so only on a true address miss — a
-// CodeNotFound that is NOT ErrEndpointUnavailable. A resolvable-but-unavailable
-// address (errors.Is(err, ErrEndpointUnavailable)) is terminal.
-func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, slug string) (*repo.McpEndpoint, *mcpservers_repo.McpServer, *metamcp_repo.MetaMcpServer, error) {
-	var customDomainID uuid.NullUUID
-	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
-		customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
+// ResolutionResult distinguishes a genuine address miss from an authoritative
+// endpoint result. An authoritative denial must terminate the request even
+// though its public HTTP representation is 404; callers must not continue into
+// legacy toolset fallback.
+type ResolutionResult struct {
+	Endpoint   *repo.McpEndpoint
+	Server     *mcpservers_repo.McpServer
+	MetaServer *metamcp_repo.MetaMcpServer
+	Mode       networkaccess.Mode
+	Found      bool
+	Allowed    bool
+}
+
+// FromContext derives the current public/custom-domain namespace and surface.
+// Missing request-origin context fails closed: handlers behind the production
+// middleware always receive one, while direct/internal callers must stamp it.
+func FromContext(ctx context.Context, slug string) (ResolutionInput, error) {
+	origin, hasOrigin := requestorigin.FromContext(ctx)
+	input := ResolutionInput{
+		Slug:                 slug,
+		NamespaceKind:        NamespacePlatform,
+		CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ExpectedOrganization: "",
+		Surface:              networkaccess.SurfacePublic,
+	}
+	if !hasOrigin {
+		// Direct internal/test callers that bypass HTTP middleware retain the
+		// legacy public namespace. They cannot acquire private surface authority.
+		if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
+			input.NamespaceKind = NamespaceCustomDomain
+			input.CustomDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
+			input.ExpectedOrganization = domainCtx.OrganizationID
+		}
+		return input, nil
+	}
+	input.ExpectedOrganization = origin.OrganizationID
+	switch origin.Surface {
+	case requestorigin.SurfacePlatform:
+	case requestorigin.SurfaceCustomDomain:
+		domainCtx := customdomains.FromContext(ctx)
+		if domainCtx == nil || domainCtx.DomainID == uuid.Nil || origin.OrganizationID == "" || origin.OrganizationID != domainCtx.OrganizationID {
+			return ResolutionInput{}, fmt.Errorf("custom-domain request authority is incomplete")
+		}
+		input.NamespaceKind = NamespaceCustomDomain
+		input.CustomDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
+	case requestorigin.SurfacePrivateNetwork:
+		input.Surface = networkaccess.SurfacePrivate
+		return ResolutionInput{}, fmt.Errorf("private request namespace must be supplied by the private listener")
+	default:
+		return ResolutionInput{}, fmt.Errorf("unknown request origin surface %q", origin.Surface)
+	}
+	return input, nil
+}
+
+// Resolve walks the namespace-scoped addressing chain and applies visibility,
+// tenant, and network-mode policy before any route-specific side effects.
+func Resolve(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, input ResolutionInput) (ResolutionResult, error) {
+	if input.Slug == "" {
+		return ResolutionResult{}, oops.E(oops.CodeNotFound, nil, "mcp endpoint not found")
+	}
+	if input.Surface == networkaccess.SurfacePrivate && input.ExpectedOrganization == "" {
+		return deniedResult(nil, nil, nil, networkaccess.ModePrivateOnly), nil
+	}
+	switch input.NamespaceKind {
+	case NamespacePlatform:
+		if input.CustomDomainID.Valid {
+			return deniedResult(nil, nil, nil, networkaccess.ModePrivateOnly), nil
+		}
+	case NamespaceCustomDomain:
+		if !input.CustomDomainID.Valid || input.CustomDomainID.UUID == uuid.Nil || input.ExpectedOrganization == "" {
+			// A pinned custom-domain namespace whose FK was cleared must never be
+			// reinterpreted as the platform namespace.
+			return deniedResult(nil, nil, nil, networkaccess.ModePrivateOnly), nil
+		}
+	default:
+		return deniedResult(nil, nil, nil, networkaccess.ModePrivateOnly), nil
 	}
 
 	endpoint, err := repo.New(db).GetMCPEndpointByCustomDomainAndSlug(ctx, repo.GetMCPEndpointByCustomDomainAndSlugParams{
-		Slug:           slug,
-		CustomDomainID: customDomainID,
+		Slug:           input.Slug,
+		CustomDomainID: input.CustomDomainID,
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, nil, nil, oops.E(oops.CodeNotFound, err, "mcp endpoint not found")
+		return ResolutionResult{Endpoint: nil, Server: nil, MetaServer: nil, Mode: networkaccess.ModePublicOnly, Found: false, Allowed: false}, nil
 	case err != nil:
-		return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").LogError(ctx, logger)
+		return ResolutionResult{}, oops.E(oops.CodeUnexpected, err, "load mcp endpoint").LogError(ctx, logger)
+	}
+
+	project, err := projects_repo.New(db).GetProjectByID(ctx, endpoint.ProjectID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return deniedResult(&endpoint, nil, nil, networkaccess.ModePrivateOnly), nil
+	case err != nil:
+		return ResolutionResult{}, oops.E(oops.CodeUnexpected, err, "load mcp endpoint project").LogError(ctx, logger)
+	}
+	if input.ExpectedOrganization != "" && project.OrganizationID != input.ExpectedOrganization {
+		return deniedResult(&endpoint, nil, nil, networkaccess.ModePrivateOnly), nil
 	}
 
 	if endpoint.MetaMcpServerID.Valid {
@@ -72,16 +148,18 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 		})
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return nil, nil, nil, oops.E(oops.CodeNotFound, fmt.Errorf("%w: %w", ErrEndpointUnavailable, err), "meta mcp server not found")
+			return deniedResult(&endpoint, nil, nil, networkaccess.ModePrivateOnly), nil
 		case err != nil:
-			return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load meta mcp server").LogError(ctx, logger)
+			return ResolutionResult{}, oops.E(oops.CodeUnexpected, err, "load meta mcp server").LogError(ctx, logger)
 		}
-
-		if metaServer.Visibility == metamcp_visibility.Disabled {
-			return nil, nil, nil, oops.E(oops.CodeNotFound, ErrEndpointUnavailable, "mcp endpoint not found")
+		mode, modeErr := networkaccess.Effective(metaServer.NetworkAccessMode)
+		if modeErr != nil {
+			return deniedResult(&endpoint, nil, &metaServer, networkaccess.ModePrivateOnly), nil
 		}
-
-		return &endpoint, nil, &metaServer, nil
+		if metaServer.OrganizationID != project.OrganizationID || metaServer.Visibility == metamcp_visibility.Disabled || !mode.Allows(input.Surface) {
+			return deniedResult(&endpoint, nil, &metaServer, mode), nil
+		}
+		return ResolutionResult{Endpoint: &endpoint, Server: nil, MetaServer: &metaServer, Mode: mode, Found: true, Allowed: true}, nil
 	}
 
 	server, err := mcpservers_repo.New(db).GetMCPServerByIDAndProjectID(ctx, mcpservers_repo.GetMCPServerByIDAndProjectIDParams{
@@ -90,18 +168,59 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, nil, nil, oops.E(oops.CodeNotFound, fmt.Errorf("%w: %w", ErrEndpointUnavailable, err), "mcp server not found")
+		return deniedResult(&endpoint, nil, nil, networkaccess.ModePrivateOnly), nil
 	case err != nil:
-		return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
+		return ResolutionResult{}, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
 	}
-
-	switch server.Visibility {
-	case mcpservers.VisibilityPublic, mcpservers.VisibilityPrivate:
-	default:
-		// Disabled or unrecognized visibility never serves; unknown values
-		// must not silently map onto a servable policy.
-		return nil, nil, nil, oops.E(oops.CodeNotFound, ErrEndpointUnavailable, "mcp endpoint not found")
+	mode, modeErr := networkaccess.Effective(server.NetworkAccessMode)
+	if modeErr != nil {
+		return deniedResult(&endpoint, &server, nil, networkaccess.ModePrivateOnly), nil
 	}
+	if server.Visibility == mcpservers.VisibilityDisabled || !mode.Allows(input.Surface) {
+		return deniedResult(&endpoint, &server, nil, mode), nil
+	}
+	return ResolutionResult{Endpoint: &endpoint, Server: &server, MetaServer: nil, Mode: mode, Found: true, Allowed: true}, nil
+}
 
-	return &endpoint, &server, nil, nil
+func deniedResult(endpoint *repo.McpEndpoint, server *mcpservers_repo.McpServer, metaServer *metamcp_repo.MetaMcpServer, mode networkaccess.Mode) ResolutionResult {
+	return ResolutionResult{Endpoint: endpoint, Server: server, MetaServer: metaServer, Mode: mode, Found: true, Allowed: false}
+}
+
+// ErrPolicyDenied marks a terminal address result whose public representation
+// is 404. Callers that support legacy fallback must not fall through when this
+// cause is present.
+var ErrPolicyDenied = errors.New("mcp endpoint policy denied")
+
+// IsPolicyDenied reports whether an error is the terminal policy outcome.
+func IsPolicyDenied(err error) bool {
+	return errors.Is(err, ErrPolicyDenied)
+}
+
+// IsAddressMiss reports whether an error is a genuine address miss that may
+// fall back to legacy toolset lookup rather than an authoritative policy denial.
+func IsAddressMiss(err error) bool {
+	var shareErr *oops.ShareableError
+	return errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound && !IsPolicyDenied(err)
+}
+
+// BySlugAndCustomDomain preserves the public resolver signature while callers
+// migrate to ResolutionResult. A genuine miss remains CodeNotFound. Policy
+// denial is also represented as 404 to clients, but is authoritative and must
+// never be converted into legacy fallback by callers using Resolve directly.
+func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, slug string) (*repo.McpEndpoint, *mcpservers_repo.McpServer, *metamcp_repo.MetaMcpServer, error) {
+	input, err := FromContext(ctx, slug)
+	if err != nil {
+		return nil, nil, nil, oops.E(oops.CodeNotFound, errors.Join(ErrPolicyDenied, err), "mcp endpoint not found")
+	}
+	result, err := Resolve(ctx, db, logger, input)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !result.Found {
+		return nil, nil, nil, oops.E(oops.CodeNotFound, nil, "mcp endpoint not found")
+	}
+	if !result.Allowed {
+		return nil, nil, nil, oops.E(oops.CodeNotFound, ErrPolicyDenied, "mcp endpoint not found")
+	}
+	return result.Endpoint, result.Server, result.MetaServer, nil
 }

--- a/server/internal/mcpendpoints/resolve_policy_test.go
+++ b/server/internal/mcpendpoints/resolve_policy_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
+	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/metamcp/visibility"
 	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/requestorigin"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -132,6 +134,51 @@ func TestResolveWrongOrganizationIsAuthoritativeDenial(t *testing.T) {
 	require.False(t, result.Allowed)
 }
 
+func TestResolveDisabledServersDenyEverySurface(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []string{"generic", "meta"} {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			slug := authCtx.OrganizationSlug + "-disabled-" + backend
+
+			var mcpServerID, metaMcpServerID *string
+			if backend == "generic" {
+				id := seedMcpServerWithMode(t, ctx, ti.conn, *authCtx.ProjectID, "disabled", networkaccess.ModeDual).String()
+				mcpServerID = &id
+			} else {
+				meta, err := metamcprepo.New(ti.conn).CreateMetaMCPServer(ctx, metamcprepo.CreateMetaMCPServerParams{
+					OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID,
+					Name: "disabled meta", UserSessionIssuerID: uuid.NullUUID{},
+					Visibility: visibility.Disabled, NetworkAccessMode: networkaccess.Storage(networkaccess.ModeDual),
+				})
+				require.NoError(t, err)
+				id := meta.ID.String()
+				metaMcpServerID = &id
+			}
+			_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+				SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+				CustomDomainID: nil, McpServerID: mcpServerID, MetaMcpServerID: metaMcpServerID,
+				Slug: types.McpEndpointSlug(slug),
+			})
+			require.NoError(t, err)
+
+			for _, surface := range []networkaccess.Surface{networkaccess.SurfacePublic, networkaccess.SurfacePrivate} {
+				result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+					Slug: slug, NamespaceKind: mcpendpoints.NamespacePlatform,
+					CustomDomainID: uuid.NullUUID{}, ExpectedOrganization: authCtx.ActiveOrganizationID, Surface: surface,
+				})
+				require.NoError(t, err)
+				require.True(t, result.Found)
+				require.False(t, result.Allowed)
+			}
+		})
+	}
+}
+
 func TestResolveUnknownStoredModeDeniesEverySurface(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +212,38 @@ func TestResolveUnknownStoredModeDeniesEverySurface(t *testing.T) {
 			require.True(t, result.Found)
 			require.False(t, result.Allowed)
 		})
+	}
+}
+
+func TestResolveMetaUnknownStoredModeDeniesEverySurface(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	metaID := seedMetaMcpServerWithMode(t, ctx, ti, *authCtx.ProjectID, networkaccess.ModeDual)
+	slug := authCtx.OrganizationSlug + "-meta-unknown"
+	_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		CustomDomainID: nil, McpServerID: nil, MetaMcpServerID: conv.PtrEmpty(metaID.String()),
+		Slug: types.McpEndpointSlug(slug),
+	})
+	require.NoError(t, err)
+	rows, err := testrepo.New(ti.conn).SetMetaMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMetaMCPServerNetworkAccessModeFixtureParams{
+		NetworkAccessMode: pgtype.Text{String: "future_mode", Valid: true}, ID: metaID,
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	for _, surface := range []networkaccess.Surface{networkaccess.SurfacePublic, networkaccess.SurfacePrivate} {
+		result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+			Slug: slug, NamespaceKind: mcpendpoints.NamespacePlatform, CustomDomainID: uuid.NullUUID{},
+			ExpectedOrganization: authCtx.ActiveOrganizationID, Surface: surface,
+		})
+		require.NoError(t, err)
+		require.True(t, result.Found)
+		require.False(t, result.Allowed)
 	}
 }
 

--- a/server/internal/mcpendpoints/resolve_policy_test.go
+++ b/server/internal/mcpendpoints/resolve_policy_test.go
@@ -1,0 +1,236 @@
+package mcpendpoints_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_endpoints"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
+	"github.com/speakeasy-api/gram/server/internal/requestorigin"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func TestResolveNetworkAccessModeMatrix(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		mode    networkaccess.Mode
+		surface networkaccess.Surface
+		allowed bool
+	}{
+		{name: "public_only_public", mode: networkaccess.ModePublicOnly, surface: networkaccess.SurfacePublic, allowed: true},
+		{name: "public_only_private", mode: networkaccess.ModePublicOnly, surface: networkaccess.SurfacePrivate, allowed: false},
+		{name: "dual_public", mode: networkaccess.ModeDual, surface: networkaccess.SurfacePublic, allowed: true},
+		{name: "dual_private", mode: networkaccess.ModeDual, surface: networkaccess.SurfacePrivate, allowed: true},
+		{name: "private_only_public", mode: networkaccess.ModePrivateOnly, surface: networkaccess.SurfacePublic, allowed: false},
+		{name: "private_only_private", mode: networkaccess.ModePrivateOnly, surface: networkaccess.SurfacePrivate, allowed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+
+			serverID := seedMcpServerWithMode(t, ctx, ti.conn, *authCtx.ProjectID, "public", tc.mode)
+			slug := authCtx.OrganizationSlug + "-" + tc.name
+			_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+				SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+				CustomDomainID: nil, McpServerID: conv.PtrEmpty(serverID.String()), MetaMcpServerID: nil,
+				Slug: types.McpEndpointSlug(slug),
+			})
+			require.NoError(t, err)
+
+			result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+				Slug:                 slug,
+				NamespaceKind:        mcpendpoints.NamespacePlatform,
+				CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				ExpectedOrganization: authCtx.ActiveOrganizationID,
+				Surface:              tc.surface,
+			})
+			require.NoError(t, err)
+			require.True(t, result.Found)
+			require.Equal(t, tc.allowed, result.Allowed)
+			require.Equal(t, tc.mode, result.Mode)
+		})
+	}
+}
+
+func TestResolveMetaNetworkAccessModeMatrix(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		mode    networkaccess.Mode
+		surface networkaccess.Surface
+		allowed bool
+	}{
+		{name: "public_only_public", mode: networkaccess.ModePublicOnly, surface: networkaccess.SurfacePublic, allowed: true},
+		{name: "public_only_private", mode: networkaccess.ModePublicOnly, surface: networkaccess.SurfacePrivate, allowed: false},
+		{name: "dual_public", mode: networkaccess.ModeDual, surface: networkaccess.SurfacePublic, allowed: true},
+		{name: "dual_private", mode: networkaccess.ModeDual, surface: networkaccess.SurfacePrivate, allowed: true},
+		{name: "private_only_public", mode: networkaccess.ModePrivateOnly, surface: networkaccess.SurfacePublic, allowed: false},
+		{name: "private_only_private", mode: networkaccess.ModePrivateOnly, surface: networkaccess.SurfacePrivate, allowed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			metaID := seedMetaMcpServerWithMode(t, ctx, ti, *authCtx.ProjectID, tc.mode)
+			slug := authCtx.OrganizationSlug + "-meta-" + tc.name
+			_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+				SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+				CustomDomainID: nil, McpServerID: nil, MetaMcpServerID: conv.PtrEmpty(metaID.String()),
+				Slug: types.McpEndpointSlug(slug),
+			})
+			require.NoError(t, err)
+
+			result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+				Slug: slug, NamespaceKind: mcpendpoints.NamespacePlatform,
+				CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				ExpectedOrganization: authCtx.ActiveOrganizationID, Surface: tc.surface,
+			})
+			require.NoError(t, err)
+			require.True(t, result.Found)
+			require.Equal(t, tc.allowed, result.Allowed)
+			require.Equal(t, tc.mode, result.Mode)
+		})
+	}
+}
+
+func TestResolveWrongOrganizationIsAuthoritativeDenial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	serverID := seedMcpServerWithMode(t, ctx, ti.conn, *authCtx.ProjectID, "public", networkaccess.ModeDual)
+	slug := authCtx.OrganizationSlug + "-wrong-org"
+	_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		CustomDomainID: nil, McpServerID: conv.PtrEmpty(serverID.String()), MetaMcpServerID: nil,
+		Slug: types.McpEndpointSlug(slug),
+	})
+	require.NoError(t, err)
+
+	result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+		Slug: slug, NamespaceKind: mcpendpoints.NamespacePlatform,
+		CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ExpectedOrganization: "other-org", Surface: networkaccess.SurfacePrivate,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Found)
+	require.False(t, result.Allowed)
+}
+
+func TestResolveUnknownStoredModeDeniesEverySurface(t *testing.T) {
+	t.Parallel()
+
+	for _, surface := range []networkaccess.Surface{networkaccess.SurfacePublic, networkaccess.SurfacePrivate} {
+		t.Run(string(surface), func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			serverID := seedMcpServerWithMode(t, ctx, ti.conn, *authCtx.ProjectID, "public", networkaccess.ModeDual)
+			slug := authCtx.OrganizationSlug + "-unknown-" + string(surface)
+			_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+				SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+				CustomDomainID: nil, McpServerID: conv.PtrEmpty(serverID.String()), MetaMcpServerID: nil,
+				Slug: types.McpEndpointSlug(slug),
+			})
+			require.NoError(t, err)
+			rows, err := testrepo.New(ti.conn).SetMCPServerNetworkAccessModeFixture(ctx, testrepo.SetMCPServerNetworkAccessModeFixtureParams{
+				NetworkAccessMode: pgtype.Text{String: "future_mode", Valid: true},
+				ID:                serverID, ProjectID: *authCtx.ProjectID,
+			})
+			require.NoError(t, err)
+			require.EqualValues(t, 1, rows)
+
+			result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+				Slug: slug, NamespaceKind: mcpendpoints.NamespacePlatform,
+				CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				ExpectedOrganization: authCtx.ActiveOrganizationID, Surface: surface,
+			})
+			require.NoError(t, err)
+			require.True(t, result.Found)
+			require.False(t, result.Allowed)
+		})
+	}
+}
+
+func TestResolvePrivateSurfaceWithoutOrganizationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+		Slug: "does-not-matter", NamespaceKind: mcpendpoints.NamespacePlatform,
+		CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ExpectedOrganization: "", Surface: networkaccess.SurfacePrivate,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Found)
+	require.False(t, result.Allowed)
+}
+
+func TestResolveClearedCustomDomainNamespaceFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	result, err := mcpendpoints.Resolve(ctx, ti.conn, testenv.NewLogger(t), mcpendpoints.ResolutionInput{
+		Slug:                 "does-not-matter",
+		NamespaceKind:        mcpendpoints.NamespaceCustomDomain,
+		CustomDomainID:       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ExpectedOrganization: "org",
+		Surface:              networkaccess.SurfacePrivate,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Found)
+	require.False(t, result.Allowed)
+}
+
+func TestBySlugAndCustomDomainMarksMalformedOriginAsPolicyDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	ctx = requestorigin.WithContext(ctx, requestorigin.Origin{
+		Surface: requestorigin.SurfaceCustomDomain, BaseURL: "https://custom.example.com",
+		OrganizationID: "org", NetworkIngressID: uuid.Nil, NetworkIdentity: nil,
+	})
+	_, _, _, err := mcpendpoints.BySlugAndCustomDomain(ctx, ti.conn, testenv.NewLogger(t), "slug")
+	require.Error(t, err)
+	require.True(t, mcpendpoints.IsPolicyDenied(err))
+}
+
+func TestBySlugAndCustomDomainMarksPrivateOnlyPublicDenial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	serverID := seedMcpServerWithMode(t, ctx, ti.conn, *authCtx.ProjectID, "public", networkaccess.ModePrivateOnly)
+	slug := authCtx.OrganizationSlug + "-terminal-policy"
+	_, err := ti.service.CreateMcpEndpoint(ctx, &gen.CreateMcpEndpointPayload{
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		CustomDomainID: nil, McpServerID: conv.PtrEmpty(serverID.String()), MetaMcpServerID: nil,
+		Slug: types.McpEndpointSlug(slug),
+	})
+	require.NoError(t, err)
+
+	ctx = requestorigin.WithContext(ctx, requestorigin.Origin{
+		Surface: requestorigin.SurfacePlatform, BaseURL: "https://api.example.com",
+		OrganizationID: "", NetworkIngressID: uuid.Nil, NetworkIdentity: nil,
+	})
+	_, _, _, err = mcpendpoints.BySlugAndCustomDomain(ctx, ti.conn, testenv.NewLogger(t), slug)
+	require.Error(t, err)
+	require.True(t, mcpendpoints.IsPolicyDenied(err))
+}

--- a/server/internal/mcpendpoints/setup_test.go
+++ b/server/internal/mcpendpoints/setup_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
@@ -251,6 +252,12 @@ func seedMcpServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projec
 func seedMcpServerWithVisibility(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, visibility string) uuid.UUID {
 	t.Helper()
 
+	return seedMcpServerWithMode(t, ctx, conn, projectID, visibility, networkaccess.ModePublicOnly)
+}
+
+func seedMcpServerWithMode(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID, visibility string, mode networkaccess.Mode) uuid.UUID {
+	t.Helper()
+
 	server := remotemcptest.SeedServer(t, ctx, conn, remotemcprepo.CreateServerParams{
 		ProjectID:     projectID,
 		TransportType: "streamable-http",
@@ -271,6 +278,7 @@ func seedMcpServerWithVisibility(t *testing.T, ctx context.Context, conn *pgxpoo
 		RemoteMcpServerID:   uuid.NullUUID{UUID: server.ID, Valid: true},
 		ToolsetID:           uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		Visibility:          visibility,
+		NetworkAccessMode:   networkaccess.Storage(mode),
 	})
 	require.NoError(t, err)
 

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1035,10 +1035,8 @@ func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*i
 	switch {
 	case mcpendpoints.IsAddressMiss(err):
 		// Fall through to legacy toolset lookup.
-	case errors.Is(err, mcpendpoints.ErrEndpointUnavailable):
-		// Disabled or dangling backend: the endpoint row owns the slug, so
-		// render the not-found page rather than an unexpected failure.
-		return nil, fmt.Errorf("%w: mcp endpoint backend unavailable", errToolsetNotFound)
+	case mcpendpoints.IsPolicyDenied(err):
+		return nil, fmt.Errorf("%w: endpoint is not available on this network surface", errToolsetNotFound)
 	case err != nil:
 		return nil, fmt.Errorf("resolve mcp endpoint: %w", err)
 	case metaServer != nil:

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1027,9 +1027,10 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	return s.renderRemoteMcpInstallPage(ctx, w, ic, metadataRecord)
 }
 
-// resolveInstallContext resolves mcp_endpoints → mcp_server first, mirroring
-// mcp.ServePublic: only a true address miss falls back to the legacy
-// toolsets.mcp_slug lookup; an unavailable address is terminal (AIS-633).
+// resolveInstallContext tries the mcp_endpoints → mcp_server resolution path
+// first, then falls back to the legacy toolsets.mcp_slug lookup only for a
+// plain namespace miss. Policy denials are authoritative 404s and never fall
+// through to an unrelated legacy toolset.
 func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*installContext, error) {
 	endpoint, server, metaServer, err := mcpendpoints.BySlugAndCustomDomain(ctx, s.db, s.logger, mcpSlug)
 	switch {

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1952,11 +1952,8 @@ func TestServeInstallPage_CustomDomain_RootEndpointRendersBareDomainURL(t *testi
 	require.NotContains(t, body, "https://root-install.example.com/mcp/", "root endpoint installs do not use the /mcp path")
 }
 
-// TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound verifies that a
-// meta-MCP-backed endpoint's install page is an authoritative 404 (AGE-3299
-// will add a real page): the response is the rendered not-found page rather
-// than a 500, and the slug must not fall through to an unrelated legacy
-// toolset sharing the same mcp_slug.
+// A private-only endpoint is an authoritative 404 on the public install
+// surface and cannot fall through to a legacy toolset sharing its slug.
 func TestServeInstallPage_PrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestMCPMetadataService(t)
@@ -1988,6 +1985,11 @@ func TestServeInstallPage_PrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
 	require.NotContains(t, rr.Body.String(), "Legacy Install Fallback")
 }
 
+// TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound verifies that a
+// meta-MCP-backed endpoint's install page is an authoritative 404 (AGE-3299
+// will add a real page): the response is the rendered not-found page rather
+// than a 500, and the slug must not fall through to an unrelated legacy
+// toolset sharing the same mcp_slug.
 func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	ctx, testInstance := newTestMCPMetadataService(t)

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/metamcp/visibility"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	organizations_repo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projects_repo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
@@ -1956,6 +1957,37 @@ func TestServeInstallPage_CustomDomain_RootEndpointRendersBareDomainURL(t *testi
 // will add a real page): the response is the rendered not-found page rather
 // than a 500, and the slug must not fall through to an unrelated legacy
 // toolset sharing the same mcp_slug.
+func TestServeInstallPage_PrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPMetadataService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	mcpSlug := "private-only-install-" + uuid.NewString()[:8]
+	createMcpServerWithEndpoint(t, ctx, ti, mcpServerFixtureOptions{
+		name: "Private Only Install", visibility: mcpservers.VisibilityPublic,
+		endpointSlug: mcpSlug, networkAccessMode: networkaccess.ModePrivateOnly,
+	})
+	legacy, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID,
+		Name: "Legacy Install Fallback", Slug: "legacy-" + mcpSlug, McpSlug: conv.ToPGText(mcpSlug),
+		Description: conv.ToPGText("must not render"), DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false}, McpEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ti.toolsetRepo.SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true, ID: legacy.ID, ProjectID: legacy.ProjectID,
+	}))
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.NotContains(t, rr.Body.String(), "Legacy Install Fallback")
+}
+
 func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	ctx, testInstance := newTestMCPMetadataService(t)

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -120,6 +121,7 @@ type mcpServerFixtureOptions struct {
 	tunneledMcpServerID uuid.NullUUID
 	customDomainID      uuid.NullUUID
 	userSessionIssuerID uuid.NullUUID
+	networkAccessMode   networkaccess.Mode
 }
 
 func createMcpServerWithEndpoint(
@@ -173,6 +175,7 @@ func createMcpServerWithEndpoint(
 		TunneledMcpServerID: opts.tunneledMcpServerID,
 		ToolsetID:           opts.toolsetID,
 		Visibility:          opts.visibility,
+		NetworkAccessMode:   networkaccess.Storage(opts.networkAccessMode),
 	})
 	require.NoError(t, err)
 

--- a/server/internal/middleware/network_serving_policy.go
+++ b/server/internal/middleware/network_serving_policy.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
+)
+
+// NetworkServingPolicyVersion stamps every response with the serving-policy
+// contract implemented by this process. Rollout tooling can probe each pod
+// directly and must not enable non-public writes until every serving pod
+// reports at least the required version.
+func NetworkServingPolicyVersion(next http.Handler) http.Handler {
+	value := strconv.Itoa(networkaccess.ServingPolicyVersion)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(networkaccess.ServingPolicyVersionHeader, value)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/middleware/network_serving_policy_test.go
+++ b/server/internal/middleware/network_serving_policy_test.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/networkaccess"
+)
+
+func TestNetworkServingPolicyVersion(t *testing.T) {
+	t.Parallel()
+
+	handler := NetworkServingPolicyVersion(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, strconv.Itoa(networkaccess.ServingPolicyVersion), rec.Header().Get(networkaccess.ServingPolicyVersionHeader))
+}

--- a/server/internal/middleware/private_ingress_headers.go
+++ b/server/internal/middleware/private_ingress_headers.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// PrivateIngressAttestationHeader is reserved for workload attestation on the
+// isolated private listener. Public requests must never be able to supply it.
+const PrivateIngressAttestationHeader = "X-Gram-Network-Ingress-Attestation"
+
+// StripPrivateIngressHeaders removes provider identity and Gram attestation
+// headers from the public listener before tracing, logging, or context
+// extraction. Header names are case-insensitive under net/http.
+func StripPrivateIngressHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for name := range r.Header {
+			if strings.HasPrefix(strings.ToLower(name), "tailscale-") {
+				r.Header.Del(name)
+			}
+		}
+		r.Header.Del(PrivateIngressAttestationHeader)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/middleware/private_ingress_headers_test.go
+++ b/server/internal/middleware/private_ingress_headers_test.go
@@ -1,0 +1,36 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripPrivateIngressHeaders(t *testing.T) {
+	t.Parallel()
+
+	var observed http.Header
+	handler := StripPrivateIngressHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/test", nil)
+	req.Header.Set("Tailscale-User-Login", "forged@example.com")
+	req.Header.Set("tailscale-user-name", "forged")
+	req.Header.Set("Tailscale-Capabilities", "forged")
+	req.Header.Set(PrivateIngressAttestationHeader, "forged")
+	req.Header.Set("Authorization", "Bearer preserved")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, observed.Get("Tailscale-User-Login"))
+	require.Empty(t, observed.Get("Tailscale-User-Name"))
+	require.Empty(t, observed.Get("Tailscale-Capabilities"))
+	require.Empty(t, observed.Get(PrivateIngressAttestationHeader))
+	require.Equal(t, "Bearer preserved", observed.Get("Authorization"))
+}

--- a/server/internal/networkaccess/mode.go
+++ b/server/internal/networkaccess/mode.go
@@ -53,6 +53,12 @@ func Effective(value pgtype.Text) (Mode, error) {
 	return mode, nil
 }
 
+// EffectiveValidated is kept for serving-policy callers introduced before
+// Effective became fail-closed. Both names deliberately share one policy path.
+func EffectiveValidated(value pgtype.Text) (Mode, error) {
+	return Effective(value)
+}
+
 // EffectiveForView keeps API responses inside the published enum. It is not a
 // policy decision: unknown persisted values render as the safe recovery mode,
 // while policy callers must use Effective and handle its error. If a client

--- a/server/internal/networkaccess/mode.go
+++ b/server/internal/networkaccess/mode.go
@@ -13,6 +13,13 @@ const (
 	ModePublicOnly  Mode = "public_only"
 	ModeDual        Mode = "dual"
 	ModePrivateOnly Mode = "private_only"
+
+	// ServingPolicyVersion is incremented whenever a deployment gains a new
+	// network-mode enforcement contract. Rollout tooling must verify every
+	// serving pod reports at least this version before admitting non-public
+	// writes, preventing mixed-version fail-open rollouts.
+	ServingPolicyVersion       = 1
+	ServingPolicyVersionHeader = "X-Gram-Network-Serving-Policy-Version"
 )
 
 type Surface string


### PR DESCRIPTION
AIS-606: https://linear.app/speakeasy/issue/AIS-606

Stacked on #5893, which is stacked on #5848. Review only this child commit while the lower PRs remain open.

## Why

Non-public MCP modes cannot be admitted safely until every public/custom-domain route enforces the stored network mode before side effects or legacy fallback. This checkpoint centralizes that serving gate, tenant/namespace checks, and public-listener header hygiene while keeping non-public writes disabled.

## What changed

- Add a namespace-, organization-, and surface-aware resolver for generic and Meta MCP endpoints with public/private mode matrices and fail-closed unknown-mode behavior.
- Distinguish genuine address misses from authoritative denials so private-only, disabled, malformed-authority, and tenant failures cannot continue into legacy toolset fallback.
- Apply the shared policy result across `/mcp`, `/x/mcp`, well-known metadata, issuer OAuth handlers, install pages, and cached OAuth re-entry.
- Pin in-flight OAuth challenges and authorization codes to mint-time issuer, backend, visibility, namespace, route surface, toolset identity, and base origin, with compatibility limited to pre-field cache TTLs.
- Strip every `Tailscale-*` header and the internal attestation header at the outer public-listener boundary before short-circuit handlers, tracing, logging, or context extraction.
- Stamp a serving-policy version response header so rollout tooling can verify every serving pod supports network-mode enforcement before enabling non-public writes.

## Review notes

- The central contract is in `server/internal/mcpendpoints/resolve.go`; `ErrPolicyDenied` is intentionally represented as 404 but must remain terminal.
- The OAuth state pinning is in `server/internal/mcp/resolved_mcp_endpoint.go`, consent grant creation, and authorization-code redemption.
- Legacy direct-toolset fallback remains available only on genuine endpoint misses. Existing cached states/grants missing newly added pins remain compatible only for their 10-minute TTL.
- Private-listener TokenReview/identity parsing and global callback mint-time private authority remain AIS-667/AIS-666.
- The `network_ingress` entitlement, PostHog rollout clearance, and provider mutations remain off. This PR still does not allow `dual` or `private_only` writes.

## Testing

- `mise run test:server ./internal/mcp/... ./internal/mcpendpoints/... ./internal/mcpmetadata/... ./internal/xmcp/...` — 974 tests passed.
- `go test ./server/internal/middleware -run 'Test(NetworkServingPolicyVersion|StripPrivateIngressHeaders)$'` — passed.
- `go test ./server/internal/networkaccess ./server/internal/requestorigin` — passed.
- `mise lint:server` — passed.
- `mise build:server` — passed.
- `git diff --check` — passed.
- Multiple independent security reviews were run; all findings were fixed, and the definitive closure review found no remaining high/medium issues.
- One aggregate run previously hit transient Redis/testcontainer failures; the exact failures passed in isolation and subsequent full affected-package runs passed.

## Rollout / deployment notes

- Deploy only after #5893 and #5848.
- Rollout tooling must verify the serving-policy version on every serving pod before replacing the deny-all eligibility checker.
- This PR enables no private listener, organization entitlement, PostHog authorization, or provider mutation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces stored MCP network access modes on every public serving path so private-only, disabled, and wrong-tenant endpoints can no longer fall through to legacy toolset lookups. Policy denials are now terminal 404s represented by `ErrPolicyDenied`, OAuth flows and authorization codes are pinned to their mint-time endpoint, and the public listener strips `Tailscale-*` and attestation headers before any request processing.

**New Features**
- Shared resolver applies namespace, organization, surface, and network-mode policy before side effects; legacy fallback runs only on genuine address misses, and the terminal denial marker replaced the older `ErrEndpointUnavailable`.
- Unknown or invalid stored modes and disabled/cleared custom-domain namespaces deny all surfaces instead of failing open; NULL/empty modes keep prior behavior, and updates that omit the mode preserve the stored value.
- OAuth challenges and authorization codes are pinned to the endpoint's mint-time identity (issuer, visibility, backend/toolset, route surface, base origin) so a wrong-endpoint presentation cannot burn the code; client, redirect, and PKCE mismatches still consume it.
- Public listener strips `Tailscale-*` and attestation headers and stamps a serving-policy version header for rollout verification.

**Migration**
- Deploy only after the stacked serving-foundations PRs, after verifying every serving pod reports the policy version. No non-public writes, entitlements, or provider mutations are enabled.

<sup>Written for commit 4822a39f2c1157830b8c28b2066620cae0897808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

