### PR TITLE
chore: upgrade and pin ClickHouse 26.2 image

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -757,7 +757,7 @@ jobs:
     if: needs.changes.outputs.migrations == 'true' && github.event_name == 'pull_request'
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:25.8.3
+        image: clickhouse/clickhouse-server:26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd
         env:
           CLICKHOUSE_USER: gram
           CLICKHOUSE_PASSWORD: gram
@@ -899,7 +899,7 @@ jobs:
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
-          dev-url: docker://clickhouse/clickhouse-server/25.8.3/dev
+          dev-url: docker://clickhouse/clickhouse-server/26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd/dev
           git-base: origin/main
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -1008,7 +1008,7 @@ jobs:
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
-          dev-url: docker://clickhouse/clickhouse-server/25.8.3/dev
+          dev-url: docker://clickhouse/clickhouse-server/26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd/dev
           tag: ${{ steps.tag.outputs.tag }}
 
   webhooks-catalog-breaking-changes:

--- a/.mise-tasks/clickhouse/diff.sh
+++ b/.mise-tasks/clickhouse/diff.sh
@@ -15,7 +15,7 @@ atlas migrate diff "${usage_name:?}" \
   --dir file://clickhouse/migrations \
   --config file://atlas.hcl \
   --to file://clickhouse/schema.sql \
-  --dev-url "docker://clickhouse/clickhouse-server/25.8.3/dev"
+  --dev-url "docker://clickhouse/clickhouse-server/26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd/dev"
 
 
 # We also generate golang-migrate migrations so to allow 
@@ -26,7 +26,7 @@ atlas migrate diff "${usage_name:?}" \
   --dir file://clickhouse/local/golang_migrate?format=golang-migrate \
   --config file://atlas.hcl \
   --to file://clickhouse/schema.sql \
-  --dev-url "docker://clickhouse/clickhouse-server/25.8.3/dev" \
+  --dev-url "docker://clickhouse/clickhouse-server/26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd/dev" \
   --format "{{ sql . \"  \" }}"
 
 mise run clickhouse:gen-materialized-cols

--- a/.mise-tasks/clickhouse/down.sh
+++ b/.mise-tasks/clickhouse/down.sh
@@ -14,4 +14,4 @@ exec atlas migrate down --to-version "${usage_target:?}" \
   --dir file://clickhouse/migrations \
   --config file://atlas.hcl \
   --url "$GRAM_CLICKHOUSE_URL" \
-  --dev-url "docker://clickhouse/clickhouse-server/25.8.3/dev"
+  --dev-url "docker://clickhouse/clickhouse-server/26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd/dev"

--- a/compose.yml
+++ b/compose.yml
@@ -58,8 +58,7 @@ services:
       retries: 12
 
   clickhouse:
-    build:
-      context: ./local/clickhouse
+    image: clickhouse/clickhouse-server:26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd
     restart: unless-stopped
     ports:
       - "${CLICKHOUSE_HTTP_PORT}:8123"
@@ -71,6 +70,11 @@ services:
       CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
     volumes:
       - clickhouse_data:/var/lib/clickhouse
+      - ./local/clickhouse/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml:ro
+      - ./local/clickhouse/config.d/limits.xml:/etc/clickhouse-server/config.d/limits.xml:ro
+      - ./local/clickhouse/config.d/ssl.xml:/etc/clickhouse-server/config.d/ssl.xml:ro
+      - ./local/clickhouse/users.d/dev_profile.xml:/etc/clickhouse-server/users.d/dev_profile.xml:ro
+      - ./local/clickhouse/certs:/etc/clickhouse-server/certs:ro
     ulimits:
       nofile:
         soft: 262144

--- a/examples/clickhouse/docker-compose.yml
+++ b/examples/clickhouse/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd
     container_name: clickhouse-dev
     ports:
       - "8124:8123" # HTTP interface

--- a/local/clickhouse/Dockerfile
+++ b/local/clickhouse/Dockerfile
@@ -1,5 +1,0 @@
-FROM clickhouse/clickhouse-server:25.8.3
-
-COPY config.d /etc/clickhouse-server/config.d
-COPY users.d /etc/clickhouse-server/users.d
-COPY certs /etc/clickhouse-server/certs

--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -19,7 +19,7 @@ type ClickhouseClientFunc func(t *testing.T) (clickhouse.Conn, error)
 // from migration files. Returns a container reference and a function to create
 // test connections. The per-test connection is automatically closed via t.Cleanup.
 func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseContainer, ClickhouseClientFunc, error) {
-	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:25.8.3",
+	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd",
 		clickhousecontainer.WithUsername("gram"),
 		clickhousecontainer.WithPassword("gram"),
 		clickhousecontainer.WithInitScripts(rootPath("clickhouse", "schema.sql")),


### PR DESCRIPTION
## Summary

- Upgrade ClickHouse Docker references to `26.2.19.43` and pin the multi-platform image digest.
- Replace the local custom ClickHouse image build with the upstream image and read-only bind mounts for local configuration, user settings, and certificates.
- Keep CI migration checks, Atlas development databases, examples, and test containers on the same immutable image.

## Motivation

Using one digest-pinned image prevents environments from drifting between ClickHouse releases. Mounting individual configuration files removes an unnecessary custom image while preserving the configuration fragments supplied by the upstream image.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades ClickHouse from `25.8.3` to `26.2.19.43` and pins the multi-platform digest so every environment runs the same immutable image. Replaces the local custom `Dockerfile` with read-only bind mounts for config files, user settings, and certificates.

- Updates CI migration checks, Atlas `dev-url` references, `compose.yml`, the example compose file, and `server/internal/testenv/clickhouse.go` to the pinned image.
- Deletes `local/clickhouse/Dockerfile`; its contents now mount directly into the upstream image.

<sup>Written for commit fc5294e99a2ef0ad05cdd213af480826ded122bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

