### PR TITLE
fix: validate Origin and Content-Type on MCP endpoints

### DIFF
--- a/.changeset/mcp-origin-content-type-validation.md
+++ b/.changeset/mcp-origin-content-type-validation.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+MCP endpoints now validate the `Origin` header and answer cross-origin browser requests with 403, as the MCP specification requires, and reject POSTs sent with a form or plain-text `Content-Type` with 415. Native MCP clients are unaffected because they send neither `Sec-Fetch-Site` nor `Origin`, and Gram Elements keeps working through the chat-session token's audience claim.

--- a/.changeset/mcp-origin-content-type-validation.md
+++ b/.changeset/mcp-origin-content-type-validation.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-MCP endpoints now validate the `Origin` header and answer cross-origin browser requests with 403, as the MCP specification requires, and reject POSTs sent with a form or plain-text `Content-Type` with 415. Native MCP clients are unaffected because they send neither `Sec-Fetch-Site` nor `Origin`, and Gram Elements keeps working through the chat-session token's audience claim.
+MCP endpoints now validate the `Origin` header and answer cross-origin browser requests with 403, as the MCP specification requires, and MCP POSTs must be sent with `Content-Type: application/json` or are rejected with 415. Native MCP clients are unaffected because they send neither `Sec-Fetch-Site` nor `Origin`, and Gram Elements keeps working through the chat-session token's audience claim.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1320,6 +1320,19 @@ func newStartCommand() *cli.Command {
 			mux.Use(middleware.NewHTTPLoggingMiddleware(logger))
 			mux.Use(middleware.NewRecovery(logger))
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url"), chatSessionsManager))
+			// Must stay below CORSMiddleware: chatSessionsCORS runs inside it and
+			// marks requests whose Origin matched the chat-session audience claim,
+			// which MCPSecurity reads to exempt Elements. The Gram first-party
+			// origins are trusted so the dashboard's MCP inspection tabs can reach a
+			// customer's custom domain, which is cross-site and cannot be rebased
+			// onto the platform host (mcp_endpoint rows resolve by slug + custom
+			// domain). site-url and server-url are the same origin in production and
+			// differ only in local development.
+			mcpSecurity, err := middleware.MCPSecurity(logger, []string{c.String("server-url"), c.String("site-url")})
+			if err != nil {
+				return fmt.Errorf("configure mcp security middleware: %w", err)
+			}
+			mux.Use(mcpSecurity)
 			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL))
 			mux.Use(middleware.SessionMiddleware)
 			mux.Use(middleware.RBACOverrideMiddleware())

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -27,6 +27,8 @@ const (
 	HTTPRequestHeaderRefererKey      = attribute.Key("http.request.header.referer")
 	HTTPRequestHeaderContentTypeKey  = attribute.Key("http.request.header.content_type")
 	HTTPRequestHeaderUserAgentKey    = attribute.Key("http.request.header.user_agent")
+	HTTPRequestHeaderOriginKey       = attribute.Key("http.request.header.origin")
+	HTTPRequestHeaderSecFetchSiteKey = attribute.Key("http.request.header.sec_fetch_site")
 	HTTPRequestMethodKey             = semconv.HTTPRequestMethodKey
 	HTTPRequestBodyKey               = attribute.Key("http.request.body")
 	HTTPResponseBodyKey              = attribute.Key("http.response.body")
@@ -782,6 +784,22 @@ func HTTPRequestHeaderUserAgent(v string) attribute.KeyValue {
 
 func SlogHTTPRequestHeaderUserAgent(v string) slog.Attr {
 	return slog.String(string(HTTPRequestHeaderUserAgentKey), v)
+}
+
+func HTTPRequestHeaderOrigin(v string) attribute.KeyValue {
+	return HTTPRequestHeaderOriginKey.String(v)
+}
+
+func SlogHTTPRequestHeaderOrigin(v string) slog.Attr {
+	return slog.String(string(HTTPRequestHeaderOriginKey), v)
+}
+
+func HTTPRequestHeaderSecFetchSite(v string) attribute.KeyValue {
+	return HTTPRequestHeaderSecFetchSiteKey.String(v)
+}
+
+func SlogHTTPRequestHeaderSecFetchSite(v string) slog.Attr {
+	return slog.String(string(HTTPRequestHeaderSecFetchSiteKey), v)
 }
 
 func HTTPRequestBody(v string) attribute.KeyValue { return HTTPRequestBodyKey.String(v) }

--- a/server/internal/middleware/chat_session_cors.go
+++ b/server/internal/middleware/chat_session_cors.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"slices"
@@ -18,9 +19,55 @@ var chatSessionsAllowedRoutes = []string{
 	"/rpc/chatSessions.",
 }
 
+// gramKeyCORSRoutes are the routes that actually authenticate with a Gram-Key
+// header and therefore need the requesting origin echoed back so the browser
+// will surface the response. Elements' dangerousApiKey flow bootstraps against
+// /rpc/chatSessions.create before any chat session exists, and the chat routes
+// accept the key directly (see chat.Service.Authorize).
+//
+// This is deliberately an allowlist rather than "every chatSessionsAllowedRoutes
+// entry". The /mcp prefix in that list also covers /mcp/{slug} and the OAuth
+// sub-routes (/token, /register, /authorize, /connect), none of which read
+// Gram-Key at all — nothing under internal/mcp or internal/xmcp consults it,
+// as MCP identity auth reads Authorization or Gram-Chat-Session only. Echoing
+// the origin there authenticated nothing and let any page read a response it
+// should not have been able to: a hostile origin that attached a dummy
+// Gram-Key got Access-Control-Allow-Origin plus Allow-Credentials on a
+// credential-free public MCP server, making tools/list and tools/call results
+// readable cross-site.
+var gramKeyCORSRoutes = []string{
+	"/chat/completions",
+	"/chat/turnstream",
+	"/rpc/chat.",
+	"/rpc/chatSessions.",
+}
+
+// ChatSessionValidator validates a chat-session token. Narrowed from
+// *chatsessions.Manager so this package stays testable without standing up
+// Redis: Manager.ValidateToken checks token revocation on the happy path,
+// which would otherwise drag a testcontainer into every CORS test.
+type ChatSessionValidator interface {
+	ValidateToken(ctx context.Context, token string) (*chatsessions.ChatSessionClaims, bool, error)
+}
+
+// chatSessionOriginTrustedKey marks a request whose Origin was validated
+// against a chat-session token's audience claim. The key type is unexported so
+// only this package can set it — a forgeable marker would hand any caller the
+// MCPSecurity exemption.
+type chatSessionOriginTrustedKey struct{}
+
+func markChatSessionOriginTrusted(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), chatSessionOriginTrustedKey{}, true))
+}
+
+func chatSessionOriginTrusted(ctx context.Context) bool {
+	trusted, _ := ctx.Value(chatSessionOriginTrustedKey{}).(bool)
+	return trusted
+}
+
 // This isn't practical to do as a proper middleware because it needs to interoperate with the CORSMiddleware which does things like returning early for OPTIONS requests.
 // Instead, we combine it with the CORSMiddleware so that all CORS stuff is handled in one place.
-func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.Handler) http.Handler {
+func chatSessionsCORS(validator ChatSessionValidator) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodOptions {
@@ -30,6 +77,7 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 				if requestedHeaders := r.Header.Get("Access-Control-Request-Headers"); requestedHeaders != "" {
 					w.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
 				}
+				w.Header().Add("Vary", "Origin")
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
@@ -38,14 +86,15 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 			if chatSession == "" {
 				// If the request uses API key auth (e.g. dangerousApiKey from Elements),
 				// allow the requesting origin so the browser doesn't block the response.
-				if r.Header.Get(constants.APIKeyHeader) != "" {
+				if r.Header.Get(constants.APIKeyHeader) != "" && isGramKeyCORSRoute(r.URL.Path) {
 					w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+					w.Header().Add("Vary", "Origin")
 				}
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			claims, invalidToken, err := chatSessionsManager.ValidateToken(r.Context(), chatSession)
+			claims, invalidToken, err := validator.ValidateToken(r.Context(), chatSession)
 			if invalidToken {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
 				return
@@ -62,6 +111,7 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 			if origin != "" {
 				if slices.Contains(claims.Audience, origin) {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Add("Vary", "Origin")
 				} else {
 					http.Error(w, fmt.Sprintf("Origin %s does not match audience claim: %s", origin, strings.Join(claims.Audience, ", ")), http.StatusForbidden)
 					return
@@ -85,7 +135,18 @@ func chatSessionsCORS(chatSessionsManager *chatsessions.Manager) func(next http.
 				}
 			}
 
-			next.ServeHTTP(w, r)
+			// The audience claim is the trusted-origin mechanism for Elements,
+			// which is embedded on customer domains and is therefore genuinely
+			// cross-site against /mcp/{slug}. Having just proven the origin
+			// against that claim, exempt the request from MCPSecurity's
+			// same-origin check downstream.
+			next.ServeHTTP(w, markChatSessionOriginTrusted(r))
 		})
 	}
+}
+
+func isGramKeyCORSRoute(path string) bool {
+	return slices.ContainsFunc(gramKeyCORSRoutes, func(route string) bool {
+		return strings.HasPrefix(path, route)
+	})
 }

--- a/server/internal/middleware/chat_session_cors.go
+++ b/server/internal/middleware/chat_session_cors.go
@@ -25,6 +25,11 @@ var chatSessionsAllowedRoutes = []string{
 // /rpc/chatSessions.create before any chat session exists, and the chat routes
 // accept the key directly (see chat.Service.Authorize).
 //
+// /rpc/chat.load rather than the whole /rpc/chat. family: loadChat is the only
+// chat method declaring security.ByKey (design/chat/design.go), so the other
+// twelve /rpc/chat.* routes would be handing out credentialed CORS on
+// responses no API key was consulted for.
+//
 // This is deliberately an allowlist rather than "every chatSessionsAllowedRoutes
 // entry". The /mcp prefix in that list also covers /mcp/{slug} and the OAuth
 // sub-routes (/token, /register, /authorize, /connect), none of which read
@@ -38,7 +43,7 @@ var chatSessionsAllowedRoutes = []string{
 var gramKeyCORSRoutes = []string{
 	"/chat/completions",
 	"/chat/turnstream",
-	"/rpc/chat.",
+	"/rpc/chat.load",
 	"/rpc/chatSessions.",
 }
 

--- a/server/internal/middleware/chat_session_cors_test.go
+++ b/server/internal/middleware/chat_session_cors_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -146,7 +147,7 @@ func TestChatSessionsCORS_GramKeyEchoesOriginOnConsumingRoutes(t *testing.T) {
 
 	for _, path := range []string{
 		"/rpc/chatSessions.create",
-		"/rpc/chat.list",
+		"/rpc/chat.load",
 		"/chat/completions",
 		"/chat/turnstream",
 	} {
@@ -161,6 +162,82 @@ func TestChatSessionsCORS_GramKeyEchoesOriginOnConsumingRoutes(t *testing.T) {
 
 			require.True(t, reached)
 			require.Equal(t, elementsOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+// loadChat is the only chat method declaring security.ByKey, so the rest of
+// the /rpc/chat.* family must not hand out credentialed CORS for a key that
+// was never consulted.
+func TestChatSessionsCORS_GramKeyDoesNotEchoOriginOnNonConsumingChatRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/rpc/chat.list",
+		"/rpc/chat.delete",
+		"/rpc/chat.summarize",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai"+path, strings.NewReader("{}"))
+			req.Header.Set(constants.APIKeyHeader, "gram_key_whatever")
+			req.Header.Set("Origin", hostileOrigin)
+
+			rec, reached, _ := serveChatSessionCORS(t, stubChatSessionValidator{audience: nil, invalidToken: false, err: nil}, req)
+
+			require.True(t, reached)
+			require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+// A validator fault is a server fault, not an auth failure: the caller must
+// see 500 and the handler must not run.
+func TestChatSessionsCORS_ValidatorErrorIsInternalError(t *testing.T) {
+	t.Parallel()
+
+	validator := stubChatSessionValidator{audience: nil, invalidToken: false, err: errors.New("redis unavailable")}
+
+	rec, reached, _ := serveChatSessionCORS(t, validator, elementsMCPRequest())
+
+	require.False(t, reached)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// Browsers omit Origin on same-origin GET/HEAD, so the audience check falls
+// back to comparing Host. That fallback is what stops a stripped Origin from
+// bypassing the audience claim, so both outcomes are pinned.
+func TestChatSessionsCORS_HostFallbackWhenOriginAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		host       string
+		audience   []string
+		wantStatus int
+		wantReach  bool
+	}{
+		{name: "host matches audience", host: "app.getgram.ai", audience: []string{"https://app.getgram.ai"}, wantStatus: http.StatusOK, wantReach: true},
+		{name: "host matches http audience", host: "app.getgram.ai", audience: []string{"http://app.getgram.ai"}, wantStatus: http.StatusOK, wantReach: true},
+		{name: "host does not match", host: "app.getgram.ai", audience: []string{"https://docs.customer.com"}, wantStatus: http.StatusForbidden, wantReach: false},
+		{name: "empty audience", host: "app.getgram.ai", audience: nil, wantStatus: http.StatusForbidden, wantReach: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil)
+			req.Host = tt.host
+			req.Header.Set(constants.ChatSessionsTokenHeader, "a-chat-session-token")
+
+			validator := stubChatSessionValidator{audience: tt.audience, invalidToken: false, err: nil}
+			rec, reached, originTrusted := serveChatSessionCORS(t, validator, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.Equal(t, tt.wantReach, reached)
+			require.Equal(t, tt.wantReach, originTrusted, "trust marker must track the audience decision")
 		})
 	}
 }

--- a/server/internal/middleware/chat_session_cors_test.go
+++ b/server/internal/middleware/chat_session_cors_test.go
@@ -1,0 +1,222 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+)
+
+// stubChatSessionValidator stands in for *chatsessions.Manager, whose real
+// ValidateToken checks revocation against Redis. The narrow interface is what
+// lets this file exist at all: the middleware package has no testcontainer
+// harness and should not grow one to test header handling.
+type stubChatSessionValidator struct {
+	audience     []string
+	invalidToken bool
+	err          error
+}
+
+func (s stubChatSessionValidator) ValidateToken(_ context.Context, _ string) (*chatsessions.ChatSessionClaims, bool, error) {
+	if s.invalidToken || s.err != nil {
+		return nil, s.invalidToken, s.err
+	}
+	return &chatsessions.ChatSessionClaims{
+		RegisteredClaims: jwt.RegisteredClaims{Audience: jwt.ClaimStrings(s.audience)},
+	}, false, nil
+}
+
+// serveChatSessionCORS runs a request through chatSessionsCORS and reports
+// what the downstream handler saw.
+func serveChatSessionCORS(t *testing.T, validator ChatSessionValidator, req *http.Request) (rec *httptest.ResponseRecorder, reached bool, originTrusted bool) {
+	t.Helper()
+
+	handler := chatSessionsCORS(validator)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		originTrusted = chatSessionOriginTrusted(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec, reached, originTrusted
+}
+
+func elementsMCPRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai/mcp/petstore", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(constants.ChatSessionsTokenHeader, "a-chat-session-token")
+	req.Header.Set("Origin", elementsOrigin)
+	return req
+}
+
+// Elements embedded on a customer domain: the audience claim names the
+// embedding origin, so the request is admitted and marked trusted for
+// MCPSecurity downstream.
+func TestChatSessionsCORS_AudienceMatchMarksOriginTrusted(t *testing.T) {
+	t.Parallel()
+
+	validator := stubChatSessionValidator{audience: []string{elementsOrigin}, invalidToken: false, err: nil}
+
+	rec, reached, originTrusted := serveChatSessionCORS(t, validator, elementsMCPRequest())
+
+	require.True(t, reached)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, elementsOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, rec.Header().Get("Vary"), "Origin")
+	require.True(t, originTrusted, "an audience-validated origin must be exempt from the same-origin check")
+}
+
+func TestChatSessionsCORS_AudienceMismatchIsForbidden(t *testing.T) {
+	t.Parallel()
+
+	validator := stubChatSessionValidator{audience: []string{"https://someone-else.com"}, invalidToken: false, err: nil}
+
+	rec, reached, _ := serveChatSessionCORS(t, validator, elementsMCPRequest())
+
+	require.False(t, reached)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestChatSessionsCORS_InvalidTokenIsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	validator := stubChatSessionValidator{audience: nil, invalidToken: true, err: nil}
+
+	rec, reached, _ := serveChatSessionCORS(t, validator, elementsMCPRequest())
+
+	require.False(t, reached)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// A request with no chat session is passed through unmarked, so MCPSecurity
+// applies its own check. This is the credential-free public MCP path.
+func TestChatSessionsCORS_NoSessionDoesNotMarkTrusted(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai/mcp/petstore", strings.NewReader("{}"))
+	req.Header.Set("Origin", hostileOrigin)
+
+	_, reached, originTrusted := serveChatSessionCORS(t, stubChatSessionValidator{audience: nil, invalidToken: false, err: nil}, req)
+
+	require.True(t, reached, "chatSessionsCORS itself does not gate anonymous requests")
+	require.False(t, originTrusted, "no chat session means no exemption")
+}
+
+// The regression this issue uncovered: a dummy Gram-Key used to buy a hostile
+// origin a readable response from a public MCP server. Gram-Key authenticates
+// nothing under /mcp, so the echo is gone there.
+func TestChatSessionsCORS_GramKeyDoesNotEchoOriginOnMCPRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/petstore",
+		"/mcp/petstore/token",
+		"/mcp/petstore/register",
+		"/mcp/petstore/authorize",
+		"/mcp/petstore/connect",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai"+path, strings.NewReader("{}"))
+			req.Header.Set(constants.APIKeyHeader, "gram_key_whatever")
+			req.Header.Set("Origin", hostileOrigin)
+
+			rec, reached, _ := serveChatSessionCORS(t, stubChatSessionValidator{audience: nil, invalidToken: false, err: nil}, req)
+
+			require.True(t, reached, "the request still runs; only the CORS echo is withheld")
+			require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"),
+				"a Gram-Key must not make an MCP response readable cross-origin")
+		})
+	}
+}
+
+// Elements' dangerousApiKey flow exchanges the key for a chat session here,
+// cross-site, before any session exists — so this route must keep the echo.
+func TestChatSessionsCORS_GramKeyEchoesOriginOnConsumingRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/rpc/chatSessions.create",
+		"/rpc/chat.list",
+		"/chat/completions",
+		"/chat/turnstream",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai"+path, strings.NewReader("{}"))
+			req.Header.Set(constants.APIKeyHeader, "gram_key_whatever")
+			req.Header.Set("Origin", elementsOrigin)
+
+			rec, reached, _ := serveChatSessionCORS(t, stubChatSessionValidator{audience: nil, invalidToken: false, err: nil}, req)
+
+			require.True(t, reached)
+			require.Equal(t, elementsOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}
+
+// End to end through both middlewares in their real order: CORSMiddleware runs
+// chatSessionsCORS, which marks the request, which MCPSecurity then honours.
+func TestChatSessionsCORS_ElementsSurvivesMCPSecurity(t *testing.T) {
+	t.Parallel()
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	validator := stubChatSessionValidator{audience: []string{elementsOrigin}, invalidToken: false, err: nil}
+	handler := CORSMiddleware("prod", gramOrigin, validator)(newMCPSecurity(t)(inner))
+
+	req := elementsMCPRequest()
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, reached, "Elements must still reach the MCP handler cross-site")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, elementsOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
+// The same chain without a chat session is the attack, and must be refused.
+func TestChatSessionsCORS_HostileOriginBlockedThroughFullChain(t *testing.T) {
+	t.Parallel()
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	validator := stubChatSessionValidator{audience: nil, invalidToken: false, err: nil}
+	handler := CORSMiddleware("prod", gramOrigin, validator)(newMCPSecurity(t)(inner))
+
+	req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai/mcp/petstore", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(constants.APIKeyHeader, "gram_key_whatever")
+	req.Header.Set("Origin", hostileOrigin)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.False(t, reached)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	// The base CORS middleware still stamps the server's own origin, which is
+	// the point: the browser compares it against the requesting origin, so the
+	// hostile page can neither run the call nor read the refusal.
+	require.Equal(t, gramOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+	require.NotEqual(t, hostileOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+}

--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-
-	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 )
 
 var mcpOpenAccessControlRoutes = []string{
@@ -17,7 +15,7 @@ var mcpOpenAccessControlRoutes = []string{
 	"/openapi.yaml",
 }
 
-func CORSMiddleware(env string, serverURL string, chatSessionsManager *chatsessions.Manager) func(next http.Handler) http.Handler {
+func CORSMiddleware(env string, serverURL string, chatSessionValidator ChatSessionValidator) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch env {
@@ -59,7 +57,7 @@ func CORSMiddleware(env string, serverURL string, chatSessionsManager *chatsessi
 			if slices.ContainsFunc(chatSessionsAllowedRoutes, func(route string) bool {
 				return strings.HasPrefix(r.URL.Path, route)
 			}) {
-				chatSessionsCORS(chatSessionsManager)(next).ServeHTTP(w, r)
+				chatSessionsCORS(chatSessionValidator)(next).ServeHTTP(w, r)
 				return
 			}
 

--- a/server/internal/middleware/mcp_protocol_version.go
+++ b/server/internal/middleware/mcp_protocol_version.go
@@ -14,7 +14,7 @@ import (
 // server span for requests to an MCP JSON-RPC endpoint, so a request that
 // carries one can be attributed to a protocol revision in traces.
 //
-// This is the only instrument covering all five inbound MCP paths and all three
+// This is the only instrument covering every inbound MCP path and all three
 // Streamable HTTP verbs from a single place, but it sees only what the header
 // carries, which varies by revision. Clients on revisions before 2025-06-18 do
 // not send it at all. Clients that do send it omit it from an `initialize`
@@ -74,6 +74,13 @@ func isMCPJSONRPCEndpoint(path string) bool {
 		// /platform/mcp/{toolsetSlug}.
 		slug, ok := strings.CutPrefix(tail, "mcp/")
 		return ok && slug != "" && !strings.Contains(slug, "/")
+	case "platform-mcp":
+		// POST /platform-mcp is Gram's own platform MCP server
+		// (internal/platformmcp), served by the go-sdk's Streamable HTTP
+		// handler. It carries no slug — the bare path is the endpoint — and
+		// everything below it (/authorize, /token, /provider-setup,
+		// /local-fixture/*) is OAuth or setup machinery, not JSON-RPC.
+		return tail == ""
 	default:
 		return false
 	}

--- a/server/internal/middleware/mcp_protocol_version.go
+++ b/server/internal/middleware/mcp_protocol_version.go
@@ -14,7 +14,8 @@ import (
 // server span for requests to an MCP JSON-RPC endpoint, so a request that
 // carries one can be attributed to a protocol revision in traces.
 //
-// This is the only instrument covering every inbound MCP path and all three
+// This is the only instrument covering every production inbound MCP path and
+// all three
 // Streamable HTTP verbs from a single place, but it sees only what the header
 // carries, which varies by revision. Clients on revisions before 2025-06-18 do
 // not send it at all. Clients that do send it omit it from an `initialize`
@@ -78,8 +79,10 @@ func isMCPJSONRPCEndpoint(path string) bool {
 		// POST /platform-mcp is Gram's own platform MCP server
 		// (internal/platformmcp), served by the go-sdk's Streamable HTTP
 		// handler. It carries no slug — the bare path is the endpoint — and
-		// everything below it (/authorize, /token, /provider-setup,
-		// /local-fixture/*) is OAuth or setup machinery, not JSON-RPC.
+		// everything below it (/authorize, /token, /provider-setup) is OAuth or
+		// setup machinery, not JSON-RPC. /platform-mcp/local-fixture/mcp is a
+		// JSON-RPC endpoint but is mounted only when the local fixture is
+		// configured and is bound to loopback, so it is deliberately excluded.
 		return tail == ""
 	default:
 		return false

--- a/server/internal/middleware/mcp_protocol_version_test.go
+++ b/server/internal/middleware/mcp_protocol_version_test.go
@@ -120,6 +120,15 @@ func TestMCPProtocolVersionTelemetryMatchesRegisteredRoutes(t *testing.T) {
 				"route %q resolved to %q, which the middleware does not match for %s", pattern, path, method)
 		}
 	}
+
+	// Gram's own platform MCP server carries no slug, so routePathForSlug
+	// cannot derive it, and the constant cannot be imported: internal/platformmcp
+	// imports this package, so referencing platformmcp.Path here would be an
+	// import cycle. Keep this literal in lockstep with it. Registered for POST
+	// only (see cmd/gram/platform_mcp.go), hence no verb cross-product.
+	got := recordSpanForRequest(t, http.MethodPost, "/platform-mcp", mcpversions.Version20250618)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)],
+		"/platform-mcp is an MCP JSON-RPC endpoint and must be matched")
 }
 
 func TestMCPProtocolVersionTelemetryIgnoresOAuthSubRoutes(t *testing.T) {
@@ -133,6 +142,10 @@ func TestMCPProtocolVersionTelemetryIgnoresOAuthSubRoutes(t *testing.T) {
 		"/mcp/my-server/authorize",
 		"/mcp/my-server/connect",
 		"/mcp/my-server/install",
+		"/platform-mcp/authorize",
+		"/platform-mcp/token",
+		"/platform-mcp/provider-setup",
+		"/platform-mcp/local-fixture/mcp",
 	} {
 		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
 		require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "path %s", path)

--- a/server/internal/middleware/mcp_security.go
+++ b/server/internal/middleware/mcp_security.go
@@ -11,31 +11,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
-// simpleRequestContentTypes are the three media types a browser can send on a
-// cross-origin POST without triggering a CORS preflight (the Fetch spec's
-// "CORS-safelisted request-header" set for Content-Type). A JSON-RPC body sent
-// under one of these reaches an MCP handler having never been preflighted, so
-// on the surfaces whose only protection was the preflight it bypassed the
-// check entirely.
-//
-// This is deliberately a denylist of the bypass vector rather than an
-// allowlist of application/json. Requiring application/json would reject
-// conforming non-browser callers for no real gain: `curl -d @body.json` with
-// no -H sends application/x-www-form-urlencoded, and a bare POST with no
-// Content-Type at all is common in hand-rolled integrations.
-//
-// An absent Content-Type is allowed even though a browser CAN produce one
-// un-preflighted (fetch with a Uint8Array or a type-less Blob body sends no
-// Content-Type). That case is covered by the Origin check above, which is the
-// real control here; this check is defence in depth for the pre-Sec-Fetch-Site
-// browsers that the Origin check falls back to Host comparison for. Rejecting
-// an absent header would break real clients to close nothing.
-var simpleRequestContentTypes = map[string]struct{}{
-	"text/plain":                        {},
-	"multipart/form-data":               {},
-	"application/x-www-form-urlencoded": {},
-}
-
 // MCPSecurity enforces the MCP Streamable HTTP transport's browser-facing
 // security requirements on the MCP JSON-RPC endpoints: Origin validation
 // (2025-11-25 and 2026-07-28 both make this a MUST, answered with 403) and
@@ -99,24 +74,48 @@ func MCPSecurity(logger *slog.Logger, trustedOrigins []string) (func(http.Handle
 			}
 
 			if !chatSessionOriginTrusted(r.Context()) {
-				if err := protection.Check(r); err != nil {
+				if err := protection.Check(originCheckProbe(r)); err != nil {
 					logMCPSecurityRejection(r, logger, "cross_origin", err.Error())
 					http.Error(w, "forbidden: cross-origin request rejected", http.StatusForbidden)
 					return
 				}
 			}
 
-			if r.Method == http.MethodPost {
-				if mediaType, ok := disallowedRequestMediaType(r.Header.Get("Content-Type")); ok {
-					logMCPSecurityRejection(r, logger, "content_type", mediaType)
-					http.Error(w, "unsupported media type: send MCP requests as application/json", http.StatusUnsupportedMediaType)
-					return
-				}
+			if r.Method == http.MethodPost && !isJSONRequest(r.Header.Get("Content-Type")) {
+				logMCPSecurityRejection(r, logger, "content_type", r.Header.Get("Content-Type"))
+				http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)
+				return
 			}
 
 			next.ServeHTTP(w, r)
 		})
 	}, nil
+}
+
+// originCheckProbe returns the request CrossOriginProtection should judge.
+//
+// Check exempts GET and HEAD as "safe methods", on the reasoning that a safe
+// method performs no state change. That does not hold for MCP: GET on a
+// Streamable HTTP endpoint opens the standalone SSE stream, and against a
+// proxy-backed server it establishes a session upstream. The spec's Origin
+// MUST is not scoped to a method either, so a cross-site GET is exactly the
+// DNS-rebinding shape the requirement exists to refuse.
+//
+// Check reads only the method, Sec-Fetch-Site, Origin, and Host, so presenting
+// GET and HEAD under POST semantics applies the identical origin logic without
+// reimplementing it. The copy is shallow and the headers are read-only in
+// Check. OPTIONS is left alone: a preflight must be answerable, and one never
+// reaches this middleware anyway because CORSMiddleware and chatSessionsCORS
+// both answer OPTIONS before calling next.
+func originCheckProbe(r *http.Request) *http.Request {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		probe := *r
+		probe.Method = http.MethodPost
+		return &probe
+	default:
+		return r
+	}
 }
 
 // normalizeOrigin reduces a configured URL to the bare scheme://host form
@@ -132,32 +131,42 @@ func normalizeOrigin(raw string) (string, error) {
 	if parsed.Scheme == "" || parsed.Host == "" {
 		return "", fmt.Errorf("trusted origin %q needs a scheme and host", raw)
 	}
-	return parsed.Scheme + "://" + parsed.Host, nil
+
+	// AddTrustedOrigin compares the configured string to the Origin header
+	// byte for byte, and a browser sends a lowercased host with the scheme's
+	// default port omitted. A flag set to "https://APP.getgram.ai" or
+	// "https://app.getgram.ai:443" would otherwise register an origin nothing
+	// can ever match, silently dropping the exemption.
+	scheme := strings.ToLower(parsed.Scheme)
+	host := strings.ToLower(parsed.Host)
+	if (scheme == "https" && strings.HasSuffix(host, ":443")) ||
+		(scheme == "http" && strings.HasSuffix(host, ":80")) {
+		host = host[:strings.LastIndex(host, ":")]
+	}
+
+	return scheme + "://" + host, nil
 }
 
-// disallowedRequestMediaType reports whether a Content-Type header names one
-// of the CORS-simple media types, returning the media type for telemetry. An
-// empty header is allowed (see simpleRequestContentTypes).
+// isJSONRequest reports whether a Content-Type header names application/json,
+// ignoring parameters such as "; charset=utf-8".
 //
-// A header Go cannot parse falls back to the bare type token rather than being
-// waved through. Fetch's CORS-safelist check uses a more lenient MIME parser
-// than mime.ParseMediaType, so values Go rejects — "text/plain;;",
-// "multipart/form-data; boundary=", a duplicated charset parameter — are still
-// sent un-preflighted by a browser and would otherwise walk straight past this
-// check.
-func disallowedRequestMediaType(header string) (string, bool) {
-	if strings.TrimSpace(header) == "" {
-		return "", false
-	}
-
+// This matches modelcontextprotocol/go-sdk, whose Streamable HTTP handler
+// rejects any POST whose base media type is not application/json with 415
+// (streamable.go:388). That handler already serves Gram's own /platform-mcp
+// endpoint, so anything laxer here would leave the hosted MCP surfaces more
+// permissive than one we already ship.
+//
+// An absent or unparseable header fails closed. Every conforming MCP client
+// sends application/json (the go-sdk client sets it unconditionally), so a
+// request without it is not a client this transport supports. Rejecting it
+// also closes the CORS-simple-request bypass, where a JSON-RPC body sent as
+// text/plain reaches a handler having never been preflighted.
+func isJSONRequest(header string) bool {
 	mediaType, _, err := mime.ParseMediaType(header)
 	if err != nil {
-		bare, _, _ := strings.Cut(header, ";")
-		mediaType = strings.ToLower(strings.TrimSpace(bare))
+		return false
 	}
-
-	_, disallowed := simpleRequestContentTypes[mediaType]
-	return mediaType, disallowed
+	return mediaType == "application/json"
 }
 
 // logMCPSecurityRejection records a rejection with enough context to tell an

--- a/server/internal/middleware/mcp_security.go
+++ b/server/internal/middleware/mcp_security.go
@@ -1,0 +1,179 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// simpleRequestContentTypes are the three media types a browser can send on a
+// cross-origin POST without triggering a CORS preflight (the Fetch spec's
+// "CORS-safelisted request-header" set for Content-Type). A JSON-RPC body sent
+// under one of these reaches an MCP handler having never been preflighted, so
+// on the surfaces whose only protection was the preflight it bypassed the
+// check entirely.
+//
+// This is deliberately a denylist of the bypass vector rather than an
+// allowlist of application/json. Requiring application/json would reject
+// conforming non-browser callers for no real gain: `curl -d @body.json` with
+// no -H sends application/x-www-form-urlencoded, and a bare POST with no
+// Content-Type at all is common in hand-rolled integrations.
+//
+// An absent Content-Type is allowed even though a browser CAN produce one
+// un-preflighted (fetch with a Uint8Array or a type-less Blob body sends no
+// Content-Type). That case is covered by the Origin check above, which is the
+// real control here; this check is defence in depth for the pre-Sec-Fetch-Site
+// browsers that the Origin check falls back to Host comparison for. Rejecting
+// an absent header would break real clients to close nothing.
+var simpleRequestContentTypes = map[string]struct{}{
+	"text/plain":                        {},
+	"multipart/form-data":               {},
+	"application/x-www-form-urlencoded": {},
+}
+
+// MCPSecurity enforces the MCP Streamable HTTP transport's browser-facing
+// security requirements on the MCP JSON-RPC endpoints: Origin validation
+// (2025-11-25 and 2026-07-28 both make this a MUST, answered with 403) and
+// rejection of the un-preflighted Content-Type values that would otherwise
+// route around it.
+//
+// Origin validation delegates to net/http.CrossOriginProtection, which decides
+// cross-origin-ness from Sec-Fetch-Site (sent by every browser since 2023 and
+// not settable from JavaScript), falling back to comparing the Origin host
+// with Host. Crucially it allows requests carrying neither header, so native
+// MCP clients — Claude Desktop, Cursor, CLI tools — pass untouched and no
+// per-server origin configuration is needed. Note that the pinned
+// modelcontextprotocol/go-sdk v1.7.0 does NOT do this for you: its
+// StreamableHTTPOptions.CrossOriginProtection defaults to nil and is only
+// populated when MCPGODEBUG=enableoriginverification=1 (streamable.go:243),
+// which this deployment does not set — so /platform-mcp, which is served by
+// that handler, depends on this middleware too.
+//
+// Two categories of legitimate cross-origin browser traffic are exempt:
+//
+//   - Gram Elements, embedded on customer domains. Those requests carry a
+//     chat-session token whose audience claim names the embedding origin;
+//     chatSessionsCORS validates Origin against that claim and marks the
+//     request trusted (see markChatSessionOriginTrusted). The audience claim,
+//     not this middleware, is the trusted-origin mechanism for Elements.
+//   - The Gram first-party origins passed as trustedOrigins. The dashboard's
+//     MCP inspection tabs connect to a customer's *custom domain*, which is
+//     cross-site from app.getgram.ai and cannot be rebased onto the Gram
+//     origin — mcp_endpoint rows are looked up by (slug, custom_domain_id),
+//     so the same slug does not resolve on the platform host. Trusting our own
+//     origin costs nothing an attacker could use: MCP auth reads only
+//     Authorization and Gram-Chat-Session, never cookies, so a request forged
+//     from app.getgram.ai carries no ambient credential to replay.
+//
+// Registration must come after CORSMiddleware so this runs downstream of
+// chatSessionsCORS and can observe the trust marker it sets. Non-MCP routes
+// are untouched; OPTIONS preflights never reach here for /mcp because
+// chatSessionsCORS answers them itself.
+func MCPSecurity(logger *slog.Logger, trustedOrigins []string) (func(http.Handler) http.Handler, error) {
+	protection := http.NewCrossOriginProtection()
+	for _, origin := range trustedOrigins {
+		if origin == "" {
+			continue
+		}
+		normalized, err := normalizeOrigin(origin)
+		if err != nil {
+			return nil, err
+		}
+		if err := protection.AddTrustedOrigin(normalized); err != nil {
+			return nil, fmt.Errorf("add trusted origin %q: %w", normalized, err)
+		}
+	}
+
+	logger = logger.With(attr.SlogComponent("mcp-security"))
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isMCPJSONRPCEndpoint(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !chatSessionOriginTrusted(r.Context()) {
+				if err := protection.Check(r); err != nil {
+					logMCPSecurityRejection(r, logger, "cross_origin", err.Error())
+					http.Error(w, "forbidden: cross-origin request rejected", http.StatusForbidden)
+					return
+				}
+			}
+
+			if r.Method == http.MethodPost {
+				if mediaType, ok := disallowedRequestMediaType(r.Header.Get("Content-Type")); ok {
+					logMCPSecurityRejection(r, logger, "content_type", mediaType)
+					http.Error(w, "unsupported media type: send MCP requests as application/json", http.StatusUnsupportedMediaType)
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}, nil
+}
+
+// normalizeOrigin reduces a configured URL to the bare scheme://host form
+// AddTrustedOrigin demands. server-url and site-url are ordinary URL flags
+// everywhere else in the server and a trailing slash is legal in them, but
+// AddTrustedOrigin rejects any path at all — including "/" — so passing one
+// through unnormalized would refuse to boot the server.
+func normalizeOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse trusted origin %q: %w", raw, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("trusted origin %q needs a scheme and host", raw)
+	}
+	return parsed.Scheme + "://" + parsed.Host, nil
+}
+
+// disallowedRequestMediaType reports whether a Content-Type header names one
+// of the CORS-simple media types, returning the media type for telemetry. An
+// empty header is allowed (see simpleRequestContentTypes).
+//
+// A header Go cannot parse falls back to the bare type token rather than being
+// waved through. Fetch's CORS-safelist check uses a more lenient MIME parser
+// than mime.ParseMediaType, so values Go rejects — "text/plain;;",
+// "multipart/form-data; boundary=", a duplicated charset parameter — are still
+// sent un-preflighted by a browser and would otherwise walk straight past this
+// check.
+func disallowedRequestMediaType(header string) (string, bool) {
+	if strings.TrimSpace(header) == "" {
+		return "", false
+	}
+
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		bare, _, _ := strings.Cut(header, ";")
+		mediaType = strings.ToLower(strings.TrimSpace(bare))
+	}
+
+	_, disallowed := simpleRequestContentTypes[mediaType]
+	return mediaType, disallowed
+}
+
+// logMCPSecurityRejection records a rejection with enough context to tell an
+// attack apart from a first-party client that lost its exemption. Enforcement
+// ships without a staged rollout, so this log is the only signal available for
+// answering "did we break someone" — keep it on every rejection path.
+func logMCPSecurityRejection(r *http.Request, logger *slog.Logger, reason, detail string) {
+	logger.InfoContext(r.Context(), "rejected mcp request",
+		attr.SlogReason(reason),
+		attr.SlogErrorMessage(detail),
+		attr.SlogHTTPRequestMethod(r.Method),
+		attr.SlogURLOriginal(r.URL.Path),
+		attr.SlogHTTPRequestHeaderOrigin(r.Header.Get("Origin")),
+		attr.SlogHTTPRequestHeaderSecFetchSite(r.Header.Get("Sec-Fetch-Site")),
+		attr.SlogHTTPRequestHeaderContentType(r.Header.Get("Content-Type")),
+		attr.SlogHostName(r.Host),
+		attr.SlogHTTPRequestHeaderUserAgent(r.Header.Get("User-Agent")),
+	)
+}

--- a/server/internal/middleware/mcp_security_test.go
+++ b/server/internal/middleware/mcp_security_test.go
@@ -150,17 +150,40 @@ func TestMCPSecurity_RejectsCrossSiteDelete(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, rec.Code)
 }
 
-// GET opens the Streamable HTTP SSE stream. The stdlib treats safe methods as
-// always allowed, so this is knowingly not covered — documented here so the
-// gap is visible rather than assumed closed.
-func TestMCPSecurity_AllowsCrossSiteGetAsSafeMethod(t *testing.T) {
+// GET opens the Streamable HTTP SSE stream, and against a proxy-backed server
+// establishes a session upstream. The spec's Origin MUST is not method-scoped,
+// so safe-method exemption does not apply here.
+func TestMCPSecurity_RejectsCrossSiteGet(t *testing.T) {
 	t.Parallel()
 
 	req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil)
 	req.Header.Set("Sec-Fetch-Site", "cross-site")
 	req.Header.Set("Origin", hostileOrigin)
 
+	rec, reached := serveMCPSecurity(t, req)
+
+	require.False(t, reached, "a cross-site SSE GET must not open a stream")
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestMCPSecurity_AllowsSameOriginGet(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil)
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("Origin", gramOrigin)
+
 	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached)
+}
+
+// A native client polling the SSE stream sends no browser fetch metadata and
+// must keep working.
+func TestMCPSecurity_AllowsNonBrowserGet(t *testing.T) {
+	t.Parallel()
+
+	_, reached := serveMCPSecurity(t, httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil))
 
 	require.True(t, reached)
 }
@@ -228,6 +251,10 @@ func TestMCPSecurity_ContentType(t *testing.T) {
 		contentType string
 		wantStatus  int
 	}{
+		{name: "json", contentType: "application/json", wantStatus: http.StatusOK},
+		{name: "json with charset", contentType: "application/json; charset=utf-8", wantStatus: http.StatusOK},
+		{name: "json uppercase", contentType: "APPLICATION/JSON", wantStatus: http.StatusOK},
+
 		// The CORS-simple set: these reach a handler without a preflight, so
 		// they are how the Origin check would be routed around.
 		{name: "text/plain", contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
@@ -235,20 +262,12 @@ func TestMCPSecurity_ContentType(t *testing.T) {
 		{name: "form urlencoded", contentType: "application/x-www-form-urlencoded", wantStatus: http.StatusUnsupportedMediaType},
 		{name: "multipart", contentType: "multipart/form-data; boundary=x", wantStatus: http.StatusUnsupportedMediaType},
 
-		// Fetch safelists these without a preflight, but mime.ParseMediaType
-		// rejects them. Falling back to the bare type token keeps them closed.
-		{name: "text/plain empty params", contentType: "text/plain;;", wantStatus: http.StatusUnsupportedMediaType},
-		{name: "text/plain bare param", contentType: "text/plain; x", wantStatus: http.StatusUnsupportedMediaType},
-		{name: "text/plain duplicate charset", contentType: "text/plain; charset=utf-8; charset=iso-8859-1", wantStatus: http.StatusUnsupportedMediaType},
-		{name: "multipart empty boundary", contentType: "multipart/form-data; boundary=", wantStatus: http.StatusUnsupportedMediaType},
-		{name: "uppercase text/plain", contentType: "TEXT/PLAIN", wantStatus: http.StatusUnsupportedMediaType},
-
-		// Everything else passes. Requiring application/json outright would
-		// reject conforming non-browser clients for no security gain.
-		{name: "json", contentType: "application/json", wantStatus: http.StatusOK},
-		{name: "json with charset", contentType: "application/json; charset=utf-8", wantStatus: http.StatusOK},
-		{name: "absent", contentType: "", wantStatus: http.StatusOK},
-		{name: "unparseable non-safelisted", contentType: "application/json;;", wantStatus: http.StatusOK},
+		// Absent and unparseable fail closed. Every conforming MCP client
+		// sends application/json.
+		{name: "absent", contentType: "", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "unparseable", contentType: "text/plain;;", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "json unparseable params", contentType: "application/json;;", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "json-rpc", contentType: "application/json-rpc", wantStatus: http.StatusUnsupportedMediaType},
 	}
 
 	for _, tt := range tests {
@@ -279,38 +298,47 @@ func TestMCPSecurity_ContentTypeOnlyCheckedForPost(t *testing.T) {
 	require.True(t, reached)
 }
 
+// A browser sends a lowercased host and omits the scheme's default port, so a
+// flag carrying either would register an origin nothing can match.
+func TestMCPSecurity_CanonicalizesTrustedOrigins(t *testing.T) {
+	t.Parallel()
+
+	for _, configured := range []string{
+		"https://APP.getgram.ai",
+		"https://app.getgram.ai:443",
+		"https://app.getgram.ai/",
+	} {
+		t.Run(configured, func(t *testing.T) {
+			t.Parallel()
+
+			mw, err := MCPSecurity(testenv.NewLogger(t), []string{configured})
+			require.NoError(t, err)
+
+			reached := false
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "https://mcp.customer.com/mcp/petstore", strings.NewReader("{}"))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Origin", gramOrigin)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			require.True(t, reached, "configured origin %q must match the browser's Origin header", configured)
+		})
+	}
+}
+
 func TestMCPSecurity_RejectsInvalidTrustedOrigin(t *testing.T) {
 	t.Parallel()
 
 	_, err := MCPSecurity(testenv.NewLogger(t), []string{"app.getgram.ai"})
 
 	require.Error(t, err, "an origin without a scheme must fail at construction, not silently at runtime")
-}
-
-// server-url and site-url are ordinary URL flags elsewhere and may carry a
-// trailing slash; AddTrustedOrigin rejects any path, so an unnormalized value
-// would refuse to boot the server.
-func TestMCPSecurity_NormalizesTrustedOrigins(t *testing.T) {
-	t.Parallel()
-
-	mw, err := MCPSecurity(testenv.NewLogger(t), []string{"https://app.getgram.ai/"})
-	require.NoError(t, err)
-
-	reached := false
-	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reached = true
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	req := httptest.NewRequest(http.MethodPost, "https://mcp.customer.com/mcp/petstore", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Sec-Fetch-Site", "cross-site")
-	req.Header.Set("Origin", gramOrigin)
-
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	require.True(t, reached, "a trailing slash in the flag must still yield a usable trusted origin")
 }
 
 func TestMCPSecurity_SkipsEmptyTrustedOrigins(t *testing.T) {

--- a/server/internal/middleware/mcp_security_test.go
+++ b/server/internal/middleware/mcp_security_test.go
@@ -1,0 +1,322 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+const (
+	gramOrigin     = "https://app.getgram.ai"
+	hostileOrigin  = "https://evil.example.com"
+	elementsOrigin = "https://docs.customer.com"
+)
+
+func newMCPSecurity(t *testing.T) func(http.Handler) http.Handler {
+	t.Helper()
+
+	mw, err := MCPSecurity(
+		testenv.NewLogger(t),
+		[]string{gramOrigin, "https://localhost:5173"},
+	)
+	require.NoError(t, err)
+	return mw
+}
+
+// serveMCPSecurity runs a request through the middleware and reports whether
+// the downstream handler was reached, alongside the recorded response.
+func serveMCPSecurity(t *testing.T, req *http.Request) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+
+	reached := false
+	handler := newMCPSecurity(t)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec, reached
+}
+
+func mcpPost(path string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai"+path, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// A native MCP client (Claude Desktop, Cursor, a CLI) sends neither
+// Sec-Fetch-Site nor Origin. The stdlib fails open for those, which is what
+// makes this protection deployable without per-server origin configuration.
+func TestMCPSecurity_AllowsNonBrowserClient(t *testing.T) {
+	t.Parallel()
+
+	_, reached := serveMCPSecurity(t, mcpPost("/mcp/petstore"))
+
+	require.True(t, reached, "a request with no browser fetch metadata must pass")
+}
+
+func TestMCPSecurity_AllowsSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	req := mcpPost("/mcp/petstore")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	req.Header.Set("Origin", gramOrigin)
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached)
+}
+
+// The exposure this issue exists to close: a hostile page driving a
+// credential-free public MCP server from a victim's browser.
+func TestMCPSecurity_RejectsCrossSitePost(t *testing.T) {
+	t.Parallel()
+
+	req := mcpPost("/mcp/petstore")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", hostileOrigin)
+
+	rec, reached := serveMCPSecurity(t, req)
+
+	require.False(t, reached, "handler must not run for a cross-site request")
+	require.Equal(t, http.StatusForbidden, rec.Code, "the MCP spec requires 403 for an invalid Origin")
+}
+
+// same-site is not same-origin: the stdlib rejects it, which is why local dev
+// (dashboard and server on different ports of localhost) needs the site URL in
+// the trusted set.
+func TestMCPSecurity_RejectsSameSiteFromUntrustedOrigin(t *testing.T) {
+	t.Parallel()
+
+	req := mcpPost("/mcp/petstore")
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("Origin", "https://other.getgram.ai")
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.False(t, reached)
+}
+
+// The dashboard's MCP inspection tabs connect to a customer's custom domain,
+// which is cross-site from the Gram origin and cannot be rebased onto the
+// platform host because mcp_endpoint rows resolve by (slug, custom_domain_id).
+func TestMCPSecurity_AllowsTrustedGramOriginCrossSite(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "https://mcp.customer.com/mcp/petstore", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", gramOrigin)
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached, "the Gram first-party origin must reach a custom domain")
+}
+
+// Elements is embedded on customer domains and is genuinely cross-site. Its
+// exemption comes from the chat-session audience claim, proven upstream in
+// chatSessionsCORS and carried on the request context.
+func TestMCPSecurity_AllowsChatSessionTrustedOrigin(t *testing.T) {
+	t.Parallel()
+
+	req := mcpPost("/mcp/petstore")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", elementsOrigin)
+	req = markChatSessionOriginTrusted(req)
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached, "an audience-validated Elements request must pass")
+}
+
+// DELETE terminates an MCP session and, for a proxy-backed server, tears down
+// the real upstream session. It is not a safe method, so it is covered.
+func TestMCPSecurity_RejectsCrossSiteDelete(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodDelete, "https://app.getgram.ai/mcp/petstore", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", hostileOrigin)
+
+	rec, reached := serveMCPSecurity(t, req)
+
+	require.False(t, reached)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// GET opens the Streamable HTTP SSE stream. The stdlib treats safe methods as
+// always allowed, so this is knowingly not covered — documented here so the
+// gap is visible rather than assumed closed.
+func TestMCPSecurity_AllowsCrossSiteGetAsSafeMethod(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", hostileOrigin)
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached)
+}
+
+// Protection is attached to the shared route, not to a backend. /mcp/{slug}
+// fronts both toolset-backed and meta-MCP-backed servers, so a later backend
+// addition cannot silently regress out of coverage.
+func TestMCPSecurity_CoversEveryMCPJSONRPCRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/petstore",              // toolset-backed and meta-MCP-backed
+		"/x/mcp/petstore",            // experimental runtime
+		"/platform/mcp/gram-billing", // platform toolsets
+		"/platform-mcp",              // Gram's own platform MCP server
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := mcpPost(path)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Origin", hostileOrigin)
+
+			rec, reached := serveMCPSecurity(t, req)
+
+			require.False(t, reached)
+			require.Equal(t, http.StatusForbidden, rec.Code)
+		})
+	}
+}
+
+// The OAuth, metadata, and install routes share the /mcp/ prefix but are not
+// JSON-RPC endpoints; they have their own browser-facing flows.
+func TestMCPSecurity_IgnoresNonJSONRPCRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/petstore/token",
+		"/mcp/petstore/register",
+		"/mcp/petstore/connect",
+		"/platform-mcp/authorize",
+		"/platform-mcp/token",
+		"/platform-mcp/provider-setup",
+		"/rpc/chatSessions.create",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := mcpPost(path)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Origin", hostileOrigin)
+
+			_, reached := serveMCPSecurity(t, req)
+
+			require.True(t, reached, "non-JSON-RPC routes must be untouched")
+		})
+	}
+}
+
+func TestMCPSecurity_ContentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+		wantStatus  int
+	}{
+		// The CORS-simple set: these reach a handler without a preflight, so
+		// they are how the Origin check would be routed around.
+		{name: "text/plain", contentType: "text/plain", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "text/plain with charset", contentType: "text/plain;charset=UTF-8", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "form urlencoded", contentType: "application/x-www-form-urlencoded", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "multipart", contentType: "multipart/form-data; boundary=x", wantStatus: http.StatusUnsupportedMediaType},
+
+		// Fetch safelists these without a preflight, but mime.ParseMediaType
+		// rejects them. Falling back to the bare type token keeps them closed.
+		{name: "text/plain empty params", contentType: "text/plain;;", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "text/plain bare param", contentType: "text/plain; x", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "text/plain duplicate charset", contentType: "text/plain; charset=utf-8; charset=iso-8859-1", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "multipart empty boundary", contentType: "multipart/form-data; boundary=", wantStatus: http.StatusUnsupportedMediaType},
+		{name: "uppercase text/plain", contentType: "TEXT/PLAIN", wantStatus: http.StatusUnsupportedMediaType},
+
+		// Everything else passes. Requiring application/json outright would
+		// reject conforming non-browser clients for no security gain.
+		{name: "json", contentType: "application/json", wantStatus: http.StatusOK},
+		{name: "json with charset", contentType: "application/json; charset=utf-8", wantStatus: http.StatusOK},
+		{name: "absent", contentType: "", wantStatus: http.StatusOK},
+		{name: "unparseable non-safelisted", contentType: "application/json;;", wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "https://app.getgram.ai/mcp/petstore", strings.NewReader("{}"))
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+
+			rec, _ := serveMCPSecurity(t, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
+
+// A GET carries no body, so Content-Type is not consulted for it.
+func TestMCPSecurity_ContentTypeOnlyCheckedForPost(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai/mcp/petstore", nil)
+	req.Header.Set("Content-Type", "text/plain")
+
+	_, reached := serveMCPSecurity(t, req)
+
+	require.True(t, reached)
+}
+
+func TestMCPSecurity_RejectsInvalidTrustedOrigin(t *testing.T) {
+	t.Parallel()
+
+	_, err := MCPSecurity(testenv.NewLogger(t), []string{"app.getgram.ai"})
+
+	require.Error(t, err, "an origin without a scheme must fail at construction, not silently at runtime")
+}
+
+// server-url and site-url are ordinary URL flags elsewhere and may carry a
+// trailing slash; AddTrustedOrigin rejects any path, so an unnormalized value
+// would refuse to boot the server.
+func TestMCPSecurity_NormalizesTrustedOrigins(t *testing.T) {
+	t.Parallel()
+
+	mw, err := MCPSecurity(testenv.NewLogger(t), []string{"https://app.getgram.ai/"})
+	require.NoError(t, err)
+
+	reached := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://mcp.customer.com/mcp/petstore", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	req.Header.Set("Origin", gramOrigin)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, reached, "a trailing slash in the flag must still yield a usable trusted origin")
+}
+
+func TestMCPSecurity_SkipsEmptyTrustedOrigins(t *testing.T) {
+	t.Parallel()
+
+	_, err := MCPSecurity(testenv.NewLogger(t), []string{"", gramOrigin})
+
+	require.NoError(t, err, "an unset server-url or site-url flag must not break startup")
+}

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -60,6 +60,7 @@ func isSkippedRequestHeader(name string) bool {
 		"sec-fetch-dest",
 		"sec-fetch-mode",
 		"sec-fetch-site",
+		"sec-fetch-user",
 		"te",
 		"trailer",
 		"transfer-encoding",

--- a/server/internal/remotemcp/proxy/headers.go
+++ b/server/internal/remotemcp/proxy/headers.go
@@ -51,6 +51,15 @@ func isSkippedRequestHeader(name string) bool {
 		"proxy-authenticate",
 		"proxy-authorization",
 		"referer",
+		// Sec-Fetch-* describe the dashboard's own fetch, not the caller's
+		// intent toward the upstream, and are dropped for the same reason as
+		// Origin above. Forwarding them is doubly wrong now that Gram enforces
+		// the same protection inbound: "cross-site" 403s any upstream running
+		// net/http.CrossOriginProtection, while "same-origin" would falsely
+		// satisfy that upstream's check on Gram's behalf.
+		"sec-fetch-dest",
+		"sec-fetch-mode",
+		"sec-fetch-site",
 		"te",
 		"trailer",
 		"transfer-encoding",


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-49/fix-validate-origin-and-content-type-on-mcp-endpoints

## Summary

Adds an `MCPSecurity` middleware over all four inbound MCP JSON-RPC surfaces (`/mcp/{slug}`, `/x/mcp/{slug}`, `/platform/mcp/{slug}`, `/platform-mcp`), delegating to `net/http.CrossOriginProtection`. Requests carrying neither `Sec-Fetch-Site` nor `Origin` are allowed, so native MCP clients pass untouched and no per-server origin configuration is needed. POSTs using one of the three CORS-simple media types are rejected with 415, closing the un-preflighted bypass around the Origin check.

`/platform-mcp` previously had no protection at all: it fell outside the route predicate, and the go-sdk v1.7.0 handler behind it leaves `CrossOriginProtection` nil unless `MCPGODEBUG enableoriginverification` is set. It is now covered, and gains the protocol-version telemetry it was also missing.

Legitimate cross-origin browser traffic keeps working. Elements is embedded on customer domains and carries a chat-session token whose audience claim names the embedding origin, which `chatSessionsCORS` validates and then marks exempt. The Gram first-party origins are trusted so the dashboard MCP inspection tabs can reach a custom domain, which cannot be rebased onto the platform host because `mcp_endpoint` rows resolve by slug plus custom domain.

Three smaller changes ride along:

- Narrow the `Gram-Key` `Access-Control-Allow-Origin` echo to the routes that consume that header. Nothing under `internal/mcp` or `internal/xmcp` reads `Gram-Key`, so on MCP routes the echo authenticated nothing while letting a page that attached a dummy key read `tools/list` and `tools/call` responses from a public server cross-site.
- Strip `Sec-Fetch-*` when proxying to a remote MCP server, alongside `Origin` and `Referer`. Forwarding `cross-site` would 403 any upstream running the same protection, and `same-origin` would falsely satisfy that upstream's check on Gram's behalf.
- `chatSessionsCORS` takes a `ChatSessionValidator` interface rather than `*chatsessions.Manager`, keeping the middleware package free of Redis and making the Elements audience path unit-testable for the first time.

## Motivation

Gram validated neither the `Origin` header nor `Content-Type` on any MCP JSON-RPC endpoint, so a hostile page could drive `initialize`, `tools/list`, and `tools/call` against a credential-free public MCP server from a victim's browser. Both the 2025-11-25 and 2026-07-28 specs make Origin validation a MUST answered with 403.

`CrossOriginProtection` was chosen over a per-server origin allowlist because it needs no configuration and no schema change: it detects cross-origin requests from `Sec-Fetch-Site`, which every browser has sent since 2023 and which is not settable from JavaScript, and it fails open for callers that send no browser fetch metadata. A public multi-tenant host has no knowable set of legitimate client origins, so an allowlist would have pushed that burden onto every customer publishing a public server.

Note this deliberately does not claim full spec compliance: GET stays exempt under the standard library's safe-method model, which leaves the Streamable HTTP SSE stream uncovered. That gap is pinned by a test so it stays visible rather than assumed closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Origin and Content-Type validation on all MCP JSON-RPC endpoints so a hostile page can no longer drive `initialize`, `tools/list`, and `tools/call` against a credential-free public MCP server from a victim's browser. Cross-origin browser requests now get the 403 the MCP spec requires, and POSTs must be `application/json` or get 415; native MCP clients pass untouched and legitimate cross-origin traffic (Elements, dashboard inspection tabs) keeps working.

**Bug Fixes**
- New `MCPSecurity` middleware delegates cross-origin detection to `net/http.CrossOriginProtection` on `/mcp/{slug}`, `/x/mcp/{slug}`, `/platform/mcp/{slug}`, and `/platform-mcp`.
- `/platform-mcp` previously had no protection at all and now also gets protocol-version telemetry.
- POSTs must declare `application/json`; absent or unparseable `Content-Type` headers fail closed, closing the un-preflighted bypass.
- GET and HEAD are covered too, since a cross-site GET opens the SSE stream and can establish an upstream session.

**Refactors**
- `Gram-Key` CORS echo narrowed to routes that consume it, so MCP responses are no longer readable cross-site.
- `Sec-Fetch-*` headers stripped when proxying to remote MCP servers so upstreams running the same protection don't misjudge the request.
- `chatSessionsCORS` now takes a `ChatSessionValidator` interface, making the middleware testable without Redis.
- Trusted origins are canonicalized so configured URLs match the browser-sent `Origin` header byte for byte.

<sup>Written for commit e3c86ada63c7681f0d041d481429654819eb41db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

