### PR TITLE
feat: add AI detection target catalog and ai_scan_interval_seconds config key

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -85773,7 +85773,7 @@ components:
       properties:
         config:
           type: object
-          description: Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, and sync_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
+          description: Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, sync_interval_seconds, and ai_scan_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
           additionalProperties: true
       required:
         - config

--- a/client/dashboard/src/sdk/src/models/components/updateconfigurationrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/updateconfigurationrequestbody.ts
@@ -6,7 +6,7 @@ import * as z from "zod/v4-mini";
 
 export type UpdateConfigurationRequestBody = {
   /**
-   * Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, and sync_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
+   * Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, sync_interval_seconds, and ai_scan_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
    */
   config: { [k: string]: any };
 };

--- a/server/design/agent/design.go
+++ b/server/design/agent/design.go
@@ -131,7 +131,7 @@ var _ = Service("agent", func() {
 
 		Payload(func() {
 			security.SessionPayload()
-			Attribute("config", MapOf(String, Any), "Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, and sync_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.")
+			Attribute("config", MapOf(String, Any), "Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, sync_interval_seconds, and ai_scan_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.")
 			Required("config")
 		})
 

--- a/server/gen/agent/service.go
+++ b/server/gen/agent/service.go
@@ -297,10 +297,10 @@ type SyncedAgentUser struct {
 type UpdateConfigurationPayload struct {
 	SessionToken *string
 	// Shareable device-agent settings. Supported keys include platforms,
-	// update_channel, auto_update, pinned_target, blocked_versions, and
-	// sync_interval_seconds. update_channel and blocked_versions can only be set
-	// by Speakeasy platform administrators; per-device identity and secret keys
-	// are forbidden.
+	// update_channel, auto_update, pinned_target, blocked_versions,
+	// sync_interval_seconds, and ai_scan_interval_seconds. update_channel and
+	// blocked_versions can only be set by Speakeasy platform administrators;
+	// per-device identity and secret keys are forbidden.
 	Config map[string]any
 }
 

--- a/server/gen/http/agent/client/types.go
+++ b/server/gen/http/agent/client/types.go
@@ -16,10 +16,10 @@ import (
 // "updateConfiguration" endpoint HTTP request body.
 type UpdateConfigurationRequestBody struct {
 	// Shareable device-agent settings. Supported keys include platforms,
-	// update_channel, auto_update, pinned_target, blocked_versions, and
-	// sync_interval_seconds. update_channel and blocked_versions can only be set
-	// by Speakeasy platform administrators; per-device identity and secret keys
-	// are forbidden.
+	// update_channel, auto_update, pinned_target, blocked_versions,
+	// sync_interval_seconds, and ai_scan_interval_seconds. update_channel and
+	// blocked_versions can only be set by Speakeasy platform administrators;
+	// per-device identity and secret keys are forbidden.
 	Config map[string]any `form:"config" json:"config" xml:"config"`
 }
 

--- a/server/gen/http/agent/server/types.go
+++ b/server/gen/http/agent/server/types.go
@@ -18,10 +18,10 @@ import (
 // "updateConfiguration" endpoint HTTP request body.
 type UpdateConfigurationRequestBody struct {
 	// Shareable device-agent settings. Supported keys include platforms,
-	// update_channel, auto_update, pinned_target, blocked_versions, and
-	// sync_interval_seconds. update_channel and blocked_versions can only be set
-	// by Speakeasy platform administrators; per-device identity and secret keys
-	// are forbidden.
+	// update_channel, auto_update, pinned_target, blocked_versions,
+	// sync_interval_seconds, and ai_scan_interval_seconds. update_channel and
+	// blocked_versions can only be set by Speakeasy platform administrators;
+	// per-device identity and secret keys are forbidden.
 	Config map[string]any `form:"config,omitempty" json:"config,omitempty" xml:"config,omitempty"`
 }
 

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -87316,7 +87316,7 @@ components:
             properties:
                 config:
                     type: object
-                    description: Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, and sync_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
+                    description: Shareable device-agent settings. Supported keys include platforms, update_channel, auto_update, pinned_target, blocked_versions, sync_interval_seconds, and ai_scan_interval_seconds. update_channel and blocked_versions can only be set by Speakeasy platform administrators; per-device identity and secret keys are forbidden.
                     additionalProperties: true
             required:
                 - config

--- a/server/internal/agent/aitargets/aitargets.go
+++ b/server/internal/agent/aitargets/aitargets.go
@@ -1,0 +1,76 @@
+// Package aitargets is the code-owned catalog of AI developer tools the
+// device agent's AI scan can report (Shadow AI detection). The catalog is
+// server-side only: agents compile their own scan target lists into the
+// binary, so this package's consumers are the ingest and read paths — the
+// read API decorates display names and categories from it — plus the demo
+// seed and dashboard. Target ids align with the dashboard's
+// PRODUCT_SURFACE_LABELS keys in client/dashboard/src/lib/formatPlatform.ts
+// where a surface already exists there, and with the ids the device agent's
+// compiled-in list reports.
+package aitargets
+
+import "sync"
+
+// Category classifies what kind of AI tool a target is.
+type Category string
+
+const (
+	// CategoryHarness is an agentic coding tool or AI IDE (e.g. Claude Code,
+	// Cursor).
+	CategoryHarness Category = "harness"
+
+	// CategoryLocalModel is a local model runtime (e.g. Ollama, LM Studio).
+	CategoryLocalModel Category = "local_model"
+)
+
+// Target is one AI tool the catalog knows.
+type Target struct {
+	// ID is the stable catalog identifier scan reports and reads key on.
+	// Never reuse an id for a different tool.
+	ID string
+
+	// DisplayName is the human-readable name surfaced in the dashboard.
+	DisplayName string
+
+	// Category classifies the target.
+	Category Category
+}
+
+// targets is the catalog. Keep ids aligned with the dashboard's
+// PRODUCT_SURFACE_LABELS keys where the surface exists there and with the
+// device agent's compiled-in scan target list.
+var targets = []Target{
+	{ID: "claude-code", DisplayName: "Claude Code", Category: CategoryHarness},
+	{ID: "cursor", DisplayName: "Cursor", Category: CategoryHarness},
+	{ID: "codex", DisplayName: "Codex", Category: CategoryHarness},
+	{ID: "gemini-cli", DisplayName: "Gemini CLI", Category: CategoryHarness},
+	{ID: "windsurf", DisplayName: "Windsurf", Category: CategoryHarness},
+	{ID: "aider", DisplayName: "Aider", Category: CategoryHarness},
+	{ID: "opencode", DisplayName: "opencode", Category: CategoryHarness},
+	{ID: "openclaw", DisplayName: "OpenClaw", Category: CategoryHarness},
+	{ID: "ollama", DisplayName: "Ollama", Category: CategoryLocalModel},
+	{ID: "lmstudio", DisplayName: "LM Studio", Category: CategoryLocalModel},
+}
+
+var targetsByID = sync.OnceValue(func() map[string]Target {
+	byID := make(map[string]Target, len(targets))
+	for _, target := range targets {
+		byID[target.ID] = target
+	}
+	return byID
+})
+
+// Targets returns the catalog target list as a copy.
+func Targets() []Target {
+	out := make([]Target, len(targets))
+	copy(out, targets)
+	return out
+}
+
+// ByID resolves a catalog target by id. Ids the catalog does not know — for
+// example from an agent binary compiled with a newer target list — resolve
+// to ok=false; callers fall back to the raw reported values.
+func ByID(id string) (Target, bool) {
+	target, ok := targetsByID()[id]
+	return target, ok
+}

--- a/server/internal/agent/aitargets/aitargets_test.go
+++ b/server/internal/agent/aitargets/aitargets_test.go
@@ -1,0 +1,60 @@
+package aitargets_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/agent/aitargets"
+)
+
+func TestTargetsAreWellFormed(t *testing.T) {
+	t.Parallel()
+
+	targets := aitargets.Targets()
+	require.NotEmpty(t, targets)
+
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		_, duplicate := seen[target.ID]
+		assert.False(t, duplicate, "duplicate target id %q", target.ID)
+		seen[target.ID] = struct{}{}
+
+		assert.NotEmpty(t, target.ID, "target id must be set")
+		assert.Equal(t, strings.ToLower(target.ID), target.ID, "target id %q must be lowercase", target.ID)
+		assert.NotContains(t, target.ID, " ", "target id %q must not contain spaces", target.ID)
+		assert.NotEmpty(t, target.DisplayName, "target %q must have a display name", target.ID)
+		assert.Contains(t,
+			[]aitargets.Category{aitargets.CategoryHarness, aitargets.CategoryLocalModel},
+			target.Category,
+			"target %q has unknown category %q", target.ID, target.Category,
+		)
+	}
+}
+
+func TestByIDResolvesEveryTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range aitargets.Targets() {
+		resolved, ok := aitargets.ByID(target.ID)
+		require.True(t, ok, "target %q must resolve", target.ID)
+		assert.Equal(t, target, resolved)
+	}
+
+	_, ok := aitargets.ByID("definitely-not-a-target")
+	assert.False(t, ok)
+}
+
+// TestTargetsReturnsACopy guards the accessor against callers mutating the
+// package-level catalog.
+func TestTargetsReturnsACopy(t *testing.T) {
+	t.Parallel()
+
+	first := aitargets.Targets()
+	first[0].DisplayName = "mutated"
+
+	fresh := aitargets.Targets()
+	assert.NotEqual(t, "mutated", fresh[0].DisplayName)
+}

--- a/server/internal/agent/configuration.go
+++ b/server/internal/agent/configuration.go
@@ -37,12 +37,13 @@ var forbiddenDeviceAgentConfigurationKeys = map[string]struct{}{
 // while any other stored key is preserved so a server that predates a setting
 // cannot delete it on behalf of a client that never saw it.
 var knownDeviceAgentConfigurationKeys = map[string]struct{}{
-	"platforms":             {},
-	"update_channel":        {},
-	"auto_update":           {},
-	"pinned_target":         {},
-	"blocked_versions":      {},
-	"sync_interval_seconds": {},
+	"platforms":                {},
+	"update_channel":           {},
+	"auto_update":              {},
+	"pinned_target":            {},
+	"blocked_versions":         {},
+	"sync_interval_seconds":    {},
+	"ai_scan_interval_seconds": {},
 }
 
 // platformAdminOnlyDeviceAgentConfigurationKeys are Speakeasy-internal
@@ -131,16 +132,19 @@ func validateDeviceAgentConfiguration(config map[string]any) ([]byte, error) {
 		}
 	}
 
-	if value, ok := config["sync_interval_seconds"]; ok {
-		seconds, valid := integerValue(value)
-		if !valid || seconds < minSyncIntervalSeconds || seconds > maxSyncIntervalSeconds {
-			return nil, oops.E(
-				oops.CodeInvalid,
-				nil,
-				"sync_interval_seconds must be a whole number between %d and %d",
-				minSyncIntervalSeconds,
-				maxSyncIntervalSeconds,
-			)
+	for _, key := range []string{"sync_interval_seconds", "ai_scan_interval_seconds"} {
+		if value, ok := config[key]; ok {
+			seconds, valid := integerValue(value)
+			if !valid || seconds < minSyncIntervalSeconds || seconds > maxSyncIntervalSeconds {
+				return nil, oops.E(
+					oops.CodeInvalid,
+					nil,
+					"%s must be a whole number between %d and %d",
+					key,
+					minSyncIntervalSeconds,
+					maxSyncIntervalSeconds,
+				)
+			}
 		}
 	}
 

--- a/server/internal/agent/configuration_test.go
+++ b/server/internal/agent/configuration_test.go
@@ -142,6 +142,40 @@ func TestUpdateConfigurationRejectsInvalidPlatformLayer(t *testing.T) {
 	require.Equal(t, oops.CodeInvalid, shareableErr.Code)
 }
 
+func TestUpdateConfigurationAcceptsAIScanInterval(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
+
+	updated, err := ti.service.UpdateConfiguration(ctx, &gen.UpdateConfigurationPayload{
+		Config: map[string]any{"ai_scan_interval_seconds": 21600},
+	})
+	require.NoError(t, err)
+	require.True(t, updated.IsConfigured)
+
+	// The setting flows to agents through the existing configuration blob on
+	// the plugin poll, like every other admin-saved key.
+	poll, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: new("developer@example.com")})
+	require.NoError(t, err)
+	require.NotNil(t, poll.Configuration)
+	require.EqualValues(t, 21600, poll.Configuration.Config["ai_scan_interval_seconds"])
+}
+
+func TestUpdateConfigurationRejectsInvalidAIScanInterval(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
+
+	for _, invalid := range []any{"six hours", 0, 59, 24*60*60 + 1, 1.5} {
+		_, err := ti.service.UpdateConfiguration(ctx, &gen.UpdateConfigurationPayload{
+			Config: map[string]any{"ai_scan_interval_seconds": invalid},
+		})
+		var shareableErr *oops.ShareableError
+		require.ErrorAs(t, err, &shareableErr, "value %v must be rejected", invalid)
+		require.Equal(t, oops.CodeInvalid, shareableErr.Code)
+	}
+}
+
 func TestUpdateConfigurationPreservesStoredUnknownKeys(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)


### PR DESCRIPTION
AGE-3360

## Summary

- Adds `server/internal/agent/aitargets`, a code-owned catalog of the AI tools the device agent's Shadow AI scan reports on: ten targets (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Aider, opencode, OpenClaw, Ollama, LM Studio), each with a stable id, display name, and category (`harness` | `local_model`). Unit tests pin id uniqueness, lowercase/no-space id shape, and category validity.
- Adds `ai_scan_interval_seconds` as an admin-tunable known device-agent configuration key, validated in `configuration.go` exactly like the existing `sync_interval_seconds` (whole number, 60–86400) and delivered to agents through the existing admin configuration blob on the plugin poll. The `updateConfiguration` design description now lists it.

## Motivation

Shadow AI detection needs a server-side source of truth for what a detected target id means. Scan target lists are compiled into the device-agent binary, so nothing here is delivered to agents; the catalog's consumers are the read API (display-name/category decoration, added in the stacked follow-up PR), the demo seed, and the dashboard. The scan interval is the one delivery-related knob: org admins can tune how often enrolled devices scan without a new agent release, using the remote-configuration channel that already exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a code-owned catalog of ten AI detection targets and an admin-tunable `ai_scan_interval_seconds` config key for AGE-3360. The catalog gives scan detections stable display metadata, and the interval reaches agents through the existing configuration poll without an agent release.

- Accepts the interval as a whole number from 60 to 86,400 seconds, validated like `sync_interval_seconds`, and preserves unknown configuration keys.
- Target lists stay compiled into agent binaries; unknown target ids still resolve through raw-value fallbacks.

<sup>Written for commit a6616ecea671c79020fe8e1550d2c3ef931ab805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

