### PR TITLE
fix: normalize ClickHouse tuple syntax

### DIFF
--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1152,7 +1152,7 @@ SELECT
     groupUniqArrayArray(arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)'))) AS groups,
     -- Attribution values only exist meaningfully on api_request rows; the If
     -- guard keeps other rows from contributing an all-empty tuple.
-    groupUniqArrayIf(tuple(toString(attributes.query_source), toString(attributes.skill.name), toString(attributes.agent.name), toString(attributes.mcp_server.name), toString(attributes.mcp_tool.name)), is_claude_api_request) AS attribution_tuples
+    groupUniqArrayIf((toString(attributes.query_source), toString(attributes.skill.name), toString(attributes.agent.name), toString(attributes.mcp_server.name), toString(attributes.mcp_tool.name)), is_claude_api_request) AS attribution_tuples
 FROM telemetry_logs
 WHERE time_unix_nano >= chat_session_cutoff_unix_nano
   AND chat_id != ''


### PR DESCRIPTION
## Summary

Normalize the `chat_session_summaries_mv` attribution tuple expression to the tuple-literal form already represented by the checked ClickHouse migrations.

This is a semantic no-op that prevents Atlas from proposing an unnecessary drop and recreation of the materialized view during migration drift checks. No ClickHouse migration or hash change is required.

## Verification

- `mise run clickhouse:diff ci-drift-check`
  - Atlas migration directory synced; no changes
  - golang-migrate directory synced; no changes
- Independent review: APPROVE, zero findings
- Clean worktree and `git diff --check`
