### PR TITLE
mig: add tunneled_mcp_servers.resource_identifier

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4410,6 +4410,12 @@ CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
   allow_public boolean NOT NULL DEFAULT false,
   -- Last persisted tunnel agent version reported for this source.
   agent_version TEXT CHECK (agent_version IS NULL OR agent_version <> ''),
+  -- The tunneled server's own RFC 9728 protected-resource identifier: the
+  -- value an authorization server co-hosted with it recognizes as its
+  -- audience. Recorded as the RFC 8707 resource on grants and used only for
+  -- exact-match credential routing. Names a host inside the customer's
+  -- private network — this value must NEVER be dialed by Gram.
+  resource_identifier TEXT CHECK (resource_identifier IS NULL OR resource_identifier <> ''),
   -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
   last_seen_at timestamptz,
 
@@ -4443,6 +4449,7 @@ COMMENT ON COLUMN tunneled_mcp_servers.key_prefix IS 'Non-secret prefix of the t
 COMMENT ON COLUMN tunneled_mcp_servers.status IS 'Durable lifecycle state for the source: created, active, or revoked. Live connection state is derived from Redis.';
 COMMENT ON COLUMN tunneled_mcp_servers.allow_public IS 'Owner consent for anonymous public MCP serving of this source. Double opt-in with mcp_servers.visibility=public, enforced in application code.';
 COMMENT ON COLUMN tunneled_mcp_servers.agent_version IS 'Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.';
+COMMENT ON COLUMN tunneled_mcp_servers.resource_identifier IS 'RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer''s private network — never dialed by Gram.';
 COMMENT ON COLUMN tunneled_mcp_servers.last_seen_at IS 'Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.';
 COMMENT ON COLUMN tunneled_mcp_servers.created_at IS 'Time when the tunneled MCP source was created.';
 COMMENT ON COLUMN tunneled_mcp_servers.updated_at IS 'Time when the durable tunneled MCP source record was last updated.';

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2934,6 +2934,8 @@ type TunneledMcpServer struct {
 	AllowPublic bool
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
+	// RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer's private network — never dialed by Gram.
+	ResourceIdentifier pgtype.Text
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
 	LastSeenAt pgtype.Timestamptz
 	// Time when the tunneled MCP source was created.

--- a/server/internal/tunneledmcp/repo/models.go
+++ b/server/internal/tunneledmcp/repo/models.go
@@ -27,6 +27,8 @@ type TunneledMcpServer struct {
 	AllowPublic bool
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
+	// RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer's private network — never dialed by Gram.
+	ResourceIdentifier pgtype.Text
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
 	LastSeenAt pgtype.Timestamptz
 	// Time when the tunneled MCP source was created.

--- a/server/internal/tunneledmcp/repo/queries.sql.go
+++ b/server/internal/tunneledmcp/repo/queries.sql.go
@@ -31,7 +31,7 @@ func (q *Queries) CountActiveServersByOrganizationID(ctx context.Context, organi
 const createServer = `-- name: CreateServer :one
 INSERT INTO tunneled_mcp_servers (id, project_id, name, key_hash, key_prefix)
 VALUES ($1, $2, $3, $4, $5)
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateServerParams struct {
@@ -60,6 +60,7 @@ func (q *Queries) CreateServer(ctx context.Context, arg CreateServerParams) (Tun
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -76,7 +77,7 @@ SET
     deleted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteServerParams struct {
@@ -96,6 +97,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -106,7 +108,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 }
 
 const getServerByID = `-- name: GetServerByID :one
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -128,6 +130,7 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (T
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -138,7 +141,7 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (T
 }
 
 const getServerByIDForUpdate = `-- name: GetServerByIDForUpdate :one
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 FOR UPDATE
@@ -164,6 +167,7 @@ func (q *Queries) GetServerByIDForUpdate(ctx context.Context, arg GetServerByIDF
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -188,7 +192,7 @@ func (q *Queries) GetTunneledMcpServerLimitByOrganizationID(ctx context.Context,
 }
 
 const listServersByProjectID = `-- name: ListServersByProjectID :many
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -212,6 +216,7 @@ func (q *Queries) ListServersByProjectID(ctx context.Context, projectID uuid.UUI
 			&i.Status,
 			&i.AllowPublic,
 			&i.AgentVersion,
+			&i.ResourceIdentifier,
 			&i.LastSeenAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -250,7 +255,7 @@ SET
     last_seen_at = NULL,
     updated_at = clock_timestamp()
 WHERE id = $3 AND project_id = $4 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type RotateServerKeyParams struct {
@@ -277,6 +282,7 @@ func (q *Queries) RotateServerKey(ctx context.Context, arg RotateServerKeyParams
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -293,7 +299,7 @@ SET
     allow_public = COALESCE($2, allow_public),
     updated_at = clock_timestamp()
 WHERE id = $3 AND project_id = $4 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateServerParams struct {
@@ -320,6 +326,7 @@ func (q *Queries) UpdateServer(ctx context.Context, arg UpdateServerParams) (Tun
 		&i.Status,
 		&i.AllowPublic,
 		&i.AgentVersion,
+		&i.ResourceIdentifier,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260831170736_tunneled-mcp-server-resource-identifier.sql
+++ b/server/migrations/20260831170736_tunneled-mcp-server-resource-identifier.sql
@@ -1,0 +1,4 @@
+-- Modify "tunneled_mcp_servers" table
+ALTER TABLE "tunneled_mcp_servers" ADD CONSTRAINT "tunneled_mcp_servers_resource_identifier_check" CHECK ((resource_identifier IS NULL) OR (resource_identifier <> ''::text)), ADD COLUMN "resource_identifier" text NULL;
+-- Set comment to column: "resource_identifier" on table: "tunneled_mcp_servers"
+COMMENT ON COLUMN "tunneled_mcp_servers"."resource_identifier" IS 'RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer''s private network — never dialed by Gram.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/TZ6U2XcrA/EVl1x7RxQ2JVSZKMXikDb7LTHTF9R600=
+h1:2w/Ajbac4XM4CO712uj4TNnf0LYamPpaXlooyBehh1Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -377,3 +377,4 @@ h1:/TZ6U2XcrA/EVl1x7RxQ2JVSZKMXikDb7LTHTF9R600=
 20260828181110_dno-978-killswitch-expiry-discovery-index.sql h1:O4HoCdj2hCOhQHKbtzOJIza01sNlC+1mD+frDob19f8=
 20260829131739_dno-983-killswitch-review-fixes.sql h1:t5J2SbzQwB8YWbJ6hz1wpMvbzxGn9URFT+lJe+9x1MQ=
 20260829222004_openrouter-api-keys-add-disable-causes.sql h1:aY46q4PFvjI52Gs25EhX0vKD3cv/3YUhBzI/7DVIl7A=
+20260831170736_tunneled-mcp-server-resource-identifier.sql h1:knIZQZflX4azED7sFXe+uPiJJexkH2eTDfteUGnaKXg=


### PR DESCRIPTION
AIM-151

## Summary

Adds a nullable `resource_identifier` text column to `tunneled_mcp_servers`, with a non-empty CHECK matching the table's existing style and a column comment stating the safety contract: the value is an RFC 9728 protected resource identifier used only for exact-match credential routing and must never be dialed by Gram (it names a host inside the customer's private network).

Migration only — regenerated sqlc models included, no application logic. The follow-up PR records this value as the RFC 8707 resource on grants and routes tunneled credentials by exact match on both serving surfaces.

Atlas lint will flag the CHECK on an existing table (PG305); the constraint only covers the column added in the same statement with no default, so the scan cannot fail and the table is small.

## Motivation

Tunneled backends record no RFC 8707 resource today, so credential routing falls back to a guess: forward a lone stored token as-is, fail closed when the caller holds several. A gateway holding several providers breaks every tunneled member, and a lone token can be forwarded to a backend it was never granted for. Recording the tunneled server's own protected-resource identifier gives grants a routable audience, restoring symmetry with `remote_mcp_servers.url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gm43HhrAUR6poQA5xKK9W


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the migration groundwork for routing tunneled credentials by exact match on the tunneled server's own protected-resource identifier (AIM-151). Today tunneled backends record no RFC 8707 resource, so routing either forwards a lone stored token as-is or fails when a caller holds several.

**Migration notes**

- Adds a nullable `resource_identifier` text column to `tunneled_mcp_servers` with a non-empty CHECK, matching the table's existing style.
- The column comment documents the safety contract: the value names a host inside the customer's private network and must never be dialed by Gram.
- Regenerates sqlc models; no application logic changes in this PR.
- Atlas lint may flag the CHECK on an existing table (PG305), but the constraint only covers the new column, so a scan cannot fail.

<sup>Written for commit 4bc009f20dc2ef0bafc143688df21faff8bdbf70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

