### PR TITLE
fix: key MCP server management authz on server grant ids

### DIFF
--- a/.changeset/mcp-server-scoped-management-authz.md
+++ b/.changeset/mcp-server-scoped-management-authz.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Key MCP server management authorization on the server's grant resource id instead of the project id, aligning it with the toolsets surface and the serving path. Get, update, delete, and tool-filter reads now check `mcp:read`/`mcp:write` against the toolset id (toolset-backed) or mcp_servers row id (remote/tunneled), and listing filters to the servers the caller holds a grant for — so role grants scoped to a single server now unlock managing exactly that server. Project-wide (`project_id` dimension) and wildcard grants behave as before. Listing with no matching grants now returns an empty list instead of forbidden, and get/update/delete on a server the caller lacks now return forbidden after the project-scoped row lookup (404 for rows that don't exist in the project).

--- a/server/internal/mcpservers/deletemcpserver_test.go
+++ b/server/internal/mcpservers/deletemcpserver_test.go
@@ -324,10 +324,12 @@ func TestDeleteMcpServer_RBACForbidden(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 
-	ctx = withExactAuthzGrants(t, ctx, ti.conn)
+	fixture := createRemoteServerFixture(t, ctx, ti, "rbac forbidden delete")
 
-	err := ti.service.DeleteMcpServer(ctx, &gen.DeleteMcpServerPayload{
-		ID:               uuid.NewString(),
+	denied := withExactAuthzGrants(t, ctx, ti.conn)
+
+	err := ti.service.DeleteMcpServer(denied, &gen.DeleteMcpServerPayload{
+		ID:               fixture.server.ID,
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,

--- a/server/internal/mcpservers/getmcpserver_test.go
+++ b/server/internal/mcpservers/getmcpserver_test.go
@@ -149,11 +149,12 @@ func TestGetMcpServer_RBACForbidden(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 
-	ctx = withExactAuthzGrants(t, ctx, ti.conn)
+	fixture := createRemoteServerFixture(t, ctx, ti, "rbac forbidden get")
 
-	id := uuid.NewString()
-	_, err := ti.service.GetMcpServer(ctx, &gen.GetMcpServerPayload{
-		ID:               &id,
+	denied := withExactAuthzGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.GetMcpServer(denied, &gen.GetMcpServerPayload{
+		ID:               &fixture.server.ID,
 		Slug:             nil,
 		SessionToken:     nil,
 		ApikeyToken:      nil,

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -335,6 +335,26 @@ func grantResourceID(id uuid.UUID, toolsetID uuid.NullUUID) string {
 	return id.String()
 }
 
+// requireServerWriteUnlocked rejects a caller lacking mcp:write on the server
+// before the mutation transaction takes any FOR UPDATE locks, so an
+// unauthorized member cannot contend server-lifecycle locks. It keys on a
+// non-locking read; UpdateMcpServer/DeleteMcpServer re-check against the
+// locked row, which is authoritative if the backing changes concurrently.
+func (s *Service) requireServerWriteUnlocked(ctx context.Context, serverID uuid.UUID, projectID uuid.UUID, logger *slog.Logger) error {
+	server, err := repo.New(s.db).GetMCPServerByIDAndProjectID(ctx, repo.GetMCPServerByIDAndProjectIDParams{
+		ID:        serverID,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
+		}
+		return oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, logger)
+	}
+
+	return s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, grantResourceID(server.ID, server.ToolsetID), projectID.String()))
+}
+
 func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPayload) (*types.McpServer, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
@@ -585,6 +605,10 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogError(ctx, logger)
 	}
 
+	if err := s.requireServerWriteUnlocked(ctx, serverID, *authCtx.ProjectID, logger); err != nil {
+		return nil, err
+	}
+
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
@@ -815,6 +839,10 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 	serverID, err := uuid.Parse(payload.ID)
 	if err != nil {
 		return oops.E(oops.CodeBadRequest, err, "invalid mcp server id").LogError(ctx, logger)
+	}
+
+	if err := s.requireServerWriteUnlocked(ctx, serverID, *authCtx.ProjectID, logger); err != nil {
+		return err
 	}
 
 	dbtx, err := s.db.Begin(ctx)

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -324,14 +324,21 @@ func vendorFaviconURL(scheme, host string) string {
 	)
 }
 
+// grantResourceID is the RBAC resource id for an mcp_servers row: the backing
+// toolset id when toolset-backed, else the row id. These are the ids the
+// serving path checks and the ids role-grant selectors name, so keying
+// management checks on them makes server-scoped grants effective here too.
+func grantResourceID(id uuid.UUID, toolsetID uuid.NullUUID) string {
+	if toolsetID.Valid {
+		return toolsetID.UUID.String()
+	}
+	return id.String()
+}
+
 func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPayload) (*types.McpServer, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
-	}
-
-	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, authCtx.ProjectID.String(), authCtx.ProjectID.String())); err != nil {
-		return nil, err
 	}
 
 	idProvided := payload.ID != nil && *payload.ID != ""
@@ -367,6 +374,10 @@ func (s *Service) GetMcpServer(ctx context.Context, payload *gen.GetMcpServerPay
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, s.logger)
+	}
+
+	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, grantResourceID(server.ID, server.ToolsetID), authCtx.ProjectID.String())); err != nil {
+		return nil, err
 	}
 
 	return mv.BuildMcpServerView(server), nil
@@ -378,10 +389,6 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, authCtx.ProjectID.String(), authCtx.ProjectID.String())); err != nil {
-		return nil, err
-	}
-
 	idProvided := payload.ID != nil && *payload.ID != ""
 	slugProvided := payload.Slug != nil && *payload.Slug != ""
 	if !idProvided && !slugProvided {
@@ -415,6 +422,10 @@ func (s *Service) ListToolFilters(ctx context.Context, payload *gen.ListToolFilt
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, s.logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, s.logger)
+	}
+
+	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, grantResourceID(server.ID, server.ToolsetID), authCtx.ProjectID.String())); err != nil {
+		return nil, err
 	}
 
 	// Only toolset-backed servers expose a tool list to filter. Remote-backed
@@ -471,10 +482,6 @@ func (s *Service) ListMcpServers(ctx context.Context, payload *gen.ListMcpServer
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPRead, authCtx.ProjectID.String(), authCtx.ProjectID.String())); err != nil {
-		return nil, err
-	}
-
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	remoteMcpServerID, err := conv.PtrToNullUUID(payload.RemoteMcpServerID)
@@ -508,7 +515,26 @@ func (s *Service) ListMcpServers(ctx context.Context, payload *gen.ListMcpServer
 		return nil, oops.E(oops.CodeUnexpected, err, "list mcp servers").LogError(ctx, logger)
 	}
 
-	return &gen.ListMcpServersResult{McpServers: mv.BuildMcpServerListView(servers)}, nil
+	checks := make([]authz.Check, len(servers))
+	for i, server := range servers {
+		checks[i] = authz.MCPCheck(authz.ScopeMCPRead, grantResourceID(server.ID, server.ToolsetID), authCtx.ProjectID.String())
+	}
+	allowedIDs, err := s.authz.Filter(ctx, checks)
+	if err != nil {
+		return nil, err
+	}
+	allowedSet := make(map[string]struct{}, len(allowedIDs))
+	for _, id := range allowedIDs {
+		allowedSet[id] = struct{}{}
+	}
+	allowed := make([]repo.McpServer, 0, len(allowedIDs))
+	for _, server := range servers {
+		if _, ok := allowedSet[grantResourceID(server.ID, server.ToolsetID)]; ok {
+			allowed = append(allowed, server)
+		}
+	}
+
+	return &gen.ListMcpServersResult{McpServers: mv.BuildMcpServerListView(allowed)}, nil
 }
 
 func (s *Service) ListMcpServersForOrg(ctx context.Context, payload *gen.ListMcpServersForOrgPayload) (*gen.ListMcpServersResult, error) {
@@ -535,10 +561,6 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return nil, oops.C(oops.CodeUnauthorized)
-	}
-
-	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, authCtx.ProjectID.String(), authCtx.ProjectID.String())); err != nil {
-		return nil, err
 	}
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
@@ -585,6 +607,12 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 			return nil, oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
 		}
 		return nil, oops.E(oops.CodeUnexpected, err, "get mcp server").LogError(ctx, logger)
+	}
+
+	// Authorization keys on the row as it exists, not the backing the payload
+	// may switch it to.
+	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, grantResourceID(existing.ID, existing.ToolsetID), authCtx.ProjectID.String())); err != nil {
+		return nil, err
 	}
 
 	// Only gate on staff when the unproxied backend reference is actually
@@ -782,10 +810,6 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 		return oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, authCtx.ProjectID.String(), authCtx.ProjectID.String())); err != nil {
-		return err
-	}
-
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	serverID, err := uuid.Parse(payload.ID)
@@ -818,14 +842,19 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "lock mcp endpoints").LogError(ctx, logger)
 	}
-	if _, err := txRepo.LockMCPServerByIDAndProjectID(ctx, repo.LockMCPServerByIDAndProjectIDParams{
+	locked, err := txRepo.LockMCPServerByIDAndProjectID(ctx, repo.LockMCPServerByIDAndProjectIDParams{
 		ID:        serverID,
 		ProjectID: *authCtx.ProjectID,
-	}); err != nil {
+	})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "mcp server not found").LogError(ctx, logger)
 		}
 		return oops.E(oops.CodeUnexpected, err, "lock mcp server").LogError(ctx, logger)
+	}
+
+	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPWrite, grantResourceID(locked.ID, locked.ToolsetID), authCtx.ProjectID.String())); err != nil {
+		return err
 	}
 	// Post-server-lock read is the authoritative root set: the server FOR SHARE in root selection means no new root can commit past this point, and rows here carry pre-delete is_domain_root.
 	rootEndpoints, err := mcpendpointsrepo.New(dbtx).LockMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.LockMCPEndpointsByMCPServerIDParams{

--- a/server/internal/mcpservers/listmcpservers_test.go
+++ b/server/internal/mcpservers/listmcpservers_test.go
@@ -184,14 +184,17 @@ func TestListMcpServers_RBACForbidden(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 
-	ctx = withExactAuthzGrants(t, ctx, ti.conn)
+	_ = createRemoteServerFixture(t, ctx, ti, "rbac forbidden list")
 
-	_, err := ti.service.ListMcpServers(ctx, &gen.ListMcpServersPayload{
+	denied := withExactAuthzGrants(t, ctx, ti.conn)
+
+	result, err := ti.service.ListMcpServers(denied, &gen.ListMcpServersPayload{
 		SessionToken:      nil,
 		ApikeyToken:       nil,
 		ProjectSlugInput:  nil,
 		RemoteMcpServerID: nil,
 		ToolsetID:         nil,
 	})
-	requireOopsCode(t, err, oops.CodeForbidden)
+	require.NoError(t, err)
+	require.Empty(t, result.McpServers)
 }

--- a/server/internal/mcpservers/listtoolfilters_test.go
+++ b/server/internal/mcpservers/listtoolfilters_test.go
@@ -236,12 +236,13 @@ func TestListToolFilters_RBAC_DeniedWithoutGrant(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 
-	// No grants: the mcp:read project-scope check rejects the caller before any
-	// server lookup, so a random id still yields forbidden.
+	fixture := createRemoteServerFixture(t, ctx, ti, "rbac denied tool filters")
+
+	// No grants: the per-server mcp:read check rejects the caller after the
+	// project-scoped row lookup.
 	deniedCtx := withExactAuthzGrants(t, ctx, ti.conn)
-	id := uuid.New().String()
 	_, err := ti.service.ListToolFilters(deniedCtx, &gen.ListToolFiltersPayload{
-		ID:               &id,
+		ID:               &fixture.server.ID,
 		Slug:             nil,
 		SessionToken:     nil,
 		ApikeyToken:      nil,
@@ -271,9 +272,13 @@ func TestListToolFilters_RBAC_AllowedWithProjectGrant(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Canonical project-wide grant shape: wildcard resource narrowed by the
+	// project_id dimension.
+	projectSelector := authz.NewSelector(authz.ScopeMCPRead, "*")
+	projectSelector[authz.SelectorKeyProjectID] = authCtx.ProjectID.String()
 	grantedCtx := withExactAuthzGrants(t, ctx, ti.conn, authz.Grant{
 		Scope:    authz.ScopeMCPRead,
-		Selector: authz.NewSelector(authz.ScopeMCPRead, authCtx.ProjectID.String()),
+		Selector: projectSelector,
 	})
 	res, err := ti.service.ListToolFilters(grantedCtx, &gen.ListToolFiltersPayload{
 		ID:               &created.ID,

--- a/server/internal/mcpservers/rbac_scoped_test.go
+++ b/server/internal/mcpservers/rbac_scoped_test.go
@@ -293,3 +293,196 @@ func TestDeleteMcpServer_RBAC_OtherServerGrantDenied(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, a.server.ID, fetched.ID)
 }
+
+// The following tests exercise the toolset-id grant branch of grantResourceID
+// across every management endpoint (only Get is covered above), and pin the
+// UpdateMcpServer invariant that authorization keys on the server's existing
+// backing rather than the backing the payload switches it to.
+
+func TestListMcpServers_RBAC_ToolsetScopedGrantReturnsServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped list toolset")
+	_ = createRemoteServerFixture(t, ctx, ti, "scoped list toolset other")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, toolsetID.String()))
+
+	result, err := ti.service.ListMcpServers(scoped, &gen.ListMcpServersPayload{
+		RemoteMcpServerID:    nil,
+		TunneledMcpServerID:  nil,
+		ToolsetID:            nil,
+		UnproxiedMcpServerID: nil,
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.McpServers, 1)
+	require.Equal(t, server.ID, result.McpServers[0].ID)
+}
+
+func TestListToolFilters_RBAC_ToolsetScopedGrantAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped tool filters")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, toolsetID.String()))
+
+	_, err := ti.service.ListToolFilters(scoped, &gen.ListToolFiltersPayload{
+		ID:               &server.ID,
+		Slug:             nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+}
+
+func TestListToolFilters_RBAC_OtherServerGrantDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, _ := createToolsetBackedServerFixture(t, ctx, ti, "scoped tool filters denied")
+	other := createRemoteServerFixture(t, ctx, ti, "scoped tool filters denied other")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, other.server.ID))
+
+	_, err := ti.service.ListToolFilters(scoped, &gen.ListToolFiltersPayload{
+		ID:               &server.ID,
+		Slug:             nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestDeleteMcpServer_RBAC_ToolsetScopedGrantAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped delete toolset")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, toolsetID.String()))
+
+	err := ti.service.DeleteMcpServer(scoped, &gen.DeleteMcpServerPayload{
+		ID:               server.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = getMcpServerByID(ctx, ti, server.ID)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestUpdateMcpServer_RBAC_ToolsetScopedGrantAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped update toolset")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, toolsetID.String()))
+
+	name := "scoped update toolset renamed"
+	toolsetIDStr := toolsetID.String()
+	updated, err := ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    server.ID,
+		Name:                  &name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     nil,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             &toolsetIDStr,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, name, conv.PtrValOr(updated.Name, ""))
+}
+
+// A grant on the server's existing backing authorizes an update that switches
+// the backing to a target the caller has no grant on — authorization keys on
+// the row as it exists, not the payload's new backing.
+func TestUpdateMcpServer_RBAC_AuthorizesOnExistingBackingAllowsSwitch(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped update switch allow")
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	newBackend := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	// Grant is on the existing toolset backing only, not the remote target.
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, toolsetID.String()))
+
+	updated, err := ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    server.ID,
+		Name:                  nil,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     &newBackend,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             nil,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.RemoteMcpServerID)
+	require.Equal(t, newBackend, *updated.RemoteMcpServerID)
+}
+
+// A grant on the payload's target backing does NOT authorize an update of a
+// server the caller has no grant on — proving the check keys on the existing
+// backing, so a grant on a new toolset can't be used to hijack a server.
+func TestUpdateMcpServer_RBAC_TargetBackingGrantDoesNotAuthorize(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server := createRemoteServerFixture(t, ctx, ti, "scoped update switch deny")
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	targetToolset, err := toolsetsrepo.New(ti.conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "scoped update switch deny target toolset",
+		Slug:                   "rbac-scoped-" + uuid.NewString(),
+		Description:            conv.ToPGText("scoped rbac fixture"),
+		DefaultEnvironmentSlug: conv.ToPGTextEmpty(""),
+		McpSlug:                conv.ToPGTextEmpty(""),
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+
+	// Grant is on the toolset the payload would switch TO, not the server's
+	// existing remote backing.
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, targetToolset.ID.String()))
+
+	targetToolsetID := targetToolset.ID.String()
+	_, err = ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    server.server.ID,
+		Name:                  nil,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     nil,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             &targetToolsetID,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}

--- a/server/internal/mcpservers/rbac_scoped_test.go
+++ b/server/internal/mcpservers/rbac_scoped_test.go
@@ -1,0 +1,295 @@
+package mcpservers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+type remoteServerFixture struct {
+	server *types.McpServer
+	// remoteMcpServerID is the backend id needed to round-trip updates, which
+	// replace the full backend reference set.
+	remoteMcpServerID string
+}
+
+func createRemoteServerFixture(t *testing.T, ctx context.Context, ti *testInstance, name string) remoteServerFixture {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	backendID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		Name:                  name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     &backendID,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             nil,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+
+	return remoteServerFixture{server: created, remoteMcpServerID: backendID}
+}
+
+func createToolsetBackedServerFixture(t *testing.T, ctx context.Context, ti *testInstance, name string) (*types.McpServer, uuid.UUID) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset, err := toolsetsrepo.New(ti.conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   name + " toolset",
+		Slug:                   "rbac-scoped-" + uuid.NewString(),
+		Description:            conv.ToPGText("scoped rbac fixture"),
+		DefaultEnvironmentSlug: conv.ToPGTextEmpty(""),
+		McpSlug:                conv.ToPGTextEmpty(""),
+		McpEnabled:             false,
+	})
+	require.NoError(t, err)
+
+	toolsetID := toolset.ID.String()
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		Name:                  name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     nil,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             &toolsetID,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+
+	return created, toolset.ID
+}
+
+func getMcpServerByID(ctx context.Context, ti *testInstance, id string) (*types.McpServer, error) {
+	server, err := ti.service.GetMcpServer(ctx, &gen.GetMcpServerPayload{
+		ID:               &id,
+		Slug:             nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	return server, err //nolint:wrapcheck // returned for oops-code assertions on the chain
+}
+
+func TestGetMcpServer_RBAC_ServerScopedGrantAllowsOnlyThatServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped get a")
+	b := createRemoteServerFixture(t, ctx, ti, "scoped get b")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, a.server.ID))
+
+	fetched, err := getMcpServerByID(scoped, ti, a.server.ID)
+	require.NoError(t, err)
+	require.Equal(t, a.server.ID, fetched.ID)
+
+	_, err = getMcpServerByID(scoped, ti, b.server.ID)
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestGetMcpServer_RBAC_ToolsetScopedGrantAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, toolsetID := createToolsetBackedServerFixture(t, ctx, ti, "scoped toolset get")
+
+	// The grant resource id for a toolset-backed server is the toolset id,
+	// matching the ids checked at serve time and on the toolsets surface.
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, toolsetID.String()))
+
+	fetched, err := getMcpServerByID(scoped, ti, server.ID)
+	require.NoError(t, err)
+	require.Equal(t, server.ID, fetched.ID)
+}
+
+func TestListMcpServers_RBAC_FiltersToGrantedServers(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped list a")
+	_ = createRemoteServerFixture(t, ctx, ti, "scoped list b")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, a.server.ID))
+
+	result, err := ti.service.ListMcpServers(scoped, &gen.ListMcpServersPayload{
+		RemoteMcpServerID:    nil,
+		TunneledMcpServerID:  nil,
+		ToolsetID:            nil,
+		UnproxiedMcpServerID: nil,
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.McpServers, 1)
+	require.Equal(t, a.server.ID, result.McpServers[0].ID)
+}
+
+func TestListMcpServers_RBAC_NoGrantsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	_ = createRemoteServerFixture(t, ctx, ti, "scoped list empty")
+
+	denied := withExactAuthzGrants(t, ctx, ti.conn)
+
+	result, err := ti.service.ListMcpServers(denied, &gen.ListMcpServersPayload{
+		RemoteMcpServerID:    nil,
+		TunneledMcpServerID:  nil,
+		ToolsetID:            nil,
+		UnproxiedMcpServerID: nil,
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.McpServers)
+}
+
+func TestUpdateMcpServer_RBAC_ServerScopedWriteAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped update a")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, a.server.ID))
+
+	name := "scoped update a renamed"
+	updated, err := ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    a.server.ID,
+		Name:                  &name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     &a.remoteMcpServerID,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             nil,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, name, conv.PtrValOr(updated.Name, ""))
+}
+
+func TestUpdateMcpServer_RBAC_OtherServerGrantDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped update denied a")
+	b := createRemoteServerFixture(t, ctx, ti, "scoped update denied b")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, b.server.ID))
+
+	name := "should not apply"
+	_, err := ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    a.server.ID,
+		Name:                  &name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     &a.remoteMcpServerID,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             nil,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestUpdateMcpServer_RBAC_ReadGrantDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped update read-only")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, a.server.ID))
+
+	name := "should not apply"
+	_, err := ti.service.UpdateMcpServer(scoped, &gen.UpdateMcpServerPayload{
+		SessionToken:          nil,
+		ApikeyToken:           nil,
+		ProjectSlugInput:      nil,
+		ID:                    a.server.ID,
+		Name:                  &name,
+		EnvironmentID:         nil,
+		RemoteMcpServerID:     &a.remoteMcpServerID,
+		TunneledMcpServerID:   nil,
+		ToolsetID:             nil,
+		UnproxiedMcpServerID:  nil,
+		ToolVariationsGroupID: nil,
+		Visibility:            types.McpServerVisibility("private"),
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+func TestDeleteMcpServer_RBAC_ServerScopedWriteAllows(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped delete a")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, a.server.ID))
+
+	err := ti.service.DeleteMcpServer(scoped, &gen.DeleteMcpServerPayload{
+		ID:               a.server.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = getMcpServerByID(ctx, ti, a.server.ID)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestDeleteMcpServer_RBAC_OtherServerGrantDenied(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	a := createRemoteServerFixture(t, ctx, ti, "scoped delete denied a")
+	b := createRemoteServerFixture(t, ctx, ti, "scoped delete denied b")
+
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPWrite, b.server.ID))
+
+	err := ti.service.DeleteMcpServer(scoped, &gen.DeleteMcpServerPayload{
+		ID:               a.server.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+
+	fetched, err := getMcpServerByID(ctx, ti, a.server.ID)
+	require.NoError(t, err)
+	require.Equal(t, a.server.ID, fetched.ID)
+}

--- a/server/internal/mcpservers/rbac_scoped_test.go
+++ b/server/internal/mcpservers/rbac_scoped_test.go
@@ -128,6 +128,20 @@ func TestGetMcpServer_RBAC_ToolsetScopedGrantAllows(t *testing.T) {
 	require.Equal(t, server.ID, fetched.ID)
 }
 
+func TestGetMcpServer_RBAC_RowIdGrantDeniedOnToolsetBackedServer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	server, _ := createToolsetBackedServerFixture(t, ctx, ti, "scoped row-id denied")
+
+	// A toolset-backed server's grant id is its toolset id, so a grant naming
+	// the raw row id must not authorize it — the inverse of the toolset branch.
+	scoped := withExactAuthzGrants(t, ctx, ti.conn, authz.NewGrant(authz.ScopeMCPRead, server.ID))
+
+	_, err := getMcpServerByID(scoped, ti, server.ID)
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
 func TestListMcpServers_RBAC_FiltersToGrantedServers(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -347,15 +347,17 @@ func TestUpdateMcpServer_RBACForbidden(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 
-	ctx = withExactAuthzGrants(t, ctx, ti.conn)
+	fixture := createRemoteServerFixture(t, ctx, ti, "rbac forbidden update")
 
-	_, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+	denied := withExactAuthzGrants(t, ctx, ti.conn)
+
+	_, err := ti.service.UpdateMcpServer(denied, &gen.UpdateMcpServerPayload{
 		SessionToken:      nil,
 		ApikeyToken:       nil,
 		ProjectSlugInput:  nil,
-		ID:                uuid.NewString(),
+		ID:                fixture.server.ID,
 		EnvironmentID:     nil,
-		RemoteMcpServerID: nil,
+		RemoteMcpServerID: &fixture.remoteMcpServerID,
 		ToolsetID:         nil,
 		Visibility:        types.McpServerVisibility("disabled"),
 	})


### PR DESCRIPTION
## Summary

MCP server management endpoints (`mcpservers.get`, `listToolFilters`, `list`, `update`, `delete`) previously authorized `mcp:read`/`mcp:write` with the **project id** as the check's resource id, so a role grant scoped to a single server never matched — it granted serving/connect access but none of the management surface, while the dashboard's team-access matrix implied otherwise. This keys those checks on the server's grant resource id instead, matching the toolsets surface and the serving path:

- New `grantResourceID(id, toolsetID)` helper mirrors the grant-id invariant used everywhere else (toolset id when toolset-backed, else the `mcp_servers` row id).
- Get / tool-filter reads check `mcp:read` against the loaded row's grant id (project id stays as a selector dimension, so project-wide and wildcard grants keep matching).
- Update / delete check `mcp:write` against the locked row's grant id before any mutation; update authorizes against the row's existing backing, not the backing the payload may switch it to.
- Listing replaces the blanket project check with a per-server `authz.Filter`, same as `toolsets.List` — callers see exactly the servers they hold `mcp:read` for; no matching grants returns an empty list rather than 403.
- Create stays project-keyed: a per-server grant cannot authorize creating new servers.

New `rbac_scoped_test.go` covers server-scoped allow/deny for get/list/update/delete, toolset-id keying for toolset-backed servers, and read-grant-cannot-write. Pre-existing RBAC tests that asserted a 403 before the row lookup were updated to real fixtures.

Behavior changes to be aware of:

1. Get/update/delete on an existing server without a matching grant now return forbidden after the project-scoped row lookup; nonexistent ids return not found (the toolsets surface already behaves this way).
2. A nonstandard grant shape — `mcp:read`/`mcp:write` with `resource_id` set to a project uuid — only ever matched these endpoints because the old checks used the project id as the resource id, and no longer matches. The dashboard never writes that shape; the canonical project-wide form (`resource_id='*'` + `project_id` dimension) is unaffected.

## Motivation

The Grant Access dialog (#5883) one-click-creates roles scoped to a single server. Adversarial review of that PR found the scoped grants were only fully effective for toolset-backed servers: for remote/tunneled servers the management endpoints checked a project-keyed selector no grant editor ever produces per-server, so a "this server only" `mcp:write` grant did not actually let the member manage that server. Aligning the management checks with the grant-id invariant makes server-scoped roles mean what the UI says they mean. A frontend follow-up can then relax the dialog's restriction that offers read/write scoped grants only for toolset-backed servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1AvLHvF7Z5UH66JQzYPwr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP server management authorization so server-scoped role grants actually control management endpoints. Management checks previously authorized with the project id as the resource id, so a grant scoped to a single server never matched; they now key on the server's grant resource id (toolset id for toolset-backed servers, else the MCP server row id), aligning with the serving path and the dashboard's access matrix.

**Changes**
- Adds a `grantResourceID` helper to derive the grant resource id consistently across endpoints.
- Get, tool-filter reads, update, and delete now check `mcp:read`/`mcp:write` against the server's grant id; the project id remains a selector dimension.
- Update and delete reject unauthorized callers before the transaction takes `FOR UPDATE` locks by pre-checking against a non-locking read, then re-checking against the locked row.
- Update authorizes against the row's existing backing, not the backing the payload may switch to.
- Listing filters per-server via `authz.Filter`, so callers see only servers they hold `mcp:read` for; no matching grants returns an empty list instead of 403.
- Create stays project-keyed: a per-server grant cannot create new servers.
- Get/update/delete on an existing server without a matching grant now return 403 after the project-scoped row lookup; nonexistent ids return 404. A nonstandard grant shape with `resource_id` set to a project uuid no longer matches, but the canonical project-wide form (`resource_id='*'` + `project_id` dimension) is unaffected.
- Adds `rbac_scoped_test.go` covering server-scoped allow/deny for get/list/update/delete, toolset-id keying across all endpoints, and read-grant-cannot-write; pre-existing RBAC tests were updated to use real server fixtures.

<sup>Written for commit 251cf4e96c32347845f8424b58209a2299155ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

