### PR TITLE
fix: clear cached site data on logout (AIS-551)

### DIFF
--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -213,8 +213,8 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// context so validateAuthNonce() can verify it.
 	server.Callback = callbackNonceBindingMiddleware(server.Callback)
 
-	// Wrap Logout handler: have the browser drop the origin's cookies and
-	// client-side storage once the session has been invalidated server-side.
+	// Wrap Logout handler: have the browser drop the origin's cached data,
+	// cookies, and client-side storage once the session has been invalidated server-side.
 	server.Logout = middleware.ClearSiteDataOnLogout(server.Logout)
 
 	srv.Mount(mux, server)

--- a/server/internal/middleware/clear_site_data.go
+++ b/server/internal/middleware/clear_site_data.go
@@ -6,7 +6,7 @@ import (
 )
 
 const clearSiteDataHeader = "Clear-Site-Data"
-const clearSiteDataLogout = `"cookies", "storage"`
+const clearSiteDataLogout = `"cache", "cookies", "storage"`
 
 func ClearSiteDataOnLogout(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/middleware/clear_site_data_test.go
+++ b/server/internal/middleware/clear_site_data_test.go
@@ -29,7 +29,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnOK(t *testing.T) {
 
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
 
-	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // Any success status carries the directive, not just 200 — a bodiless logout
@@ -44,7 +44,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnNoContent(t *testing.T) {
 
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
 
-	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // A handler that writes a body without calling WriteHeader still sends a 200,
@@ -62,7 +62,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnImplicitOK(t *testing.T) {
 
 	require.NoError(t, writeErr)
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // A logout that never invalidated anything must leave the caller's state alone:
@@ -127,7 +127,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveAfterEarlyHints(t *testing.T) {
 	// Only the header is asserted: httptest.ResponseRecorder records the first
 	// WriteHeader it sees, so rec.Code reports the 103 that a real server would
 	// have sent as an informational response ahead of the final status.
-	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // 101 is terminal, not informational: nothing follows it, and a protocol switch
@@ -154,12 +154,12 @@ func TestClearSiteDataOnLogout_SetsDirectiveBeforeFlush(t *testing.T) {
 	w.Flush()
 
 	require.True(t, inner.flushed)
-	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
 
 	// The flush committed the headers, so a later error status must not be
 	// able to un-commit them — but it must not gain a directive either.
 	w.WriteHeader(http.StatusInternalServerError)
-	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cache", "cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
 }
 
 // A flush the underlying writer cannot serve commits nothing, so the directive


### PR DESCRIPTION
## Summary
- clear cached data with cookies and browser storage after successful logout
- update the logout comment and all positive header expectations
- keep the header limited to logout responses, with no `GET /` or `gram-infra` change

## Testing
- `mise run test:server ./internal/middleware ./internal/auth -count=1`
