### PR TITLE
feat: grant legacy pro enterprise feature access

### DIFF
--- a/.changeset/legacy-pro-enterprise-access.md
+++ b/.changeset/legacy-pro-enterprise-access.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add a dry-run-by-default `pro-entitlements` backfill command that grants Legacy Pro organizations the enterprise-access entitlement bundle.

--- a/server/cmd/tools/migrations/PRO_ENTITLEMENTS_BACKFILL.md
+++ b/server/cmd/tools/migrations/PRO_ENTITLEMENTS_BACKFILL.md
@@ -1,0 +1,31 @@
+# Pro organization entitlement backfill
+
+This offline application-data backfill gives every organization whose `gram_account_type` is `pro` the shared enterprise-access entitlement bundle. It calls the same `productfeatures.SeedEnterpriseAccessEntitlementsTx` seeder used for PAYG activation; it does not alter the schema or Atlas migrations. Existing soft-deleted feature rows are treated as explicit disables and are never restored.
+
+Run from `server/`. `GRAM_DATABASE_URL` must point directly at the intended PostgreSQL database. Output contains aggregate counts only.
+
+## Preview (default)
+
+```sh
+GRAM_DATABASE_URL=... go run ./cmd/tools/migrations pro-entitlements \
+  -environment=staging
+```
+
+The default mode runs the shared entitlement seeder for every candidate in a transaction that is always rolled back. `features_added` is therefore the prospective insert count, including the same soft-delete preservation behavior as apply mode. No writes are committed.
+
+## Apply
+
+```sh
+GRAM_DATABASE_URL=... go run ./cmd/tools/migrations pro-entitlements \
+  -apply \
+  -environment=staging \
+  -confirm-environment=staging \
+  -confirm-target=db.example.internal:5432/gram \
+  -confirm-apply=pro-entitlements
+```
+
+`-confirm-target` must exactly match the host, port, and database parsed from `GRAM_DATABASE_URL` by pgx; this ties write confirmation to the actual database target rather than the descriptive environment label. Every apply also requires `-confirm-apply=pro-entitlements`.
+
+Each candidate is handled in its own transaction. After taking a row lock, the command rechecks `gram_account_type` and skips the organization if it is no longer `pro`. The operation is idempotent: rerunning it inserts only never-configured entitlements. Stop on any error, investigate, then rerun the same command.
+
+After applying, rerun the preview and inspect `organizations` plus `features_added`. A subsequent preview or apply should report `features_added=0`. Application feature caches may retain pre-backfill values for up to their normal TTL.

--- a/server/cmd/tools/migrations/main.go
+++ b/server/cmd/tools/migrations/main.go
@@ -9,6 +9,8 @@
 //     OPENROUTER_DISABLE_CAUSES_MIGRATION.md. It defaults to a non-writing dry
 //     run. Writes use -apply or -manual-override and require explicit target
 //     confirmation.
+//   - pro-entitlements: PostgreSQL application-data backfill; see
+//     PRO_ENTITLEMENTS_BACKFILL.md. It defaults to a non-writing dry run.
 //
 // Each guide documents its own connectivity, secret environment variables,
 // invocation modes, output, and recovery procedure. Flags are subcommand-local;
@@ -89,9 +91,11 @@ func run() int {
 		return runOpenRouterDisableCauses(args, os.Stdin, os.Stdout, os.Getenv)
 	case "legacy-policy-scope":
 		return runLegacyPolicyScope(args, os.Stdout, os.Getenv)
+	case "pro-entitlements":
+		return runProEntitlements(args, os.Stdout, os.Getenv)
 	default:
 		// The unrecognized name is deliberately not echoed (log injection).
-		log.Printf("unknown migration subcommand (available: riskfindings, riskfindingscols, openrouter-disable-causes, legacy-policy-scope)")
+		log.Printf("unknown migration subcommand (available: riskfindings, riskfindingscols, openrouter-disable-causes, legacy-policy-scope, pro-entitlements)")
 		return 2
 	}
 }

--- a/server/cmd/tools/migrations/pro_entitlements_cmd.go
+++ b/server/cmd/tools/migrations/pro_entitlements_cmd.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+)
+
+type proEntitlementsConfig struct {
+	dbURL       string
+	environment string
+	apply       bool
+}
+
+func parseProEntitlementsFlags(args []string, getenv func(string) string) (proEntitlementsConfig, error) {
+	fs := flag.NewFlagSet("pro-entitlements", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	apply := fs.Bool("apply", false, "write the backfill (default is dry run)")
+	environment := fs.String("environment", "", "target environment name")
+	confirmEnvironment := fs.String("confirm-environment", "", "must exactly match environment for writes")
+	confirmTarget := fs.String("confirm-target", "", "must exactly match the parsed host, port, and database for writes")
+	confirmApply := fs.String("confirm-apply", "", "must equal pro-entitlements for writes")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
+		return proEntitlementsConfig{}, errors.New("invalid pro-entitlements flags")
+	}
+	if *environment == "" {
+		return proEntitlementsConfig{}, errors.New("environment is required")
+	}
+	if *apply && *confirmEnvironment != *environment {
+		return proEntitlementsConfig{}, errors.New("writes require -confirm-environment to exactly match -environment")
+	}
+	dbURL := getenv("GRAM_DATABASE_URL")
+	if dbURL == "" {
+		return proEntitlementsConfig{}, errors.New("missing $GRAM_DATABASE_URL")
+	}
+	dbConfig, err := pgx.ParseConfig(dbURL)
+	if err != nil {
+		return proEntitlementsConfig{}, errors.New("invalid $GRAM_DATABASE_URL")
+	}
+	target := net.JoinHostPort(dbConfig.Host, strconv.Itoa(int(dbConfig.Port))) + "/" + dbConfig.Database
+	if *apply && *confirmTarget != target {
+		return proEntitlementsConfig{}, fmt.Errorf("writes require -confirm-target=%s to match the parsed database target", target)
+	}
+	if *apply && *confirmApply != "pro-entitlements" {
+		return proEntitlementsConfig{}, errors.New("writes require -confirm-apply=pro-entitlements")
+	}
+	return proEntitlementsConfig{dbURL: dbURL, environment: *environment, apply: *apply}, nil
+}
+
+type proEntitlementsDB interface {
+	featurerepo.DBTX
+	Begin(context.Context) (pgx.Tx, error)
+}
+
+type proEntitlementsReport struct {
+	Organizations int
+	FeaturesAdded int
+}
+
+type proOrganizationTx interface {
+	LockAndCheckPro(context.Context, string) (bool, error)
+	SeedEntitlements(context.Context, string) ([]productfeatures.Feature, error)
+	Commit(context.Context) error
+	Rollback(context.Context) error
+}
+
+type pgxProOrganizationTx struct{ pgx.Tx }
+
+func (t pgxProOrganizationTx) LockAndCheckPro(ctx context.Context, organizationID string) (bool, error) {
+	return featurerepo.New(t.Tx).LockAndCheckProOrganization(ctx, organizationID)
+}
+
+func (t pgxProOrganizationTx) SeedEntitlements(ctx context.Context, organizationID string) ([]productfeatures.Feature, error) {
+	return productfeatures.SeedEnterpriseAccessEntitlementsTx(ctx, t.Tx, organizationID)
+}
+
+func backfillProEntitlements(ctx context.Context, db proEntitlementsDB, apply bool) (proEntitlementsReport, error) {
+	organizationIDs, err := featurerepo.New(db).ListProOrganizations(ctx)
+	if err != nil {
+		return proEntitlementsReport{}, fmt.Errorf("list pro organizations: %w", err)
+	}
+
+	return backfillProOrganizations(organizationIDs, apply, func(organizationID string, apply bool) (int, error) {
+		tx, err := db.Begin(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("begin organization transaction: %w", err)
+		}
+		return migrateProOrganization(ctx, pgxProOrganizationTx{Tx: tx}, organizationID, apply)
+	})
+}
+
+func migrateProOrganization(ctx context.Context, tx proOrganizationTx, organizationID string, apply bool) (int, error) {
+	rollback := func() { _ = tx.Rollback(ctx) }
+	isPro, err := tx.LockAndCheckPro(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) || (err == nil && !isPro) {
+		rollback()
+		return 0, nil
+	}
+	if err != nil {
+		rollback()
+		return 0, fmt.Errorf("lock and recheck pro organization: %w", err)
+	}
+	enabled, err := tx.SeedEntitlements(ctx, organizationID)
+	if err != nil {
+		rollback()
+		return 0, fmt.Errorf("seed pro organization entitlements: %w", err)
+	}
+	if !apply {
+		if err := tx.Rollback(ctx); err != nil {
+			return 0, fmt.Errorf("roll back dry-run organization entitlements: %w", err)
+		}
+		return len(enabled), nil
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit organization entitlements: %w", err)
+	}
+	return len(enabled), nil
+}
+
+func backfillProOrganizations(organizationIDs []string, apply bool, seed func(string, bool) (int, error)) (proEntitlementsReport, error) {
+	report := proEntitlementsReport{Organizations: len(organizationIDs)}
+	for _, organizationID := range organizationIDs {
+		added, err := seed(organizationID, apply)
+		if err != nil {
+			return report, err
+		}
+		report.FeaturesAdded += added
+	}
+	return report, nil
+}
+
+func runProEntitlements(args []string, stdout io.Writer, getenv func(string) string) int {
+	cfg, err := parseProEntitlementsFlags(args, getenv)
+	if err != nil {
+		fmt.Fprintf(stdout, "invalid arguments: %v\n", err)
+		return 2
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	pool, err := pgxpool.New(ctx, cfg.dbURL)
+	if err != nil {
+		fmt.Fprintln(stdout, "migration failed: connect postgres")
+		return 1
+	}
+	defer pool.Close()
+	report, err := backfillProEntitlements(ctx, pool, cfg.apply)
+	if err != nil {
+		fmt.Fprintf(stdout, "migration failed: %v\n", err)
+		return 1
+	}
+	mode := "dry-run"
+	if cfg.apply {
+		mode = "apply"
+	}
+	fmt.Fprintf(stdout, "mode=%s environment=%s organizations=%d features_added=%d\n", mode, cfg.environment, report.Organizations, report.FeaturesAdded)
+	return 0
+}

--- a/server/cmd/tools/migrations/pro_entitlements_cmd.go
+++ b/server/cmd/tools/migrations/pro_entitlements_cmd.go
@@ -79,11 +79,19 @@ type proOrganizationTx interface {
 type pgxProOrganizationTx struct{ pgx.Tx }
 
 func (t pgxProOrganizationTx) LockAndCheckPro(ctx context.Context, organizationID string) (bool, error) {
-	return featurerepo.New(t.Tx).LockAndCheckProOrganization(ctx, organizationID)
+	isPro, err := featurerepo.New(t.Tx).LockAndCheckProOrganization(ctx, organizationID)
+	if err != nil {
+		return false, fmt.Errorf("lock and check pro organization: %w", err)
+	}
+	return isPro, nil
 }
 
 func (t pgxProOrganizationTx) SeedEntitlements(ctx context.Context, organizationID string) ([]productfeatures.Feature, error) {
-	return productfeatures.SeedEnterpriseAccessEntitlementsTx(ctx, t.Tx, organizationID)
+	features, err := productfeatures.SeedEnterpriseAccessEntitlementsTx(ctx, t.Tx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("seed enterprise access entitlements: %w", err)
+	}
+	return features, nil
 }
 
 func backfillProEntitlements(ctx context.Context, db proEntitlementsDB, apply bool) (proEntitlementsReport, error) {
@@ -130,7 +138,7 @@ func migrateProOrganization(ctx context.Context, tx proOrganizationTx, organizat
 }
 
 func backfillProOrganizations(organizationIDs []string, apply bool, seed func(string, bool) (int, error)) (proEntitlementsReport, error) {
-	report := proEntitlementsReport{Organizations: len(organizationIDs)}
+	report := proEntitlementsReport{Organizations: len(organizationIDs), FeaturesAdded: 0}
 	for _, organizationID := range organizationIDs {
 		added, err := seed(organizationID, apply)
 		if err != nil {
@@ -144,26 +152,26 @@ func backfillProOrganizations(organizationIDs []string, apply bool, seed func(st
 func runProEntitlements(args []string, stdout io.Writer, getenv func(string) string) int {
 	cfg, err := parseProEntitlementsFlags(args, getenv)
 	if err != nil {
-		fmt.Fprintf(stdout, "invalid arguments: %v\n", err)
+		_, _ = fmt.Fprintf(stdout, "invalid arguments: %v\n", err)
 		return 2
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	pool, err := pgxpool.New(ctx, cfg.dbURL)
 	if err != nil {
-		fmt.Fprintln(stdout, "migration failed: connect postgres")
+		_, _ = fmt.Fprintln(stdout, "migration failed: connect postgres")
 		return 1
 	}
 	defer pool.Close()
 	report, err := backfillProEntitlements(ctx, pool, cfg.apply)
 	if err != nil {
-		fmt.Fprintf(stdout, "migration failed: %v\n", err)
+		_, _ = fmt.Fprintf(stdout, "migration failed: %v\n", err)
 		return 1
 	}
 	mode := "dry-run"
 	if cfg.apply {
 		mode = "apply"
 	}
-	fmt.Fprintf(stdout, "mode=%s environment=%s organizations=%d features_added=%d\n", mode, cfg.environment, report.Organizations, report.FeaturesAdded)
+	_, _ = fmt.Fprintf(stdout, "mode=%s environment=%s organizations=%d features_added=%d\n", mode, cfg.environment, report.Organizations, report.FeaturesAdded)
 	return 0
 }

--- a/server/cmd/tools/migrations/pro_entitlements_cmd_test.go
+++ b/server/cmd/tools/migrations/pro_entitlements_cmd_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+)
+
+type fakeProOrganizationTx struct {
+	isPro      bool
+	seeded     bool
+	committed  bool
+	rolledBack bool
+}
+
+func (f *fakeProOrganizationTx) LockAndCheckPro(context.Context, string) (bool, error) {
+	return f.isPro, nil
+}
+func (f *fakeProOrganizationTx) SeedEntitlements(context.Context, string) ([]productfeatures.Feature, error) {
+	f.seeded = true
+	return []productfeatures.Feature{productfeatures.FeatureLogs, productfeatures.FeatureSSO}, nil
+}
+func (f *fakeProOrganizationTx) Commit(context.Context) error   { f.committed = true; return nil }
+func (f *fakeProOrganizationTx) Rollback(context.Context) error { f.rolledBack = true; return nil }
+
+func TestParseProEntitlementsFlagsDryRunByDefault(t *testing.T) {
+	t.Parallel()
+	cfg, err := parseProEntitlementsFlags([]string{"-environment=staging"}, func(key string) string {
+		if key == "GRAM_DATABASE_URL" {
+			return "postgres://test"
+		}
+		return ""
+	})
+	require.NoError(t, err)
+	require.False(t, cfg.apply)
+}
+
+func TestMigrateProOrganizationDryRunSeedsThenRollsBack(t *testing.T) {
+	t.Parallel()
+	tx := &fakeProOrganizationTx{isPro: true}
+	added, err := migrateProOrganization(t.Context(), tx, "org-a", false)
+	require.NoError(t, err)
+	require.Equal(t, 2, added)
+	require.True(t, tx.seeded)
+	require.True(t, tx.rolledBack)
+	require.False(t, tx.committed)
+}
+
+func TestMigrateProOrganizationSkipsOrganizationNoLongerPro(t *testing.T) {
+	t.Parallel()
+	tx := &fakeProOrganizationTx{isPro: false}
+	added, err := migrateProOrganization(t.Context(), tx, "org-a", true)
+	require.NoError(t, err)
+	require.Zero(t, added)
+	require.False(t, tx.seeded)
+	require.True(t, tx.rolledBack)
+	require.False(t, tx.committed)
+}
+
+func TestBackfillProOrganizationsDryRunSeedsProspectively(t *testing.T) {
+	t.Parallel()
+	var seeded []string
+	report, err := backfillProOrganizations([]string{"org-a", "org-b"}, false, func(id string, apply bool) (int, error) {
+		require.False(t, apply)
+		seeded = append(seeded, id)
+		return 2, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"org-a", "org-b"}, seeded)
+	require.Equal(t, proEntitlementsReport{Organizations: 2, FeaturesAdded: 4}, report)
+}
+
+func TestBackfillProOrganizationsAppliesEachOrganization(t *testing.T) {
+	t.Parallel()
+	var seeded []string
+	report, err := backfillProOrganizations([]string{"org-a", "org-b"}, true, func(id string, apply bool) (int, error) {
+		require.True(t, apply)
+		seeded = append(seeded, id)
+		return 3, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"org-a", "org-b"}, seeded)
+	require.Equal(t, proEntitlementsReport{Organizations: 2, FeaturesAdded: 6}, report)
+}
+
+func TestParseProEntitlementsFlagsRequiresWriteConfirmations(t *testing.T) {
+	t.Parallel()
+	getenv := func(string) string { return "postgres://user@db.internal:5432/gram" }
+
+	_, err := parseProEntitlementsFlags([]string{"-apply", "-environment=staging"}, getenv)
+	require.ErrorContains(t, err, "confirm-environment")
+
+	_, err = parseProEntitlementsFlags([]string{"-apply", "-environment=staging", "-confirm-environment=staging", "-confirm-target=other.internal:5432/gram"}, getenv)
+	require.ErrorContains(t, err, "-confirm-target=db.internal:5432/gram")
+
+	_, err = parseProEntitlementsFlags([]string{"-apply", "-environment=staging", "-confirm-environment=staging", "-confirm-target=db.internal:5432/gram"}, getenv)
+	require.ErrorContains(t, err, "confirm-apply")
+
+	cfg, err := parseProEntitlementsFlags([]string{"-apply", "-environment=staging", "-confirm-environment=staging", "-confirm-target=db.internal:5432/gram", "-confirm-apply=pro-entitlements"}, getenv)
+	require.NoError(t, err)
+	require.True(t, cfg.apply)
+}

--- a/server/cmd/tools/migrations/pro_entitlements_cmd_test.go
+++ b/server/cmd/tools/migrations/pro_entitlements_cmd_test.go
@@ -49,6 +49,17 @@ func TestMigrateProOrganizationDryRunSeedsThenRollsBack(t *testing.T) {
 	require.False(t, tx.committed)
 }
 
+func TestMigrateProOrganizationApplyCommits(t *testing.T) {
+	t.Parallel()
+	tx := &fakeProOrganizationTx{isPro: true}
+	added, err := migrateProOrganization(t.Context(), tx, "org-a", true)
+	require.NoError(t, err)
+	require.Equal(t, 2, added)
+	require.True(t, tx.seeded)
+	require.True(t, tx.committed)
+	require.False(t, tx.rolledBack)
+}
+
 func TestMigrateProOrganizationSkipsOrganizationNoLongerPro(t *testing.T) {
 	t.Parallel()
 	tx := &fakeProOrganizationTx{isPro: false}

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -1691,7 +1691,7 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	span.AddEvent("invite.callback.invitation_accepted")
 
 	if trialArmed {
-		for _, feature := range productfeatures.EnterpriseTrialBundle {
+		for _, feature := range productfeatures.EnterpriseAccessBundle {
 			s.features.UpdateFeatureCache(ctx, acceptedInvite.OrganizationID, feature, true)
 		}
 	}

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -50,7 +50,7 @@ func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
 
 	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "platform-admin-first-user", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
-	for _, feature := range productfeatures.EnterpriseTrialBundle {
+	for _, feature := range productfeatures.EnterpriseAccessBundle {
 		enabled, featureErr := ti.features.IsFeatureEnabled(ctx, organizationID, feature)
 		require.NoError(t, featureErr)
 		require.Falsef(t, enabled, "feature %s should be cached as disabled before trial arming", feature)
@@ -80,7 +80,7 @@ func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "enterprise", trial.Tier)
 	require.WithinDuration(t, armedAt.Add(14*24*time.Hour), trial.EndsAt.Time, time.Minute)
-	for _, feature := range productfeatures.EnterpriseTrialBundle {
+	for _, feature := range productfeatures.EnterpriseAccessBundle {
 		enabled, featureErr := ti.features.IsFeatureEnabled(ctx, organizationID, feature)
 		require.NoError(t, featureErr)
 		require.Truef(t, enabled, "feature %s cache should refresh after trial arming", feature)

--- a/server/internal/productfeatures/bundle_test.go
+++ b/server/internal/productfeatures/bundle_test.go
@@ -49,7 +49,7 @@ func TestSeedEnterpriseTrialBundleTx_Idempotent(t *testing.T) {
 	// Skills sits outside the bundle: EnableSkillsTx enables it alongside the
 	// role grants it needs. slices.Concat rather than append, so this never
 	// writes into spare capacity the exported bundle might grow.
-	entitlements := slices.Concat(productfeatures.EnterpriseTrialBundle, []productfeatures.Feature{productfeatures.FeatureSkills})
+	entitlements := slices.Concat(productfeatures.EnterpriseAccessBundle, []productfeatures.Feature{productfeatures.FeatureSkills})
 
 	poolRepo := featurerepo.New(ti.conn)
 	for _, feature := range entitlements {
@@ -114,7 +114,7 @@ func TestSetTrialRuntimeFeaturesTx_TogglesOnlyRuntimeFeatures(t *testing.T) {
 	}
 }
 
-func TestSeedPaygEntitlementsTxPreservesExplicitDisable(t *testing.T) {
+func TestSeedEnterpriseAccessEntitlementsTxPreservesExplicitDisable(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProductFeaturesService(t)
@@ -134,7 +134,7 @@ func TestSeedPaygEntitlementsTxPreservesExplicitDisable(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := testenv.BeginTx(t, ctx, ti.conn)
-	enabled, err := productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
+	enabled, err := productfeatures.SeedEnterpriseAccessEntitlementsTx(ctx, tx, organizationID)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit(ctx))
 	require.NotContains(t, enabled, productfeatures.FeatureSSO)
@@ -148,7 +148,7 @@ func TestSeedPaygEntitlementsTxPreservesExplicitDisable(t *testing.T) {
 
 	for _, feature := range slices.Concat(
 		[]productfeatures.Feature{productfeatures.FeaturePlatformMCP},
-		productfeatures.EnterpriseTrialBundle,
+		productfeatures.EnterpriseAccessBundle,
 		[]productfeatures.Feature{productfeatures.FeatureSkills},
 	) {
 		if feature == productfeatures.FeatureSSO {

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -319,16 +319,17 @@ func SeedOrganizationDefaultsTx(ctx context.Context, tx pgx.Tx, organizationID s
 	return nil
 }
 
-// EnterpriseTrialBundle is the entitlement set an enterprise trial organization
-// receives at signup. A trial gates only on the time window, so identity (SSO,
-// SCIM) is included rather than held back as a conversion lever.
+// EnterpriseAccessBundle is the entitlement set an enterprise-level
+// organization receives at signup or paid-tier activation. A trial gates only
+// on the time window, so identity (SSO, SCIM) is included rather than held back
+// as a conversion lever.
 //
-// FeatureSkills is absent because Skills is generally available. The bundle
-// still calls EnableSkillsTx, which provisions the Skills role grants that the
-// entitlement cannot work without. FeatureHooksFailOpen and
+// FeatureSkills is absent because Skills is generally available. The trial and
+// paid-tier seeders separately provision the Skills role grants that access
+// requires. FeatureHooksFailOpen and
 // FeatureSkillCaptureMetadataOnly are absent because they change how an
 // entitlement behaves rather than granting one.
-var EnterpriseTrialBundle = []Feature{
+var EnterpriseAccessBundle = []Feature{
 	FeatureLogs,
 	FeatureToolIOLogs,
 	FeatureSessionCapture,
@@ -381,7 +382,7 @@ func SetTrialRuntimeFeaturesTx(ctx context.Context, tx pgx.Tx, organizationID st
 func SeedEnterpriseTrialBundleTx(ctx context.Context, tx pgx.Tx, organizationID string) error {
 	q := repo.New(tx)
 
-	for _, feature := range EnterpriseTrialBundle {
+	for _, feature := range EnterpriseAccessBundle {
 		if _, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
 			OrganizationID: organizationID,
 			FeatureName:    string(feature),
@@ -397,15 +398,15 @@ func SeedEnterpriseTrialBundleTx(ctx context.Context, tx pgx.Tx, organizationID 
 	return nil
 }
 
-// SeedPaygEntitlementsTx grants PAYG capabilities only when an organization
-// has never configured them. A soft-deleted feature remains disabled. The
-// returned features are the rows this transaction inserted, so callers can
+// SeedEnterpriseAccessEntitlementsTx grants enterprise-level capabilities only
+// when an organization has never configured them. A soft-deleted feature remains
+// disabled. The returned features are the rows this transaction inserted, so callers can
 // update caches after commit without exposing uncommitted state.
-func SeedPaygEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID string) ([]Feature, error) {
+func SeedEnterpriseAccessEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID string) ([]Feature, error) {
 	q := repo.New(tx)
-	features := make([]Feature, 0, len(EnterpriseTrialBundle)+2)
+	features := make([]Feature, 0, len(EnterpriseAccessBundle)+2)
 	features = append(features, FeaturePlatformMCP)
-	features = append(features, EnterpriseTrialBundle...)
+	features = append(features, EnterpriseAccessBundle...)
 	features = append(features, FeatureSkills)
 
 	enabled := make([]Feature, 0, len(features))
@@ -415,7 +416,7 @@ func SeedPaygEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID strin
 			FeatureName:    string(feature),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("enable new PAYG entitlement %s: %w", feature, err)
+			return nil, fmt.Errorf("enable new enterprise-access entitlement %s: %w", feature, err)
 		}
 		if inserted == 0 {
 			continue
@@ -423,7 +424,7 @@ func SeedPaygEntitlementsTx(ctx context.Context, tx pgx.Tx, organizationID strin
 
 		if feature == FeatureSkills {
 			if err := provisionSkillsSystemRoleGrantsTx(ctx, tx, organizationID); err != nil {
-				return nil, fmt.Errorf("provision PAYG Skills grants: %w", err)
+				return nil, fmt.Errorf("provision enterprise-access Skills grants: %w", err)
 			}
 		}
 		enabled = append(enabled, feature)

--- a/server/internal/productfeatures/queries.sql
+++ b/server/internal/productfeatures/queries.sql
@@ -1,3 +1,15 @@
+-- name: ListProOrganizations :many
+SELECT id
+FROM organization_metadata
+WHERE gram_account_type = 'pro'
+ORDER BY id;
+
+-- name: LockAndCheckProOrganization :one
+SELECT gram_account_type = 'pro' AS is_pro
+FROM organization_metadata
+WHERE id = @organization_id
+FOR UPDATE;
+
 -- name: LockOrganizationMetadata :one
 SELECT id
 FROM organization_metadata
@@ -43,8 +55,8 @@ ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE
 DO NOTHING;
 
 -- name: EnableFeatureIfNeverConfigured :execrows
--- PAYG activation grants purchased capabilities to legacy organizations while
--- preserving a soft-deleted row as an explicit administrator choice.
+-- Paid-tier activation grants enterprise-access capabilities while preserving
+-- a soft-deleted row as an explicit administrator choice.
 INSERT INTO organization_features (
     organization_id,
     feature_name

--- a/server/internal/productfeatures/repo/queries.sql.go
+++ b/server/internal/productfeatures/repo/queries.sql.go
@@ -101,8 +101,8 @@ type EnableFeatureIfNeverConfiguredParams struct {
 	FeatureName    string
 }
 
-// PAYG activation grants purchased capabilities to legacy organizations while
-// preserving a soft-deleted row as an explicit administrator choice.
+// Paid-tier activation grants enterprise-access capabilities while preserving
+// a soft-deleted row as an explicit administrator choice.
 func (q *Queries) EnableFeatureIfNeverConfigured(ctx context.Context, arg EnableFeatureIfNeverConfiguredParams) (int64, error) {
 	result, err := q.db.Exec(ctx, enableFeatureIfNeverConfigured, arg.OrganizationID, arg.FeatureName)
 	if err != nil {
@@ -149,6 +149,47 @@ func (q *Queries) IsFeatureEnabled(ctx context.Context, arg IsFeatureEnabledPara
 	var enabled bool
 	err := row.Scan(&enabled)
 	return enabled, err
+}
+
+const lockAndCheckProOrganization = `-- name: LockAndCheckProOrganization :one
+SELECT gram_account_type = 'pro' AS is_pro
+FROM organization_metadata
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockAndCheckProOrganization(ctx context.Context, organizationID string) (bool, error) {
+	row := q.db.QueryRow(ctx, lockAndCheckProOrganization, organizationID)
+	var isPro bool
+	err := row.Scan(&isPro)
+	return isPro, err
+}
+
+const listProOrganizations = `-- name: ListProOrganizations :many
+SELECT id
+FROM organization_metadata
+WHERE gram_account_type = 'pro'
+ORDER BY id
+`
+
+func (q *Queries) ListProOrganizations(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, listProOrganizations)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const lockOrganizationMetadata = `-- name: LockOrganizationMetadata :one

--- a/server/internal/productfeatures/repo/queries.sql.go
+++ b/server/internal/productfeatures/repo/queries.sql.go
@@ -151,20 +151,6 @@ func (q *Queries) IsFeatureEnabled(ctx context.Context, arg IsFeatureEnabledPara
 	return enabled, err
 }
 
-const lockAndCheckProOrganization = `-- name: LockAndCheckProOrganization :one
-SELECT gram_account_type = 'pro' AS is_pro
-FROM organization_metadata
-WHERE id = $1
-FOR UPDATE
-`
-
-func (q *Queries) LockAndCheckProOrganization(ctx context.Context, organizationID string) (bool, error) {
-	row := q.db.QueryRow(ctx, lockAndCheckProOrganization, organizationID)
-	var isPro bool
-	err := row.Scan(&isPro)
-	return isPro, err
-}
-
 const listProOrganizations = `-- name: ListProOrganizations :many
 SELECT id
 FROM organization_metadata
@@ -190,6 +176,20 @@ func (q *Queries) ListProOrganizations(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockAndCheckProOrganization = `-- name: LockAndCheckProOrganization :one
+SELECT gram_account_type = 'pro' AS is_pro
+FROM organization_metadata
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockAndCheckProOrganization(ctx context.Context, organizationID string) (bool, error) {
+	row := q.db.QueryRow(ctx, lockAndCheckProOrganization, organizationID)
+	var is_pro bool
+	err := row.Scan(&is_pro)
+	return is_pro, err
 }
 
 const lockOrganizationMetadata = `-- name: LockOrganizationMetadata :one

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -617,7 +617,7 @@ func (s *Service) activatePaygCheckout(ctx context.Context, tx pgx.Tx, organizat
 	convertedDemotedTrial := false
 	trial, err := trialsrepo.New(tx).GetTrial(ctx, organizationID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		newlyEnabled, err = productfeatures.SeedPaygEntitlementsTx(ctx, tx, organizationID)
+		newlyEnabled, err = productfeatures.SeedEnterpriseAccessEntitlementsTx(ctx, tx, organizationID)
 		if err != nil {
 			return stripeWebhookResult{}, fmt.Errorf("seed PAYG entitlements: %w", err)
 		}

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1099,7 +1099,7 @@ func TestStripeCheckoutCompletionActivatesColdPaygOrganization(t *testing.T) {
 	require.True(t, organization.Whitelisted)
 	require.Equal(t, 1, paygSchedulingIntentCount(t, db))
 
-	expectedFeatures := append([]productfeatures.Feature{productfeatures.FeaturePlatformMCP}, productfeatures.EnterpriseTrialBundle...)
+	expectedFeatures := append([]productfeatures.Feature{productfeatures.FeaturePlatformMCP}, productfeatures.EnterpriseAccessBundle...)
 	expectedFeatures = append(expectedFeatures, productfeatures.FeatureSkills)
 	featureQueries := featurerepo.New(db)
 	for _, feature := range expectedFeatures {
@@ -2530,7 +2530,7 @@ func TestStripeSubscriptionDeletionDeactivatesCurrentPaygBillingAtomically(t *te
 	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeInternal, 654)
 
 	tx := testenv.BeginTx(t, t.Context(), db)
-	_, err := productfeatures.SeedPaygEntitlementsTx(t.Context(), tx, stripeWebhookOrganizationID)
+	_, err := productfeatures.SeedEnterpriseAccessEntitlementsTx(t.Context(), tx, stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.NoError(t, tx.Commit(t.Context()))
 


### PR DESCRIPTION
## Summary

- add a dry-run-by-default offline backfill that grants Legacy Pro organizations the shared enterprise-access entitlement bundle
- preserve explicitly disabled entitlements, lock and recheck tier eligibility before writes, and make reruns idempotent
- require target-bound apply confirmations and document the operator workflow
- generalize the entitlement seeder naming so enterprise trials, PAYG activation, and the Pro backfill share one source of truth

## Motivation

Legacy Pro organizations should receive enterprise-level feature access without changing their billing behavior or resource limits. An application data backfill follows the repository's migration rules while preserving administrator choices represented by soft-deleted feature rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dry-run-by-default backfill that grants Legacy Pro organizations the shared enterprise-access entitlement bundle without changing their billing or resource limits.

**New Features**
- Adds the `pro-entitlements` command under `server/cmd/tools/migrations`; it defaults to a non-writing preview and requires explicit environment, target, and subcommand confirmations to apply.
- Locks each organization, rechecks `gram_account_type` before writing, and preserves soft-deleted features as administrator disables so reruns stay idempotent.
- Documents the operator workflow, including the required `GRAM_DATABASE_URL` target and error-and-rerun recovery, in `PRO_ENTITLEMENTS_BACKFILL.md`, and marks the change as a server patch.

**Refactors**
- Renames `SeedPaygEntitlementsTx` and `EnterpriseTrialBundle` to `SeedEnterpriseAccessEntitlementsTx` and `EnterpriseAccessBundle` so enterprise trials, PAYG activation, and the Pro backfill share one seeder.
- Application feature caches may hold pre-backfill values for up to their normal TTL after an apply.

<sup>Written for commit e43be8e615a344d2186e08f57e3324add2cb7160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

