### PR TITLE
fix: exempt MCP OAuth callback routes from Origin validation

### DIFF
--- a/.changeset/mcp-origin-validation-oauth-callbacks.md
+++ b/.changeset/mcp-origin-validation-oauth-callbacks.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fixed MCP `Origin` validation rejecting the OAuth callback routes registered under `/mcp/` and `/x/mcp/`. `idp_callback` and `remote_login_callback` sit in the same path position as a server slug, so they were treated as MCP endpoints and answered with 403 when the browser followed the upstream identity provider's redirect back to Gram. The hashed consent and install page scripts were misclassified the same way. Origin validation on the MCP JSON-RPC endpoints themselves is unchanged.

--- a/server/internal/middleware/mcp_protocol_version.go
+++ b/server/internal/middleware/mcp_protocol_version.go
@@ -56,6 +56,11 @@ func MCPProtocolVersionTelemetry(next http.Handler) http.Handler {
 // this middleware is registered via goa's Muxer.Use, which delegates to chi's
 // Router.Use and therefore runs before routing.
 //
+// Segment shape alone is not enough, though: several static routes are
+// registered directly beside /mcp/{mcpSlug} and occupy the same one-segment
+// shape without being MCP endpoints. Those are excluded by name — see
+// isSlugSiblingRoute.
+//
 // The shapes matched here are the MCP JSON-RPC routes the server registers. A
 // new MCP route that does not match one of them is served uninstrumented, with
 // no failure to signal it.
@@ -69,12 +74,17 @@ func isMCPJSONRPCEndpoint(path string) bool {
 	case "mcp":
 		// /mcp/{mcpSlug} — the hosted toolset endpoint. A further slash means
 		// an OAuth or metadata sub-route, not the MCP endpoint itself.
-		return tail != "" && !strings.Contains(tail, "/")
-	case "x", "platform":
-		// /x/mcp/{slug} (toolset-backed, remote-backed, and tunneled) and
-		// /platform/mcp/{toolsetSlug}.
+		return isEndpointSlug(tail) && !isSlugSiblingRoute(tail)
+	case "x":
+		// /x/mcp/{slug} — toolset-backed, remote-backed, and tunneled. Carries
+		// the same OAuth callback siblings as /mcp/ (internal/xmcp/service.go).
 		slug, ok := strings.CutPrefix(tail, "mcp/")
-		return ok && slug != "" && !strings.Contains(slug, "/")
+		return ok && isEndpointSlug(slug) && !isSlugSiblingRoute(slug)
+	case "platform":
+		// /platform/mcp/{toolsetSlug}. Nothing static is registered beside it,
+		// so every one-segment tail here really is a slug.
+		slug, ok := strings.CutPrefix(tail, "mcp/")
+		return ok && isEndpointSlug(slug)
 	case "platform-mcp":
 		// POST /platform-mcp is Gram's own platform MCP server
 		// (internal/platformmcp), served by the go-sdk's Streamable HTTP
@@ -87,4 +97,46 @@ func isMCPJSONRPCEndpoint(path string) bool {
 	default:
 		return false
 	}
+}
+
+// isEndpointSlug reports whether seg is a single non-empty path segment, the
+// shape an MCP endpoint slug occupies. A further slash means a sub-route.
+func isEndpointSlug(seg string) bool {
+	return seg != "" && !strings.Contains(seg, "/")
+}
+
+// isSlugSiblingRoute reports whether seg names a static route registered
+// directly under /mcp/ or /x/mcp/ rather than an endpoint slug.
+//
+// chi resolves a static pattern ahead of a parameterized one, so these paths
+// always reach their own handler and never the MCP endpoint handler. This
+// middleware runs before routing, however, and sees only the path, where a
+// static one-segment route is indistinguishable from a slug by shape alone.
+//
+// Getting this wrong is not merely a telemetry gap, because MCPSecurity shares
+// this predicate. A misclassified OAuth callback gets origin-checked, and the
+// browser navigation returning from an upstream IdP carries
+// Sec-Fetch-Site: cross-site by construction — it is a redirect arriving from
+// the IdP's own origin, with no Origin header, which is exactly the shape
+// CrossOriginProtection refuses. That is a 403 in the middle of every
+// remote-login and IdP-backed authorization flow, which is what shipping the
+// original predicate did to production.
+func isSlugSiblingRoute(seg string) bool {
+	switch seg {
+	// GET /mcp/idp_callback and GET /x/mcp/idp_callback: the upstream IdP
+	// redirects the browser here to complete an authorization code exchange.
+	case "idp_callback":
+		return true
+	// GET /mcp/remote_login_callback and GET /x/mcp/remote_login_callback: the
+	// same, for the remote-session login flow that writes remote_sessions.
+	case "remote_login_callback":
+		return true
+	}
+
+	// /mcp/install-page-{hash}.js, /mcp/consent-page-{hash}.js and
+	// /mcp/consent-tools-{hash}.js are content-hashed browser assets. No slug
+	// can collide with them: constants.SlugPattern is ^[a-z0-9_-]{1,128}$,
+	// which admits no dot, so the suffix alone settles it and new hashed
+	// assets need no update here.
+	return strings.HasSuffix(seg, ".js")
 }

--- a/server/internal/middleware/mcp_protocol_version_test.go
+++ b/server/internal/middleware/mcp_protocol_version_test.go
@@ -152,6 +152,53 @@ func TestMCPProtocolVersionTelemetryIgnoresOAuthSubRoutes(t *testing.T) {
 	}
 }
 
+// TestMCPProtocolVersionTelemetryIgnoresSlugSiblingRoutes is the inverse of
+// TestMCPProtocolVersionTelemetryMatchesRegisteredRoutes: these static routes
+// are registered directly beside /mcp/{mcpSlug} and /x/mcp/{mcpSlug}, so they
+// occupy the slug position without being MCP endpoints and chi resolves them
+// first. Shape alone cannot tell them apart from a slug, so they are excluded
+// by name.
+//
+// Keep this list in lockstep with the one-segment routes registered in
+// internal/mcp/impl.go and internal/xmcp/service.go. MCPSecurity shares this
+// predicate, so a route that regresses back into it is answered with 403
+// rather than merely losing an attribute.
+func TestMCPProtocolVersionTelemetryIgnoresSlugSiblingRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/idp_callback",
+		"/mcp/remote_login_callback",
+		"/mcp/install-page-9f86d081.js",
+		"/mcp/consent-page-9f86d081.js",
+		"/mcp/consent-tools-9f86d081.js",
+		"/x/mcp/idp_callback",
+		"/x/mcp/remote_login_callback",
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			got := recordSpanForRequest(t, method, path, mcpversions.Version20250618)
+			require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "%s %s", method, path)
+		}
+	}
+}
+
+// The exclusions above are exact segment matches, not prefixes or substrings.
+// A customer slug that merely resembles a callback is still an MCP endpoint,
+// and /platform/mcp/ registers no static siblings at all.
+func TestMCPProtocolVersionTelemetryMatchesSlugsResemblingSiblingRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/idp_callback_service",
+		"/mcp/my-remote_login_callback",
+		"/platform/mcp/idp_callback",
+		"/platform/mcp/remote_login_callback",
+	} {
+		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
+		require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)], "path %s", path)
+	}
+}
+
 func TestMCPProtocolVersionTelemetryIgnoresNonMCPRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/middleware/mcp_security_test.go
+++ b/server/internal/middleware/mcp_security_test.go
@@ -215,6 +215,92 @@ func TestMCPSecurity_CoversEveryMCPJSONRPCRoute(t *testing.T) {
 	}
 }
 
+// The OAuth callbacks and hashed browser assets registered directly under
+// /mcp/ and /x/mcp/ sit in the same one-segment shape as a slug, so the
+// original predicate read them as MCP endpoints and origin-checked them.
+//
+// A callback is reached by the browser following the upstream IdP's redirect,
+// which is cross-site by construction and, being a top-level navigation,
+// carries no Origin header at all. That combination is precisely what
+// CrossOriginProtection refuses, so remote-login and IdP-backed authorization
+// flows terminated in a 403 in production. The request shape asserted here is
+// the one observed in those rejections.
+func TestMCPSecurity_AllowsOAuthCallbackNavigation(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/idp_callback",
+		"/mcp/remote_login_callback",
+		"/x/mcp/idp_callback",
+		"/x/mcp/remote_login_callback",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai"+path+"?code=abc&state=xyz", nil)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Sec-Fetch-Mode", "navigate")
+
+			rec, reached := serveMCPSecurity(t, req)
+
+			require.True(t, reached, "the OAuth callback must survive the IdP's cross-site redirect")
+			require.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// The consent and install scripts are content-hashed assets, not JSON-RPC
+// endpoints. A slug cannot collide with them because constants.SlugPattern
+// admits no dot.
+func TestMCPSecurity_AllowsHashedBrowserAssets(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/install-page-9f86d081.js",
+		"/mcp/consent-page-9f86d081.js",
+		"/mcp/consent-tools-9f86d081.js",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "https://app.getgram.ai"+path, nil)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Sec-Fetch-Mode", "no-cors")
+
+			_, reached := serveMCPSecurity(t, req)
+
+			require.True(t, reached, "a hashed browser asset is not an MCP endpoint")
+		})
+	}
+}
+
+// Exempting the callbacks by name must not hand an attacker a way to shed the
+// origin check. Only the exact static segments chi resolves ahead of
+// {mcpSlug} are excluded, and only on the two prefixes that register them.
+func TestMCPSecurity_StillCoversSlugsResemblingCallbacks(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/mcp/idp_callback_service",
+		"/mcp/my-remote_login_callback",
+		"/platform/mcp/idp_callback",
+		"/platform/mcp/remote_login_callback",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			req := mcpPost(path)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+			req.Header.Set("Origin", hostileOrigin)
+
+			rec, reached := serveMCPSecurity(t, req)
+
+			require.False(t, reached)
+			require.Equal(t, http.StatusForbidden, rec.Code)
+		})
+	}
+}
+
 // The OAuth, metadata, and install routes share the /mcp/ prefix but are not
 // JSON-RPC endpoints; they have their own browser-facing flows.
 func TestMCPSecurity_IgnoresNonJSONRPCRoutes(t *testing.T) {
@@ -224,8 +310,11 @@ func TestMCPSecurity_IgnoresNonJSONRPCRoutes(t *testing.T) {
 		"/mcp/petstore/token",
 		"/mcp/petstore/register",
 		"/mcp/petstore/connect",
+		"/mcp/petstore/remote_login_callback",
+		"/mcp/petstore/idp_callback",
 		"/platform-mcp/authorize",
 		"/platform-mcp/token",
+		"/platform-mcp/idp_callback",
 		"/platform-mcp/provider-setup",
 		"/rpc/chatSessions.create",
 	} {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-49/fix-validate-origin-and-content-type-on-mcp-endpoints

## Summary

Follow-up to #5899. `isMCPJSONRPCEndpoint` classified any single path segment under `/mcp/` and `/x/mcp/` as a server slug, but several static routes are registered in exactly that position and are not MCP endpoints. `MCPSecurity` shares that predicate, so those routes were origin-checked and answered with 403.

The OAuth callbacks are the ones that mattered: `/mcp/idp_callback`, `/mcp/remote_login_callback`, and their `/x/mcp/` equivalents (`internal/mcp/impl.go`, `internal/xmcp/service.go`). A browser reaches them by following the upstream identity provider's redirect, so the request is `Sec-Fetch-Site: cross-site` with no `Origin` header at all, which is exactly what `CrossOriginProtection` refuses. The GET-as-POST probe added in #5899 removed the safe-method exemption that would otherwise have let them through.

The three content-hashed browser assets (`/mcp/install-page-{hash}.js`, `/mcp/consent-page-{hash}.js`, `/mcp/consent-tools-{hash}.js`) were misclassified the same way and are excluded too. A slug can never collide with them because `constants.SlugPattern` is `^[a-z0-9_-]{1,128}$`, which admits no dot, so a `.js` suffix settles it without needing a per-asset list.

`case "x", "platform"` is split because `/platform/mcp/` registers no static siblings, so nothing should be exempted there. Origin and `Content-Type` validation on the MCP JSON-RPC endpoints themselves is unchanged.

## Production impact

Confirmed on `sha-14b71e4` in prod: rejections logged from `middleware.logMCPSecurityRejection` with `gram.component:mcp-security`, `reason:cross_origin`, `http.request.method:GET`, `sec_fetch_site:cross-site`, empty `origin`, and real browser user agents. Only `/mcp/remote_login_callback` and `/mcp/idp_callback` appear. Every remote-login and IdP-backed authorization flow that routed through those callbacks terminated in a 403.

## Notes

`isSlugSiblingRoute` duplicates route knowledge outside the router, which is unavoidable here since the middleware is registered via goa's `Muxer.Use` and runs before routing. The exclusion list needs to stay in lockstep with the one-segment routes registered in `internal/mcp/impl.go` and `internal/xmcp/service.go`; `TestMCPProtocolVersionTelemetryIgnoresSlugSiblingRoutes` documents that and carries a comment saying so, because a route regressing back into the predicate is a 403 rather than a missing span attribute.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a production 403 on the MCP OAuth callback routes. `isMCPJSONRPCEndpoint` classified every one-segment path under `/mcp/` and `/x/mcp/` as a server slug, so the statically registered `idp_callback`, `remote_login_callback`, and the hashed `.js` assets were origin-checked by `MCPSecurity` and rejected with 403 — breaking every remote-login and IdP-backed authorization flow, since the browser's return navigation from the IdP is cross-site with no `Origin` header.

**Notes**
- Excludes the callback names and the `.js` suffix by exact match; `SlugPattern` admits no dot, so no slug can collide with the assets.
- `/platform/mcp/` registers no static siblings and keeps matching every one-segment tail; validation on the JSON-RPC endpoints themselves is unchanged.
- The exclusion list must stay in lockstep with the static routes in `internal/mcp/impl.go` and `internal/xmcp/service.go` — a route regressing back into the predicate becomes a 403, not just missing telemetry.
- Addresses AIM-49.

<sup>Written for commit e7adf0d60dae9923572b28c9408d3d4eafdd5d62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

