### PR TITLE
feat(dashboard): declare external assets cross-origin

### DIFF
--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -16,11 +16,13 @@ server {
     sub_filter_once off;
     sub_filter '"/assets/' '"${GRAM_CDN_URL}/assets/';
 
-    # Serve JS under /external with CORS enabled
-    location ~* ^/external/.+\.js$ {
+    # Public resources embedded by customer-hosted pages. Keep both CORS and
+    # CORP permissive: the sticker logo is intentionally loaded cross-site.
+    location ^~ /external/ {
         expires max;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Access-Control-Allow-Origin "*";
+        add_header Cross-Origin-Resource-Policy "cross-origin" always;
     }
 
     # Serve static assets with an efficient cache policy. Note: with


### PR DESCRIPTION
[AIS-552](https://linear.app/speakeasy/issue/AIS-552/apply-accurate-cross-origin-resource-policy-to-public-resource)

## Summary

- Serve every `/external/*` dashboard resource with `Cross-Origin-Resource-Policy: cross-origin` and the existing wildcard CORS policy.
- Preserve the pentest-approved `same-origin` value on dashboard HTML and SPA fallback responses.
- Include the approved Gram and CDN implementation plans.

## Motivation

The public sticker logo is embedded by install pages on custom domains. Giving the `/external` resource family an explicit permissive policy preserves that supported cross-site load without weakening the dashboard HTML remediation.

## Stack

This is the base of a two-PR Gram stack. The follow-up adds the same explicit policy to uploaded image responses.

## Rollout gates

- After dev deployment, confirm dashboard HTML remains exactly `same-origin` and the sticker response is `cross-origin`.
- Confirm default sticker branding renders on a custom-domain install page, then repeat the header checks after production promotion.

## Related PRs

- Gram follow-up: https://github.com/speakeasy-api/gram/pull/5916
- CDN companion: https://github.com/speakeasy-api/gram-infra/pull/2966
