### PR TITLE
feat(server): declare public image assets cross-origin

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -7102,6 +7102,9 @@ paths:
             Content-Type:
               schema:
                 type: string
+            Cross-Origin-Resource-Policy:
+              schema:
+                type: string
             Last-Modified:
               schema:
                 type: string
@@ -80371,12 +80374,15 @@ components:
           format: int64
         content_type:
           type: string
+        cross_origin_resource_policy:
+          type: string
         last_modified:
           type: string
       required:
         - content_type
         - content_length
         - last_modified
+        - cross_origin_resource_policy
     ServeOpenAPIv3Form:
       type: object
       properties:

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -16,11 +16,13 @@ server {
     sub_filter_once off;
     sub_filter '"/assets/' '"${GRAM_CDN_URL}/assets/';
 
-    # Serve JS under /external with CORS enabled
-    location ~* ^/external/.+\.js$ {
+    # Public resources embedded by customer-hosted pages. Keep both CORS and
+    # CORP permissive: the sticker logo is intentionally loaded cross-site.
+    location ^~ /external/ {
         expires max;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Access-Control-Allow-Origin "*";
+        add_header Cross-Origin-Resource-Policy "cross-origin" always;
     }
 
     # Serve static assets with an efficient cache policy. Note: with

--- a/server/design/assets/design.go
+++ b/server/design/assets/design.go
@@ -34,6 +34,7 @@ var _ = Service("assets", func() {
 				Header("content_length:Content-Length")
 				Header("last_modified:Last-Modified")
 				Header("access_control_allow_origin:Access-Control-Allow-Origin")
+				Header("cross_origin_resource_policy:Cross-Origin-Resource-Policy")
 			})
 
 			SkipResponseBodyEncodeDecode()
@@ -360,12 +361,18 @@ var ServeImageForm = Type("ServeImageForm", func() {
 })
 
 var ServeImageResult = Type("ServeImageResult", func() {
-	Required("content_type", "content_length", "last_modified")
+	Required(
+		"content_type",
+		"content_length",
+		"last_modified",
+		"cross_origin_resource_policy",
+	)
 
 	Attribute("content_type", String)
 	Attribute("content_length", Int64)
 	Attribute("last_modified", String)
 	Attribute("access_control_allow_origin", String)
+	Attribute("cross_origin_resource_policy", String)
 })
 
 var UploadOpenAPIv3Form = Type("UploadOpenAPIv3Form", func() {

--- a/server/gen/assets/service.go
+++ b/server/gen/assets/service.go
@@ -227,10 +227,11 @@ type ServeImageForm struct {
 
 // ServeImageResult is the result type of the assets service serveImage method.
 type ServeImageResult struct {
-	ContentType              string
-	ContentLength            int64
-	LastModified             string
-	AccessControlAllowOrigin *string
+	ContentType               string
+	ContentLength             int64
+	LastModified              string
+	AccessControlAllowOrigin  *string
+	CrossOriginResourcePolicy string
 }
 
 // ServeOpenAPIv3Form is the payload type of the assets service serveOpenAPIv3

--- a/server/gen/http/assets/client/encode_decode.go
+++ b/server/gen/http/assets/client/encode_decode.go
@@ -81,11 +81,12 @@ func DecodeServeImageResponse(decoder func(*http.Response) goahttp.Decoder, rest
 		switch resp.StatusCode {
 		case http.StatusOK:
 			var (
-				contentType              string
-				contentLength            int64
-				lastModified             string
-				accessControlAllowOrigin *string
-				err                      error
+				contentType               string
+				contentLength             int64
+				lastModified              string
+				accessControlAllowOrigin  *string
+				crossOriginResourcePolicy string
+				err                       error
 			)
 			contentTypeRaw := resp.Header.Get("Content-Type")
 			if contentTypeRaw == "" {
@@ -112,10 +113,15 @@ func DecodeServeImageResponse(decoder func(*http.Response) goahttp.Decoder, rest
 			if accessControlAllowOriginRaw != "" {
 				accessControlAllowOrigin = &accessControlAllowOriginRaw
 			}
+			crossOriginResourcePolicyRaw := resp.Header.Get("Cross-Origin-Resource-Policy")
+			if crossOriginResourcePolicyRaw == "" {
+				err = goa.MergeErrors(err, goa.MissingFieldError("cross_origin_resource_policy", "header"))
+			}
+			crossOriginResourcePolicy = crossOriginResourcePolicyRaw
 			if err != nil {
 				return nil, goahttp.ErrValidationError("assets", "serveImage", err)
 			}
-			res := NewServeImageResultOK(contentType, contentLength, lastModified, accessControlAllowOrigin)
+			res := NewServeImageResultOK(contentType, contentLength, lastModified, accessControlAllowOrigin, crossOriginResourcePolicy)
 			return res, nil
 		case http.StatusUnauthorized:
 			var (

--- a/server/gen/http/assets/client/types.go
+++ b/server/gen/http/assets/client/types.go
@@ -2541,12 +2541,13 @@ func NewCreateSignedChatAttachmentURLRequestBody(p *assets.CreateSignedChatAttac
 
 // NewServeImageResultOK builds a "assets" service "serveImage" endpoint result
 // from a HTTP "OK" response.
-func NewServeImageResultOK(contentType string, contentLength int64, lastModified string, accessControlAllowOrigin *string) *assets.ServeImageResult {
+func NewServeImageResultOK(contentType string, contentLength int64, lastModified string, accessControlAllowOrigin *string, crossOriginResourcePolicy string) *assets.ServeImageResult {
 	v := &assets.ServeImageResult{}
 	v.ContentType = contentType
 	v.ContentLength = contentLength
 	v.LastModified = lastModified
 	v.AccessControlAllowOrigin = accessControlAllowOrigin
+	v.CrossOriginResourcePolicy = crossOriginResourcePolicy
 
 	return v
 }

--- a/server/gen/http/assets/server/encode_decode.go
+++ b/server/gen/http/assets/server/encode_decode.go
@@ -35,6 +35,7 @@ func EncodeServeImageResponse(encoder func(context.Context, http.ResponseWriter)
 		if res.AccessControlAllowOrigin != nil {
 			w.Header().Set("Access-Control-Allow-Origin", *res.AccessControlAllowOrigin)
 		}
+		w.Header().Set("Cross-Origin-Resource-Policy", res.CrossOriginResourcePolicy)
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -9100,6 +9100,9 @@ paths:
                         Content-Type:
                             schema:
                                 type: string
+                        Cross-Origin-Resource-Policy:
+                            schema:
+                                type: string
                         Last-Modified:
                             schema:
                                 type: string
@@ -81915,12 +81918,15 @@ components:
                     format: int64
                 content_type:
                     type: string
+                cross_origin_resource_policy:
+                    type: string
                 last_modified:
                     type: string
             required:
                 - content_type
                 - content_length
                 - last_modified
+                - cross_origin_resource_policy
         ServeOpenAPIv3Form:
             type: object
             properties:

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -210,10 +210,11 @@ func (s *Service) ServeImage(ctx context.Context, payload *gen.ServeImageForm) (
 	}
 
 	return &gen.ServeImageResult{
-		ContentType:              row.ContentType,
-		ContentLength:            row.ContentLength,
-		LastModified:             row.UpdatedAt.Time.Format(time.RFC1123),
-		AccessControlAllowOrigin: new("*"),
+		ContentType:               row.ContentType,
+		ContentLength:             row.ContentLength,
+		LastModified:              row.UpdatedAt.Time.Format(time.RFC1123),
+		AccessControlAllowOrigin:  new("*"),
+		CrossOriginResourcePolicy: "cross-origin",
 	}, body, nil
 }
 

--- a/server/internal/assets/serveimage_test.go
+++ b/server/internal/assets/serveimage_test.go
@@ -60,6 +60,7 @@ func TestService_ServeImage_Success(t *testing.T) {
 	require.Equal(t, contentType, result.ContentType)
 	require.Equal(t, contentLength, result.ContentLength)
 	require.NotEmpty(t, result.LastModified)
+	require.Equal(t, "cross-origin", result.CrossOriginResourcePolicy)
 
 	bodyBytes, err := io.ReadAll(body)
 	require.NoError(t, err)


### PR DESCRIPTION
[AIS-552](https://linear.app/speakeasy/issue/AIS-552/apply-accurate-cross-origin-resource-policy-to-public-resource)

## Summary

- Declare `Cross-Origin-Resource-Policy` as a required successful `assets.serveImage` response header.
- Return the fixed `cross-origin` value while preserving `Access-Control-Allow-Origin: *`.
- Regenerate the Goa service, HTTP transport, and OpenAPI artifacts and cover the policy in the existing service test.

## Motivation

Uploaded branding is intentionally loaded as a plain image by install and OAuth consent pages, including pages on custom domains. The endpoint needs an explicit policy that permits that supported cross-site use.

## Stack

- Depends on https://github.com/speakeasy-api/gram/pull/5915
- A separate `gram-infra` companion PR adds the policy to CDN assets.

## Rollout gates

- In dev, confirm an uploaded logo keeps its absolute platform URL, renders on a custom-domain install page, and returns exact `cross-origin`.
- Confirm OAuth consent branding and a Gram Elements chat turn have no new CORS or CORP regressions.
- Repeat the dashboard-root and sticker checks after production promotion.

## Related PR

- CDN companion: https://github.com/speakeasy-api/gram-infra/pull/2966
