### PR TITLE
feat: serve toolset-backed mcp_servers under the wrapper's configuration

### DIFF
--- a/.changeset/wrapper-governed-hosted-mcp-serving.md
+++ b/.changeset/wrapper-governed-hosted-mcp-serving.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Toolset-backed MCP servers resolved through `mcp_endpoints` are now served under their `mcp_servers` row's configuration: visibility, issuer gating, the RBAC resource id for `mcp:connect` (per-server, per-tool, and the consent tool picker), and the variation-group override all come from the wrapper, and the toolset's own `mcp_is_public` / `user_session_issuer_id` columns are no longer consulted on that path. Bearer validation on toolset-backed wrappers accepts the legacy toolset-URN audience as a counted fallback (`mcp.legacy_audience_accepted`). A resolvable `mcp_endpoints` address whose backend is disabled or dangling is now a terminal not-found on every surface instead of falling back to the legacy `toolsets.mcp_slug` lookup, and every remaining legacy fallback resolution increments `mcp.toolset_slug_fallback` by entry point. No production traffic changes on deploy: no toolset-backed `mcp_servers` rows exist yet.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1164,7 +1164,7 @@ func newStartCommand() *cli.Command {
 			assistantsSvc := assistants.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv}, ratelimit.NewRedisStore(redisClient))
 			triggerApp.RegisterDispatcher(assistantsSvc)
 
-			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
+			mcpMetadataService := mcpmetadata.NewService(logger, tracerProvider, meterProvider, db, sessionManager, serverURL, siteURL, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger)
 
 			otelForwardClient := otelforwarding.NewClient(logger, db, encryptionClient, cache.NewRedisCacheAdapter(redisClient))
 			otelForwarder := otelforwarding.NewForwarder(logger, tracerProvider, meterProvider, guardianPolicy)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -325,6 +325,10 @@ const (
 	// McpKillswitchResourceClassKey is the bounded kill-switch resource
 	// coverage class of a covered MCP tools/call. Never a server identifier.
 	McpKillswitchResourceClassKey = attribute.Key("gram.mcp.killswitch.resource_class")
+	// McpEntryPointKey is the bounded entry-point dimension on the
+	// mcp.toolset_slug_fallback counter: which public surface resolved a
+	// request through the legacy toolsets.mcp_slug lookup.
+	McpEntryPointKey              = attribute.Key("gram.mcp.entry_point")
 	McpRequestedTagsKey           = attribute.Key("gram.mcp.requested_tags")
 	McpToolsReturnedKey           = attribute.Key("gram.mcp.tools_returned")
 	McpToolsFilteredKey           = attribute.Key("gram.mcp.tools_filtered")
@@ -2052,6 +2056,8 @@ func SlogMcpMethod(v string) slog.Attr      { return slog.String(string(McpMetho
 
 func McpSurface(v string) attribute.KeyValue { return McpSurfaceKey.String(v) }
 func SlogMcpSurface(v string) slog.Attr      { return slog.String(string(McpSurfaceKey), v) }
+
+func McpEntryPoint[V ~string](v V) attribute.KeyValue { return McpEntryPointKey.String(string(v)) }
 
 func McpKillswitchSurface[V ~string](v V) attribute.KeyValue {
 	return McpKillswitchSurfaceKey.String(string(v))

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -339,19 +339,12 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	return newCtx, &subject, toolSelection, nil
 }
 
-// validateLegacyToolsetAudience re-validates a bearer whose primary audience
-// check failed, against the pre-migration toolset-URN audience. Only
-// toolset-backed wrappers accept it: sessions minted while the server was
-// gated on toolsets.user_session_issuer_id — before its mcp_servers wrapper
-// existed — carry urn.NewToolset as their audience and must keep validating
-// for one access-token lifetime after the backfill (AIS-633). Every
-// acceptance increments mcp.legacy_audience_accepted, whose zero reading is
-// the merge gate for deleting this path (AIS-646). ok is false when the
-// endpoint is not a toolset-backed wrapper, the primary failure was not an
-// audience mismatch, or the legacy validation fails too — callers then
-// surface the original error.
+// validateLegacyToolsetAudience re-validates a bearer that failed the primary
+// audience check against the pre-migration toolset-URN audience (AIS-633;
+// counted acceptance, deleted by AIS-646). ok is false when inapplicable or
+// the legacy validation fails too — callers surface the original error.
 func (s *Service) validateLegacyToolsetAudience(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint, primaryErr error) (sessiontokens.ValidatedSession, bool) {
-	legacyAudience, ok := endpoint.LegacyToolsetAudienceURN()
+	legacyAudience, ok := endpoint.legacyToolsetAudienceURN()
 	if !ok || !errors.Is(primaryErr, jwt.ErrTokenInvalidAudience) {
 		return sessiontokens.ValidatedSession{}, false
 	}

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -41,6 +42,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -306,7 +308,11 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	}
 	session, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
 	if err != nil {
-		return ctx, nil, nil, fmt.Errorf("validate user-session bearer: %w", err)
+		legacySession, ok := s.validateLegacyToolsetAudience(ctx, token, endpoint, err)
+		if !ok {
+			return ctx, nil, nil, fmt.Errorf("validate user-session bearer: %w", err)
+		}
+		session = legacySession
 	}
 
 	// The consent-screen tool selection loads for every subject kind —
@@ -317,7 +323,7 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	if err != nil {
 		return ctx, nil, nil, fmt.Errorf("%w: %w", errToolSelectionLoad, err)
 	}
-	if toolSelection != nil && toolSelection.Resource != endpointToolSelectionResource(endpoint) {
+	if toolSelection != nil && !endpointAcceptsToolSelectionResource(endpoint, toolSelection.Resource) {
 		// Issuer-scoped tokens are portable across endpoints sharing the
 		// issuer; a selection consented on endpoint A must not authorize
 		// same-named tools on endpoint B. Reject into reauth.
@@ -331,6 +337,30 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	}
 	newCtx = s.identityValidator.StampValidatedSession(newCtx, session)
 	return newCtx, &subject, toolSelection, nil
+}
+
+// validateLegacyToolsetAudience re-validates a bearer whose primary audience
+// check failed, against the pre-migration toolset-URN audience. Only
+// toolset-backed wrappers accept it: sessions minted while the server was
+// gated on toolsets.user_session_issuer_id — before its mcp_servers wrapper
+// existed — carry urn.NewToolset as their audience and must keep validating
+// for one access-token lifetime after the backfill (AIS-633). Every
+// acceptance increments mcp.legacy_audience_accepted, whose zero reading is
+// the merge gate for deleting this path (AIS-646). ok is false when the
+// endpoint is not a toolset-backed wrapper, the primary failure was not an
+// audience mismatch, or the legacy validation fails too — callers then
+// surface the original error.
+func (s *Service) validateLegacyToolsetAudience(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint, primaryErr error) (sessiontokens.ValidatedSession, bool) {
+	legacyAudience, ok := endpoint.LegacyToolsetAudienceURN()
+	if !ok || !errors.Is(primaryErr, jwt.ErrTokenInvalidAudience) {
+		return sessiontokens.ValidatedSession{}, false
+	}
+	session, err := s.userSessionSigner.ValidateBearer(ctx, token, legacyAudience, s.chatSessionsManager)
+	if err != nil {
+		return sessiontokens.ValidatedSession{}, false
+	}
+	s.metrics.RecordLegacyAudienceAccepted(ctx, endpoint.UserSessionIssuerID.String())
+	return session, true
 }
 
 // contextForSessionSubject stamps the request context for a resolved session

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -263,13 +263,7 @@ func (s *Service) serveConsentToolsetMCP(w http.ResponseWriter, r *http.Request,
 			if authzCtx, cerr = s.authz.PrepareContext(authzCtx); cerr != nil {
 				return oops.E(oops.CodeUnexpected, cerr, "load access grants for consent inventory").LogError(ctx, logger)
 			}
-			// mcp:connect keys on the wrapper's id when one fronts the
-			// endpoint, matching the runtime request the minted session will
-			// make.
-			connectResourceID := endpoint.ToolsetID.UUID
-			if endpoint.McpServerID.Valid {
-				connectResourceID = endpoint.McpServerID.UUID
-			}
+			connectResourceID := endpoint.connectResourceID()
 			if cerr = s.authz.Require(authzCtx, authz.MCPCheck(authz.ScopeMCPConnect, connectResourceID.String(), endpoint.ProjectID.String())); cerr != nil {
 				return fmt.Errorf("authorize consent inventory access: %w", mcpaccess.ServerPermissionDenied(cerr, s.requestAccessURL(authzCtx, connectResourceID.String(), toolset.Name)))
 			}

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -237,7 +237,14 @@ func (s *Service) serveConsentToolsetMCP(w http.ResponseWriter, r *http.Request,
 		if terr != nil {
 			return oops.E(oops.CodeUnexpected, terr, "load toolset for consent authorization").LogError(ctx, logger)
 		}
-		private := !endpoint.IsPublic || !toolset.McpIsPublic
+		// Wrapper-governed endpoints (toolset-backed mcp_servers) take
+		// publicness from wrapper visibility alone (AIS-633); the legacy
+		// toolset-resolved endpoint keeps consulting the toolset flag so a
+		// mid-flow flip still closes the inventory.
+		private := !endpoint.IsPublic
+		if !endpoint.McpServerID.Valid {
+			private = !endpoint.IsPublic || !toolset.McpIsPublic
+		}
 		if private && challengeState.Subject.Kind == urn.SessionSubjectKindAnonymous {
 			return oops.E(oops.CodeUnauthorized, nil, "anonymous subject cannot enumerate a private MCP server").LogWarn(ctx, logger)
 		}
@@ -256,8 +263,15 @@ func (s *Service) serveConsentToolsetMCP(w http.ResponseWriter, r *http.Request,
 			if authzCtx, cerr = s.authz.PrepareContext(authzCtx); cerr != nil {
 				return oops.E(oops.CodeUnexpected, cerr, "load access grants for consent inventory").LogError(ctx, logger)
 			}
-			if cerr = s.authz.Require(authzCtx, authz.MCPCheck(authz.ScopeMCPConnect, endpoint.ToolsetID.UUID.String(), endpoint.ProjectID.String())); cerr != nil {
-				return fmt.Errorf("authorize consent inventory access: %w", mcpaccess.ServerPermissionDenied(cerr, s.requestAccessURL(authzCtx, endpoint.ToolsetID.UUID.String(), toolset.Name)))
+			// mcp:connect keys on the wrapper's id when one fronts the
+			// endpoint, matching the runtime request the minted session will
+			// make.
+			connectResourceID := endpoint.ToolsetID.UUID
+			if endpoint.McpServerID.Valid {
+				connectResourceID = endpoint.McpServerID.UUID
+			}
+			if cerr = s.authz.Require(authzCtx, authz.MCPCheck(authz.ScopeMCPConnect, connectResourceID.String(), endpoint.ProjectID.String())); cerr != nil {
+				return fmt.Errorf("authorize consent inventory access: %w", mcpaccess.ServerPermissionDenied(cerr, s.requestAccessURL(authzCtx, connectResourceID.String(), toolset.Name)))
 			}
 		}
 		tools, roleHidden, terr := s.enumerateToolsetConsentInventory(authzCtx, endpoint)

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
@@ -122,16 +123,14 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
-	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
 		if metaServer != nil {
 			return s.ServeWellKnownProtectedResourceForMetaServer(ctx, w, r, logger, mcpEndpoint, metaServer, "mcp")
 		}
 		return s.ServeWellKnownProtectedResourceForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
-	case isMCPEndpointAddressMiss(err, &shareErr):
-		// Fall through to the legacy toolset-by-slug lookup below; a
-		// resolvable-but-unavailable address is terminal.
+	case mcpendpoints.IsAddressMiss(err):
+		// Address miss: fall through to the legacy toolset lookup.
 	default:
 		return err
 	}
@@ -179,16 +178,14 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
-	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
 		if metaServer != nil {
 			return s.ServeWellKnownAuthorizationServerForMetaServer(ctx, w, r, logger, mcpEndpoint, metaServer, "mcp")
 		}
 		return s.ServeWellKnownAuthorizationServerForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
-	case isMCPEndpointAddressMiss(err, &shareErr):
-		// Fall through to the legacy toolset-by-slug lookup below; a
-		// resolvable-but-unavailable address is terminal.
+	case mcpendpoints.IsAddressMiss(err):
+		// Address miss: fall through to the legacy toolset lookup.
 	default:
 		return err
 	}

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
@@ -128,8 +129,9 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 			return s.ServeWellKnownProtectedResourceForMetaServer(ctx, w, r, logger, mcpEndpoint, metaServer, "mcp")
 		}
 		return s.ServeWellKnownProtectedResourceForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
-		// Fall through to the legacy toolset-by-slug lookup below.
+	case isMCPEndpointAddressMiss(err, &shareErr):
+		// Fall through to the legacy toolset-by-slug lookup below; a
+		// resolvable-but-unavailable address is terminal.
 	default:
 		return err
 	}
@@ -145,6 +147,7 @@ func (s *Service) HandleGetProtectedResource(w http.ResponseWriter, r *http.Requ
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
+	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackWellKnownProtectedResource)
 
 	if toolset.UserSessionIssuerID.Valid {
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, "mcp")
@@ -183,8 +186,9 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 			return s.ServeWellKnownAuthorizationServerForMetaServer(ctx, w, r, logger, mcpEndpoint, metaServer, "mcp")
 		}
 		return s.ServeWellKnownAuthorizationServerForServer(w, r, logger, mcpEndpoint, mcpServer, "mcp")
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
-		// Fall through to the legacy toolset-by-slug lookup below.
+	case isMCPEndpointAddressMiss(err, &shareErr):
+		// Fall through to the legacy toolset-by-slug lookup below; a
+		// resolvable-but-unavailable address is terminal.
 	default:
 		return err
 	}
@@ -200,6 +204,7 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
+	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackWellKnownAuthorizationServer)
 
 	if toolset.UserSessionIssuerID.Valid {
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, "mcp")

--- a/server/internal/mcp/consent_tool_inventory.go
+++ b/server/internal/mcp/consent_tool_inventory.go
@@ -256,19 +256,12 @@ func (s *Service) enumerateToolsetConsentInventory(ctx context.Context, endpoint
 		return nil, nil, fmt.Errorf("endpoint is not toolset-backed")
 	}
 
-	// Wrapper-governed endpoints take publicness from wrapper visibility
-	// alone; only the legacy toolset-resolved endpoint reads the toolset flag
-	// (AIS-633).
+	// Wrapper visibility wins; only the legacy endpoint reads the toolset flag.
 	private := !endpoint.IsPublic
 	if !endpoint.McpServerID.Valid {
 		private = toolset.McpIsPublic == nil || !*toolset.McpIsPublic
 	}
-	// Per-tool checks key on the wrapper's id when one fronts the endpoint,
-	// matching the runtime tools/list gate.
-	connectResourceID := toolset.ID
-	if endpoint.McpServerID.Valid {
-		connectResourceID = endpoint.McpServerID.UUID.String()
-	}
+	connectResourceID := endpoint.connectResourceID().String()
 	tools = []consentInventoryTool{}
 	for _, tool := range toolset.Tools {
 		if tool == nil || conv.IsProxyTool(tool) {

--- a/server/internal/mcp/consent_tool_inventory.go
+++ b/server/internal/mcp/consent_tool_inventory.go
@@ -256,7 +256,19 @@ func (s *Service) enumerateToolsetConsentInventory(ctx context.Context, endpoint
 		return nil, nil, fmt.Errorf("endpoint is not toolset-backed")
 	}
 
-	private := toolset.McpIsPublic == nil || !*toolset.McpIsPublic
+	// Wrapper-governed endpoints take publicness from wrapper visibility
+	// alone; only the legacy toolset-resolved endpoint reads the toolset flag
+	// (AIS-633).
+	private := !endpoint.IsPublic
+	if !endpoint.McpServerID.Valid {
+		private = toolset.McpIsPublic == nil || !*toolset.McpIsPublic
+	}
+	// Per-tool checks key on the wrapper's id when one fronts the endpoint,
+	// matching the runtime tools/list gate.
+	connectResourceID := toolset.ID
+	if endpoint.McpServerID.Valid {
+		connectResourceID = endpoint.McpServerID.UUID.String()
+	}
 	tools = []consentInventoryTool{}
 	for _, tool := range toolset.Tools {
 		if tool == nil || conv.IsProxyTool(tool) {
@@ -274,7 +286,7 @@ func (s *Service) enumerateToolsetConsentInventory(ctx context.Context, endpoint
 			if len(values) > 0 {
 				disposition = values[0]
 			}
-			if rerr := s.authz.Require(ctx, authz.MCPToolCallCheck(toolset.ID, authz.MCPToolCallDimensions{
+			if rerr := s.authz.Require(ctx, authz.MCPToolCallCheck(connectResourceID, authz.MCPToolCallDimensions{
 				Tool:        base.Name,
 				Disposition: disposition,
 				ProjectID:   endpoint.ProjectID.String(),

--- a/server/internal/mcp/handle_get_server_proxy_test.go
+++ b/server/internal/mcp/handle_get_server_proxy_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -151,6 +152,7 @@ func TestRuntimeMethods_MountedOnMux(t *testing.T) {
 	metadataService := mcpmetadata.NewService(
 		ti.logger,
 		ti.tracerProvider,
+		testenv.NewMeterProvider(t),
 		ti.conn,
 		ti.sessionManager,
 		ti.serverURL,

--- a/server/internal/mcp/handle_get_server_test.go
+++ b/server/internal/mcp/handle_get_server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -25,6 +26,7 @@ func TestHandleGetServer_ContentNegotiation(t *testing.T) {
 	metadataService := mcpmetadata.NewService(
 		testInstance.logger,
 		testInstance.tracerProvider,
+		testenv.NewMeterProvider(t),
 		testInstance.conn,
 		testInstance.sessionManager,
 		testInstance.serverURL,

--- a/server/internal/mcp/hosted_tools_call_coverage_test.go
+++ b/server/internal/mcp/hosted_tools_call_coverage_test.go
@@ -44,7 +44,7 @@ func TestHostedMalformedToolsCall_RecordsCoverageAtMethodBoundary(t *testing.T) 
 	_, err = servePublicHTTP(t, ctx, ti, endpointSlug, body, "", nil)
 	require.NoError(t, err)
 
-	coveragePoints := collectKillswitchCoverage(t, reader)
+	coveragePoints := collectCounterPoints(t, reader, mcpmetrics.InstrumentMCPToolCallKillswitchIdentity)
 	require.Equal(t, map[attribute.Set]int64{
 		attribute.NewSet(
 			attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -64,6 +64,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
+	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -253,6 +254,26 @@ func appendRemoteSessionTokenInputs(dst []oauthTokenInputs, tokens map[uuid.UUID
 	return dst, nil
 }
 
+// effectiveMCPPrivate reports whether per-tool RBAC applies to this request:
+// wrapper visibility when the request is wrapper-governed (AIS-633), else the
+// described toolset's flag (nil reads as private).
+func (m *mcpInputs) effectiveMCPPrivate(toolsetIsPublic *bool) bool {
+	if m.wrapperIsPublic != nil {
+		return !*m.wrapperIsPublic
+	}
+	return toolsetIsPublic == nil || !*toolsetIsPublic
+}
+
+// mcpConnectResourceID is the resource id for per-tool mcp:connect checks:
+// the wrapper's id when the request is wrapper-governed, else the described
+// toolset's own id.
+func (m *mcpInputs) mcpConnectResourceID(toolsetID string) string {
+	if m.wrapperRBACResourceID != "" {
+		return m.wrapperRBACResourceID
+	}
+	return toolsetID
+}
+
 type mcpInputs struct {
 	projectID        uuid.UUID
 	organizationID   string
@@ -278,6 +299,15 @@ type mcpInputs struct {
 	// via an mcp_endpoint. Nil on the legacy toolset-by-slug path and for
 	// internal (agent-workflow) callers, which have no fronting server.
 	mcpServerID *uuid.UUID
+	// wrapperRBACResourceID overrides the resource id for per-tool mcp:connect
+	// checks: the fronting mcp_servers id when the request is wrapper-governed
+	// (AIS-633). Empty falls back to the described toolset's own id, which is
+	// what the meta-member and internal paths rely on.
+	wrapperRBACResourceID string
+	// wrapperIsPublic overrides the effective publicness read from the
+	// described toolset when non-nil (wrapper visibility governs). Nil falls
+	// back to the toolset flag.
+	wrapperIsPublic *bool
 	// tags is the parsed ?tags= filter. When non-empty, tools/list and
 	// tools/call expose only tools whose variation row carries one of these
 	// tags. Empty means no filtering.
@@ -654,8 +684,25 @@ func (s *Service) serveProxyBackedEndpoint(w http.ResponseWriter, r *http.Reques
 	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+	case isMCPEndpointAddressMiss(err, &shareErr):
+		// The legacy behavior behind handled=false (405, or the install page
+		// on HTML GETs) still answers for a live toolset slug and disappears
+		// with the fallback removal, so a miss that lands on a live toolset
+		// counts against the merge gate. The probe only runs on address
+		// misses, which post-backfill are scanner probes of nonexistent slugs.
+		var customDomainID uuid.NullUUID
+		if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
+			customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
+		}
+		if _, terr := s.loadToolset(ctx, mcpSlug, customDomainID, false); terr == nil {
+			s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackProxyGetDelete)
+		}
 		return false, nil
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+		// Resolvable but unavailable (disabled wrapper, dangling backend):
+		// the address is authoritative, so the outcome is a terminal 404
+		// rather than the caller's legacy fallback behavior.
+		return true, err
 	default:
 		return true, err
 	}
@@ -721,10 +768,11 @@ func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *sl
 // backend dispatch, then RemoteMcpServerID-backed rows proxy via
 // remotemcp and ToolsetID-backed rows delegate to ServeToolsetResolved.
 //
-// On any not-found from endpoint resolution — no matching mcp_endpoint,
-// dangling mcp_endpoint.mcp_server_id FK, or an mcp_server with
-// visibility="disabled" — ServePublic falls back to the legacy
-// toolsets.mcp_slug lookup. The fallback's loadToolset has
+// Only a true address miss — no matching mcp_endpoint row — falls back to
+// the legacy toolsets.mcp_slug lookup. A matching endpoint whose backend is
+// unavailable (visibility "disabled", dangling backend FK) is a terminal
+// not-found: the endpoint row owns the address (AIS-633). The fallback's
+// loadToolset has
 // platform/custom-domain handling distinct from mcp_endpoints'
 // scoping: a platform-context lookup may resolve a toolset bound to a
 // custom domain when no platform-scoped row exists. This asymmetry is
@@ -758,8 +806,10 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 			return s.serveResolvedMetaMCPEndpoint(w, r, logger, mcpEndpoint, metaServer)
 		}
 		return s.serveResolvedMCPEndpoint(w, r, logger, mcpEndpoint, mcpServer, mcpSlug, "mcp")
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
-		// Fall through to legacy toolset lookup.
+	case isMCPEndpointAddressMiss(err, &shareErr):
+		// Fall through to legacy toolset lookup. A resolvable-but-unavailable
+		// address (disabled wrapper, dangling backend) is terminal instead: the
+		// endpoint row owns the slug, so its toolset must not resurrect it.
 	default:
 		return err
 	}
@@ -775,62 +825,97 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
+	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackServePublic)
 
 	if err := s.enforceCustomDomainLockdown(ctx, logger, toolset.ProjectID); err != nil {
 		return err
 	}
 
-	// Legacy toolset-by-slug path has no mcp_server, so there is no
-	// server-level variation group override (ServeToolsetResolved falls back to
-	// the toolset's own column) and no fronting mcp_servers id to record.
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil, nil, nil)
+	// Legacy toolset-by-slug path has no mcp_server: hosting configuration
+	// comes entirely from the toolset columns.
+	return s.serveToolsetResolved(w, r, toolset, mcpSlug, "mcp", hostedServingFromToolset(toolset), nil, nil, nil)
 }
 
-// ServeToolsetResolved serves an MCP runtime request after the slug has
-// already been resolved to a toolset. It is exported so other runtime
-// surfaces (currently /x/mcp) can delegate the toolset-backed serving body
-// without re-implementing the OAuth/visibility/RBAC and tool dispatch flow.
+// isMCPEndpointAddressMiss reports whether an mcp_endpoints resolution error
+// is a true address miss — the only outcome that may fall back to the legacy
+// toolsets.mcp_slug lookup. shareErr receives the unwrapped ShareableError as
+// a side effect of the check, matching the errors.As idiom at call sites.
+func isMCPEndpointAddressMiss(err error, shareErr **oops.ShareableError) bool {
+	return errors.As(err, shareErr) && (*shareErr).Code == oops.CodeNotFound && !errors.Is(err, mcpendpoints.ErrEndpointUnavailable)
+}
+
+// hostedServing is the hosting configuration one toolset-backed MCP request
+// is served under. The wrapper-resolved path (mcp_endpoints → mcp_servers)
+// derives it from the mcp_servers row — visibility, issuer gating, RBAC
+// resource id, variation-group override, and telemetry identity — and the
+// toolset's own mcp_is_public / user_session_issuer_id columns are not
+// consulted (AIS-633). The legacy toolsets.mcp_slug path derives every field
+// from the toolset row. The toolset always keeps what remains a toolset
+// concern: tools, resources, prompts, environment, tool selection mode, and
+// external OAuth.
+type hostedServing struct {
+	// isPublic is the effective publicness: wrapper visibility == 'public' on
+	// the wrapper path, toolsets.mcp_is_public on the legacy path.
+	isPublic bool
+
+	// runInToolsetGate makes serveToolsetResolved run the issuer gate keyed
+	// on toolsets.user_session_issuer_id. Legacy path only — the wrapper path
+	// gates pre-dispatch on mcp_servers.user_session_issuer_id.
+	runInToolsetGate bool
+
+	// callerGated marks the request as already authenticated by a caller-side
+	// issuer gate, so the legacy identity-auth chain must be skipped or it
+	// would re-reject the user-session JWT it doesn't recognise.
+	callerGated bool
+
+	// rbacResourceID is the resource id for mcp:connect checks (per-server
+	// and per-tool): the mcp_servers id on the wrapper path, the toolset id
+	// on the legacy path.
+	rbacResourceID uuid.UUID
+
+	// toolVariationsGroupID is the wrapper's variation-group override; nil
+	// falls through to the toolset's own column, then the project default.
+	toolVariationsGroupID *uuid.UUID
+
+	// mcpServerID is the fronting mcp_servers row id for telemetry and the
+	// hosted kill switch; nil on the legacy path, leaving the attribute off
+	// the rows.
+	mcpServerID *uuid.UUID
+}
+
+// hostedServingFromToolset derives the hosting configuration for the legacy
+// toolsets.mcp_slug path, where the toolset columns govern serving.
+func hostedServingFromToolset(toolset *toolsets_repo.Toolset) *hostedServing {
+	return &hostedServing{
+		isPublic:              toolset.McpIsPublic,
+		runInToolsetGate:      toolset.UserSessionIssuerID.Valid,
+		callerGated:           false,
+		rbacResourceID:        toolset.ID,
+		toolVariationsGroupID: nil,
+		mcpServerID:           nil,
+	}
+}
+
+// serveToolsetResolved serves an MCP runtime request after the slug has
+// already been resolved to a toolset, under the hosting configuration cfg.
 //
 // mcpSlug and mcpRouteBase are used to build the WWW-Authenticate
 // resource_metadata URL. mcpRouteBase is the route segment that sits
 // between the well-known prefix and the slug — "mcp" for /mcp/{slug} or
 // "x/mcp" for /x/mcp/{slug}, no leading or trailing slashes.
 //
-// skipIssuerGate skips the in-toolset user_session_issuer_id JWT-validation
-// branch. /x/mcp callers set this to true once they have run their own
-// gate keyed on mcp_servers.user_session_issuer_id, so the same request
-// isn't gated twice. /mcp callers always pass false.
-//
 // extraUpstreamTokens are the upstream remote-session access tokens
-// collected by a caller-side issuer gate (today: /x/mcp's pre-dispatch
-// ApplyIssuerGate run), keyed by remote_session_issuer_id. When non-empty
-// they satisfy the toolset's oauth2 security schemes so the downstream tool
-// dispatch doesn't 401 when the in-toolset gate is skipped. /mcp callers
-// pass nil.
-//
-// mcpServerVariationsGroupID is the variation group resolved from the
-// mcp_servers row, when this request arrived via an mcp_endpoint that maps to
-// one. It takes precedence over the toolset's own tool_variations_group_id;
-// when nil, the toolset's column is used, and when that is also unset the
-// project-default group applies. /mcp's legacy toolset-by-slug path has no
-// mcp_server and passes nil.
-//
-// mcpServerID is the fronting mcp_servers row id when this request arrived via
-// an mcp_endpoint, recorded on the tools/call telemetry row so toolset-backed
-// activity can be sliced from the fronting-server perspective. /mcp's legacy
-// toolset-by-slug path has no mcp_server and passes nil, leaving the attribute
-// off the row.
+// collected by a caller-side issuer gate, keyed by remote_session_issuer_id.
+// When non-empty they satisfy the toolset's oauth2 security schemes so the
+// downstream tool dispatch doesn't 401 when the in-toolset gate is skipped.
+// The legacy /mcp path passes nil.
 //
 // The caller is responsible for closing r.Body.
 // callerToolSelection is the consent-screen tool policy resolved by a
-// caller-side issuer gate (today: /x/mcp's pre-dispatch ApplyIssuerGate run).
-// Nil when the caller ran no gate or the session carries no policy; the
-// in-toolset gate below populates it for /mcp callers.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID) error {
-	return s.serveToolsetResolved(w, r, toolset, mcpSlug, mcpRouteBase, skipIssuerGate, extraUpstreamTokens, callerToolSelection, mcpServerVariationsGroupID, mcpServerID, nil)
-}
-
-func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID, pendingIssuerGate *issuerGateAuthentication) error {
+// caller-side issuer gate. Nil when the caller ran no gate or the session
+// carries no policy; the in-toolset gate below populates it for legacy-path
+// callers.
+func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, cfg *hostedServing, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, pendingIssuerGate *issuerGateAuthentication) error {
 	ctx := r.Context()
 	var err error
 
@@ -873,15 +958,14 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	// auth chain entirely; on miss, 401 with WWW-Authenticate so the client
 	// can discover the AS surface.
 	//
-	// runInToolsetGate is the in-function variant of the gate, only run when
-	// the toolset itself is issuer-gated AND the caller hasn't already gated
-	// (skipIssuerGate). callerAlreadyGated tracks the orthogonal case where
-	// the caller (/x/mcp) ran its own gate keyed on a different column
-	// (mcp_servers.user_session_issuer_id) — the request has been
-	// authenticated, so the legacy auth chain below must also be skipped or
-	// it would re-reject the JWT it doesn't recognise.
-	runInToolsetGate := toolset.UserSessionIssuerID.Valid && !skipIssuerGate
-	callerAlreadyGated := skipIssuerGate
+	// runInToolsetGate is the in-function variant of the gate, run only on the
+	// legacy path when the toolset is issuer-gated. callerGated tracks the
+	// orthogonal case where the caller ran its own gate keyed on
+	// mcp_servers.user_session_issuer_id — the request has been authenticated,
+	// so the legacy auth chain below must also be skipped or it would
+	// re-reject the JWT it doesn't recognise.
+	runInToolsetGate := cfg.runInToolsetGate
+	callerAlreadyGated := cfg.callerGated
 	if runInToolsetGate {
 		// Pass mcpRouteBase (the surface the request arrived under) rather
 		// than letting the constructor default to "mcp": when called from
@@ -898,7 +982,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		callerToolSelection = gateToolSelection
 	}
 
-	isHostedToolsCall := bodyReadErr == nil && bodyDecodeErr == nil && req.Method == "tools/call" && mcpServerID != nil
+	isHostedToolsCall := bodyReadErr == nil && bodyDecodeErr == nil && req.Method == "tools/call" && cfg.mcpServerID != nil
 	resolvePendingIssuerGate := func() error {
 		if pendingIssuerGate == nil {
 			return nil
@@ -928,7 +1012,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 
 	if !runInToolsetGate && !callerAlreadyGated {
 		switch {
-		case toolset.McpIsPublic && toolset.ExternalOauthServerID.Valid:
+		case cfg.isPublic && toolset.ExternalOauthServerID.Valid:
 			// External OAuth server flow — collect token if present
 			if authToken != "" {
 				tokenInputs = append(tokenInputs, oauthTokenInputs{
@@ -937,7 +1021,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 					Token:                 authToken,
 				})
 			}
-		case !toolset.McpIsPublic:
+		case !cfg.isPublic:
 			ctx, err = s.RequirePrivateIdentityAuth(ctx, w, r, false, toolset.ID, oauthProtectedResourceURL)
 			if err != nil {
 				return err
@@ -971,7 +1055,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 
 		if projectInOrg {
 			authenticated = true
-		} else if !toolset.McpIsPublic {
+		} else if !cfg.isPublic {
 			// Only return 401 for non-public MCPs when the user is not in the owning org
 			return oops.C(oops.CodeUnauthorized)
 		}
@@ -979,14 +1063,15 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		// so they get public access without environment/secrets
 	}
 
-	if !toolset.McpIsPublic && !authenticated {
+	if !cfg.isPublic && !authenticated {
 		return oops.C(oops.CodeNotFound)
 	}
 
 	if authenticated {
-		// Private MCPs require mcp:connect on the specific toolset.
+		// Private MCPs require mcp:connect on the specific server (the
+		// wrapper's id when one fronts the request, else the toolset's).
 		// Public MCPs are open to everyone — no RBAC enforcement.
-		if !toolset.McpIsPublic {
+		if !cfg.isPublic {
 			// Ensure grants are loaded — not all auth strategies in authenticateToken
 			// go through auth.Authorize (which calls PrepareContext). This is a no-op
 			// if grants are already in context.
@@ -994,8 +1079,8 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			if err != nil {
 				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
-			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
-				return fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err, s.requestAccessURL(ctx, toolset.ID.String(), toolset.Name)))
+			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, cfg.rbacResourceID.String(), toolset.ProjectID.String())); err != nil {
+				return fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err, s.requestAccessURL(ctx, cfg.rbacResourceID.String(), toolset.Name)))
 			}
 		}
 
@@ -1021,14 +1106,14 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	}
 	hostedCoverageRecorded := false
 	if isHostedToolsCall {
-		if err := s.enforceHostedToolsCall(ctx, toolset.OrganizationID, mcpServerID); err != nil {
+		if err := s.enforceHostedToolsCall(ctx, toolset.OrganizationID, cfg.mcpServerID); err != nil {
 			return s.respondMCPError(ctx, w, req.ID, err)
 		}
 		hostedCoverageRecorded = true
 	}
 
 	// Resolve tool configuration and credentials only after the hosted checkpoint.
-	toolVariationsGroupID := mcpServerVariationsGroupID
+	toolVariationsGroupID := cfg.toolVariationsGroupID
 	if toolVariationsGroupID == nil && toolset.ToolVariationsGroupID.Valid {
 		id := toolset.ToolVariationsGroupID.UUID
 		toolVariationsGroupID = &id
@@ -1065,6 +1150,18 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		apiKeyID = authCtx.APIKeyID
 	}
 
+	// Wrapper-governed requests carry the wrapper's RBAC id and visibility
+	// into the RPC handlers so per-tool checks key on the mcp_servers row;
+	// legacy requests leave both unset and the handlers derive them from the
+	// described toolset, unchanged.
+	var wrapperRBACResourceID string
+	var wrapperIsPublic *bool
+	if cfg.mcpServerID != nil {
+		wrapperRBACResourceID = cfg.rbacResourceID.String()
+		isPublic := cfg.isPublic
+		wrapperIsPublic = &isPublic
+	}
+
 	mcpInputs := &mcpInputs{
 		projectID:                toolset.ProjectID,
 		organizationID:           toolset.OrganizationID,
@@ -1080,7 +1177,9 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		externalUserID:           externalUserID,
 		apiKeyID:                 apiKeyID,
 		toolVariationsGroupID:    toolVariationsGroupID,
-		mcpServerID:              mcpServerID,
+		mcpServerID:              cfg.mcpServerID,
+		wrapperRBACResourceID:    wrapperRBACResourceID,
+		wrapperIsPublic:          wrapperIsPublic,
 		skipProxyTools:           false,
 		tags:                     tags,
 		protocolVersion:          mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
@@ -1088,8 +1187,9 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		toolSelection:            callerToolSelection,
 	}
 
-	// Record the resolved variation group and requested tag filter for
-	// debugging which tools a client sees.
+	// Record the resolved variation group, requested tag filter, and the
+	// fronting server for debugging which tools a client sees and which
+	// wrapper served them.
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {
 		if toolVariationsGroupID != nil {
 			span.SetAttributes(attr.ToolVariationsGroupID(toolVariationsGroupID.String()))
@@ -1097,12 +1197,15 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		if len(tags) > 0 {
 			span.SetAttributes(attr.MCPRequestedTags(tags))
 		}
+		if cfg.mcpServerID != nil {
+			span.SetAttributes(attr.McpServerID(cfg.mcpServerID.String()))
+		}
 	}
 
 	// Check security schemes before dispatching any RPC — including initialize.
 	// Some MCP clients (e.g. Claude Desktop) require 401 on initialize to trigger
 	// their OAuth flow, so we can't defer this to individual RPC handlers.
-	satisfied, err := s.checkToolsetSecurity(ctx, toolset, mcpInputs)
+	satisfied, err := s.checkToolsetSecurity(ctx, toolset, cfg.isPublic, mcpInputs)
 	if err != nil {
 		return err
 	}
@@ -1191,8 +1294,10 @@ func (s *Service) respondMCPError(ctx context.Context, w http.ResponseWriter, id
 
 // checkToolsetSecurity loads the toolset's security variables and checks if the
 // request environment satisfies at least one scheme. Returns true if satisfied
-// (or if the toolset has no security requirements).
-func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_repo.Toolset, payload *mcpInputs) (bool, error) {
+// (or if the toolset has no security requirements). isPublic is the effective
+// publicness the request is served under (wrapper visibility when a wrapper
+// fronts it), not necessarily the toolset's own flag.
+func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_repo.Toolset, isPublic bool, payload *mcpInputs) (bool, error) {
 	projectID := mv.ProjectID(payload.projectID)
 	// Security-scheme detection must see the full, unfiltered toolset, so this
 	// always uses the project-default variation group (nil) regardless of any
@@ -1209,7 +1314,7 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 		// OAuth at the server level (proxy or external). If so, require the
 		// user to have provided a token — otherwise the 401 + WWW-Authenticate
 		// must be sent so MCP clients can initiate the OAuth flow.
-		oauthRequired := toolset.McpIsPublic && (toolset.ExternalOauthServerID.Valid || toolset.OauthProxyServerID.Valid)
+		oauthRequired := isPublic && (toolset.ExternalOauthServerID.Valid || toolset.OauthProxyServerID.Valid)
 		if oauthRequired {
 			for _, t := range payload.oauthTokenInputs {
 				if t.Token != "" {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -681,15 +681,12 @@ func (s *Service) serveProxyBackedEndpoint(w http.ResponseWriter, r *http.Reques
 	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
 
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
-	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
-	case isMCPEndpointAddressMiss(err, &shareErr):
-		// The legacy behavior behind handled=false (405, or the install page
-		// on HTML GETs) still answers for a live toolset slug and disappears
-		// with the fallback removal, so a miss that lands on a live toolset
-		// counts against the merge gate. The probe only runs on address
-		// misses, which post-backfill are scanner probes of nonexistent slugs.
+	case mcpendpoints.IsAddressMiss(err):
+		// The legacy handled=false behavior (405, or the install page on HTML
+		// GETs) still answers for a live toolset slug, so a miss landing on a
+		// live toolset counts against the merge gate.
 		var customDomainID uuid.NullUUID
 		if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
 			customDomainID = uuid.NullUUID{UUID: domainCtx.DomainID, Valid: true}
@@ -698,12 +695,8 @@ func (s *Service) serveProxyBackedEndpoint(w http.ResponseWriter, r *http.Reques
 			s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackProxyGetDelete)
 		}
 		return false, nil
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
-		// Resolvable but unavailable (disabled wrapper, dangling backend):
-		// the address is authoritative, so the outcome is a terminal 404
-		// rather than the caller's legacy fallback behavior.
-		return true, err
 	default:
+		// Unavailable addresses are terminal, never the legacy behavior.
 		return true, err
 	}
 
@@ -796,7 +789,6 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	// unified backend switch (remote proxy / toolset). On 404, fall through
 	// to the legacy toolset-by-slug path below.
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
-	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
 		if err := s.enforceCustomDomainLockdown(ctx, logger, mcpEndpoint.ProjectID); err != nil {
@@ -806,10 +798,8 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 			return s.serveResolvedMetaMCPEndpoint(w, r, logger, mcpEndpoint, metaServer)
 		}
 		return s.serveResolvedMCPEndpoint(w, r, logger, mcpEndpoint, mcpServer, mcpSlug, "mcp")
-	case isMCPEndpointAddressMiss(err, &shareErr):
-		// Fall through to legacy toolset lookup. A resolvable-but-unavailable
-		// address (disabled wrapper, dangling backend) is terminal instead: the
-		// endpoint row owns the slug, so its toolset must not resurrect it.
+	case mcpendpoints.IsAddressMiss(err):
+		// Address miss: fall through to the legacy toolset lookup.
 	default:
 		return err
 	}
@@ -836,50 +826,34 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	return s.serveToolsetResolved(w, r, toolset, mcpSlug, "mcp", hostedServingFromToolset(toolset), nil, nil, nil)
 }
 
-// isMCPEndpointAddressMiss reports whether an mcp_endpoints resolution error
-// is a true address miss — the only outcome that may fall back to the legacy
-// toolsets.mcp_slug lookup. shareErr receives the unwrapped ShareableError as
-// a side effect of the check, matching the errors.As idiom at call sites.
-func isMCPEndpointAddressMiss(err error, shareErr **oops.ShareableError) bool {
-	return errors.As(err, shareErr) && (*shareErr).Code == oops.CodeNotFound && !errors.Is(err, mcpendpoints.ErrEndpointUnavailable)
-}
-
 // hostedServing is the hosting configuration one toolset-backed MCP request
-// is served under. The wrapper-resolved path (mcp_endpoints → mcp_servers)
-// derives it from the mcp_servers row — visibility, issuer gating, RBAC
-// resource id, variation-group override, and telemetry identity — and the
-// toolset's own mcp_is_public / user_session_issuer_id columns are not
-// consulted (AIS-633). The legacy toolsets.mcp_slug path derives every field
-// from the toolset row. The toolset always keeps what remains a toolset
-// concern: tools, resources, prompts, environment, tool selection mode, and
-// external OAuth.
+// is served under: derived from the mcp_servers row on the wrapper-resolved
+// path (AIS-633), from the toolset columns on the legacy toolsets.mcp_slug
+// path. Toolset concerns (tools, resources, prompts, environment, tool
+// selection mode, external OAuth) always stay on the toolset.
 type hostedServing struct {
-	// isPublic is the effective publicness: wrapper visibility == 'public' on
-	// the wrapper path, toolsets.mcp_is_public on the legacy path.
+	// isPublic: wrapper visibility == 'public', or toolsets.mcp_is_public on
+	// the legacy path.
 	isPublic bool
 
-	// runInToolsetGate makes serveToolsetResolved run the issuer gate keyed
-	// on toolsets.user_session_issuer_id. Legacy path only — the wrapper path
-	// gates pre-dispatch on mcp_servers.user_session_issuer_id.
+	// runInToolsetGate: run the in-toolset issuer gate (legacy path only; the
+	// wrapper path gates pre-dispatch).
 	runInToolsetGate bool
 
-	// callerGated marks the request as already authenticated by a caller-side
-	// issuer gate, so the legacy identity-auth chain must be skipped or it
-	// would re-reject the user-session JWT it doesn't recognise.
+	// callerGated: already authenticated by a caller-side issuer gate, so the
+	// legacy identity-auth chain must be skipped or it would re-reject the
+	// user-session JWT it doesn't recognise.
 	callerGated bool
 
-	// rbacResourceID is the resource id for mcp:connect checks (per-server
-	// and per-tool): the mcp_servers id on the wrapper path, the toolset id
-	// on the legacy path.
+	// rbacResourceID for mcp:connect checks: mcp_servers id or toolset id.
 	rbacResourceID uuid.UUID
 
-	// toolVariationsGroupID is the wrapper's variation-group override; nil
-	// falls through to the toolset's own column, then the project default.
+	// toolVariationsGroupID override; nil falls through to the toolset's
+	// column, then the project default.
 	toolVariationsGroupID *uuid.UUID
 
-	// mcpServerID is the fronting mcp_servers row id for telemetry and the
-	// hosted kill switch; nil on the legacy path, leaving the attribute off
-	// the rows.
+	// mcpServerID for telemetry and the hosted kill switch; nil on the legacy
+	// path.
 	mcpServerID *uuid.UUID
 }
 

--- a/server/internal/mcp/internal_tools_call_coverage_test.go
+++ b/server/internal/mcp/internal_tools_call_coverage_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -36,7 +35,7 @@ func TestHandleToolsCall_RecordsCoverageWithoutRequestContext(t *testing.T) {
 	}, "missing_tool", json.RawMessage(`{}`))
 	require.Error(t, err)
 
-	coveragePoints := collectKillswitchCoverage(t, reader)
+	coveragePoints := collectCounterPoints(t, reader, mcpmetrics.InstrumentMCPToolCallKillswitchIdentity)
 	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
 		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
 		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityUnattributed),
@@ -63,7 +62,7 @@ func TestServePublic_RecordsCanonicalServerCoverage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, response.Code)
 
-	coveragePoints := collectKillswitchCoverage(t, reader)
+	coveragePoints := collectCounterPoints(t, reader, mcpmetrics.InstrumentMCPToolCallKillswitchIdentity)
 	require.Equal(t, int64(1), coveragePoints[attribute.NewSet(
 		attr.McpKillswitchSurface(mcpmetrics.KillswitchSurfaceHosted),
 		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityActiveUser),
@@ -74,25 +73,4 @@ func TestServePublic_RecordsCanonicalServerCoverage(t *testing.T) {
 		attr.McpKillswitchIdentityClass(mcpmetrics.KillswitchIdentityActiveUser),
 		attr.McpKillswitchResourceClass(mcpmetrics.KillswitchResourceLegacyNoServer),
 	)])
-}
-
-func collectKillswitchCoverage(t *testing.T, reader *sdkmetric.ManualReader) map[attribute.Set]int64 {
-	t.Helper()
-
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &rm))
-	coveragePoints := map[attribute.Set]int64{}
-	for _, scope := range rm.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name != mcpmetrics.InstrumentMCPToolCallKillswitchIdentity {
-				continue
-			}
-			sum, ok := metric.Data.(metricdata.Sum[int64])
-			require.True(t, ok)
-			for _, point := range sum.DataPoints {
-				coveragePoints[point.Attributes] = point.Value
-			}
-		}
-	}
-	return coveragePoints
 }

--- a/server/internal/mcp/mcpmetrics/doc.go
+++ b/server/internal/mcp/mcpmetrics/doc.go
@@ -1,7 +1,8 @@
 // Package mcpmetrics owns every OpenTelemetry instrument the MCP runtime
 // publishes: the per-request census counter, the handshake counter, the
-// tool-call counter, the request-duration histogram, and the user-facing
-// OAuth flow counters.
+// tool-call counter, the request-duration histogram, the user-facing
+// OAuth flow counters, and the toolsets→mcp_servers migration counters
+// (legacy slug fallback and legacy audience acceptance).
 //
 // It is a leaf package for the same reason as its sibling mcprequests: the
 // remote MCP proxy stack (server/internal/remotemcp) publishes the

--- a/server/internal/mcp/mcpmetrics/legacyfallback.go
+++ b/server/internal/mcp/mcpmetrics/legacyfallback.go
@@ -1,0 +1,107 @@
+package mcpmetrics
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// InstrumentToolsetSlugFallback counts requests a public MCP surface served
+// through the legacy toolsets.mcp_slug lookup after an mcp_endpoints address
+// miss. Recorded only when the legacy lookup actually resolved a live toolset,
+// so the series converges to zero once every hosted server has its wrapper and
+// endpoints — this counter reading zero for the agreed window is the merge
+// gate for removing the fallback (AIS-646).
+const InstrumentToolsetSlugFallback = "mcp.toolset_slug_fallback"
+
+// InstrumentLegacyAudienceAccepted counts bearer validations on a
+// toolset-backed wrapper that only passed against the legacy toolset-URN
+// audience. Same merge-gate role as InstrumentToolsetSlugFallback: zero for
+// longer than the maximum session lifetime observed at backfill time lets
+// AIS-646 delete the acceptance.
+const InstrumentLegacyAudienceAccepted = "mcp.legacy_audience_accepted"
+
+// LegacyFallbackEntryPoint is the closed set of public surfaces that can
+// resolve a request through the legacy toolsets.mcp_slug lookup. It is the
+// only dimension on the fallback counter; keep it bounded — the counter's
+// purpose is a per-surface zero check, not per-server attribution.
+type LegacyFallbackEntryPoint string
+
+const (
+	// LegacyFallbackServePublic: POST /mcp/{slug} runtime dispatch.
+	LegacyFallbackServePublic LegacyFallbackEntryPoint = "serve_public"
+	// LegacyFallbackProxyGetDelete: the GET (SSE) / DELETE /mcp/{slug}
+	// handlers, whose legacy outcome after an address miss still answers for a
+	// live toolset slug (405 today, 404 once the fallback is removed).
+	LegacyFallbackProxyGetDelete LegacyFallbackEntryPoint = "proxy_get_delete"
+	// LegacyFallbackWellKnownProtectedResource: RFC 9728 metadata route.
+	LegacyFallbackWellKnownProtectedResource LegacyFallbackEntryPoint = "well_known_protected_resource"
+	// LegacyFallbackWellKnownAuthorizationServer: RFC 8414 metadata route.
+	LegacyFallbackWellKnownAuthorizationServer LegacyFallbackEntryPoint = "well_known_authorization_server"
+	// LegacyFallbackOAuth: the issuer-gated OAuth handler family resolving via
+	// LoadResolvedMcpEndpointBySlug (authorize, token, register, revoke,
+	// consent — on both the /mcp and /x/mcp surfaces).
+	LegacyFallbackOAuth LegacyFallbackEntryPoint = "oauth"
+	// LegacyFallbackInstallPage: the install-page resolver in mcpmetadata.
+	LegacyFallbackInstallPage LegacyFallbackEntryPoint = "install_page"
+	// LegacyFallbackChallengeResume: cached authorization-challenge state
+	// resuming through the strict-platform toolset lookup.
+	LegacyFallbackChallengeResume LegacyFallbackEntryPoint = "challenge_resume"
+)
+
+// LegacyFallbackCounter owns the two migration merge-gate instruments for the
+// toolsets → mcp_servers cutover (AIS-633). A nil *LegacyFallbackCounter is
+// valid — every Record becomes a no-op — so callers never nil-check.
+type LegacyFallbackCounter struct {
+	slugFallback     metric.Int64Counter
+	audienceAccepted metric.Int64Counter
+}
+
+// NewLegacyFallbackCounter constructs both instruments. An instrument-creation
+// failure is logged and leaves that instrument nil; Record methods handle nil
+// instruments so partial construction still records what it can.
+func NewLegacyFallbackCounter(meter metric.Meter, logger *slog.Logger) *LegacyFallbackCounter {
+	slugFallback, err := meter.Int64Counter(
+		InstrumentToolsetSlugFallback,
+		metric.WithDescription("MCP requests resolved through the legacy toolsets.mcp_slug lookup after an mcp_endpoints miss, by entry point"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentToolsetSlugFallback), attr.SlogError(err))
+	}
+
+	audienceAccepted, err := meter.Int64Counter(
+		InstrumentLegacyAudienceAccepted,
+		metric.WithDescription("Bearer validations on toolset-backed wrappers that passed only against the legacy toolset-URN audience, by issuer"),
+		metric.WithUnit("{validation}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentLegacyAudienceAccepted), attr.SlogError(err))
+	}
+
+	return &LegacyFallbackCounter{slugFallback: slugFallback, audienceAccepted: audienceAccepted}
+}
+
+// RecordToolsetSlugFallback counts one request served through the legacy
+// toolsets.mcp_slug lookup. Call it only after the legacy lookup resolved a
+// live toolset — counting bare address misses would keep the series nonzero
+// forever on scanner probes of nonexistent slugs.
+func (c *LegacyFallbackCounter) RecordToolsetSlugFallback(ctx context.Context, entryPoint LegacyFallbackEntryPoint) {
+	if c == nil || c.slugFallback == nil {
+		return
+	}
+	c.slugFallback.Add(ctx, 1, metric.WithAttributes(attr.McpEntryPoint(entryPoint)))
+}
+
+// RecordLegacyAudienceAccepted counts one bearer accepted via the legacy
+// toolset-URN audience, dimensioned by the issuer whose sessions still carry
+// it.
+func (c *LegacyFallbackCounter) RecordLegacyAudienceAccepted(ctx context.Context, issuerID string) {
+	if c == nil || c.audienceAccepted == nil {
+		return
+	}
+	c.audienceAccepted.Add(ctx, 1, metric.WithAttributes(attr.UserSessionIssuerID(issuerID)))
+}

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -73,6 +73,7 @@ type Metrics struct {
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
 	identityCoverage   *IdentityCoverageCounter
+	legacyFallback     *LegacyFallbackCounter
 
 	// oauthFlow{Started,Completed,Failed,Declined}Counter instrument the
 	// user-facing OAuth flow as a unit. They decompose a flow's terminal
@@ -193,6 +194,7 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 		mcpRequestRejectedCounter:            mcpRequestRejectedCounter,
 		requestCensus:                        NewRequestCounter(meter, logger),
 		identityCoverage:                     NewIdentityCoverageCounter(meter, logger),
+		legacyFallback:                       NewLegacyFallbackCounter(meter, logger),
 		oauthFlowStartedCounter:              oauthFlowStartedCounter,
 		oauthFlowCompletedCounter:            oauthFlowCompletedCounter,
 		oauthFlowFailedCounter:               oauthFlowFailedCounter,
@@ -221,6 +223,26 @@ func (m *Metrics) RecordKillswitchIdentityCoverage(ctx context.Context, surface 
 		return
 	}
 	m.identityCoverage.Record(ctx, surface, identity, resource)
+}
+
+// RecordToolsetSlugFallback counts one request served through the legacy
+// toolsets.mcp_slug lookup after an mcp_endpoints address miss. Semantics on
+// [LegacyFallbackCounter.RecordToolsetSlugFallback].
+func (m *Metrics) RecordToolsetSlugFallback(ctx context.Context, entryPoint LegacyFallbackEntryPoint) {
+	if m == nil {
+		return
+	}
+	m.legacyFallback.RecordToolsetSlugFallback(ctx, entryPoint)
+}
+
+// RecordLegacyAudienceAccepted counts one bearer accepted via the legacy
+// toolset-URN audience. Semantics on
+// [LegacyFallbackCounter.RecordLegacyAudienceAccepted].
+func (m *Metrics) RecordLegacyAudienceAccepted(ctx context.Context, issuerID string) {
+	if m == nil {
+		return
+	}
+	m.legacyFallback.RecordLegacyAudienceAccepted(ctx, issuerID)
 }
 
 // RecordMCPInitialize counts one observed MCP handshake, dimensioned by the

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -328,13 +328,19 @@ func NewResolvedMcpEndpointFromMcpServer(
 	}
 }
 
-// LegacyToolsetAudienceURN is the pre-migration toolset-URN audience a
-// toolset-backed wrapper's bearers may still carry: sessions minted while the
-// server was gated on toolsets.user_session_issuer_id were bound to
-// urn.NewToolset rather than the issuer URN. ok is false for every endpoint
-// that is not a toolset-backed wrapper — only that shape ever accepts the
-// legacy audience (AIS-633; acceptance is deleted by AIS-646).
-func (e *ResolvedMcpEndpoint) LegacyToolsetAudienceURN() (string, bool) {
+// connectResourceID is the mcp:connect resource id: the wrapper's id when one
+// fronts the endpoint, else the toolset id.
+func (e *ResolvedMcpEndpoint) connectResourceID() uuid.UUID {
+	if e.McpServerID.Valid {
+		return e.McpServerID.UUID
+	}
+	return e.ToolsetID.UUID
+}
+
+// legacyToolsetAudienceURN is the pre-migration toolset-URN audience a
+// toolset-backed wrapper's bearers may still carry; ok is false for every
+// other endpoint shape (AIS-633; acceptance is deleted by AIS-646).
+func (e *ResolvedMcpEndpoint) legacyToolsetAudienceURN() (string, bool) {
 	if !e.McpServerID.Valid || !e.ToolsetID.Valid {
 		return "", false
 	}

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -299,12 +300,15 @@ func (e *ResolvedMcpEndpoint) ValidateRef(ref EndpointRef) error {
 // mcpServer.UserSessionIssuerID.Valid; organizationID comes from a
 // separate projects lookup since mcp_servers doesn't carry the org id
 // directly. AudienceURN is bound to the issuer URN rather than a
-// backend-specific id so /x/mcp tokens stay portable between
-// toolset-backed and remote-backed servers under the same issuer.
+// backend-specific id so tokens stay portable between toolset-backed and
+// remote-backed servers under the same issuer. routeBase is the URL surface
+// the request arrived under ("mcp" or "x/mcp") — always taken from the
+// inbound request or the cached ref, never assumed.
 func NewResolvedMcpEndpointFromMcpServer(
 	mcpEndpoint *mcpendpoints_repo.McpEndpoint,
 	mcpServer *mcpservers_repo.McpServer,
 	organizationID string,
+	routeBase string,
 ) *ResolvedMcpEndpoint {
 	return &ResolvedMcpEndpoint{
 		AudienceURN: urn.NewUserSessionIssuer(mcpServer.UserSessionIssuerID.UUID).String(),
@@ -316,12 +320,25 @@ func NewResolvedMcpEndpointFromMcpServer(
 		MetaMcpServerID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		OrganizationID:       organizationID,
 		ProjectID:            mcpEndpoint.ProjectID,
-		RouteBase:            "x/mcp",
+		RouteBase:            routeBase,
 		Slug:                 mcpEndpoint.Slug,
 		ToolsetID:            mcpServer.ToolsetID,
 		UpstreamResource:     "",
 		UserSessionIssuerID:  mcpServer.UserSessionIssuerID.UUID,
 	}
+}
+
+// LegacyToolsetAudienceURN is the pre-migration toolset-URN audience a
+// toolset-backed wrapper's bearers may still carry: sessions minted while the
+// server was gated on toolsets.user_session_issuer_id were bound to
+// urn.NewToolset rather than the issuer URN. ok is false for every endpoint
+// that is not a toolset-backed wrapper — only that shape ever accepts the
+// legacy audience (AIS-633; acceptance is deleted by AIS-646).
+func (e *ResolvedMcpEndpoint) LegacyToolsetAudienceURN() (string, bool) {
+	if !e.McpServerID.Valid || !e.ToolsetID.Valid {
+		return "", false
+	}
+	return urn.NewToolset(e.ToolsetID.UUID).String(), true
 }
 
 // NewResolvedMcpEndpointFromMetaMcpServer materialises a ResolvedMcpEndpoint
@@ -451,10 +468,9 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 		case err != nil:
 			return nil, oops.E(oops.CodeUnexpected, err, "load project").LogError(ctx, s.logger)
 		}
-		endpoint := NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
-		if ref.RouteBase != "" {
-			endpoint.RouteBase = ref.RouteBase
-		}
+		// Refs cached before EndpointRef.RouteBase existed were only ever
+		// minted on the /x/mcp surface for server-keyed endpoints.
+		endpoint := NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, conv.Default(ref.RouteBase, "x/mcp"))
 		upstreamResource, err := s.resolveUpstreamResource(ctx, s.logger, mcpEndpoint.ProjectID, &mcpServer)
 		if err != nil {
 			return nil, err
@@ -470,6 +486,7 @@ func (s *Service) buildResolvedMcpEndpointByRef(ctx context.Context, ref Endpoin
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
 	}
+	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackChallengeResume)
 	if !toolset.UserSessionIssuerID.Valid {
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")
 	}
@@ -504,6 +521,7 @@ func (s *Service) loadResolvedMcpEndpointByToolsetSlug(ctx context.Context, mcpS
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
+	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackOAuth)
 	if !toolset.UserSessionIssuerID.Valid {
 		return nil, oops.E(oops.CodeNotFound, nil, "not found")
 	}

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -266,8 +266,10 @@ func handleToolsCall(
 	// verify they have mcp:connect for this specific tool (not just the server).
 	// The connection-level check only validates the server; this narrows to the
 	// tool and disposition dimensions. Public MCPs skip this — they're open to
-	// everyone, mirroring the connection-level guard in impl.go.
-	if payload.authenticated && authzEngine != nil && (toolset.McpIsPublic == nil || !*toolset.McpIsPublic) {
+	// everyone, mirroring the connection-level guard in impl.go. Both the
+	// privacy read and the resource id follow the wrapper when one fronts
+	// the request.
+	if payload.authenticated && authzEngine != nil && payload.effectiveMCPPrivate(toolset.McpIsPublic) {
 		var disposition string
 		if tool != nil {
 			baseTool, err := conv.ToBaseTool(tool)
@@ -275,7 +277,7 @@ func handleToolsCall(
 				disposition = conv.DispositionFromAnnotations(baseTool.Annotations)
 			}
 		}
-		if err := authzEngine.Require(ctx, authz.MCPToolCallCheck(toolset.ID, authz.MCPToolCallDimensions{
+		if err := authzEngine.Require(ctx, authz.MCPToolCallCheck(payload.mcpConnectResourceID(toolset.ID), authz.MCPToolCallDimensions{
 			Tool:        params.Name,
 			Disposition: disposition,
 			ProjectID:   payload.projectID.String(),

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -152,11 +152,13 @@ func handleToolsList(
 	// Filter tools by RBAC grants. Private authenticated MCPs enforce
 	// per-tool mcp:connect checks — the same dimensions used by tools/call.
 	// Public MCPs skip this (open to everyone, matching the connection guard).
-	if payload.authenticated && authzEngine != nil && (toolset.McpIsPublic == nil || !*toolset.McpIsPublic) {
+	// Both the privacy read and the resource id follow the wrapper when one
+	// fronts the request.
+	if payload.authenticated && authzEngine != nil && payload.effectiveMCPPrivate(toolset.McpIsPublic) {
 		allowed := make([]*toolListEntry, 0, len(tools))
 		for _, t := range tools {
 			disposition := dispositionFromAnnotations(t.Annotations)
-			if err := authzEngine.Require(ctx, authz.MCPToolCallCheck(toolset.ID, authz.MCPToolCallDimensions{
+			if err := authzEngine.Require(ctx, authz.MCPToolCallCheck(payload.mcpConnectResourceID(toolset.ID), authz.MCPToolCallDimensions{
 				Tool:        t.Name,
 				Disposition: disposition,
 				ProjectID:   payload.projectID.String(),

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -231,8 +231,10 @@ func (s *Service) handleMetaExecuteToolCall(
 	}
 
 	// Pre-dispatch security check so an unsatisfied member surfaces as a
-	// member-scoped result (as in ServeToolsetResolved).
-	satisfied, err := s.checkToolsetSecurity(ctx, toolset, inputs)
+	// member-scoped result (as in serveToolsetResolved). Members keep the
+	// toolset's own publicness; the meta surface is outside wrapper
+	// governance.
+	satisfied, err := s.checkToolsetSecurity(ctx, toolset, toolset.McpIsPublic, inputs)
 	if err != nil {
 		return nil, err
 	}
@@ -440,21 +442,25 @@ func (s *Service) buildMemberDispatch(
 
 	serverID := member.serverID
 	inputs := &mcpInputs{
-		projectID:                projectID,
-		organizationID:           toolset.OrganizationID,
-		toolset:                  toolset.Slug,
-		environment:              environment,
-		mcpEnvVariables:          nil,
-		oauthTokenInputs:         tokenInputs,
-		authenticated:            gate.authenticated,
-		sessionID:                gate.sessionID,
-		chatID:                   gate.chatID,
-		mode:                     ToolModeStatic,
-		userID:                   gate.userID,
-		externalUserID:           gate.externalUserID,
-		apiKeyID:                 gate.apiKeyID,
-		toolVariationsGroupID:    variationsGroupID,
-		mcpServerID:              &serverID,
+		projectID:             projectID,
+		organizationID:        toolset.OrganizationID,
+		toolset:               toolset.Slug,
+		environment:           environment,
+		mcpEnvVariables:       nil,
+		oauthTokenInputs:      tokenInputs,
+		authenticated:         gate.authenticated,
+		sessionID:             gate.sessionID,
+		chatID:                gate.chatID,
+		mode:                  ToolModeStatic,
+		userID:                gate.userID,
+		externalUserID:        gate.externalUserID,
+		apiKeyID:              gate.apiKeyID,
+		toolVariationsGroupID: variationsGroupID,
+		mcpServerID:           &serverID,
+		// Meta members keep their toolset-keyed per-tool checks; the meta
+		// surface's RBAC model is outside the wrapper-governance cutover.
+		wrapperRBACResourceID:    "",
+		wrapperIsPublic:          nil,
 		skipProxyTools:           true,
 		tags:                     nil,
 		protocolVersion:          gate.protocolVersion,

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -212,12 +212,12 @@ func (s *Service) serveResolvedMCPEndpoint(
 		}
 		return s.serveTunneledBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate, sessionToolSelection)
 	case mcpServer.ToolsetID.Valid:
-		// AGE-1902: toolset-backed branch still reads runtime config from the
-		// toolsets row (visibility, OAuth, default environment). Once
-		// /mcp/{mcpSlug} is migrated to source these from the linked
-		// mcp_servers row instead, this branch should switch to passing the
-		// mcp_server config into ServeToolsetResolved (or its successor) and
-		// the toolset load below can be dropped.
+		// Wrapper-governed dispatch (AIS-633): visibility, issuer gating, the
+		// RBAC resource id, and the variation-group override come from the
+		// mcp_servers row; the toolset supplies only what remains a toolset
+		// concern (tools, resources, prompts, environment, tool selection
+		// mode, external OAuth). A soft-deleted toolset behind a live wrapper
+		// surfaces as not found here.
 		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{
 			ID:        mcpServer.ToolsetID.UUID,
 			ProjectID: mcpEndpoint.ProjectID,
@@ -229,16 +229,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			return oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 		}
 
-		// The mcp_servers row's variation group, when set, overrides the
-		// toolset's own column. Pass it through so ServeToolsetResolved resolves
-		// the effective group (mcp_server, then toolset, then project default).
-		var mcpServerVariationsGroupID *uuid.UUID
-		if mcpServer.ToolVariationsGroupID.Valid {
-			id := mcpServer.ToolVariationsGroupID.UUID
-			mcpServerVariationsGroupID = &id
-		}
-
-		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, nil, sessionToolSelection, mcpServerVariationsGroupID, &mcpServer.ID, pendingIssuerGate); err != nil {
+		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, hostedServingFromWrapper(mcpServer, issuerGated), nil, sessionToolSelection, pendingIssuerGate); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil
@@ -246,6 +237,29 @@ func (s *Service) serveResolvedMCPEndpoint(
 		// CHECK constraint mcp_servers_backend_exclusivity_check guarantees
 		// exactly one backend is set; this is defensive.
 		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
+	}
+}
+
+// hostedServingFromWrapper derives the hosting configuration for a request
+// that resolved through an mcp_endpoints → mcp_servers pair: the wrapper row
+// governs visibility, issuer gating, RBAC, and the variation group (AIS-633).
+// callerGated reports whether the caller already ran the issuer gate keyed on
+// mcp_servers.user_session_issuer_id; the in-toolset gate never runs on this
+// path regardless.
+func hostedServingFromWrapper(mcpServer *mcpserversrepo.McpServer, callerGated bool) *hostedServing {
+	var groupID *uuid.UUID
+	if mcpServer.ToolVariationsGroupID.Valid {
+		id := mcpServer.ToolVariationsGroupID.UUID
+		groupID = &id
+	}
+	serverID := mcpServer.ID
+	return &hostedServing{
+		isPublic:              mcpServer.Visibility == mcpservers.VisibilityPublic,
+		runInToolsetGate:      false,
+		callerGated:           callerGated,
+		rbacResourceID:        mcpServer.ID,
+		toolVariationsGroupID: groupID,
+		mcpServerID:           &serverID,
 	}
 }
 
@@ -380,10 +394,11 @@ func (s *Service) ResolveMCPEndpointAndServer(ctx context.Context, logger *slog.
 //     authoritative for the slug and is not an OAuth endpoint, so we do
 //     NOT fall back — this keeps non-issuer-gated remote-backed servers
 //     returning not-found, matching the well-known surface.
-//   - Addressing miss (CodeNotFound): fall back to the legacy
-//     toolsets.mcp_slug lookup so issuer-gated toolset-backed servers
-//     without an mcp_endpoint row (predating the toolsets → mcp_servers
-//     migration) still resolve.
+//   - Addressing miss (CodeNotFound, not ErrEndpointUnavailable): fall back
+//     to the legacy toolsets.mcp_slug lookup so issuer-gated toolset-backed
+//     servers without an mcp_endpoint row (predating the toolsets →
+//     mcp_servers migration) still resolve. A resolvable-but-unavailable
+//     address (disabled wrapper, dangling backend) is terminal.
 //
 // mcpRouteBase ("mcp" or "x/mcp") propagates into the resolved endpoint's
 // URL building on both the primary and fallback paths.
@@ -408,7 +423,7 @@ func (s *Service) LoadResolvedMcpEndpointBySlug(ctx context.Context, logger *slo
 			return nil, oops.E(oops.CodeNotFound, nil, "not found")
 		}
 		return s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+	case isMCPEndpointAddressMiss(err, &shareErr):
 		return s.loadResolvedMcpEndpointByToolsetSlug(ctx, slug, mcpRouteBase)
 	default:
 		return nil, err
@@ -442,8 +457,7 @@ func (s *Service) BuildResolvedMcpEndpointForServer(
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "load project").LogError(ctx, logger)
 	}
-	resolved := NewResolvedMcpEndpointFromMcpServer(mcpEndpoint, mcpServer, project.OrganizationID)
-	resolved.RouteBase = mcpRouteBase
+	resolved := NewResolvedMcpEndpointFromMcpServer(mcpEndpoint, mcpServer, project.OrganizationID, mcpRouteBase)
 	upstreamResource, err := s.resolveUpstreamResource(ctx, logger, mcpEndpoint.ProjectID, mcpServer)
 	if err != nil {
 		return nil, err

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -404,7 +404,6 @@ func (s *Service) ResolveMCPEndpointAndServer(ctx context.Context, logger *slog.
 // URL building on both the primary and fallback paths.
 func (s *Service) LoadResolvedMcpEndpointBySlug(ctx context.Context, logger *slog.Logger, slug, mcpRouteBase string) (*ResolvedMcpEndpoint, error) {
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, slug)
-	var shareErr *oops.ShareableError
 	switch {
 	case err == nil:
 		if metaServer != nil {
@@ -423,7 +422,7 @@ func (s *Service) LoadResolvedMcpEndpointBySlug(ctx context.Context, logger *slo
 			return nil, oops.E(oops.CodeNotFound, nil, "not found")
 		}
 		return s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
-	case isMCPEndpointAddressMiss(err, &shareErr):
+	case mcpendpoints.IsAddressMiss(err):
 		return s.loadResolvedMcpEndpointByToolsetSlug(ctx, slug, mcpRouteBase)
 	default:
 		return nil, err

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -505,6 +505,29 @@ func TestServePublic_McpEndpoint_DisabledMcpServer_DoesNotFallBack(t *testing.T)
 	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }
 
+// An unrecognized visibility value must not silently map onto a servable
+// policy: the endpoint is terminally not-found, like disabled.
+func TestServePublic_McpEndpoint_UnknownVisibility_DoesNotServe(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "unknown-vis-" + uuid.NewString()[:8]
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "unknown-vis-ts-"+uuid.NewString()[:8])
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "archived", uuid.NullUUID{}, uuid.Nil)
+
+	_, err := servePublicHTTP(t, ctx, ti, slug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "an unknown visibility must not serve")
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+}
+
 // TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint
 // regression-guards the platform-only resolution semantic: a
 // custom-domain-scoped mcp_endpoint must not resolve for a request

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -1,6 +1,8 @@
 // servepublic_mcpendpoint_test.go verifies that /mcp/{mcpSlug} resolves
 // through mcp_endpoints → mcp_servers first and falls back to the
-// legacy toolsets.mcp_slug lookup on any not-found.
+// legacy toolsets.mcp_slug lookup only on a true address miss — a
+// resolvable-but-unavailable address (disabled wrapper, dangling backend)
+// is terminal (AIS-633).
 package mcp_test
 
 import (
@@ -305,7 +307,7 @@ func mintIssuerBearerForEndpointSubject(
 		CustomDomainID: uuid.NullUUID{},
 	})
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, organizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, organizationID, "mcp")
 
 	clientID := "test-client-" + uuid.NewString()
 	redirectURI := "http://localhost:3000/callback"
@@ -470,13 +472,13 @@ func TestServePublic_McpEndpoint_IssuerGated_NoAuth_EmitsChallenge(t *testing.T)
 	require.Equal(t, expected, wwwAuth, "mcpRouteBase must be 'mcp' (not 'x/mcp') for /mcp callers")
 }
 
-// TestServePublic_McpEndpoint_DisabledMcpServer_FallsBackToLegacyToolset
-// verifies the ServePublic doc contract that a disabled mcp_server
-// surfaces as CodeNotFound from ResolveMCPEndpointAndServer and falls
-// through to the legacy toolsets.mcp_slug lookup. A toolset with
-// mcp_slug equal to the endpoint slug acts as the legacy-path target
-// the fallback must find.
-func TestServePublic_McpEndpoint_DisabledMcpServer_FallsBackToLegacyToolset(t *testing.T) {
+// TestServePublic_McpEndpoint_DisabledMcpServer_DoesNotFallBack pins the
+// endpoint-authority rule (AIS-633): a disabled mcp_server behind a live
+// mcp_endpoint is a terminal not-found. Even when a public toolset carries
+// the same slug via toolsets.mcp_slug, the endpoint row owns the address and
+// the disabled server must not resurrect through its toolset. (This reverses
+// the pre-AIS-633 fallback behavior, where the same setup served the toolset.)
+func TestServePublic_McpEndpoint_DisabledMcpServer_DoesNotFallBack(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -486,21 +488,21 @@ func TestServePublic_McpEndpoint_DisabledMcpServer_FallsBackToLegacyToolset(t *t
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	// A separate (disabled) toolset is the mcp_endpoint's backend; the
-	// fallback target is a different public toolset sharing the slug
-	// via createPublicMCPToolset (which sets both Slug and McpSlug to
-	// the same value). The mcp_endpoint resolution finds the disabled
-	// server (returns CodeNotFound); the fallback's GetToolsetByMcpSlug
-	// finds the public legacy toolset.
+	// A separate (disabled) wrapper is the mcp_endpoint's backend; a second
+	// public toolset shares the slug via createPublicMCPToolset (which sets
+	// both Slug and McpSlug to the same value) and would have served the
+	// request under the old fallback.
 	sharedSlug := "shared-" + uuid.NewString()[:8]
 	disabledToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "disabled-"+uuid.NewString()[:8])
 	createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, sharedSlug)
 
 	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, disabledToolset.ID, sharedSlug, "disabled", uuid.NullUUID{}, uuid.Nil)
 
-	w, err := servePublicHTTP(t, ctx, ti, sharedSlug, makeInitializeBody(), "", nil)
-	require.NoError(t, err, "disabled mcp_server must fall through to the legacy toolset lookup")
-	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	_, err := servePublicHTTP(t, ctx, ti, sharedSlug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "a disabled wrapper must not fall back to the legacy toolset lookup")
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }
 
 // TestServePublic_PlatformDomain_DoesNotResolveCustomDomainEndpoint

--- a/server/internal/mcp/toolselection.go
+++ b/server/internal/mcp/toolselection.go
@@ -75,6 +75,20 @@ func endpointToolSelectionResource(endpoint *ResolvedMcpEndpoint) string {
 	}
 }
 
+// endpointAcceptsToolSelectionResource reports whether a stored consent
+// selection belongs to this endpoint. A toolset-backed wrapper additionally
+// accepts the legacy "toolset:<id>" form: selections consented while the
+// server was still resolved through toolsets.mcp_slug were stored against the
+// toolset resource and must keep authorizing the same server for one
+// access-token lifetime after the backfill (AIS-633; removed with the legacy
+// audience acceptance by AIS-646).
+func endpointAcceptsToolSelectionResource(endpoint *ResolvedMcpEndpoint, resource string) bool {
+	if resource == endpointToolSelectionResource(endpoint) {
+		return true
+	}
+	return endpoint.McpServerID.Valid && endpoint.ToolsetID.Valid && resource == "toolset:"+endpoint.ToolsetID.UUID.String()
+}
+
 // loadSessionToolSelection resolves the tool policy for a validated session
 // jti. Returns nil for an all-tools session. Any error means the request
 // must be rejected: missing row (a live jti always has one — refresh

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -103,6 +103,8 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		// version, so they resolve to the unversioned default.
 		toolVariationsGroupID:    nil,
 		mcpServerID:              nil,
+		wrapperRBACResourceID:    "",
+		wrapperIsPublic:          nil,
 		skipProxyTools:           false,
 		tags:                     nil,
 		protocolVersion:          mcpversions.Resolve("", mcpversions.SupportedHostedToolset()),

--- a/server/internal/mcp/wrapper_governance_test.go
+++ b/server/internal/mcp/wrapper_governance_test.go
@@ -30,9 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 )
 
-// collectCounterPoints returns the data points of one int64 counter by
-// attribute set, mirroring collectKillswitchCoverage for arbitrary
-// instruments.
+// collectCounterPoints returns one int64 counter's data points by attribute set.
 func collectCounterPoints(t *testing.T, reader *sdkmetric.ManualReader, instrument string) map[attribute.Set]int64 {
 	t.Helper()
 
@@ -145,7 +143,7 @@ func TestServePublic_WrapperGovernance_WrapperIssuerGatesToolsetBacked(t *testin
 	endpointSlug := "wg-endpoint-" + uuid.NewString()
 	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
 
-	w, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "", nil)
+	w, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), "", nil)
 	require.Error(t, err, "issuer-gated wrapper must reject unauthenticated requests")
 
 	expected := `Bearer resource_metadata="` + ti.serverURL.String() + `/.well-known/oauth-protected-resource/mcp/` + endpointSlug + `"`

--- a/server/internal/mcp/wrapper_governance_test.go
+++ b/server/internal/mcp/wrapper_governance_test.go
@@ -1,0 +1,328 @@
+// wrapper_governance_test.go pins the AIS-633 contract: when a request
+// resolves through an mcp_endpoints row to a toolset-backed mcp_servers row,
+// hosting configuration (visibility, issuer gating, RBAC resource id) comes
+// from the wrapper, and the toolset's own mcp_is_public /
+// user_session_issuer_id columns are not consulted. It also covers the legacy
+// toolset-URN audience acceptance and the migration merge-gate counters.
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	mockidp "github.com/speakeasy-api/gram/dev-idp/pkg/testidp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+)
+
+// collectCounterPoints returns the data points of one int64 counter by
+// attribute set, mirroring collectKillswitchCoverage for arbitrary
+// instruments.
+func collectCounterPoints(t *testing.T, reader *sdkmetric.ManualReader, instrument string) map[attribute.Set]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	points := map[attribute.Set]int64{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != instrument {
+				continue
+			}
+			sum, ok := metric.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, point := range sum.DataPoints {
+				points[point.Attributes] = point.Value
+			}
+		}
+	}
+	return points
+}
+
+// A public wrapper over a private toolset serves anonymously: wrapper
+// visibility wins and toolsets.mcp_is_public is not consulted. Before
+// AIS-633 the same setup 401'd on the toolset's private flag.
+func TestServePublic_WrapperGovernance_PublicWrapperOverPrivateToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPrivateMCPToolset(t, ctx, ti, "wg-private-ts-"+uuid.NewString()[:8])
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	// Plain context: no session, no bearer — only a public server answers.
+	w, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.NoError(t, err, "wrapper visibility 'public' must govern; toolset privacy must not be consulted")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.NotEmpty(t, w.Header().Get("Mcp-Session-Id"))
+}
+
+// A private wrapper over a public toolset requires identity auth: wrapper
+// visibility wins in the restrictive direction too.
+func TestServePublic_WrapperGovernance_PrivateWrapperOverPublicToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "wg-public-ts-"+uuid.NewString()[:8])
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "private", uuid.NullUUID{}, uuid.Nil)
+
+	_, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "wrapper visibility 'private' must govern even though the toolset is public")
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+}
+
+// The issuer gate keys on mcp_servers.user_session_issuer_id: a toolset-side
+// issuer with no wrapper issuer must NOT gate a wrapper-resolved request.
+// Before AIS-633 the in-toolset gate ran off the toolset column and 401'd.
+func TestServePublic_WrapperGovernance_ToolsetIssuerIgnoredWhenWrapperUngated(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "wg-ts-issuer-"+uuid.NewString()[:8])
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	_, err := toolsetsRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	w, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.NoError(t, err, "an ungated wrapper must serve without a challenge despite the toolset-side issuer")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// An issuer-gated toolset-backed wrapper challenges unauthenticated callers
+// with the /mcp-surface resource metadata URL — the gate keys on the wrapper.
+func TestServePublic_WrapperGovernance_WrapperIssuerGatesToolsetBacked(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "wg-gated-"+uuid.NewString()[:8])
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
+
+	w, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "issuer-gated wrapper must reject unauthenticated requests")
+
+	expected := `Bearer resource_metadata="` + ti.serverURL.String() + `/.well-known/oauth-protected-resource/mcp/` + endpointSlug + `"`
+	require.Equal(t, expected, w.Header().Get("WWW-Authenticate"))
+}
+
+// mintWrapperUserBearer mints a user-session JWT bound to the wrapper's
+// issuer-URN audience and persists its user_sessions row, mirroring what
+// /token emits for a wrapper-resolved endpoint.
+func mintWrapperUserBearer(t *testing.T, ti *testInstance, issuerID uuid.UUID, endpointSlug string, subject urn.SessionSubject) string {
+	t.Helper()
+
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: urn.NewUserSessionIssuer(issuerID).String(),
+		Issuer:   ti.serverURL.String() + "/mcp/" + endpointSlug,
+		Lifetime: time.Hour,
+	})
+	require.NoError(t, err)
+	persistTestUserSession(t, ti, issuerID, subject, jti)
+	return token
+}
+
+// mcp:connect on a private toolset-backed wrapper keys on the mcp_servers id:
+// a grant on the toolset id does not satisfy the check, and a grant on the
+// wrapper id does.
+func TestServePublic_WrapperGovernance_RBACKeysOnWrapperID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "wg-rbac-"+uuid.NewString()[:8])
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	mcpServer := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "private", uuid.NullUUID{}, issuerID)
+
+	subject := urn.NewUserSubject(mockidp.MockUserID)
+	token := mintWrapperUserBearer(t, ti, issuerID, endpointSlug, subject)
+
+	// A toolset-id grant is the wrong id space and must not admit the caller.
+	seedUserMCPConnectGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockidp.MockUserID, toolset.ID.String())
+
+	_, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)
+	require.Error(t, err, "a toolset-id grant must not satisfy the wrapper-keyed mcp:connect check")
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Contains(t, oopsErr.Error(), "resource_id="+mcpServer.ID.String(), "denial must reference the wrapper id")
+
+	// The wrapper-id grant admits the caller.
+	seedUserMCPConnectGrant(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockidp.MockUserID, mcpServer.ID.String())
+	w, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+}
+
+// A bearer minted against the legacy toolset-URN audience keeps validating on
+// the toolset-backed wrapper, and every acceptance increments
+// mcp.legacy_audience_accepted with the issuer dimension.
+func TestServePublic_WrapperGovernance_LegacyToolsetAudienceAccepted(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "wg-legacyaud-"+uuid.NewString()[:8])
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
+
+	// The pre-migration mint bound the audience to the toolset URN.
+	subject := urn.NewAnonymousSubject(uuid.NewString())
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: urn.NewToolset(toolset.ID).String(),
+		Issuer:   ti.serverURL.String() + "/mcp/" + endpointSlug,
+		Lifetime: time.Hour,
+	})
+	require.NoError(t, err)
+	persistTestUserSession(t, ti, issuerID, subject, jti)
+
+	w, err := servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)
+	require.NoError(t, err, "legacy toolset-URN audience must stay valid on the toolset-backed wrapper")
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	points := collectCounterPoints(t, reader, mcpmetrics.InstrumentLegacyAudienceAccepted)
+	require.Equal(t, int64(1), points[attribute.NewSet(attr.UserSessionIssuerID(issuerID.String()))],
+		"acceptance must increment mcp.legacy_audience_accepted with the issuer dimension")
+}
+
+// The legacy audience is only accepted on toolset-backed wrappers: a
+// remote-backed endpoint rejects a toolset-URN-audience bearer outright.
+func TestServePublic_WrapperGovernance_LegacyAudienceRejectedOffWrapper(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, "https://upstream.invalid/mcp", endpointSlug, "public", issuerID)
+
+	subject := urn.NewAnonymousSubject(uuid.NewString())
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: urn.NewToolset(uuid.New()).String(),
+		Issuer:   ti.serverURL.String() + "/mcp/" + endpointSlug,
+		Lifetime: time.Hour,
+	})
+	require.NoError(t, err)
+	persistTestUserSession(t, ti, issuerID, subject, jti)
+
+	_, err = servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)
+	require.Error(t, err, "a toolset-URN audience must not authenticate a non-toolset-backed endpoint")
+
+	points := collectCounterPoints(t, reader, mcpmetrics.InstrumentLegacyAudienceAccepted)
+	require.Empty(t, points, "no acceptance may be recorded for a rejected bearer")
+}
+
+// Legacy toolsets.mcp_slug resolutions increment mcp.toolset_slug_fallback
+// with the entry point as the dimension, and wrapper-resolved requests do
+// not. Exercises the runtime (serve_public) and well-known
+// (well_known_protected_resource) sites; the remaining sites share the same
+// instrumented lookups.
+func TestServePublic_WrapperGovernance_FallbackCounterByEntryPoint(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	// Legacy-only toolset: no mcp_endpoints row, resolves via mcp_slug.
+	legacyToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "wg-legacy-"+uuid.NewString()[:8])
+
+	w, err := servePublicHTTP(t, ctx, ti, legacyToolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// The well-known handler falls back on the same legacy slug. The toolset
+	// carries no OAuth configuration so the handler ultimately 404s, but the
+	// fallback resolution itself must still be counted.
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp/"+legacyToolset.McpSlug.String, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", legacyToolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	_ = ti.service.HandleGetProtectedResource(httptest.NewRecorder(), req)
+
+	// Wrapper-resolved request: must not count.
+	wrappedToolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "wg-wrapped-"+uuid.NewString()[:8])
+	endpointSlug := "wg-endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, wrappedToolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
+	w2, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w2.Code, "body=%s", w2.Body.String())
+
+	points := collectCounterPoints(t, reader, mcpmetrics.InstrumentToolsetSlugFallback)
+	require.Equal(t, int64(1), points[attribute.NewSet(attr.McpEntryPoint(mcpmetrics.LegacyFallbackServePublic))])
+	require.Equal(t, int64(1), points[attribute.NewSet(attr.McpEntryPoint(mcpmetrics.LegacyFallbackWellKnownProtectedResource))])
+	var total int64
+	for _, v := range points {
+		total += v
+	}
+	require.Equal(t, int64(2), total, "wrapper-resolved requests must not increment the fallback counter")
+}

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -27,6 +27,13 @@ import (
 // disabled server resurrect the same slug through its toolset (AIS-633).
 var ErrEndpointUnavailable = errors.New("mcp endpoint unavailable")
 
+// IsAddressMiss reports whether a resolution error is a true address miss —
+// the only outcome that may fall back to a legacy toolsets.mcp_slug lookup.
+func IsAddressMiss(err error) bool {
+	var shareErr *oops.ShareableError
+	return errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound && !errors.Is(err, ErrEndpointUnavailable)
+}
+
 // BySlugAndCustomDomain walks the public addressing chain shared by the /mcp
 // and /x/mcp slug handlers, the install-page handlers, and the .well-known
 // routes: it scopes the lookup to the request's customdomains.Context, loads
@@ -88,7 +95,11 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 		return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
 	}
 
-	if server.Visibility == mcpservers.VisibilityDisabled {
+	switch server.Visibility {
+	case mcpservers.VisibilityPublic, mcpservers.VisibilityPrivate:
+	default:
+		// Disabled or unrecognized visibility never serves; unknown values
+		// must not silently map onto a servable policy.
 		return nil, nil, nil, oops.E(oops.CodeNotFound, ErrEndpointUnavailable, "mcp endpoint not found")
 	}
 

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -3,6 +3,7 @@ package mcpendpoints
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -18,6 +19,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
+// ErrEndpointUnavailable marks an address that resolved to an mcp_endpoints
+// row whose backend cannot serve: disabled visibility, or a dangling backend
+// FK. The endpoint row makes the address authoritative, so this outcome is a
+// terminal not-found on every surface — unlike a plain address miss, it must
+// never fall back to the legacy toolsets.mcp_slug lookup, which would let a
+// disabled server resurrect the same slug through its toolset (AIS-633).
+var ErrEndpointUnavailable = errors.New("mcp endpoint unavailable")
+
 // BySlugAndCustomDomain walks the public addressing chain shared by the /mcp
 // and /x/mcp slug handlers, the install-page handlers, and the .well-known
 // routes: it scopes the lookup to the request's customdomains.Context, loads
@@ -29,8 +38,9 @@ import (
 // carry the slug attribute.
 //
 // Callers that want to fall back to a legacy lookup (e.g. /mcp's existing
-// toolsets.mcp_slug path) should check for oops.CodeNotFound and proceed
-// accordingly.
+// toolsets.mcp_slug path) may do so only on a true address miss — a
+// CodeNotFound that is NOT ErrEndpointUnavailable. A resolvable-but-unavailable
+// address (errors.Is(err, ErrEndpointUnavailable)) is terminal.
 func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, slug string) (*repo.McpEndpoint, *mcpservers_repo.McpServer, *metamcp_repo.MetaMcpServer, error) {
 	var customDomainID uuid.NullUUID
 	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
@@ -55,13 +65,13 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 		})
 		switch {
 		case errors.Is(err, pgx.ErrNoRows):
-			return nil, nil, nil, oops.E(oops.CodeNotFound, err, "meta mcp server not found")
+			return nil, nil, nil, oops.E(oops.CodeNotFound, fmt.Errorf("%w: %w", ErrEndpointUnavailable, err), "meta mcp server not found")
 		case err != nil:
 			return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load meta mcp server").LogError(ctx, logger)
 		}
 
 		if metaServer.Visibility == metamcp_visibility.Disabled {
-			return nil, nil, nil, oops.C(oops.CodeNotFound)
+			return nil, nil, nil, oops.E(oops.CodeNotFound, ErrEndpointUnavailable, "mcp endpoint not found")
 		}
 
 		return &endpoint, nil, &metaServer, nil
@@ -73,13 +83,13 @@ func BySlugAndCustomDomain(ctx context.Context, db *pgxpool.Pool, logger *slog.L
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, nil, nil, oops.E(oops.CodeNotFound, err, "mcp server not found")
+		return nil, nil, nil, oops.E(oops.CodeNotFound, fmt.Errorf("%w: %w", ErrEndpointUnavailable, err), "mcp server not found")
 	case err != nil:
 		return nil, nil, nil, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
 	}
 
 	if server.Visibility == mcpservers.VisibilityDisabled {
-		return nil, nil, nil, oops.C(oops.CodeNotFound)
+		return nil, nil, nil, oops.E(oops.CodeNotFound, ErrEndpointUnavailable, "mcp endpoint not found")
 	}
 
 	return &endpoint, &server, nil, nil

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1030,27 +1030,22 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	return s.renderRemoteMcpInstallPage(ctx, w, ic, metadataRecord)
 }
 
-// resolveInstallContext tries the mcp_endpoints → mcp_server resolution path
-// first (via the shared mcpendpoints.BySlugAndCustomDomain helper, mirroring
-// mcp.ServePublic's resolution), then falls back to the legacy
-// toolsets.mcp_slug lookup so platform-domain install pages keep working for
-// customers that pre-date mcp_endpoints. Only a true address miss falls
-// through; a resolvable-but-unavailable address (disabled wrapper, dangling
-// backend) is terminal, again matching mcp.ServePublic (AIS-633).
+// resolveInstallContext resolves mcp_endpoints → mcp_server first, mirroring
+// mcp.ServePublic: only a true address miss falls back to the legacy
+// toolsets.mcp_slug lookup; an unavailable address is terminal (AIS-633).
 func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*installContext, error) {
 	endpoint, server, metaServer, err := mcpendpoints.BySlugAndCustomDomain(ctx, s.db, s.logger, mcpSlug)
-	var shareErr *oops.ShareableError
 	switch {
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound && !errors.Is(err, mcpendpoints.ErrEndpointUnavailable):
+	case mcpendpoints.IsAddressMiss(err):
 		// Fall through to legacy toolset lookup.
+	case errors.Is(err, mcpendpoints.ErrEndpointUnavailable):
+		// Disabled or dangling backend: the endpoint row owns the slug, so
+		// render the not-found page rather than an unexpected failure.
+		return nil, fmt.Errorf("%w: mcp endpoint backend unavailable", errToolsetNotFound)
 	case err != nil:
 		return nil, fmt.Errorf("resolve mcp endpoint: %w", err)
 	case metaServer != nil:
-		// Meta-backed endpoints have no install page yet (AGE-3299); the
-		// slug is authoritative, so surface not-found rather than falling
-		// through to an unrelated legacy toolset. Wrapping errToolsetNotFound
-		// is what makes ServeInstallPage render the not-found page instead of
-		// treating this as an unexpected failure.
+		// Meta-backed endpoints have no install page yet (AGE-3299).
 		return nil, fmt.Errorf("%w: meta-backed endpoint has no install page", errToolsetNotFound)
 	default:
 		var bridgeToolset *toolsets_repo.Toolset

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
@@ -44,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomains_repo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	environments_repo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -207,6 +209,7 @@ type Service struct {
 	siteURL        *url.URL
 	toolsetCache   cache.TypedCacheObject[mv.ToolsetBaseContents]
 	audit          *audit.Logger
+	legacyFallback *mcpmetrics.LegacyFallbackCounter
 
 	// Hosted install page script (embedded and served with cache-busting hash)
 	installPageScriptHash string
@@ -221,6 +224,7 @@ var (
 func NewService(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
 	sessions *sessions.Manager,
 	serverURL *url.URL,
@@ -250,6 +254,7 @@ func NewService(
 		siteURL:        siteURL,
 		toolsetCache:   cache.NewTypedObjectCache[mv.ToolsetBaseContents](logger.With(attr.SlogCacheNamespace("toolset")), cacheAdapter, cache.SuffixNone),
 		audit:          auditLogger,
+		legacyFallback: mcpmetrics.NewLegacyFallbackCounter(meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcpmetadata"), logger),
 
 		installPageScriptHash: scriptHashStr,
 		installPageScriptData: hostedPageScriptData,
@@ -1029,14 +1034,14 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 // first (via the shared mcpendpoints.BySlugAndCustomDomain helper, mirroring
 // mcp.ServePublic's resolution), then falls back to the legacy
 // toolsets.mcp_slug lookup so platform-domain install pages keep working for
-// customers that pre-date mcp_endpoints. A disabled mcp_server resolves like
-// a 404 and is allowed to fall through to the legacy path, again matching
-// mcp.ServePublic.
+// customers that pre-date mcp_endpoints. Only a true address miss falls
+// through; a resolvable-but-unavailable address (disabled wrapper, dangling
+// backend) is terminal, again matching mcp.ServePublic (AIS-633).
 func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*installContext, error) {
 	endpoint, server, metaServer, err := mcpendpoints.BySlugAndCustomDomain(ctx, s.db, s.logger, mcpSlug)
 	var shareErr *oops.ShareableError
 	switch {
-	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound && !errors.Is(err, mcpendpoints.ErrEndpointUnavailable):
 		// Fall through to legacy toolset lookup.
 	case err != nil:
 		return nil, fmt.Errorf("resolve mcp endpoint: %w", err)
@@ -1079,6 +1084,7 @@ func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*i
 	if err != nil {
 		return nil, err
 	}
+	s.legacyFallback.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackInstallPage)
 	org, err := s.orgsRepo.GetOrganizationMetadata(ctx, toolset.OrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("load organization: %w", err)

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1949,3 +1949,27 @@ func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "Server Not Found")
 	assert.NotContains(t, rr.Body.String(), "Legacy Same-Slug Toolset")
 }
+
+// A live endpoint whose backend server is disabled renders the not-found page
+// rather than a 500: the address is authoritative and terminal (AIS-633).
+func TestServeInstallPage_DisabledServerBackend_ReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	mcpSlug := "disabled-install-" + uuid.New().String()[:8]
+	createMcpServerWithEndpoint(t, ctx, testInstance, mcpServerFixtureOptions{
+		name:         "Disabled Server",
+		visibility:   mcpservers.VisibilityDisabled,
+		endpointSlug: mcpSlug,
+	})
+
+	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, testInstance.service.ServeInstallPage(rr, req))
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Server Not Found")
+}

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1956,12 +1956,35 @@ func TestServeInstallPage_DisabledServerBackend_ReturnsNotFound(t *testing.T) {
 	t.Parallel()
 	ctx, testInstance := newTestMCPMetadataService(t)
 
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
 	mcpSlug := "disabled-install-" + uuid.New().String()[:8]
 	createMcpServerWithEndpoint(t, ctx, testInstance, mcpServerFixtureOptions{
 		name:         "Disabled Server",
 		visibility:   mcpservers.VisibilityDisabled,
 		endpointSlug: mcpSlug,
 	})
+
+	// A public legacy toolset shares the slug; a wrongly-falling-through
+	// legacy lookup would render it instead of the not-found page.
+	toolset, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Shadowing Legacy Toolset",
+		Slug:                   "legacy-" + mcpSlug,
+		McpSlug:                conv.ToPGText(mcpSlug),
+		Description:            conv.ToPGText("must not shadow the disabled wrapper"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, toolsets_repo.New(testInstance.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	}))
 
 	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
 	rctx := chi.NewRouteContext()
@@ -1972,4 +1995,5 @@ func TestServeInstallPage_DisabledServerBackend_ReturnsNotFound(t *testing.T) {
 	require.NoError(t, testInstance.service.ServeInstallPage(rr, req))
 	assert.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Server Not Found")
+	assert.NotContains(t, rr.Body.String(), "Shadowing Legacy Toolset")
 }

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -96,7 +96,7 @@ func newTestMCPMetadataService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := mcpmetadata.NewService(logger, tracerProvider, conn, sessionManager, serverURL, siteURL, cacheAdapter, authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger)
+	svc := mcpmetadata.NewService(logger, tracerProvider, testenv.NewMeterProvider(t), conn, sessionManager, serverURL, siteURL, cacheAdapter, authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/xmcp/serveruntime_test.go
+++ b/server/internal/xmcp/serveruntime_test.go
@@ -526,7 +526,7 @@ func TestServeMCP_IssuerGatedRemoteBackend_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	// Public OAuth client (token_endpoint_auth_method=none) — no
 	// client_secret_hash, PKCE alone establishes proof-of-possession.
@@ -626,7 +626,7 @@ func mintAccessTokenForSeededEndpoint(
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, mcpServer.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	require.True(t, mcpServer.UserSessionIssuerID.Valid, "remote-backed seeds always carry an issuer")
 	subject := urn.NewAnonymousSubject(uuid.NewString())
@@ -733,7 +733,7 @@ func TestServeMCP_IssuerGatedToolsetBackend_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	subject := urn.NewAnonymousSubject(uuid.NewString())
 	accessToken := mintIssuerGatedAccessToken(t, ctx, ti, slug, endpoint, issuerID, subject)
@@ -761,7 +761,7 @@ func TestServeMCP_IssuerGatedToolsetBackend_Killswitch(t *testing.T) {
 		CustomDomainID: uuid.NullUUID{},
 	})
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, authCtx.ActiveOrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, authCtx.ActiveOrganizationID, "x/mcp")
 	accessToken := mintIssuerGatedAccessToken(t, ctx, ti, slug, endpoint, issuerID, urn.NewUserSubject(authCtx.UserID))
 
 	err = testrepo.New(ti.conn).InsertKillswitchPrescriptionFixture(ctx, testrepo.InsertKillswitchPrescriptionFixtureParams{
@@ -816,7 +816,7 @@ func TestServeMCP_IssuerGatedRemoteBackend_PrivateHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	// Private endpoints route through the IDP, which stamps a user
 	// subject (not anonymous) onto the cached challenge state.
@@ -859,7 +859,7 @@ func TestServeMCP_IssuerGatedRemoteBackend_PrivateKillswitch(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 	accessToken := mintIssuerGatedAccessToken(t, ctx, ti, slug, endpoint, issuerID, urn.NewUserSubject(authCtx.UserID))
 
 	err = testrepo.New(ti.conn).InsertKillswitchPrescriptionFixture(ctx, testrepo.InsertKillswitchPrescriptionFixtureParams{
@@ -916,7 +916,7 @@ func TestServeMCP_IssuerGatedRemoteBackend_CrossIssuerTokenRejected(t *testing.T
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpointA := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpointA, &mcpServerA, project.OrganizationID)
+	endpointA := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpointA, &mcpServerA, project.OrganizationID, "x/mcp")
 
 	// Endpoint B: a sibling under a different issuer.
 	slugB, _, _ := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, upstream.URL, "public")
@@ -1219,7 +1219,7 @@ func TestRequireUserSessionIssuer_DanglingFKReturnsNotFound(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	// Sanity check: the issuer FK resolves cleanly before deletion.
 	require.NoError(t, ti.mcpService.RequireUserSessionIssuer(ctx, endpoint))
@@ -1452,7 +1452,7 @@ func TestServeMCP_IssuerGatedToolsetBackend_PrivateHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, *authCtx.ProjectID)
 	require.NoError(t, err)
-	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID)
+	endpoint := mcp.NewResolvedMcpEndpointFromMcpServer(&mcpEndpoint, &mcpServer, project.OrganizationID, "x/mcp")
 
 	// Private endpoints route through the IDP and stamp user subjects.
 	subject := urn.NewUserSubject("user_" + uuid.NewString()[:8])


### PR DESCRIPTION
AIM-21

## Summary

- When a request resolves through an `mcp_endpoints` row to a toolset-backed `mcp_servers` row, hosting configuration now comes from the wrapper: a new `hostedServing` resolved-config value carries visibility, the user-session issuer, the RBAC resource id, and the tool-variation-group override into the toolset serving path, replacing the previous boolean parameters. `toolsets.mcp_is_public` and `toolsets.user_session_issuer_id` are no longer consulted when a wrapper is present; tools, resources, prompts, environment, tool selection mode, and external OAuth still come from the toolset.
- RBAC: `mcp:connect` checks key on `mcp_servers.id` for wrapper-governed requests — connection-level, per-tool (tools/call and tools/list), and the consent tool picker. Meta-member and internal agent-workflow paths deliberately keep toolset-keyed checks.
- Audience: wrapper-backed endpoints bind the JWT audience to the issuer URN with the route base taken from the inbound surface (the hardcoded `x/mcp` default is removed). Bearer validation accepts the legacy toolset-URN audience for toolset-backed wrappers only, on audience mismatch only, counted by `mcp.legacy_audience_accepted{user_session_issuer.id}`; stored consent tool-selection resources get the same legacy acceptance so restricted sessions are not forced into reauth.
- Endpoint authority: `mcpendpoints.BySlugAndCustomDomain` distinguishes an address miss from a resolvable-but-unavailable address (disabled visibility, dangling backend) via a new `ErrEndpointUnavailable`. Only a true miss falls through to the legacy toolset lookup; a disabled wrapper can no longer resurrect its slug through the toolset, on any surface.
- Fallback observability: new counter `mcp.toolset_slug_fallback{gram.mcp.entry_point}` increments at all seven legacy resolve points (ServePublic, GET/DELETE proxy, both well-known handlers, the OAuth family via `LoadResolvedMcpEndpointBySlug`, the install page resolver, cached-challenge resume), only when the legacy lookup resolves a live toolset so scanner probes cannot keep it nonzero. The hosted serving path also stamps `gram.mcp_server.id` on the request span when a wrapper is present.

No production behavior changes on deploy: no toolset-backed `mcp_servers` rows exist yet, so the wrapper-governed paths are dormant until the backfill populates them.

## Motivation

Hosted (toolset-backed) MCP servers are migrating under `mcp_servers`/`mcp_endpoints`. This PR establishes the runtime contract that migration depends on: the wrapper governs hosting configuration, the audience and RBAC conventions converge on the server id with a counted compatibility window for outstanding legacy bearers, and the two counters introduced here are the merge gate for later removing the `toolsets.mcp_slug` fallback entirely. It also closes the resolver hole behind INC-420, where a disabled server could keep serving through the legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCzhsvUYz5VMieXYaQUC2Z

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When a request resolves through an `mcp_endpoints` row to a toolset-backed `mcp_servers` row, hosting configuration now comes from the wrapper: visibility, issuer gating, the RBAC resource id for `mcp:connect`, and the variation-group override. The toolset's `mcp_is_public` and `user_session_issuer_id` columns are no longer consulted on that path, and the JWT audience now binds to the issuer URN with the route base taken from the inbound surface instead of the hardcoded `x/mcp` default.

**Migration compatibility**
- Bearer validation on toolset-backed wrappers accepts the legacy toolset-URN audience on mismatch, counted by `mcp.legacy_audience_accepted`, so pre-backfill sessions aren't forced into reauth.
- Stored consent tool-selection resources get the same legacy acceptance.
- All seven legacy `toolsets.mcp_slug` resolve points increment `mcp.toolset_slug_fallback` by entry point, but only when the lookup resolves a live toolset.

**Endpoint authority**
- `mcpendpoints.BySlugAndCustomDomain` now returns `ErrEndpointUnavailable` for a resolvable-but-unavailable address instead of a plain not-found.
- A disabled or dangling backend is a terminal not-found on every surface, including the install page, so it no longer falls back and resurrects its slug through the toolset.
- Wrapper-governed requests stamp `gram.mcp_server.id` on the request span.

No production behavior changes on deploy: no toolset-backed `mcp_servers` rows exist yet, so the wrapper-governed paths stay dormant until the backfill populates them.

<sup>Written for commit d1c7863c3b54795bc93b206aee5d200b5573e2d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

