### PR TITLE
feat: start trials from platform admin invites

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1427,7 +1427,7 @@ func newStartCommand() *cli.Command {
 				auditLogger,
 				trialEmailNotifier,
 			))
-			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailNotifier, serverURL.String(), siteURL.String(), auditLogger, svixClient)
+			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailNotifier, productfeatures.SeedEnterpriseTrialBundleTx, posthogClient, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
 				Client:         ghClient,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -74,10 +74,9 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_workos_id_key
 ON organization_metadata (workos_id);
 
--- One row per organization provisioned by the trial signup flow. Only that
--- transaction inserts a row; a trial is never attached to an organization that
--- already exists, which is what lets expiry hardcode its demotion. Unrelated to
--- organization_metadata.free_trial_*, another concept.
+-- One enterprise-trial lifecycle per organization. Lifecycle operations update
+-- the row in place. Unrelated to organization_metadata.free_trial_*, another
+-- concept.
 CREATE TABLE IF NOT EXISTS trials (
   organization_id TEXT NOT NULL,
 

--- a/server/internal/auth/enterprise_trial.go
+++ b/server/internal/auth/enterprise_trial.go
@@ -29,18 +29,18 @@ type OrganizationFeatureSeeder func(ctx context.Context, tx pgx.Tx, organization
 // trial organization starts with.
 type EnterpriseTrialBundleSeeder func(ctx context.Context, tx pgx.Tx, organizationID string) error
 
-// armEnterpriseTrialTx turns an organization the caller's transaction just
-// created into an enterprise trial. Every write joins that transaction, so a
-// signup produces either a complete trial or no organization.
+// ArmEnterpriseTrialTx turns an organization into an enterprise trial. Every
+// write joins the caller's transaction. Callers must first establish that the
+// organization has no existing trial lifecycle.
 //
 // A trial sits on the real enterprise tier rather than a tier of its own, so
 // every account-type lookup downstream, including the OpenRouter credit
 // ceiling, resolves against a value it already knows.
 //
 // actorEmail is the display name recorded on the audit entry. It travels as a
-// parameter rather than an auth-context read because signup arms a trial from
-// the unauthenticated callback, where there is no auth context to read.
-func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID, actorEmail string) error {
+// parameter rather than an auth-context read because signup and invite callbacks
+// have no auth context to read.
+func ArmEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID, actorEmail string, trialBundleSeeder EnterpriseTrialBundleSeeder, auditLogger *audit.Logger) error {
 	if err := orgRepo.New(tx).SetAccountType(ctx, orgRepo.SetAccountTypeParams{
 		ID:              org.ID,
 		GramAccountType: string(billing.TierEnterprise),
@@ -48,7 +48,7 @@ func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRe
 		return fmt.Errorf("set enterprise trial account type: %w", err)
 	}
 
-	if err := s.trialBundleSeeder(ctx, tx, org.ID); err != nil {
+	if err := trialBundleSeeder(ctx, tx, org.ID); err != nil {
 		return fmt.Errorf("seed enterprise trial entitlements: %w", err)
 	}
 
@@ -61,7 +61,7 @@ func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRe
 		return fmt.Errorf("create enterprise trial: %w", err)
 	}
 
-	if err := s.auditLogger.LogOrganizationEnterpriseTrialArmed(ctx, tx, audit.LogOrganizationEnterpriseTrialArmedEvent{
+	if err := auditLogger.LogOrganizationEnterpriseTrialArmed(ctx, tx, audit.LogOrganizationEnterpriseTrialArmedEvent{
 		OrganizationID:   org.ID,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, userID),
 		ActorDisplayName: conv.PtrEmpty(actorEmail),
@@ -74,4 +74,8 @@ func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRe
 	}
 
 	return nil
+}
+
+func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID, actorEmail string) error {
+	return ArmEnterpriseTrialTx(ctx, tx, org, userID, actorEmail, s.trialBundleSeeder, s.auditLogger)
 }

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1493,6 +1494,53 @@ func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email
 	}
 	if err := s.posthog.IdentifyUser(ctx, email, map[string]any{"created_via": "platform_admin_invite"}); err != nil {
 		s.logger.ErrorContext(ctx, "failed to set platform admin invite created_via person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
+	}
+}
+
+func (s *Service) reconcileInvitationWorkOSMembership(ctx context.Context, invite orgrepo.OrganizationInvitation, org orgrepo.OrganizationMetadatum, gramUserID, workosUserID string) {
+	if !invite.RoleSlug.Valid || !org.WorkosID.Valid || org.WorkosID.String == "" {
+		return
+	}
+
+	workosRoleSlugs := []string{invite.RoleSlug.String}
+	membershipID, err := s.orgs.CreateOrganizationMembership(ctx, workosUserID, org.WorkosID.String, invite.RoleSlug.String)
+	if err != nil {
+		s.logger.WarnContext(ctx, "invite callback: failed to create WorkOS membership; checking for an existing membership", attr.SlogError(err))
+
+		member, lookupErr := s.orgs.GetOrgMembership(ctx, workosUserID, org.WorkosID.String)
+		if lookupErr != nil {
+			s.logger.WarnContext(ctx, "invite callback: failed to look up WorkOS membership", attr.SlogError(lookupErr))
+			return
+		}
+		if member == nil {
+			return
+		}
+
+		workosRoleSlugs = append([]string(nil), member.RoleSlugs...)
+		if !slices.Contains(workosRoleSlugs, invite.RoleSlug.String) {
+			workosRoleSlugs = append(workosRoleSlugs, invite.RoleSlug.String)
+		}
+		updated, updateErr := s.orgs.UpdateMemberRoles(ctx, member.ID, workosRoleSlugs)
+		if updateErr != nil {
+			s.logger.WarnContext(ctx, "invite callback: failed to update WorkOS membership role", attr.SlogError(updateErr))
+			return
+		}
+		membershipID = member.ID
+		if updated != nil && updated.ID != "" {
+			membershipID = updated.ID
+		}
+	}
+
+	if err := orgrepo.New(s.db).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     invite.OrganizationID,
+		WorkosUserID:       workosUserID,
+		WorkosRoleSlugs:    workosRoleSlugs,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    pgtype.Timestamptz{Time: time.Now(), InfinityModifier: pgtype.Finite, Valid: true},
+		WorkosLastEventID:  pgtype.Text{},
+	}); err != nil {
+		s.logger.WarnContext(ctx, "invite callback: failed to attach WorkOS membership locally", attr.SlogError(err))
 	}
 }
 

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -50,6 +50,7 @@ import (
 	telemrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	svix "github.com/svix/svix-webhooks/go"
@@ -86,6 +87,11 @@ type orgFeatureChecker interface {
 	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
 }
 
+type onboardingTelemetry interface {
+	CaptureEvent(ctx context.Context, eventName string, distinctID string, eventProperties map[string]any) error
+	IdentifyUser(ctx context.Context, distinctID string, properties map[string]any) error
+}
+
 // HookEventReader is the subset of the telemetry repo used by the onboarding
 // wizard's verifyOnboardingHooksSetup poll. Decoupled from a concrete repo so
 // tests can stub it.
@@ -95,51 +101,55 @@ type HookEventReader interface {
 }
 
 type Service struct {
-	logger    *slog.Logger
-	tracer    trace.Tracer
-	db        *pgxpool.Pool
-	auth      *auth.Auth
-	authz     *authz.Engine
-	sessions  *sessions.Manager
-	orgs      OrganizationProvider
-	invite    InviteIdentityProvider
-	features  orgFeatureChecker
-	hooks     HookEventReader // optional; nil disables verifyOnboardingHooksSetup
-	email     *email.Service
-	trial     trialemails.Notifier
-	serverURL string // API server URL; used to build invite links
-	siteURL   string // frontend URL; used for post-callback browser redirects
-	audit     *audit.Logger
-	svix      *svix.Svix
+	logger            *slog.Logger
+	tracer            trace.Tracer
+	db                *pgxpool.Pool
+	auth              *auth.Auth
+	authz             *authz.Engine
+	sessions          *sessions.Manager
+	orgs              OrganizationProvider
+	invite            InviteIdentityProvider
+	features          orgFeatureChecker
+	hooks             HookEventReader // optional; nil disables verifyOnboardingHooksSetup
+	email             *email.Service
+	trial             trialemails.Notifier
+	trialBundleSeeder auth.EnterpriseTrialBundleSeeder
+	posthog           onboardingTelemetry
+	serverURL         string // API server URL; used to build invite links
+	siteURL           string // frontend URL; used for post-callback browser redirects
+	audit             *audit.Logger
+	svix              *svix.Svix
 }
 
 var _ gen.Service = (*Service)(nil)
 
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService *email.Service, trialNotifier trialemails.Notifier, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService *email.Service, trialNotifier trialemails.Notifier, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, posthog onboardingTelemetry, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
 	logger = logger.With(attr.SlogComponent("organizations"))
 	if trialNotifier == nil {
 		trialNotifier = trialemails.NoopNotifier{}
 	}
 
 	return &Service{
-		logger:    logger,
-		tracer:    tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/organizations"),
-		db:        db,
-		auth:      auth.New(logger, db, sessionMgr, authzEngine),
-		authz:     authzEngine,
-		sessions:  sessionMgr,
-		orgs:      orgs,
-		invite:    invite,
-		features:  features,
-		hooks:     hooks,
-		email:     emailService,
-		trial:     trialNotifier,
-		serverURL: serverURL,
-		siteURL:   siteURL,
-		audit:     auditLogger,
-		svix:      svix,
+		logger:            logger,
+		tracer:            tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/organizations"),
+		db:                db,
+		auth:              auth.New(logger, db, sessionMgr, authzEngine),
+		authz:             authzEngine,
+		sessions:          sessionMgr,
+		orgs:              orgs,
+		invite:            invite,
+		features:          features,
+		hooks:             hooks,
+		email:             emailService,
+		trial:             trialNotifier,
+		trialBundleSeeder: trialBundleSeeder,
+		posthog:           posthog,
+		serverURL:         serverURL,
+		siteURL:           siteURL,
+		audit:             auditLogger,
+		svix:              svix,
 	}
 }
 
@@ -1378,6 +1388,113 @@ func dbInvitationToGen(row *orgrepo.OrganizationInvitation, inviterUserID *strin
 	}
 }
 
+var errInvitationAcceptanceRace = errors.New("invitation is no longer pending")
+
+func (s *Service) acceptInvitationTx(ctx context.Context, invite orgrepo.OrganizationInvitation, gramUserID, workosUserID, workosMembershipID string) (orgrepo.OrganizationMetadatum, bool, error) {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("begin invite acceptance transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	repo := orgrepo.New(tx)
+	org, err := repo.LockOrganizationForInviteAcceptance(ctx, invite.OrganizationID)
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("lock invite organization: %w", err)
+	}
+
+	hasOtherActiveUsers, err := repo.HasOtherActiveOrganizationUsers(ctx, orgrepo.HasOtherActiveOrganizationUsersParams{
+		OrganizationID: invite.OrganizationID,
+		UserID:         gramUserID,
+	})
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("check for other active organization users: %w", err)
+	}
+
+	eligibleInviter := false
+	inviterEmail := ""
+	if invite.InviterUserID.Valid {
+		inviter, inviterErr := userrepo.New(tx).LockUserForPlatformAdminCheck(ctx, invite.InviterUserID.String)
+		if inviterErr == nil {
+			eligibleInviter = inviter.Admin && !inviter.DeletedAt.Valid
+			inviterEmail = inviter.Email
+		} else if !errors.Is(inviterErr, pgx.ErrNoRows) {
+			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("get invitation creator: %w", inviterErr)
+		}
+	}
+
+	hasLifecycle := true
+	if _, err := trialsrepo.New(tx).GetTrial(ctx, invite.OrganizationID); errors.Is(err, pgx.ErrNoRows) {
+		hasLifecycle = false
+	} else if err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("get trial lifecycle: %w", err)
+	}
+
+	if _, err := repo.UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: invite.OrganizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	}); err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("create organization user relationship: %w", err)
+	}
+
+	if invite.RoleSlug.Valid {
+		if err := repo.SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+			OrganizationID:     invite.OrganizationID,
+			WorkosUserID:       workosUserID,
+			WorkosRoleSlugs:    []string{invite.RoleSlug.String},
+			UserID:             conv.ToPGText(gramUserID),
+			WorkosMembershipID: conv.ToPGText(workosMembershipID),
+			WorkosUpdatedAt:    pgtype.Timestamptz{Time: time.Now(), InfinityModifier: pgtype.Finite, Valid: true},
+			WorkosLastEventID:  pgtype.Text{},
+		}); err != nil {
+			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("sync invitation role assignments: %w", err)
+		}
+	}
+
+	trialArmed := !hasOtherActiveUsers && eligibleInviter && !hasLifecycle
+	if trialArmed {
+		if s.trialBundleSeeder == nil {
+			return orgrepo.OrganizationMetadatum{}, false, errors.New("enterprise trial bundle seeder is not configured")
+		}
+		if err := auth.ArmEnterpriseTrialTx(ctx, tx, org, invite.InviterUserID.String, inviterEmail, s.trialBundleSeeder, s.audit); err != nil {
+			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("arm invitation enterprise trial: %w", err)
+		}
+	}
+
+	rowsAffected, err := repo.AcceptInvitation(ctx, invite.ID)
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("accept invitation: %w", err)
+	}
+	if rowsAffected == 0 {
+		return orgrepo.OrganizationMetadatum{}, false, errInvitationAcceptanceRace
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("commit invite acceptance transaction: %w", err)
+	}
+
+	return org, trialArmed, nil
+}
+
+func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email string, org orgrepo.OrganizationMetadatum) {
+	if s.posthog == nil {
+		return
+	}
+	properties := map[string]any{
+		"action":            "new_org_created",
+		"created_via":       "platform_admin_invite",
+		"company_name":      org.Name,
+		"organization_id":   org.ID,
+		"organization_slug": org.Slug,
+	}
+	if err := s.posthog.CaptureEvent(ctx, "onboarding_event", email, properties); err != nil {
+		s.logger.ErrorContext(ctx, "failed to capture platform admin invite onboarding event", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
+	}
+	if err := s.posthog.IdentifyUser(ctx, email, map[string]any{"created_via": "platform_admin_invite"}); err != nil {
+		s.logger.ErrorContext(ctx, "failed to set platform admin invite created_via person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
+	}
+}
+
 // handleInviteCallback processes Gram invite-token links. Flow: invitee clicks
 // the Gram invite link, we validate the invite token, authenticate the invitee
 // with a server-created WorkOS Magic Auth code, verify the email, accept the
@@ -1490,17 +1607,6 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	)
 	span.AddEvent("invite.callback.user_provisioned", trace.WithAttributes(attr.UserID(gramUserID)))
 
-	if _, err := repo.UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
-		OrganizationID: invite.OrganizationID,
-		UserID:         conv.ToPGText(gramUserID),
-	}); err != nil {
-		s.logger.ErrorContext(ctx, "invite callback: failed to create org membership", attr.SlogError(err))
-		span.RecordError(err)
-		redirectError("failed to join organization")
-		return
-	}
-	span.AddEvent("invite.callback.org_membership_created")
-
 	// Create the WorkOS organization membership so ListMembers returns the
 	// invited user with the correct role.
 	var workosMembershipID string
@@ -1520,54 +1626,36 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Eagerly sync role assignments so the invited user gets RBAC grants
-	// immediately. The background sync job will eventually do this too, but
-	// it isn't running in all environments yet.
-	if invite.RoleSlug.Valid {
-		if err := repo.SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
-			OrganizationID:     invite.OrganizationID,
-			WorkosUserID:       idpUser.Sub,
-			WorkosRoleSlugs:    []string{invite.RoleSlug.String},
-			UserID:             conv.ToPGText(gramUserID),
-			WorkosMembershipID: conv.ToPGText(workosMembershipID),
-			WorkosUpdatedAt:    pgtype.Timestamptz{Time: time.Now(), InfinityModifier: pgtype.Finite, Valid: true},
-			WorkosLastEventID:  pgtype.Text{String: "", Valid: false},
-		}); err != nil {
-			s.logger.WarnContext(ctx, "invite callback: failed to sync role assignments", attr.SlogError(err))
-			span.RecordError(err)
-		} else {
-			span.AddEvent("invite.callback.rbac_synced", trace.WithAttributes(
-				attr.OrganizationInviteRoleSlug(invite.RoleSlug.String),
-			))
-		}
-	}
-
-	// Accept the invite AFTER all provisioning succeeds. This ensures a
-	// transient failure in user creation or org membership doesn't burn the
-	// invite — the invitee can retry. The WHERE clause guards against a
-	// concurrent revoke or expiry winning the race.
-	rowsAffected, err := repo.AcceptInvitation(ctx, invite.ID)
+	org, trialArmed, err := s.acceptInvitationTx(ctx, invite, gramUserID, idpUser.Sub, workosMembershipID)
 	if err != nil {
+		if workosMembershipID != "" {
+			if deleteErr := s.orgs.DeleteOrganizationMembership(ctx, workosMembershipID); deleteErr != nil {
+				s.logger.ErrorContext(ctx, "invite callback: failed to compensate WorkOS membership", attr.SlogError(deleteErr), attr.SlogOrganizationID(invite.OrganizationID))
+				span.RecordError(deleteErr)
+			}
+		}
+		if errors.Is(err, errInvitationAcceptanceRace) {
+			s.logger.WarnContext(ctx, "invite callback: invite was revoked or expired before acceptance")
+			span.AddEvent("invite.callback.acceptance_race_lost")
+			redirectError("invite already used, revoked, or expired")
+			return
+		}
 		s.logger.ErrorContext(ctx, "invite callback: failed to accept invitation", attr.SlogError(err))
+		span.RecordError(err)
 		redirectError("failed to accept invite")
 		return
 	}
-	if rowsAffected == 0 {
-		s.logger.WarnContext(ctx, "invite callback: invite was revoked or expired before acceptance")
-		span.AddEvent("invite.callback.acceptance_race_lost")
-		redirectError("invite already used, revoked, or expired")
-		return
-	}
+	span.AddEvent("invite.callback.org_membership_created")
 	span.AddEvent("invite.callback.invitation_accepted")
 
-	if invite.RoleSlug.Valid && invite.RoleSlug.String == authz.SystemRoleAdmin {
+	if trialArmed {
+		if err := s.trial.TrialStarted(ctx, invite.OrganizationID); err != nil {
+			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(invite.OrganizationID))
+		}
+		s.capturePlatformAdminInviteTelemetry(ctx, inviteeEmail, org)
+	} else if invite.RoleSlug.Valid && invite.RoleSlug.String == authz.SystemRoleAdmin {
 		if err := s.trial.AdminAdded(ctx, invite.OrganizationID, gramUserID); err != nil {
-			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial admin added",
-				attr.SlogError(err),
-				attr.SlogOrganizationID(invite.OrganizationID),
-				attr.SlogUserID(gramUserID),
-				attr.SlogOrganizationInviteID(invite.ID.String()),
-			)
+			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial admin added", attr.SlogError(err), attr.SlogOrganizationID(invite.OrganizationID), attr.SlogUserID(gramUserID), attr.SlogOrganizationInviteID(invite.ID.String()))
 		}
 	}
 

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -67,6 +67,8 @@ const (
 type OrganizationProvider interface {
 	DeleteOrganizationMembership(ctx context.Context, workosMembershipID string) error
 	CreateOrganizationMembership(ctx context.Context, workosUserID, workosOrgID, roleSlug string) (string, error)
+	GetOrgMembership(ctx context.Context, workosUserID, workosOrgID string) (*workos.Member, error)
+	UpdateMemberRoles(ctx context.Context, membershipID string, roleSlugs []string) (*workos.Member, error)
 	GetOrganizationDomainPolicy(ctx context.Context, workosOrgID string) (*workos.OrganizationDomainPolicy, error)
 	ListRoles(ctx context.Context, workosOrgID string) ([]workos.Role, error)
 	GenerateAdminPortalLink(ctx context.Context, workosOrgID string, intent workos.PortalIntent, opts workos.GenerateAdminPortalLinkOpts) (string, error)
@@ -1392,90 +1394,90 @@ func dbInvitationToGen(row *orgrepo.OrganizationInvitation, inviterUserID *strin
 
 var errInvitationAcceptanceRace = errors.New("invitation is no longer pending")
 
-func (s *Service) acceptInvitationTx(ctx context.Context, invite orgrepo.OrganizationInvitation, gramUserID, workosUserID, workosMembershipID string) (orgrepo.OrganizationMetadatum, bool, error) {
+func (s *Service) acceptInvitationTx(ctx context.Context, inviteID uuid.UUID, organizationID, gramUserID, workosUserID string) (orgrepo.OrganizationMetadatum, orgrepo.OrganizationInvitation, bool, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("begin invite acceptance transaction: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("begin invite acceptance transaction: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	repo := orgrepo.New(tx)
-	org, err := repo.LockOrganizationForInviteAcceptance(ctx, invite.OrganizationID)
+	org, err := repo.LockOrganizationForInviteAcceptance(ctx, organizationID)
 	if err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("lock invite organization: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("lock invite organization: %w", err)
+	}
+
+	acceptedInvite, err := repo.AcceptInvitation(ctx, inviteID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, errInvitationAcceptanceRace
+	}
+	if err != nil {
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("accept invitation: %w", err)
 	}
 
 	hasOtherActiveUsers, err := repo.HasOtherActiveOrganizationUsers(ctx, orgrepo.HasOtherActiveOrganizationUsersParams{
-		OrganizationID: invite.OrganizationID,
+		OrganizationID: acceptedInvite.OrganizationID,
 		UserID:         gramUserID,
 	})
 	if err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("check for other active organization users: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("check for other active organization users: %w", err)
 	}
 
 	eligibleInviter := false
 	inviterEmail := ""
-	if invite.InviterUserID.Valid {
-		inviter, inviterErr := userrepo.New(tx).LockUserForPlatformAdminCheck(ctx, invite.InviterUserID.String)
+	if acceptedInvite.InviterUserID.Valid {
+		inviter, inviterErr := userrepo.New(tx).LockUserForPlatformAdminCheck(ctx, acceptedInvite.InviterUserID.String)
 		if inviterErr == nil {
 			eligibleInviter = inviter.Admin && !inviter.DeletedAt.Valid
 			inviterEmail = inviter.Email
 		} else if !errors.Is(inviterErr, pgx.ErrNoRows) {
-			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("get invitation creator: %w", inviterErr)
+			return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("get invitation creator: %w", inviterErr)
 		}
 	}
 
 	hasLifecycle := true
-	if _, err := trialsrepo.New(tx).GetTrial(ctx, invite.OrganizationID); errors.Is(err, pgx.ErrNoRows) {
+	if _, err := trialsrepo.New(tx).GetTrial(ctx, acceptedInvite.OrganizationID); errors.Is(err, pgx.ErrNoRows) {
 		hasLifecycle = false
 	} else if err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("get trial lifecycle: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("get trial lifecycle: %w", err)
 	}
 
 	if _, err := repo.UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
-		OrganizationID: invite.OrganizationID,
+		OrganizationID: acceptedInvite.OrganizationID,
 		UserID:         conv.ToPGText(gramUserID),
 	}); err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("create organization user relationship: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("create organization user relationship: %w", err)
 	}
 
-	if invite.RoleSlug.Valid {
+	if acceptedInvite.RoleSlug.Valid {
 		if err := repo.SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
-			OrganizationID:     invite.OrganizationID,
+			OrganizationID:     acceptedInvite.OrganizationID,
 			WorkosUserID:       workosUserID,
-			WorkosRoleSlugs:    []string{invite.RoleSlug.String},
+			WorkosRoleSlugs:    []string{acceptedInvite.RoleSlug.String},
 			UserID:             conv.ToPGText(gramUserID),
-			WorkosMembershipID: conv.ToPGText(workosMembershipID),
+			WorkosMembershipID: pgtype.Text{String: "", Valid: false},
 			WorkosUpdatedAt:    pgtype.Timestamptz{Time: time.Now(), InfinityModifier: pgtype.Finite, Valid: true},
-			WorkosLastEventID:  pgtype.Text{},
+			WorkosLastEventID:  pgtype.Text{String: "", Valid: false},
 		}); err != nil {
-			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("sync invitation role assignments: %w", err)
+			return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("sync invitation role assignments: %w", err)
 		}
 	}
 
 	trialArmed := !hasOtherActiveUsers && eligibleInviter && !hasLifecycle
 	if trialArmed {
 		if s.trialBundleSeeder == nil {
-			return orgrepo.OrganizationMetadatum{}, false, errors.New("enterprise trial bundle seeder is not configured")
+			return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, errors.New("enterprise trial bundle seeder is not configured")
 		}
-		if err := auth.ArmEnterpriseTrialTx(ctx, tx, org, invite.InviterUserID.String, inviterEmail, s.trialBundleSeeder, s.audit); err != nil {
-			return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("arm invitation enterprise trial: %w", err)
+		if err := auth.ArmEnterpriseTrialTx(ctx, tx, org, acceptedInvite.InviterUserID.String, inviterEmail, s.trialBundleSeeder, s.audit); err != nil {
+			return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("arm invitation enterprise trial: %w", err)
 		}
-	}
-
-	rowsAffected, err := repo.AcceptInvitation(ctx, invite.ID)
-	if err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("accept invitation: %w", err)
-	}
-	if rowsAffected == 0 {
-		return orgrepo.OrganizationMetadatum{}, false, errInvitationAcceptanceRace
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return orgrepo.OrganizationMetadatum{}, false, fmt.Errorf("commit invite acceptance transaction: %w", err)
+		return orgrepo.OrganizationMetadatum{}, orgrepo.OrganizationInvitation{}, false, fmt.Errorf("commit invite acceptance transaction: %w", err)
 	}
 
-	return org, trialArmed, nil
+	return org, acceptedInvite, trialArmed, nil
 }
 
 func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email string, org orgrepo.OrganizationMetadatum) {
@@ -1538,7 +1540,7 @@ func (s *Service) reconcileInvitationWorkOSMembership(ctx context.Context, invit
 		UserID:             conv.ToPGText(gramUserID),
 		WorkosMembershipID: conv.ToPGText(membershipID),
 		WorkosUpdatedAt:    pgtype.Timestamptz{Time: time.Now(), InfinityModifier: pgtype.Finite, Valid: true},
-		WorkosLastEventID:  pgtype.Text{},
+		WorkosLastEventID:  pgtype.Text{String: "", Valid: false},
 	}); err != nil {
 		s.logger.WarnContext(ctx, "invite callback: failed to attach WorkOS membership locally", attr.SlogError(err))
 	}
@@ -1656,33 +1658,8 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	)
 	span.AddEvent("invite.callback.user_provisioned", trace.WithAttributes(attr.UserID(gramUserID)))
 
-	// Create the WorkOS organization membership so ListMembers returns the
-	// invited user with the correct role.
-	var workosMembershipID string
-	if invite.RoleSlug.Valid {
-		org, err := repo.GetOrganizationMetadata(ctx, invite.OrganizationID)
-		if err != nil {
-			s.logger.WarnContext(ctx, "invite callback: failed to get org metadata for WorkOS membership", attr.SlogError(err))
-		} else if org.WorkosID.Valid && org.WorkosID.String != "" {
-			mid, err := s.orgs.CreateOrganizationMembership(ctx, idpUser.Sub, org.WorkosID.String, invite.RoleSlug.String)
-			if err != nil {
-				s.logger.WarnContext(ctx, "invite callback: failed to create WorkOS membership", attr.SlogError(err))
-				span.RecordError(err)
-			} else {
-				workosMembershipID = mid
-				span.AddEvent("invite.callback.workos_membership_created")
-			}
-		}
-	}
-
-	org, trialArmed, err := s.acceptInvitationTx(ctx, invite, gramUserID, idpUser.Sub, workosMembershipID)
+	org, acceptedInvite, trialArmed, err := s.acceptInvitationTx(ctx, invite.ID, invite.OrganizationID, gramUserID, idpUser.Sub)
 	if err != nil {
-		if workosMembershipID != "" {
-			if deleteErr := s.orgs.DeleteOrganizationMembership(ctx, workosMembershipID); deleteErr != nil {
-				s.logger.ErrorContext(ctx, "invite callback: failed to compensate WorkOS membership", attr.SlogError(deleteErr), attr.SlogOrganizationID(invite.OrganizationID))
-				span.RecordError(deleteErr)
-			}
-		}
 		if errors.Is(err, errInvitationAcceptanceRace) {
 			s.logger.WarnContext(ctx, "invite callback: invite was revoked or expired before acceptance")
 			span.AddEvent("invite.callback.acceptance_race_lost")
@@ -1698,13 +1675,21 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 	span.AddEvent("invite.callback.invitation_accepted")
 
 	if trialArmed {
-		if err := s.trial.TrialStarted(ctx, invite.OrganizationID); err != nil {
-			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(invite.OrganizationID))
+		for _, feature := range productfeatures.EnterpriseTrialBundle {
+			s.features.UpdateFeatureCache(ctx, acceptedInvite.OrganizationID, feature, true)
+		}
+	}
+
+	s.reconcileInvitationWorkOSMembership(ctx, acceptedInvite, org, gramUserID, idpUser.Sub)
+
+	if trialArmed {
+		if err := s.trial.TrialStarted(ctx, acceptedInvite.OrganizationID); err != nil {
+			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(acceptedInvite.OrganizationID))
 		}
 		s.capturePlatformAdminInviteTelemetry(ctx, inviteeEmail, org)
-	} else if invite.RoleSlug.Valid && invite.RoleSlug.String == authz.SystemRoleAdmin {
-		if err := s.trial.AdminAdded(ctx, invite.OrganizationID, gramUserID); err != nil {
-			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial admin added", attr.SlogError(err), attr.SlogOrganizationID(invite.OrganizationID), attr.SlogUserID(gramUserID), attr.SlogOrganizationInviteID(invite.ID.String()))
+	} else if acceptedInvite.RoleSlug.Valid && acceptedInvite.RoleSlug.String == authz.SystemRoleAdmin {
+		if err := s.trial.AdminAdded(ctx, acceptedInvite.OrganizationID, gramUserID); err != nil {
+			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial admin added", attr.SlogError(err), attr.SlogOrganizationID(acceptedInvite.OrganizationID), attr.SlogUserID(gramUserID), attr.SlogOrganizationInviteID(acceptedInvite.ID.String()))
 		}
 	}
 

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -85,6 +85,7 @@ type InviteIdentityProvider interface {
 type orgFeatureChecker interface {
 	// Uncached: revocation must gate the very next portal link request.
 	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
+	UpdateFeatureCache(ctx context.Context, organizationID string, feature productfeatures.Feature, enabled bool)
 }
 
 type onboardingTelemetry interface {

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -37,7 +38,7 @@ func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 
 	ctx, ti := newTestOrganizationsServiceWithRealFeatures(t)
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_platform_admin_invite"
@@ -114,7 +115,7 @@ func TestInviteCallback_ExistingInviteeRelationshipStillArmsTrial(t *testing.T) 
 
 	ctx, ti := newTestOrganizationsService(t)
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_existing_invitee_relationship"
@@ -220,12 +221,11 @@ func TestInviteCallback_ExistingWorkOSMembershipRoleIsReconciled(t *testing.T) {
 	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
 	require.NoError(t, err)
 	require.Equal(t, "accepted", storedInvite.State)
-	var membershipID string
-	require.NoError(t, ti.conn.QueryRow(ctx, `
-		SELECT workos_membership_id
-		FROM organization_role_assignments
-		WHERE organization_id = $1 AND user_id = $2 AND deleted_at IS NULL
-	`, organizationID, "user_01INVITEE").Scan(&membershipID))
+	membershipID, err := testrepo.New(ti.conn).GetOrganizationRoleAssignmentMembershipIDFixture(ctx, testrepo.GetOrganizationRoleAssignmentMembershipIDFixtureParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText("user_01INVITEE"),
+	})
+	require.NoError(t, err)
 	require.Equal(t, member.ID, membershipID)
 	roles, err := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
 		OrganizationID: organizationID,
@@ -260,12 +260,12 @@ func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
 	seederErr := errors.New("seed trial bundle")
 	ctx, ti := newTestOrganizationsServiceWithTrialBundleSeeder(t, func(ctx context.Context, tx pgx.Tx, organizationID string) error {
 		if err := productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, organizationID); err != nil {
-			return err
+			return fmt.Errorf("seed enterprise trial bundle: %w", err)
 		}
 		return seederErr
 	})
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_failed_platform_invite"
@@ -302,8 +302,8 @@ func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "free", org.GramAccountType)
 	require.True(t, org.Whitelisted)
-	var entitlementRows int
-	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM organization_features WHERE organization_id = $1", organizationID).Scan(&entitlementRows))
+	entitlementRows, err := testrepo.New(ti.conn).CountOrganizationFeaturesFixture(ctx, organizationID)
+	require.NoError(t, err)
 	require.Zero(t, entitlementRows)
 	auditsAfter, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)
@@ -317,7 +317,7 @@ func TestInviteCallback_DeletedPlatformAdminInviterDoesNotArmTrial(t *testing.T)
 
 	ctx, ti := newTestOrganizationsService(t)
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_deleted_platform_admin_inviter"
@@ -358,7 +358,7 @@ func TestInviteCallback_ConcurrentFirstUserAcceptancesArmOneTrial(t *testing.T) 
 	}
 	ctx, ti := newTestOrganizationsServiceWithInviteIdentityProvider(t, testInviteIdentityProvider{identities: identities})
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_concurrent_platform_invites"
@@ -402,9 +402,8 @@ func TestInviteCallback_ConcurrentFirstUserAcceptancesArmOneTrial(t *testing.T) 
 		require.Len(t, roles, 1)
 		require.Equal(t, authz.SystemRoleAdmin, roles[0].RoleSlug)
 	}
-	var trials int
-	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM trials WHERE organization_id = $1", organizationID).Scan(&trials))
-	require.Equal(t, 1, trials)
+	_, err = trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
 	audits, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, audits)
@@ -447,7 +446,7 @@ func TestInviteCallback_ExistingTrialLifecycleIsUnchanged(t *testing.T) {
 
 	ctx, ti := newTestOrganizationsService(t)
 	authCtx := requireAuthContext(t, ctx)
-	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	err := testrepo.New(ti.conn).SetUserPlatformAdminFixture(ctx, testrepo.SetUserPlatformAdminFixtureParams{Admin: true, ID: authCtx.UserID})
 	require.NoError(t, err)
 
 	const organizationID = "org_existing_invite_trial"

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -7,13 +7,19 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	goahttp "goa.design/goa/v3/http"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -21,7 +27,287 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/organizations"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
+
+func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_platform_admin_invite"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Invited Organization", Slug: "invited-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "platform-admin-first-user", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	seedInviteeUser(t, ctx, ti)
+	ti.trial.trialStartedErr = errors.New("notify failed")
+	ti.posthog.captureErr = errors.New("capture failed")
+	ti.posthog.identifyErr = errors.New("identify failed")
+
+	armedAt := time.Now().UTC()
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+
+	org, err := orgrepo.New(ti.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", org.GramAccountType)
+	require.True(t, org.Whitelisted)
+	roles, err := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID,
+		UserID:         "user_01INVITEE",
+	})
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	require.Equal(t, authz.SystemRoleAdmin, roles[0].RoleSlug)
+	trial, err := trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", trial.Tier)
+	require.WithinDuration(t, armedAt.Add(14*24*time.Hour), trial.EndsAt.Time, time.Minute)
+
+	require.Equal(t, []string{organizationID}, ti.trial.trialStarted)
+	require.Empty(t, ti.trial.adminAdded)
+	require.Len(t, ti.posthog.events, 1)
+	require.Equal(t, "onboarding_event", ti.posthog.events[0].eventName)
+	require.Equal(t, "invitee@example.test", ti.posthog.events[0].distinctID)
+	require.Equal(t, "platform_admin_invite", ti.posthog.events[0].properties["created_via"])
+	require.Len(t, ti.posthog.identified, 1)
+	require.Equal(t, "platform_admin_invite", ti.posthog.identified[0].properties["created_via"])
+
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+	audits, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, audits)
+
+	serveInviteCallback(t, ti, rawToken)
+	require.Len(t, ti.trial.trialStarted, 1)
+	require.Len(t, ti.posthog.events, 1)
+	audits, err = audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, audits)
+}
+
+func TestInviteCallback_ExistingInviteeRelationshipStillArmsTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_existing_invitee_relationship"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Existing Relationship Organization", Slug: "existing-relationship-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "existing-invitee-relationship", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	seedInviteeUser(t, ctx, ti)
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID, UserID: conv.ToPGText("user_01INVITEE"),
+	})
+	require.NoError(t, err)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Equal(t, "http://localhost:5173", recorder.Header().Get("Location"))
+	_, err = trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+}
+
+func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
+	t.Parallel()
+
+	seederErr := errors.New("seed trial bundle")
+	ctx, ti := newTestOrganizationsServiceWithTrialBundleSeeder(t, func(context.Context, pgx.Tx, string) error { return seederErr })
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_failed_platform_invite"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Failed Invite Organization", Slug: "failed-invite-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "trial-bundle-failure", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	ti.orgs.On("DeleteOrganizationMembership", mock.Anything, "membership_01INVITE").Return(nil).Once()
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+
+	active, err := orgrepo.New(ti.conn).HasActiveOrganizationUser(ctx, orgrepo.HasActiveOrganizationUserParams{
+		UserID: "user_01INVITEE", OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+	require.False(t, active)
+	roles, err := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID, UserID: "user_01INVITEE",
+	})
+	require.NoError(t, err)
+	require.Empty(t, roles)
+	_, err = trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", storedInvite.State)
+	org, err := orgrepo.New(ti.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	require.True(t, org.Whitelisted)
+	require.Empty(t, ti.trial.trialStarted)
+	require.Empty(t, ti.posthog.events)
+}
+
+func TestInviteCallback_ConcurrentFirstUserAcceptancesArmOneTrial(t *testing.T) {
+	t.Parallel()
+
+	identities := map[string]inviteTestIdentity{
+		"invitee-one@example.test": {gramUserID: "gram_user_01INVITEE", workosUserID: "workos_user_01INVITEE"},
+		"invitee-two@example.test": {gramUserID: "gram_user_02INVITEE", workosUserID: "workos_user_02INVITEE"},
+	}
+	ctx, ti := newTestOrganizationsServiceWithInviteIdentityProvider(t, testInviteIdentityProvider{identities: identities})
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_concurrent_platform_invites"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Concurrent Invite Organization", Slug: "concurrent-invite-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+
+	rawTokenOne, inviteOne := seedInviteCallbackInviteForEmail(t, ctx, ti, "concurrent-one", organizationID, authCtx.UserID, authz.SystemRoleAdmin, "invitee-one@example.test")
+	rawTokenTwo, inviteTwo := seedInviteCallbackInviteForEmail(t, ctx, ti, "concurrent-two", organizationID, authCtx.UserID, authz.SystemRoleAdmin, "invitee-two@example.test")
+	seedInviteeUserIdentity(t, ctx, ti, "gram_user_01INVITEE", "invitee-one@example.test")
+	seedInviteeUserIdentity(t, ctx, ti, "gram_user_02INVITEE", "invitee-two@example.test")
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "workos_user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITEE", nil).Once()
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "workos_user_02INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_02INVITEE", nil).Once()
+
+	tokens := []string{rawTokenOne, rawTokenTwo}
+	recorders := make([]*httptest.ResponseRecorder, len(tokens))
+	var wg sync.WaitGroup
+	for i, rawToken := range tokens {
+		wg.Go(func() { recorders[i] = serveInviteCallback(t, ti, rawToken) })
+	}
+	wg.Wait()
+
+	for _, recorder := range recorders {
+		require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+		require.Equal(t, "http://localhost:5173", recorder.Header().Get("Location"))
+	}
+	for _, invite := range []orgrepo.OrganizationInvitation{inviteOne, inviteTwo} {
+		storedInvite, getErr := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+		require.NoError(t, getErr)
+		require.Equal(t, "accepted", storedInvite.State)
+	}
+	for _, invitee := range identities {
+		active, activeErr := orgrepo.New(ti.conn).HasActiveOrganizationUser(ctx, orgrepo.HasActiveOrganizationUserParams{UserID: invitee.gramUserID, OrganizationID: organizationID})
+		require.NoError(t, activeErr)
+		require.True(t, active)
+		roles, rolesErr := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{OrganizationID: organizationID, UserID: invitee.gramUserID})
+		require.NoError(t, rolesErr)
+		require.Len(t, roles, 1)
+		require.Equal(t, authz.SystemRoleAdmin, roles[0].RoleSlug)
+	}
+	var trials int
+	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM trials WHERE organization_id = $1", organizationID).Scan(&trials))
+	require.Equal(t, 1, trials)
+	audits, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, audits)
+	require.Len(t, ti.trial.trialStarted, 1)
+	require.Len(t, ti.posthog.events, 1)
+}
+
+func TestInviteCallback_FirstUserWithoutPlatformAdminInviterGetsNoTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+
+	const organizationID = "org_ordinary_first_invite"
+	_, err := orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Ordinary Invite Organization", Slug: "ordinary-invite-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, _ := seedInviteCallbackInvite(t, ctx, ti, "ordinary-first-user", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	_, err = trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.Error(t, err)
+	org, err := orgrepo.New(ti.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	require.True(t, org.Whitelisted)
+	require.Empty(t, ti.trial.trialStarted)
+	require.Len(t, ti.trial.adminAdded, 1)
+	require.Empty(t, ti.posthog.events)
+}
+
+func TestInviteCallback_ExistingTrialLifecycleIsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_existing_invite_trial"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Existing Trial Organization", Slug: "existing-trial-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: false, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	require.NoError(t, trialsrepo.New(ti.conn).CreateTrial(ctx, trialsrepo.CreateTrialParams{
+		OrganizationID: organizationID, Tier: "enterprise", EndsAt: pgtype.Timestamptz{Time: time.Now().Add(-24 * time.Hour), Valid: true},
+	}))
+	before, err := trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
+
+	rawToken, _ := seedInviteCallbackInvite(t, ctx, ti, "existing-lifecycle", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	after, err := trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+	org, err := orgrepo.New(ti.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	require.False(t, org.Whitelisted)
+	require.Empty(t, ti.trial.trialStarted)
+	require.Len(t, ti.trial.adminAdded, 1)
+	require.Empty(t, ti.posthog.events)
+}
 
 func TestInviteCallback_AdminInviteNotifiesTrialAdminAdded(t *testing.T) {
 	t.Parallel()
@@ -120,11 +406,16 @@ func requireAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthCo
 
 func seedInviteCallbackInvite(t *testing.T, ctx context.Context, ti *testInstance, name, organizationID, inviterUserID, roleSlug string) (string, orgrepo.OrganizationInvitation) {
 	t.Helper()
+	return seedInviteCallbackInviteForEmail(t, ctx, ti, name, organizationID, inviterUserID, roleSlug, "invitee@example.test")
+}
+
+func seedInviteCallbackInviteForEmail(t *testing.T, ctx context.Context, ti *testInstance, name, organizationID, inviterUserID, roleSlug, email string) (string, orgrepo.OrganizationInvitation) {
+	t.Helper()
 
 	rawToken := "token-" + name
 	invite, err := orgrepo.New(ti.conn).CreateInvitation(ctx, orgrepo.CreateInvitationParams{
 		OrganizationID: organizationID,
-		Email:          "invitee@example.test",
+		Email:          email,
 		TokenHash:      inviteTokenHash(rawToken),
 		InviterUserID:  conv.ToPGText(inviterUserID),
 		RoleSlug:       pgtype.Text{String: roleSlug, Valid: roleSlug != ""},
@@ -136,10 +427,15 @@ func seedInviteCallbackInvite(t *testing.T, ctx context.Context, ti *testInstanc
 
 func seedInviteeUser(t *testing.T, ctx context.Context, ti *testInstance) {
 	t.Helper()
+	seedInviteeUserIdentity(t, ctx, ti, "user_01INVITEE", "invitee@example.test")
+}
+
+func seedInviteeUserIdentity(t *testing.T, ctx context.Context, ti *testInstance, userID, email string) {
+	t.Helper()
 
 	require.NoError(t, testrepo.New(ti.conn).InsertUserFixture(ctx, testrepo.InsertUserFixtureParams{
-		ID:          "user_01INVITEE",
-		Email:       "invitee@example.test",
+		ID:          userID,
+		Email:       email,
 		DisplayName: "Invitee",
 	}))
 }

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -26,14 +26,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/organizations"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	thirdpartyworkos "github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestOrganizationsService(t)
+	ctx, ti := newTestOrganizationsServiceWithRealFeatures(t)
 	authCtx := requireAuthContext(t, ctx)
 	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
 	require.NoError(t, err)
@@ -47,6 +49,11 @@ func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
 
 	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "platform-admin-first-user", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	for _, feature := range productfeatures.EnterpriseTrialBundle {
+		enabled, featureErr := ti.features.IsFeatureEnabled(ctx, organizationID, feature)
+		require.NoError(t, featureErr)
+		require.Falsef(t, enabled, "feature %s should be cached as disabled before trial arming", feature)
+	}
 	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
 	seedInviteeUser(t, ctx, ti)
 	ti.trial.trialStartedErr = errors.New("notify failed")
@@ -72,6 +79,11 @@ func TestInviteCallback_FirstUserInvitedByPlatformAdminArmsTrial(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "enterprise", trial.Tier)
 	require.WithinDuration(t, armedAt.Add(14*24*time.Hour), trial.EndsAt.Time, time.Minute)
+	for _, feature := range productfeatures.EnterpriseTrialBundle {
+		enabled, featureErr := ti.features.IsFeatureEnabled(ctx, organizationID, feature)
+		require.NoError(t, featureErr)
+		require.Truef(t, enabled, "feature %s cache should refresh after trial arming", feature)
+	}
 
 	require.Equal(t, []string{organizationID}, ti.trial.trialStarted)
 	require.Empty(t, ti.trial.adminAdded)
@@ -130,11 +142,116 @@ func TestInviteCallback_ExistingInviteeRelationshipStillArmsTrial(t *testing.T) 
 	require.Equal(t, "accepted", storedInvite.State)
 }
 
+func TestInviteCallback_RoleUpdateDuringAuthenticationUsesAuthoritativeRole(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseAuth := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseAuth)
+
+	ctx, ti := newTestOrganizationsServiceWithInviteIdentityProvider(t, blockingInviteIdentityProvider{started: started, release: release})
+	authCtx := requireAuthContext(t, ctx)
+	const organizationID = "org_invite_role_update"
+	_, err := orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Role Update Organization", Slug: "role-update-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "role-update-during-authentication", organizationID, authCtx.UserID, authz.SystemRoleMember)
+	seedInviteeUser(t, ctx, ti)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+
+	result := make(chan *httptest.ResponseRecorder, 1)
+	go func() { result <- serveInviteCallback(t, ti, rawToken) }()
+	<-started
+
+	updated, err := orgrepo.New(ti.conn).UpdateInvitationRole(ctx, orgrepo.UpdateInvitationRoleParams{
+		ID: invite.ID, OrganizationID: organizationID, RoleSlug: conv.ToPGText(authz.SystemRoleAdmin),
+	})
+	require.NoError(t, err)
+	require.Equal(t, authz.SystemRoleAdmin, updated.RoleSlug.String)
+	releaseAuth()
+
+	recorder := <-result
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+	require.Equal(t, authz.SystemRoleAdmin, storedInvite.RoleSlug.String)
+	roles, err := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID, UserID: "user_01INVITEE",
+	})
+	require.NoError(t, err)
+	require.Len(t, roles, 1)
+	require.Equal(t, authz.SystemRoleAdmin, roles[0].RoleSlug)
+}
+
+func TestInviteCallback_ExistingWorkOSMembershipRoleIsReconciled(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	const organizationID = "org_existing_workos_membership"
+	_, err := orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Existing Membership Organization", Slug: "existing-membership-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "existing-workos-membership", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	seedInviteeUser(t, ctx, ti)
+
+	createErr := errors.New("membership already exists")
+	member := &thirdpartyworkos.Member{ID: "membership_01EXISTING", UserID: "user_01INVITEE", OrganizationID: organizationID}
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("", createErr).Once()
+	ti.orgs.On("GetOrgMembership", mock.Anything, "user_01INVITEE", organizationID).Return(member, nil).Once()
+	ti.orgs.On("UpdateMemberRoles", mock.Anything, member.ID, []string{authz.SystemRoleAdmin}).Return(member, nil).Once()
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+	var membershipID string
+	require.NoError(t, ti.conn.QueryRow(ctx, `
+		SELECT workos_membership_id
+		FROM organization_role_assignments
+		WHERE organization_id = $1 AND user_id = $2 AND deleted_at IS NULL
+	`, organizationID, "user_01INVITEE").Scan(&membershipID))
+	require.Equal(t, member.ID, membershipID)
+}
+
+func TestInviteCallback_WorkOSFailureDoesNotRollBackAcceptance(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "workos-membership-failure", authCtx.ActiveOrganizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	seedInviteeUser(t, ctx, ti)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", authCtx.ActiveOrganizationID, authz.SystemRoleAdmin).Return("", errors.New("create failed")).Once()
+	ti.orgs.On("GetOrgMembership", mock.Anything, "user_01INVITEE", authCtx.ActiveOrganizationID).Return(nil, errors.New("lookup failed")).Once()
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Equal(t, "http://localhost:5173", recorder.Header().Get("Location"))
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+}
+
 func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
 	t.Parallel()
 
 	seederErr := errors.New("seed trial bundle")
-	ctx, ti := newTestOrganizationsServiceWithTrialBundleSeeder(t, func(context.Context, pgx.Tx, string) error { return seederErr })
+	ctx, ti := newTestOrganizationsServiceWithTrialBundleSeeder(t, func(ctx context.Context, tx pgx.Tx, organizationID string) error {
+		if err := productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, organizationID); err != nil {
+			return err
+		}
+		return seederErr
+	})
 	authCtx := requireAuthContext(t, ctx)
 	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
 	require.NoError(t, err)
@@ -147,8 +264,8 @@ func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
 	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "trial-bundle-failure", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
-	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
-	ti.orgs.On("DeleteOrganizationMembership", mock.Anything, "membership_01INVITE").Return(nil).Once()
+	auditsBefore, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
 	seedInviteeUser(t, ctx, ti)
 
 	recorder := serveInviteCallback(t, ti, rawToken)
@@ -173,8 +290,51 @@ func TestInviteCallback_TrialBundleFailureRollsBackAcceptance(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "free", org.GramAccountType)
 	require.True(t, org.Whitelisted)
+	var entitlementRows int
+	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM organization_features WHERE organization_id = $1", organizationID).Scan(&entitlementRows))
+	require.Zero(t, entitlementRows)
+	auditsAfter, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.Equal(t, auditsBefore, auditsAfter)
 	require.Empty(t, ti.trial.trialStarted)
 	require.Empty(t, ti.posthog.events)
+}
+
+func TestInviteCallback_DeletedPlatformAdminInviterDoesNotArmTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	_, err := ti.conn.Exec(ctx, "UPDATE users SET admin = true WHERE id = $1", authCtx.UserID)
+	require.NoError(t, err)
+
+	const organizationID = "org_deleted_platform_admin_inviter"
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Deleted Inviter Organization", Slug: "deleted-inviter-organization",
+		WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, ti.conn, organizationID))
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "deleted-platform-admin-inviter", organizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	require.NoError(t, testrepo.New(ti.conn).ForceSoftDeleteUser(ctx, authCtx.UserID))
+	seedInviteeUser(t, ctx, ti)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	auditsBefore, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+	_, err = trialsrepo.New(ti.conn).GetTrial(ctx, organizationID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	org, err := orgrepo.New(ti.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "free", org.GramAccountType)
+	auditsAfter, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.Equal(t, auditsBefore, auditsAfter)
 }
 
 func TestInviteCallback_ConcurrentFirstUserAcceptancesArmOneTrial(t *testing.T) {

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -205,10 +205,15 @@ func TestInviteCallback_ExistingWorkOSMembershipRoleIsReconciled(t *testing.T) {
 	seedInviteeUser(t, ctx, ti)
 
 	createErr := errors.New("membership already exists")
-	member := &thirdpartyworkos.Member{ID: "membership_01EXISTING", UserID: "user_01INVITEE", OrganizationID: organizationID}
+	member := &thirdpartyworkos.Member{
+		ID:             "membership_01EXISTING",
+		UserID:         "user_01INVITEE",
+		OrganizationID: organizationID,
+		RoleSlugs:      []string{authz.SystemRoleMember},
+	}
 	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", organizationID, authz.SystemRoleAdmin).Return("", createErr).Once()
 	ti.orgs.On("GetOrgMembership", mock.Anything, "user_01INVITEE", organizationID).Return(member, nil).Once()
-	ti.orgs.On("UpdateMemberRoles", mock.Anything, member.ID, []string{authz.SystemRoleAdmin}).Return(member, nil).Once()
+	ti.orgs.On("UpdateMemberRoles", mock.Anything, member.ID, []string{authz.SystemRoleMember, authz.SystemRoleAdmin}).Return(member, nil).Once()
 
 	recorder := serveInviteCallback(t, ti, rawToken)
 	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
@@ -222,6 +227,13 @@ func TestInviteCallback_ExistingWorkOSMembershipRoleIsReconciled(t *testing.T) {
 		WHERE organization_id = $1 AND user_id = $2 AND deleted_at IS NULL
 	`, organizationID, "user_01INVITEE").Scan(&membershipID))
 	require.Equal(t, member.ID, membershipID)
+	roles, err := accessrepo.New(ti.conn).ListMemberRolePrincipalsByUser(ctx, accessrepo.ListMemberRolePrincipalsByUserParams{
+		OrganizationID: organizationID,
+		UserID:         "user_01INVITEE",
+	})
+	require.NoError(t, err)
+	require.Len(t, roles, 2)
+	require.ElementsMatch(t, []string{authz.SystemRoleMember, authz.SystemRoleAdmin}, []string{roles[0].RoleSlug, roles[1].RoleSlug})
 }
 
 func TestInviteCallback_WorkOSFailureDoesNotRollBackAcceptance(t *testing.T) {

--- a/server/internal/organizations/listinvites_test.go
+++ b/server/internal/organizations/listinvites_test.go
@@ -3,6 +3,8 @@ package organizations_test
 import (
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+
 	gen "github.com/speakeasy-api/gram/server/gen/organizations"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -80,9 +82,9 @@ func TestService_ListInvites_ExcludesAccepted(t *testing.T) {
 		ExpiresInDays:  7,
 	})
 	require.NoError(t, err)
-	affected, err := orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
+	accepted, err := orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), affected)
+	require.Equal(t, "accepted", accepted.State)
 
 	res, err := ti.service.ListInvites(ctx, &gen.ListInvitesPayload{})
 	require.NoError(t, err)
@@ -136,10 +138,9 @@ func TestAcceptInvitation_RevokedReturnsZeroRows(t *testing.T) {
 	err = orgrepo.New(ti.conn).RevokeInvitation(ctx, row.ID)
 	require.NoError(t, err)
 
-	// Accept should affect 0 rows.
-	affected, err := orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), affected, "accepting a revoked invite should affect 0 rows")
+	// Accept should return no row.
+	_, err = orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 func TestAcceptInvitation_ExpiredReturnsZeroRows(t *testing.T) {
@@ -162,10 +163,9 @@ func TestAcceptInvitation_ExpiredReturnsZeroRows(t *testing.T) {
 	err = orgrepo.New(ti.conn).ExpireInvitationForTest(ctx, row.ID)
 	require.NoError(t, err)
 
-	// Accept should affect 0 rows because expired.
-	affected, err := orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), affected, "accepting an expired invite should affect 0 rows")
+	// Accept should return no row because it expired.
+	_, err = orgrepo.New(ti.conn).AcceptInvitation(ctx, row.ID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 func TestService_ListInvites_AllowsOrgReadGrant(t *testing.T) {

--- a/server/internal/organizations/mock_organizations_test.go
+++ b/server/internal/organizations/mock_organizations_test.go
@@ -39,6 +39,24 @@ func (m *MockOrganizationProvider) CreateOrganizationMembership(ctx context.Cont
 	return args.String(0), nil
 }
 
+func (m *MockOrganizationProvider) GetOrgMembership(ctx context.Context, workosUserID, workosOrgID string) (*thirdpartyworkos.Member, error) {
+	args := m.Called(ctx, workosUserID, workosOrgID)
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock GetOrgMembership: %w", err)
+	}
+	member, _ := args.Get(0).(*thirdpartyworkos.Member)
+	return member, nil
+}
+
+func (m *MockOrganizationProvider) UpdateMemberRoles(ctx context.Context, membershipID string, roleSlugs []string) (*thirdpartyworkos.Member, error) {
+	args := m.Called(ctx, membershipID, roleSlugs)
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock UpdateMemberRoles: %w", err)
+	}
+	member, _ := args.Get(0).(*thirdpartyworkos.Member)
+	return member, nil
+}
+
 func (m *MockOrganizationProvider) GetOrganizationDomainPolicy(ctx context.Context, workosOrgID string) (*thirdpartyworkos.OrganizationDomainPolicy, error) {
 	for _, call := range m.ExpectedCalls {
 		if call.Method == "GetOrganizationDomainPolicy" {
@@ -124,6 +142,21 @@ func (stubUserProvisioner) AuthenticateWithMagicAuth(_ context.Context, email st
 }
 
 func (stubUserProvisioner) UpsertUserFromIDP(_ context.Context, idpUser *identity.IDPUserInfo) (string, error) {
+	return idpUser.Sub, nil
+}
+
+type blockingInviteIdentityProvider struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p blockingInviteIdentityProvider) AuthenticateWithMagicAuth(_ context.Context, email string) (*identity.IDPUserInfo, error) {
+	close(p.started)
+	<-p.release
+	return stubUserProvisioner{}.AuthenticateWithMagicAuth(context.Background(), email)
+}
+
+func (blockingInviteIdentityProvider) UpsertUserFromIDP(_ context.Context, idpUser *identity.IDPUserInfo) (string, error) {
 	return idpUser.Sub, nil
 }
 

--- a/server/internal/organizations/mock_organizations_test.go
+++ b/server/internal/organizations/mock_organizations_test.go
@@ -127,6 +127,24 @@ func (stubUserProvisioner) UpsertUserFromIDP(_ context.Context, idpUser *identit
 	return idpUser.Sub, nil
 }
 
+type inviteTestIdentity struct {
+	gramUserID   string
+	workosUserID string
+}
+
+type testInviteIdentityProvider struct {
+	identities map[string]inviteTestIdentity
+}
+
+func (p testInviteIdentityProvider) AuthenticateWithMagicAuth(_ context.Context, email string) (*identity.IDPUserInfo, error) {
+	invitee := p.identities[email]
+	return &identity.IDPUserInfo{Sub: invitee.workosUserID, Email: email, Name: "Invitee"}, nil
+}
+
+func (p testInviteIdentityProvider) UpsertUserFromIDP(_ context.Context, idpUser *identity.IDPUserInfo) (string, error) {
+	return p.identities[idpUser.Email].gramUserID, nil
+}
+
 // MockLoopsClient implements loops.Client for testing email send paths.
 type MockLoopsClient struct {
 	mock.Mock

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -323,14 +323,15 @@ WHERE id = @id
   AND expires_at > clock_timestamp()
 RETURNING *;
 
--- name: AcceptInvitation :execrows
+-- name: AcceptInvitation :one
 UPDATE organization_invitations
 SET state = 'accepted',
     accepted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE id = @id
   AND state = 'pending'
-  AND expires_at > clock_timestamp();
+  AND expires_at > clock_timestamp()
+RETURNING *;
 
 -- name: AcceptPendingInvitationForMember :one
 UPDATE organization_invitations

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -44,6 +44,23 @@ SELECT *
 FROM organization_metadata
 WHERE id = @id;
 
+-- name: LockOrganizationForInviteAcceptance :one
+SELECT *
+FROM organization_metadata
+WHERE id = @id
+FOR UPDATE;
+
+-- name: HasOtherActiveOrganizationUsers :one
+SELECT EXISTS (
+    SELECT 1
+    FROM organization_user_relationships AS relationship
+    JOIN users ON users.id = relationship.user_id
+    WHERE relationship.organization_id = @organization_id
+      AND relationship.deleted_at IS NULL
+      AND users.deleted_at IS NULL
+      AND users.id <> @user_id
+);
+
 -- name: GetOrganizationMetadataBySlug :one
 SELECT *
 FROM organization_metadata

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const acceptInvitation = `-- name: AcceptInvitation :execrows
+const acceptInvitation = `-- name: AcceptInvitation :one
 UPDATE organization_invitations
 SET state = 'accepted',
     accepted_at = clock_timestamp(),
@@ -20,14 +20,27 @@ SET state = 'accepted',
 WHERE id = $1
   AND state = 'pending'
   AND expires_at > clock_timestamp()
+RETURNING id, organization_id, email, token_hash, inviter_user_id, role_slug, state, expires_at, accepted_at, revoked_at, created_at, updated_at
 `
 
-func (q *Queries) AcceptInvitation(ctx context.Context, id uuid.UUID) (int64, error) {
-	result, err := q.db.Exec(ctx, acceptInvitation, id)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+func (q *Queries) AcceptInvitation(ctx context.Context, id uuid.UUID) (OrganizationInvitation, error) {
+	row := q.db.QueryRow(ctx, acceptInvitation, id)
+	var i OrganizationInvitation
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.Email,
+		&i.TokenHash,
+		&i.InviterUserID,
+		&i.RoleSlug,
+		&i.State,
+		&i.ExpiresAt,
+		&i.AcceptedAt,
+		&i.RevokedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const acceptPendingInvitationForMember = `-- name: AcceptPendingInvitationForMember :one

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -691,6 +691,30 @@ func (q *Queries) HasOrganizationUserRelationship(ctx context.Context, arg HasOr
 	return exists, err
 }
 
+const hasOtherActiveOrganizationUsers = `-- name: HasOtherActiveOrganizationUsers :one
+SELECT EXISTS (
+    SELECT 1
+    FROM organization_user_relationships AS relationship
+    JOIN users ON users.id = relationship.user_id
+    WHERE relationship.organization_id = $1
+      AND relationship.deleted_at IS NULL
+      AND users.deleted_at IS NULL
+      AND users.id <> $2
+)
+`
+
+type HasOtherActiveOrganizationUsersParams struct {
+	OrganizationID string
+	UserID         string
+}
+
+func (q *Queries) HasOtherActiveOrganizationUsers(ctx context.Context, arg HasOtherActiveOrganizationUsersParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasOtherActiveOrganizationUsers, arg.OrganizationID, arg.UserID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const linkRelationshipsToUser = `-- name: LinkRelationshipsToUser :exec
 WITH pending_relationships AS (
     SELECT
@@ -1078,6 +1102,38 @@ func (q *Queries) LockActiveOrganizationUser(ctx context.Context, arg LockActive
 	var user_id pgtype.Text
 	err := row.Scan(&user_id)
 	return user_id, err
+}
+
+const lockOrganizationForInviteAcceptance = `-- name: LockOrganizationForInviteAcceptance :one
+SELECT id, name, slug, gram_account_type, workos_id, workos_updated_at, workos_last_event_id, svix_app_id, webhooks_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, scim_enabled, sso_enabled, created_at, updated_at, disabled_at
+FROM organization_metadata
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockOrganizationForInviteAcceptance(ctx context.Context, id string) (OrganizationMetadatum, error) {
+	row := q.db.QueryRow(ctx, lockOrganizationForInviteAcceptance, id)
+	var i OrganizationMetadatum
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Slug,
+		&i.GramAccountType,
+		&i.WorkosID,
+		&i.WorkosUpdatedAt,
+		&i.WorkosLastEventID,
+		&i.SvixAppID,
+		&i.WebhooksEnabled,
+		&i.Whitelisted,
+		&i.FreeTrialStartedAt,
+		&i.FreeTrialEndsAt,
+		&i.ScimEnabled,
+		&i.SsoEnabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DisabledAt,
+	)
+	return i, err
 }
 
 const lockOrganizationSlug = `-- name: LockOrganizationSlug :exec

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -131,12 +131,16 @@ type testInstance struct {
 	orgs    *MockOrganizationProvider
 	loops   *MockLoopsClient
 	trial   *fakeTrialNotifier
+	posthog *fakeOnboardingTelemetry
 	svixSrv *svixtest.MockServer
 }
 
 type fakeTrialNotifier struct {
-	adminAddedErr error
-	adminAdded    []adminAddedNotification
+	mu              sync.Mutex
+	trialStartedErr error
+	trialStarted    []string
+	adminAddedErr   error
+	adminAdded      []adminAddedNotification
 }
 
 type adminAddedNotification struct {
@@ -144,11 +148,16 @@ type adminAddedNotification struct {
 	userID         string
 }
 
-func (f *fakeTrialNotifier) TrialStarted(context.Context, string) error {
-	return nil
+func (f *fakeTrialNotifier) TrialStarted(_ context.Context, organizationID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.trialStarted = append(f.trialStarted, organizationID)
+	return f.trialStartedErr
 }
 
 func (f *fakeTrialNotifier) AdminAdded(_ context.Context, organizationID, userID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.adminAdded = append(f.adminAdded, adminAddedNotification{organizationID: organizationID, userID: userID})
 	return f.adminAddedErr
 }
@@ -157,10 +166,50 @@ func (f *fakeTrialNotifier) TrialInactive(context.Context, string) error {
 	return nil
 }
 
+type capturedOnboardingEvent struct {
+	eventName  string
+	distinctID string
+	properties map[string]any
+}
+
+type fakeOnboardingTelemetry struct {
+	mu          sync.Mutex
+	captureErr  error
+	identifyErr error
+	events      []capturedOnboardingEvent
+	identified  []capturedOnboardingEvent
+}
+
+func (f *fakeOnboardingTelemetry) CaptureEvent(_ context.Context, eventName, distinctID string, properties map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, capturedOnboardingEvent{eventName: eventName, distinctID: distinctID, properties: properties})
+	return f.captureErr
+}
+
+func (f *fakeOnboardingTelemetry) IdentifyUser(_ context.Context, distinctID string, properties map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.identified = append(f.identified, capturedOnboardingEvent{distinctID: distinctID, properties: properties})
+	return f.identifyErr
+}
+
 func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithFeatures(t, enabledFeatures())
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{})
+}
+
+func newTestOrganizationsServiceWithTrialBundleSeeder(t *testing.T, trialBundleSeeder auth.EnterpriseTrialBundleSeeder) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), trialBundleSeeder, stubUserProvisioner{})
+}
+
+func newTestOrganizationsServiceWithInviteIdentityProvider(t *testing.T, invite organizations.InviteIdentityProvider) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, invite)
 }
 
 // newTestOrganizationsServiceRBAC creates a service instance whose feature
@@ -174,6 +223,12 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 }
 
 func newTestOrganizationsServiceWithFeatures(t *testing.T, features orgFeatureStub) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestOrganizationsServiceWithOptions(t, features, productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{})
+}
+
+func newTestOrganizationsServiceWithOptions(t *testing.T, features orgFeatureStub, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, invite organizations.InviteIdentityProvider) (context.Context, *testInstance) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -215,13 +270,15 @@ func newTestOrganizationsServiceWithFeatures(t *testing.T, features orgFeatureSt
 	require.NoError(t, err)
 
 	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, features, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	posthog := &fakeOnboardingTelemetry{}
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, invite, features, nil, authzEngine, nil, trialNotifier, trialBundleSeeder, posthog, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
 		conn:    conn,
 		orgs:    orgs,
 		trial:   trialNotifier,
+		posthog: posthog,
 		svixSrv: svixSrv,
 	}
 }
@@ -271,7 +328,7 @@ func newTestOrganizationsServiceWithEmail(t *testing.T) (context.Context, *testI
 		"team_invite": "team-invite-test-id",
 	}), true)
 	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, enabledFeatures(), nil, authzEngine, emailService, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, enabledFeatures(), nil, authzEngine, emailService, trialNotifier, productfeatures.SeedEnterpriseTrialBundleTx, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -59,6 +59,7 @@ func seedLocalRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organi
 // organizations.NewService so test constructors can parametrize it.
 type orgFeatureStub interface {
 	IsFeatureEnabledUncached(ctx context.Context, organizationID string, feature productfeatures.Feature) (bool, error)
+	UpdateFeatureCache(ctx context.Context, organizationID string, feature productfeatures.Feature, enabled bool)
 }
 
 // stubOrgFeaturesEnabled reports every feature enabled, entitling all
@@ -69,12 +70,17 @@ func (stubOrgFeaturesEnabled) IsFeatureEnabledUncached(context.Context, string, 
 	return true, nil
 }
 
+func (stubOrgFeaturesEnabled) UpdateFeatureCache(context.Context, string, productfeatures.Feature, bool) {
+}
+
 // featureMapStub enables exactly the features mapped to true.
 type featureMapStub map[productfeatures.Feature]bool
 
 func (m featureMapStub) IsFeatureEnabledUncached(_ context.Context, _ string, feature productfeatures.Feature) (bool, error) {
 	return m[feature], nil
 }
+
+func (featureMapStub) UpdateFeatureCache(context.Context, string, productfeatures.Feature, bool) {}
 
 // enabledFeatures builds a featureMapStub that enables exactly the listed features.
 func enabledFeatures(features ...productfeatures.Feature) featureMapStub {
@@ -126,13 +132,14 @@ func TestMain(m *testing.M) {
 }
 
 type testInstance struct {
-	service *organizations.Service
-	conn    *pgxpool.Pool
-	orgs    *MockOrganizationProvider
-	loops   *MockLoopsClient
-	trial   *fakeTrialNotifier
-	posthog *fakeOnboardingTelemetry
-	svixSrv *svixtest.MockServer
+	service  *organizations.Service
+	conn     *pgxpool.Pool
+	orgs     *MockOrganizationProvider
+	loops    *MockLoopsClient
+	trial    *fakeTrialNotifier
+	posthog  *fakeOnboardingTelemetry
+	features *productfeatures.Client
+	svixSrv  *svixtest.MockServer
 }
 
 type fakeTrialNotifier struct {
@@ -197,19 +204,25 @@ func (f *fakeOnboardingTelemetry) IdentifyUser(_ context.Context, distinctID str
 func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{})
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{}, false)
 }
 
 func newTestOrganizationsServiceWithTrialBundleSeeder(t *testing.T, trialBundleSeeder auth.EnterpriseTrialBundleSeeder) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), trialBundleSeeder, stubUserProvisioner{})
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), trialBundleSeeder, stubUserProvisioner{}, false)
 }
 
 func newTestOrganizationsServiceWithInviteIdentityProvider(t *testing.T, invite organizations.InviteIdentityProvider) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, invite)
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, invite, false)
+}
+
+func newTestOrganizationsServiceWithRealFeatures(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestOrganizationsServiceWithOptions(t, enabledFeatures(), productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{}, true)
 }
 
 // newTestOrganizationsServiceRBAC creates a service instance whose feature
@@ -225,10 +238,10 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 func newTestOrganizationsServiceWithFeatures(t *testing.T, features orgFeatureStub) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestOrganizationsServiceWithOptions(t, features, productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{})
+	return newTestOrganizationsServiceWithOptions(t, features, productfeatures.SeedEnterpriseTrialBundleTx, stubUserProvisioner{}, false)
 }
 
-func newTestOrganizationsServiceWithOptions(t *testing.T, features orgFeatureStub, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, invite organizations.InviteIdentityProvider) (context.Context, *testInstance) {
+func newTestOrganizationsServiceWithOptions(t *testing.T, featureStub orgFeatureStub, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, invite organizations.InviteIdentityProvider, useRealFeatures bool) (context.Context, *testInstance) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -271,15 +284,21 @@ func newTestOrganizationsServiceWithOptions(t *testing.T, features orgFeatureStu
 
 	trialNotifier := &fakeTrialNotifier{}
 	posthog := &fakeOnboardingTelemetry{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, invite, features, nil, authzEngine, nil, trialNotifier, trialBundleSeeder, posthog, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
+	var featureChecker orgFeatureStub = featureStub
+	if useRealFeatures {
+		featureChecker = features
+	}
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, invite, featureChecker, nil, authzEngine, nil, trialNotifier, trialBundleSeeder, posthog, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
-		service: svc,
-		conn:    conn,
-		orgs:    orgs,
-		trial:   trialNotifier,
-		posthog: posthog,
-		svixSrv: svixSrv,
+		service:  svc,
+		conn:     conn,
+		orgs:     orgs,
+		trial:    trialNotifier,
+		posthog:  posthog,
+		features: features,
+		svixSrv:  svixSrv,
 	}
 }
 

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
@@ -285,7 +287,7 @@ func newTestOrganizationsServiceWithOptions(t *testing.T, featureStub orgFeature
 	trialNotifier := &fakeTrialNotifier{}
 	posthog := &fakeOnboardingTelemetry{}
 	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
-	var featureChecker orgFeatureStub = featureStub
+	featureChecker := featureStub
 	if useRealFeatures {
 		featureChecker = features
 	}

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -365,6 +365,27 @@ VALUES (@plugin_id, @organization_id, @principal_urn);
 INSERT INTO users (id, email, display_name)
 VALUES (@id, @email, @display_name);
 
+-- name: SetUserPlatformAdminFixture :exec
+-- Test-only fixture: controls platform-admin eligibility for invitation flows.
+UPDATE users
+SET admin = @admin
+WHERE id = @id;
+
+-- name: GetOrganizationRoleAssignmentMembershipIDFixture :one
+-- Test-only fixture: reads the external membership attached during reconciliation.
+SELECT workos_membership_id::text
+FROM organization_role_assignments
+WHERE organization_id = @organization_id
+  AND user_id = @user_id
+  AND deleted_at IS NULL
+LIMIT 1;
+
+-- name: CountOrganizationFeaturesFixture :one
+-- Test-only fixture: verifies entitlement writes roll back with trial provisioning.
+SELECT count(*)
+FROM organization_features
+WHERE organization_id = @organization_id;
+
 -- name: InsertDeviceAgentSyncFixture :exec
 INSERT INTO device_agent_syncs (organization_id, email, first_seen_at, last_seen_at)
 VALUES (@organization_id, @email, @seen_at, @seen_at);

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -63,6 +63,20 @@ func (q *Queries) CountFunctionsAccess(ctx context.Context, arg CountFunctionsAc
 	return count, err
 }
 
+const countOrganizationFeaturesFixture = `-- name: CountOrganizationFeaturesFixture :one
+SELECT count(*)
+FROM organization_features
+WHERE organization_id = $1
+`
+
+// Test-only fixture: verifies entitlement writes roll back with trial provisioning.
+func (q *Queries) CountOrganizationFeaturesFixture(ctx context.Context, organizationID string) (int64, error) {
+	row := q.db.QueryRow(ctx, countOrganizationFeaturesFixture, organizationID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countOrganizationsForWorkosIDFixture = `-- name: CountOrganizationsForWorkosIDFixture :one
 SELECT count(*)
 FROM organization_metadata
@@ -697,6 +711,28 @@ func (q *Queries) GetOrganizationMetadataStateFixture(ctx context.Context, id st
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const getOrganizationRoleAssignmentMembershipIDFixture = `-- name: GetOrganizationRoleAssignmentMembershipIDFixture :one
+SELECT workos_membership_id::text
+FROM organization_role_assignments
+WHERE organization_id = $1
+  AND user_id = $2
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+type GetOrganizationRoleAssignmentMembershipIDFixtureParams struct {
+	OrganizationID string
+	UserID         pgtype.Text
+}
+
+// Test-only fixture: reads the external membership attached during reconciliation.
+func (q *Queries) GetOrganizationRoleAssignmentMembershipIDFixture(ctx context.Context, arg GetOrganizationRoleAssignmentMembershipIDFixtureParams) (string, error) {
+	row := q.db.QueryRow(ctx, getOrganizationRoleAssignmentMembershipIDFixture, arg.OrganizationID, arg.UserID)
+	var workos_membership_id string
+	err := row.Scan(&workos_membership_id)
+	return workos_membership_id, err
 }
 
 const getOutboxEntry = `-- name: GetOutboxEntry :one
@@ -2361,6 +2397,23 @@ type SetRemoteSessionResourceFixtureParams struct {
 // Test-only fixture stamping a stored RFC 8707 resource binding on a row.
 func (q *Queries) SetRemoteSessionResourceFixture(ctx context.Context, arg SetRemoteSessionResourceFixtureParams) error {
 	_, err := q.db.Exec(ctx, setRemoteSessionResourceFixture, arg.Resource, arg.SubjectUrn, arg.RemoteSessionClientID)
+	return err
+}
+
+const setUserPlatformAdminFixture = `-- name: SetUserPlatformAdminFixture :exec
+UPDATE users
+SET admin = $1
+WHERE id = $2
+`
+
+type SetUserPlatformAdminFixtureParams struct {
+	Admin bool
+	ID    string
+}
+
+// Test-only fixture: controls platform-admin eligibility for invitation flows.
+func (q *Queries) SetUserPlatformAdminFixture(ctx context.Context, arg SetUserPlatformAdminFixtureParams) error {
+	_, err := q.db.Exec(ctx, setUserPlatformAdminFixture, arg.Admin, arg.ID)
 	return err
 }
 

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -38,6 +38,11 @@ WHERE workos_id = @workos_id
 SELECT * FROM users
 WHERE id = $1;
 
+-- name: LockUserForPlatformAdminCheck :one
+SELECT * FROM users
+WHERE id = $1
+FOR SHARE;
+
 -- name: GetUserByEmail :one
 SELECT * FROM users
 WHERE email = $1;

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -417,6 +417,33 @@ func (q *Queries) GetUsersByWorkosIDs(ctx context.Context, workosIds []string) (
 	return items, nil
 }
 
+const lockUserForPlatformAdminCheck = `-- name: LockUserForPlatformAdminCheck :one
+SELECT id, email, display_name, photo_url, admin, last_login, workos_id, workos_created_at, workos_updated_at, workos_deleted_at, deleted_at, created_at, updated_at FROM users
+WHERE id = $1
+FOR SHARE
+`
+
+func (q *Queries) LockUserForPlatformAdminCheck(ctx context.Context, id string) (User, error) {
+	row := q.db.QueryRow(ctx, lockUserForPlatformAdminCheck, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.DisplayName,
+		&i.PhotoUrl,
+		&i.Admin,
+		&i.LastLogin,
+		&i.WorkosID,
+		&i.WorkosCreatedAt,
+		&i.WorkosUpdatedAt,
+		&i.WorkosDeletedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const overwriteUserWorkosID = `-- name: OverwriteUserWorkosID :exec
 UPDATE users
 SET workos_id = $1,


### PR DESCRIPTION
Linear: GRW-62

## Summary

- Start the existing 14-day Enterprise trial when an organization's first user accepts an invitation sent by a current platform admin.
- Keep local membership, role, entitlements, trial lifecycle, audit operation, and invitation acceptance atomic while serializing concurrent acceptances.
- Refresh cached trial entitlements after commit and reconcile the accepted invitation role into WorkOS without making external failures roll back local acceptance.

## Motivation

Organizations created and configured by platform admins previously missed the self-serve Enterprise trial lifecycle when their first customer joined. This reuses the established trial provisioning and lifecycle behavior while preserving whitelist settings, existing trial history, self-signup, and ordinary invitation behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the existing 14-day Enterprise trial when an organization's first user accepts an invite sent by a current platform admin. Organizations created by platform admins previously skipped the trial lifecycle; now the first customer to accept an invite gets the same self-serve Enterprise trial as signup.

- Makes membership, role assignment, entitlements, trial lifecycle, audit entry, and invitation acceptance atomic and serializes concurrent acceptances.
- Refreshes cached trial entitlements after commit.
- Reconciles the accepted invitation role into WorkOS without rolling back local acceptance when external calls fail, and preserves any existing WorkOS roles on the membership.

<sup>Written for commit 76c1e02bee6f937f6d64d69a3e76c8951fd44a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

