### PR TITLE
feat: add private ingress serving observability

### DIFF
--- a/server/cmd/gram/netingress_attestor.go
+++ b/server/cmd/gram/netingress_attestor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/netingress"
@@ -64,6 +65,7 @@ func newNetingressAttestorCommand() *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			logger := PullLogger(c.Context).With(attr.SlogComponent("netingress_attestor"))
+			telemetry := netingress.NewTelemetry(logger, otel.GetMeterProvider())
 			upstream, err := url.Parse(c.String("upstream-url"))
 			if err != nil {
 				return fmt.Errorf("parse private listener upstream: %w", err)
@@ -82,6 +84,7 @@ func newNetingressAttestorCommand() *cli.Command {
 				TokenPath:    c.String("token-path"),
 				Transport:    transport,
 				Logger:       logger,
+				Telemetry:    telemetry,
 			})
 			if err != nil {
 				return fmt.Errorf("configure private ingress attestor: %w", err)

--- a/server/cmd/gram/netingress_attestor.go
+++ b/server/cmd/gram/netingress_attestor.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/netingress"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
 const attestorShutdownTimeout = 60 * time.Second
@@ -62,9 +63,41 @@ func newNetingressAttestorCommand() *cli.Command {
 				EnvVars:  []string{"GRAM_NETINGRESS_TOKEN_PATH"},
 				Required: true,
 			},
+			&cli.BoolFlag{
+				Name:    "with-otel-tracing",
+				Usage:   "Enable OpenTelemetry traces",
+				EnvVars: []string{"GRAM_ENABLE_OTEL_TRACES"},
+			},
+			&cli.BoolFlag{
+				Name:    "with-otel-metrics",
+				Usage:   "Enable OpenTelemetry metrics",
+				EnvVars: []string{"GRAM_ENABLE_OTEL_METRICS"},
+			},
 		},
 		Action: func(c *cli.Context) error {
-			logger := PullLogger(c.Context).With(attr.SlogComponent("netingress_attestor"))
+			serviceName := "gram-netingress-attestor"
+			logger := PullLogger(c.Context).With(
+				attr.SlogComponent("netingress_attestor"),
+				attr.SlogServiceName(serviceName),
+				attr.SlogServiceVersion(shortGitSHA()),
+			)
+			ctx, cancel := context.WithCancel(c.Context)
+			defer cancel()
+			shutdownOTel, err := o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
+				ServiceName:    serviceName,
+				ServiceVersion: shortGitSHA(),
+				GitSHA:         GitSHA,
+				EnableTracing:  c.Bool("with-otel-tracing"),
+				EnableMetrics:  c.Bool("with-otel-metrics"),
+			})
+			if err != nil {
+				return fmt.Errorf("setup opentelemetry sdk: %w", err)
+			}
+			defer func() {
+				shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), attestorShutdownTimeout)
+				defer shutdownCancel()
+				_ = shutdownOTel(shutdownCtx)
+			}()
 			telemetry := netingress.NewTelemetry(logger, otel.GetMeterProvider())
 			upstream, err := url.Parse(c.String("upstream-url"))
 			if err != nil {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1764,6 +1764,7 @@ func newStartCommand() *cli.Command {
 				if err != nil {
 					return fmt.Errorf("load private network ingress TLS certificate: %w", err)
 				}
+				privateTelemetry := netingress.NewTelemetry(logger, meterProvider)
 				privateMux := goahttp.NewMuxer()
 				privateMux.Use(middleware.NetworkServingPolicyVersion)
 				privateMux.Use(netingress.RouteGuard)
@@ -1784,8 +1785,10 @@ func newStartCommand() *cli.Command {
 						netingress.NewIngressLookup(db),
 						netingress.DefaultTokenAudience,
 						30*time.Second,
+						privateTelemetry,
 					),
 					netingress.IdentityParsers{netingress.ProviderTailscale: netingress.TailscaleIdentityParser{}},
+					privateTelemetry,
 				))
 				privateMux.Use(middleware.SessionMiddleware)
 				mcp.AttachPrivate(privateMux, mcpService, mcpMetadataService)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -305,6 +305,10 @@ const (
 	HTTPStatusCodePatternKey       = attribute.Key("gram.http.status_code_pattern")
 	IngressNameKey                 = attribute.Key("gram.ingress.name")
 	CustomDomainProvisionerKindKey = attribute.Key("gram.custom_domain.provisioner.kind")
+	NetworkSurfaceKey              = attribute.Key("gram.network.surface")
+	NetworkIngressOperationKey     = attribute.Key("gram.network_ingress.operation")
+	NetworkIngressResultKey        = attribute.Key("gram.network_ingress.result")
+	NetworkIngressReasonKey        = attribute.Key("gram.network_ingress.reason")
 
 	CustomDomainHealthStatusKey         = attribute.Key("gram.custom_domain.health.status")
 	CustomDomainHealthIssueKey          = attribute.Key("gram.custom_domain.health.issue")
@@ -1562,6 +1566,34 @@ func SlogHTTPParamValue(v any) slog.Attr      { return slog.Any(string(HTTPParam
 func IngressName(v string) attribute.KeyValue { return IngressNameKey.String(v) }
 func SlogIngressName(v string) slog.Attr      { return slog.String(string(IngressNameKey), v) }
 
+func NetworkSurface[V ~string](v V) attribute.KeyValue {
+	return NetworkSurfaceKey.String(string(v))
+}
+func SlogNetworkSurface[V ~string](v V) slog.Attr {
+	return slog.String(string(NetworkSurfaceKey), string(v))
+}
+
+func NetworkIngressOperation[V ~string](v V) attribute.KeyValue {
+	return NetworkIngressOperationKey.String(string(v))
+}
+func SlogNetworkIngressOperation[V ~string](v V) slog.Attr {
+	return slog.String(string(NetworkIngressOperationKey), string(v))
+}
+
+func NetworkIngressResult[V ~string](v V) attribute.KeyValue {
+	return NetworkIngressResultKey.String(string(v))
+}
+func SlogNetworkIngressResult[V ~string](v V) slog.Attr {
+	return slog.String(string(NetworkIngressResultKey), string(v))
+}
+
+func NetworkIngressReason[V ~string](v V) attribute.KeyValue {
+	return NetworkIngressReasonKey.String(string(v))
+}
+func SlogNetworkIngressReason[V ~string](v V) slog.Attr {
+	return slog.String(string(NetworkIngressReasonKey), string(v))
+}
+
 func CustomDomainProvisionerKind(v string) attribute.KeyValue {
 	return CustomDomainProvisionerKindKey.String(v)
 }
@@ -1691,6 +1723,7 @@ func SlogOAuthAssertionExpiresAt(v time.Time) slog.Attr {
 }
 
 func Provider(v string) attribute.KeyValue { return ProviderKey.String(v) }
+func SlogProvider(v string) slog.Attr      { return slog.String(string(ProviderKey), v) }
 
 func OAuthProvider(v string) attribute.KeyValue { return OAuthProviderKey.String(v) }
 func SlogOAuthProvider(v string) slog.Attr      { return slog.String(string(OAuthProviderKey), v) }

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -727,8 +727,10 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 
 	// Capture private live authority while the challenge remains retryable. A
 	// transient ingress lookup failure must not consume state or persist consent.
+	authorityStarted := time.Now()
 	grantEndpoint, err := endpoint.EndpointRef(ctx, s.db, challengeState.mintOriginOr(s.BaseURLForRequest(r)))
 	if err != nil {
+		s.recordPrivateOAuthAuthority(ctx, challengeState.Endpoint.Authority, authorityStarted, err)
 		if errors.Is(err, networkingress.ErrAuthorityUnavailable) {
 			s.metrics.RecordOAuthAuthorityUnavailable(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageConsent)
 			return oops.E(oops.CodeUnavailable, err, "capture authorization-code endpoint authority").LogError(ctx, logger)
@@ -736,6 +738,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageConsent)
 		return oops.E(oops.CodeUnauthorized, err, "private OAuth authority is no longer valid").LogError(ctx, logger)
 	}
+	s.recordPrivateOAuthAuthority(ctx, challengeState.Endpoint.Authority, authorityStarted, nil)
 
 	// Atomic GETDEL: a consent approval consumes the authn-challenge state
 	// single-use. Parallel POSTs (e.g. user double-submits) lose the race

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -9,6 +9,7 @@ package mcp
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -89,7 +90,9 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
 		return err
 	}
+	authorityStarted := time.Now()
 	if err := endpoint.ValidateGlobalChallenge(ctx, s.db, challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
+		s.recordPrivateOAuthAuthority(ctx, challengeState.Endpoint.Authority, authorityStarted, err)
 		if errors.Is(err, networkingress.ErrAuthorityUnavailable) {
 			s.metrics.RecordOAuthAuthorityUnavailable(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
 			return oops.E(oops.CodeUnavailable, err, "private OAuth authority lookup is unavailable").LogError(ctx, logger)
@@ -97,6 +100,7 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageIDPCallback)
 		return oops.E(oops.CodeUnauthorized, err, "authn challenge endpoint authority changed while the flow was in progress").LogError(ctx, logger)
 	}
+	s.recordPrivateOAuthAuthority(ctx, challengeState.Endpoint.Authority, authorityStarted, nil)
 
 	challengeState, err = s.authnChallengeCache.GetAndDelete(ctx, "authnChallenge:"+stateID)
 	if err != nil {

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -313,7 +313,9 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 		}
+		authorityStarted := time.Now()
 		if err := endpoint.ValidateLiveChallenge(ctx, s.db, *grant.Endpoint); err != nil {
+			s.recordPrivateOAuthAuthority(ctx, grant.Endpoint.Authority, authorityStarted, err)
 			if errors.Is(err, networkingress.ErrAuthorityUnavailable) {
 				s.metrics.RecordOAuthAuthorityUnavailable(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
 				return oops.E(oops.CodeUnavailable, err, "private OAuth authority lookup is unavailable").LogError(ctx, logger)
@@ -321,6 +323,7 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code not found or expired")
 		}
+		s.recordPrivateOAuthAuthority(ctx, grant.Endpoint.Authority, authorityStarted, nil)
 	}
 
 	grant, err = s.userSessionGrantCache.GetAndDelete(ctx, grantKey)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/networkingress"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/temporal"
@@ -105,6 +106,7 @@ type Service struct {
 	logger                    *slog.Logger
 	tracer                    trace.Tracer
 	metrics                   *mcpmetrics.Metrics
+	networkIngressTelemetry   *networkingress.Telemetry
 	identityCoverage          *mcptoolexecution.IdentityCoverageCheckpoint
 	hostedToolsCallCheckpoint *mcptoolexecution.HostedCheckpoint
 	guardianPolicy            *guardian.Policy
@@ -398,6 +400,7 @@ func NewService(
 		logger:                    logger,
 		tracer:                    tracer,
 		metrics:                   metrics,
+		networkIngressTelemetry:   networkingress.NewTelemetry(logger, meterProvider),
 		identityCoverage:          mcptoolexecution.NewIdentityCoverageCheckpoint(db, metrics),
 		hostedToolsCallCheckpoint: hostedToolsCallCheckpoint,
 		guardianPolicy:            guardianPolicy,

--- a/server/internal/mcp/issuergate_rejected_metric_test.go
+++ b/server/internal/mcp/issuergate_rejected_metric_test.go
@@ -64,10 +64,12 @@ func TestServePublic_McpEndpoint_IssuerGated_RecordsRejectedRequests(t *testing.
 		attr.OAuthFailureReason("no_credentials"),
 		attr.McpURL(mcpURL),
 		attr.McpSurface(string(mcpmetrics.SurfaceHosting)),
+		attr.NetworkSurface(mcpmetrics.NetworkSurfacePublic),
 	)])
 	require.Equal(t, int64(1), points[attribute.NewSet(
 		attr.OAuthFailureReason("invalid_bearer_token"),
 		attr.McpURL(mcpURL),
 		attr.McpSurface(string(mcpmetrics.SurfaceHosting)),
+		attr.NetworkSurface(mcpmetrics.NetworkSurfacePublic),
 	)])
 }

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -383,6 +383,7 @@ func (m *Metrics) RecordMCPRequestRejected(ctx context.Context, reason string, m
 		attr.OAuthFailureReason(reason),
 		attr.McpURL(mcpURL),
 		attr.McpSurface(string(surface)),
+		attr.NetworkSurface(NetworkSurfaceFromContext(ctx)),
 	))
 }
 

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -212,7 +212,7 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 
 	mcpRequestRejectedCounter, err := meter.Int64Counter(
 		InstrumentMCPRequestRejected,
-		metric.WithDescription("MCP requests rejected by the Session OAuth authentication gate before dispatch, by failure reason, server URL, and surface"),
+		metric.WithDescription("MCP requests rejected by the Session OAuth authentication gate before dispatch, by failure reason, server URL, serving surface, and public/private network surface"),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {

--- a/server/internal/mcp/mcpmetrics/metrics_test.go
+++ b/server/internal/mcp/mcpmetrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -13,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/requestorigin"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -211,6 +213,7 @@ func TestRequestCounterRecord_PinsInstrumentAndDimensions(t *testing.T) {
 		attr.MCPNegotiatedProtocolVersion(mcpversions.Version20260728),
 		attr.McpMethod("tools/list"),
 		attr.McpSurface(string(SurfaceHosting)),
+		attr.NetworkSurface(NetworkSurfacePublic),
 	)
 }
 
@@ -231,6 +234,29 @@ func TestRequestCounterRecord_ClampsAtRecordSite(t *testing.T) {
 		attr.MCPNegotiatedProtocolVersion(mcpversions.Other),
 		attr.McpMethod(mcprequests.MethodOther),
 		attr.McpSurface(string(SurfacePlatform)),
+		attr.NetworkSurface(NetworkSurfacePublic),
+	)
+}
+
+func TestRequestCounterRecordUsesTrustedPrivateOrigin(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+	ctx := requestorigin.WithContext(t.Context(), requestorigin.Origin{
+		Surface:          requestorigin.SurfacePrivateNetwork,
+		BaseURL:          "https://private.example",
+		OrganizationID:   "<ORG_ID>",
+		NetworkIngressID: uuid.New(),
+	})
+
+	NewRequestCounter(meter, testenv.NewLogger(t)).Record(ctx, mcpversions.Version20260728, "tools/list", SurfaceHosting)
+
+	metricdatatest.AssertHasAttributes(t, collectMetric(t, reader, InstrumentMCPRequest),
+		attr.MCPNegotiatedProtocolVersion(mcpversions.Version20260728),
+		attr.McpMethod("tools/list"),
+		attr.McpSurface(string(SurfaceHosting)),
+		attr.NetworkSurface(NetworkSurfacePrivate),
 	)
 }
 

--- a/server/internal/mcp/mcpmetrics/requestcounter.go
+++ b/server/internal/mcp/mcpmetrics/requestcounter.go
@@ -31,7 +31,7 @@ type RequestCounter struct {
 func NewRequestCounter(meter metric.Meter, logger *slog.Logger) *RequestCounter {
 	requests, err := meter.Int64Counter(
 		InstrumentMCPRequest,
-		metric.WithDescription("MCP JSON-RPC requests observed at dispatch, by protocol revision, method, and surface"),
+		metric.WithDescription("MCP JSON-RPC requests observed at dispatch, by protocol revision, method, serving surface, and public/private network surface"),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {
@@ -80,5 +80,6 @@ func (c *RequestCounter) Record(ctx context.Context, protocolVersion, method str
 		attr.MCPNegotiatedProtocolVersion(mcpversions.Clamp(mcpversions.Sanitize(protocolVersion))),
 		attr.McpMethod(mcprequests.ClampMethod(method)),
 		attr.McpSurface(string(surface)),
+		attr.NetworkSurface(NetworkSurfaceFromContext(ctx)),
 	))
 }

--- a/server/internal/mcp/mcpmetrics/surface.go
+++ b/server/internal/mcp/mcpmetrics/surface.go
@@ -1,5 +1,11 @@
 package mcpmetrics
 
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/requestorigin"
+)
+
 // Surface identifies which inbound MCP serving surface observed a request.
 // The values match the policy boundaries mcpversions draws: arbitrary
 // third-party clients versus the assistant-token-only platform surface. The
@@ -26,3 +32,18 @@ const (
 	// than the hosting surface.
 	SurfaceMeta Surface = "meta"
 )
+
+type NetworkSurface string
+
+const (
+	NetworkSurfacePublic  NetworkSurface = "public"
+	NetworkSurfacePrivate NetworkSurface = "private"
+)
+
+func NetworkSurfaceFromContext(ctx context.Context) NetworkSurface {
+	origin, ok := requestorigin.FromContext(ctx)
+	if ok && origin.Surface == requestorigin.SurfacePrivateNetwork {
+		return NetworkSurfacePrivate
+	}
+	return NetworkSurfacePublic
+}

--- a/server/internal/mcp/private_oauth_authority.go
+++ b/server/internal/mcp/private_oauth_authority.go
@@ -2,15 +2,32 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	"github.com/speakeasy-api/gram/server/internal/networkaccess"
+	"github.com/speakeasy-api/gram/server/internal/networkingress"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
+
+func (s *Service) recordPrivateOAuthAuthority(ctx context.Context, authority networkingress.Authority, started time.Time, err error) {
+	if !authority.IsPrivate() {
+		return
+	}
+	result, reason := networkingress.ResultAllowed, networkingress.ReasonNone
+	if err != nil {
+		result, reason = networkingress.ResultDenied, networkingress.ReasonAuthorityRejected
+		if errors.Is(err, networkingress.ErrAuthorityUnavailable) {
+			result, reason = networkingress.ResultError, networkingress.ReasonAuthorityUnavailable
+		}
+	}
+	s.networkIngressTelemetry.Record(ctx, networkingress.OperationOAuthAuthority, result, reason, "unknown", time.Since(started))
+}
 
 // ValidateRemoteLoginPrivateAuthority re-resolves a private endpoint before a
 // remote-login callback exchanges an upstream authorization code.

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -453,16 +454,23 @@ func (s *Service) ResolveMCPEndpointAndServer(ctx context.Context, logger *slog.
 		return mcpendpoints.BySlugAndCustomDomain(ctx, s.db, logger, slug) //nolint:wrapcheck // thin passthrough; underlying error already carries context.
 	}
 
+	started := time.Now()
+	record := func(result, reason string) {
+		s.networkIngressTelemetry.Record(ctx, networkingress.OperationResolution, result, reason, "unknown", time.Since(started))
+	}
 	authority, err := networkingress.LoadRequestAuthority(ctx, s.db)
 	if errors.Is(err, networkingress.ErrAuthorityUnavailable) {
+		record(networkingress.ResultError, networkingress.ReasonAuthorityUnavailable)
 		return nil, nil, nil, oops.E(oops.CodeUnavailable, err, "private network ingress authority is unavailable").LogError(ctx, logger)
 	}
 	if err != nil {
+		record(networkingress.ResultDenied, networkingress.ReasonAuthorityRejected)
 		logger.WarnContext(ctx, "private network ingress authority rejected", attr.SlogError(err))
 		return nil, nil, nil, oops.E(oops.CodeNotFound, errors.Join(mcpendpoints.ErrPolicyDenied, err), "mcp endpoint not found")
 	}
 	namespaceKind, err := privateEndpointNamespace(authority.NamespaceKind)
 	if err != nil {
+		record(networkingress.ResultDenied, networkingress.ReasonNamespaceRejected)
 		logger.WarnContext(ctx, "private network ingress namespace rejected", attr.SlogError(err))
 		return nil, nil, nil, oops.E(oops.CodeNotFound, errors.Join(mcpendpoints.ErrPolicyDenied, err), "mcp endpoint not found")
 	}
@@ -474,11 +482,18 @@ func (s *Service) ResolveMCPEndpointAndServer(ctx context.Context, logger *slog.
 		Surface:              networkaccess.SurfacePrivate,
 	})
 	if err != nil {
+		record(networkingress.ResultError, networkingress.ReasonDependencyFailed)
 		return nil, nil, nil, fmt.Errorf("resolve private MCP endpoint: %w", err)
 	}
-	if !result.Found || !result.Allowed {
+	if !result.Found {
+		record(networkingress.ResultDenied, networkingress.ReasonEndpointNotFound)
 		return nil, nil, nil, oops.E(oops.CodeNotFound, mcpendpoints.ErrPolicyDenied, "mcp endpoint not found")
 	}
+	if !result.Allowed {
+		record(networkingress.ResultDenied, networkingress.ReasonPolicyDenied)
+		return nil, nil, nil, oops.E(oops.CodeNotFound, mcpendpoints.ErrPolicyDenied, "mcp endpoint not found")
+	}
+	record(networkingress.ResultAllowed, networkingress.ReasonNone)
 	return result.Endpoint, result.Server, result.MetaServer, nil
 }
 

--- a/server/internal/netingress/attestation.go
+++ b/server/internal/netingress/attestation.go
@@ -61,14 +61,19 @@ type AttestationVerifier struct {
 	globalLimiter  *rate.Limiter
 	rechecks       singleflight.Group
 	recheckJoined  func()
+	telemetry      *Telemetry
 }
 
-func NewAttestationVerifier(reviewer TokenReviewer, lookup AttestorIngressLookup, audience string, maxTTL time.Duration) *AttestationVerifier {
+func NewAttestationVerifier(reviewer TokenReviewer, lookup AttestorIngressLookup, audience string, maxTTL time.Duration, telemetry ...*Telemetry) *AttestationVerifier {
 	if audience == "" {
 		audience = DefaultTokenAudience
 	}
 	if maxTTL <= 0 {
 		maxTTL = 30 * time.Second
+	}
+	var metrics *Telemetry
+	if len(telemetry) > 0 {
+		metrics = telemetry[0]
 	}
 	return &AttestationVerifier{
 		reviewer:       reviewer,
@@ -82,14 +87,28 @@ func NewAttestationVerifier(reviewer TokenReviewer, lookup AttestorIngressLookup
 		globalLimiter:  rate.NewLimiter(globalReviewRate, globalReviewBurst),
 		rechecks:       singleflight.Group{},
 		recheckJoined:  nil,
+		telemetry:      metrics,
 	}
 }
 
-func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) (Ingress, error) {
+func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) (ingress Ingress, err error) {
+	started := time.Now()
+	result, reason, provider := ResultError, ReasonDependencyFailed, ""
+	defer func() {
+		if err == nil {
+			result = ResultAllowed
+			provider = ingress.Provider
+		} else if reason != ReasonVerifierUnavailable && (errors.Is(err, ErrAttestationRejected) || reason == ReasonRateLimited) {
+			result = ResultDenied
+		}
+		v.telemetry.Record(ctx, OperationAttestation, result, reason, provider, time.Since(started))
+	}()
 	if v.reviewer == nil || v.lookup == nil {
+		reason = ReasonVerifierUnavailable
 		return Ingress{}, fmt.Errorf("%w: verifier is not configured", ErrAttestationRejected)
 	}
 	if token == "" || strings.TrimSpace(token) != token || len(token) > maxAttestationBytes || source == "" {
+		reason = ReasonAttestationRejected
 		return Ingress{}, fmt.Errorf("%w: invalid bearer token", ErrAttestationRejected)
 	}
 
@@ -97,15 +116,26 @@ func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) 
 	now := v.now()
 	if cached, ok := v.cached(hash, now); ok {
 		if cached.rejected {
+			reason = ReasonNegativeCacheHit
 			return Ingress{}, fmt.Errorf("%w: token was recently rejected", ErrAttestationRejected)
 		}
 		if now.Sub(cached.lastChecked) >= servingStateRecheckTTL {
-			return v.recheckCached(ctx, hash)
+			ingress, err = v.recheckCached(ctx, hash)
+			if err != nil {
+				if errors.Is(err, ErrAttestationRejected) {
+					reason = ReasonAuthorityRejected
+				}
+				return Ingress{}, err
+			}
+			reason = ReasonCacheHit
+			return ingress, nil
 		}
+		reason = ReasonCacheHit
 		return cached.ingress, nil
 	}
 
 	if !v.allowSource(source) {
+		reason = ReasonRateLimited
 		return Ingress{}, errors.New("token review rate limit exceeded")
 	}
 	//nolint:exhaustruct // request populates only TokenReview spec; API server owns response metadata/status
@@ -116,30 +146,36 @@ func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) 
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
+		reason = ReasonDependencyFailed
 		return Ingress{}, fmt.Errorf("review private ingress token: %w", err)
 	}
 	if review == nil || !review.Status.Authenticated || review.Status.Error != "" || !containsAudience(review.Status.Audiences, v.audience) {
+		reason = ReasonTokenReviewDenied
 		v.storeRejected(hash, now)
 		return Ingress{}, fmt.Errorf("%w: token review denied", ErrAttestationRejected)
 	}
 
 	namespace, serviceAccount, err := parseServiceAccountSubject(review.Status.User.Username)
 	if err != nil {
+		reason = ReasonAttestationRejected
 		v.storeRejected(hash, now)
 		return Ingress{}, fmt.Errorf("%w: %w", ErrAttestationRejected, err)
 	}
 	expiresAt, err := tokenExpiry(token)
 	if err != nil || !expiresAt.After(now) {
+		reason = ReasonAttestationRejected
 		v.storeRejected(hash, now)
 		return Ingress{}, fmt.Errorf("%w: token expiry is invalid", ErrAttestationRejected)
 	}
 
-	ingress, err := v.lookup.ByAttestor(ctx, namespace, serviceAccount)
+	ingress, err = v.lookup.ByAttestor(ctx, namespace, serviceAccount)
 	if errors.Is(err, ErrIngressUnavailable) {
+		reason = ReasonAuthorityRejected
 		v.storeRejected(hash, now)
 		return Ingress{}, fmt.Errorf("%w: attestor is not authorized", ErrAttestationRejected)
 	}
 	if err != nil {
+		reason = ReasonDependencyFailed
 		return Ingress{}, fmt.Errorf("lookup attestor ingress: %w", err)
 	}
 
@@ -147,6 +183,7 @@ func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) 
 	if expiresAt.Before(cacheExpiry) {
 		cacheExpiry = expiresAt
 	}
+	reason = ReasonNone
 	v.storeCached(hash, cacheEntry{ingress: ingress, expiresAt: cacheExpiry, rejected: false, lastChecked: now})
 	return ingress, nil
 }

--- a/server/internal/netingress/attestation.go
+++ b/server/internal/netingress/attestation.go
@@ -120,6 +120,7 @@ func (v *AttestationVerifier) Verify(ctx context.Context, token, source string) 
 			return Ingress{}, fmt.Errorf("%w: token was recently rejected", ErrAttestationRejected)
 		}
 		if now.Sub(cached.lastChecked) >= servingStateRecheckTTL {
+			provider = cached.ingress.Provider
 			ingress, err = v.recheckCached(ctx, hash)
 			if err != nil {
 				if errors.Is(err, ErrAttestationRejected) {

--- a/server/internal/netingress/attestor.go
+++ b/server/internal/netingress/attestor.go
@@ -6,12 +6,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -90,13 +92,17 @@ func NewAttestorHandler(config AttestorConfig) (http.Handler, error) {
 		ErrorLog:      nil,
 		BufferPool:    nil,
 		ModifyResponse: func(response *http.Response) error {
-			if response.Request == nil {
+			if response.Request == nil || response.Body == nil {
 				return nil
 			}
 			ctx := response.Request.Context()
 			started, _ := ctx.Value(proxyStartedKey{}).(time.Time)
-			if !started.IsZero() {
-				config.Telemetry.Record(ctx, OperationProxy, ResultAllowed, ReasonNone, ProviderTailscale, time.Since(started))
+			response.Body = &telemetryResponseBody{
+				ReadCloser: response.Body,
+				once:       sync.Once{},
+				complete: func() {
+					config.Telemetry.Record(ctx, OperationProxy, ResultAllowed, ReasonNone, ProviderTailscale, time.Since(started))
+				},
 			}
 			return nil
 		},
@@ -115,23 +121,24 @@ func NewAttestorHandler(config AttestorConfig) (http.Handler, error) {
 	}
 
 	return RouteGuard(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		started := time.Now()
+		request = request.WithContext(context.WithValue(request.Context(), proxyStartedKey{}, started))
 		host, hostErr := canonicalAuthority(request.Host)
 		if hostErr != nil || host != expectedHost {
-			config.Telemetry.Record(request.Context(), OperationProxy, ResultDenied, ReasonHostMismatch, ProviderTailscale, 0)
+			config.Telemetry.Record(request.Context(), OperationProxy, ResultDenied, ReasonHostMismatch, ProviderTailscale, time.Since(started))
 			http.NotFound(w, request)
 			return
 		}
 		token, readErr := readProjectedToken(config.TokenPath)
 		if readErr != nil {
-			config.Telemetry.Record(request.Context(), OperationProxy, ResultError, ReasonTokenReadFailed, ProviderTailscale, 0)
+			config.Telemetry.Record(request.Context(), OperationProxy, ResultError, ReasonTokenReadFailed, ProviderTailscale, time.Since(started))
 			if config.Logger != nil {
 				config.Logger.ErrorContext(request.Context(), "read projected private ingress token", attr.SlogError(readErr))
 			}
 			http.Error(w, "private ingress attestor unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		ctx := context.WithValue(withProjectedToken(request.Context(), token), proxyStartedKey{}, time.Now())
-		proxy.ServeHTTP(w, request.WithContext(ctx))
+		proxy.ServeHTTP(w, request.WithContext(withProjectedToken(request.Context(), token)))
 	})), nil
 }
 
@@ -161,6 +168,33 @@ func readProjectedToken(path string) (string, error) {
 
 type projectedTokenKey struct{}
 type proxyStartedKey struct{}
+
+type telemetryResponseBody struct {
+	io.ReadCloser
+	complete func()
+	once     sync.Once
+}
+
+func (b *telemetryResponseBody) Read(buffer []byte) (int, error) {
+	count, err := b.ReadCloser.Read(buffer)
+	if errors.Is(err, io.EOF) {
+		b.once.Do(b.complete)
+		return count, err //nolint:wrapcheck // io.Reader callers require the EOF sentinel.
+	}
+	if err != nil {
+		return count, fmt.Errorf("read proxied response body: %w", err)
+	}
+	return count, nil
+}
+
+func (b *telemetryResponseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.complete)
+	if err != nil {
+		return fmt.Errorf("close proxied response body: %w", err)
+	}
+	return nil
+}
 
 func withProjectedToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, projectedTokenKey{}, token)

--- a/server/internal/netingress/attestor.go
+++ b/server/internal/netingress/attestor.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -49,6 +50,7 @@ type AttestorConfig struct {
 	TokenPath    string
 	Transport    http.RoundTripper
 	Logger       *slog.Logger
+	Telemetry    *Telemetry
 }
 
 func NewAttestorHandler(config AttestorConfig) (http.Handler, error) {
@@ -87,10 +89,24 @@ func NewAttestorHandler(config AttestorConfig) (http.Handler, error) {
 		FlushInterval: 0,
 		ErrorLog:      nil,
 		BufferPool:    nil,
-		ModifyResponse: func(*http.Response) error {
+		ModifyResponse: func(response *http.Response) error {
+			if response.Request == nil {
+				return nil
+			}
+			ctx := response.Request.Context()
+			started, _ := ctx.Value(proxyStartedKey{}).(time.Time)
+			if !started.IsZero() {
+				config.Telemetry.Record(ctx, OperationProxy, ResultAllowed, ReasonNone, ProviderTailscale, time.Since(started))
+			}
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, request *http.Request, proxyErr error) {
+			started, _ := request.Context().Value(proxyStartedKey{}).(time.Time)
+			duration := time.Duration(0)
+			if !started.IsZero() {
+				duration = time.Since(started)
+			}
+			config.Telemetry.Record(request.Context(), OperationProxy, ResultError, ReasonUpstreamFailed, ProviderTailscale, duration)
 			if config.Logger != nil {
 				config.Logger.ErrorContext(request.Context(), "private ingress attestor proxy error", attr.SlogError(proxyErr))
 			}
@@ -101,18 +117,21 @@ func NewAttestorHandler(config AttestorConfig) (http.Handler, error) {
 	return RouteGuard(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		host, hostErr := canonicalAuthority(request.Host)
 		if hostErr != nil || host != expectedHost {
+			config.Telemetry.Record(request.Context(), OperationProxy, ResultDenied, ReasonHostMismatch, ProviderTailscale, 0)
 			http.NotFound(w, request)
 			return
 		}
 		token, readErr := readProjectedToken(config.TokenPath)
 		if readErr != nil {
+			config.Telemetry.Record(request.Context(), OperationProxy, ResultError, ReasonTokenReadFailed, ProviderTailscale, 0)
 			if config.Logger != nil {
 				config.Logger.ErrorContext(request.Context(), "read projected private ingress token", attr.SlogError(readErr))
 			}
 			http.Error(w, "private ingress attestor unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		proxy.ServeHTTP(w, request.WithContext(withProjectedToken(request.Context(), token)))
+		ctx := context.WithValue(withProjectedToken(request.Context(), token), proxyStartedKey{}, time.Now())
+		proxy.ServeHTTP(w, request.WithContext(ctx))
 	})), nil
 }
 
@@ -141,6 +160,7 @@ func readProjectedToken(path string) (string, error) {
 }
 
 type projectedTokenKey struct{}
+type proxyStartedKey struct{}
 
 func withProjectedToken(ctx context.Context, token string) context.Context {
 	return context.WithValue(ctx, projectedTokenKey{}, token)

--- a/server/internal/netingress/attestor_test.go
+++ b/server/internal/netingress/attestor_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -165,6 +167,22 @@ func TestAttestorHandlerStreamsAndCancels(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("upstream request was not cancelled")
 	}
+}
+
+func TestTelemetryResponseBodyRecordsCompletionOnce(t *testing.T) {
+	t.Parallel()
+
+	completed := 0
+	body := &telemetryResponseBody{
+		ReadCloser: io.NopCloser(strings.NewReader("streamed response")),
+		complete:   func() { completed++ },
+	}
+	contents, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "streamed response", string(contents))
+	require.Equal(t, 1, completed)
+	require.NoError(t, body.Close())
+	require.Equal(t, 1, completed)
 }
 
 func TestPrivateRouteCensus(t *testing.T) {

--- a/server/internal/netingress/middleware.go
+++ b/server/internal/netingress/middleware.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/requestorigin"
@@ -17,30 +18,43 @@ type WorkloadVerifier interface {
 	Verify(ctx context.Context, token, source string) (Ingress, error)
 }
 
-func Middleware(verifier WorkloadVerifier, parsers IdentityParsers) func(http.Handler) http.Handler {
+func Middleware(verifier WorkloadVerifier, parsers IdentityParsers, telemetry ...*Telemetry) func(http.Handler) http.Handler {
+	var metrics *Telemetry
+	if len(telemetry) > 0 {
+		metrics = telemetry[0]
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+			started := time.Now()
+			record := func(result, reason, provider string) {
+				metrics.Record(request.Context(), OperationAdmission, result, reason, provider, time.Since(started))
+			}
 			token, ok := bearerToken(request.Header.Values(AttestationHeader))
 			request.Header.Del(AttestationHeader)
 			if !ok {
+				record(ResultDenied, ReasonMissingAttestation, "")
 				http.Error(w, "workload attestation required", http.StatusUnauthorized)
 				return
 			}
 			if verifier == nil {
+				record(ResultError, ReasonVerifierUnavailable, "")
 				http.Error(w, "private ingress unavailable", http.StatusServiceUnavailable)
 				return
 			}
 
 			source, err := transportSource(request.RemoteAddr)
 			if err != nil {
+				record(ResultError, ReasonInvalidSource, "")
 				http.Error(w, "private ingress unavailable", http.StatusServiceUnavailable)
 				return
 			}
 			ingress, err := verifier.Verify(request.Context(), token, source)
 			if err != nil {
 				if errors.Is(err, ErrAttestationRejected) {
+					record(ResultDenied, ReasonAttestationRejected, "")
 					http.Error(w, "invalid workload attestation", http.StatusUnauthorized)
 				} else {
+					record(ResultError, ReasonDependencyFailed, "")
 					http.Error(w, "private ingress unavailable", http.StatusServiceUnavailable)
 				}
 				return
@@ -48,6 +62,7 @@ func Middleware(verifier WorkloadVerifier, parsers IdentityParsers) func(http.Ha
 
 			host, err := requestorigin.CanonicalHost(request.Host)
 			if err != nil || host != ingress.DNSName {
+				record(ResultDenied, ReasonHostMismatch, ingress.Provider)
 				http.NotFound(w, request)
 				return
 			}
@@ -56,13 +71,16 @@ func Middleware(verifier WorkloadVerifier, parsers IdentityParsers) func(http.Ha
 			identity, err := parsers.Parse(ingress.Provider, request.Header)
 			if err != nil {
 				if errors.Is(err, ErrUnsupportedProvider) {
+					record(ResultError, ReasonProviderUnsupported, ingress.Provider)
 					http.Error(w, "private ingress unavailable", http.StatusServiceUnavailable)
 				} else {
+					record(ResultDenied, ReasonIdentityInvalid, ingress.Provider)
 					http.Error(w, "invalid network identity", http.StatusUnauthorized)
 				}
 				return
 			}
 			if ingress.IdentityRequired && identity == nil {
+				record(ResultDenied, ReasonIdentityRequired, ingress.Provider)
 				http.Error(w, "network identity required", http.StatusUnauthorized)
 				return
 			}
@@ -70,9 +88,11 @@ func Middleware(verifier WorkloadVerifier, parsers IdentityParsers) func(http.Ha
 
 			baseURL, err := requestorigin.HTTPSBaseURL(ingress.DNSName)
 			if err != nil {
+				record(ResultError, ReasonOriginInvalid, ingress.Provider)
 				http.Error(w, "private ingress unavailable", http.StatusServiceUnavailable)
 				return
 			}
+			record(ResultAllowed, ReasonNone, ingress.Provider)
 			origin := requestorigin.Origin{
 				Surface:          requestorigin.SurfacePrivateNetwork,
 				BaseURL:          baseURL,

--- a/server/internal/netingress/telemetry.go
+++ b/server/internal/netingress/telemetry.go
@@ -1,0 +1,46 @@
+package netingress
+
+import (
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/networkingress"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	NetworkIngressOperationsMetric = networkingress.OperationsMetric
+	NetworkIngressDurationMetric   = networkingress.DurationMetric
+
+	OperationAdmission   = networkingress.OperationAdmission
+	OperationAttestation = networkingress.OperationAttestation
+	OperationProxy       = networkingress.OperationProxy
+
+	ResultAllowed = networkingress.ResultAllowed
+	ResultDenied  = networkingress.ResultDenied
+	ResultError   = networkingress.ResultError
+
+	ReasonNone                = networkingress.ReasonNone
+	ReasonMissingAttestation  = networkingress.ReasonMissingAttestation
+	ReasonInvalidSource       = networkingress.ReasonInvalidSource
+	ReasonAttestationRejected = networkingress.ReasonAttestationRejected
+	ReasonVerifierUnavailable = networkingress.ReasonVerifierUnavailable
+	ReasonHostMismatch        = networkingress.ReasonHostMismatch
+	ReasonIdentityInvalid     = networkingress.ReasonIdentityInvalid
+	ReasonIdentityRequired    = networkingress.ReasonIdentityRequired
+	ReasonProviderUnsupported = networkingress.ReasonProviderUnsupported
+	ReasonOriginInvalid       = networkingress.ReasonOriginInvalid
+	ReasonTokenReadFailed     = networkingress.ReasonTokenReadFailed
+	ReasonUpstreamFailed      = networkingress.ReasonUpstreamFailed
+	ReasonRateLimited         = networkingress.ReasonRateLimited
+	ReasonCacheHit            = networkingress.ReasonCacheHit
+	ReasonNegativeCacheHit    = networkingress.ReasonNegativeCacheHit
+	ReasonTokenReviewDenied   = networkingress.ReasonTokenReviewDenied
+	ReasonAuthorityRejected   = networkingress.ReasonAuthorityRejected
+	ReasonDependencyFailed    = networkingress.ReasonDependencyFailed
+)
+
+type Telemetry = networkingress.Telemetry
+
+func NewTelemetry(logger *slog.Logger, meterProvider metric.MeterProvider) *Telemetry {
+	return networkingress.NewTelemetry(logger, meterProvider)
+}

--- a/server/internal/netingress/telemetry_test.go
+++ b/server/internal/netingress/telemetry_test.go
@@ -1,0 +1,139 @@
+package netingress
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestTelemetryClampsDimensionsAndExcludesSensitiveValues(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewTelemetry(testenv.NewLogger(t), provider)
+
+	telemetry.Record(
+		t.Context(),
+		"https://customer.invalid/operation",
+		"secret-result",
+		"postgres://credential@host/database",
+		"customer-provider-token",
+		250*time.Millisecond,
+	)
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+	points := networkIngressCounterPoints(t, resourceMetrics, NetworkIngressOperationsMetric)
+	require.Len(t, points, 1)
+	require.Equal(t, int64(1), points[0].Value)
+	require.Equal(t, attribute.NewSet(
+		attr.NetworkIngressOperation(OperationAdmission),
+		attr.NetworkIngressResult(ResultError),
+		attr.NetworkIngressReason(ReasonDependencyFailed),
+		attr.Provider("unknown"),
+		attr.NetworkSurface("private"),
+	), points[0].Attributes)
+
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, candidate := range scope.Metrics {
+			require.NotContains(t, candidate.Name, "credential")
+		}
+	}
+}
+
+func TestAttestationTelemetryClassifiesUnavailableVerifierAsError(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewTelemetry(testenv.NewLogger(t), provider)
+	verifier := NewAttestationVerifier(nil, nil, DefaultTokenAudience, time.Second, telemetry)
+
+	_, err := verifier.Verify(t.Context(), "opaque-token", "192.0.2.1:1234")
+	require.Error(t, err)
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+	points := networkIngressCounterPoints(t, resourceMetrics, NetworkIngressOperationsMetric)
+	require.Len(t, points, 1)
+	require.Equal(t, attribute.NewSet(
+		attr.NetworkIngressOperation(OperationAttestation),
+		attr.NetworkIngressResult(ResultError),
+		attr.NetworkIngressReason(ReasonVerifierUnavailable),
+		attr.Provider("unknown"),
+		attr.NetworkSurface("private"),
+	), points[0].Attributes)
+}
+
+func TestAttestorTelemetryRecordsHostMismatch(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewTelemetry(testenv.NewLogger(t), provider)
+	handler, err := NewAttestorHandler(AttestorConfig{
+		Upstream:     &url.URL{Scheme: "https", Host: "upstream.invalid"},
+		ExpectedHost: "private.example.ts.net",
+		TokenPath:    "/unused-on-host-mismatch",
+		Transport:    http.DefaultTransport,
+		Logger:       testenv.NewLogger(t),
+		Telemetry:    telemetry,
+	})
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(http.MethodPost, "https://other.example.ts.net/mcp/server", nil)
+	request.Host = "other.example.ts.net"
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	require.Equal(t, http.StatusNotFound, response.Code)
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+	points := networkIngressCounterPoints(t, resourceMetrics, NetworkIngressOperationsMetric)
+	require.Len(t, points, 1)
+	require.Equal(t, attribute.NewSet(
+		attr.NetworkIngressOperation(OperationProxy),
+		attr.NetworkIngressResult(ResultDenied),
+		attr.NetworkIngressReason(ReasonHostMismatch),
+		attr.Provider(ProviderTailscale),
+		attr.NetworkSurface("private"),
+	), points[0].Attributes)
+}
+
+func TestTelemetryNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var telemetry *Telemetry
+	telemetry.Record(t.Context(), OperationAdmission, ResultAllowed, ReasonNone, ProviderTailscale, time.Millisecond)
+	require.NotNil(t, NewTelemetry(testenv.NewLogger(t), nil))
+}
+
+func networkIngressCounterPoints(t *testing.T, metrics metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+	for _, scope := range metrics.ScopeMetrics {
+		for _, candidate := range scope.Metrics {
+			if candidate.Name != name {
+				continue
+			}
+			sum, ok := candidate.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			return sum.DataPoints
+		}
+	}
+	t.Fatalf("metric %s not found", name)
+	return nil
+}

--- a/server/internal/netingress/telemetry_test.go
+++ b/server/internal/netingress/telemetry_test.go
@@ -1,6 +1,7 @@
 package netingress
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/networkingress"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -39,9 +41,9 @@ func TestTelemetryClampsDimensionsAndExcludesSensitiveValues(t *testing.T) {
 	require.Len(t, points, 1)
 	require.Equal(t, int64(1), points[0].Value)
 	require.Equal(t, attribute.NewSet(
-		attr.NetworkIngressOperation(OperationAdmission),
-		attr.NetworkIngressResult(ResultError),
-		attr.NetworkIngressReason(ReasonDependencyFailed),
+		attr.NetworkIngressOperation(networkingress.OperationUnknown),
+		attr.NetworkIngressResult(networkingress.ResultUnknown),
+		attr.NetworkIngressReason(networkingress.ReasonUnknown),
 		attr.Provider("unknown"),
 		attr.NetworkSurface("private"),
 	), points[0].Attributes)
@@ -76,6 +78,33 @@ func TestAttestationTelemetryClassifiesUnavailableVerifierAsError(t *testing.T) 
 		attr.Provider("unknown"),
 		attr.NetworkSurface("private"),
 	), points[0].Attributes)
+}
+
+func TestAttestationTelemetryRetainsCachedProviderOnRecheckFailure(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+	telemetry := NewTelemetry(testenv.NewLogger(t), provider)
+	now := time.Now().UTC()
+	token := unsignedToken(t, now.Add(time.Minute))
+	lookup := &fakeAttestorLookup{ingress: Ingress{Provider: ProviderTailscale}, recheckErr: errors.New("database unavailable")}
+	verifier := NewAttestationVerifier(&fakeTokenReviewer{response: authenticatedTokenReview(DefaultTokenAudience, "system:serviceaccount:ns:sa")}, lookup, DefaultTokenAudience, time.Minute, telemetry)
+	verifier.now = func() time.Time { return now }
+	_, err := verifier.Verify(t.Context(), token, "192.0.2.1:1234")
+	require.NoError(t, err)
+	verifier.now = func() time.Time { return now.Add(servingStateRecheckTTL) }
+	_, err = verifier.Verify(t.Context(), token, "192.0.2.1:1234")
+	require.ErrorContains(t, err, "database unavailable")
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+	points := networkIngressCounterPoints(t, resourceMetrics, NetworkIngressOperationsMetric)
+	require.Len(t, points, 2)
+	providerValue, ok := points[1].Attributes.Value(attr.ProviderKey)
+	require.True(t, ok)
+	require.Equal(t, attr.Provider(ProviderTailscale).Value, providerValue)
 }
 
 func TestAttestorTelemetryRecordsHostMismatch(t *testing.T) {

--- a/server/internal/networkingress/telemetry.go
+++ b/server/internal/networkingress/telemetry.go
@@ -1,0 +1,162 @@
+package networkingress
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	OperationsMetric = "gram.network_ingress.operation"
+	DurationMetric   = "gram.network_ingress.operation.duration"
+
+	OperationAdmission      = "admission"
+	OperationAttestation    = "attestation"
+	OperationProxy          = "proxy"
+	OperationResolution     = "resolution"
+	OperationOAuthAuthority = "oauth_authority"
+
+	ResultAllowed = "allowed"
+	ResultDenied  = "denied"
+	ResultError   = "error"
+
+	ReasonNone                 = "none"
+	ReasonMissingAttestation   = "missing_attestation"
+	ReasonInvalidSource        = "invalid_source"
+	ReasonAttestationRejected  = "attestation_rejected"
+	ReasonVerifierUnavailable  = "verifier_unavailable"
+	ReasonHostMismatch         = "host_mismatch"
+	ReasonIdentityInvalid      = "identity_invalid"
+	ReasonIdentityRequired     = "identity_required"
+	ReasonProviderUnsupported  = "provider_unsupported"
+	ReasonOriginInvalid        = "origin_invalid"
+	ReasonTokenReadFailed      = "token_read_failed"
+	ReasonUpstreamFailed       = "upstream_failed"
+	ReasonRateLimited          = "rate_limited"
+	ReasonCacheHit             = "cache_hit"
+	ReasonNegativeCacheHit     = "negative_cache_hit"
+	ReasonTokenReviewDenied    = "token_review_denied"
+	ReasonAuthorityRejected    = "authority_rejected"
+	ReasonAuthorityUnavailable = "authority_unavailable"
+	ReasonNamespaceRejected    = "namespace_rejected"
+	ReasonEndpointNotFound     = "endpoint_not_found"
+	ReasonPolicyDenied         = "policy_denied"
+	ReasonDependencyFailed     = "dependency_failed"
+)
+
+type Telemetry struct {
+	logger     *slog.Logger
+	operations metric.Int64Counter
+	duration   metric.Float64Histogram
+}
+
+func NewTelemetry(logger *slog.Logger, meterProvider metric.MeterProvider) *Telemetry {
+	if logger != nil {
+		logger = logger.With(attr.SlogComponent("network_ingress_telemetry"))
+	}
+	if meterProvider == nil {
+		return &Telemetry{
+			logger:     logger,
+			operations: nil,
+			duration:   nil,
+		}
+	}
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/networkingress")
+	operations, err := meter.Int64Counter(
+		OperationsMetric,
+		metric.WithDescription("Private network ingress trust-boundary operations by bounded operation, result, reason, provider, and network surface."),
+		metric.WithUnit("{operation}"),
+	)
+	if err != nil && logger != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(OperationsMetric), attr.SlogError(err))
+	}
+	duration, err := meter.Float64Histogram(
+		DurationMetric,
+		metric.WithDescription("Private network ingress trust-boundary operation duration in seconds."),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+	if err != nil && logger != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(DurationMetric), attr.SlogError(err))
+	}
+	return &Telemetry{logger: logger, operations: operations, duration: duration}
+}
+
+func (t *Telemetry) Record(ctx context.Context, operation, result, reason, provider string, duration time.Duration) {
+	if t == nil {
+		return
+	}
+	operation, result, reason, provider = clampOperation(operation), clampResult(result), clampReason(reason), clampProvider(provider)
+	attributes := []attribute.KeyValue{
+		attr.NetworkIngressOperation(operation),
+		attr.NetworkIngressResult(result),
+		attr.NetworkIngressReason(reason),
+		attr.Provider(provider),
+		attr.NetworkSurface("private"),
+	}
+	if t.operations != nil {
+		t.operations.Add(ctx, 1, metric.WithAttributes(attributes...))
+	}
+	if t.duration != nil {
+		t.duration.Record(ctx, duration.Seconds(), metric.WithAttributes(attributes...))
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attributes...)
+	if t.logger != nil && result != ResultAllowed {
+		logAttrs := []any{
+			attr.SlogNetworkIngressOperation(operation),
+			attr.SlogNetworkIngressResult(result),
+			attr.SlogNetworkIngressReason(reason),
+			attr.SlogProvider(provider),
+			attr.SlogNetworkSurface("private"),
+		}
+		if result == ResultError {
+			t.logger.ErrorContext(ctx, "private network ingress operation failed", logAttrs...)
+		} else {
+			t.logger.WarnContext(ctx, "private network ingress operation denied", logAttrs...)
+		}
+	}
+}
+
+func clampOperation(value string) string {
+	switch value {
+	case OperationAdmission, OperationAttestation, OperationProxy, OperationResolution, OperationOAuthAuthority:
+		return value
+	default:
+		return OperationAdmission
+	}
+}
+
+func clampResult(value string) string {
+	switch value {
+	case ResultAllowed, ResultDenied, ResultError:
+		return value
+	default:
+		return ResultError
+	}
+}
+
+func clampReason(value string) string {
+	switch value {
+	case ReasonNone, ReasonMissingAttestation, ReasonInvalidSource, ReasonAttestationRejected,
+		ReasonVerifierUnavailable, ReasonHostMismatch, ReasonIdentityInvalid, ReasonIdentityRequired,
+		ReasonProviderUnsupported, ReasonOriginInvalid, ReasonTokenReadFailed, ReasonUpstreamFailed,
+		ReasonRateLimited, ReasonCacheHit, ReasonNegativeCacheHit, ReasonTokenReviewDenied,
+		ReasonAuthorityRejected, ReasonAuthorityUnavailable, ReasonNamespaceRejected,
+		ReasonEndpointNotFound, ReasonPolicyDenied, ReasonDependencyFailed:
+		return value
+	default:
+		return ReasonDependencyFailed
+	}
+}
+
+func clampProvider(value string) string {
+	if value == "tailscale" {
+		return value
+	}
+	return "unknown"
+}

--- a/server/internal/networkingress/telemetry.go
+++ b/server/internal/networkingress/telemetry.go
@@ -20,10 +20,12 @@ const (
 	OperationProxy          = "proxy"
 	OperationResolution     = "resolution"
 	OperationOAuthAuthority = "oauth_authority"
+	OperationUnknown        = "unknown"
 
 	ResultAllowed = "allowed"
 	ResultDenied  = "denied"
 	ResultError   = "error"
+	ResultUnknown = "unknown"
 
 	ReasonNone                 = "none"
 	ReasonMissingAttestation   = "missing_attestation"
@@ -47,6 +49,7 @@ const (
 	ReasonEndpointNotFound     = "endpoint_not_found"
 	ReasonPolicyDenied         = "policy_denied"
 	ReasonDependencyFailed     = "dependency_failed"
+	ReasonUnknown              = "unknown"
 )
 
 type Telemetry struct {
@@ -124,19 +127,19 @@ func (t *Telemetry) Record(ctx context.Context, operation, result, reason, provi
 
 func clampOperation(value string) string {
 	switch value {
-	case OperationAdmission, OperationAttestation, OperationProxy, OperationResolution, OperationOAuthAuthority:
+	case OperationAdmission, OperationAttestation, OperationProxy, OperationResolution, OperationOAuthAuthority, OperationUnknown:
 		return value
 	default:
-		return OperationAdmission
+		return OperationUnknown
 	}
 }
 
 func clampResult(value string) string {
 	switch value {
-	case ResultAllowed, ResultDenied, ResultError:
+	case ResultAllowed, ResultDenied, ResultError, ResultUnknown:
 		return value
 	default:
-		return ResultError
+		return ResultUnknown
 	}
 }
 
@@ -147,10 +150,10 @@ func clampReason(value string) string {
 		ReasonProviderUnsupported, ReasonOriginInvalid, ReasonTokenReadFailed, ReasonUpstreamFailed,
 		ReasonRateLimited, ReasonCacheHit, ReasonNegativeCacheHit, ReasonTokenReviewDenied,
 		ReasonAuthorityRejected, ReasonAuthorityUnavailable, ReasonNamespaceRejected,
-		ReasonEndpointNotFound, ReasonPolicyDenied, ReasonDependencyFailed:
+		ReasonEndpointNotFound, ReasonPolicyDenied, ReasonDependencyFailed, ReasonUnknown:
 		return value
 	default:
-		return ReasonDependencyFailed
+		return ReasonUnknown
 	}
 }
 


### PR DESCRIPTION
## Why

The private-ingress stack establishes new serving and trust boundaries, but the earlier checkpoints did not provide a consistent way to distinguish public/private MCP traffic or understand where private admission and authority checks fail. This follow-up adds bounded observability before provisioning work continues.

Stacked on #5922.

## What changed

- Add provider-neutral private-ingress operation and duration telemetry for admission, attestation, proxying, endpoint resolution, and OAuth authority revalidation.
- Use closed operation/result/reason/provider dimensions only; no customer identifiers, hosts, URLs, identities, credentials, or raw errors enter metric labels.
- Add the trusted public/private network surface to existing MCP request and rejection metrics.
- Instrument private listener, attestor, TokenReview/cache, endpoint resolution, and OAuth authority outcomes while preserving existing fail-closed behavior.
- Cover dimension clamping, nil safety, public/private classification, unavailable-verifier classification, and attestor host mismatch.

## Review notes

- Focus on bounded-cardinality conventions and whether trust-boundary outcomes are classified usefully.
- Public custom-domain and platform traffic remain classified as public; only requests stamped by the private listener after attestation are private.
- Dashboards/alerts and provisioner lifecycle metrics remain separate follow-up scope.

## Validation

- [x] `mise run test:server ./internal/netingress ./internal/networkingress ./internal/mcp/mcpmetrics ./internal/mcp ./cmd/gram` (817 tests)
- [x] `mise lint:server`
- [x] `mise build:server`
- [x] `git diff --check`
- [x] Independent review completed; attestor nil/duration safety, host-mismatch telemetry, and unavailable-verifier classification findings fixed and retested
- [ ] `cubic review -j` could not complete because local Cubic authentication is expired (`cubic auth login` required)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded serving observability for the AIS-667 private network ingress boundary: per-operation counter and duration telemetry for admission, attestation, proxying, endpoint resolution, and OAuth authority revalidation, plus public/private network-surface labels on existing MCP request and rejection metrics. No serving behavior changes—the listener and attestor stay off by default (empty `netingress-address`), and when enabled only private MCP/OAuth/install routes are mounted with admission failing closed on stale or missing attestation, host mismatch, and disabled or deleted ingress. The attestor binary now also accepts OpenTelemetry tracing/metrics flags.

Only clamped operation/result/reason/provider dimensions are emitted, and denied or failed operations are logged at warn/error, so no customer identifiers, hosts, URLs, or raw errors enter labels or logs.

**Review focus**
- Confirm bounded-cardinality conventions, trust-boundary classification, and attestation fail-closed behavior.
- Only requests stamped by the private listener after attestation are private; custom-domain and platform traffic stay public.
- Dashboards, alerts, and provisioner lifecycle metrics are separate follow-up.

<sup>Written for commit f60839e8486d9517ffccb53c5f5416abc230f39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

