### PR TITLE
feat: add tailscale network ingress provisioner

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -309,6 +309,8 @@ const (
 	NetworkIngressOperationKey     = attribute.Key("gram.network_ingress.operation")
 	NetworkIngressResultKey        = attribute.Key("gram.network_ingress.result")
 	NetworkIngressReasonKey        = attribute.Key("gram.network_ingress.reason")
+	NetworkIngressErrorCodeKey     = attribute.Key("gram.network_ingress.error_code")
+	NetworkIngressDurationKey      = attribute.Key("gram.network_ingress.operation.duration")
 
 	CustomDomainHealthStatusKey         = attribute.Key("gram.custom_domain.health.status")
 	CustomDomainHealthIssueKey          = attribute.Key("gram.custom_domain.health.issue")
@@ -1592,6 +1594,17 @@ func NetworkIngressReason[V ~string](v V) attribute.KeyValue {
 }
 func SlogNetworkIngressReason[V ~string](v V) slog.Attr {
 	return slog.String(string(NetworkIngressReasonKey), string(v))
+}
+
+func NetworkIngressErrorCode[V ~string](v V) attribute.KeyValue {
+	return NetworkIngressErrorCodeKey.String(string(v))
+}
+func SlogNetworkIngressErrorCode[V ~string](v V) slog.Attr {
+	return slog.String(string(NetworkIngressErrorCodeKey), string(v))
+}
+
+func SlogNetworkIngressDuration(v time.Duration) slog.Attr {
+	return slog.Duration(string(NetworkIngressDurationKey), v)
 }
 
 func CustomDomainProvisionerKind(v string) attribute.KeyValue {

--- a/server/internal/k8s/network_ingress_metrics.go
+++ b/server/internal/k8s/network_ingress_metrics.go
@@ -1,0 +1,188 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	networkIngressMeterScope        = "github.com/speakeasy-api/gram/server/internal/k8s"
+	networkIngressOperationsMetric  = "gram.network_ingress.provisioner.operations"
+	networkIngressDurationMetric    = "gram.network_ingress.provisioner.operation.duration"
+	networkIngressOperationApply    = "apply"
+	networkIngressOperationObserve  = "observe"
+	networkIngressOperationDelete   = "delete"
+	networkIngressOperationUnknown  = "unknown"
+	networkIngressResultSuccess     = "success"
+	networkIngressResultError       = "error"
+	networkIngressErrorCodeNone     = "none"
+	networkIngressErrorCodeInternal = "internal"
+)
+
+type NetworkIngressMetrics struct {
+	operations metric.Int64Counter
+	duration   metric.Float64Histogram
+}
+
+func NewNetworkIngressMetrics(logger *slog.Logger, meterProvider metric.MeterProvider) *NetworkIngressMetrics {
+	if meterProvider == nil {
+		return &NetworkIngressMetrics{operations: nil, duration: nil}
+	}
+	meter := meterProvider.Meter(networkIngressMeterScope)
+	operations, err := meter.Int64Counter(
+		networkIngressOperationsMetric,
+		metric.WithDescription("Network ingress provisioner operations by provider, operation, result, and redacted error code."),
+		metric.WithUnit("{operation}"),
+	)
+	if err != nil && logger != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(networkIngressOperationsMetric), attr.SlogError(err))
+	}
+	duration, err := meter.Float64Histogram(
+		networkIngressDurationMetric,
+		metric.WithDescription("Network ingress provisioner operation duration in seconds."),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+	)
+	if err != nil && logger != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(networkIngressDurationMetric), attr.SlogError(err))
+	}
+	return &NetworkIngressMetrics{operations: operations, duration: duration}
+}
+
+func (m *NetworkIngressMetrics) Record(ctx context.Context, provider, operation, result, errorCode string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	provider = clampNetworkIngressProvider(provider)
+	operation = clampNetworkIngressOperation(operation)
+	result = clampNetworkIngressResult(result)
+	errorCode = clampNetworkIngressErrorCode(errorCode)
+	attributes := metric.WithAttributes(
+		attr.Provider(provider),
+		attr.NetworkIngressOperation(operation),
+		attr.NetworkIngressResult(result),
+		attr.NetworkIngressErrorCode(errorCode),
+	)
+	if m.operations != nil {
+		m.operations.Add(ctx, 1, attributes)
+	}
+	if m.duration != nil {
+		m.duration.Record(ctx, duration.Seconds(), attributes)
+	}
+}
+
+type observedNetworkIngressProvisioner struct {
+	provider    string
+	provisioner NetworkIngressProvisioner
+	logger      *slog.Logger
+	metrics     *NetworkIngressMetrics
+}
+
+func ObserveNetworkIngressProvisioner(provider string, provisioner NetworkIngressProvisioner, logger *slog.Logger, metrics *NetworkIngressMetrics) NetworkIngressProvisioner {
+	if provisioner == nil {
+		return nil
+	}
+	if logger != nil {
+		logger = logger.With(attr.SlogComponent("network_ingress_provisioner"))
+	}
+	return &observedNetworkIngressProvisioner{provider: provider, provisioner: provisioner, logger: logger, metrics: metrics}
+}
+
+func (p *observedNetworkIngressProvisioner) Apply(ctx context.Context, desired NetworkIngressDesired) (observation NetworkIngressObservation, err error) {
+	started := time.Now()
+	defer func() { p.record(ctx, networkIngressOperationApply, observation, err, time.Since(started)) }()
+	observation, err = p.provisioner.Apply(ctx, desired)
+	if err != nil {
+		return observation, fmt.Errorf("apply network ingress resources: %w", err)
+	}
+	return observation, nil
+}
+
+func (p *observedNetworkIngressProvisioner) Observe(ctx context.Context, resources NetworkIngressResourceNames) (observation NetworkIngressObservation, err error) {
+	started := time.Now()
+	defer func() { p.record(ctx, networkIngressOperationObserve, observation, err, time.Since(started)) }()
+	observation, err = p.provisioner.Observe(ctx, resources)
+	if err != nil {
+		return observation, fmt.Errorf("observe network ingress resources: %w", err)
+	}
+	return observation, nil
+}
+
+func (p *observedNetworkIngressProvisioner) Delete(ctx context.Context, resources NetworkIngressResourceNames) (err error) {
+	started := time.Now()
+	defer func() {
+		p.record(ctx, networkIngressOperationDelete, NetworkIngressObservation{Status: "", DNSName: "", ErrorCode: "", ConnectedAt: nil}, err, time.Since(started))
+	}()
+	if err = p.provisioner.Delete(ctx, resources); err != nil {
+		return fmt.Errorf("delete network ingress resources: %w", err)
+	}
+	return nil
+}
+
+func (p *observedNetworkIngressProvisioner) record(ctx context.Context, operation string, observation NetworkIngressObservation, err error, duration time.Duration) {
+	result := networkIngressResultSuccess
+	errorCode := networkIngressErrorCodeNone
+	if err != nil {
+		result = networkIngressResultError
+		errorCode = clampNetworkIngressErrorCode(observation.ErrorCode)
+	}
+	p.metrics.Record(ctx, p.provider, operation, result, errorCode, duration)
+	if p.logger == nil {
+		return
+	}
+	attrs := []any{
+		attr.SlogProvider(p.provider),
+		attr.SlogOutcome(result),
+		attr.SlogNetworkIngressOperation(operation),
+		attr.SlogNetworkIngressErrorCode(errorCode),
+		attr.SlogNetworkIngressDuration(duration),
+	}
+	if err != nil {
+		attrs = append(attrs, attr.SlogError(err))
+		p.logger.ErrorContext(ctx, "network ingress provisioner operation failed", attrs...)
+		return
+	}
+	p.logger.InfoContext(ctx, "network ingress provisioner operation completed", attrs...)
+}
+
+func clampNetworkIngressProvider(value string) string {
+	if value == NetworkIngressProviderTailscale {
+		return value
+	}
+	return "unknown"
+}
+
+func clampNetworkIngressOperation(value string) string {
+	switch value {
+	case networkIngressOperationApply, networkIngressOperationObserve, networkIngressOperationDelete:
+		return value
+	default:
+		return networkIngressOperationUnknown
+	}
+}
+
+func clampNetworkIngressResult(value string) string {
+	if value == networkIngressResultSuccess {
+		return value
+	}
+	return networkIngressResultError
+}
+
+func clampNetworkIngressErrorCode(value string) string {
+	switch value {
+	case networkIngressErrorCodeNone,
+		networkIngressErrorCodeInternal,
+		NetworkIngressErrorInvalidDesiredState,
+		NetworkIngressErrorUnsupportedProvider,
+		NetworkIngressErrorInvalidCredentials,
+		NetworkIngressErrorKubernetes:
+		return value
+	default:
+		return networkIngressErrorCodeInternal
+	}
+}

--- a/server/internal/k8s/network_ingress_metrics.go
+++ b/server/internal/k8s/network_ingress_metrics.go
@@ -147,6 +147,10 @@ func (p *observedNetworkIngressProvisioner) record(ctx context.Context, operatio
 		p.logger.ErrorContext(ctx, "network ingress provisioner operation failed", attrs...)
 		return
 	}
+	if operation == networkIngressOperationObserve {
+		p.logger.DebugContext(ctx, "network ingress provisioner observation completed", attrs...)
+		return
+	}
 	p.logger.InfoContext(ctx, "network ingress provisioner operation completed", attrs...)
 }
 

--- a/server/internal/k8s/network_ingress_provisioner.go
+++ b/server/internal/k8s/network_ingress_provisioner.go
@@ -2,9 +2,12 @@ package k8s
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -56,8 +59,8 @@ func NewNetworkIngressResourceNames(id uuid.UUID) (NetworkIngressResourceNames, 
 	if id == uuid.Nil {
 		return NetworkIngressResourceNames{}, fmt.Errorf("%w: ingress id is required", ErrNetworkIngressInvalidDesiredState)
 	}
-	suffix := strings.ToLower(strings.ReplaceAll(id.String(), "-", ""))
-	prefix := "gram-netingress-" + suffix[:20]
+	digest := sha256.Sum256(id[:])
+	prefix := "gram-netingress-" + hex.EncodeToString(digest[:10])
 	return NetworkIngressResourceNames{
 		OwnerID:                id,
 		Namespace:              prefix,
@@ -78,6 +81,13 @@ func NewNetworkIngressResourceNames(id uuid.UUID) (NetworkIngressResourceNames, 
 func (n NetworkIngressResourceNames) Validate() error {
 	if n.OwnerID == uuid.Nil {
 		return fmt.Errorf("%w: resource owner is required", ErrNetworkIngressInvalidDesiredState)
+	}
+	expected, err := NewNetworkIngressResourceNames(n.OwnerID)
+	if err != nil {
+		return err
+	}
+	if n != expected {
+		return fmt.Errorf("%w: resource identities do not match owner", ErrNetworkIngressInvalidDesiredState)
 	}
 	values := []string{
 		n.Namespace,
@@ -130,19 +140,22 @@ func ParseNetworkIngressResourceNames(encoded []byte) (NetworkIngressResourceNam
 // decrypted provider-opaque bytes and must remain in-memory only. Only the
 // selected provider adapter may decode their contents.
 type NetworkIngressDesired struct {
-	ID             uuid.UUID
-	Provider       string
-	Hostname       string
-	Credentials    []byte
-	Resources      NetworkIngressResourceNames
-	AttestorImage  string
-	BackendService string
-	BackendPort    int32
+	ID             uuid.UUID                   `json:"id"`
+	Provider       string                      `json:"provider"`
+	Hostname       string                      `json:"hostname"`
+	Credentials    []byte                      `json:"-"`
+	Resources      NetworkIngressResourceNames `json:"resources"`
+	AttestorImage  string                      `json:"attestor_image"`
+	BackendService string                      `json:"backend_service"`
+	BackendPort    int32                       `json:"backend_port"`
 }
 
 func (d NetworkIngressDesired) Validate() error {
-	if d.ID == uuid.Nil || d.Provider == "" || d.Hostname == "" || len(d.Credentials) == 0 || d.AttestorImage == "" || d.BackendService == "" || d.BackendPort <= 0 {
+	if d.ID == uuid.Nil || d.Provider == "" || d.Hostname == "" || len(d.Credentials) == 0 || d.AttestorImage == "" || d.BackendService == "" || d.BackendPort <= 0 || d.BackendPort > 65535 {
 		return fmt.Errorf("%w: desired state is incomplete", ErrNetworkIngressInvalidDesiredState)
+	}
+	if d.Hostname != strings.ToLower(d.Hostname) || len(k8svalidation.IsDNS1123Label(d.Hostname)) > 0 {
+		return fmt.Errorf("%w: hostname must be a lowercase DNS label", ErrNetworkIngressInvalidDesiredState)
 	}
 	if err := d.Resources.Validate(); err != nil {
 		return err
@@ -170,14 +183,14 @@ type NetworkIngressProvisionerRegistry struct {
 	providers map[string]NetworkIngressProvisioner
 }
 
-func NewNetworkIngressProvisionerRegistry(providers map[string]NetworkIngressProvisioner) (*NetworkIngressProvisionerRegistry, error) {
+func NewNetworkIngressProvisionerRegistry(providers map[string]NetworkIngressProvisioner, logger *slog.Logger, metrics *NetworkIngressMetrics) (*NetworkIngressProvisionerRegistry, error) {
 	registry := &NetworkIngressProvisionerRegistry{providers: make(map[string]NetworkIngressProvisioner, len(providers))}
 	for provider, provisioner := range providers {
 		provider = strings.TrimSpace(provider)
 		if provider == "" || provisioner == nil {
 			return nil, fmt.Errorf("%w: provider registry entry is invalid", ErrNetworkIngressInvalidDesiredState)
 		}
-		registry.providers[provider] = provisioner
+		registry.providers[provider] = ObserveNetworkIngressProvisioner(provider, provisioner, logger, metrics)
 	}
 	return registry, nil
 }

--- a/server/internal/k8s/network_ingress_provisioner.go
+++ b/server/internal/k8s/network_ingress_provisioner.go
@@ -1,0 +1,194 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	NetworkIngressProviderTailscale = "tailscale"
+
+	NetworkIngressStatusPending  = "pending"
+	NetworkIngressStatusOnline   = "online"
+	NetworkIngressStatusDegraded = "degraded"
+	NetworkIngressStatusError    = "error"
+
+	NetworkIngressErrorInvalidDesiredState = "invalid_desired_state"
+	NetworkIngressErrorUnsupportedProvider = "unsupported_provider"
+	NetworkIngressErrorInvalidCredentials  = "invalid_credentials" // #nosec G101 -- bounded status code, not credential material.
+	NetworkIngressErrorKubernetes          = "kubernetes_api"
+)
+
+var (
+	ErrNetworkIngressUnsupportedProvider = errors.New("unsupported network ingress provider")
+	ErrNetworkIngressInvalidDesiredState = errors.New("invalid network ingress desired state")
+	ErrNetworkIngressReplacementPending  = errors.New("network ingress immutable replacement pending")
+)
+
+// NetworkIngressResourceNames is the provider-neutral, persisted identity of
+// every Kubernetes resource owned by one ingress. Reconciliation and deletion
+// consume this value verbatim; they never derive names from mutable customer
+// input or from a tombstone.
+type NetworkIngressResourceNames struct {
+	OwnerID                uuid.UUID `json:"owner_id"`
+	Namespace              string    `json:"namespace"`
+	CredentialsSecret      string    `json:"credentials_secret"`
+	Tailnet                string    `json:"tailnet"`
+	ProxyGroup             string    `json:"proxy_group"`
+	ProxyGroupPolicy       string    `json:"proxy_group_policy"`
+	AttestorServiceAccount string    `json:"attestor_service_account"`
+	AttestorCASecret       string    `json:"attestor_ca_secret"`
+	AttestorDeployment     string    `json:"attestor_deployment"`
+	AttestorService        string    `json:"attestor_service"`
+	AttestorNetworkPolicy  string    `json:"attestor_network_policy"`
+	ProxyNetworkPolicy     string    `json:"proxy_network_policy"`
+	Ingress                string    `json:"ingress"`
+}
+
+func NewNetworkIngressResourceNames(id uuid.UUID) (NetworkIngressResourceNames, error) {
+	if id == uuid.Nil {
+		return NetworkIngressResourceNames{}, fmt.Errorf("%w: ingress id is required", ErrNetworkIngressInvalidDesiredState)
+	}
+	suffix := strings.ToLower(strings.ReplaceAll(id.String(), "-", ""))
+	prefix := "gram-netingress-" + suffix[:20]
+	return NetworkIngressResourceNames{
+		OwnerID:                id,
+		Namespace:              prefix,
+		CredentialsSecret:      prefix + "-oauth",
+		Tailnet:                prefix,
+		ProxyGroup:             prefix,
+		ProxyGroupPolicy:       prefix,
+		AttestorServiceAccount: prefix + "-attestor",
+		AttestorCASecret:       prefix + "-ca",
+		AttestorDeployment:     prefix + "-attestor",
+		AttestorService:        prefix + "-attestor",
+		AttestorNetworkPolicy:  prefix + "-attestor",
+		ProxyNetworkPolicy:     prefix + "-proxy",
+		Ingress:                prefix,
+	}, nil
+}
+
+func (n NetworkIngressResourceNames) Validate() error {
+	if n.OwnerID == uuid.Nil {
+		return fmt.Errorf("%w: resource owner is required", ErrNetworkIngressInvalidDesiredState)
+	}
+	values := []string{
+		n.Namespace,
+		n.CredentialsSecret,
+		n.Tailnet,
+		n.ProxyGroup,
+		n.ProxyGroupPolicy,
+		n.AttestorServiceAccount,
+		n.AttestorCASecret,
+		n.AttestorDeployment,
+		n.AttestorService,
+		n.AttestorNetworkPolicy,
+		n.ProxyNetworkPolicy,
+		n.Ingress,
+	}
+	for _, value := range values {
+		if len(k8svalidation.IsDNS1123Label(value)) > 0 {
+			return fmt.Errorf("%w: resource identity is invalid", ErrNetworkIngressInvalidDesiredState)
+		}
+	}
+	return nil
+}
+
+func (n NetworkIngressResourceNames) Marshal() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(n)
+	if err != nil {
+		return nil, fmt.Errorf("marshal network ingress resource names: %w", err)
+	}
+	return encoded, nil
+}
+
+func ParseNetworkIngressResourceNames(encoded []byte) (NetworkIngressResourceNames, error) {
+	var names NetworkIngressResourceNames
+	if len(encoded) == 0 {
+		return names, fmt.Errorf("%w: resource identities are required", ErrNetworkIngressInvalidDesiredState)
+	}
+	if err := json.Unmarshal(encoded, &names); err != nil {
+		return names, fmt.Errorf("parse network ingress resource names: %w", err)
+	}
+	if err := names.Validate(); err != nil {
+		return NetworkIngressResourceNames{}, err
+	}
+	return names, nil
+}
+
+// NetworkIngressDesired carries provider-neutral desired state. Credentials are
+// decrypted provider-opaque bytes and must remain in-memory only. Only the
+// selected provider adapter may decode their contents.
+type NetworkIngressDesired struct {
+	ID             uuid.UUID
+	Provider       string
+	Hostname       string
+	Credentials    []byte
+	Resources      NetworkIngressResourceNames
+	AttestorImage  string
+	BackendService string
+	BackendPort    int32
+}
+
+func (d NetworkIngressDesired) Validate() error {
+	if d.ID == uuid.Nil || d.Provider == "" || d.Hostname == "" || len(d.Credentials) == 0 || d.AttestorImage == "" || d.BackendService == "" || d.BackendPort <= 0 {
+		return fmt.Errorf("%w: desired state is incomplete", ErrNetworkIngressInvalidDesiredState)
+	}
+	if err := d.Resources.Validate(); err != nil {
+		return err
+	}
+	if d.Resources.OwnerID != d.ID {
+		return fmt.Errorf("%w: resource owner does not match ingress", ErrNetworkIngressInvalidDesiredState)
+	}
+	return nil
+}
+
+type NetworkIngressObservation struct {
+	Status      string
+	DNSName     string
+	ErrorCode   string
+	ConnectedAt *time.Time
+}
+
+type NetworkIngressProvisioner interface {
+	Apply(context.Context, NetworkIngressDesired) (NetworkIngressObservation, error)
+	Observe(context.Context, NetworkIngressResourceNames) (NetworkIngressObservation, error)
+	Delete(context.Context, NetworkIngressResourceNames) error
+}
+
+type NetworkIngressProvisionerRegistry struct {
+	providers map[string]NetworkIngressProvisioner
+}
+
+func NewNetworkIngressProvisionerRegistry(providers map[string]NetworkIngressProvisioner) (*NetworkIngressProvisionerRegistry, error) {
+	registry := &NetworkIngressProvisionerRegistry{providers: make(map[string]NetworkIngressProvisioner, len(providers))}
+	for provider, provisioner := range providers {
+		provider = strings.TrimSpace(provider)
+		if provider == "" || provisioner == nil {
+			return nil, fmt.Errorf("%w: provider registry entry is invalid", ErrNetworkIngressInvalidDesiredState)
+		}
+		registry.providers[provider] = provisioner
+	}
+	return registry, nil
+}
+
+func (r *NetworkIngressProvisionerRegistry) Provisioner(provider string) (NetworkIngressProvisioner, error) {
+	if r == nil {
+		return nil, ErrNetworkIngressUnsupportedProvider
+	}
+	provisioner, ok := r.providers[provider]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrNetworkIngressUnsupportedProvider, provider)
+	}
+	return provisioner, nil
+}

--- a/server/internal/k8s/network_ingress_provisioner_test.go
+++ b/server/internal/k8s/network_ingress_provisioner_test.go
@@ -1,0 +1,102 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type stubNetworkIngressProvisioner struct{}
+
+func (stubNetworkIngressProvisioner) Apply(context.Context, NetworkIngressDesired) (NetworkIngressObservation, error) {
+	return NetworkIngressObservation{}, nil
+}
+
+func (stubNetworkIngressProvisioner) Observe(context.Context, NetworkIngressResourceNames) (NetworkIngressObservation, error) {
+	return NetworkIngressObservation{}, nil
+}
+
+func (stubNetworkIngressProvisioner) Delete(context.Context, NetworkIngressResourceNames) error {
+	return nil
+}
+
+func TestNetworkIngressResourceNamesStableAndRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ingressID := uuid.MustParse("0199aabb-ccdd-7000-8000-001122334455")
+	first, err := NewNetworkIngressResourceNames(ingressID)
+	require.NoError(t, err)
+	second, err := NewNetworkIngressResourceNames(ingressID)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Equal(t, "gram-netingress-0199aabbccdd70008000", first.Namespace)
+	require.NotContains(t, first.Namespace, ".")
+
+	encoded, err := first.Marshal()
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "organization")
+	parsed, err := ParseNetworkIngressResourceNames(encoded)
+	require.NoError(t, err)
+	require.Equal(t, first, parsed)
+}
+
+func TestNetworkIngressResourceNamesRejectIncompleteState(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewNetworkIngressResourceNames(uuid.Nil)
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
+	_, err = ParseNetworkIngressResourceNames([]byte(`{"namespace":"only-one-field"}`))
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
+	_, err = ParseNetworkIngressResourceNames([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+func TestNetworkIngressDesiredValidationDoesNotExposeCredentials(t *testing.T) {
+	t.Parallel()
+
+	ingressID := uuid.New()
+	names, err := NewNetworkIngressResourceNames(ingressID)
+	require.NoError(t, err)
+	secret := []byte(`{"client_id":"sensitive-client","client_secret":"sensitive-secret"}`)
+	desired := NetworkIngressDesired{
+		ID:             ingressID,
+		Provider:       NetworkIngressProviderTailscale,
+		Hostname:       "private-example",
+		Credentials:    secret,
+		Resources:      names,
+		AttestorImage:  "attestor@example",
+		BackendService: "gram-server-private",
+		BackendPort:    8443,
+	}
+	require.NoError(t, desired.Validate())
+
+	desired.BackendPort = 0
+	err = desired.Validate()
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
+	require.NotContains(t, err.Error(), "sensitive-client")
+	require.NotContains(t, err.Error(), "sensitive-secret")
+}
+
+func TestNetworkIngressProvisionerRegistry(t *testing.T) {
+	t.Parallel()
+
+	provisioner := stubNetworkIngressProvisioner{}
+	registry, err := NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{
+		NetworkIngressProviderTailscale: provisioner,
+	})
+	require.NoError(t, err)
+
+	got, err := registry.Provisioner(NetworkIngressProviderTailscale)
+	require.NoError(t, err)
+	require.Equal(t, provisioner, got)
+	_, err = registry.Provisioner("unknown")
+	require.ErrorIs(t, err, ErrNetworkIngressUnsupportedProvider)
+
+	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"": provisioner})
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
+	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"nil": nil})
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
+
+}

--- a/server/internal/k8s/network_ingress_provisioner_test.go
+++ b/server/internal/k8s/network_ingress_provisioner_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
@@ -31,7 +32,7 @@ func TestNetworkIngressResourceNamesStableAndRoundTrip(t *testing.T) {
 	second, err := NewNetworkIngressResourceNames(ingressID)
 	require.NoError(t, err)
 	require.Equal(t, first, second)
-	require.Equal(t, "gram-netingress-0199aabbccdd70008000", first.Namespace)
+	require.Equal(t, "gram-netingress-86c7c63bb062541a6ba1", first.Namespace)
 	require.NotContains(t, first.Namespace, ".")
 
 	encoded, err := first.Marshal()
@@ -40,6 +41,10 @@ func TestNetworkIngressResourceNamesStableAndRoundTrip(t *testing.T) {
 	parsed, err := ParseNetworkIngressResourceNames(encoded)
 	require.NoError(t, err)
 	require.Equal(t, first, parsed)
+
+	drifted := first
+	drifted.Ingress = "valid-but-wrong"
+	require.ErrorIs(t, drifted.Validate(), ErrNetworkIngressInvalidDesiredState)
 }
 
 func TestNetworkIngressResourceNamesRejectIncompleteState(t *testing.T) {
@@ -71,7 +76,16 @@ func TestNetworkIngressDesiredValidationDoesNotExposeCredentials(t *testing.T) {
 		BackendPort:    8443,
 	}
 	require.NoError(t, desired.Validate())
+	serialized, err := json.Marshal(struct {
+		NetworkIngressDesired NetworkIngressDesired `json:"desired"`
+	}{NetworkIngressDesired: desired})
+	require.NoError(t, err)
+	require.NotContains(t, string(serialized), "sensitive")
+	require.NotContains(t, string(serialized), "Credentials")
 
+	desired.BackendPort = 65536
+	err = desired.Validate()
+	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
 	desired.BackendPort = 0
 	err = desired.Validate()
 	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
@@ -85,18 +99,18 @@ func TestNetworkIngressProvisionerRegistry(t *testing.T) {
 	provisioner := stubNetworkIngressProvisioner{}
 	registry, err := NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{
 		NetworkIngressProviderTailscale: provisioner,
-	})
+	}, nil, nil)
 	require.NoError(t, err)
 
 	got, err := registry.Provisioner(NetworkIngressProviderTailscale)
 	require.NoError(t, err)
-	require.Equal(t, provisioner, got)
+	require.IsType(t, &observedNetworkIngressProvisioner{}, got)
 	_, err = registry.Provisioner("unknown")
 	require.ErrorIs(t, err, ErrNetworkIngressUnsupportedProvider)
 
-	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"": provisioner})
+	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"": provisioner}, nil, nil)
 	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
-	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"nil": nil})
+	_, err = NewNetworkIngressProvisionerRegistry(map[string]NetworkIngressProvisioner{"nil": nil}, nil, nil)
 	require.ErrorIs(t, err, ErrNetworkIngressInvalidDesiredState)
 
 }

--- a/server/internal/k8s/tailscale_network_ingress_provisioner.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -84,7 +86,7 @@ func NewTailscaleNetworkIngressProvisioner(clientset kubernetes.Interface, dynam
 			return nil, fmt.Errorf("%w: Kubernetes API network is invalid", ErrNetworkIngressInvalidDesiredState)
 		}
 	}
-	config.ClusterCIDRs = append([]string{"169.254.0.0/16"}, config.ClusterCIDRs...)
+	config.ClusterCIDRs = append([]string{"169.254.169.254/32"}, config.ClusterCIDRs...)
 	for _, cidr := range config.ClusterCIDRs {
 		if _, _, err := net.ParseCIDR(cidr); err != nil {
 			return nil, fmt.Errorf("%w: cluster network is invalid", ErrNetworkIngressInvalidDesiredState)
@@ -149,11 +151,11 @@ func (p *TailscaleNetworkIngressProvisioner) Apply(ctx context.Context, desired 
 	if err := p.applyIngress(ctx, desired); err != nil {
 		return p.applyError(NetworkIngressErrorKubernetes, err)
 	}
-	return p.Observe(ctx, desired.Resources)
+	return p.observe(ctx, desired.Resources, desired.Hostname)
 }
 
 //nolint:exhaustruct // observations intentionally populate only known current state.
-func (p *TailscaleNetworkIngressProvisioner) Observe(ctx context.Context, resources NetworkIngressResourceNames) (NetworkIngressObservation, error) {
+func (p *TailscaleNetworkIngressProvisioner) observe(ctx context.Context, resources NetworkIngressResourceNames, desiredHostname string) (NetworkIngressObservation, error) {
 	if err := resources.Validate(); err != nil {
 		return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: NetworkIngressErrorInvalidDesiredState}, err
 	}
@@ -187,123 +189,148 @@ func (p *TailscaleNetworkIngressProvisioner) Observe(ctx context.Context, resour
 	}
 
 	dnsName := ingressHostname(ingress)
-	ready := unstructuredConditionTrue(tailnet, "TailnetReady") && unstructuredConditionTrue(proxyGroup, "ProxyGroupReady") && deployment.Status.AvailableReplicas > 0 && dnsName != "" && deploymentExpectedHost(deployment) == dnsName
+	desiredReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+	rolloutReady := deployment.Status.ObservedGeneration >= deployment.Generation && deployment.Status.UpdatedReplicas == desiredReplicas && deployment.Status.ReadyReplicas == desiredReplicas && deployment.Status.AvailableReplicas == desiredReplicas
+	configuredHostname := ingressDesiredHostname(ingress)
+	if desiredHostname != "" {
+		configuredHostname = desiredHostname
+	}
+	hostReady := dnsName != "" && configuredHostname != "" && deploymentExpectedHost(deployment) == dnsName && hostnameMatchesDesired(dnsName, configuredHostname)
+	ready := unstructuredConditionTrue(tailnet, "TailnetReady") && unstructuredConditionTrue(proxyGroup, "ProxyGroupReady") && rolloutReady && hostReady
 	if ready {
 		return NetworkIngressObservation{Status: NetworkIngressStatusOnline, DNSName: dnsName}, nil
 	}
 	return NetworkIngressObservation{Status: NetworkIngressStatusPending, DNSName: dnsName}, nil
 }
 
-func (p *TailscaleNetworkIngressProvisioner) verifyOwnedResources(ctx context.Context, resources NetworkIngressResourceNames) error {
-	ownerID := resources.OwnerID.String()
-	checks := []func() (map[string]string, error){
-		func() (map[string]string, error) {
-			object, err := p.clientset.CoreV1().Namespaces().Get(ctx, resources.Namespace, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				return nil, nil
-			}
-			if err != nil {
-				return nil, fmt.Errorf("verify namespace ownership: %w", err)
-			}
-			return nonNilLabels(object.Labels), nil
-		},
-		func() (map[string]string, error) {
-			object, err := p.clientset.CoreV1().Secrets(p.config.OperatorNamespace).Get(ctx, resources.CredentialsSecret, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				return nil, nil
-			}
-			if err != nil {
-				return nil, fmt.Errorf("verify OAuth Secret ownership: %w", err)
-			}
-			return nonNilLabels(object.Labels), nil
-		},
-		func() (map[string]string, error) {
-			object, err := p.dynamic.Resource(tailnetGVR).Get(ctx, resources.Tailnet, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				return nil, nil
-			}
-			if err != nil {
-				return nil, fmt.Errorf("verify Tailnet ownership: %w", err)
-			}
-			return object.GetLabels(), nil
-		},
-		func() (map[string]string, error) {
-			object, err := p.dynamic.Resource(proxyGroupGVR).Get(ctx, resources.ProxyGroup, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				return nil, nil
-			}
-			if err != nil {
-				return nil, fmt.Errorf("verify ProxyGroup ownership: %w", err)
-			}
-			return object.GetLabels(), nil
-		},
-		func() (map[string]string, error) {
-			object, err := p.clientset.NetworkingV1().NetworkPolicies(p.config.OperatorNamespace).Get(ctx, resources.ProxyNetworkPolicy, metav1.GetOptions{})
-			if k8serrors.IsNotFound(err) {
-				return nil, nil
-			}
-			if err != nil {
-				return nil, fmt.Errorf("verify proxy NetworkPolicy ownership: %w", err)
-			}
-			return nonNilLabels(object.Labels), nil
-		},
+func (p *TailscaleNetworkIngressProvisioner) Observe(ctx context.Context, resources NetworkIngressResourceNames) (NetworkIngressObservation, error) {
+	return p.observe(ctx, resources, "")
+}
+
+func deleteOwnedResource(ctx context.Context, name, ownerID, kind string, get func(context.Context, string) (metav1.Object, error), remove func(context.Context, string, metav1.DeleteOptions) error) error {
+	object, err := get(ctx, name)
+	if k8serrors.IsNotFound(err) {
+		return nil
 	}
-	for _, check := range checks {
-		labels, err := check()
-		if err != nil {
-			return err
-		}
-		if labels != nil {
-			if err := ensureResourceOwned(labels, ownerID); err != nil {
-				return fmt.Errorf("refuse to delete unowned resource: %w", err)
-			}
-		}
+	if err != nil {
+		return fmt.Errorf("get %s before delete: %w", kind, err)
 	}
-	return nil
+	if err := ensureResourceOwned(object.GetLabels(), ownerID); err != nil {
+		return fmt.Errorf("refuse to delete unowned %s: %w", kind, err)
+	}
+	uid := object.GetUID()
+	err = remove(ctx, name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}})
+	if err == nil || k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return fmt.Errorf("delete %s: %w", kind, err)
+}
+
+func (p *TailscaleNetworkIngressProvisioner) deleteOwnedIngress(ctx context.Context, resources NetworkIngressResourceNames, kind string) error {
+	client := p.clientset.NetworkingV1().Ingresses(resources.Namespace)
+	return deleteOwnedResource(ctx, resources.Ingress, resources.OwnerID.String(), kind,
+		func(ctx context.Context, name string) (metav1.Object, error) {
+			return client.Get(ctx, name, metav1.GetOptions{})
+		},
+		func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.Delete(ctx, name, options)
+		},
+	)
+}
+
+func deleteOwnedDynamic(ctx context.Context, client dynamic.ResourceInterface, name, ownerID, kind string) error {
+	return deleteOwnedResource(ctx, name, ownerID, kind,
+		func(ctx context.Context, name string) (metav1.Object, error) {
+			return client.Get(ctx, name, metav1.GetOptions{})
+		},
+		func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+			return client.Delete(ctx, name, options)
+		},
+	)
 }
 
 func (p *TailscaleNetworkIngressProvisioner) Delete(ctx context.Context, resources NetworkIngressResourceNames) error {
 	if err := resources.Validate(); err != nil {
 		return err
 	}
-	if err := p.verifyOwnedResources(ctx, resources); err != nil {
-		return err
-	}
+	ownerID := resources.OwnerID.String()
 	deletes := []func() error{
+		func() error { return p.deleteOwnedIngress(ctx, resources, "Ingress") },
 		func() error {
-			return deleteTyped(p.clientset.NetworkingV1().Ingresses(resources.Namespace), ctx, resources.Ingress, "Ingress")
+			client := p.clientset.CoreV1().Services(resources.Namespace)
+			return deleteOwnedResource(ctx, resources.AttestorService, ownerID, "attestor Service", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
 		},
 		func() error {
-			return deleteDynamic(p.dynamic.Resource(proxyGroupPolicyGVR).Namespace(resources.Namespace), ctx, resources.ProxyGroupPolicy, "ProxyGroupPolicy")
-		},
-
-		func() error {
-			return deleteTyped(p.clientset.CoreV1().Services(resources.Namespace), ctx, resources.AttestorService, "attestor Service")
-		},
-		func() error {
-			return deleteTyped(p.clientset.AppsV1().Deployments(resources.Namespace), ctx, resources.AttestorDeployment, "attestor Deployment")
+			client := p.clientset.AppsV1().Deployments(resources.Namespace)
+			return deleteOwnedResource(ctx, resources.AttestorDeployment, ownerID, "attestor Deployment", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
 		},
 		func() error {
-			return deleteDynamic(p.dynamic.Resource(proxyGroupGVR), ctx, resources.ProxyGroup, "ProxyGroup")
-		},
-		func() error { return deleteDynamic(p.dynamic.Resource(tailnetGVR), ctx, resources.Tailnet, "Tailnet") },
-		func() error {
-			return deleteTyped(p.clientset.CoreV1().Secrets(p.config.OperatorNamespace), ctx, resources.CredentialsSecret, "OAuth Secret")
+			return deleteOwnedDynamic(ctx, p.dynamic.Resource(proxyGroupPolicyGVR).Namespace(resources.Namespace), resources.ProxyGroupPolicy, ownerID, "ProxyGroupPolicy")
 		},
 		func() error {
-			return deleteTyped(p.clientset.CoreV1().Secrets(resources.Namespace), ctx, resources.AttestorCASecret, "attestor CA Secret")
+			return deleteOwnedDynamic(ctx, p.dynamic.Resource(proxyGroupGVR), resources.ProxyGroup, ownerID, "ProxyGroup")
 		},
 		func() error {
-			return deleteTyped(p.clientset.CoreV1().ServiceAccounts(resources.Namespace), ctx, resources.AttestorServiceAccount, "attestor ServiceAccount")
+			return deleteOwnedDynamic(ctx, p.dynamic.Resource(tailnetGVR), resources.Tailnet, ownerID, "Tailnet")
 		},
 		func() error {
-			return deleteTyped(p.clientset.NetworkingV1().NetworkPolicies(resources.Namespace), ctx, resources.AttestorNetworkPolicy, "attestor NetworkPolicy")
+			client := p.clientset.CoreV1().Secrets(p.config.OperatorNamespace)
+			return deleteOwnedResource(ctx, resources.CredentialsSecret, ownerID, "OAuth Secret", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
 		},
 		func() error {
-			return deleteTyped(p.clientset.NetworkingV1().NetworkPolicies(p.config.OperatorNamespace), ctx, resources.ProxyNetworkPolicy, "proxy NetworkPolicy")
+			client := p.clientset.CoreV1().Secrets(resources.Namespace)
+			return deleteOwnedResource(ctx, resources.AttestorCASecret, ownerID, "attestor CA Secret", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
 		},
 		func() error {
-			return deleteTyped(p.clientset.CoreV1().Namespaces(), ctx, resources.Namespace, "namespace")
+			client := p.clientset.CoreV1().ServiceAccounts(resources.Namespace)
+			return deleteOwnedResource(ctx, resources.AttestorServiceAccount, ownerID, "attestor ServiceAccount", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
+		},
+		func() error {
+			client := p.clientset.NetworkingV1().NetworkPolicies(resources.Namespace)
+			return deleteOwnedResource(ctx, resources.AttestorNetworkPolicy, ownerID, "attestor NetworkPolicy", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
+		},
+		func() error {
+			client := p.clientset.NetworkingV1().NetworkPolicies(p.config.OperatorNamespace)
+			return deleteOwnedResource(ctx, resources.ProxyNetworkPolicy, ownerID, "proxy NetworkPolicy", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
+		},
+		func() error {
+			client := p.clientset.CoreV1().Namespaces()
+			return deleteOwnedResource(ctx, resources.Namespace, ownerID, "namespace", func(ctx context.Context, name string) (metav1.Object, error) {
+				return client.Get(ctx, name, metav1.GetOptions{})
+			}, func(ctx context.Context, name string, options metav1.DeleteOptions) error {
+				return client.Delete(ctx, name, options)
+			})
 		},
 	}
 	var errs []error
@@ -322,6 +349,9 @@ func parseTailscaleCredentials(encoded []byte) (TailscaleCredentials, error) {
 	if err := decoder.Decode(&credentials); err != nil {
 		return credentials, fmt.Errorf("%w: invalid Tailscale credential payload", ErrNetworkIngressInvalidDesiredState)
 	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return TailscaleCredentials{}, fmt.Errorf("%w: invalid Tailscale credential payload", ErrNetworkIngressInvalidDesiredState)
+	}
 	if credentials.ClientID == "" || credentials.ClientSecret == "" {
 		return TailscaleCredentials{}, fmt.Errorf("%w: Tailscale credentials are incomplete", ErrNetworkIngressInvalidDesiredState)
 	}
@@ -339,13 +369,6 @@ func ingressLabels(desired NetworkIngressDesired) map[string]string {
 		networkIngressIDLabel:  desired.ID.String(),
 		networkIngressAppLabel: "gram-netingress-attestor",
 	}
-}
-
-func nonNilLabels(labels map[string]string) map[string]string {
-	if labels == nil {
-		return map[string]string{}
-	}
-	return labels
 }
 
 func resourceOwnerLabels(ownerID string) map[string]string {
@@ -473,7 +496,7 @@ func (p *TailscaleNetworkIngressProvisioner) applyDeployment(ctx context.Context
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorDeployment, Namespace: desired.Resources.Namespace, Labels: labels},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(1),
+			Replicas: new(int32(1)),
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
@@ -488,7 +511,7 @@ func (p *TailscaleNetworkIngressProvisioner) applyDeployment(ctx context.Context
 						VolumeMounts:   []corev1.VolumeMount{{Name: "attestation-token", MountPath: "/var/run/secrets/gram", ReadOnly: true}, {Name: "upstream-ca", MountPath: "/var/run/secrets/gram/upstream", ReadOnly: true}},
 					}},
 					Volumes: []corev1.Volume{
-						{Name: "attestation-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token", Audience: networkIngressTokenAudience, ExpirationSeconds: int64Ptr(600)}}}}}},
+						{Name: "attestation-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token", Audience: networkIngressTokenAudience, ExpirationSeconds: new(int64(600))}}}}}},
 						{Name: "upstream-ca", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: desired.Resources.AttestorCASecret}}},
 					},
 				},
@@ -581,9 +604,9 @@ func (p *TailscaleNetworkIngressProvisioner) attestorNetworkPolicy(desired Netwo
 		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorNetworkPolicy, Namespace: desired.Resources.Namespace, Labels: labels},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: labels}, PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.OperatorNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{tailscaleParentResourceType: "proxygroup", tailscaleParentResource: desired.Resources.ProxyGroup}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}}},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.OperatorNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{tailscaleParentResourceType: "proxygroup", tailscaleParentResource: desired.Resources.ProxyGroup}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
-				{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.BackendNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: p.config.BackendPodLabels}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt32(desired.BackendPort))}}},
+				{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.BackendNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: p.config.BackendPodLabels}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolTCP), Port: new(intstr.FromInt32(desired.BackendPort))}}},
 				dnsEgressRule(),
 			},
 		},
@@ -592,18 +615,18 @@ func (p *TailscaleNetworkIngressProvisioner) attestorNetworkPolicy(desired Netwo
 
 func (p *TailscaleNetworkIngressProvisioner) proxyNetworkPolicy(desired NetworkIngressDesired) *networkingv1.NetworkPolicy {
 	rules := []networkingv1.NetworkPolicyEgressRule{
-		{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: desired.Resources.Namespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: ingressLabels(desired)}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}},
+		{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: desired.Resources.Namespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: ingressLabels(desired)}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}},
 		dnsEgressRule(),
 	}
 	if p.config.KubernetesAPICIDR != "" {
-		rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: p.config.KubernetesAPICIDR}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt32(p.config.KubernetesAPIPort))}}})
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: p.config.KubernetesAPICIDR}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolTCP), Port: new(intstr.FromInt32(p.config.KubernetesAPIPort))}}})
 	}
 	rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0", Except: append([]string(nil), p.config.ClusterCIDRs...)}}}})
 	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.ProxyNetworkPolicy, Namespace: p.config.OperatorNamespace, Labels: ingressLabels(desired)}, Spec: networkingv1.NetworkPolicySpec{PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{tailscaleParentResourceType: "proxygroup", tailscaleParentResource: desired.Resources.ProxyGroup}}, PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, Egress: rules}}
 }
 
 func dnsEgressRule() networkingv1.NetworkPolicyEgressRule {
-	return networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: metav1.NamespaceSystem}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolUDP), Port: new(intstr.FromInt(53))}, {Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(53))}}}
+	return networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: metav1.NamespaceSystem}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolUDP), Port: new(intstr.FromInt(53))}, {Protocol: new(corev1.ProtocolTCP), Port: new(intstr.FromInt(53))}}}
 }
 
 func upsertNetworkPolicy(ctx context.Context, clientset kubernetes.Interface, policy *networkingv1.NetworkPolicy) error {
@@ -641,6 +664,11 @@ func (p *TailscaleNetworkIngressProvisioner) applyDynamic(ctx context.Context, g
 		return fmt.Errorf("refuse to adopt %s: %w", desired.GetKind(), err)
 	}
 	desired.SetResourceVersion(existing.GetResourceVersion())
+	desired.SetUID(existing.GetUID())
+	desired.SetFinalizers(existing.GetFinalizers())
+	desired.SetOwnerReferences(existing.GetOwnerReferences())
+	desired.SetAnnotations(mergeLabels(existing.GetAnnotations(), desired.GetAnnotations()))
+	desired.SetLabels(mergeLabels(existing.GetLabels(), desired.GetLabels()))
 	if status, ok := existing.Object["status"]; ok {
 		desired.Object["status"] = status
 	}
@@ -666,13 +694,21 @@ func (p *TailscaleNetworkIngressProvisioner) replaceImmutableProxyGroup(ctx cont
 	if err != nil {
 		return fmt.Errorf("read ProxyGroup tailnet: %w", err)
 	}
-	if tailnet == desired.Resources.Tailnet {
+	proxyType, _, err := unstructured.NestedString(existing.Object, "spec", "type")
+	if err != nil {
+		return fmt.Errorf("read ProxyGroup type: %w", err)
+	}
+	tags, _, err := unstructured.NestedStringSlice(existing.Object, "spec", "tags")
+	if err != nil {
+		return fmt.Errorf("read ProxyGroup tags: %w", err)
+	}
+	if tailnet == desired.Resources.Tailnet && proxyType == "ingress" && reflect.DeepEqual(tags, []string{p.config.ProxyTag}) {
 		return nil
 	}
-	if err := deleteTyped(p.clientset.NetworkingV1().Ingresses(desired.Resources.Namespace), ctx, desired.Resources.Ingress, "Ingress before ProxyGroup replacement"); err != nil {
+	if err := p.deleteOwnedIngress(ctx, desired.Resources, "Ingress before ProxyGroup replacement"); err != nil {
 		return err
 	}
-	if err := deleteDynamic(p.dynamic.Resource(proxyGroupGVR), ctx, desired.Resources.ProxyGroup, "immutable ProxyGroup"); err != nil {
+	if err := deleteOwnedDynamic(ctx, p.dynamic.Resource(proxyGroupGVR), desired.Resources.ProxyGroup, desired.ID.String(), "immutable ProxyGroup"); err != nil {
 		return err
 	}
 	return ErrNetworkIngressReplacementPending
@@ -702,6 +738,18 @@ func unstructuredConditionTrue(resource *unstructured.Unstructured, conditionTyp
 		}
 	}
 	return false
+}
+
+func hostnameMatchesDesired(dnsName, desiredHostname string) bool {
+	label, _, _ := strings.Cut(dnsName, ".")
+	return label == desiredHostname
+}
+
+func ingressDesiredHostname(ingress *networkingv1.Ingress) string {
+	if ingress == nil || len(ingress.Spec.TLS) == 0 || len(ingress.Spec.TLS[0].Hosts) == 0 {
+		return ""
+	}
+	return ingress.Spec.TLS[0].Hosts[0]
 }
 
 func ingressHostname(ingress *networkingv1.Ingress) string {
@@ -741,38 +789,3 @@ func wrapKubernetesMutation(operation string, err error) error {
 	}
 	return fmt.Errorf("%s: %w", operation, err)
 }
-
-type namedDeleter interface {
-	Delete(context.Context, string, metav1.DeleteOptions) error
-}
-
-func deleteTyped(client namedDeleter, ctx context.Context, name, kind string) error {
-	err := client.Delete(ctx, name, metav1.DeleteOptions{})
-	if err == nil || k8serrors.IsNotFound(err) {
-		return nil
-	}
-	return fmt.Errorf("delete %s: %w", kind, err)
-}
-
-func deleteDynamic(client dynamic.ResourceInterface, ctx context.Context, name, kind string) error {
-	err := client.Delete(ctx, name, metav1.DeleteOptions{})
-	if err == nil || k8serrors.IsNotFound(err) {
-		return nil
-	}
-	return fmt.Errorf("delete %s: %w", kind, err)
-}
-
-//go:fix inline
-func boolPtr(value bool) *bool { return new(value) }
-
-//go:fix inline
-func int32Ptr(value int32) *int32 { return new(value) }
-
-//go:fix inline
-func int64Ptr(value int64) *int64 { return new(value) }
-
-//go:fix inline
-func protocolPtr(value corev1.Protocol) *corev1.Protocol { return new(value) }
-
-//go:fix inline
-func intstrPtr(value intstr.IntOrString) *intstr.IntOrString { return new(value) }

--- a/server/internal/k8s/tailscale_network_ingress_provisioner.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner.go
@@ -1,0 +1,778 @@
+package k8s
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	tailscaleAPIGroup                = "tailscale.com"
+	tailscaleAPIVersion              = "v1alpha1"
+	networkIngressManagedBy          = "gram-network-ingress"
+	networkIngressAppLabel           = "app.kubernetes.io/name"
+	networkIngressIDLabel            = "gram.ai/network-ingress-id"
+	tailscaleParentResourceType      = "tailscale.com/parent-resource-type"
+	tailscaleParentResource          = "tailscale.com/parent-resource"
+	tailscaleProxyGroupAnnotation    = "tailscale.com/proxy-group"
+	tailscaleTagsAnnotation          = "tailscale.com/tags"
+	tailscaleIngressClass            = "tailscale"
+	networkIngressAttestorPort       = 8080
+	networkIngressAttestorHealthPort = 8081
+	networkIngressTokenAudience      = "gram-netingress"             // #nosec G101 -- Kubernetes TokenReview audience, not a credential.
+	networkIngressTokenPath          = "/var/run/secrets/gram/token" // #nosec G101 -- projected token path, not token material.
+	networkIngressCAPath             = "/var/run/secrets/gram/upstream/ca.crt"
+)
+
+var (
+	tailnetGVR          = schema.GroupVersionResource{Group: tailscaleAPIGroup, Version: tailscaleAPIVersion, Resource: "tailnets"}
+	proxyGroupGVR       = schema.GroupVersionResource{Group: tailscaleAPIGroup, Version: tailscaleAPIVersion, Resource: "proxygroups"}
+	proxyGroupPolicyGVR = schema.GroupVersionResource{Group: tailscaleAPIGroup, Version: tailscaleAPIVersion, Resource: "proxygrouppolicies"}
+)
+
+type TailscaleCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+type TailscaleNetworkIngressConfig struct {
+	OperatorNamespace string
+	BackendNamespace  string
+	BackendPodLabels  map[string]string
+	ProxyTag          string
+	ServiceTag        string
+	AttestorCASecret  string
+	KubernetesAPICIDR string
+	KubernetesAPIPort int32
+	ClusterCIDRs      []string
+}
+
+type TailscaleNetworkIngressProvisioner struct {
+	clientset kubernetes.Interface
+	dynamic   dynamic.Interface
+	config    TailscaleNetworkIngressConfig
+}
+
+var _ NetworkIngressProvisioner = (*TailscaleNetworkIngressProvisioner)(nil)
+
+func NewTailscaleNetworkIngressProvisioner(clientset kubernetes.Interface, dynamicClient dynamic.Interface, config TailscaleNetworkIngressConfig) (*TailscaleNetworkIngressProvisioner, error) {
+	if clientset == nil || dynamicClient == nil {
+		return nil, fmt.Errorf("%w: Kubernetes clients are required", ErrNetworkIngressInvalidDesiredState)
+	}
+	if config.OperatorNamespace == "" || config.BackendNamespace == "" || len(config.BackendPodLabels) == 0 || config.ProxyTag == "" || config.ServiceTag == "" || config.AttestorCASecret == "" {
+		return nil, fmt.Errorf("%w: Tailscale provisioner configuration is incomplete", ErrNetworkIngressInvalidDesiredState)
+	}
+	if config.KubernetesAPICIDR != "" {
+		if _, _, err := net.ParseCIDR(config.KubernetesAPICIDR); err != nil || config.KubernetesAPIPort <= 0 {
+			return nil, fmt.Errorf("%w: Kubernetes API network is invalid", ErrNetworkIngressInvalidDesiredState)
+		}
+	}
+	config.ClusterCIDRs = append([]string{"169.254.0.0/16"}, config.ClusterCIDRs...)
+	for _, cidr := range config.ClusterCIDRs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return nil, fmt.Errorf("%w: cluster network is invalid", ErrNetworkIngressInvalidDesiredState)
+		}
+	}
+	return &TailscaleNetworkIngressProvisioner{clientset: clientset, dynamic: dynamicClient, config: config}, nil
+}
+
+//nolint:exhaustruct // observations intentionally populate only known current state.
+func (p *TailscaleNetworkIngressProvisioner) Apply(ctx context.Context, desired NetworkIngressDesired) (NetworkIngressObservation, error) {
+	if err := desired.Validate(); err != nil {
+		return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: NetworkIngressErrorInvalidDesiredState}, err
+	}
+	if desired.Provider != NetworkIngressProviderTailscale {
+		return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: NetworkIngressErrorUnsupportedProvider}, ErrNetworkIngressUnsupportedProvider
+	}
+	credentials, err := parseTailscaleCredentials(desired.Credentials)
+	if err != nil {
+		return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: NetworkIngressErrorInvalidCredentials}, err
+	}
+
+	if err := p.applyNamespace(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyNetworkPolicies(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyCredentialsSecret(ctx, desired.Resources, credentials); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyDynamic(ctx, tailnetGVR, "", tailnetObject(desired)); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.replaceImmutableProxyGroup(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyDynamic(ctx, proxyGroupGVR, "", proxyGroupObject(desired, p.config.ProxyTag)); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyServiceAccount(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyAttestorCASecret(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	expectedHost, err := p.existingIngressHostname(ctx, desired.Resources)
+	if err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if expectedHost == "" {
+		expectedHost = desired.Hostname
+	}
+	if err := p.applyDeployment(ctx, desired, expectedHost); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyService(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyDynamic(ctx, proxyGroupPolicyGVR, desired.Resources.Namespace, proxyGroupPolicyObject(desired)); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	if err := p.applyIngress(ctx, desired); err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, err)
+	}
+	return p.Observe(ctx, desired.Resources)
+}
+
+//nolint:exhaustruct // observations intentionally populate only known current state.
+func (p *TailscaleNetworkIngressProvisioner) Observe(ctx context.Context, resources NetworkIngressResourceNames) (NetworkIngressObservation, error) {
+	if err := resources.Validate(); err != nil {
+		return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: NetworkIngressErrorInvalidDesiredState}, err
+	}
+	tailnet, err := p.dynamic.Resource(tailnetGVR).Get(ctx, resources.Tailnet, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return NetworkIngressObservation{Status: NetworkIngressStatusPending}, nil
+	}
+	if err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, fmt.Errorf("get Tailnet: %w", err))
+	}
+	proxyGroup, err := p.dynamic.Resource(proxyGroupGVR).Get(ctx, resources.ProxyGroup, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return NetworkIngressObservation{Status: NetworkIngressStatusPending}, nil
+	}
+	if err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, fmt.Errorf("get ProxyGroup: %w", err))
+	}
+	deployment, err := p.clientset.AppsV1().Deployments(resources.Namespace).Get(ctx, resources.AttestorDeployment, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return NetworkIngressObservation{Status: NetworkIngressStatusPending}, nil
+	}
+	if err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, fmt.Errorf("get attestor Deployment: %w", err))
+	}
+	ingress, err := p.clientset.NetworkingV1().Ingresses(resources.Namespace).Get(ctx, resources.Ingress, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return NetworkIngressObservation{Status: NetworkIngressStatusPending}, nil
+	}
+	if err != nil {
+		return p.applyError(NetworkIngressErrorKubernetes, fmt.Errorf("get Tailscale Ingress: %w", err))
+	}
+
+	dnsName := ingressHostname(ingress)
+	ready := unstructuredConditionTrue(tailnet, "TailnetReady") && unstructuredConditionTrue(proxyGroup, "ProxyGroupReady") && deployment.Status.AvailableReplicas > 0 && dnsName != "" && deploymentExpectedHost(deployment) == dnsName
+	if ready {
+		return NetworkIngressObservation{Status: NetworkIngressStatusOnline, DNSName: dnsName}, nil
+	}
+	return NetworkIngressObservation{Status: NetworkIngressStatusPending, DNSName: dnsName}, nil
+}
+
+func (p *TailscaleNetworkIngressProvisioner) verifyOwnedResources(ctx context.Context, resources NetworkIngressResourceNames) error {
+	ownerID := resources.OwnerID.String()
+	checks := []func() (map[string]string, error){
+		func() (map[string]string, error) {
+			object, err := p.clientset.CoreV1().Namespaces().Get(ctx, resources.Namespace, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return nil, nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("verify namespace ownership: %w", err)
+			}
+			return nonNilLabels(object.Labels), nil
+		},
+		func() (map[string]string, error) {
+			object, err := p.clientset.CoreV1().Secrets(p.config.OperatorNamespace).Get(ctx, resources.CredentialsSecret, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return nil, nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("verify OAuth Secret ownership: %w", err)
+			}
+			return nonNilLabels(object.Labels), nil
+		},
+		func() (map[string]string, error) {
+			object, err := p.dynamic.Resource(tailnetGVR).Get(ctx, resources.Tailnet, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return nil, nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("verify Tailnet ownership: %w", err)
+			}
+			return object.GetLabels(), nil
+		},
+		func() (map[string]string, error) {
+			object, err := p.dynamic.Resource(proxyGroupGVR).Get(ctx, resources.ProxyGroup, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return nil, nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("verify ProxyGroup ownership: %w", err)
+			}
+			return object.GetLabels(), nil
+		},
+		func() (map[string]string, error) {
+			object, err := p.clientset.NetworkingV1().NetworkPolicies(p.config.OperatorNamespace).Get(ctx, resources.ProxyNetworkPolicy, metav1.GetOptions{})
+			if k8serrors.IsNotFound(err) {
+				return nil, nil
+			}
+			if err != nil {
+				return nil, fmt.Errorf("verify proxy NetworkPolicy ownership: %w", err)
+			}
+			return nonNilLabels(object.Labels), nil
+		},
+	}
+	for _, check := range checks {
+		labels, err := check()
+		if err != nil {
+			return err
+		}
+		if labels != nil {
+			if err := ensureResourceOwned(labels, ownerID); err != nil {
+				return fmt.Errorf("refuse to delete unowned resource: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func (p *TailscaleNetworkIngressProvisioner) Delete(ctx context.Context, resources NetworkIngressResourceNames) error {
+	if err := resources.Validate(); err != nil {
+		return err
+	}
+	if err := p.verifyOwnedResources(ctx, resources); err != nil {
+		return err
+	}
+	deletes := []func() error{
+		func() error {
+			return deleteTyped(p.clientset.NetworkingV1().Ingresses(resources.Namespace), ctx, resources.Ingress, "Ingress")
+		},
+		func() error {
+			return deleteDynamic(p.dynamic.Resource(proxyGroupPolicyGVR).Namespace(resources.Namespace), ctx, resources.ProxyGroupPolicy, "ProxyGroupPolicy")
+		},
+
+		func() error {
+			return deleteTyped(p.clientset.CoreV1().Services(resources.Namespace), ctx, resources.AttestorService, "attestor Service")
+		},
+		func() error {
+			return deleteTyped(p.clientset.AppsV1().Deployments(resources.Namespace), ctx, resources.AttestorDeployment, "attestor Deployment")
+		},
+		func() error {
+			return deleteDynamic(p.dynamic.Resource(proxyGroupGVR), ctx, resources.ProxyGroup, "ProxyGroup")
+		},
+		func() error { return deleteDynamic(p.dynamic.Resource(tailnetGVR), ctx, resources.Tailnet, "Tailnet") },
+		func() error {
+			return deleteTyped(p.clientset.CoreV1().Secrets(p.config.OperatorNamespace), ctx, resources.CredentialsSecret, "OAuth Secret")
+		},
+		func() error {
+			return deleteTyped(p.clientset.CoreV1().Secrets(resources.Namespace), ctx, resources.AttestorCASecret, "attestor CA Secret")
+		},
+		func() error {
+			return deleteTyped(p.clientset.CoreV1().ServiceAccounts(resources.Namespace), ctx, resources.AttestorServiceAccount, "attestor ServiceAccount")
+		},
+		func() error {
+			return deleteTyped(p.clientset.NetworkingV1().NetworkPolicies(resources.Namespace), ctx, resources.AttestorNetworkPolicy, "attestor NetworkPolicy")
+		},
+		func() error {
+			return deleteTyped(p.clientset.NetworkingV1().NetworkPolicies(p.config.OperatorNamespace), ctx, resources.ProxyNetworkPolicy, "proxy NetworkPolicy")
+		},
+		func() error {
+			return deleteTyped(p.clientset.CoreV1().Namespaces(), ctx, resources.Namespace, "namespace")
+		},
+	}
+	var errs []error
+	for _, remove := range deletes {
+		if err := remove(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func parseTailscaleCredentials(encoded []byte) (TailscaleCredentials, error) {
+	var credentials TailscaleCredentials
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&credentials); err != nil {
+		return credentials, fmt.Errorf("%w: invalid Tailscale credential payload", ErrNetworkIngressInvalidDesiredState)
+	}
+	if credentials.ClientID == "" || credentials.ClientSecret == "" {
+		return TailscaleCredentials{}, fmt.Errorf("%w: Tailscale credentials are incomplete", ErrNetworkIngressInvalidDesiredState)
+	}
+	return credentials, nil
+}
+
+//nolint:exhaustruct // error observations intentionally omit unavailable state.
+func (p *TailscaleNetworkIngressProvisioner) applyError(code string, err error) (NetworkIngressObservation, error) {
+	return NetworkIngressObservation{Status: NetworkIngressStatusError, ErrorCode: code}, err
+}
+
+func ingressLabels(desired NetworkIngressDesired) map[string]string {
+	return map[string]string{
+		managedByLabelKey:      networkIngressManagedBy,
+		networkIngressIDLabel:  desired.ID.String(),
+		networkIngressAppLabel: "gram-netingress-attestor",
+	}
+}
+
+func nonNilLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		return map[string]string{}
+	}
+	return labels
+}
+
+func resourceOwnerLabels(ownerID string) map[string]string {
+	return map[string]string{managedByLabelKey: networkIngressManagedBy, networkIngressIDLabel: ownerID}
+}
+
+func ensureResourceOwned(labels map[string]string, ownerID string) error {
+	if labels[managedByLabelKey] != networkIngressManagedBy || labels[networkIngressIDLabel] != ownerID {
+		return fmt.Errorf("resource ownership does not match persisted ingress")
+	}
+	return nil
+}
+
+func mergeLabels(existing, desired map[string]string) map[string]string {
+	result := make(map[string]string, len(existing)+len(desired))
+	maps.Copy(result, existing)
+	maps.Copy(result, desired)
+	return result
+}
+
+func unstructuredIngressLabels(desired NetworkIngressDesired) map[string]any {
+	labels := ingressLabels(desired)
+	result := make(map[string]any, len(labels))
+	for key, value := range labels {
+		result[key] = value
+	}
+	return result
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyNamespace(ctx context.Context, desired NetworkIngressDesired) error {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Namespace, Labels: resourceOwnerLabels(desired.ID.String())}}
+	client := p.clientset.CoreV1().Namespaces()
+	existing, err := client.Get(ctx, namespace.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, namespace, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create namespace", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get namespace: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt namespace: %w", err)
+	}
+	existing.Labels = mergeLabels(existing.Labels, namespace.Labels)
+	_, err = client.Update(ctx, existing, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update namespace", err)
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyCredentialsSecret(ctx context.Context, resources NetworkIngressResourceNames, credentials TailscaleCredentials) error {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: resources.CredentialsSecret, Namespace: p.config.OperatorNamespace, Labels: resourceOwnerLabels(resources.OwnerID.String())}, Type: corev1.SecretTypeOpaque, Data: map[string][]byte{"client_id": []byte(credentials.ClientID), "client_secret": []byte(credentials.ClientSecret)}}
+	client := p.clientset.CoreV1().Secrets(p.config.OperatorNamespace)
+	existing, err := client.Get(ctx, secret.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, secret, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create OAuth Secret", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get OAuth Secret: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, resources.OwnerID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt OAuth Secret: %w", err)
+	}
+	secret.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, secret, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update OAuth Secret", err)
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyAttestorCASecret(ctx context.Context, desired NetworkIngressDesired) error {
+	source, err := p.clientset.CoreV1().Secrets(p.config.BackendNamespace).Get(ctx, p.config.AttestorCASecret, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get private listener CA Secret: %w", err)
+	}
+	ca, ok := source.Data["ca.crt"]
+	if !ok || len(ca) == 0 {
+		return fmt.Errorf("private listener CA Secret is invalid")
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorCASecret, Namespace: desired.Resources.Namespace, Labels: ingressLabels(desired)},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"ca.crt": append([]byte(nil), ca...)},
+	}
+	client := p.clientset.CoreV1().Secrets(desired.Resources.Namespace)
+	existing, err := client.Get(ctx, secret.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, secret, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create attestor CA Secret", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get attestor CA Secret: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt attestor CA Secret: %w", err)
+	}
+	secret.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, secret, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update attestor CA Secret", err)
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyServiceAccount(ctx context.Context, desired NetworkIngressDesired) error {
+	account := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorServiceAccount, Namespace: desired.Resources.Namespace, Labels: ingressLabels(desired)}, AutomountServiceAccountToken: new(false)}
+	client := p.clientset.CoreV1().ServiceAccounts(desired.Resources.Namespace)
+	existing, err := client.Get(ctx, account.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, account, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create attestor ServiceAccount", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get attestor ServiceAccount: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt attestor ServiceAccount: %w", err)
+	}
+	account.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, account, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update attestor ServiceAccount", err)
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyDeployment(ctx context.Context, desired NetworkIngressDesired, expectedHost string) error {
+	labels := ingressLabels(desired)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorDeployment, Namespace: desired.Resources.Namespace, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:           desired.Resources.AttestorServiceAccount,
+					AutomountServiceAccountToken: new(false),
+					Containers: []corev1.Container{{
+						Name: "attestor", Image: desired.AttestorImage, ImagePullPolicy: corev1.PullIfNotPresent,
+						Args:           []string{"netingress-attestor", "--upstream-url=https://" + desired.BackendService + "." + p.config.BackendNamespace + ".svc.cluster.local:" + strconv.Itoa(int(desired.BackendPort)), "--upstream-ca-file=" + networkIngressCAPath, "--expected-host=" + expectedHost, "--token-path=" + networkIngressTokenPath},
+						Ports:          []corev1.ContainerPort{{Name: "http", ContainerPort: networkIngressAttestorPort}, {Name: "health", ContainerPort: networkIngressAttestorHealthPort}},
+						ReadinessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("health")}}},
+						VolumeMounts:   []corev1.VolumeMount{{Name: "attestation-token", MountPath: "/var/run/secrets/gram", ReadOnly: true}, {Name: "upstream-ca", MountPath: "/var/run/secrets/gram/upstream", ReadOnly: true}},
+					}},
+					Volumes: []corev1.Volume{
+						{Name: "attestation-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token", Audience: networkIngressTokenAudience, ExpirationSeconds: int64Ptr(600)}}}}}},
+						{Name: "upstream-ca", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: desired.Resources.AttestorCASecret}}},
+					},
+				},
+			},
+		},
+	}
+	client := p.clientset.AppsV1().Deployments(desired.Resources.Namespace)
+	existing, err := client.Get(ctx, deployment.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, deployment, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create attestor Deployment", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get attestor Deployment: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt attestor Deployment: %w", err)
+	}
+	deployment.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, deployment, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update attestor Deployment", err)
+}
+
+//nolint:exhaustruct // Kubernetes desired-state literals omit API-owned defaults and status.
+func (p *TailscaleNetworkIngressProvisioner) applyService(ctx context.Context, desired NetworkIngressDesired) error {
+	labels := ingressLabels(desired)
+	service := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorService, Namespace: desired.Resources.Namespace, Labels: labels}, Spec: corev1.ServiceSpec{Selector: labels, Ports: []corev1.ServicePort{{Name: "http", Port: 80, TargetPort: intstr.FromString("http")}}}}
+	client := p.clientset.CoreV1().Services(desired.Resources.Namespace)
+	existing, err := client.Get(ctx, service.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, service, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create attestor Service", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get attestor Service: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt attestor Service: %w", err)
+	}
+	service.ResourceVersion = existing.ResourceVersion
+	service.Spec.ClusterIP = existing.Spec.ClusterIP
+	service.Spec.ClusterIPs = existing.Spec.ClusterIPs
+	service.Spec.IPFamilies = existing.Spec.IPFamilies
+	service.Spec.IPFamilyPolicy = existing.Spec.IPFamilyPolicy
+	service.Spec.HealthCheckNodePort = existing.Spec.HealthCheckNodePort
+	_, err = client.Update(ctx, service, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update attestor Service", err)
+}
+
+func (p *TailscaleNetworkIngressProvisioner) applyIngress(ctx context.Context, desired NetworkIngressDesired) error {
+	className := tailscaleIngressClass
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Ingress, Namespace: desired.Resources.Namespace, Labels: ingressLabels(desired), Annotations: map[string]string{tailscaleProxyGroupAnnotation: desired.Resources.ProxyGroup, tailscaleTagsAnnotation: p.config.ServiceTag}},
+		Spec:       networkingv1.IngressSpec{IngressClassName: &className, TLS: []networkingv1.IngressTLS{{Hosts: []string{desired.Hostname}}}, DefaultBackend: &networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: desired.Resources.AttestorService, Port: networkingv1.ServiceBackendPort{Name: "http"}}}},
+	}
+	client := p.clientset.NetworkingV1().Ingresses(desired.Resources.Namespace)
+	existing, err := client.Get(ctx, ingress.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, ingress, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create Tailscale Ingress", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get Tailscale Ingress: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt Tailscale Ingress: %w", err)
+	}
+	ingress.ResourceVersion = existing.ResourceVersion
+	ingress.Status = existing.Status
+	for key, value := range existing.Annotations {
+		if _, owned := ingress.Annotations[key]; !owned {
+			ingress.Annotations[key] = value
+		}
+	}
+	_, err = client.Update(ctx, ingress, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update Tailscale Ingress", err)
+}
+
+func (p *TailscaleNetworkIngressProvisioner) applyNetworkPolicies(ctx context.Context, desired NetworkIngressDesired) error {
+	attestor := p.attestorNetworkPolicy(desired)
+	if err := upsertNetworkPolicy(ctx, p.clientset, attestor); err != nil {
+		return err
+	}
+	return upsertNetworkPolicy(ctx, p.clientset, p.proxyNetworkPolicy(desired))
+}
+
+func (p *TailscaleNetworkIngressProvisioner) attestorNetworkPolicy(desired NetworkIngressDesired) *networkingv1.NetworkPolicy {
+	labels := ingressLabels(desired)
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.AttestorNetworkPolicy, Namespace: desired.Resources.Namespace, Labels: labels},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: labels}, PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{From: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.OperatorNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{tailscaleParentResourceType: "proxygroup", tailscaleParentResource: desired.Resources.ProxyGroup}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: p.config.BackendNamespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: p.config.BackendPodLabels}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt32(desired.BackendPort))}}},
+				dnsEgressRule(),
+			},
+		},
+	}
+}
+
+func (p *TailscaleNetworkIngressProvisioner) proxyNetworkPolicy(desired NetworkIngressDesired) *networkingv1.NetworkPolicy {
+	rules := []networkingv1.NetworkPolicyEgressRule{
+		{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: desired.Resources.Namespace}}, PodSelector: &metav1.LabelSelector{MatchLabels: ingressLabels(desired)}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(networkIngressAttestorPort))}}},
+		dnsEgressRule(),
+	}
+	if p.config.KubernetesAPICIDR != "" {
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: p.config.KubernetesAPICIDR}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt32(p.config.KubernetesAPIPort))}}})
+	}
+	rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0", Except: append([]string(nil), p.config.ClusterCIDRs...)}}}})
+	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.ProxyNetworkPolicy, Namespace: p.config.OperatorNamespace, Labels: ingressLabels(desired)}, Spec: networkingv1.NetworkPolicySpec{PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{tailscaleParentResourceType: "proxygroup", tailscaleParentResource: desired.Resources.ProxyGroup}}, PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, Egress: rules}}
+}
+
+func dnsEgressRule() networkingv1.NetworkPolicyEgressRule {
+	return networkingv1.NetworkPolicyEgressRule{To: []networkingv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{corev1.LabelMetadataName: metav1.NamespaceSystem}}, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k8s-app": "kube-dns"}}}}, Ports: []networkingv1.NetworkPolicyPort{{Protocol: protocolPtr(corev1.ProtocolUDP), Port: new(intstr.FromInt(53))}, {Protocol: protocolPtr(corev1.ProtocolTCP), Port: new(intstr.FromInt(53))}}}
+}
+
+func upsertNetworkPolicy(ctx context.Context, clientset kubernetes.Interface, policy *networkingv1.NetworkPolicy) error {
+	client := clientset.NetworkingV1().NetworkPolicies(policy.Namespace)
+	existing, err := client.Get(ctx, policy.Name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, policy, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create NetworkPolicy", err)
+	}
+	if err != nil {
+		return fmt.Errorf("get NetworkPolicy: %w", err)
+	}
+	if err := ensureResourceOwned(existing.Labels, policy.Labels[networkIngressIDLabel]); err != nil {
+		return fmt.Errorf("refuse to adopt NetworkPolicy: %w", err)
+	}
+	policy.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, policy, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update NetworkPolicy", err)
+}
+
+func (p *TailscaleNetworkIngressProvisioner) applyDynamic(ctx context.Context, gvr schema.GroupVersionResource, namespace string, desired *unstructured.Unstructured) error {
+	var client dynamic.ResourceInterface = p.dynamic.Resource(gvr)
+	if namespace != "" {
+		client = p.dynamic.Resource(gvr).Namespace(namespace)
+	}
+	existing, err := client.Get(ctx, desired.GetName(), metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err = client.Create(ctx, desired, metav1.CreateOptions{})
+		return wrapKubernetesMutation("create "+desired.GetKind(), err)
+	}
+	if err != nil {
+		return fmt.Errorf("get %s: %w", desired.GetKind(), err)
+	}
+	if err := ensureResourceOwned(existing.GetLabels(), desired.GetLabels()[networkIngressIDLabel]); err != nil {
+		return fmt.Errorf("refuse to adopt %s: %w", desired.GetKind(), err)
+	}
+	desired.SetResourceVersion(existing.GetResourceVersion())
+	if status, ok := existing.Object["status"]; ok {
+		desired.Object["status"] = status
+	}
+	_, err = client.Update(ctx, desired, metav1.UpdateOptions{})
+	return wrapKubernetesMutation("update "+desired.GetKind(), err)
+}
+
+func (p *TailscaleNetworkIngressProvisioner) replaceImmutableProxyGroup(ctx context.Context, desired NetworkIngressDesired) error {
+	existing, err := p.dynamic.Resource(proxyGroupGVR).Get(ctx, desired.Resources.ProxyGroup, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get ProxyGroup for immutable check: %w", err)
+	}
+	if existing.GetDeletionTimestamp() != nil {
+		return ErrNetworkIngressReplacementPending
+	}
+	if err := ensureResourceOwned(existing.GetLabels(), desired.ID.String()); err != nil {
+		return fmt.Errorf("refuse to adopt ProxyGroup: %w", err)
+	}
+	tailnet, _, err := unstructured.NestedString(existing.Object, "spec", "tailnet")
+	if err != nil {
+		return fmt.Errorf("read ProxyGroup tailnet: %w", err)
+	}
+	if tailnet == desired.Resources.Tailnet {
+		return nil
+	}
+	if err := deleteTyped(p.clientset.NetworkingV1().Ingresses(desired.Resources.Namespace), ctx, desired.Resources.Ingress, "Ingress before ProxyGroup replacement"); err != nil {
+		return err
+	}
+	if err := deleteDynamic(p.dynamic.Resource(proxyGroupGVR), ctx, desired.Resources.ProxyGroup, "immutable ProxyGroup"); err != nil {
+		return err
+	}
+	return ErrNetworkIngressReplacementPending
+}
+
+func tailnetObject(desired NetworkIngressDesired) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{"apiVersion": tailscaleAPIGroup + "/" + tailscaleAPIVersion, "kind": "Tailnet", "metadata": map[string]any{"name": desired.Resources.Tailnet, "labels": unstructuredIngressLabels(desired)}, "spec": map[string]any{"credentials": map[string]any{"secretName": desired.Resources.CredentialsSecret}}}}
+}
+
+func proxyGroupObject(desired NetworkIngressDesired, proxyTag string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{"apiVersion": tailscaleAPIGroup + "/" + tailscaleAPIVersion, "kind": "ProxyGroup", "metadata": map[string]any{"name": desired.Resources.ProxyGroup, "labels": unstructuredIngressLabels(desired)}, "spec": map[string]any{"type": "ingress", "replicas": int64(2), "tailnet": desired.Resources.Tailnet, "tags": []any{proxyTag}}}}
+}
+
+func proxyGroupPolicyObject(desired NetworkIngressDesired) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{"apiVersion": tailscaleAPIGroup + "/" + tailscaleAPIVersion, "kind": "ProxyGroupPolicy", "metadata": map[string]any{"name": desired.Resources.ProxyGroupPolicy, "namespace": desired.Resources.Namespace, "labels": unstructuredIngressLabels(desired)}, "spec": map[string]any{"ingress": []any{desired.Resources.ProxyGroup}, "egress": []any{}}}}
+}
+
+func unstructuredConditionTrue(resource *unstructured.Unstructured, conditionType string) bool {
+	conditions, found, err := unstructured.NestedSlice(resource.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, candidate := range conditions {
+		condition, ok := candidate.(map[string]any)
+		if ok && condition["type"] == conditionType && condition["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+func ingressHostname(ingress *networkingv1.Ingress) string {
+	if ingress == nil || len(ingress.Status.LoadBalancer.Ingress) == 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.ToLower(ingress.Status.LoadBalancer.Ingress[0].Hostname), ".")
+}
+
+func (p *TailscaleNetworkIngressProvisioner) existingIngressHostname(ctx context.Context, resources NetworkIngressResourceNames) (string, error) {
+	ingress, err := p.clientset.NetworkingV1().Ingresses(resources.Namespace).Get(ctx, resources.Ingress, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get existing Tailscale Ingress hostname: %w", err)
+	}
+	return ingressHostname(ingress), nil
+}
+
+func deploymentExpectedHost(deployment *appsv1.Deployment) string {
+	if deployment == nil || len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return ""
+	}
+	const prefix = "--expected-host="
+	for _, argument := range deployment.Spec.Template.Spec.Containers[0].Args {
+		if after, ok := strings.CutPrefix(argument, prefix); ok {
+			return after
+		}
+	}
+	return ""
+}
+
+func wrapKubernetesMutation(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
+}
+
+type namedDeleter interface {
+	Delete(context.Context, string, metav1.DeleteOptions) error
+}
+
+func deleteTyped(client namedDeleter, ctx context.Context, name, kind string) error {
+	err := client.Delete(ctx, name, metav1.DeleteOptions{})
+	if err == nil || k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return fmt.Errorf("delete %s: %w", kind, err)
+}
+
+func deleteDynamic(client dynamic.ResourceInterface, ctx context.Context, name, kind string) error {
+	err := client.Delete(ctx, name, metav1.DeleteOptions{})
+	if err == nil || k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return fmt.Errorf("delete %s: %w", kind, err)
+}
+
+//go:fix inline
+func boolPtr(value bool) *bool { return new(value) }
+
+//go:fix inline
+func int32Ptr(value int32) *int32 { return new(value) }
+
+//go:fix inline
+func int64Ptr(value int64) *int64 { return new(value) }
+
+//go:fix inline
+func protocolPtr(value corev1.Protocol) *corev1.Protocol { return new(value) }
+
+//go:fix inline
+func intstrPtr(value intstr.IntOrString) *intstr.IntOrString { return new(value) }

--- a/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -71,6 +72,10 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 
 	setUnstructuredReady(t, dynamicClient, tailnetGVR, "", desired.Resources.Tailnet, "TailnetReady")
 	setUnstructuredReady(t, dynamicClient, proxyGroupGVR, "", desired.Resources.ProxyGroup, "ProxyGroupReady")
+	deployment.Generation = 2
+	deployment.Status.ObservedGeneration = 2
+	deployment.Status.UpdatedReplicas = 1
+	deployment.Status.ReadyReplicas = 1
 	deployment.Status.AvailableReplicas = 1
 	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
@@ -84,6 +89,9 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	deployment, err = typed.AppsV1().Deployments(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorDeployment, metav1.GetOptions{})
 	require.NoError(t, err)
+	deployment.Status.ObservedGeneration = deployment.Generation
+	deployment.Status.UpdatedReplicas = 1
+	deployment.Status.ReadyReplicas = 1
 	deployment.Status.AvailableReplicas = 1
 	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
 	require.NoError(t, err)
@@ -92,11 +100,29 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 	require.Equal(t, NetworkIngressStatusOnline, observation.Status)
 	require.Equal(t, "private-test.example.ts.net", observation.DNSName)
 
+	deployment.Status.ObservedGeneration--
+	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	pending, err := provisioner.observe(t.Context(), desired.Resources, desired.Hostname)
+	require.NoError(t, err)
+	require.Equal(t, NetworkIngressStatusPending, pending.Status)
+	deployment.Status.ObservedGeneration = deployment.Generation
+	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	pending, err = provisioner.observe(t.Context(), desired.Resources, "renamed-private-test")
+	require.NoError(t, err)
+	require.Equal(t, NetworkIngressStatusPending, pending.Status)
+
 	var mu sync.Mutex
 	var deletes []string
+	var missingPrecondition bool
 	recordDelete := func(action ktesting.Action) (bool, runtime.Object, error) {
 		if action.GetVerb() == "delete" {
+			deleteAction, ok := action.(ktesting.DeleteAction)
 			mu.Lock()
+			if !ok || deleteAction.GetDeleteOptions().Preconditions == nil || deleteAction.GetDeleteOptions().Preconditions.UID == nil {
+				missingPrecondition = true
+			}
 			deletes = append(deletes, action.GetResource().Resource)
 			mu.Unlock()
 		}
@@ -106,8 +132,28 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 	dynamicClient.PrependReactor("delete", "*", recordDelete)
 	require.NoError(t, provisioner.Delete(t.Context(), desired.Resources))
 	require.NoError(t, provisioner.Delete(t.Context(), desired.Resources))
-	require.GreaterOrEqual(t, len(deletes), 11)
-	require.Equal(t, []string{"ingresses", "proxygrouppolicies", "services", "deployments", "proxygroups", "tailnets", "secrets", "secrets", "serviceaccounts", "networkpolicies", "networkpolicies", "namespaces"}, deletes[:12])
+	require.False(t, missingPrecondition)
+	require.GreaterOrEqual(t, len(deletes), 12)
+	require.Equal(t, []string{"ingresses", "services", "deployments", "proxygrouppolicies", "proxygroups", "tailnets", "secrets", "secrets", "serviceaccounts", "networkpolicies", "networkpolicies", "namespaces"}, deletes[:12])
+}
+
+func TestTailscaleNetworkIngressProvisionerPreservesDynamicMetadata(t *testing.T) {
+	t.Parallel()
+
+	provisioner, _, dynamicClient, desired := newTestTailscaleProvisioner(t)
+	tailnet := tailnetObject(desired)
+	tailnet.SetUID(types.UID("tailnet-uid"))
+	tailnet.SetFinalizers([]string{"tailscale.com/finalizer"})
+	tailnet.SetAnnotations(map[string]string{"tailscale.com/controller-state": "preserve"})
+	_, err := dynamicClient.Resource(tailnetGVR).Create(t.Context(), tailnet, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, provisioner.applyDynamic(t.Context(), tailnetGVR, "", tailnetObject(desired)))
+	got, err := dynamicClient.Resource(tailnetGVR).Get(t.Context(), desired.Resources.Tailnet, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, types.UID("tailnet-uid"), got.GetUID())
+	require.Equal(t, []string{"tailscale.com/finalizer"}, got.GetFinalizers())
+	require.Equal(t, "preserve", got.GetAnnotations()["tailscale.com/controller-state"])
 }
 
 func TestTailscaleNetworkIngressProvisionerRefusesUnownedResources(t *testing.T) {
@@ -124,7 +170,7 @@ func TestTailscaleNetworkIngressProvisionerRefusesUnownedResources(t *testing.T)
 
 	err = provisioner.Delete(t.Context(), desired.Resources)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "refuse to delete unowned resource")
+	require.Contains(t, err.Error(), "refuse to delete unowned namespace")
 	_, err = typed.CoreV1().Namespaces().Get(t.Context(), desired.Resources.Namespace, metav1.GetOptions{})
 	require.NoError(t, err)
 }
@@ -152,17 +198,23 @@ func TestTailscaleNetworkIngressProvisionerPartialFailureAndRedaction(t *testing
 	require.Equal(t, NetworkIngressErrorInvalidCredentials, observation.ErrorCode)
 	require.NotContains(t, err.Error(), "sensitive-client")
 	require.NotContains(t, err.Error(), "sensitive-secret")
+
+	desired.Credentials = []byte(`{"client_id":"sensitive-client","client_secret":"sensitive-secret"} garbage`)
+	observation, err = provisioner.Apply(t.Context(), desired)
+	require.Error(t, err)
+	require.Equal(t, NetworkIngressErrorInvalidCredentials, observation.ErrorCode)
+	require.NotContains(t, err.Error(), "sensitive-client")
+	require.NotContains(t, err.Error(), "sensitive-secret")
 }
 
 func TestTailscaleNetworkIngressProvisionerReplacesImmutableProxyGroup(t *testing.T) {
 	t.Parallel()
 
 	provisioner, typed, dynamicClient, desired := newTestTailscaleProvisioner(t)
-	wrong := proxyGroupObject(desired, "tag:test-proxy")
-	require.NoError(t, unstructured.SetNestedField(wrong.Object, "another-tailnet", "spec", "tailnet"))
+	wrong := proxyGroupObject(desired, "tag:wrong-proxy")
 	_, err := dynamicClient.Resource(proxyGroupGVR).Create(t.Context(), wrong, metav1.CreateOptions{})
 	require.NoError(t, err)
-	_, err = typed.NetworkingV1().Ingresses(desired.Resources.Namespace).Create(t.Context(), &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Ingress, Namespace: desired.Resources.Namespace}}, metav1.CreateOptions{})
+	_, err = typed.NetworkingV1().Ingresses(desired.Resources.Namespace).Create(t.Context(), &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Ingress, Namespace: desired.Resources.Namespace, Labels: ingressLabels(desired)}}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
 	var deleted []string

--- a/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
@@ -1,0 +1,226 @@
+package k8s
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
+	t.Parallel()
+
+	provisioner, typed, dynamicClient, desired := newTestTailscaleProvisioner(t)
+	first, err := provisioner.Apply(t.Context(), desired)
+	require.NoError(t, err)
+	require.Equal(t, NetworkIngressStatusPending, first.Status)
+	second, err := provisioner.Apply(t.Context(), desired)
+	require.NoError(t, err)
+	require.Equal(t, NetworkIngressStatusPending, second.Status)
+
+	secret, err := typed.CoreV1().Secrets("tailscale").Get(t.Context(), desired.Resources.CredentialsSecret, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("test-client"), secret.Data["client_id"])
+	require.Equal(t, []byte("test-secret"), secret.Data["client_secret"])
+	tailnet, err := dynamicClient.Resource(tailnetGVR).Get(t.Context(), desired.Resources.Tailnet, metav1.GetOptions{})
+	require.NoError(t, err)
+	secretName, found, err := unstructured.NestedString(tailnet.Object, "spec", "credentials", "secretName")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, desired.Resources.CredentialsSecret, secretName)
+	proxyGroup, err := dynamicClient.Resource(proxyGroupGVR).Get(t.Context(), desired.Resources.ProxyGroup, metav1.GetOptions{})
+	require.NoError(t, err)
+	tailnetName, found, err := unstructured.NestedString(proxyGroup.Object, "spec", "tailnet")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, desired.Resources.Tailnet, tailnetName)
+	policy, err := dynamicClient.Resource(proxyGroupPolicyGVR).Namespace(desired.Resources.Namespace).Get(t.Context(), desired.Resources.ProxyGroupPolicy, metav1.GetOptions{})
+	require.NoError(t, err)
+	allowedGroups, found, err := unstructured.NestedSlice(policy.Object, "spec", "ingress")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []any{desired.Resources.ProxyGroup}, allowedGroups)
+
+	deployment, err := typed.AppsV1().Deployments(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorDeployment, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.False(t, *deployment.Spec.Template.Spec.AutomountServiceAccountToken)
+	require.Equal(t, networkIngressTokenAudience, deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[0].ServiceAccountToken.Audience)
+	require.Equal(t, int64(600), *deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[0].ServiceAccountToken.ExpirationSeconds)
+	caSecret, err := typed.CoreV1().Secrets(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorCASecret, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("test-ca"), caSecret.Data["ca.crt"])
+
+	attestorPolicy, err := typed.NetworkingV1().NetworkPolicies(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorNetworkPolicy, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, desired.Resources.ProxyGroup, attestorPolicy.Spec.Ingress[0].From[0].PodSelector.MatchLabels[tailscaleParentResource])
+	proxyPolicy, err := typed.NetworkingV1().NetworkPolicies("tailscale").Get(t.Context(), desired.Resources.ProxyNetworkPolicy, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, desired.Resources.ProxyGroup, proxyPolicy.Spec.PodSelector.MatchLabels[tailscaleParentResource])
+
+	setUnstructuredReady(t, dynamicClient, tailnetGVR, "", desired.Resources.Tailnet, "TailnetReady")
+	setUnstructuredReady(t, dynamicClient, proxyGroupGVR, "", desired.Resources.ProxyGroup, "ProxyGroupReady")
+	deployment.Status.AvailableReplicas = 1
+	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	ingress, err := typed.NetworkingV1().Ingresses(desired.Resources.Namespace).Get(t.Context(), desired.Resources.Ingress, metav1.GetOptions{})
+	require.NoError(t, err)
+	ingress.Status.LoadBalancer.Ingress = []networkingv1.IngressLoadBalancerIngress{{Hostname: "Private-Test.Example.TS.NET."}}
+	_, err = typed.NetworkingV1().Ingresses(desired.Resources.Namespace).UpdateStatus(t.Context(), ingress, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = provisioner.Apply(t.Context(), desired)
+	require.NoError(t, err)
+	deployment, err = typed.AppsV1().Deployments(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorDeployment, metav1.GetOptions{})
+	require.NoError(t, err)
+	deployment.Status.AvailableReplicas = 1
+	_, err = typed.AppsV1().Deployments(desired.Resources.Namespace).UpdateStatus(t.Context(), deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	observation, err := provisioner.Observe(t.Context(), desired.Resources)
+	require.NoError(t, err)
+	require.Equal(t, NetworkIngressStatusOnline, observation.Status)
+	require.Equal(t, "private-test.example.ts.net", observation.DNSName)
+
+	var mu sync.Mutex
+	var deletes []string
+	recordDelete := func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetVerb() == "delete" {
+			mu.Lock()
+			deletes = append(deletes, action.GetResource().Resource)
+			mu.Unlock()
+		}
+		return false, nil, nil
+	}
+	typed.PrependReactor("delete", "*", recordDelete)
+	dynamicClient.PrependReactor("delete", "*", recordDelete)
+	require.NoError(t, provisioner.Delete(t.Context(), desired.Resources))
+	require.NoError(t, provisioner.Delete(t.Context(), desired.Resources))
+	require.GreaterOrEqual(t, len(deletes), 11)
+	require.Equal(t, []string{"ingresses", "proxygrouppolicies", "services", "deployments", "proxygroups", "tailnets", "secrets", "secrets", "serviceaccounts", "networkpolicies", "networkpolicies", "namespaces"}, deletes[:12])
+}
+
+func TestTailscaleNetworkIngressProvisionerRefusesUnownedResources(t *testing.T) {
+	t.Parallel()
+
+	provisioner, typed, _, desired := newTestTailscaleProvisioner(t)
+	_, err := typed.CoreV1().Namespaces().Create(t.Context(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Namespace}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	observation, err := provisioner.Apply(t.Context(), desired)
+	require.Error(t, err)
+	require.Equal(t, NetworkIngressStatusError, observation.Status)
+	require.Contains(t, err.Error(), "refuse to adopt namespace")
+
+	err = provisioner.Delete(t.Context(), desired.Resources)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "refuse to delete unowned resource")
+	_, err = typed.CoreV1().Namespaces().Get(t.Context(), desired.Resources.Namespace, metav1.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestTailscaleNetworkIngressProvisionerPartialFailureAndRedaction(t *testing.T) {
+	t.Parallel()
+
+	provisioner, typed, dynamicClient, desired := newTestTailscaleProvisioner(t)
+	typed.PrependReactor("create", "deployments", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("injected deployment failure")
+	})
+	observation, err := provisioner.Apply(t.Context(), desired)
+	require.Error(t, err)
+	require.Equal(t, NetworkIngressStatusError, observation.Status)
+	require.Equal(t, NetworkIngressErrorKubernetes, observation.ErrorCode)
+	require.NotContains(t, err.Error(), "test-secret")
+	_, err = dynamicClient.Resource(proxyGroupGVR).Get(t.Context(), desired.Resources.ProxyGroup, metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = typed.CoreV1().Services(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorService, metav1.GetOptions{})
+	require.Error(t, err)
+
+	desired.Credentials = []byte(`{"client_id":"sensitive-client","unexpected":"sensitive-secret"}`)
+	observation, err = provisioner.Apply(t.Context(), desired)
+	require.Error(t, err)
+	require.Equal(t, NetworkIngressErrorInvalidCredentials, observation.ErrorCode)
+	require.NotContains(t, err.Error(), "sensitive-client")
+	require.NotContains(t, err.Error(), "sensitive-secret")
+}
+
+func TestTailscaleNetworkIngressProvisionerReplacesImmutableProxyGroup(t *testing.T) {
+	t.Parallel()
+
+	provisioner, typed, dynamicClient, desired := newTestTailscaleProvisioner(t)
+	wrong := proxyGroupObject(desired, "tag:test-proxy")
+	require.NoError(t, unstructured.SetNestedField(wrong.Object, "another-tailnet", "spec", "tailnet"))
+	_, err := dynamicClient.Resource(proxyGroupGVR).Create(t.Context(), wrong, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = typed.NetworkingV1().Ingresses(desired.Resources.Namespace).Create(t.Context(), &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: desired.Resources.Ingress, Namespace: desired.Resources.Namespace}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var deleted []string
+	typed.PrependReactor("delete", "ingresses", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleted = append(deleted, "ingress")
+		return false, nil, nil
+	})
+	dynamicClient.PrependReactor("delete", "proxygroups", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deleted = append(deleted, "proxygroup")
+		return false, nil, nil
+	})
+	_, err = provisioner.Apply(t.Context(), desired)
+	require.ErrorIs(t, err, ErrNetworkIngressReplacementPending)
+	_, err = provisioner.Apply(t.Context(), desired)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ingress", "proxygroup"}, deleted)
+	got, err := dynamicClient.Resource(proxyGroupGVR).Get(t.Context(), desired.Resources.ProxyGroup, metav1.GetOptions{})
+	require.NoError(t, err)
+	tailnet, _, err := unstructured.NestedString(got.Object, "spec", "tailnet")
+	require.NoError(t, err)
+	require.Equal(t, desired.Resources.Tailnet, tailnet)
+}
+
+func newTestTailscaleProvisioner(t *testing.T) (*TailscaleNetworkIngressProvisioner, *fake.Clientset, *dynamicfake.FakeDynamicClient, NetworkIngressDesired) {
+	t.Helper()
+	id := uuid.MustParse("0199aabb-ccdd-7000-8000-001122334455")
+	resources, err := NewNetworkIngressResourceNames(id)
+	require.NoError(t, err)
+	typed := fake.NewSimpleClientset(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "private-listener-ca", Namespace: "gram-system"}, Data: map[string][]byte{"ca.crt": []byte("test-ca")}})
+	scheme := runtime.NewScheme()
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{tailnetGVR: "TailnetList", proxyGroupGVR: "ProxyGroupList", proxyGroupPolicyGVR: "ProxyGroupPolicyList"})
+	provisioner, err := NewTailscaleNetworkIngressProvisioner(typed, dynamicClient, TailscaleNetworkIngressConfig{
+		OperatorNamespace: "tailscale",
+		BackendNamespace:  "gram-system",
+		BackendPodLabels:  map[string]string{"app": "gram-server"},
+		ProxyTag:          "tag:test-proxy",
+		ServiceTag:        "tag:test-service",
+		AttestorCASecret:  "private-listener-ca",
+		KubernetesAPICIDR: "10.96.0.1/32",
+		KubernetesAPIPort: 443,
+		ClusterCIDRs:      []string{"10.0.0.0/8", "192.168.0.0/16"},
+	})
+	require.NoError(t, err)
+	return provisioner, typed, dynamicClient, NetworkIngressDesired{
+		ID: id, Provider: NetworkIngressProviderTailscale, Hostname: "private-test", Credentials: []byte(`{"client_id":"test-client","client_secret":"test-secret"}`), Resources: resources,
+		AttestorImage: "gram-attestor@example", BackendService: "gram-server-private", BackendPort: 8443,
+	}
+}
+
+func setUnstructuredReady(t *testing.T, client *dynamicfake.FakeDynamicClient, gvr schema.GroupVersionResource, namespace, name, conditionType string) {
+	t.Helper()
+	var resource dynamic.ResourceInterface = client.Resource(gvr)
+	if namespace != "" {
+		resource = client.Resource(gvr).Namespace(namespace)
+	}
+	object, err := resource.Get(t.Context(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NoError(t, unstructured.SetNestedSlice(object.Object, []any{map[string]any{"type": conditionType, "status": "True"}}, "status", "conditions"))
+	_, err = resource.UpdateStatus(t.Context(), object, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Why

Private ingress needs a provider-neutral Kubernetes lifecycle contract before Temporal orchestration can safely create or tear down Tailscale resources. This checkpoint implements that resource boundary without adding customer APIs or workflows.

Stacked on #5923.

## What changed

- Add provider-neutral `NetworkIngressProvisioner` Apply/Observe/Delete contracts, UUID-derived persisted resource identities, provider registry dispatch, and bounded lifecycle telemetry.
- Add the Tailscale adapter using typed clients for Namespace, Secret, ServiceAccount, Deployment, Service, NetworkPolicy, and Ingress, plus the dynamic client for pinned `tailscale.com/v1alpha1` Tailnet, ProxyGroup, and ProxyGroupPolicy resources.
- Reconcile in validated dependency order with policy-first isolation, projected TokenReview tokens, copied private-listener CA trust, and final MagicDNS/attestor convergence before reporting online.
- Delete in reverse dependency order using persisted names only, continue cleanup after individual failures, and keep isolation policies until workloads are gone.
- Gate updates and deletion on Gram ownership labels to prevent accidental adoption or deletion of colliding Kubernetes resources; immutable ProxyGroup replacement is explicitly retryable.
- Keep OAuth credentials provider-owned and in memory except for the Kubernetes Secret; errors, logs, and metric dimensions remain redacted and bounded.

## Review notes

- AIS-611 owns Temporal orchestration, periodic health, rotation workflows, tombstones, and deletion races.
- AIS-608 owns production operator deployment, RBAC, namespaces, config values, baseline monitoring, and infrastructure policies.
- Focus review on ownership safety, apply/delete ordering, NetworkPolicy selectors, and observed hostname readiness.

## Validation

- [x] `mise run test:server ./internal/k8s` (36 tests)
- [x] `mise lint:server`
- [x] `mise build:server`
- [x] `git diff --check`
- [x] Independent review completed; ownership/adoption safety, hostname convergence, immutable replacement, policy ordering, cleanup continuation, metadata egress, and metric findings addressed and retested
- [ ] `cubic review -j` could not complete because local Cubic authentication is expired (`cubic auth login` required)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the provider-neutral `NetworkIngressProvisioner` contract from AIS-605 with a working Tailscale adapter, so Temporal orchestration can safely create and tear down private ingress resources. No customer-facing APIs or workflows are added yet.

**Provisioner contract**
- Defines Apply/Observe/Delete with UUID-derived, persisted resource names and provider registry dispatch.
- Refuses to adopt or delete resources that lack the Gram ownership labels, and deletes with UID preconditions so recreated resources are never removed.
- Wraps provisioners to record operation counts, durations, and clamped redacted error codes as metrics; OAuth credentials are written only to the operator-namespace Secret.

**Tailscale adapter**
- Creates Namespace, Secret, ServiceAccount, Deployment, Service, NetworkPolicy, and Ingress with typed clients, plus Tailnet, ProxyGroup, and ProxyGroupPolicy via the pinned `tailscale.com/v1alpha1` dynamic client.
- Applies in dependency order with policy-first isolation, projected TokenReview tokens, copied private-listener CA trust, and preserved Tailscale controller metadata on updates.
- Reports online only after Tailnet, ProxyGroup, attestor, and MagicDNS hostname converge.
- Deletes in reverse dependency order using persisted names only, continuing after individual failures; immutable ProxyGroup replacement is retryable.

Temporal orchestration, health, rotation, and tombstones remain in AIS-611.

<sup>Written for commit 495df858432c102fdb0c1ad2e46ac1ff92b6d185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

