### PR TITLE
fix: tolerate inactive ClickHouse replicas during telemetry promotion

### DIFF
--- a/server/internal/background/activities/promote_staged_telemetry_test.go
+++ b/server/internal/background/activities/promote_staged_telemetry_test.go
@@ -624,8 +624,8 @@ func TestPromoteStagedTelemetry_ShadowPublishesPromotedRows(t *testing.T) {
 	require.Equal(t, 1, result.Deduped)
 	require.Equal(t, 0, result.Remaining)
 
-	// The staging delete is a lightweight delete, synchronous by default
-	// (lightweight_deletes_sync = 2), so the drain is visible immediately.
+	// The staging delete waits for active replicas, so the drain is visible
+	// immediately without depending on inactive ClickHouse Cloud compute.
 	staged, err := queries.ListStagedTelemetryLogs(ctx, projectID.String())
 	require.NoError(t, err)
 	require.Empty(t, staged)

--- a/server/internal/telemetry/repo/staging.go
+++ b/server/internal/telemetry/repo/staging.go
@@ -306,10 +306,11 @@ func (q *Queries) ListExistingTelemetryLogIDs(ctx context.Context, projectID str
 }
 
 // DeleteStagedTelemetryLogs synchronously removes promoted rows from staging
-// with a lightweight delete. Waiting for every replica keeps the activity's
-// next drain pass from observing rows it already promoted. Safe to retry:
-// deleting an already-deleted id is a no-op, and a crash before this delete
-// only leaves rows the next promotion pass skips via the dedup guard.
+// with a lightweight delete. Waiting for active replicas keeps the activity's
+// next drain pass from observing rows it already promoted without failing when
+// ClickHouse Cloud has an inactive compute replica. Safe to retry: deleting an
+// already-deleted id is a no-op, and a crash before this delete only leaves
+// rows the next promotion pass skips via the dedup guard.
 func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
@@ -325,7 +326,7 @@ func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID strin
 	}
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"lightweight_deletes_sync": 2,
+		"lightweight_deletes_sync": 3,
 	}))
 
 	if err := q.conn.Exec(ctx, query, args...); err != nil {


### PR DESCRIPTION
## Summary

- Make staged telemetry cleanup wait for active ClickHouse Cloud replicas instead of every replica.
- Preserve synchronous delete visibility for the promotion drain loop and update the existing behavior test commentary.

## Motivation

Production promotion activities failed when ClickHouse Cloud temporarily had an inactive compute replica. The previous `lightweight_deletes_sync = 2` setting waited for every replica, so Temporal either reached its 60-second activity deadline or received ClickHouse `UNFINISHED` error code 341 even though ClickHouse had queued the delete to finish asynchronously.

Promotion inserts happen before staging cleanup, and the destination-table existence guard prevents a retry from reinserting rows that already landed. The observed impact was retry churn, failed workflow runs, and delayed staging cleanup rather than a failed promotion insert.

`lightweight_deletes_sync = 3` is the SharedMergeTree mode that waits only for active replicas. It retains the drain loop's immediate visibility guarantee across available compute while removing the liveness dependency on a scaled-down or unavailable replica.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes telemetry promotion failing when ClickHouse Cloud has an inactive replica by waiting only for active replicas during staged cleanup. Previously `lightweight_deletes_sync = 2` waited on every replica, causing activity timeout or ClickHouse error 341. Now uses `lightweight_deletes_sync = 3`, which preserves synchronous delete visibility for the drain loop without depending on scaled-down or unavailable replicas.

- The delete stays idempotent, so retrying after a crash is safe.

<sup>Written for commit 177d43769bf1c4f70ab119a049be24700838471e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

