### PR TITLE
feat: gate MCP killswitch rollout

### DIFF
--- a/.changeset/mcp-killswitch-rollout.md
+++ b/.changeset/mcp-killswitch-rollout.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Authenticated MCP tool-call Killswitch evaluation now has a default-off server-side shadow and enforcement rollout gate, with audited break-glass deactivation and operational readiness guidance.

--- a/docs/runbooks/mcp-killswitch-evaluator-incidents.md
+++ b/docs/runbooks/mcp-killswitch-evaluator-incidents.md
@@ -9,7 +9,7 @@ policy fails closed in enforce mode.
 
 1. Declare an incident and assign an incident commander and database owner.
 2. Stop rollout cohort expansion. Do not create or edit prescriptions.
-3. Check `killswitch.evaluation.duration{outcome:evaluator_failure}`, p95/p99
+3. Check `killswitch.evaluation.duration{gram.outcome:evaluator_failure}`, p95/p99
    latency, PostgreSQL health, pool saturation, lock waits, and deploy changes.
 4. Compare hosted and private proxy outcomes. A one-surface failure can indicate
    a mixed or unhealthy serving fleet.
@@ -52,8 +52,9 @@ A partial binary rollback is unsafe while prescriptions might remain active.
 - Break-glass credentials are restricted to approved incident responders.
 - Prefer deactivation. Activation or change during an evaluator incident needs
   explicit incident-commander approval and an audited reason.
-- Use a new operation ID for each intended mutation; never retry with altered
-  input under an existing operation ID.
+- Use a new operation ID for each new or changed mutation. If a request times out
+  after commit, retry the identical input with the same operation ID; never reuse
+  that ID with altered input.
 - Confirm organization authorization and tenant binding. Never infer authority
   from email, API-key ownership, creator fields, or cached attribution.
 - Record only prescription IDs and internal evidence in the restricted incident
@@ -64,18 +65,22 @@ total database outage.
 
 ## Recovery checks
 
-Before leaving off mode:
+After repair, restore the cohort to shadow before running evaluator and coverage
+checks or approving enforce:
 
 1. PostgreSQL query latency, lock waits, CPU, and pool saturation are healthy.
 2. Every serving instance runs the approved checkpoint build.
-3. Hosted and private proxy coverage metrics are present.
+3. Restore the controlled cohort to shadow and confirm hosted and private proxy
+   coverage metrics are present.
 4. In a controlled environment, unmatched, matched, and evaluator-failure
    outcomes are observable and bounded.
 5. Shadow traffic runs through a peak period without exceeding approved latency,
    failure, coverage, or database-load thresholds.
-6. A controlled activation denies the next matching call, lift restores the
+6. The incident commander and service owner approve enforce for a controlled
+   cohort; enable enforce for that cohort.
+7. A controlled activation denies the next matching call, lift restores the
    next call, and expiry follows database time.
-7. The incident commander and service owner approve cohort enforcement.
+8. Review the controlled evidence before expanding enforcement.
 
 ## Rollback validation
 

--- a/docs/runbooks/mcp-killswitch-evaluator-incidents.md
+++ b/docs/runbooks/mcp-killswitch-evaluator-incidents.md
@@ -1,0 +1,95 @@
+# MCP Killswitch Evaluator Incidents
+
+Use this runbook when authenticated MCP `tools/call` traffic is denied because
+the authoritative Killswitch checkpoint cannot evaluate PostgreSQL state, or
+when rollout telemetry indicates unsafe evaluator behavior. The registered M2
+policy fails closed in enforce mode.
+
+## Immediate response
+
+1. Declare an incident and assign an incident commander and database owner.
+2. Stop rollout cohort expansion. Do not create or edit prescriptions.
+3. Check `killswitch.evaluation.duration{outcome:evaluator_failure}`, p95/p99
+   latency, PostgreSQL health, pool saturation, lock waits, and deploy changes.
+4. Compare hosted and private proxy outcomes. A one-surface failure can indicate
+   a mixed or unhealthy serving fleet.
+5. Determine whether lifecycle APIs can still reach PostgreSQL. Do not assume
+   that management access works merely because it bypasses evaluation.
+
+Do not copy bearer tokens, external notes, user identifiers, organization
+identifiers, server identifiers, or customer request bodies into logs, tickets,
+dashboards, or comments.
+
+## Safe mitigation order
+
+When lifecycle access is healthy and PostgreSQL is not saturated:
+
+1. Enumerate active and scheduled prescriptions through the restricted platform
+   management path.
+2. Lift or deactivate them with unique operation IDs. Deactivation remains
+   available while activation and change are rollout-gated.
+3. Verify each operation is audited and no active or scheduled prescriptions
+   remain.
+4. Switch affected cohorts to rollout off and verify every serving instance
+   received the mode and calls continue without an evaluator query.
+5. Repair the evaluator or database, restore shadow, observe, then re-enter the
+   normal rollout gate.
+
+When PostgreSQL latency, pool saturation, or lock load is itself the incident,
+switch affected cohorts off first and prove the local flag converged across the
+fleet. After load stabilizes, enumerate and deactivate prescriptions in bounded,
+paginated batches. If flag convergence cannot be proved, prefer deactivation
+before any binary rollback.
+
+When lifecycle access is also unavailable, use the approved out-of-band
+configuration path to switch affected cohorts off from the locally cached
+feature state. Confirm the new local state reached every serving instance. If
+that path cannot converge, perform an explicitly approved full-fleet rollback.
+A partial binary rollback is unsafe while prescriptions might remain active.
+
+## Break-glass rules
+
+- Break-glass credentials are restricted to approved incident responders.
+- Prefer deactivation. Activation or change during an evaluator incident needs
+  explicit incident-commander approval and an audited reason.
+- Use a new operation ID for each intended mutation; never retry with altered
+  input under an existing operation ID.
+- Confirm organization authorization and tenant binding. Never infer authority
+  from email, API-key ownership, creator fields, or cached attribution.
+- Record only prescription IDs and internal evidence in the restricted incident
+  system. Keep concrete customer identifiers out of repository artifacts.
+
+Break-glass lifecycle operations still depend on PostgreSQL. They do not solve a
+total database outage.
+
+## Recovery checks
+
+Before leaving off mode:
+
+1. PostgreSQL query latency, lock waits, CPU, and pool saturation are healthy.
+2. Every serving instance runs the approved checkpoint build.
+3. Hosted and private proxy coverage metrics are present.
+4. In a controlled environment, unmatched, matched, and evaluator-failure
+   outcomes are observable and bounded.
+5. Shadow traffic runs through a peak period without exceeding approved latency,
+   failure, coverage, or database-load thresholds.
+6. A controlled activation denies the next matching call, lift restores the
+   next call, and expiry follows database time.
+7. The incident commander and service owner approve cohort enforcement.
+
+## Rollback validation
+
+After mitigation or binary rollback:
+
+- no mixed serving version remains;
+- no active or scheduled prescription can be silently bypassed;
+- off mode performs no evaluator query;
+- ordinary MCP traffic is restored;
+- audit records exist for every break-glass mutation;
+- monitors have returned to baseline;
+- unsupported identities, resources, and methods remain outside the published
+  coverage boundary.
+
+Do not add a TTL negative cache as an incident fix. A future summary or cache
+must be transactionally updated with prescription activation and changes so the
+next call observes authoritative state.

--- a/docs/runbooks/mcp-killswitch-rollout.md
+++ b/docs/runbooks/mcp-killswitch-rollout.md
@@ -1,0 +1,146 @@
+# MCP Killswitch Rollout
+
+This runbook gates the authenticated MCP tool-call Killswitch rollout. Do not
+enable customer prescriptions until every serving instance has the approved
+hosted and private checkpoint build.
+
+## Coverage boundary
+
+This rollout covers `tools/call` for an authoritative, active organization user
+and a canonical organization-owned MCP server on these surfaces:
+
+- hosted MCP dispatch;
+- private remote or tunnel proxy forwarding.
+
+It does not cover anonymous sessions, API keys, assistants, chat-session end
+users, inactive users, unattributed requests, legacy toolset-only routes, meta
+or platform MCP, direct internal calls, or MCP methods other than `tools/call`.
+Do not describe this rollout as controlling chat, hooks, model inference,
+assistant work, or all AI activity.
+
+## Server-side modes
+
+Two locally evaluated PostHog flags form the backend gate. Target them by the
+organization distinct ID; do not put concrete organization identifiers in this
+repository or rollout tickets.
+
+| Mode    | `mcp-killswitch-shadow` | `mcp-killswitch-enforce` | Serving behavior                                | Management behavior                                 |
+| ------- | ----------------------- | ------------------------ | ----------------------------------------------- | --------------------------------------------------- |
+| Off     | off                     | off                      | Skip derivation and evaluation                  | Create and edit unavailable; lift remains available |
+| Shadow  | on                      | off                      | Evaluate and emit metrics, but always continue  | Create and edit unavailable; lift remains available |
+| Enforce | either                  | on                       | Apply matched denial and registered fail policy | Create and edit available                           |
+
+Enforce takes precedence if both flags are on. Missing, unavailable, or
+indeterminate local evaluation resolves to off. A successfully cached PostHog
+result remains in effect until the local poller refreshes it, so every mode
+change must be verified on every serving instance. Flag evaluation stays local
+to the process; the serving path does not perform a remote PostHog request.
+
+## Fleet-readiness gate
+
+Before enabling shadow for any production cohort:
+
+1. Identify the approved build containing both hosted and private checkpoints.
+2. Prove every server instance and tunnel/private forwarding instance runs that
+   build. Drain old instances; a mixed fleet is not ready.
+3. Confirm dashboards and monitors below are live and owned.
+4. Confirm no active production prescriptions exist before a mixed-version
+   deploy. If any exist, lift them before changing serving versions.
+5. Enable shadow for a controlled cohort. Then confirm both
+   `gram.mcp.killswitch.surface:hosted` and
+   `gram.mcp.killswitch.surface:private_proxy` appear in
+   `mcp.tool.call.killswitch_identity`. Off mode intentionally emits no coverage
+   observation.
+6. Confirm `killswitch.evaluation.duration` emits
+   `gram.outcome:matched`, `gram.outcome:unmatched`, and
+   `gram.outcome:evaluator_failure` in a non-production or controlled test. Do
+   not create synthetic customer prescriptions.
+
+Record the build, instance inventory, evidence links, reviewer, and timestamp in
+the internal rollout record. Repository tests cannot prove fleet uniformity.
+
+## Shadow observation
+
+Start with an internal or restricted cohort. Keep shadow active for at least one
+normal traffic cycle and one peak period. Select quantitative thresholds from a
+reviewed baseline; the values below are initial stop conditions, not permanent
+SLOs.
+
+Observe:
+
+- p95 and p99 of `killswitch.evaluation.duration`; p99 must remain comfortably
+  below the one-second private checkpoint timeout and two-second hosted timeout;
+- `outcome:evaluator_failure` ratio; stop on any sustained rate above 0.1% for
+  five minutes or any correlated serving incident;
+- matched and unmatched query volume; histogram count is the authoritative
+  evaluator-query count;
+- active-user plus canonical-server coverage by `surface`; investigate any
+  increase in `unavailable`, `invalid_owner`, or unsupported classes;
+- PostgreSQL query rate, latency, CPU, lock waits, and pool saturation compared
+  with the pre-shadow baseline. Stop on a sustained 10% load increase or pool
+  saturation unless the database owner approves a different bound.
+
+Shadow suppresses transport denial, including fail-closed evaluator outcomes.
+It does not suppress evaluator and coverage telemetry. Shadow evaluation is
+synchronous by design so it measures the serving-path cost that enforce mode
+will add; restrict cohort size and monitor end-to-end MCP request latency.
+
+## Datadog monitors
+
+Create these in Datadog; monitor configuration is not stored in this repository.
+Scope every monitor by environment. Evaluator duration has no surface attribute;
+only the identity-coverage counter can be split by surface. Tune only after a
+reviewed baseline.
+
+1. **Evaluator failure ratio**: count of
+   `killswitch.evaluation.duration{gram.outcome:evaluator_failure}` divided by
+   all outcomes over five minutes. Warn at 0.05%; alert at 0.1%.
+2. **Evaluator latency**: p95 and p99 of `killswitch.evaluation.duration`. Warn
+   at 250 ms; alert at 500 ms.
+3. **Coverage regression**: ratio of
+   `mcp.tool.call.killswitch_identity{gram.mcp.killswitch.identity_class:active_user,gram.mcp.killswitch.resource_class:canonical_server}`
+   to all observations, split by `gram.mcp.killswitch.surface`. Alert on a
+   reviewed baseline regression, not on an arbitrary global percentage.
+4. **Coverage unavailable**: any sustained
+   `gram.mcp.killswitch.identity_class:unavailable` or
+   `gram.mcp.killswitch.resource_class:unavailable`, plus
+   `gram.mcp.killswitch.resource_class:invalid_owner` above baseline.
+5. **PostgreSQL load**: query latency, pool saturation, lock waits, CPU, and
+   evaluator query volume. Correlate changes with shadow cohort expansion.
+
+Metric dimensions are bounded server classes. Never add organization IDs, user
+IDs, server IDs, notes, URLs, or error text as metric tags.
+
+## Enforce progression
+
+Enable `mcp-killswitch-enforce` only after the fleet gate and shadow criteria
+pass. Progress one restricted cohort at a time. For each cohort:
+
+1. Enable enforce while shadow remains on.
+2. Create a controlled prescription through the audited management path.
+3. Verify the next matching call is denied with the exact external note. No
+   restart, cache expiry, or propagation delay is expected.
+4. Verify a non-matching call continues.
+5. Lift the prescription and verify the next call continues.
+6. Exercise a bounded expiry and verify database time restores the next call.
+7. Review all monitors before expanding the cohort.
+
+There is no TTL allow/deny cache. Any future summary optimization must be
+updated transactionally with activation or change and visible on the next call.
+
+## Rollback criteria
+
+Stop expansion and roll back the cohort to off when any of these occurs:
+
+- a mixed serving fleet is detected;
+- evaluator failures exceed the approved threshold;
+- p99 approaches a checkpoint timeout;
+- authoritative identity or canonical-resource coverage regresses;
+- PostgreSQL load exceeds the approved bound;
+- denial text or JSON-RPC behavior differs from acceptance evidence.
+
+Before rolling binaries backward, stop cohort expansion, lift active
+prescriptions, verify no active or scheduled prescriptions remain, switch the
+cohort off, and then drain newer instances. Never leave active prescriptions
+while an older instance can bypass evaluation. Use the evaluator incident
+runbook for an active failure.

--- a/docs/runbooks/mcp-killswitch-rollout.md
+++ b/docs/runbooks/mcp-killswitch-rollout.md
@@ -30,11 +30,16 @@ repository or rollout tickets.
 | Shadow  | on                      | off                      | Evaluate and emit metrics, but always continue  | Create and edit unavailable; lift remains available |
 | Enforce | either                  | on                       | Apply matched denial and registered fail policy | Create and edit available                           |
 
-Enforce takes precedence if both flags are on. Missing, unavailable, or
-indeterminate local evaluation resolves to off. A successfully cached PostHog
-result remains in effect until the local poller refreshes it, so every mode
-change must be verified on every serving instance. Flag evaluation stays local
-to the process; the serving path does not perform a remote PostHog request.
+Management behavior in the table applies to fresh mutations. A completed
+operation replay bypasses the current gate and returns its stored result in every
+mode.
+
+Enforce takes precedence if both flags are on. Missing or disabled flags resolve
+to off; a local flag-resolution error rejects the call as an infrastructure
+failure. A successfully cached PostHog result remains in effect until the local
+poller refreshes it, so every mode change must be verified on every serving
+instance. Flag evaluation stays local to the process; the serving path does not
+perform a remote PostHog request.
 
 ## Fleet-readiness gate
 
@@ -46,11 +51,12 @@ Before enabling shadow for any production cohort:
 3. Confirm dashboards and monitors below are live and owned.
 4. Confirm no active production prescriptions exist before a mixed-version
    deploy. If any exist, lift them before changing serving versions.
-5. Enable shadow for a controlled cohort. Then confirm both
+5. Direct `HandleToolsCall` census observations remain active in off mode, while
+   routed hosted and private-proxy checkpoint derivation starts in shadow. Enable
+   shadow for a controlled cohort, then confirm both
    `gram.mcp.killswitch.surface:hosted` and
    `gram.mcp.killswitch.surface:private_proxy` appear in
-   `mcp.tool.call.killswitch_identity`. Off mode intentionally emits no coverage
-   observation.
+   `mcp.tool.call.killswitch_identity`.
 6. Confirm `killswitch.evaluation.duration` emits
    `gram.outcome:matched`, `gram.outcome:unmatched`, and
    `gram.outcome:evaluator_failure` in a non-production or controlled test. Do
@@ -70,10 +76,10 @@ Observe:
 
 - p95 and p99 of `killswitch.evaluation.duration`; p99 must remain comfortably
   below the one-second private checkpoint timeout and two-second hosted timeout;
-- `outcome:evaluator_failure` ratio; stop on any sustained rate above 0.1% for
+- `gram.outcome:evaluator_failure` ratio; stop on any sustained rate above 0.1% for
   five minutes or any correlated serving incident;
-- matched and unmatched query volume; histogram count is the authoritative
-  evaluator-query count;
+- matched and unmatched evaluator-invocation volume; the histogram count records
+  evaluator invocations, not PostgreSQL query count;
 - active-user plus canonical-server coverage by `surface`; investigate any
   increase in `unavailable`, `invalid_owner`, or unsupported classes;
 - PostgreSQL query rate, latency, CPU, lock waits, and pool saturation compared

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1060,7 +1060,7 @@ func newStartCommand() *cli.Command {
 
 			toolDispositionCache := mcpservers.NewToolDispositionCache(logger, db, cache.NewRedisCacheAdapter(redisClient))
 			var platformSelectedUseRecorder toolcallobserver.SuccessRecorder = platformmcp.NewSelectedUseRecorder(db)
-			mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(db, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger)
+			mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(db, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, featureFlags)
 			if err != nil {
 				return fmt.Errorf("initialize mcp tool-execution checkpoint: %w", err)
 			}
@@ -1526,13 +1526,13 @@ func newStartCommand() *cli.Command {
 			chatanalysis.Attach(mux, chatanalysis.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger,
 				&background.TemporalChatAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger}))
 			openrouterkeys.Attach(mux, openrouterkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, openRouter, encryptionClient))
-			// Platform break-glass remains separately unavailable; this composition is
-			// intentionally customer-only and enforces ordinary live admin sessions.
-			killswitches.AttachPlatformService(mux, killswitches.NewPlatformService(logger, tracerProvider, db, sessionManager, authzEngine, nil))
-			killswitchService, err := killswitchapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger)
+			killswitchService, err := killswitchapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, featureFlags)
 			if err != nil {
 				return fmt.Errorf("build customer killswitch service: %w", err)
 			}
+			// Platform break-glass shares the validated lifecycle so list and
+			// deactivation remain available when rollout enforcement is off.
+			killswitches.AttachPlatformService(mux, killswitches.NewPlatformService(logger, tracerProvider, db, sessionManager, authzEngine, killswitchService.GenericService()))
 			killswitchapi.Attach(mux, killswitchService)
 			skillsService := skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger,
 				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, siteURL)

--- a/server/internal/auth/authenticate_test.go
+++ b/server/internal/auth/authenticate_test.go
@@ -29,9 +29,10 @@ func TestIsPlatformAdminReadsCurrentDurableEntitlement(t *testing.T) {
 	require.NoError(t, authRepo.New(instance.conn).SetUserAdminFixture(ctx, authRepo.SetUserAdminFixtureParams{
 		Admin: true, UserID: userInfo.UserID,
 	}))
-	isAdmin, err = instance.sessionManager.IsPlatformAdmin(ctx, userInfo.UserID)
+	isAdmin, displayName, err := instance.sessionManager.GetPlatformAdminIdentity(ctx, userInfo.UserID)
 	require.NoError(t, err)
 	require.True(t, isAdmin)
+	require.Equal(t, userInfo.Email, displayName)
 
 	require.NoError(t, testrepo.New(instance.conn).ForceSoftDeleteUser(ctx, userInfo.UserID))
 	isAdmin, err = instance.sessionManager.IsPlatformAdmin(ctx, userInfo.UserID)

--- a/server/internal/auth/platformadmin.go
+++ b/server/internal/auth/platformadmin.go
@@ -27,51 +27,52 @@ func RequirePlatformAdmin(ctx context.Context, logger *slog.Logger) (*contextval
 	return authCtx, logger, nil
 }
 
-// PlatformAdminEntitlementReader checks the current durable users.admin value.
+// PlatformAdminEntitlementReader checks the current durable users.admin value
+// and returns the actor display name from the same authoritative row.
 type PlatformAdminEntitlementReader interface {
-	IsPlatformAdmin(context.Context, string) (bool, error)
+	GetPlatformAdminIdentity(context.Context, string) (isAdmin bool, displayName string, err error)
 }
 
 // RequireFreshPlatformAdminSession authorizes incident-sensitive platform paths.
 // It accepts only an ordinary validated Gram session, rejects impersonation and
 // alternate credentials, and re-reads the durable platform-admin entitlement.
-func RequireFreshPlatformAdminSession(ctx context.Context, logger *slog.Logger, reader PlatformAdminEntitlementReader) (*contextvalues.AuthContext, *slog.Logger, error) {
+func RequireFreshPlatformAdminSession(ctx context.Context, logger *slog.Logger, reader PlatformAdminEntitlementReader) (*contextvalues.AuthContext, string, *slog.Logger, error) {
 	authCtx, logger, err := platformAdminContext(ctx, logger)
 	if err != nil {
-		return nil, logger, err
+		return nil, "", logger, err
 	}
 	if !contextvalues.HasValidatedGramSession(ctx) || authCtx.SessionID == nil || *authCtx.SessionID == "" || authCtx.UserID == "" || authCtx.Email == nil || strings.TrimSpace(*authCtx.Email) == "" {
-		return nil, logger, oops.C(oops.CodeUnauthorized)
+		return nil, "", logger, oops.C(oops.CodeUnauthorized)
 	}
 	if authCtx.APIKeyID != "" || authCtx.APIKeyName != "" || len(authCtx.APIKeyScopes) != 0 || authCtx.OrgWidePluginHooksKey {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if _, ok := contextvalues.GetAssistantPrincipal(ctx); ok {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if _, ok := contextvalues.GetOAuthClientID(ctx); ok {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if _, ok := contextvalues.GetActingSurface(ctx); ok {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if contextvalues.IsSupportSession(ctx) || contextvalues.IsLegacyImpersonatedSession(ctx) {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if _, ok := contextvalues.GetRBACScopeOverride(ctx); ok {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
 	if reader == nil {
-		return nil, logger, oops.E(oops.CodeUnavailable, nil, "service is temporarily unavailable")
+		return nil, "", logger, oops.E(oops.CodeUnavailable, nil, "service is temporarily unavailable")
 	}
-	isAdmin, err := reader.IsPlatformAdmin(ctx, authCtx.UserID)
+	isAdmin, displayName, err := reader.GetPlatformAdminIdentity(ctx, authCtx.UserID)
 	if err != nil {
-		return nil, logger, oops.E(oops.CodeUnavailable, err, "service is temporarily unavailable")
+		return nil, "", logger, oops.E(oops.CodeUnavailable, err, "service is temporarily unavailable")
 	}
 	if !isAdmin {
-		return nil, logger, oops.C(oops.CodeForbidden)
+		return nil, "", logger, oops.C(oops.CodeForbidden)
 	}
-	return authCtx, logger, nil
+	return authCtx, displayName, logger, nil
 }
 
 func platformAdminContext(ctx context.Context, logger *slog.Logger) (*contextvalues.AuthContext, *slog.Logger, error) {

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -236,14 +236,21 @@ func (s *Manager) AuthenticateWithCookie(ctx context.Context) (context.Context, 
 // identity cache because an administrator may have been revoked after that
 // cache was populated.
 func (s *Manager) IsPlatformAdmin(ctx context.Context, userID string) (bool, error) {
+	isAdmin, _, err := s.GetPlatformAdminIdentity(ctx, userID)
+	return isAdmin, err
+}
+
+// GetPlatformAdminIdentity returns current platform-admin status and display name
+// from one authoritative user-row read.
+func (s *Manager) GetPlatformAdminIdentity(ctx context.Context, userID string) (bool, string, error) {
 	user, err := s.userRepo.GetUser(ctx, userID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return false, nil
+		return false, "", nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("get user for platform admin check: %w", err)
+		return false, "", fmt.Errorf("get user for platform admin check: %w", err)
 	}
-	return isCurrentPlatformAdmin(user.Admin, user.DeletedAt.Valid), nil
+	return isCurrentPlatformAdmin(user.Admin, user.DeletedAt.Valid), user.DisplayName, nil
 }
 
 func isCurrentPlatformAdmin(admin, deleted bool) bool {

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -36,6 +36,13 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
+	// FlagMCPKillswitchShadow and FlagMCPKillswitchEnforce form the server-side
+	// rollout gate for authenticated MCP tools/call evaluation. Both are
+	// evaluated from PostHog's local cache on every call. Enforce takes
+	// precedence when both are enabled; absent or indeterminate flags mean off.
+	FlagMCPKillswitchShadow  Flag = "mcp-killswitch-shadow"
+	FlagMCPKillswitchEnforce Flag = "mcp-killswitch-enforce"
+
 	// FlagPlatformMCPRiskMutations is the exact-project kill switch for risk
 	// policy and exclusion writes exposed through Platform MCP. It is evaluated
 	// at invocation time and fails closed when absent, disabled, or indeterminate.

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -37,9 +37,9 @@ const (
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
 	// FlagMCPKillswitchShadow and FlagMCPKillswitchEnforce form the server-side
-	// rollout gate for authenticated MCP tools/call evaluation. Both are
-	// evaluated from PostHog's local cache on every call. Enforce takes
-	// precedence when both are enabled; absent or indeterminate flags mean off.
+	// rollout gate for authenticated MCP tools/call evaluation. Mode resolution
+	// uses PostHog's local cache and checks enforce first, so it takes precedence
+	// when both flags are enabled.
 	FlagMCPKillswitchShadow  Flag = "mcp-killswitch-shadow"
 	FlagMCPKillswitchEnforce Flag = "mcp-killswitch-enforce"
 

--- a/server/internal/killswitchapi/service.go
+++ b/server/internal/killswitchapi/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	killswitchrepo "github.com/speakeasy-api/gram/server/internal/killswitches/repo"
@@ -49,19 +50,24 @@ type Service struct {
 	auth       *gramauth.Auth
 	db         *pgxpool.Pool
 	authorized *killswitches.AuthorizedService
+	generic    killswitches.GenericService
 	user       killswitches.PrincipalAdapter
 	server     killswitches.ResourceAdapter
+	features   feature.Provider
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, authzEngine *authz.Engine, auditLogger *audit.Logger) (*Service, error) {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, authzEngine *authz.Engine, auditLogger *audit.Logger, features feature.Provider) (*Service, error) {
 	registry, err := mcptoolexecution.NewRegistry(db)
 	if err != nil {
 		return nil, fmt.Errorf("build MCP tool-call killswitch registry: %w", err)
 	}
-	lifecycle, err := killswitches.NewLifecycleService(db, registry, mcptoolexecution.NewCustomerLifecycleValidator(), killswitches.NewAuditBeforeCommitHook(auditLogger))
+	lifecycle, err := killswitches.NewLifecycleService(
+		db, registry, mcptoolexecution.NewCustomerLifecycleValidator(), killswitches.NewAuditBeforeCommitHook(auditLogger),
+		killswitches.WithBeforeApplyHook(rolloutBeforeApply(features)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("build killswitch lifecycle service: %w", err)
 	}
@@ -83,9 +89,29 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 	}
 	return &Service{
 		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/killswitchapi"), logger: logger,
-		auth: gramauth.New(logger, db, sessionManager, authzEngine), db: db, authorized: authorized,
-		user: user, server: server,
+		auth: gramauth.New(logger, db, sessionManager, authzEngine), db: db, authorized: authorized, generic: facade,
+		user: user, server: server, features: features,
 	}, nil
+}
+
+func (s *Service) GenericService() killswitches.GenericService {
+	return s.generic
+}
+
+func rolloutBeforeApply(features feature.Provider) killswitches.BeforeApplyHook {
+	return func(ctx context.Context, mutation killswitches.MutationContext, operation killswitches.MutationOperation) error {
+		if operation == killswitches.MutationOperationDeactivate {
+			return nil
+		}
+		mode, err := mcptoolexecution.ResolveRolloutMode(ctx, features, string(mutation.OrganizationID))
+		if err != nil {
+			return fmt.Errorf("%w: resolve MCP killswitch rollout mode: %w", killswitches.ErrOperationUnavailable, err)
+		}
+		if mode != mcptoolexecution.RolloutModeEnforce {
+			return fmt.Errorf("%w: killswitch activation is not enabled for this organization", killswitches.ErrOperationUnavailable)
+		}
+		return nil
+	}
 }
 
 func Attach(mux goahttp.Muxer, service *Service) {
@@ -737,8 +763,7 @@ func mapError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var shareable *oops.ShareableError
-	if errors.As(err, &shareable) {
+	if _, ok := errors.AsType[*oops.ShareableError](err); ok {
 		return err
 	}
 	switch {

--- a/server/internal/killswitchapi/service_test.go
+++ b/server/internal/killswitchapi/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -103,6 +104,39 @@ func TestCustomerKillswitchLifecycleAndReadModels(t *testing.T) {
 	require.Equal(t, created.Version+1, lifted.Result.Version)
 	require.Empty(t, lifted.RemainingOverlaps)
 	require.False(t, lifted.Truncated)
+}
+
+func TestCustomerKillswitchRolloutGateBlocksActivationButAllowsLift(t *testing.T) {
+	t.Parallel()
+	service, _, orgID, userID, _ := newIntegrationService(t)
+	ctx := customerContext(t, orgID, userID)
+
+	payload := &gen.CreatePayload{
+		OperationID: uuid.NewString(), CapabilityKey: CapabilityMCPToolCalls, UserID: userID,
+		Scope: &gen.KillswitchScope{Type: "all_servers"}, Schedule: &gen.KillswitchSchedule{Start: "now", End: "until_lifted"},
+		ExternalNote: "Paused.", InternalNote: "Rollout gate test.",
+	}
+	created, err := service.Create(ctx, payload)
+	require.NoError(t, err)
+
+	flags, ok := service.features.(*feature.InMemory)
+	require.True(t, ok)
+	flags.SetFlag(feature.FlagMCPKillswitchEnforce, orgID, false)
+
+	replayed, err := service.Create(ctx, payload)
+	require.NoError(t, err)
+	require.True(t, replayed.Replayed)
+
+	_, err = service.Create(ctx, &gen.CreatePayload{
+		OperationID: uuid.NewString(), CapabilityKey: CapabilityMCPToolCalls, UserID: userID,
+		Scope: &gen.KillswitchScope{Type: "all_servers"}, Schedule: &gen.KillswitchSchedule{Start: "now", End: "until_lifted"},
+		ExternalNote: "Blocked.", InternalNote: "Must not activate while rollout is off.",
+	})
+	requireOops(t, err, oops.CodeUnavailable)
+
+	lifted, err := service.Lift(ctx, &gen.LiftPayload{OperationID: uuid.NewString(), ID: created.ID, ExpectedVersion: created.Version})
+	require.NoError(t, err)
+	require.Equal(t, created.Version+1, lifted.Result.Version)
 }
 
 func TestCustomerKillswitchOverlapResultsReportTruncation(t *testing.T) {
@@ -637,8 +671,7 @@ func requireServiceError(t *testing.T, err error, name string) {
 	var named goa.GoaErrorNamer
 	require.ErrorAs(t, err, &named)
 	require.Equal(t, name, named.GoaErrorName())
-	var conflict *gen.KillswitchConflict
-	if errors.As(err, &conflict) {
+	if conflict, ok := errors.AsType[*gen.KillswitchConflict](err); ok {
 		message := strings.ToLower(conflict.Message)
 		for _, internal := range []string{"prescription", "definition", "failure policy", "failure_policy"} {
 			require.NotContains(t, message, internal)

--- a/server/internal/killswitchapi/setup_test.go
+++ b/server/internal/killswitchapi/setup_test.go
@@ -14,6 +14,7 @@ import (
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -73,7 +74,12 @@ func newIntegrationServiceWithAdmin(t *testing.T, grantAdmin bool) (*Service, *p
 	}
 	registry, err := mcptoolexecution.NewRegistry(db)
 	require.NoError(t, err)
-	lifecycle, err := killswitches.NewLifecycleService(db, registry, mcptoolexecution.NewCustomerLifecycleValidator(), killswitches.NewAuditBeforeCommitHook(audit.NewLogger()))
+	features := &feature.InMemory{}
+	features.SetFlag(feature.FlagMCPKillswitchEnforce, orgID, true)
+	lifecycle, err := killswitches.NewLifecycleService(
+		db, registry, mcptoolexecution.NewCustomerLifecycleValidator(), killswitches.NewAuditBeforeCommitHook(audit.NewLogger()),
+		killswitches.WithBeforeApplyHook(rolloutBeforeApply(features)),
+	)
 	require.NoError(t, err)
 	facade, err := killswitches.NewFacade(lifecycle)
 	require.NoError(t, err)
@@ -84,7 +90,7 @@ func newIntegrationServiceWithAdmin(t *testing.T, grantAdmin bool) (*Service, *p
 	require.True(t, ok)
 	server, ok := registry.ResourceAdapter(mcptoolexecution.ResourceKindMCPServer)
 	require.True(t, ok)
-	return &Service{db: db, authorized: authorized, user: user, server: server}, db, orgID, userID, servers, authzEngine
+	return &Service{db: db, authorized: authorized, generic: facade, user: user, server: server, features: features}, db, orgID, userID, servers, authzEngine
 }
 
 func insertForeignServer(t *testing.T, db *pgxpool.Pool) uuid.UUID {

--- a/server/internal/killswitches/audit_test.go
+++ b/server/internal/killswitches/audit_test.go
@@ -219,6 +219,7 @@ func TestManagementAuditAndBreakGlassRemainAvailableDuringEvaluatorIncident(t *t
 	require.Equal(t, "user:customer-admin", rows[0].ActorID)
 	require.Equal(t, string(audit.SurfaceDashboard), rows[0].ActingSurface)
 	require.Equal(t, "user:platform-admin", rows[1].ActorID)
+	require.Equal(t, "platform-admin@example.com", rows[1].ActorDisplayName)
 	require.Equal(t, string(audit.SurfacePlatformBreakGlass), rows[1].ActingSurface)
 	require.Len(t, listOutboxMessages(t, conn, orgID), 2)
 }

--- a/server/internal/killswitches/lifecycle.go
+++ b/server/internal/killswitches/lifecycle.go
@@ -28,14 +28,31 @@ type LifecycleService struct {
 	db           *pgxpool.Pool
 	registry     *Registry
 	validator    LifecycleValidator
+	beforeApply  BeforeApplyHook
 	beforeCommit BeforeCommitHook
 }
 
-func NewLifecycleService(db *pgxpool.Pool, registry *Registry, validator LifecycleValidator, beforeCommit BeforeCommitHook) (*LifecycleService, error) {
+// BeforeApplyHook runs only for a newly claimed mutation receipt. Completed
+// operation replays bypass it, preserving durable idempotency during rollbacks.
+type BeforeApplyHook func(context.Context, MutationContext, MutationOperation) error
+
+type LifecycleOption func(*LifecycleService)
+
+func WithBeforeApplyHook(hook BeforeApplyHook) LifecycleOption {
+	return func(service *LifecycleService) { service.beforeApply = hook }
+}
+
+func NewLifecycleService(db *pgxpool.Pool, registry *Registry, validator LifecycleValidator, beforeCommit BeforeCommitHook, options ...LifecycleOption) (*LifecycleService, error) {
 	if db == nil || registry == nil || isNilInterface(validator) {
 		return nil, ErrInvalidArgument
 	}
-	return &LifecycleService{db: db, registry: registry, validator: validator, beforeCommit: beforeCommit}, nil
+	service := &LifecycleService{db: db, registry: registry, validator: validator, beforeCommit: beforeCommit}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service, nil
 }
 
 type mutationQueries struct {
@@ -319,6 +336,11 @@ func (s *LifecycleService) executeMutation(ctx context.Context, mutation Mutatio
 	}
 	if !fresh {
 		return replayOperation(receipt, operation, requestHash)
+	}
+	if s.beforeApply != nil {
+		if err := s.beforeApply(ctx, mutation, operation); err != nil {
+			return MutationResult{}, fmt.Errorf("before killswitch lifecycle apply: %w", err)
+		}
 	}
 
 	result, err := apply(mutationQueries{repo: queries, restricted: restricted})

--- a/server/internal/killswitches/mcptoolexecution/checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 )
@@ -34,11 +35,12 @@ type Checkpoint struct {
 	failurePolicy killswitches.FailurePolicy
 	timeout       time.Duration
 	recorder      IdentityCoverageRecorder
+	flags         feature.Provider
 }
 
 // NewCheckpoint builds the private MCP tool-execution checkpoint
 // from the registered adapters and authoritative PostgreSQL evaluator.
-func NewCheckpoint(db *pgxpool.Pool, timeout time.Duration, meterProvider metric.MeterProvider, logger *slog.Logger) (*Checkpoint, error) {
+func NewCheckpoint(db *pgxpool.Pool, timeout time.Duration, meterProvider metric.MeterProvider, logger *slog.Logger, flags feature.Provider) (*Checkpoint, error) {
 	registry, err := NewRegistry(db)
 	if err != nil {
 		return nil, err
@@ -47,10 +49,10 @@ func NewCheckpoint(db *pgxpool.Pool, timeout time.Duration, meterProvider metric
 	if err != nil {
 		return nil, fmt.Errorf("build mcp tool-execution evaluator: %w", err)
 	}
-	return newCheckpoint(registry, evaluation, timeout)
+	return newCheckpoint(registry, evaluation, timeout, flags)
 }
 
-func newCheckpoint(registry *killswitches.Registry, evaluation evaluator, timeout time.Duration) (*Checkpoint, error) {
+func newCheckpoint(registry *killswitches.Registry, evaluation evaluator, timeout time.Duration, flags feature.Provider) (*Checkpoint, error) {
 	if registry == nil {
 		return nil, errors.New("mcp tool-execution registry is required")
 	}
@@ -85,6 +87,7 @@ func newCheckpoint(registry *killswitches.Registry, evaluation evaluator, timeou
 		failurePolicy: coverage.FailurePolicy,
 		timeout:       timeout,
 		recorder:      nil,
+		flags:         flags,
 	}, nil
 }
 
@@ -108,6 +111,12 @@ func (c *Checkpoint) Evaluate(ctx context.Context, organizationID, mcpServerID s
 		return killswitches.NewInfrastructureRejectionDisposition(), errors.New("mcp tool-execution checkpoint is unavailable")
 	}
 
+	return evaluateForRollout(ctx, c.flags, organizationID, func() (killswitches.TransportDisposition, error) {
+		return c.evaluate(ctx, organizationID, mcpServerID)
+	})
+}
+
+func (c *Checkpoint) evaluate(ctx context.Context, organizationID, mcpServerID string) (killswitches.TransportDisposition, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 

--- a/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -35,6 +36,12 @@ func (e *fixedEvaluator) Evaluate(context.Context, killswitches.EvaluationReques
 	return e.result
 }
 
+func enforcedRollout(organizationID string) *feature.InMemory {
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagMCPKillswitchEnforce, organizationID, true)
+	return flags
+}
+
 func TestCheckpointEvaluatesEveryCoveredCallWithRealEvaluator(t *testing.T) {
 	t.Parallel()
 	conn, orgID := newTestDatabase(t, "ks_mcp_checkpoint")
@@ -43,7 +50,7 @@ func TestCheckpointEvaluatesEveryCoveredCallWithRealEvaluator(t *testing.T) {
 	realEvaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
 	require.NoError(t, err)
 	counted := &countingEvaluator{delegate: realEvaluator}
-	checkpoint, err := newCheckpoint(registry, counted, time.Second)
+	checkpoint, err := newCheckpoint(registry, counted, time.Second, enforcedRollout(orgID))
 	require.NoError(t, err)
 
 	userID := "user_" + uuid.NewString()
@@ -112,7 +119,7 @@ func TestCheckpointPreservesUnsupportedIdentityAndFailsClosedOnCoverageFailure(t
 	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
 	require.NoError(t, err)
 	evaluation := &fixedEvaluator{result: noMatch}
-	checkpoint, err := newCheckpoint(registry, evaluation, time.Second)
+	checkpoint, err := newCheckpoint(registry, evaluation, time.Second, enforcedRollout(orgID))
 	require.NoError(t, err)
 
 	projectID := insertProject(t, conn, orgID, "unsupported-identity", nil)
@@ -215,7 +222,7 @@ func TestCheckpointReturnsEvaluatorInfrastructureFailureWithoutMatch(t *testing.
 	failure, err := killswitches.NewInfrastructureFailureResult(cause)
 	require.NoError(t, err)
 	evaluation := &fixedEvaluator{result: failure}
-	checkpoint, err := newCheckpoint(registry, evaluation, time.Second)
+	checkpoint, err := newCheckpoint(registry, evaluation, time.Second, enforcedRollout(orgID))
 	require.NoError(t, err)
 
 	userID := "user_" + uuid.NewString()

--- a/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
@@ -204,6 +204,7 @@ func TestCheckpointBoundsAllIdentityAndResourceResolution(t *testing.T) {
 		transport:     killswitches.ResolveTransportDisposition,
 		failurePolicy: killswitches.FailurePolicyFailClosed,
 		timeout:       20 * time.Millisecond,
+		flags:         enforcedRollout("org_example"),
 	}
 	ctx := testIdentityContext(t, mcpidentity.KindUserSession, "user_example")
 	started := time.Now()

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -30,7 +30,7 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
 	source := ServerSource{FrontingServerID: uuid.NullUUID{UUID: serverID, Valid: true}}
 	recorder := &coverageRecorder{}
-	checkpoint, err := NewHostedCheckpoint(conn, testenv.NewMeterProvider(t), testenv.NewLogger(t), recorder)
+	checkpoint, err := NewHostedCheckpoint(conn, testenv.NewMeterProvider(t), testenv.NewLogger(t), recorder, enforcedRollout(orgID))
 	require.NoError(t, err)
 	ctx := testIdentityContext(t, mcpidentity.KindUserSession, userID)
 

--- a/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 )
@@ -27,11 +28,12 @@ type HostedCheckpoint struct {
 	failurePolicy killswitches.FailurePolicy
 	recorder      IdentityCoverageRecorder
 	logger        *slog.Logger
+	flags         feature.Provider
 }
 
 // NewHostedCheckpoint builds the production checkpoint from the registered M2
 // contracts and the authoritative PostgreSQL evaluator.
-func NewHostedCheckpoint(db *pgxpool.Pool, meterProvider metric.MeterProvider, logger *slog.Logger, recorder IdentityCoverageRecorder) (*HostedCheckpoint, error) {
+func NewHostedCheckpoint(db *pgxpool.Pool, meterProvider metric.MeterProvider, logger *slog.Logger, recorder IdentityCoverageRecorder, flags feature.Provider) (*HostedCheckpoint, error) {
 	registry, err := NewRegistry(db)
 	if err != nil {
 		return nil, err
@@ -67,12 +69,23 @@ func NewHostedCheckpoint(db *pgxpool.Pool, meterProvider metric.MeterProvider, l
 		failurePolicy: definition.FailurePolicy,
 		recorder:      recorder,
 		logger:        logger,
+		flags:         flags,
 	}, nil
 }
 
 // Evaluate revalidates principal membership and server ownership on every call.
 // Unsupported identities and resources remain outside M2 and continue unchanged.
 func (c *HostedCheckpoint) Evaluate(ctx context.Context, organizationID string, resourceSource ServerSource) (killswitches.TransportDisposition, error) {
+	if c == nil {
+		return killswitches.NewInfrastructureRejectionDisposition(), errors.New("hosted MCP killswitch checkpoint is unavailable")
+	}
+
+	return evaluateForRollout(ctx, c.flags, organizationID, func() (killswitches.TransportDisposition, error) {
+		return c.evaluate(ctx, organizationID, resourceSource)
+	})
+}
+
+func (c *HostedCheckpoint) evaluate(ctx context.Context, organizationID string, resourceSource ServerSource) (killswitches.TransportDisposition, error) {
 	organization := killswitches.OrganizationID(organizationID)
 	evaluationCtx, cancel := context.WithTimeout(ctx, hostedEvaluatorTimeout)
 	defer cancel()

--- a/server/internal/killswitches/mcptoolexecution/rollout.go
+++ b/server/internal/killswitches/mcptoolexecution/rollout.go
@@ -1,0 +1,64 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+// RolloutMode controls whether an organization skips evaluation, observes it
+// without transport enforcement, or enforces the authoritative result.
+type RolloutMode uint8
+
+const (
+	RolloutModeOff RolloutMode = iota
+	RolloutModeShadow
+	RolloutModeEnforce
+)
+
+// ResolveRolloutMode uses only locally cached feature-flag state so the serving
+// path never adds a remote feature-provider dependency. Missing, disabled, or
+// indeterminate flags fail safe to off. Enforce wins if both flags are enabled.
+func ResolveRolloutMode(ctx context.Context, flags feature.Provider, organizationID string) (RolloutMode, error) {
+	if flags == nil {
+		return RolloutModeOff, nil
+	}
+
+	enforce, err := flags.IsFlagEnabledLocal(ctx, feature.FlagMCPKillswitchEnforce, organizationID, nil, nil)
+	if err != nil {
+		return RolloutModeOff, fmt.Errorf("resolve MCP killswitch enforce flag: %w", err)
+	}
+	if enforce {
+		return RolloutModeEnforce, nil
+	}
+
+	shadow, err := flags.IsFlagEnabledLocal(ctx, feature.FlagMCPKillswitchShadow, organizationID, nil, nil)
+	if err != nil {
+		return RolloutModeOff, fmt.Errorf("resolve MCP killswitch shadow flag: %w", err)
+	}
+	if shadow {
+		return RolloutModeShadow, nil
+	}
+
+	return RolloutModeOff, nil
+}
+
+func evaluateForRollout(
+	ctx context.Context,
+	flags feature.Provider,
+	organizationID string,
+	evaluate func() (killswitches.TransportDisposition, error),
+) (killswitches.TransportDisposition, error) {
+	mode, err := ResolveRolloutMode(ctx, flags, organizationID)
+	if err != nil || mode == RolloutModeOff {
+		return killswitches.NewContinueDisposition(), nil
+	}
+
+	disposition, evaluationErr := evaluate()
+	if mode == RolloutModeShadow {
+		return killswitches.NewContinueDisposition(), nil
+	}
+	return disposition, evaluationErr
+}

--- a/server/internal/killswitches/mcptoolexecution/rollout.go
+++ b/server/internal/killswitches/mcptoolexecution/rollout.go
@@ -19,8 +19,8 @@ const (
 )
 
 // ResolveRolloutMode uses only locally cached feature-flag state so the serving
-// path never adds a remote feature-provider dependency. Missing, disabled, or
-// indeterminate flags fail safe to off. Enforce wins if both flags are enabled.
+// path never adds a remote feature-provider dependency. Missing or disabled
+// flags resolve to off. Enforce wins if both flags are enabled.
 func ResolveRolloutMode(ctx context.Context, flags feature.Provider, organizationID string) (RolloutMode, error) {
 	if flags == nil {
 		return RolloutModeOff, nil
@@ -52,7 +52,10 @@ func evaluateForRollout(
 	evaluate func() (killswitches.TransportDisposition, error),
 ) (killswitches.TransportDisposition, error) {
 	mode, err := ResolveRolloutMode(ctx, flags, organizationID)
-	if err != nil || mode == RolloutModeOff {
+	if err != nil {
+		return killswitches.NewInfrastructureRejectionDisposition(), fmt.Errorf("resolve MCP killswitch rollout mode: %w", err)
+	}
+	if mode == RolloutModeOff {
 		return killswitches.NewContinueDisposition(), nil
 	}
 

--- a/server/internal/killswitches/mcptoolexecution/rollout_test.go
+++ b/server/internal/killswitches/mcptoolexecution/rollout_test.go
@@ -1,0 +1,105 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type failingRolloutProvider struct{ feature.InMemory }
+
+func (*failingRolloutProvider) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+	return false, errors.New("local flag state unavailable")
+}
+
+func TestResolveRolloutMode(t *testing.T) {
+	t.Parallel()
+
+	const organizationID = "org_test"
+	flags := &feature.InMemory{}
+
+	mode, err := ResolveRolloutMode(t.Context(), nil, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, RolloutModeOff, mode)
+
+	mode, err = ResolveRolloutMode(t.Context(), flags, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, RolloutModeOff, mode)
+
+	flags.SetFlag(feature.FlagMCPKillswitchShadow, organizationID, true)
+	mode, err = ResolveRolloutMode(t.Context(), flags, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, RolloutModeShadow, mode)
+
+	flags.SetFlag(feature.FlagMCPKillswitchEnforce, organizationID, true)
+	mode, err = ResolveRolloutMode(t.Context(), flags, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, RolloutModeEnforce, mode)
+
+	mode, err = ResolveRolloutMode(t.Context(), &failingRolloutProvider{}, organizationID)
+	require.Error(t, err)
+	require.Equal(t, RolloutModeOff, mode)
+}
+
+func TestEvaluateForRolloutFailsSafeWithoutEvaluation(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	disposition, err := evaluateForRollout(t.Context(), &failingRolloutProvider{}, "org_test", func() (killswitches.TransportDisposition, error) {
+		called = true
+		return killswitches.NewInfrastructureRejectionDisposition(), errors.New("must not run")
+	})
+	require.NoError(t, err)
+	require.False(t, called)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+}
+
+func TestCheckpointTransitionsFromOffToShadowToEnforce(t *testing.T) {
+	t.Parallel()
+
+	conn, orgID := newTestDatabase(t, "ks_mcp_rollout")
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	realEvaluator, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
+	require.NoError(t, err)
+	counted := &countingEvaluator{delegate: realEvaluator}
+	flags := &feature.InMemory{}
+	checkpoint, err := newCheckpoint(registry, counted, time.Second, flags)
+	require.NoError(t, err)
+
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	projectID := insertProject(t, conn, orgID, "rollout", nil)
+	serverID := insertMCPServer(t, conn, orgID, projectID, nil)
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID: uuid.New(), PrincipalKey: userID, Scope: "all", ExternalNote: "Paused during rollout.",
+	})
+	ctx := testIdentityContext(t, mcpidentity.KindUserSession, userID)
+
+	disposition, err := checkpoint.Evaluate(ctx, orgID, serverID.String())
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+	require.Zero(t, counted.calls, "off mode must not query the evaluator")
+
+	flags.SetFlag(feature.FlagMCPKillswitchShadow, orgID, true)
+	disposition, err = checkpoint.Evaluate(ctx, orgID, serverID.String())
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+	require.Equal(t, 1, counted.calls, "shadow mode must evaluate without denying")
+
+	flags.SetFlag(feature.FlagMCPKillswitchEnforce, orgID, true)
+	disposition, err = checkpoint.Evaluate(ctx, orgID, serverID.String())
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionMatchedDenial, disposition.Kind())
+	require.Equal(t, 2, counted.calls)
+}

--- a/server/internal/killswitches/mcptoolexecution/rollout_test.go
+++ b/server/internal/killswitches/mcptoolexecution/rollout_test.go
@@ -50,17 +50,17 @@ func TestResolveRolloutMode(t *testing.T) {
 	require.Equal(t, RolloutModeOff, mode)
 }
 
-func TestEvaluateForRolloutFailsSafeWithoutEvaluation(t *testing.T) {
+func TestEvaluateForRolloutFailsClosedWithoutEvaluation(t *testing.T) {
 	t.Parallel()
 
 	called := false
 	disposition, err := evaluateForRollout(t.Context(), &failingRolloutProvider{}, "org_test", func() (killswitches.TransportDisposition, error) {
 		called = true
-		return killswitches.NewInfrastructureRejectionDisposition(), errors.New("must not run")
+		return killswitches.NewContinueDisposition(), nil
 	})
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "local flag state unavailable")
 	require.False(t, called)
-	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
 }
 
 func TestCheckpointTransitionsFromOffToShadowToEnforce(t *testing.T) {

--- a/server/internal/killswitches/platform_service.go
+++ b/server/internal/killswitches/platform_service.go
@@ -122,7 +122,7 @@ func (s *PlatformService) ActivatePrescription(ctx context.Context, payload *gen
 		prescriptionID = &value
 	}
 	result, err := generic.ActivatePrescription(ctx, ActivatePrescriptionInput{
-		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.email, OperationID: operationID},
+		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.displayName, OperationID: operationID},
 		PrescriptionID:  prescriptionID, ExpectedVersion: payload.ExpectedVersion,
 		Definition: DefinitionKey(conv.PtrValOrEmpty(payload.Definition, "")), PrincipalKind: PrincipalKind(conv.PtrValOrEmpty(payload.PrincipalKind, "")), PrincipalInput: conv.PtrValOrEmpty(payload.PrincipalInput, ""),
 		ResourceKind: ResourceKind(conv.PtrValOrEmpty(payload.ResourceKind, "")), Desired: desired,
@@ -151,7 +151,7 @@ func (s *PlatformService) ChangePrescription(ctx context.Context, payload *gen.C
 		return nil, err
 	}
 	result, err := generic.ChangePrescription(ctx, ChangePrescriptionRequest{
-		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.email, OperationID: operationID},
+		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.displayName, OperationID: operationID},
 		PrescriptionID:  PrescriptionID(payload.PrescriptionID), ExpectedVersion: payload.ExpectedVersion, Desired: desired,
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func (s *PlatformService) DeactivatePrescription(ctx context.Context, payload *g
 		return nil, badPlatformRequest(err)
 	}
 	result, err := generic.DeactivatePrescription(ctx, DeactivatePrescriptionRequest{
-		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.email, OperationID: operationID},
+		MutationContext: MutationContext{OrganizationID: OrganizationID(payload.OrganizationID), ActorUserID: actor.userID, ActorDisplayName: actor.displayName, OperationID: operationID},
 		PrescriptionID:  PrescriptionID(payload.PrescriptionID), ExpectedVersion: payload.ExpectedVersion,
 	})
 	if err != nil {
@@ -234,17 +234,23 @@ func (s *PlatformService) ListPrescriptions(ctx context.Context, payload *gen.Li
 }
 
 type platformActor struct {
-	userID string
-	email  string
+	userID      string
+	displayName string
 }
 
 func (s *PlatformService) authorize(ctx context.Context) (context.Context, platformActor, error) {
-	authCtx, _, err := gramauth.RequireFreshPlatformAdminSession(ctx, s.logger, s.sessions)
+	authCtx, displayName, _, err := gramauth.RequireFreshPlatformAdminSession(ctx, s.logger, s.sessions)
 	if err != nil {
 		return ctx, platformActor{}, fmt.Errorf("authorize platform killswitch request: %w", err)
 	}
+
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" {
+		displayName = strings.TrimSpace(*authCtx.Email)
+	}
+
 	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfacePlatformBreakGlass))
-	return ctx, platformActor{userID: authCtx.UserID, email: strings.TrimSpace(*authCtx.Email)}, nil
+	return ctx, platformActor{userID: authCtx.UserID, displayName: displayName}, nil
 }
 
 func (s *PlatformService) configuredGeneric() (GenericService, error) {
@@ -258,8 +264,7 @@ func mapPlatformLifecycleError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var shareable *oops.ShareableError
-	if errors.As(err, &shareable) {
+	if _, ok := errors.AsType[*oops.ShareableError](err); ok {
 		return err
 	}
 	switch {

--- a/server/internal/killswitches/platform_service_test.go
+++ b/server/internal/killswitches/platform_service_test.go
@@ -22,24 +22,25 @@ import (
 )
 
 type platformAdminReaderStub struct {
-	results []bool
-	err     error
-	calls   []string
+	results     []bool
+	err         error
+	calls       []string
+	displayName string
 }
 
-func (s *platformAdminReaderStub) IsPlatformAdmin(_ context.Context, userID string) (bool, error) {
+func (s *platformAdminReaderStub) GetPlatformAdminIdentity(_ context.Context, userID string) (bool, string, error) {
 	s.calls = append(s.calls, userID)
 	if s.err != nil {
-		return false, s.err
+		return false, "", s.err
 	}
 	if len(s.results) == 0 {
-		return false, nil
+		return false, "", nil
 	}
 	result := s.results[0]
 	if len(s.results) > 1 {
 		s.results = s.results[1:]
 	}
-	return result, nil
+	return result, s.displayName, nil
 }
 
 type platformGenericStub struct {
@@ -98,7 +99,7 @@ func TestPlatformServiceDelegatesAllSixOperationsWithExplicitTargetAndSessionAct
 	t.Parallel()
 
 	generic := &platformGenericStub{}
-	admins := &platformAdminReaderStub{results: []bool{true}}
+	admins := &platformAdminReaderStub{results: []bool{true}, displayName: "Platform Operator"}
 	service := &PlatformService{logger: testenv.NewLogger(t), sessions: admins, generic: generic}
 	ctx := validatedCustomerContext(t, "", "actor_user", " actor@example.com ")
 
@@ -114,9 +115,11 @@ func TestPlatformServiceDelegatesAllSixOperationsWithExplicitTargetAndSessionAct
 	require.Equal(t, OrganizationID("org_target"), generic.get.OrganizationID)
 	require.Equal(t, OrganizationID("org_target"), generic.list.OrganizationID)
 	require.Equal(t, "actor_user", generic.activate.ActorUserID)
-	require.Equal(t, "actor@example.com", generic.activate.ActorDisplayName)
+	require.Equal(t, "Platform Operator", generic.activate.ActorDisplayName)
 	require.Equal(t, "actor_user", generic.change.ActorUserID)
+	require.Equal(t, "Platform Operator", generic.change.ActorDisplayName)
 	require.Equal(t, "actor_user", generic.deactivate.ActorUserID)
+	require.Equal(t, "Platform Operator", generic.deactivate.ActorDisplayName)
 	require.Equal(t, []string{
 		string(audit.SurfacePlatformBreakGlass), string(audit.SurfacePlatformBreakGlass), string(audit.SurfacePlatformBreakGlass),
 		string(audit.SurfacePlatformBreakGlass), string(audit.SurfacePlatformBreakGlass), string(audit.SurfacePlatformBreakGlass),

--- a/server/internal/mcp/assistant_resolver_integration_test.go
+++ b/server/internal/mcp/assistant_resolver_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	externalmcp_types "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testmcp"
@@ -42,6 +43,7 @@ func TestServePublic_AssistantTokenResolvesOwnerRemoteSessionToUpstream(t *testi
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
+	ti.features.SetFlag(feature.FlagMCPKillswitchShadow, authCtx.ActiveOrganizationID, true)
 
 	mockTools := []testmcp.Tool{{
 		Name:        "ping",

--- a/server/internal/mcp/hosted_killswitch_test.go
+++ b/server/internal/mcp/hosted_killswitch_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -29,6 +30,7 @@ func TestServePublic_HostedToolsCallKillswitch(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 	require.NotEmpty(t, authCtx.UserID)
+	ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 
 	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "killswitch-"+uuid.NewString()[:8])
 	endpointSlug := "killswitch-" + uuid.NewString()

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -340,7 +340,7 @@ func NewService(
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/mcp")
 	logger = logger.With(attr.SlogComponent("mcp"))
 	metrics := mcpmetrics.NewMetrics(meter, logger)
-	hostedToolsCallCheckpoint, err := mcptoolexecution.NewHostedCheckpoint(db, meterProvider, logger, metrics)
+	hostedToolsCallCheckpoint, err := mcptoolexecution.NewHostedCheckpoint(db, meterProvider, logger, metrics, features)
 	if err != nil {
 		return nil, fmt.Errorf("initialize hosted MCP kill-switch checkpoint: %w", err)
 	}

--- a/server/internal/mcp/internal_tools_call_coverage_test.go
+++ b/server/internal/mcp/internal_tools_call_coverage_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -52,6 +53,7 @@ func TestServePublic_RecordsCanonicalServerCoverage(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
+	ti.features.SetFlag(feature.FlagMCPKillswitchShadow, authCtx.ActiveOrganizationID, true)
 
 	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "routed-coverage-"+uuid.NewString()[:8])
 	endpointSlug := "routed-coverage-" + uuid.NewString()

--- a/server/internal/mcp/killswitch_acceptance_test.go
+++ b/server/internal/mcp/killswitch_acceptance_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	environmentsrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/killswitchapi"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
@@ -129,6 +130,8 @@ func newKillswitchAcceptanceFixture(t *testing.T) (context.Context, *killswitchA
 	require.NotNil(t, authCtx.ProjectID)
 	require.NotNil(t, authCtx.Email)
 
+	ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
+
 	selectors, err := authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID).MarshalJSON()
 	require.NoError(t, err)
 	_, err = accessrepo.New(ti.conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
@@ -139,7 +142,7 @@ func newKillswitchAcceptanceFixture(t *testing.T) (context.Context, *killswitchA
 	})
 	require.NoError(t, err)
 
-	management, err := killswitchapi.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, ti.authzEngine, ti.audit)
+	management, err := killswitchapi.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, ti.authzEngine, ti.audit, ti.features)
 	require.NoError(t, err)
 	return ctx, &killswitchAcceptanceFixture{ti: ti, management: management, auth: authCtx}
 }
@@ -671,7 +674,7 @@ func TestKillswitchAcceptancePrivateRemoteAndTunnelProductionComposition(t *test
 			noMatchAfter := f.captureNoMatchResponses(t, target, postActivationSession)
 			require.Equal(t, noMatchBefore, noMatchAfter, "initialize and list methods outside tools/call must remain byte-for-byte unchanged")
 
-			checkpoint, err := mcptoolexecution.NewCheckpoint(f.ti.conn, mcptoolexecution.DefaultEvaluationTimeout, testenv.NewMeterProvider(t), f.ti.logger)
+			checkpoint, err := mcptoolexecution.NewCheckpoint(f.ti.conn, mcptoolexecution.DefaultEvaluationTimeout, testenv.NewMeterProvider(t), f.ti.logger, f.ti.features)
 			require.NoError(t, err)
 			unsupportedCtx := mcpidentity.NewValidatorBoundary().StampAPIKey(t.Context())
 			disposition, err := checkpoint.Evaluate(unsupportedCtx, f.auth.ActiveOrganizationID, target.server.ID.String())

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -287,6 +287,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	features := &feature.InMemory{}
+	features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -287,7 +287,6 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	features := &feature.InMemory{}
-	features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -286,7 +286,8 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger)
+	features := &feature.InMemory{}
+	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)
 	managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemService)
@@ -309,7 +310,6 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 		),
 	})
 	tunnelRoutes := route.NewRouteTable()
-	features := &feature.InMemory{}
 	svc, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, mcpCache, guardianPolicy, funcs, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, featClient.PlatformFeatureCheck, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
 	require.NoError(t, err)
 

--- a/server/internal/thirdparty/posthog/posthog.go
+++ b/server/internal/thirdparty/posthog/posthog.go
@@ -200,7 +200,6 @@ func (p *Posthog) evaluateLocalFlag(flag feature.Flag, distinctID string, groups
 
 func (p *Posthog) IsFlagEnabledLocal(ctx context.Context, flag feature.Flag, distinctID string, groups, personProperties map[string]string) (bool, error) {
 	if p.disabled {
-		p.logger.InfoContext(ctx, "posthog is disabled, returning false")
 		return false, nil
 	}
 	if !p.localEvaluation {
@@ -231,11 +230,8 @@ func (p *Posthog) IsFlagEnabledLocal(ctx context.Context, flag feature.Flag, dis
 		return false, fmt.Errorf("failed to locally check feature flag: %w", err)
 	}
 
-	j, err := json.Marshal(flagState)
-	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal feature flag: %w", err)
-	}
-	return string(j) == "true", nil
+	enabled, ok := flagState.(bool)
+	return ok && enabled, nil
 }
 
 func (p *Posthog) FlagPayload(ctx context.Context, flag feature.Flag, distinctID string, groups map[string]string) ([]byte, error) {

--- a/server/internal/xmcp/serveruntime_test.go
+++ b/server/internal/xmcp/serveruntime_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -754,6 +755,7 @@ func TestServeMCP_IssuerGatedToolsetBackend_Killswitch(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 	require.NotEmpty(t, authCtx.UserID)
+	ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 
 	slug, mcpServer, issuerID := seedIssuerGatedToolsetMCPEndpoint(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "public")
 	mcpEndpoint, err := mcpendpointsrepo.New(ti.conn).GetMCPEndpointByCustomDomainAndSlug(ctx, mcpendpointsrepo.GetMCPEndpointByCustomDomainAndSlugParams{
@@ -842,6 +844,7 @@ func TestServeMCP_IssuerGatedRemoteBackend_PrivateKillswitch(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 	require.NotEmpty(t, authCtx.UserID)
+	ti.features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 
 	upstreamCalled := make(chan struct{}, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -157,6 +158,9 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	features := &feature.InMemory{}
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -103,6 +102,7 @@ type testInstance struct {
 	shadowMCPClient *shadowmcp.Client
 	cacheAdapter    cache.Cache
 	serverURL       *url.URL
+	features        *feature.InMemory
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -158,9 +158,6 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	features := &feature.InMemory{}
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-	features.SetFlag(feature.FlagMCPKillswitchEnforce, authCtx.ActiveOrganizationID, true)
 	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)
@@ -187,6 +184,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		shadowMCPClient: shadowMCPClient,
 		cacheAdapter:    cacheAdapter,
 		serverURL:       serverURL,
+		features:        features,
 	}
 }
 

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -156,10 +156,11 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, tracerProvider, meterProvider, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger)
+	features := &feature.InMemory{}
+	mcpToolExecutionCheckpoint, err := mcptoolexecution.NewCheckpoint(conn, mcptoolexecution.DefaultEvaluationTimeout, meterProvider, logger, features)
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)
-	mcpService, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, &feature.InMemory{}, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
+	mcpService, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, features, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},


### PR DESCRIPTION
## Summary

- add default-off server-side off, shadow, and enforce modes for authenticated MCP tool-call evaluation
- gate fresh activation and change mutations while preserving completed operation replay and break-glass deactivation
- document fleet readiness, bounded telemetry, incident response, rollback, and exact M2 coverage limits
- cover rollout transitions, management gating, and idempotent replay; targeted Killswitch and MCP tests pass

Closes [DNO-987](https://linear.app/speakeasy/issue/DNO-987/docs-gate-and-operate-the-mcp-killswitch-rollout)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a default-off server-side rollout gate for authenticated MCP tool-call Killswitch evaluation. Previously evaluation ran unconditionally and prescriptions could be activated at any time; activation and edits are now blocked outside enforce mode, while deactivation and completed replays stay available.

**Rollout modes**
- Evaluation runs only in shadow or enforce; shadow measures telemetry without denying and off mode never queries the evaluator.
- Missing, unavailable, or indeterminate local flags fail safe to off, and the serving path never makes a remote PostHog request.
- Enforce takes precedence when both flags are enabled, and replays of completed operations bypass the gate.

**Operational guidance**
- Adds rollout and evaluator-incident runbooks covering fleet-readiness checks, shadow thresholds, Datadog monitors, break-glass rules, and rollback criteria.
- Covers only `tools/call` for an active organization user and canonical organization-owned server on hosted dispatch and private proxy.
- Platform break-glass management now shares the validated lifecycle so list and deactivation work when rollout enforcement is off, and audit records use the actor display name from the authoritative user row.

Closes DNO-987.

<sup>Written for commit 55e866a162c820d21b340914bcb4e87ce4720378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

