### PR TITLE
fix: evict dead tunnel routes so offline tunnels 404 instead of 502

### DIFF
--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -115,6 +115,7 @@ func (m *tunnelManager) buildProxy(
 		}
 		return nil
 	}
+	p.ForwardErrorRetryer = tunnelrouting.DeadDialRetryer(logger, m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	// Redirects won't work across a tunnel boundary; disable.
 	p.DisableRedirects = true
 	p.GuardianClientOptions = m.guardianClientOptions()

--- a/server/internal/mcp/tunnelrouting/routing.go
+++ b/server/internal/mcp/tunnelrouting/routing.go
@@ -7,12 +7,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/tunnel/route"
 	"github.com/speakeasy-api/gram/tunnel/wire"
@@ -167,6 +171,47 @@ func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forw
 		addr, ok := SelectRoute(clientAffinityKey, candidates, exclude)
 		if !ok {
 			return nil, nil
+		}
+		gatewayURL, err := GatewayURL(addr)
+		if err != nil {
+			return nil, fmt.Errorf("build tunnel retry route URL: %w", err)
+		}
+		return &proxy.UpstreamResponseRetry{
+			RemoteURL: gatewayURL,
+			Headers:   Headers(tunnelID, forwardToken, clientAffinityKey),
+		}, nil
+	}
+}
+
+// DeadDialRetryer returns the tunnel-specific policy for forwards that fail
+// before any gateway response arrives. A dead-peer dial failure means the
+// selected route points at a gateway that no longer exists (e.g. a pod that
+// died without unpublishing), so the route is evicted for every subsequent
+// request rather than left to burn down its TTL one 3-second dial at a time.
+// The request never left gram-server, so replay against another candidate is
+// safe for any method; when no candidate remains the dead tunnel surfaces as
+// the same CodeNotFound that route selection uses for tunnels with no live
+// route: a customer-side outage, not platform 5xx budget.
+func DeadDialRetryer(logger *slog.Logger, routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forwardToken string) proxy.ForwardErrorRetryer {
+	return func(ctx context.Context, forwardErr error) (*proxy.UpstreamResponseRetry, error) {
+		if !guardian.IsDeadPeerDialError(forwardErr) {
+			return nil, nil
+		}
+
+		if selectedAddr != "" {
+			if err := routes.Unpublish(ctx, tunnelID, selectedAddr); err != nil {
+				return nil, fmt.Errorf("unpublish dead tunnel route: %w", err)
+			}
+		}
+
+		candidates, err := routes.Candidates(ctx, tunnelID)
+		if err != nil {
+			return nil, fmt.Errorf("list tunnel retry routes: %w", err)
+		}
+		addr, ok := SelectRoute(clientAffinityKey, candidates, map[string]struct{}{selectedAddr: {}})
+		if !ok {
+			return nil, oops.E(oops.CodeNotFound, forwardErr, "not found").
+				LogWarn(ctx, logger.With(attr.SlogErrorMessage("tunnel gateway is unreachable")))
 		}
 		gatewayURL, err := GatewayURL(addr)
 		if err != nil {

--- a/server/internal/mcp/tunnelrouting/routing_test.go
+++ b/server/internal/mcp/tunnelrouting/routing_test.go
@@ -3,14 +3,20 @@ package tunnelrouting
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"net"
 	"net/http"
+	"net/url"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/tunnel/route"
 	"github.com/speakeasy-api/gram/tunnel/wire"
 )
@@ -267,4 +273,68 @@ func headerValue(t *testing.T, headers []proxy.ConfiguredHeader, name string) st
 func expectedAffinity(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return "auth:" + hex.EncodeToString(sum[:])
+}
+
+func deadDialError() error {
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED}
+	return fmt.Errorf("proxy post: %w", &url.Error{Op: "Post", URL: "http://127.0.0.1:1001", Err: dialErr})
+}
+
+func TestDeadDialRetryerEvictsRouteAndFailsOver(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1002", time.Minute))
+
+	retryer := DeadDialRetryer(testenv.NewLogger(t), routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")
+	retry, err := retryer(ctx, deadDialError())
+	require.NoError(t, err)
+	require.NotNil(t, retry)
+	require.Equal(t, "http://127.0.0.1:1002", retry.RemoteURL)
+	require.Equal(t, "tunnel-1", headerValue(t, retry.Headers, wire.HeaderTunnelID))
+	require.Equal(t, "forward-token", headerValue(t, retry.Headers, wire.HeaderTunnelForwardToken))
+	require.Equal(t, "auth:stable", headerValue(t, retry.Headers, wire.HeaderTunnelConsumerSession))
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"127.0.0.1:1002"}, candidates)
+}
+
+func TestDeadDialRetryerLastRouteEvictsAndReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+
+	retryer := DeadDialRetryer(testenv.NewLogger(t), routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")
+	retry, err := retryer(ctx, deadDialError())
+	require.Nil(t, retry)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}
+
+func TestDeadDialRetryerIgnoresNonDialErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+
+	readErr := fmt.Errorf("proxy post: %w", &url.Error{Op: "Post", URL: "http://127.0.0.1:1001", Err: &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}})
+	retryer := DeadDialRetryer(testenv.NewLogger(t), routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")
+	retry, err := retryer(ctx, readErr)
+	require.NoError(t, err)
+	require.Nil(t, retry)
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"127.0.0.1:1001"}, candidates)
 }

--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -29,22 +29,47 @@ var ErrUndecodableJSONRPCBody = errors.New("upstream response is not a json-rpc 
 // supported") rather than a generic decode failure.
 var ErrBatchRequest = errors.New("batch requests are not supported")
 
+// classifiedForwardError keeps a transport failure unlogged while retry policy
+// decides whether it is recoverable. It unwraps to the client-facing error so
+// retryers can still inspect the original transport cause.
+type classifiedForwardError struct {
+	err *oops.ShareableError
+}
+
+func (e *classifiedForwardError) Error() string {
+	return e.err.Error()
+}
+
+func (e *classifiedForwardError) Unwrap() error {
+	return e.err
+}
+
 // classifyForwardError maps a [http.Client.Do] failure into a typed proxy
 // error. timedOut is true when the failure was caused by the proxy's own
 // phase-1 timer firing (vs. a parent-context cancellation from the user
 // disconnecting); both surface the same context.Canceled in the http
 // error chain so the caller distinguishes via the timer's Stop() return.
-func (p *Proxy) classifyForwardError(ctx context.Context, err error, timedOut bool) error {
+func classifyForwardError(err error, timedOut bool) error {
+	var classified *oops.ShareableError
 	switch {
 	case timedOut:
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
+		classified = oops.E(oops.CodeGatewayError, err, "remote mcp server timed out")
 	case errors.Is(err, context.DeadlineExceeded):
 		// Backstop in case any transport-level deadline (e.g.
 		// TLSHandshakeTimeout) fires before our phase timer.
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server timed out").LogError(ctx, p.Logger)
+		classified = oops.E(oops.CodeGatewayError, err, "remote mcp server timed out")
 	case errors.Is(err, context.Canceled):
-		return oops.E(oops.CodeBadRequest, err, "client cancelled request").LogError(ctx, p.Logger)
+		classified = oops.E(oops.CodeBadRequest, err, "client cancelled request")
 	default:
-		return oops.E(oops.CodeGatewayError, err, "remote mcp server unreachable").LogError(ctx, p.Logger)
+		classified = oops.E(oops.CodeGatewayError, err, "remote mcp server unreachable")
 	}
+	return &classifiedForwardError{err: classified}
+}
+
+func (p *Proxy) logForwardError(ctx context.Context, err error) error {
+	classified, ok := errors.AsType[*classifiedForwardError](err)
+	if !ok {
+		return err
+	}
+	return classified.err.LogError(ctx, p.Logger)
 }

--- a/server/internal/remotemcp/proxy/forward_retry_internal_test.go
+++ b/server/internal/remotemcp/proxy/forward_retry_internal_test.go
@@ -54,6 +54,7 @@ func TestForwardRequestWithRetryClosesBodyOnRetryerError(t *testing.T) {
 		UpstreamResponseRetryer: func(_ context.Context, _ *http.Response) (*UpstreamResponseRetry, error) {
 			return nil, retryerErr
 		},
+		ForwardErrorRetryer:                nil,
 		UserRequestObservationInterceptors: nil,
 		UserRequestInterceptors:            nil,
 		InitializeRequestInterceptors:      nil,

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -145,6 +145,10 @@ type UpstreamResponseRetry struct {
 
 type UpstreamResponseRetryer func(ctx context.Context, resp *http.Response) (*UpstreamResponseRetry, error)
 
+// ForwardErrorRetryer selects a replacement upstream after a recoverable
+// transport failure.
+type ForwardErrorRetryer func(ctx context.Context, err error) (*UpstreamResponseRetry, error)
+
 // Proxy is a one-request handler that forwards inbound MCP client requests
 // to a configured Remote MCP Server. A fresh value is expected per inbound
 // request so the SessionID and interceptor state stay tied to a single
@@ -233,6 +237,17 @@ type Proxy struct {
 	// response headers arrive but before any response is relayed to the user.
 	// It is used by tunneled MCP to fail over stale gateway owners.
 	UpstreamResponseRetryer UpstreamResponseRetryer
+
+	// ForwardErrorRetryer may replace the upstream target once when the
+	// forward fails with a transport-level error before any response
+	// headers arrive. The retryer owns replay safety: it must only request
+	// a retry for failures where the request cannot have reached the
+	// backend (e.g. dial-phase errors). Returning a non-nil error replaces
+	// the classified forward error; returning (nil, nil) keeps it. The
+	// response and transport retryers are each consulted at most once, so
+	// mixed failure modes can produce at most three total forward attempts.
+	// It is used by tunneled MCP to evict routes whose gateway address is dead.
+	ForwardErrorRetryer ForwardErrorRetryer
 
 	// UpstreamResponseInterceptor, when set, runs once against the final
 	// upstream response — after any retry, before any header or body byte is
@@ -944,7 +959,7 @@ func (p *Proxy) forwardRequest(
 		// inside the http.Client error chain.
 		timedOut := !phaseTimer.Stop()
 		forwardCancel()
-		return nil, nil, p.classifyForwardError(ctx, err, timedOut)
+		return nil, nil, classifyForwardError(err, timedOut)
 	}
 
 	// Atomically transition out of the headers-phase window. Stop returning
@@ -955,7 +970,7 @@ func (p *Proxy) forwardRequest(
 	if !phaseTimer.Stop() {
 		_ = resp.Body.Close()
 		forwardCancel()
-		return nil, nil, p.classifyForwardError(ctx, context.DeadlineExceeded, true)
+		return nil, nil, classifyForwardError(context.DeadlineExceeded, true)
 	}
 
 	if isEventStream(resp.Header) {
@@ -993,28 +1008,51 @@ func (p *Proxy) forwardRequestWithRetry(
 	body func() io.Reader,
 	validate func(*http.Request) error,
 ) (*http.Request, *http.Response, error) {
-	upstreamReq, upstreamResp, err := p.forwardRequest(ctx, r, body(), validate)
-	if err != nil || p.UpstreamResponseRetryer == nil {
-		return upstreamReq, upstreamResp, err
-	}
+	forwardErrorRetried := false
+	upstreamResponseRetried := false
 
-	retry, err := p.UpstreamResponseRetryer(ctx, upstreamResp)
-	if err != nil {
-		// Callers bail on err before they register their Body.Close defer,
-		// so an open response returned alongside an error is leaked — it
-		// would pin the upstream connection until the phase timer fires.
-		// Close it here and return no response.
+	for {
+		upstreamReq, upstreamResp, err := p.forwardRequest(ctx, r, body(), validate)
+		if err != nil {
+			if forwardErrorRetried || p.ForwardErrorRetryer == nil {
+				return upstreamReq, upstreamResp, p.logForwardError(ctx, err)
+			}
+			forwardErrorRetried = true
+
+			retry, retryerErr := p.ForwardErrorRetryer(ctx, err)
+			if retryerErr != nil {
+				return upstreamReq, nil, retryerErr
+			}
+			if retry == nil {
+				return upstreamReq, upstreamResp, p.logForwardError(ctx, err)
+			}
+			p.RemoteURL = retry.RemoteURL
+			p.Headers = retry.Headers
+			continue
+		}
+
+		if upstreamResponseRetried || p.UpstreamResponseRetryer == nil {
+			return upstreamReq, upstreamResp, nil
+		}
+		upstreamResponseRetried = true
+
+		retry, retryerErr := p.UpstreamResponseRetryer(ctx, upstreamResp)
+		if retryerErr != nil {
+			// Callers bail on err before they register their Body.Close defer,
+			// so an open response returned alongside an error is leaked — it
+			// would pin the upstream connection until the phase timer fires.
+			// Close it here and return no response.
+			o11y.NoLogDefer(upstreamResp.Body.Close)
+			return upstreamReq, nil, retryerErr
+		}
+		if retry == nil {
+			return upstreamReq, upstreamResp, nil
+		}
 		o11y.NoLogDefer(upstreamResp.Body.Close)
-		return upstreamReq, nil, err
-	}
-	if retry == nil {
-		return upstreamReq, upstreamResp, nil
-	}
-	o11y.NoLogDefer(upstreamResp.Body.Close)
 
-	p.RemoteURL = retry.RemoteURL
-	p.Headers = retry.Headers
-	return p.forwardRequest(ctx, r, body(), validate)
+		p.RemoteURL = retry.RemoteURL
+		p.Headers = retry.Headers
+	}
 }
 
 // relaySSEStream parses Server-Sent Events from the upstream body, relays

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,7 +31,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-const initializeRequest = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+const (
+	initializeRequest = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	deadLoopbackURL   = "http://127.0.0.1:0"
+)
 
 func TestServerIdentity_DistinguishesTunneledBackend(t *testing.T) {
 	t.Parallel()
@@ -71,6 +75,7 @@ func newProxyForTest(t *testing.T, upstreamURL string) *proxy.Proxy {
 		Headers:                            nil,
 		AuthorizationOverride:              "",
 		UpstreamResponseRetryer:            nil,
+		ForwardErrorRetryer:                nil,
 		UpstreamResponseInterceptor:        nil,
 		UserRequestObservationInterceptors: nil,
 		UserRequestInterceptors:            nil,
@@ -2810,4 +2815,143 @@ func TestProxy_Post_UpstreamResponseInterceptorErrorAbortsBeforeFlush(t *testing
 	require.Error(t, err)
 	require.Equal(t, http.StatusOK, rr.Code, "recorder default; nothing was written via WriteHeader")
 	require.Empty(t, rr.Body.String(), "no body may reach the client when the interceptor fails closed")
+}
+
+func TestProxy_Post_ForwardErrorRetryerFailsOverOnDeadDial(t *testing.T) {
+	t.Parallel()
+
+	var gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, deadLoopbackURL)
+	var logs bytes.Buffer
+	p.Logger = slog.New(slog.NewTextHandler(&logs, nil))
+	var retryerSawErr error
+	p.ForwardErrorRetryer = func(_ context.Context, forwardErr error) (*proxy.UpstreamResponseRetry, error) {
+		retryerSawErr = forwardErr
+		return &proxy.UpstreamResponseRetry{RemoteURL: upstream.URL, Headers: nil}, nil
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.JSONEq(t, initializeRequest, gotBody, "retried forward must replay the full request body")
+	require.Error(t, retryerSawErr, "retryer must receive the classified forward error")
+	require.Empty(t, logs.String(), "a recovered transport error must not be logged as terminal")
+}
+func TestProxy_Post_ForwardErrorRetryComposesWithResponseRetry(t *testing.T) {
+	t.Parallel()
+
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(final.Close)
+
+	replacement := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Gram-Tunnel-Error", "no-live-session")
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(replacement.Close)
+
+	p := newProxyForTest(t, deadLoopbackURL)
+	var forwardRetries atomic.Int32
+	p.ForwardErrorRetryer = func(context.Context, error) (*proxy.UpstreamResponseRetry, error) {
+		forwardRetries.Add(1)
+		return &proxy.UpstreamResponseRetry{RemoteURL: replacement.URL, Headers: nil}, nil
+	}
+	var responseRetries atomic.Int32
+	p.UpstreamResponseRetryer = func(context.Context, *http.Response) (*proxy.UpstreamResponseRetry, error) {
+		responseRetries.Add(1)
+		return &proxy.UpstreamResponseRetry{RemoteURL: final.URL, Headers: nil}, nil
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, int32(1), forwardRetries.Load())
+	require.Equal(t, int32(1), responseRetries.Load())
+}
+
+func TestProxy_Post_ResponseRetryComposesWithForwardErrorRetry(t *testing.T) {
+	t.Parallel()
+
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(final.Close)
+
+	initial := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Gram-Tunnel-Error", "no-live-session")
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(initial.Close)
+
+	p := newProxyForTest(t, initial.URL)
+	var responseRetries atomic.Int32
+	p.UpstreamResponseRetryer = func(context.Context, *http.Response) (*proxy.UpstreamResponseRetry, error) {
+		responseRetries.Add(1)
+		return &proxy.UpstreamResponseRetry{RemoteURL: deadLoopbackURL, Headers: nil}, nil
+	}
+	var forwardRetries atomic.Int32
+	p.ForwardErrorRetryer = func(context.Context, error) (*proxy.UpstreamResponseRetry, error) {
+		forwardRetries.Add(1)
+		return &proxy.UpstreamResponseRetry{RemoteURL: final.URL, Headers: nil}, nil
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, int32(1), responseRetries.Load())
+	require.Equal(t, int32(1), forwardRetries.Load())
+}
+
+func TestProxy_Post_ForwardErrorRetryerErrorReplacesForwardError(t *testing.T) {
+	t.Parallel()
+
+	p := newProxyForTest(t, deadLoopbackURL)
+	sentinel := errors.New("route store unavailable")
+	p.ForwardErrorRetryer = func(context.Context, error) (*proxy.UpstreamResponseRetry, error) {
+		return nil, sentinel
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.ErrorIs(t, p.Post(rr, req), sentinel)
+}
+
+func TestProxy_Post_ForwardErrorRetryerNilKeepsForwardError(t *testing.T) {
+	t.Parallel()
+
+	p := newProxyForTest(t, deadLoopbackURL)
+	p.ForwardErrorRetryer = func(context.Context, error) (*proxy.UpstreamResponseRetry, error) {
+		return nil, nil
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	err := p.Post(rr, req)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeGatewayError, oopsErr.Code)
 }

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -327,6 +327,7 @@ func (f *ProxyManager) BuildTarget(
 		Headers:                     headers,
 		AuthorizationOverride:       upstreamAuth,
 		UpstreamResponseRetryer:     nil,
+		ForwardErrorRetryer:         nil,
 		UpstreamResponseInterceptor: nil,
 		DisableRedirects:            false,
 		StrictToolSelection:         selection != nil,

--- a/server/internal/remotemcp/tools_call_killswitch_proxy_test.go
+++ b/server/internal/remotemcp/tools_call_killswitch_proxy_test.go
@@ -369,6 +369,7 @@ func newKillswitchTestProxy(t *testing.T, upstreamURL string, interceptors ...pr
 		StreamingTimeout:                5 * time.Second,
 		MaxBufferedBodyBytes:            proxy.DefaultMaxBufferedBodyBytes,
 		RemoteURL:                       upstreamURL,
+		ForwardErrorRetryer:             nil,
 		ToolsCallPreForwardInterceptors: interceptors[:1],
 		ToolsCallRequestInterceptors:    interceptors[1:],
 	}


### PR DESCRIPTION
AIS-662

## Summary

- Add a proxy transport-error retry hook for failures before upstream response headers arrive.
- Evict tunnel routes whose gateway address fails with a dead-peer dial error, fail over to another route when available, and return `CodeNotFound` when no route remains.
- Compose transport- and response-level retry policies once each, covering mixed failures without an unbounded retry loop.
- Defer terminal error logging until retry policy is exhausted so successful failovers and intentional not-found responses do not pollute platform error telemetry.

## Motivation

A gateway pod can disappear without unpublishing its tunnel route. Until the route's 30-second TTL expired, non-pinned traffic repeatedly spent the dial timeout and returned 502, inflating platform 5xx signals for a customer-side outage. Removing the route on the first definitive dial failure makes subsequent requests avoid it immediately, preserves safe failover, and reports an offline tunnel consistently as not found.
