### PR TITLE
fix: stabilize test container startup

### DIFF
--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -19,12 +19,18 @@ type ClickhouseClientFunc func(t *testing.T) (clickhouse.Conn, error)
 // from migration files. Returns a container reference and a function to create
 // test connections. The per-test connection is automatically closed via t.Cleanup.
 func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseContainer, ClickhouseClientFunc, error) {
+	if err := ensureDockerReady(ctx); err != nil {
+		return nil, nil, fmt.Errorf("wait for docker: %w", err)
+	}
+
 	container, err := clickhousecontainer.Run(ctx, "clickhouse/clickhouse-server:26.2.19.43@sha256:c2f2605585899d5103a0447daadbc0005f362200d5f0fcca7f40db3ca0dd36dd",
 		clickhousecontainer.WithUsername("gram"),
 		clickhousecontainer.WithPassword("gram"),
 		clickhousecontainer.WithInitScripts(rootPath("clickhouse", "schema.sql")),
 		testcontainers.WithWaitStrategy(
-			wait.ForExec([]string{"clickhouse-client", "--user", "gram", "--password", "gram", "--query", "SELECT 1"}),
+			// The image initializes through a localhost-only bootstrap server.
+			// Dial its hostname so readiness requires the final network listener.
+			wait.ForExec([]string{"sh", "-c", `clickhouse-client --host "$HOSTNAME" --user gram --password gram --query "SELECT 1"`}),
 		),
 		WithPublishedPortWait("9000/tcp"),
 		WithoutPublishedPorts(),

--- a/server/internal/testenv/postgresql.go
+++ b/server/internal/testenv/postgresql.go
@@ -38,6 +38,10 @@ func rootPath(elem ...string) string {
 // a function to create test databases from the template. All clone databases
 // are automatically dropped when the test ends using t.Cleanup hooks.
 func NewTestPostgres(ctx context.Context) (*postgres.PostgresContainer, PostgresDBCloneFunc, error) {
+	if err := ensureDockerReady(ctx); err != nil {
+		return nil, nil, fmt.Errorf("wait for docker: %w", err)
+	}
+
 	container, err := postgres.Run(
 		ctx,
 		"pgvector/pgvector:pg17",

--- a/server/internal/testenv/redis.go
+++ b/server/internal/testenv/redis.go
@@ -15,6 +15,10 @@ import (
 type RedisClientFunc func(t *testing.T, db int) (*redis.Client, error)
 
 func NewTestRedis(ctx context.Context) (*tcr.RedisContainer, RedisClientFunc, error) {
+	if err := ensureDockerReady(ctx); err != nil {
+		return nil, nil, fmt.Errorf("wait for docker: %w", err)
+	}
+
 	container, err := tcr.Run(
 		ctx, "redis:6.2-alpine",
 		testcontainers.WithLogger(NewTestcontainersLogger()),

--- a/server/internal/testenv/testcontainers.go
+++ b/server/internal/testenv/testcontainers.go
@@ -2,6 +2,7 @@ package testenv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -10,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/go-connections/nat"
@@ -17,6 +19,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
@@ -36,6 +39,63 @@ func NewTestcontainersLogger() log.Logger {
 			Pretty:      true,
 			DataDogAttr: false,
 		})),
+	}
+}
+
+const dockerReadyTimeout = 30 * time.Second
+
+var (
+	dockerReady      atomic.Bool
+	dockerReadyGroup singleflight.Group
+)
+
+func ensureDockerReady(ctx context.Context) error {
+	if dockerReady.Load() {
+		return nil
+	}
+
+	_, err, _ := dockerReadyGroup.Do("docker", func() (any, error) {
+		if dockerReady.Load() {
+			return nil, nil
+		}
+
+		readyCtx, cancel := context.WithTimeout(ctx, dockerReadyTimeout)
+		defer cancel()
+
+		cli, err := client.New(client.FromEnv)
+		if err != nil {
+			return nil, fmt.Errorf("create docker client: %w", err)
+		}
+		defer o11y.NoLogDefer(cli.Close)
+
+		if err := retryDockerInfo(readyCtx, func(ctx context.Context) error {
+			_, err := cli.Info(ctx, client.InfoOptions{})
+			return err
+		}); err != nil {
+			return nil, err
+		}
+
+		dockerReady.Store(true)
+		return nil, nil
+	})
+
+	return err
+}
+
+func retryDockerInfo(ctx context.Context, info func(context.Context) error) error {
+	for {
+		err := info(ctx)
+		if err == nil {
+			return nil
+		}
+
+		timer := time.NewTimer(500 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("docker info after retries: %w", errors.Join(err, ctx.Err()))
+		case <-timer.C:
+		}
 	}
 }
 

--- a/server/internal/testenv/testcontainers.go
+++ b/server/internal/testenv/testcontainers.go
@@ -69,8 +69,10 @@ func ensureDockerReady(ctx context.Context) error {
 		defer o11y.NoLogDefer(cli.Close)
 
 		if err := retryDockerInfo(readyCtx, func(ctx context.Context) error {
-			_, err := cli.Info(ctx, client.InfoOptions{})
-			return err
+			if _, err := cli.Info(ctx, client.InfoOptions{}); err != nil {
+				return fmt.Errorf("query docker info: %w", err)
+			}
+			return nil
 		}); err != nil {
 			return nil, err
 		}

--- a/server/internal/testenv/testcontainers_test.go
+++ b/server/internal/testenv/testcontainers_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestRetryDockerInfoRetriesTransientFailures(t *testing.T) {
+	t.Parallel()
+
 	synctest.Test(t, func(t *testing.T) {
 		attempts := 0
 		err := retryDockerInfo(t.Context(), func(context.Context) error {
@@ -27,6 +29,8 @@ func TestRetryDockerInfoRetriesTransientFailures(t *testing.T) {
 }
 
 func TestRetryDockerInfoStopsAtDeadline(t *testing.T) {
+	t.Parallel()
+
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 		defer cancel()

--- a/server/internal/testenv/testcontainers_test.go
+++ b/server/internal/testenv/testcontainers_test.go
@@ -1,0 +1,41 @@
+package testenv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryDockerInfoRetriesTransientFailures(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		attempts := 0
+		err := retryDockerInfo(t.Context(), func(context.Context) error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("docker unavailable")
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 3, attempts)
+	})
+}
+
+func TestRetryDockerInfoStopsAtDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+
+		err := retryDockerInfo(ctx, func(context.Context) error {
+			return errors.New("docker unavailable")
+		})
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorContains(t, err, "docker info after retries")
+	})
+}


### PR DESCRIPTION
## Summary

- Wait for the Docker daemon with bounded retries before starting PostgreSQL, Redis, or ClickHouse test containers.
- Coalesce concurrent Docker readiness calls and cache successful readiness for the test process.
- Require the ClickHouse container's final network listener before reporting readiness while retaining client-side ping retries.

## Motivation

Blacksmith runners can begin a test while Docker's API is temporarily unresponsive. Testcontainers caches its first Docker host discovery result, so a transient `docker info` timeout otherwise prevents every container from starting in that test process. A singleflight preflight makes concurrent container constructors share one bounded readiness attempt and error; later calls can retry a failure, while success remains cached.

The ClickHouse image also starts a loopback-only bootstrap server while applying initialization scripts. Waiting through the container hostname prevents that temporary server from satisfying readiness while preserving the existing host-side retry protection.
