### PR TITLE
docs: OpenClaw customer install runbook + generated README section

### DIFF
--- a/.changeset/openclaw-install-docs.md
+++ b/.changeset/openclaw-install-docs.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+The generated observability plugin package now includes OpenClaw install instructions, covering the plugin install, the conversation-access setting that must be enabled for prompt and usage capture, and the model-auth modes that determine how much of a session OpenClaw can report.

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -37,7 +37,9 @@ Team member installs from Claude/Cursor/Codex marketplace
 
 Assignments control who sees the plugin in their marketplace; RBAC (`mcp:connect` scope) still enforces access at the MCP entrypoint.
 
-**Observability plugin.** Every publish automatically includes a per-org observability plugin — one each for Claude, Cursor, Codex, OpenCode and GitHub Copilot — that bundles hooks forwarding tool-use events back to Gram. This is required for proper audit logging.
+**Observability plugin.** Every publish automatically includes a per-org observability plugin — one each for Claude, Cursor, Codex, OpenCode, OpenClaw and GitHub Copilot — that bundles hooks forwarding tool-use events back to Gram. This is required for proper audit logging.
+
+**OpenClaw.** The OpenClaw observability package is a native OpenClaw plugin (`openclaw.plugin.json` + `index.js`), installed with `openclaw plugins install <dir>` and a Gateway restart. Two caveats are load-bearing and documented in the [OpenClaw install runbook](../runbooks/openclaw-install.md): conversation-scope hooks require `plugins.entries.speakeasy-observability.hooks.allowConversationAccess: true`, and coverage depends on the customer's model-auth mode — models routed through the Claude CLI harness delegate the tool loop out-of-process, so OpenClaw's tool and LLM hooks never fire for them.
 
 **GitHub Copilot.** Copilot is supported on two separate tracks. MCP servers and skills ship through the platform-neutral Agent Plugins 1.0 package (`agent-plugins/<plugin-slug>/`), which Copilot loads in the CLI, VS Code and the Copilot app. Hooks ship through the Copilot observability package and run in **Copilot CLI only** — VS Code and the Copilot app load the plugin but never fire its hooks. See [Package format](./package-format.md#copilot-observability).
 
@@ -65,21 +67,21 @@ Slugs must be unique per `(organization_id, project_id)` (filtered index, ignore
 
 All endpoints live under `/rpc/plugins.<method>` and require session auth + `Gram-Project` header.
 
-| Endpoint                      | Auth scope | Description                                                                                                              |
-| ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `listPlugins`                 | `OrgRead`  | List plugins with server/assignment counts                                                                               |
-| `getPlugin`                   | `OrgRead`  | Full plugin detail (nested servers + assignments)                                                                        |
-| `createPlugin`                | `OrgAdmin` | Create plugin (slug auto-derived from name if omitted)                                                                   |
-| `updatePlugin`                | `OrgAdmin` | Rename/re-slug/redescribe                                                                                                |
-| `deletePlugin`                | `OrgAdmin` | Soft-delete plugin + all its servers                                                                                     |
-| `addPluginServer`             | `OrgAdmin` | Add toolset to plugin                                                                                                    |
-| `updatePluginServer`          | `OrgAdmin` | Change display name, policy, sort order                                                                                  |
-| `removePluginServer`          | `OrgAdmin` | Remove server from plugin                                                                                                |
-| `setPluginAssignments`        | `OrgAdmin` | Replace all principal assignments (atomic)                                                                               |
-| `downloadPluginPackage`       | `OrgRead`  | Download single-plugin ZIP for `claude`, `cursor`, or `codex`                                                            |
-| `downloadObservabilityPlugin` | `OrgAdmin` | Download per-org observability plugin ZIP for `claude`, `cursor`, `codex`, `opencode` or `copilot` (mints hooks API key) |
-| `getPublishStatus`            | `OrgRead`  | Check GitHub config + connection status; returns marketplace URL                                                         |
-| `publishPlugins`              | `OrgAdmin` | Generate all plugins, push to GitHub, mint API keys                                                                      |
+| Endpoint                      | Auth scope | Description                                                                                                                          |
+| ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `listPlugins`                 | `OrgRead`  | List plugins with server/assignment counts                                                                                           |
+| `getPlugin`                   | `OrgRead`  | Full plugin detail (nested servers + assignments)                                                                                    |
+| `createPlugin`                | `OrgAdmin` | Create plugin (slug auto-derived from name if omitted)                                                                               |
+| `updatePlugin`                | `OrgAdmin` | Rename/re-slug/redescribe                                                                                                            |
+| `deletePlugin`                | `OrgAdmin` | Soft-delete plugin + all its servers                                                                                                 |
+| `addPluginServer`             | `OrgAdmin` | Add toolset to plugin                                                                                                                |
+| `updatePluginServer`          | `OrgAdmin` | Change display name, policy, sort order                                                                                              |
+| `removePluginServer`          | `OrgAdmin` | Remove server from plugin                                                                                                            |
+| `setPluginAssignments`        | `OrgAdmin` | Replace all principal assignments (atomic)                                                                                           |
+| `downloadPluginPackage`       | `OrgRead`  | Download single-plugin ZIP for `claude`, `cursor`, or `codex`                                                                        |
+| `downloadObservabilityPlugin` | `OrgAdmin` | Download per-org observability plugin ZIP for `claude`, `cursor`, `codex`, `opencode`, `openclaw` or `copilot` (mints hooks API key) |
+| `getPublishStatus`            | `OrgRead`  | Check GitHub config + connection status; returns marketplace URL                                                                     |
+| `publishPlugins`              | `OrgAdmin` | Generate all plugins, push to GitHub, mint API keys                                                                                  |
 
 ## Implementation
 

--- a/docs/plugins/package-format.md
+++ b/docs/plugins/package-format.md
@@ -52,6 +52,15 @@ When plugins are published, all platform configs land in a single repo. The root
 │   ├── .codex-plugin/plugin.json
 │   └── .mcp.json
 │
+├── <org-slug>-observability-openclaw/ # OpenClaw observability plugin
+│   ├── openclaw.plugin.json
+│   ├── package.json
+│   ├── index.js                       # plugin module; proxies typed hooks to agenthooks
+│   ├── speakeasy.json
+│   └── hooks/
+│       ├── bootstrap.sh
+│       └── bootstrap.ps1
+│
 ├── <org-slug>-observability-copilot/  # Copilot observability plugin
 │   ├── plugin.json                    # at the package root, not a vendor dir
 │   ├── speakeasy.json
@@ -387,6 +396,29 @@ The hook config ships at `hooks/hooks.json` **only**. Copilot parses both `<root
 **Surface support.** Hooks run in Copilot CLI only. VS Code and the Copilot app load the plugin — MCP servers and skills work there — but never fire its hooks. Copilot's cloud agent reads hooks from `.github/hooks/*.json` in the repository and is not targeted by this package.
 
 **Hook chain ordering.** Copilot short-circuits the hook chain on the first deny, so a customer hook that denies before Gram's entry suppresses Gram's telemetry for that call.
+
+### OpenClaw observability
+
+Directory: `<org-slug>-observability-openclaw/`
+
+OpenClaw has no marketplace track: the observability package is the only OpenClaw output a publish produces, and it is a native OpenClaw plugin rather than a hooks-config package. `openclaw.plugin.json` declares the plugin and `package.json` points OpenClaw at the module:
+
+```json
+{
+  "id": "speakeasy-observability",
+  "name": "Speakeasy Observability",
+  "description": "Speakeasy observability hooks for OpenClaw.",
+  "activation": { "onStartup": true }
+}
+```
+
+`index.js` is plain JavaScript, not TypeScript: OpenClaw package installs reject a build step. It subscribes the typed plugin hooks and proxies each frame to `agenthooks serve --provider=openclaw`, returning the reply verbatim as the hook handler's return value so `before_tool_call` denials reach OpenClaw intact.
+
+**Conversation-scope hooks require opt-in.** `before_agent_run`, `llm_output` and `agent_end` only fire when the customer sets `plugins.entries.speakeasy-observability.hooks.allowConversationAccess: true`. Without it the package still reports tool calls and session lifecycle, so a half-configured install looks partly working.
+
+**The shim owns its own deadlines.** OpenClaw applies no default hook timeout, so the module enforces them: 10s for the blocking gates (`before_tool_call`, `before_agent_run`) and 30s for observe-only hooks. `--timeout=60s` bounds the serve process, not a handler.
+
+See the [OpenClaw install runbook](../runbooks/openclaw-install.md) for the customer-facing install and the model-auth modes that determine coverage.
 
 ### Copilot marketplace manifest
 

--- a/docs/plugins/publishing.md
+++ b/docs/plugins/publishing.md
@@ -110,8 +110,17 @@ If `configured` is false, the Publish button should be hidden (the server isn't 
 
 ## Observability plugin
 
-Every publish includes two observability plugins (one for Claude, one for Cursor) that forward hook events to Gram. These are automatically added at the top of the marketplace so they appear first.
+Every publish includes one observability plugin per supported platform, forwarding hook events to Gram. Those with a marketplace are automatically added at the top so they appear first.
 
-The observability plugin slug is `<org-slug>-observability` (Claude) or `<org-slug>-observability-cursor` (Cursor). Users are shown a notice in the README that this plugin is required alongside any MCP server plugins.
+| Platform | Slug                                |
+| -------- | ----------------------------------- |
+| Claude   | `<org-slug>-observability`          |
+| Cursor   | `<org-slug>-observability-cursor`   |
+| Codex    | `<org-slug>-observability-codex`    |
+| OpenCode | `<org-slug>-observability-opencode` |
+| OpenClaw | `<org-slug>-observability-openclaw` |
+| Copilot  | `<org-slug>-observability-copilot`  |
+
+OpenCode and OpenClaw have no marketplace track, so their packages are installed directly rather than listed. Users are shown a notice in the README that the observability plugin is required alongside any MCP server plugins.
 
 See [Package Format — observability plugin](./package-format.md#observability-plugin) for the hook events registered and the hook script contents.

--- a/docs/runbooks/openclaw-install.md
+++ b/docs/runbooks/openclaw-install.md
@@ -11,10 +11,10 @@ packages are generated and published.
 OpenClaw coverage is **not** uniform — it depends on how the customer's models
 authenticate. Establish this first, because it changes what you promise them.
 
-| Model auth mode                                       | What OpenClaw runs                                        | Hooks that fire                                                                                                   | Speakeasy coverage                                                                                                                     |
-| ----------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Embedded runtime (`agentRuntime: { id: "openclaw" }`) | Model + tool loop in-process                              | Full set: `before_agent_run`, `before_tool_call`, `after_tool_call`, `llm_output`, `agent_end`, session lifecycle | Full — capture **and** real-time tool blocking                                                                                         |
-| Claude CLI harness (`agentRuntime: claude-cli`)       | Delegates the loop to the Claude Code CLI, out-of-process | Only `agent_turn_prepare`, `before_prompt_build`, `before_message_write`                                          | Partial from OpenClaw — but these sessions are covered by Speakeasy's **Claude Code** hooks, which the CLI honors via managed settings |
+| Model auth mode                                       | What OpenClaw runs                                        | Hooks that fire                                                                                                   | Speakeasy coverage                                                                                                                                                              |
+| ----------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Embedded runtime (`agentRuntime: { id: "openclaw" }`) | Model + tool loop in-process                              | Full set: `before_agent_run`, `before_tool_call`, `after_tool_call`, `llm_output`, `agent_end`, session lifecycle | Full — capture **and** real-time tool blocking                                                                                                                                  |
+| Claude CLI harness (`agentRuntime: claude-cli`)       | Delegates the loop to the Claude Code CLI, out-of-process | Only `agent_turn_prepare`, `before_prompt_build`, `before_message_write`                                          | Partial from OpenClaw. Tool and LLM activity is captured **only if Claude Code hooks are separately deployed on the same machine**; without that, these sessions are unobserved |
 
 The trap: `openclaw models auth login` writes `agentRuntime: {id: "claude-cli"}`
 **by default for every model** when a claude-cli profile exists on the machine.
@@ -22,9 +22,13 @@ A customer who authenticated interactively will land in the second row without
 choosing to. Auth-profile ordering alone does not flip it — the per-model
 `agentRuntime` does.
 
-This is complementary coverage, not a hole: between the two paths every session
-is observed. But say so explicitly, or the OpenClaw dashboard will look empty
-to a customer whose models all route through the Claude CLI.
+The two paths are complementary, but only when both are deployed. A machine
+that followed this runbook and nothing else has **no** coverage for
+claude-cli-routed models: OpenClaw's hooks do not fire for them, and no Claude
+Code hooks are installed to pick them up. Either install the Claude Code
+observability plugin alongside this one, or tell the customer those sessions
+are not captured. Say which, or the OpenClaw dashboard will look empty to a
+customer whose models all route through the Claude CLI.
 
 ## Install (developer laptop)
 
@@ -32,10 +36,17 @@ to a customer whose models all route through the Claude CLI.
    (**Plugins → Observability → OpenClaw**). This mints a hooks API key and
    bakes it into the package's `speakeasy.json`. Requires `OrgAdmin`.
 
-2. Install it. `openclaw plugins install` accepts a directory or an archive
-   path, so either works:
+2. Install it. `openclaw plugins install` accepts an archive path directly, so
+   the download works as-is:
 
    ```sh
+   openclaw plugins install ./<org>-observability-openclaw.zip
+   ```
+
+   Or extract first and point at the directory:
+
+   ```sh
+   unzip <org>-observability-openclaw.zip
    openclaw plugins install ./<org>-observability-openclaw
    ```
 
@@ -59,11 +70,15 @@ to a customer whose models all route through the Claude CLI.
    ```
 
    **This step is not optional.** Without `allowConversationAccess`, the
-   conversation hooks (`before_agent_run`, `llm_input`, `llm_output`,
-   `agent_end`, `before_agent_finalize`) silently never fire — no error, no
-   warning, just no prompts, no assistant responses and no usage. Tool hooks
-   still fire, so a half-configured install looks _partly_ working, which is
-   the most confusing failure mode we have here.
+   conversation-scope hooks the plugin subscribes (`before_agent_run`,
+   `llm_output`, `agent_end`) silently never fire — no error, no warning, just
+   no prompts, no assistant responses and no usage. Tool hooks still fire, so a
+   half-configured install looks _partly_ working, which is the most confusing
+   failure mode we have here.
+
+   OpenClaw gates further conversation hooks behind the same flag (`llm_input`
+   and `before_agent_finalize` among them), but the plugin does not subscribe
+   those and never reports them.
 
 4. Restart the Gateway. Plugin changes are not hot-loaded.
 
@@ -74,8 +89,30 @@ Uninstall with `openclaw plugins uninstall speakeasy-observability`.
 ## Install (server / CI, no device agent)
 
 The plugin does not require the Speakeasy device agent. For a shared gateway or
-a CI image, skip the dashboard download and drive the hooks runtime entirely
-from the environment:
+a CI image, install the same package but drive its credentials from the
+environment instead of the key baked into the download.
+
+**At image build time:**
+
+1. Download the OpenClaw observability ZIP from the dashboard, as in step 1
+   above. It is the same artifact; the baked key is simply overridden at run
+   time by the variables below.
+
+2. Install it into the image:
+
+   ```sh
+   openclaw plugins install ./<org>-observability-openclaw.zip
+   ```
+
+3. Preinstall the `speakeasy-hooks` binary. The plugin's bootstrap otherwise
+   downloads it from `https://github.com/speakeasy-api/gram/releases` on the
+   first hook firing, which needs egress from the running container and adds
+   latency to the first turn. Set `GRAM_HOOKS_HOME` to a directory baked into
+   the image and populate it at build time; the bootstrap uses that instead of
+   its per-OS cache location. If the download is left in place, allowlist that
+   host or the first hook fails with a bootstrap error.
+
+**At run time**, supply:
 
 | Variable                  | Purpose                                 |
 | ------------------------- | --------------------------------------- |
@@ -84,9 +121,8 @@ from the environment:
 | `GRAM_HOOKS_PROJECT_SLUG` | Target project; defaults to `default`   |
 | `GRAM_HOOKS_ORG_ID`       | Org ID                                  |
 
-Bake the plugin directory into the image and install it at build time; supply
-the variables at run time so the key is not baked into a layer. Rotate by
-replacing `GRAM_HOOKS_ORG_KEY` and restarting the gateway — no reinstall.
+Supplying these at run time keeps the key out of an image layer. Rotate by
+replacing `GRAM_HOOKS_ORG_KEY` and restarting the gateway, with no reinstall.
 
 Sessions from a shared gateway attribute to the org, not to an individual.
 Per-user attribution on shared gateways is tracked separately in DNO-971.
@@ -128,8 +164,17 @@ Two behaviors worth knowing:
 - **OpenClaw does not impose the 15s fail-closed policy timeout** we originally
   briefed. A `before_tool_call` handler that stalls is awaited in full. Per-hook
   `timeoutMs` exists on the registration API but is opt-in in the versions we
-  have tested. **Our shim therefore owns its own deadline** (`--timeout=60s`);
-  without it a hung control-plane call would stall the agent turn indefinitely.
+  have tested, so **our shim owns its own deadlines**. There are three, and they
+  are not interchangeable:
+
+  | Budget               | Value | What it bounds                                                                                                         |
+  | -------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------- |
+  | `GATE_TIMEOUT_MS`    | 10s   | `before_tool_call` and `before_agent_run`. Blocking hooks fail closed here, so a stalled gate resolves in 10s, not 60. |
+  | `DEFAULT_TIMEOUT_MS` | 30s   | The observe-only hooks                                                                                                 |
+  | `--timeout=60s`      | 60s   | The `agenthooks serve` process itself, not any individual handler deadline                                             |
+
+  Without shim-owned deadlines a hung control-plane call would stall the agent
+  turn indefinitely.
 
 ## Version-pin policy
 
@@ -145,17 +190,56 @@ Note the drift: the fixtures our decoder is tested against were captured from
 2026.6.34, and nothing in the repo records that. Treat the fixture corpus as
 version-stamped evidence, not as a permanent contract.
 
-To qualify a new OpenClaw version, follow the LiteLLM precedent
-(`server/internal/litellm/fixtures/`): re-record the hook payloads from the new
-build, diff them against the checked-in fixtures, run the verification above
-for both capture and a blocked tool call, and only then document the version as
-supported. A change to any hook's payload shape, name or return contract is a
-decoder change in `agenthooks/codec_openclaw.go`, not a docs change.
+### Qualification procedure (manual)
 
-We deliberately do **not** run a nightly canary against OpenClaw `latest`. It
+Run this against a new OpenClaw build before adding it to the table above. It
+is deliberately manual; see the note on canaries below.
+
+1. Install the target version into an isolated profile so a real install is not
+   disturbed:
+
+   ```sh
+   npm i -g openclaw@<version>
+   openclaw --dev --version
+   ```
+
+2. Install the observability package into that profile and enable
+   `allowConversationAccess`, per the install steps above. Use `--dev` for
+   every command so the state stays under `~/.openclaw-dev`.
+
+3. Confirm the model is on the embedded runtime, not the claude-cli harness.
+   Under claude-cli the tool and LLM hooks never fire and the run proves
+   nothing about the payloads.
+
+4. Re-record the hook frames and diff them against
+   `agenthookstest/fixtures/openclaw/` in the agenthooks repo. Check
+   specifically that:
+   - each subscribed hook still fires with the same name
+   - `ctx.runId` is identical across `before_agent_run`, `before_tool_call`,
+     `llm_output` and `agent_end`, since turn correlation depends on it and
+     degrades silently if it breaks
+   - `llm_output.event.usage` still carries the token fields
+   - `before_tool_call` still honours `{block, blockReason}`
+
+5. Run the capture verification above, plus one blocked tool call, and confirm
+   both land in the dashboard.
+
+6. Only then update the version table here and the fixture README. Any change
+   to a hook's payload shape, name or return contract is a decoder change in
+   `agenthooks/codec_openclaw.go`, not a docs change.
+
+### Why there is no nightly canary
+
+We deliberately do **not** run a scheduled job against OpenClaw `latest`. It
 would page on OpenClaw's release cadence and registry flakes without telling us
-what we actually support — the same reasoning the LiteLLM real-proxy suite is
-`workflow_dispatch` rather than scheduled.
+what we actually support, which is the same reasoning that keeps the LiteLLM
+real-proxy suite (`.github/workflows/litellm-e2e.yml`) on `workflow_dispatch`
+rather than a schedule. The procedure above is the qualification gate instead.
+
+`openclaw agent --local` does give a headless one-shot turn, so wiring OpenClaw
+into the existing `hooks:e2e` harness alongside the other providers is the
+natural home for an automated version of this. That is tracked separately
+rather than bolted on here.
 
 ## Operational gotchas
 

--- a/docs/runbooks/openclaw-install.md
+++ b/docs/runbooks/openclaw-install.md
@@ -1,0 +1,174 @@
+# OpenClaw install runbook
+
+How a customer installs the Speakeasy observability plugin into OpenClaw, what
+coverage they get, and how we qualify a new OpenClaw version.
+
+Read [Plugins overview](../plugins/overview.md) first for how observability
+packages are generated and published.
+
+## Before you start
+
+OpenClaw coverage is **not** uniform — it depends on how the customer's models
+authenticate. Establish this first, because it changes what you promise them.
+
+| Model auth mode                                       | What OpenClaw runs                                        | Hooks that fire                                                                                                   | Speakeasy coverage                                                                                                                     |
+| ----------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Embedded runtime (`agentRuntime: { id: "openclaw" }`) | Model + tool loop in-process                              | Full set: `before_agent_run`, `before_tool_call`, `after_tool_call`, `llm_output`, `agent_end`, session lifecycle | Full — capture **and** real-time tool blocking                                                                                         |
+| Claude CLI harness (`agentRuntime: claude-cli`)       | Delegates the loop to the Claude Code CLI, out-of-process | Only `agent_turn_prepare`, `before_prompt_build`, `before_message_write`                                          | Partial from OpenClaw — but these sessions are covered by Speakeasy's **Claude Code** hooks, which the CLI honors via managed settings |
+
+The trap: `openclaw models auth login` writes `agentRuntime: {id: "claude-cli"}`
+**by default for every model** when a claude-cli profile exists on the machine.
+A customer who authenticated interactively will land in the second row without
+choosing to. Auth-profile ordering alone does not flip it — the per-model
+`agentRuntime` does.
+
+This is complementary coverage, not a hole: between the two paths every session
+is observed. But say so explicitly, or the OpenClaw dashboard will look empty
+to a customer whose models all route through the Claude CLI.
+
+## Install (developer laptop)
+
+1. In the Gram dashboard, download the OpenClaw observability plugin ZIP
+   (**Plugins → Observability → OpenClaw**). This mints a hooks API key and
+   bakes it into the package's `speakeasy.json`. Requires `OrgAdmin`.
+
+2. Install it. `openclaw plugins install` accepts a directory or an archive
+   path, so either works:
+
+   ```sh
+   openclaw plugins install ./<org>-observability-openclaw
+   ```
+
+   Add `--force` to replace an existing install — without it the command
+   refuses rather than upgrading. This copies the package to
+   `<profile>/extensions/speakeasy-observability`.
+
+3. Enable conversation-scope hooks in the OpenClaw config:
+
+   ```json
+   {
+     "plugins": {
+       "entries": {
+         "speakeasy-observability": {
+           "enabled": true,
+           "hooks": { "allowConversationAccess": true }
+         }
+       }
+     }
+   }
+   ```
+
+   **This step is not optional.** Without `allowConversationAccess`, the
+   conversation hooks (`before_agent_run`, `llm_input`, `llm_output`,
+   `agent_end`, `before_agent_finalize`) silently never fire — no error, no
+   warning, just no prompts, no assistant responses and no usage. Tool hooks
+   still fire, so a half-configured install looks _partly_ working, which is
+   the most confusing failure mode we have here.
+
+4. Restart the Gateway. Plugin changes are not hot-loaded.
+
+5. Verify — see below.
+
+Uninstall with `openclaw plugins uninstall speakeasy-observability`.
+
+## Install (server / CI, no device agent)
+
+The plugin does not require the Speakeasy device agent. For a shared gateway or
+a CI image, skip the dashboard download and drive the hooks runtime entirely
+from the environment:
+
+| Variable                  | Purpose                                 |
+| ------------------------- | --------------------------------------- |
+| `GRAM_HOOKS_SERVER_URL`   | Gram server base URL                    |
+| `GRAM_HOOKS_ORG_KEY`      | Org hooks key (mint one per deployment) |
+| `GRAM_HOOKS_PROJECT_SLUG` | Target project; defaults to `default`   |
+| `GRAM_HOOKS_ORG_ID`       | Org ID                                  |
+
+Bake the plugin directory into the image and install it at build time; supply
+the variables at run time so the key is not baked into a layer. Rotate by
+replacing `GRAM_HOOKS_ORG_KEY` and restarting the gateway — no reinstall.
+
+Sessions from a shared gateway attribute to the org, not to an individual.
+Per-user attribution on shared gateways is tracked separately in DNO-971.
+
+## Verify
+
+1. Run a turn that uses a tool:
+
+   ```sh
+   openclaw agent --local "list the files in this directory"
+   ```
+
+2. In the dashboard, filter sessions by agent type **OpenClaw**. You should see
+   the session with its prompt, the assistant response, the tool call, and
+   token/cost totals on the turn.
+
+3. If the session appears but has **no prompt or usage**, step 3 of the install
+   was missed — `allowConversationAccess` is off.
+
+4. If **no session appears at all**, check in order:
+   - `openclaw plugins doctor` — reports plugin load issues directly, and is
+     the fastest way to tell "failed to load" from "loaded but not reporting".
+   - Gateway restarted after install?
+   - `openclaw plugins list` shows `speakeasy-observability` enabled?
+   - Is the model on the Claude CLI harness? (see the coverage table above)
+   - Gateway logs for `speakeasy-observability` errors.
+
+## Enforcement
+
+`before_tool_call` is a real blocking surface: a deny returns
+`{block: true, blockReason}`, the tool never executes, and the reason text is
+delivered to the model as the tool result.
+
+Two behaviors worth knowing:
+
+- **`after_tool_call` still fires for a blocked call**, with the block text as
+  the result. The provider marks these as blocked rather than completed; a
+  blocked call must not show up as a successful tool call.
+- **OpenClaw does not impose the 15s fail-closed policy timeout** we originally
+  briefed. A `before_tool_call` handler that stalls is awaited in full. Per-hook
+  `timeoutMs` exists on the registration API but is opt-in in the versions we
+  have tested. **Our shim therefore owns its own deadline** (`--timeout=60s`);
+  without it a hung control-plane call would stall the agent turn indefinitely.
+
+## Version-pin policy
+
+OpenClaw's plugin API is not versioned independently of OpenClaw itself, so the
+supported range is whatever we have actually qualified.
+
+| Version    | Status                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026.6.34  | Ground-truthed in the DNO-950 spike; all payload shapes and the hook vocabulary in `agenthookstest/fixtures/openclaw/` come from this build |
+| 2026.7.1-2 | In use locally; **not yet re-qualified**                                                                                                    |
+
+Note the drift: the fixtures our decoder is tested against were captured from
+2026.6.34, and nothing in the repo records that. Treat the fixture corpus as
+version-stamped evidence, not as a permanent contract.
+
+To qualify a new OpenClaw version, follow the LiteLLM precedent
+(`server/internal/litellm/fixtures/`): re-record the hook payloads from the new
+build, diff them against the checked-in fixtures, run the verification above
+for both capture and a blocked tool call, and only then document the version as
+supported. A change to any hook's payload shape, name or return contract is a
+decoder change in `agenthooks/codec_openclaw.go`, not a docs change.
+
+We deliberately do **not** run a nightly canary against OpenClaw `latest`. It
+would page on OpenClaw's release cadence and registry flakes without telling us
+what we actually support — the same reasoning the LiteLLM real-proxy suite is
+`workflow_dispatch` rather than scheduled.
+
+## Operational gotchas
+
+- The gateway process argv is just `openclaw`. Find it by port
+  (`lsof -iTCP:18789`, or `19001` under `--dev`), not by process name.
+- Interactive `models auth login --provider anthropic` installs a LaunchAgent
+  (`ai.openclaw.open`) running a default-profile gateway on 18789 that
+  **respawns when killed**. Relevant when a customer asks what installing
+  OpenClaw touches on a laptop.
+- `--dev` isolates state under `~/.openclaw-dev` on port 19001; `--profile
+<name>` isolates under `~/.openclaw-<name>`. Use one of these when testing so
+  you do not disturb a real install.
+- **Plugins see gateway secrets.** `gateway_start` hands the plugin the full
+  gateway config including `gateway.auth.token`. The provider scrubs
+  config-shaped payloads before anything leaves the machine, `raw` passthrough
+  included. Preserve that when touching the OpenClaw codec.

--- a/docs/runbooks/openclaw-install.md
+++ b/docs/runbooks/openclaw-install.md
@@ -104,13 +104,17 @@ environment instead of the key baked into the download.
    openclaw plugins install ./<org>-observability-openclaw.zip
    ```
 
-3. Preinstall the `speakeasy-hooks` binary. The plugin's bootstrap otherwise
-   downloads it from `https://github.com/speakeasy-api/gram/releases` on the
-   first hook firing, which needs egress from the running container and adds
-   latency to the first turn. Set `GRAM_HOOKS_HOME` to a directory baked into
-   the image and populate it at build time; the bootstrap uses that instead of
-   its per-OS cache location. If the download is left in place, allowlist that
-   host or the first hook fails with a bootstrap error.
+3. Optionally preinstall the `speakeasy-hooks` binary. The plugin's bootstrap
+   otherwise fetches it on the first hook firing, which needs egress from the
+   running container and adds latency to the first turn. Set `GRAM_HOOKS_HOME`
+   to a directory baked into the image and populate it at build time; the
+   bootstrap uses that instead of its per-OS cache location.
+
+   If you leave the download in place, the host to allowlist is **your own Gram
+   server** (`<GRAM_HOOKS_SERVER_URL>/hooks/releases/...`), not GitHub. The
+   binary is served by the org's Gram deployment precisely so that egress
+   restricted environments only ever need the one domain they already allow for
+   ingest.
 
 **At run time**, supply:
 

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -927,6 +927,24 @@ func generateReadme(plugins []PluginInfo, cfg GenerateConfig) []byte {
 	b.WriteString("OpenCode picks the package up on next start; remove the copied files to uninstall.\n")
 	b.WriteString("Plugins that need authentication read the environment variables named in their `mcp.json`.\n")
 
+	b.WriteString("\n### OpenClaw\n\n")
+	b.WriteString("Install the observability package directly from its directory:\n\n")
+	if cfg.HooksAPIKey != "" {
+		fmt.Fprintf(&b, "```\nopenclaw plugins install ./%s\n```\n\n", OpenClawObservabilitySlug(cfg))
+	} else {
+		b.WriteString("```\nopenclaw plugins install <plugin-dir>\n```\n\n")
+	}
+	b.WriteString("Add `--force` when replacing an existing install. Then enable conversation-scope hooks — ")
+	b.WriteString("without this the prompt, assistant-response and usage hooks silently never fire:\n\n")
+	b.WriteString("```json\n{\n  \"plugins\": {\n    \"entries\": {\n      \"speakeasy-observability\": {\n        \"enabled\": true,\n        \"hooks\": { \"allowConversationAccess\": true }\n      }\n    }\n  }\n}\n```\n\n")
+	b.WriteString("Restart the Gateway to load the plugin. Uninstall with `openclaw plugins uninstall speakeasy-observability`.\n\n")
+	b.WriteString("> **Coverage depends on your model-auth mode.** When a model routes through the Claude CLI harness ")
+	b.WriteString("(`agentRuntime: claude-cli`, which `openclaw models auth login` writes by default when a claude-cli ")
+	b.WriteString("profile exists), OpenClaw delegates the model and tool loop out-of-process and the tool/LLM hooks ")
+	b.WriteString("never fire — those sessions are covered by Speakeasy's Claude Code hooks instead. For OpenClaw-side ")
+	b.WriteString("tool capture and enforcement, configure the embedded runtime (`agentRuntime: { id: \"openclaw\" }`) ")
+	b.WriteString("for the models you want covered.\n")
+
 	return []byte(b.String())
 }
 

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -927,23 +927,25 @@ func generateReadme(plugins []PluginInfo, cfg GenerateConfig) []byte {
 	b.WriteString("OpenCode picks the package up on next start; remove the copied files to uninstall.\n")
 	b.WriteString("Plugins that need authentication read the environment variables named in their `mcp.json`.\n")
 
-	b.WriteString("\n### OpenClaw\n\n")
-	b.WriteString("Install the observability package directly from its directory:\n\n")
+	// OpenClaw ships only the observability package: there is no marketplace
+	// track and no per-plugin OpenClaw output. With no hooks key nothing
+	// OpenClaw-shaped is generated, so the whole section would describe files
+	// that are not in the repo.
 	if cfg.HooksAPIKey != "" {
-		fmt.Fprintf(&b, "```\nopenclaw plugins install ./%s\n```\n\n", OpenClawObservabilitySlug(cfg))
-	} else {
-		b.WriteString("```\nopenclaw plugins install <plugin-dir>\n```\n\n")
+		obs := OpenClawObservabilitySlug(cfg)
+		b.WriteString("\n### OpenClaw\n\n")
+		fmt.Fprintf(&b, "Install the observability package from its directory:\n\n```\nopenclaw plugins install ./%s\n```\n\n", obs)
+		b.WriteString("Add `--force` when replacing an existing install. Then enable conversation-scope hooks — ")
+		b.WriteString("without this the prompt, assistant-response and usage hooks silently never fire:\n\n")
+		b.WriteString("```json\n{\n  \"plugins\": {\n    \"entries\": {\n      \"speakeasy-observability\": {\n        \"enabled\": true,\n        \"hooks\": { \"allowConversationAccess\": true }\n      }\n    }\n  }\n}\n```\n\n")
+		b.WriteString("Restart the Gateway to load the plugin. Uninstall with `openclaw plugins uninstall speakeasy-observability`.\n\n")
+		b.WriteString("> **Coverage depends on your model-auth mode.** When a model routes through the Claude CLI harness ")
+		b.WriteString("(`agentRuntime: claude-cli`, which `openclaw models auth login` writes by default when a claude-cli ")
+		b.WriteString("profile exists), OpenClaw delegates the model and tool loop out-of-process and its tool/LLM hooks ")
+		b.WriteString("never fire. Those sessions are captured only if Speakeasy's Claude Code hooks are also deployed on ")
+		b.WriteString("the machine. For OpenClaw-side tool capture and enforcement, configure the embedded runtime ")
+		b.WriteString("(`agentRuntime: { id: \"openclaw\" }`) for the models you want covered.\n")
 	}
-	b.WriteString("Add `--force` when replacing an existing install. Then enable conversation-scope hooks — ")
-	b.WriteString("without this the prompt, assistant-response and usage hooks silently never fire:\n\n")
-	b.WriteString("```json\n{\n  \"plugins\": {\n    \"entries\": {\n      \"speakeasy-observability\": {\n        \"enabled\": true,\n        \"hooks\": { \"allowConversationAccess\": true }\n      }\n    }\n  }\n}\n```\n\n")
-	b.WriteString("Restart the Gateway to load the plugin. Uninstall with `openclaw plugins uninstall speakeasy-observability`.\n\n")
-	b.WriteString("> **Coverage depends on your model-auth mode.** When a model routes through the Claude CLI harness ")
-	b.WriteString("(`agentRuntime: claude-cli`, which `openclaw models auth login` writes by default when a claude-cli ")
-	b.WriteString("profile exists), OpenClaw delegates the model and tool loop out-of-process and the tool/LLM hooks ")
-	b.WriteString("never fire — those sessions are covered by Speakeasy's Claude Code hooks instead. For OpenClaw-side ")
-	b.WriteString("tool capture and enforcement, configure the embedded runtime (`agentRuntime: { id: \"openclaw\" }`) ")
-	b.WriteString("for the models you want covered.\n")
 
 	return []byte(b.String())
 }

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2270,6 +2270,40 @@ func TestGenerateReadmeIncludesCodexInstallation(t *testing.T) {
 	require.Contains(t, readme, "codex plugin marketplace add")
 }
 
+func TestGenerateReadmeIncludesOpenClawInstallation(t *testing.T) {
+	t.Parallel()
+	files, err := GeneratePluginPackages(nil, GenerateConfig{
+		OrgName:     "Acme",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_hooks_test",
+	})
+	require.NoError(t, err)
+
+	readme := string(files["README.md"])
+	require.Contains(t, readme, "### OpenClaw")
+	require.Contains(t, readme, "openclaw plugins install ./"+OpenClawObservabilitySlug(GenerateConfig{OrgName: "Acme"}))
+	// The install is inert without this: the conversation hooks never fire and
+	// prompts, responses and usage go uncaptured with no error.
+	require.Contains(t, readme, `"allowConversationAccess": true`)
+	require.Contains(t, readme, "openclaw plugins uninstall speakeasy-observability")
+	require.Contains(t, readme, "Coverage depends on your model-auth mode")
+}
+
+// With no hooks key nothing OpenClaw-shaped is generated, so the README must
+// not tell users to install a package that is not in the repo.
+func TestGenerateReadmeOmitsOpenClawWithoutHooksKey(t *testing.T) {
+	t.Parallel()
+	files, err := GeneratePluginPackages(nil, GenerateConfig{
+		OrgName:   "Acme",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	readme := string(files["README.md"])
+	require.NotContains(t, readme, "### OpenClaw")
+	require.NotContains(t, readme, "speakeasy-observability")
+}
+
 // Bootstrap and install scripts in ZIPs must carry the execute bit, otherwise
 // extracting the archive leaves them unrunnable. Mirrors the GitHub publish
 // path's mode 100755 in thirdparty/github/repo.go.


### PR DESCRIPTION
Closes DNO-960. Split from #5929 so nothing here shares a rollback fate with the schema change.

## Why

We ship an OpenClaw observability package but never told anyone how to install it. The generated ZIP README had sections for Claude Code, Cursor, Codex and OpenCode, and nothing for OpenClaw.

There was also no runbook for the two things that silently break an OpenClaw install — both of which produce a *partly* working state rather than an obvious failure, which is the worst kind.

## What changed

- **Generated package README**: an OpenClaw install section — the directory install, `--force` when replacing, the required `allowConversationAccess` block, the Gateway restart, and the coverage caveat
- **`docs/runbooks/openclaw-install.md`**: laptop and server/CI install paths, verification, enforcement semantics, version-pin policy, and the operational gotchas from the DNO-950 spike
- **`docs/plugins/overview.md`**: OpenClaw listed alongside the other observability packages and in the `downloadObservabilityPlugin` enum

## The two traps the runbook exists for

1. **`allowConversationAccess`.** Without it the conversation hooks silently never fire — no prompts, no assistant responses, no usage — while tool hooks keep working. A half-configured install looks partly fine.
2. **The harness split.** When a model routes through the Claude CLI harness (`agentRuntime: claude-cli`, which `openclaw models auth login` writes *by default* when a claude-cli profile exists), OpenClaw delegates the model and tool loop out-of-process and its tool/LLM hooks never fire. Those sessions are still covered — by our Claude Code hooks — so this is complementary coverage rather than a hole, but a customer in that mode will otherwise think the integration is broken.

## Notes

- `generate.go` is a server implementation file, but the change is purely the customer-facing install text, so it belongs with the runbook rather than the feature PR.
- No `hooksGeneratorVersion` bump needed: the README is not part of the rendered hook-plugin subtree that `check-generator-versions` diffs. Confirmed by rendering `export-hook-plugin -published` and checking the file list.
- The runbook records that our fixtures were captured from OpenClaw 2026.6.34 while 2026.7.1-2 is what installs today, and documents the qualification procedure for that gap. The fixture-side half is speakeasy-api/agenthooks#24.
- Deliberately no nightly canary against OpenClaw `latest`: it would page on OpenClaw's release cadence and registry flakes without telling us what we actually support — the same reasoning that keeps the LiteLLM real-proxy suite on `workflow_dispatch`.

## Related PRs

Independent — all three branch from `main`, no stacking:

- #5929 — `feat:` source alias and turn correlation
- #5932 — `mig:` the materialized-view change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiJy9DrFpsmnD2vEkDHKNv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenClaw install docs for the observability plugin — the generated ZIP README now has an OpenClaw section, and a new runbook covers laptop and server/CI installs. Two configuration states silently break coverage without any error, and both are now documented.

- The README's OpenClaw section is generated only when a hooks API key exists, so it never describes files that aren't in the ZIP.
- The runbook details the two traps: missing `allowConversationAccess` drops prompt and usage capture while tool hooks keep working, and the Claude CLI harness routes sessions through Claude Code hooks, which capture them only if those hooks are also deployed on the machine.
- Documents how coverage depends on model-auth mode, the enforcement timeout budgets, the version-pin qualification procedure, and that the hooks binary is fetched from the org's Gram server rather than GitHub.
- Adds an OpenClaw package-format section in `docs/plugins/package-format.md`, and lists OpenClaw in `docs/plugins/overview.md`, the `downloadObservabilityPlugin` enum, and the observability slug table in `docs/plugins/publishing.md`.
- Closes DNO-960.

<sup>Written for commit 024520e661a50e7fbd169b8061a337384b3de967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

