### PR TITLE
fix: avoid replica waits during telemetry promotion

### DIFF
--- a/server/internal/telemetry/repo/staging.go
+++ b/server/internal/telemetry/repo/staging.go
@@ -305,12 +305,12 @@ func (q *Queries) ListExistingTelemetryLogIDs(ctx context.Context, projectID str
 	return result, nil
 }
 
-// DeleteStagedTelemetryLogs synchronously removes promoted rows from staging
-// with a lightweight delete. Waiting for active replicas keeps the activity's
-// next drain pass from observing rows it already promoted without failing when
-// ClickHouse Cloud has an inactive compute replica. Safe to retry: deleting an
-// already-deleted id is a no-op, and a crash before this delete only leaves
-// rows the next promotion pass skips via the dedup guard.
+// DeleteStagedTelemetryLogs removes promoted rows from staging and waits only
+// for the server that accepted the lightweight delete. Waiting on replicas
+// made the activity fail when a ClickHouse Cloud replica was unavailable even
+// though the delete continued asynchronously. Another replica may briefly
+// return an already-promoted row, but the telemetry_logs existence guard makes
+// that retry delete-only and safe.
 func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID string, ids []string) error {
 	if len(ids) == 0 {
 		return nil
@@ -326,7 +326,7 @@ func (q *Queries) DeleteStagedTelemetryLogs(ctx context.Context, projectID strin
 	}
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"lightweight_deletes_sync": 3,
+		"lightweight_deletes_sync": 1,
 	}))
 
 	if err := q.conn.Exec(ctx, query, args...); err != nil {


### PR DESCRIPTION
## Summary

- wait only for the ClickHouse server that accepts a promoted-staging delete instead of waiting on replica acknowledgement
- document why a temporarily stale replica cannot cause duplicate telemetry insertion

## Motivation

Telemetry promotion inserts rows into the destination table before removing them from staging. The staging delete previously used `lightweight_deletes_sync=3`, so an unavailable ClickHouse Cloud replica could make the activity return an error even though ClickHouse accepted the delete and continued it asynchronously. Temporal then retried the activity, producing repeated failure alerts and unnecessary work.

Using local delete acknowledgement removes replica availability from the activity's success condition. This is safe because promotion preserves row IDs and checks the destination table before every insert. If another replica briefly returns the staged row, the retry sees that the row was already promoted, skips the insert, and performs only the idempotent staging delete.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes telemetry promotion's staging delete to wait only for the ClickHouse server that accepted it instead of all replicas (`lightweight_deletes_sync` from 3 to 1). Previously, an unavailable ClickHouse Cloud replica could make the activity return an error even though the delete continued asynchronously, causing Temporal retries and repeated failure alerts. This is safe because the destination-table existence guard skips inserts for already-promoted rows, so a temporarily stale replica only triggers an idempotent delete.

<sup>Written for commit f94732758ce8388baa179e4169f92806f98ae270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

