### PR TITLE
fix: drain tunnel gateway routes and sessions on shutdown

### DIFF
--- a/tunnel/cmd/tunnel-gateway/main.go
+++ b/tunnel/cmd/tunnel-gateway/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -78,12 +79,28 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	var shutdownOnce sync.Once
+	shutdownDone := make(chan struct{})
+	shutdown := func() {
+		shutdownOnce.Do(func() {
+			defer close(shutdownDone)
+			shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+			defer cancel()
+			drainCtx, cancelDrain := context.WithTimeout(shutCtx, 10*time.Second)
+			gw.Drain(drainCtx)
+			cancelDrain()
+			forwardCtx, cancelForward := context.WithTimeout(shutCtx, 10*time.Second)
+			_ = forwardSrv.Shutdown(forwardCtx)
+			cancelForward()
+			closeSessionsCtx, cancelCloseSessions := context.WithTimeout(shutCtx, 4*time.Second)
+			gw.CloseSessions(closeSessionsCtx)
+			cancelCloseSessions()
+			_ = publicSrv.Shutdown(shutCtx)
+		})
+	}
 	go func() {
 		<-ctx.Done()
-		shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
-		defer cancel()
-		_ = publicSrv.Shutdown(shutCtx)
-		_ = forwardSrv.Shutdown(shutCtx)
+		shutdown()
 	}()
 
 	errCh := make(chan error, 2)
@@ -94,16 +111,17 @@ func main() {
 		slog.String("public_addr", publicListenAddr),
 		slog.String("forward_addr", forwardListenAddr),
 		slog.String("advertise", advertiseAddr))
+	var serverErr error
 	for range 2 {
-		if err := <-errCh; err != nil {
+		if err := <-errCh; err != nil && serverErr == nil {
+			serverErr = err
 			stop()
-			shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
-			_ = publicSrv.Shutdown(shutCtx)
-			_ = forwardSrv.Shutdown(shutCtx)
-			cancel()
-			logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", err))
-			os.Exit(1)
 		}
+	}
+	<-shutdownDone
+	if serverErr != nil {
+		logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", serverErr))
+		os.Exit(1)
 	}
 }
 

--- a/tunnel/e2e/tunnel_test.go
+++ b/tunnel/e2e/tunnel_test.go
@@ -49,6 +49,7 @@ func TestTunnelEndToEnd(t *testing.T) {
 	keys := gateway.NewStaticKeyStore(map[string]string{tunnelID: plaintext})
 	gw, err := gateway.New(gateway.Config{ForwardToken: forwardToken}, keys, routes, logger)
 	require.NoError(t, err)
+	cleanupGateway(t, gw)
 
 	publicServer := httptest.NewServer(gw.PublicHandler())
 	defer publicServer.Close()
@@ -163,6 +164,7 @@ func TestTunnelRouteSurvivesCurrentGatewayDisconnect(t *testing.T) {
 
 		gw, err := gateway.New(gateway.Config{ForwardToken: forwardToken}, keys, routes, logger)
 		require.NoError(t, err)
+		cleanupGateway(t, gw)
 
 		publicServer := httptest.NewServer(gw.PublicHandler())
 		t.Cleanup(publicServer.Close)
@@ -226,6 +228,7 @@ func TestTunnelConsumerSessionSticksToAgent(t *testing.T) {
 	keys := gateway.NewStaticKeyStore(map[string]string{tunnelID: plaintext})
 	gw, err := gateway.New(gateway.Config{ForwardToken: forwardToken}, keys, routes, logger)
 	require.NoError(t, err)
+	cleanupGateway(t, gw)
 
 	publicServer := httptest.NewServer(gw.PublicHandler())
 	t.Cleanup(publicServer.Close)
@@ -279,6 +282,7 @@ func TestTunnelRevoke(t *testing.T) {
 	routes := route.NewRouteTable()
 	gw, err := gateway.New(gateway.Config{ForwardToken: "forward-token"}, gateway.NewStaticKeyStore(map[string]string{tunnelID: plaintext}), routes, logger)
 	require.NoError(t, err)
+	cleanupGateway(t, gw)
 	publicServer := httptest.NewServer(gw.PublicHandler())
 	defer publicServer.Close()
 	forwardServer := httptest.NewServer(gw.ForwardHandler())
@@ -303,6 +307,67 @@ func TestTunnelRevoke(t *testing.T) {
 	candidates, err := routes.Candidates(ctx, tunnelID)
 	require.NoError(t, err)
 	require.Empty(t, candidates)
+}
+
+func TestTunnelRevokeDeletesAllGatewayOwners(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := t.Context()
+	mcp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(mcp.Close)
+
+	const (
+		tunnelID     = "tunnel-revoke-multi-owner"
+		forwardToken = "forward-token"
+	)
+	plaintext, _, err := wire.NewKey()
+	require.NoError(t, err)
+	routes := newSnapshotStore()
+	keys := gateway.NewStaticKeyStore(map[string]string{tunnelID: plaintext})
+
+	startGateway := func() (*gateway.Gateway, context.CancelFunc) {
+		gw, err := gateway.New(gateway.Config{ForwardToken: forwardToken}, keys, routes, logger)
+		require.NoError(t, err)
+		publicServer := httptest.NewServer(gw.PublicHandler())
+		t.Cleanup(publicServer.Close)
+		forwardServer := httptest.NewServer(gw.ForwardHandler())
+		t.Cleanup(forwardServer.Close)
+		gw.SetAdvertiseAddr(forwardServer.Listener.Addr().String())
+		cleanupGateway(t, gw)
+
+		ag, err := agent.New(agent.Config{
+			GatewayURL:     "ws" + strings.TrimPrefix(publicServer.URL, "http") + "/connect",
+			APIKey:         plaintext,
+			LocalMCPURL:    mcp.URL,
+			ServiceVersion: "0.1.0",
+			MaxBackoff:     200 * time.Millisecond,
+		}, logger)
+		require.NoError(t, err)
+		agentCtx, stopAgent := context.WithCancel(ctx)
+		t.Cleanup(stopAgent)
+		go func() { _ = ag.Run(agentCtx) }()
+		return gw, stopAgent
+	}
+
+	first, _ := startGateway()
+	second, stopSecond := startGateway()
+	requireEventually(t, 5*time.Second, func() bool {
+		candidates, _ := routes.Candidates(ctx, tunnelID)
+		return len(candidates) == 2 && first.ActiveSessions() == 1 && second.ActiveSessions() == 1 &&
+			len(routes.connections(tunnelID)) == 2
+	})
+
+	require.Equal(t, 1, first.RevokeTunnel(ctx, tunnelID))
+	stopSecond()
+	requireEventually(t, 5*time.Second, func() bool { return second.ActiveSessions() == 0 })
+	second.Drain(ctx)
+	candidates, err := routes.Candidates(ctx, tunnelID)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+	require.Empty(t, routes.connections(tunnelID))
 }
 
 func forwardThroughRoute(t *testing.T, ctx context.Context, routes route.Store, tunnelID, forwardToken, path string) (int, string) {
@@ -352,6 +417,18 @@ func responseAgentLabel(body string) string {
 func requireEventually(t *testing.T, d time.Duration, cond func() bool) {
 	t.Helper()
 	require.Eventually(t, cond, d, 20*time.Millisecond)
+}
+
+func cleanupGateway(t *testing.T, gw *gateway.Gateway) {
+	t.Helper()
+	t.Cleanup(func() {
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), 5*time.Second)
+		gw.Drain(drainCtx)
+		cancelDrain()
+		closeSessionsCtx, cancelCloseSessions := context.WithTimeout(context.Background(), 5*time.Second)
+		gw.CloseSessions(closeSessionsCtx)
+		cancelCloseSessions()
+	})
 }
 
 type snapshotStore struct {
@@ -450,6 +527,7 @@ func TestTunnelGatewayShedsConnectsAtSessionCap(t *testing.T) {
 		logger,
 	)
 	require.NoError(t, err)
+	cleanupGateway(t, gw)
 
 	publicServer := httptest.NewServer(gw.PublicHandler())
 	defer publicServer.Close()

--- a/tunnel/gateway/gateway.go
+++ b/tunnel/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -47,15 +48,18 @@ type Config struct {
 	// so load moves to sibling gateway pods via agent retry.
 	MaxSessions  int
 	ForwardToken string
+
+	routeRefreshInterval time.Duration
 }
 
 // Gateway owns live agent yamux sessions and maps internal forwards to substreams.
 type Gateway struct {
-	cfg    Config
-	keys   KeyResolver
-	routes route.Store
-	reg    *registry
-	logger *slog.Logger
+	cfg        Config
+	keys       KeyResolver
+	reg        *registry
+	reconciler *routeReconciler
+	logger     *slog.Logger
+	drain      sync.Once
 }
 
 func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) (*Gateway, error) {
@@ -69,12 +73,17 @@ func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) 
 	if cfg.MaxSessions <= 0 {
 		cfg.MaxSessions = defaultMaxSessions
 	}
+	if cfg.routeRefreshInterval <= 0 {
+		cfg.routeRefreshInterval = routeTTL / 2
+	}
+	reg := newRegistry()
 	return &Gateway{
-		cfg:    cfg,
-		keys:   keys,
-		routes: routes,
-		reg:    newRegistry(),
-		logger: logger,
+		cfg:        cfg,
+		keys:       keys,
+		reg:        reg,
+		reconciler: newRouteReconciler(reg, keys, routes, cfg.AdvertiseAddr, logger, cfg.routeRefreshInterval),
+		logger:     logger,
+		drain:      sync.Once{},
 	}, nil
 }
 
@@ -82,27 +91,71 @@ func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) 
 func (g *Gateway) PublicHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/connect", g.handleConnect)
-	mux.HandleFunc("/healthz", healthz)
+	mux.HandleFunc("/healthz", g.healthz)
 	return mux
 }
 
 func (g *Gateway) ForwardHandler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", healthz)
+	mux.HandleFunc("/healthz", g.healthz)
 	mux.HandleFunc("/", g.handleForward)
 	return mux
 }
 
-func healthz(w http.ResponseWriter, _ *http.Request) {
+// Liveness requires three 20s failures, longer than the 25s drain; returning
+// 503 here safely removes a draining pod from Service endpoints immediately.
+func (g *Gateway) healthz(w http.ResponseWriter, _ *http.Request) {
+	if g.reg.isDraining() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 
 func (g *Gateway) ActiveSessions() int { return g.reg.activeSessions() }
 
 // SetAdvertiseAddr lets tests publish listener addresses known only after bind.
-func (g *Gateway) SetAdvertiseAddr(addr string) { g.cfg.AdvertiseAddr = addr }
+func (g *Gateway) SetAdvertiseAddr(addr string) { g.reconciler.address.Store(addr) }
+
+// Drain stops session admission and removes every route this gateway has owned.
+// Existing sessions remain open until CloseSessions is called.
+func (g *Gateway) Drain(ctx context.Context) {
+	g.drain.Do(func() {
+		tunnelIDs := g.reg.beginDrain()
+		g.reconciler.requestDrain(ctx, tunnelIDs)
+	})
+	select {
+	case <-g.reconciler.done:
+	case <-ctx.Done():
+	}
+}
+
+// CloseSessions closes all live agent sessions concurrently within ctx.
+func (g *Gateway) CloseSessions(ctx context.Context) {
+	sessions := g.reg.sessionsSnapshot()
+	closed := make(chan struct{}, len(sessions))
+	for _, session := range sessions {
+		go func() {
+			_ = session.Close()
+			closed <- struct{}{}
+		}()
+	}
+	for range sessions {
+		select {
+		case <-closed:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
 
 func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
+	if g.reg.isDraining() {
+		http.Error(w, "tunnel gateway is draining", http.StatusServiceUnavailable)
+		return
+	}
+
 	// Shed before key lookup so a connect storm cannot load the key resolver.
 	if g.reg.activeSessions() >= g.cfg.MaxSessions {
 		g.logger.WarnContext(r.Context(), "tunnel connect rejected",
@@ -165,6 +218,16 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 
+	// This best-effort re-check only narrows the upgrade-to-MarkConnected drain race.
+	// reg.add remains the authoritative session gate; losing the remaining race can
+	// write one spurious durable activation that self-corrects when the agent re-homes.
+	if g.reg.isDraining() {
+		g.logger.InfoContext(r.Context(), "tunnel connect rejected",
+			slog.String("reason", "draining"), slog.String("tunnel_id", tunnelID))
+		_ = session.Close()
+		return
+	}
+
 	// Record durable activation only after the session is actually live: a
 	// valid-key plain-HTTP probe (no upgrade) must not flip status to active
 	// or advance last_seen_at for a tunnel that never connected. On failure,
@@ -180,7 +243,7 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	sessionID := uuid.NewString()
 	now := time.Now().UTC()
-	remove := g.reg.add(tunnelID, sessionID, session, g.newSessionProxy(tunnelID, session), route.Connection{
+	remove := g.reg.add(tunnelID, sessionID, presentedKeyHash, session, g.newSessionProxy(tunnelID, session), route.Connection{
 		GatewaySessionID:       sessionID,
 		ServiceVersion:         serviceVersion,
 		AgentVersion:           agentVersion,
@@ -191,89 +254,24 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 		ActiveConsumerSessions: 0,
 		Metadata:               metadata,
 	})
-	stateCtx, cancelState := routeOperationContext(r.Context())
-	if err := g.routes.Publish(stateCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
-		g.logger.WarnContext(r.Context(), "tunnel route publish failed", slog.Any("error", err))
+	if remove == nil {
+		g.logger.InfoContext(r.Context(), "tunnel connect rejected",
+			slog.String("reason", "draining"), slog.String("tunnel_id", tunnelID))
+		return
 	}
-	g.publishConnectionSnapshot(stateCtx, tunnelID, now)
-	cancelState()
+	g.reconciler.nudge(tunnelID)
 	g.logger.InfoContext(r.Context(), "tunnel connected",
 		slog.String("tunnel_id", tunnelID), slog.String("session_id", sessionID),
 		slog.String("agent_version", agentVersion), slog.Int("active", g.reg.activeSessions()))
 
 	go g.sayHello(session, tunnelID, sessionID)
 
-	stop := make(chan struct{})
-	go g.refreshSessionState(tunnelID, presentedKeyHash, session, stop)
-
 	<-session.CloseChan()
-	close(stop)
 	remove()
-	g.cleanupSessionState(tunnelID)
+	g.reconciler.nudge(tunnelID)
 	g.logger.InfoContext(context.Background(), "tunnel disconnected",
 		slog.String("tunnel_id", tunnelID), slog.String("session_id", sessionID),
 		slog.Int("active", g.reg.activeSessions()))
-}
-
-// cleanupSessionState tears down route/snapshot state after a session closes.
-// The count-check and Unpublish are not atomic with a concurrent connect's
-// add+Publish, so a dying session could delete the route a replacement session
-// just published; after unpublishing we re-check the registry and republish if
-// a session appeared. Any connect that adds itself after the re-check performs
-// its own Publish after our Unpublish, so every interleaving converges on a
-// published route while live sessions exist.
-func (g *Gateway) cleanupSessionState(tunnelID string) {
-	stateCtx, cancelState := routeOperationContext(context.Background())
-	defer cancelState()
-	if g.reg.tunnelSessionCount(tunnelID) > 0 {
-		g.publishConnectionSnapshot(stateCtx, tunnelID, time.Now().UTC())
-		return
-	}
-	if err := g.routes.Unpublish(stateCtx, tunnelID, g.cfg.AdvertiseAddr); err != nil {
-		g.logger.WarnContext(stateCtx, "tunnel route unpublish failed", slog.Any("error", err))
-	}
-	g.deleteConnectionSnapshot(stateCtx, tunnelID)
-	if g.reg.tunnelSessionCount(tunnelID) > 0 {
-		if err := g.routes.Publish(stateCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
-			g.logger.WarnContext(stateCtx, "tunnel route republish after reconnect race failed", slog.Any("error", err))
-		}
-		g.publishConnectionSnapshot(stateCtx, tunnelID, time.Now().UTC())
-	}
-}
-
-func (g *Gateway) refreshSessionState(tunnelID, keyHash string, session *yamux.Session, stop <-chan struct{}) {
-	t := time.NewTicker(routeTTL / 2)
-	defer t.Stop()
-	for {
-		select {
-		case <-stop:
-			return
-		case <-t.C:
-			if checker, ok := g.keys.(ActiveTunnelChecker); ok {
-				opCtx, cancel := routeOperationContext(context.Background())
-				active, err := checker.IsActive(opCtx, tunnelID, keyHash)
-				cancel()
-				if err != nil {
-					g.logger.WarnContext(context.Background(), "tunnel active check failed",
-						slog.String("tunnel_id", tunnelID), slog.Any("error", err))
-					continue
-				}
-				if !active {
-					g.logger.InfoContext(context.Background(), "tunnel session no longer active",
-						slog.String("tunnel_id", tunnelID))
-					_ = session.Close()
-					return
-				}
-			}
-			opCtx, cancel := routeOperationContext(context.Background())
-			if err := g.routes.Publish(opCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
-				g.logger.WarnContext(opCtx, "tunnel route refresh failed",
-					slog.String("tunnel_id", tunnelID), slog.Any("error", err))
-			}
-			g.publishConnectionSnapshot(opCtx, tunnelID, time.Now().UTC())
-			cancel()
-		}
-	}
 }
 
 func routeOperationContext(parent context.Context) (context.Context, context.CancelFunc) {
@@ -283,28 +281,6 @@ func routeOperationContext(parent context.Context) (context.Context, context.Can
 func hashBearerKey(bearer string) string {
 	key := strings.TrimSpace(strings.TrimPrefix(bearer, "Bearer "))
 	return wire.HashKey(key)
-}
-
-func (g *Gateway) publishConnectionSnapshot(ctx context.Context, tunnelID string, heartbeatAt time.Time) {
-	store, ok := g.routes.(route.ConnectionSnapshotStore)
-	if !ok {
-		return
-	}
-	if err := store.PublishConnections(ctx, tunnelID, g.cfg.AdvertiseAddr, g.reg.connections(tunnelID, heartbeatAt), routeTTL); err != nil {
-		g.logger.WarnContext(ctx, "tunnel connection snapshot publish failed",
-			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
-	}
-}
-
-func (g *Gateway) deleteConnectionSnapshot(ctx context.Context, tunnelID string) {
-	store, ok := g.routes.(route.ConnectionSnapshotStore)
-	if !ok {
-		return
-	}
-	if err := store.DeleteConnectionOwner(ctx, tunnelID, g.cfg.AdvertiseAddr); err != nil {
-		g.logger.WarnContext(ctx, "tunnel connection snapshot delete failed",
-			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
-	}
 }
 
 var errServiceMetadataTooLarge = errors.New("tunnel service metadata exceeds 1024 bytes serialized JSON")
@@ -397,20 +373,11 @@ func (g *Gateway) handleForward(w http.ResponseWriter, r *http.Request) {
 	// existing header map without clearing it.
 	w.Header().Set(wire.HeaderTunnelAgentSession, entry.id)
 	// Publish the begin-forward snapshot asynchronously: mid-flight counter
-	// freshness matters (dashboards show active substreams during long-lived
-	// streams), but the forward's latency path must not block on Redis. At
-	// most one goroutine per in-flight forward, bounded by the substream cap
-	// and the routeOperationTimeout.
-	go func() {
-		opCtx, cancel := routeOperationContext(context.Background())
-		defer cancel()
-		g.publishConnectionSnapshot(opCtx, tunnelID, time.Now().UTC())
-	}()
+	// freshness matters, but coalescing keeps Redis out of the forwarding path.
+	g.reconciler.nudge(tunnelID)
 	defer func() {
 		g.reg.finishForward(entry, time.Now().UTC())
-		opCtx, cancel := routeOperationContext(context.Background())
-		defer cancel()
-		g.publishConnectionSnapshot(opCtx, tunnelID, time.Now().UTC())
+		g.reconciler.nudge(tunnelID)
 	}()
 
 	entry.proxy.ServeHTTP(w, r)
@@ -437,18 +404,15 @@ func (g *Gateway) newSessionProxy(tunnelID string, session *yamux.Session) http.
 	}
 }
 
-// RevokeTunnel clears live routes/sessions; durable revocation stays in the key resolver.
+// RevokeTunnel closes this gateway's sessions and globally removes every route
+// and connection snapshot owner. Durable revocation stays in the key resolver.
 func (g *Gateway) RevokeTunnel(ctx context.Context, tunnelID string) int {
 	if revoker, ok := g.keys.(interface{ Revoke(string) }); ok {
 		revoker.Revoke(tunnelID)
 	}
-	opCtx, cancel := routeOperationContext(ctx)
-	defer cancel()
-	_ = g.routes.Delete(opCtx, tunnelID)
-	if store, ok := g.routes.(route.ConnectionSnapshotStore); ok {
-		_ = store.DeleteConnections(opCtx, tunnelID)
-	}
-	return g.reg.kill(tunnelID)
+	killed := g.reg.kill(tunnelID)
+	g.reconciler.requestRevoke(ctx, tunnelID)
+	return killed
 }
 
 // Disable keepalives so each request opens and closes its own yamux substream.

--- a/tunnel/gateway/gateway_test.go
+++ b/tunnel/gateway/gateway_test.go
@@ -36,6 +36,14 @@ func newForwardTestGateway(t *testing.T, cfg Config) *Gateway {
 	t.Helper()
 	gw, err := New(cfg, NewStaticKeyStore(map[string]string{}), route.NewRouteTable(), slog.New(slog.NewTextHandler(io.Discard, nil)))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		drainCtx, cancelDrain := context.WithTimeout(context.Background(), time.Second)
+		gw.Drain(drainCtx)
+		cancelDrain()
+		closeSessionsCtx, cancelCloseSessions := context.WithTimeout(context.Background(), time.Second)
+		gw.CloseSessions(closeSessionsCtx)
+		cancelCloseSessions()
+	})
 	return gw
 }
 
@@ -87,13 +95,8 @@ func TestForwardHandlerAcceptsValidTokenAndStripsIt(t *testing.T) {
 func TestForwardHandlerRejectsMissingForwardTokenConfig(t *testing.T) {
 	t.Parallel()
 
-	gw := &Gateway{
-		cfg:    Config{},
-		keys:   NewStaticKeyStore(map[string]string{}),
-		routes: route.NewRouteTable(),
-		reg:    newRegistry(),
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}
+	gw := newForwardTestGateway(t, Config{ForwardToken: "configured"})
+	gw.cfg.ForwardToken = ""
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/mcp/initialize", strings.NewReader(`{"jsonrpc":"2.0"}`))
@@ -126,8 +129,8 @@ func TestRegistryBeginForwardRoundRobinsWithoutConsumerSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := reg.add("tunnel-1", "session-b", "", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -143,8 +146,8 @@ func TestRegistryBeginForwardSticksStableConsumerSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := reg.add("tunnel-1", "session-b", "", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -161,8 +164,8 @@ func TestRegistryBeginForwardUsesNextRankedEligibleSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := reg.add("tunnel-1", "session-b", "", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -185,7 +188,7 @@ func TestRegistryBeginForwardDistinguishesBusyFromNoSession(t *testing.T) {
 	require.Equal(t, forwardNoSession, failure)
 
 	session := newYamuxSession(t)
-	remove := reg.add("tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := reg.add("tunnel-1", "session-a", "", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	entry, failure := reg.beginForward("tunnel-1", "", "", time.Now().UTC(), 1)
@@ -204,7 +207,7 @@ func TestForwardHandlerReportsTunnelBusyAtCap(t *testing.T) {
 
 	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", MaxStreamsPerTunnel: 1})
 	session := newYamuxSession(t)
-	remove := gw.reg.add("tunnel-1", "session-a", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := gw.reg.add("tunnel-1", "session-a", "", session, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	// Occupy the single substream slot so the next forward hits the cap.
@@ -220,71 +223,6 @@ func TestForwardHandlerReportsTunnelBusyAtCap(t *testing.T) {
 
 	require.Equal(t, http.StatusBadGateway, rec.Code)
 	require.Equal(t, wire.TunnelErrorTunnelBusy, rec.Header().Get("X-Gram-Tunnel-Error"))
-}
-
-// unpublishHookStore wraps a route.Store and runs a hook just before the
-// underlying Unpublish executes — used to interleave a concurrent connect at
-// the worst possible moment of the disconnect cleanup.
-type unpublishHookStore struct {
-	route.Store
-	beforeUnpublish func()
-}
-
-func (s *unpublishHookStore) Unpublish(ctx context.Context, tunnelID, addr string) error {
-	if s.beforeUnpublish != nil {
-		s.beforeUnpublish()
-	}
-	return s.Store.Unpublish(ctx, tunnelID, addr)
-}
-
-// TestCleanupSessionStateHealsReconnectRace reproduces the disconnect/connect
-// race: session A's cleanup reads count==0, a replacement session B registers
-// (its Publish already happened), then A's Unpublish deletes B's fresh route.
-// The cleanup must detect the survivor and republish.
-func TestCleanupSessionStateHealsReconnectRace(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	table := route.NewRouteTable()
-	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", AdvertiseAddr: "gw-1:8091"})
-
-	hooked := &unpublishHookStore{Store: table, beforeUnpublish: nil}
-	gw.routes = hooked
-
-	// Replacement session B "connected" earlier in the race: its Publish has
-	// already landed; its registry add slips in during A's cleanup below.
-	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-1:8091", time.Minute))
-	sessionB := newYamuxSession(t)
-	hooked.beforeUnpublish = func() {
-		remove := gw.reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
-		t.Cleanup(remove)
-	}
-
-	// Session A already removed itself from the registry; count reads 0.
-	gw.cleanupSessionState("tunnel-1")
-
-	candidates, err := table.Candidates(ctx, "tunnel-1")
-	require.NoError(t, err)
-	require.Equal(t, []string{"gw-1:8091"}, candidates, "route for the live replacement session must survive the stale cleanup")
-}
-
-// TestCleanupSessionStateRemovesRouteWhenLastSessionCloses covers the normal
-// path: no survivors, route and snapshot removed.
-func TestCleanupSessionStateRemovesRouteWhenLastSessionCloses(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	table := route.NewRouteTable()
-	gw := newForwardTestGateway(t, Config{ForwardToken: "s3cret", AdvertiseAddr: "gw-1:8091"})
-	gw.routes = table
-
-	require.NoError(t, table.Publish(ctx, "tunnel-1", "gw-1:8091", time.Minute))
-
-	gw.cleanupSessionState("tunnel-1")
-
-	candidates, err := table.Candidates(ctx, "tunnel-1")
-	require.NoError(t, err)
-	require.Empty(t, candidates)
 }
 
 // recordingKeyStore wraps StaticKeyStore with a MarkConnected spy.
@@ -308,6 +246,11 @@ func TestConnectProbeDoesNotMarkConnected(t *testing.T) {
 	keys := &recordingKeyStore{StaticKeyStore: NewStaticKeyStore(map[string]string{"tunnel-1": "gram_tunnel_testkey"}), markConnectedCalls: 0}
 	gw, err := New(Config{ForwardToken: "s3cret"}, keys, route.NewRouteTable(), slog.New(slog.NewTextHandler(io.Discard, nil)))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		gw.Drain(ctx)
+	})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/connect", nil)
@@ -339,8 +282,8 @@ func TestRegistryBeginForwardExactSessionHitsOnlyThatSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
 	sessionB := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
-	removeB := reg.add("tunnel-1", "session-b", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeB := reg.add("tunnel-1", "session-b", "", sessionB, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-b", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 	t.Cleanup(removeB)
 
@@ -356,7 +299,7 @@ func TestRegistryBeginForwardExactSessionHitsOnlyThatSession(t *testing.T) {
 func TestRegistryBeginForwardExactSessionMissingIsNoSession(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 
 	_, failure := reg.beginForward("tunnel-1", "", "session-gone", time.Now().UTC(), 0)
@@ -368,7 +311,7 @@ func TestRegistryBeginForwardExactSessionMissingIsNoSession(t *testing.T) {
 func TestRegistryBeginForwardExactSessionAtCapIsBusy(t *testing.T) {
 	reg := newRegistry()
 	sessionA := newYamuxSession(t)
-	removeA := reg.add("tunnel-1", "session-a", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	removeA := reg.add("tunnel-1", "session-a", "", sessionA, http.NotFoundHandler(), route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(removeA)
 
 	entry, failure := reg.beginForward("tunnel-1", "", "session-a", time.Now().UTC(), 1)
@@ -391,7 +334,7 @@ func TestForwardHandlerReportsAgentSessionAndStripsExactHeader(t *testing.T) {
 		forwarded = r.Header.Clone()
 		w.WriteHeader(http.StatusOK)
 	})
-	remove := gw.reg.add("tunnel-1", "session-a", session, captureProxy, route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
+	remove := gw.reg.add("tunnel-1", "session-a", "", session, captureProxy, route.Connection{GatewaySessionID: "session-a", Metadata: map[string]string{}})
 	t.Cleanup(remove)
 
 	rec := httptest.NewRecorder()
@@ -407,4 +350,21 @@ func TestForwardHandlerReportsAgentSessionAndStripsExactHeader(t *testing.T) {
 	require.Empty(t, forwarded.Get(wire.HeaderTunnelAgentSession))
 	require.Empty(t, forwarded.Get(wire.HeaderTunnelID))
 	require.Empty(t, forwarded.Get(wire.HeaderTunnelForwardToken))
+}
+
+func TestRegistryAddRejectsAfterDrainBegins(t *testing.T) {
+	t.Parallel()
+
+	reg := newRegistry()
+	reg.beginDrain()
+	session := newYamuxSession(t)
+
+	remove := reg.add("tunnel-1", "session-a", "key-hash", session, http.NotFoundHandler(), route.Connection{
+		GatewaySessionID: "session-a",
+		Metadata:         map[string]string{},
+	})
+
+	require.Nil(t, remove)
+	require.True(t, session.IsClosed())
+	require.Zero(t, reg.activeSessions())
 }

--- a/tunnel/gateway/reconciler.go
+++ b/tunnel/gateway/reconciler.go
@@ -1,0 +1,430 @@
+package gateway
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/speakeasy-api/gram/tunnel/route"
+)
+
+const (
+	reconcileConcurrency = 16
+	finalCleanupTimeout  = 20 * time.Second
+)
+
+type drainRequest struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	tunnelIDs []string
+}
+
+type revokeRequest struct {
+	ctx      context.Context
+	tunnelID string
+	done     chan struct{}
+}
+
+type revokeState struct {
+	globalDeleteComplete bool
+}
+
+type reconcileJob struct {
+	tunnelID        string
+	suppressPublish bool
+}
+
+type reconcileResult struct {
+	tunnelID    string
+	owned       bool
+	cleanupRan  bool
+	cleaned     bool
+	reactivated bool
+}
+
+// routeReconciler is the sole writer of this gateway's route and connection
+// projection. Passes never overlap; bounded workers shorten each pass while
+// preserving ordering between nudges, revokes, refreshes, and final cleanup.
+type routeReconciler struct {
+	lifetimeCtx     context.Context
+	cancel          context.CancelFunc
+	reg             *registry
+	keys            KeyResolver
+	routes          route.Store
+	logger          *slog.Logger
+	refreshInterval time.Duration
+	address         atomic.Value
+
+	dirtyMu sync.Mutex
+	dirty   map[string]struct{}
+	stopped bool
+
+	nudges chan struct{}
+	revoke chan revokeRequest
+	drain  chan drainRequest
+	done   chan struct{}
+}
+
+func newRouteReconciler(
+	reg *registry,
+	keys KeyResolver,
+	routes route.Store,
+	address string,
+	logger *slog.Logger,
+	refreshInterval time.Duration,
+) *routeReconciler {
+	if refreshInterval <= 0 {
+		refreshInterval = routeTTL / 2
+	}
+	lifetimeCtx, cancel := context.WithCancel(context.Background())
+	r := &routeReconciler{
+		lifetimeCtx:     lifetimeCtx,
+		cancel:          cancel,
+		reg:             reg,
+		keys:            keys,
+		routes:          routes,
+		logger:          logger,
+		refreshInterval: refreshInterval,
+		address:         atomic.Value{},
+		dirtyMu:         sync.Mutex{},
+		dirty:           make(map[string]struct{}),
+		stopped:         false,
+		nudges:          make(chan struct{}, 1),
+		revoke:          make(chan revokeRequest),
+		drain:           make(chan drainRequest, 1),
+		done:            make(chan struct{}),
+	}
+	r.address.Store(address)
+	go r.run()
+	return r
+}
+
+func (r *routeReconciler) nudge(tunnelID string) {
+	r.dirtyMu.Lock()
+	if r.stopped {
+		r.dirtyMu.Unlock()
+		return
+	}
+	r.dirty[tunnelID] = struct{}{}
+	r.dirtyMu.Unlock()
+
+	select {
+	case r.nudges <- struct{}{}:
+	default:
+	}
+}
+
+func (r *routeReconciler) requestRevoke(ctx context.Context, tunnelID string) {
+	done := make(chan struct{})
+	request := revokeRequest{ctx: ctx, tunnelID: tunnelID, done: done}
+	select {
+	case r.revoke <- request:
+	case <-r.done:
+		return
+	}
+	select {
+	case <-done:
+	case <-r.done:
+	case <-ctx.Done():
+	}
+}
+
+func (r *routeReconciler) requestDrain(ctx context.Context, tunnelIDs []string) {
+	cleanupTimeout := finalCleanupTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < cleanupTimeout {
+			cleanupTimeout = remaining
+		}
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+	r.dirtyMu.Lock()
+	r.stopped = true
+	r.dirtyMu.Unlock()
+	r.cancel()
+	r.drain <- drainRequest{ctx: cleanupCtx, cancel: cancel, tunnelIDs: tunnelIDs}
+}
+
+func (r *routeReconciler) takeDirty() []string {
+	r.dirtyMu.Lock()
+	dirty := r.dirty
+	r.dirty = make(map[string]struct{})
+	r.dirtyMu.Unlock()
+
+	tunnelIDs := make([]string, 0, len(dirty))
+	for tunnelID := range dirty {
+		tunnelIDs = append(tunnelIDs, tunnelID)
+	}
+	return tunnelIDs
+}
+
+func (r *routeReconciler) run() {
+	ticker := time.NewTicker(r.refreshInterval)
+	defer ticker.Stop()
+	defer close(r.done)
+
+	everOwned := make(map[string]struct{})
+	revokes := make(map[string]revokeState)
+	for {
+		select {
+		case req := <-r.drain:
+			r.finishDrain(req, everOwned)
+			return
+		default:
+		}
+
+		select {
+		case req := <-r.drain:
+			r.finishDrain(req, everOwned)
+			return
+		case <-r.nudges:
+			r.reconcile(r.lifetimeCtx, r.takeDirty(), false, everOwned, revokes)
+		case req := <-r.revoke:
+			state := revokeState{globalDeleteComplete: false}
+			if r.deleteTunnel(req.ctx, req.tunnelID) {
+				state.globalDeleteComplete = true
+				delete(everOwned, req.tunnelID)
+			}
+			revokes[req.tunnelID] = state
+			close(req.done)
+		case <-ticker.C:
+			for tunnelID, state := range revokes {
+				if state.globalDeleteComplete {
+					continue
+				}
+				if r.deleteTunnel(r.lifetimeCtx, tunnelID) {
+					state.globalDeleteComplete = true
+					revokes[tunnelID] = state
+					delete(everOwned, tunnelID)
+				}
+			}
+
+			tunnelIDs := r.reg.liveTunnelIDs()
+			live := make(map[string]struct{}, len(tunnelIDs))
+			for _, tunnelID := range tunnelIDs {
+				live[tunnelID] = struct{}{}
+			}
+			for tunnelID := range everOwned {
+				if _, ok := live[tunnelID]; !ok {
+					tunnelIDs = append(tunnelIDs, tunnelID)
+				}
+			}
+			r.reconcile(r.lifetimeCtx, tunnelIDs, true, everOwned, revokes)
+			for tunnelID, state := range revokes {
+				if state.globalDeleteComplete && len(r.reg.sessionKeys(tunnelID)) == 0 {
+					delete(revokes, tunnelID)
+				}
+			}
+		}
+	}
+}
+
+func (r *routeReconciler) reconcile(
+	ctx context.Context,
+	tunnelIDs []string,
+	validateActive bool,
+	everOwned map[string]struct{},
+	revokes map[string]revokeState,
+) {
+	jobs := make(chan reconcileJob, len(tunnelIDs))
+	results := make(chan reconcileResult, len(tunnelIDs))
+	for _, tunnelID := range tunnelIDs {
+		_, suppressPublish := revokes[tunnelID]
+		jobs <- reconcileJob{tunnelID: tunnelID, suppressPublish: suppressPublish}
+	}
+	close(jobs)
+
+	for range min(reconcileConcurrency, len(tunnelIDs)) {
+		go func() {
+			for job := range jobs {
+				results <- r.reconcileTunnel(ctx, job.tunnelID, validateActive, job.suppressPublish)
+			}
+		}()
+	}
+
+	for range tunnelIDs {
+		result := <-results
+		if result.owned {
+			everOwned[result.tunnelID] = struct{}{}
+		}
+		if result.cleanupRan && result.cleaned {
+			delete(everOwned, result.tunnelID)
+		}
+		if result.reactivated {
+			delete(revokes, result.tunnelID)
+		}
+	}
+}
+
+func (r *routeReconciler) reconcileTunnel(
+	ctx context.Context,
+	tunnelID string,
+	validateActive bool,
+	suppressPublish bool,
+) reconcileResult {
+	result := reconcileResult{tunnelID: tunnelID, owned: false, cleanupRan: false, cleaned: false, reactivated: false}
+	if validateActive {
+		if checker, ok := r.keys.(ActiveTunnelChecker); ok {
+			sessionKeys := r.reg.sessionKeys(tunnelID)
+			if len(sessionKeys) == 0 {
+				result.cleanupRan = true
+				result.cleaned = r.cleanupTunnel(ctx, tunnelID)
+				return result
+			}
+
+			activeByHash := make(map[string]bool, len(sessionKeys))
+			for _, sessionKey := range sessionKeys {
+				if _, checked := activeByHash[sessionKey.keyHash]; checked {
+					continue
+				}
+				opCtx, cancel := routeOperationContext(ctx)
+				active, err := checker.IsActive(opCtx, tunnelID, sessionKey.keyHash)
+				if err != nil {
+					if ctx.Err() == nil {
+						r.logger.WarnContext(opCtx, "tunnel active check failed",
+							slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+					}
+					cancel()
+					return result
+				}
+				cancel()
+				activeByHash[sessionKey.keyHash] = active
+			}
+			activeSession := false
+			for _, sessionKey := range sessionKeys {
+				if activeByHash[sessionKey.keyHash] {
+					activeSession = true
+				} else {
+					r.reg.killSession(tunnelID, sessionKey.id)
+				}
+			}
+			if suppressPublish && activeSession {
+				suppressPublish = false
+				result.reactivated = true
+			}
+		}
+	}
+	if suppressPublish {
+		return result
+	}
+
+	heartbeatAt := time.Now().UTC()
+	connections := r.reg.connections(tunnelID, heartbeatAt)
+	if len(connections) == 0 {
+		result.cleanupRan = true
+		result.cleaned = r.cleanupTunnel(ctx, tunnelID)
+		return result
+	}
+
+	result.owned = true
+	address := r.address.Load().(string)
+	opCtx, cancel := routeOperationContext(ctx)
+	if err := r.routes.Publish(opCtx, tunnelID, address, routeTTL); err != nil {
+		r.logger.WarnContext(opCtx, "tunnel route publish failed",
+			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+	}
+	if store, ok := r.routes.(route.ConnectionSnapshotStore); ok {
+		if err := store.PublishConnections(opCtx, tunnelID, address, connections, routeTTL); err != nil {
+			r.logger.WarnContext(opCtx, "tunnel connection snapshot publish failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+		}
+	}
+	cancel()
+	return result
+}
+
+func (r *routeReconciler) cleanupTunnel(ctx context.Context, tunnelID string) bool {
+	// Disconnect cleanup shares one budget to bound reconciler worker lifetime.
+	cleaned := true
+	address := r.address.Load().(string)
+	opCtx, cancel := routeOperationContext(ctx)
+	defer cancel()
+
+	if err := r.routes.Unpublish(opCtx, tunnelID, address); err != nil {
+		cleaned = false
+		r.logger.WarnContext(opCtx, "tunnel route unpublish failed",
+			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+	}
+	if store, ok := r.routes.(route.ConnectionSnapshotStore); ok {
+		if err := store.DeleteConnectionOwner(opCtx, tunnelID, address); err != nil {
+			cleaned = false
+			r.logger.WarnContext(opCtx, "tunnel connection snapshot delete failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+		}
+	}
+	return cleaned
+}
+
+func (r *routeReconciler) cleanupTunnelDuringDrain(ctx context.Context, tunnelID string) bool {
+	// Drain cleanup gives each mutation a budget to maximize cleanup completeness.
+	cleaned := true
+	address := r.address.Load().(string)
+	opCtx, cancel := routeOperationContext(ctx)
+	if err := r.routes.Unpublish(opCtx, tunnelID, address); err != nil {
+		cleaned = false
+		r.logger.WarnContext(opCtx, "tunnel route unpublish failed",
+			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+	}
+	cancel()
+	if store, ok := r.routes.(route.ConnectionSnapshotStore); ok {
+		opCtx, cancel = routeOperationContext(ctx)
+		if err := store.DeleteConnectionOwner(opCtx, tunnelID, address); err != nil {
+			cleaned = false
+			r.logger.WarnContext(opCtx, "tunnel connection snapshot delete failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+		}
+		cancel()
+	}
+	return cleaned
+}
+
+func (r *routeReconciler) deleteTunnel(ctx context.Context, tunnelID string) bool {
+	deleted := true
+	opCtx, cancel := routeOperationContext(ctx)
+	if err := r.routes.Delete(opCtx, tunnelID); err != nil {
+		deleted = false
+		r.logger.WarnContext(opCtx, "tunnel route delete failed",
+			slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+	}
+	cancel()
+	if store, ok := r.routes.(route.ConnectionSnapshotStore); ok {
+		opCtx, cancel = routeOperationContext(ctx)
+		if err := store.DeleteConnections(opCtx, tunnelID); err != nil {
+			deleted = false
+			r.logger.WarnContext(opCtx, "tunnel connection snapshots delete failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+		}
+		cancel()
+	}
+	return deleted
+}
+
+func (r *routeReconciler) finishDrain(req drainRequest, everOwned map[string]struct{}) {
+	defer req.cancel()
+	for _, tunnelID := range req.tunnelIDs {
+		everOwned[tunnelID] = struct{}{}
+	}
+	tunnelIDs := make([]string, 0, len(everOwned))
+	for tunnelID := range everOwned {
+		tunnelIDs = append(tunnelIDs, tunnelID)
+	}
+
+	jobs := make(chan string, len(tunnelIDs))
+	completed := make(chan struct{}, len(tunnelIDs))
+	for _, tunnelID := range tunnelIDs {
+		jobs <- tunnelID
+	}
+	close(jobs)
+	for range min(reconcileConcurrency, len(tunnelIDs)) {
+		go func() {
+			for tunnelID := range jobs {
+				r.cleanupTunnelDuringDrain(req.ctx, tunnelID)
+				completed <- struct{}{}
+			}
+		}()
+	}
+	for range tunnelIDs {
+		<-completed
+	}
+}

--- a/tunnel/gateway/reconciler_test.go
+++ b/tunnel/gateway/reconciler_test.go
@@ -1,0 +1,1012 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/tunnel/route"
+	"github.com/speakeasy-api/gram/tunnel/wire"
+)
+
+const testForwardToken = "reconciler-forward-token"
+
+type storeOperation struct {
+	kind     string
+	tunnelID string
+	at       time.Time
+}
+
+type recordingRouteStore struct {
+	table *route.RouteTable
+
+	mu         sync.Mutex
+	snapshots  map[string]map[string][]route.Connection
+	operations []storeOperation
+
+	blockPublish       bool
+	publishStarted     chan struct{}
+	publishRelease     chan struct{}
+	publishStartedOnce sync.Once
+	publishReleaseOnce sync.Once
+
+	blockUnpublish       bool
+	unpublishFailures    int
+	unpublishStarted     chan struct{}
+	unpublishRelease     chan struct{}
+	unpublishStartedOnce sync.Once
+	unpublishReleaseOnce sync.Once
+	deleteFailures       int
+}
+
+func newRecordingRouteStore(blockPublish, blockUnpublish bool) *recordingRouteStore {
+	return &recordingRouteStore{
+		table:                route.NewRouteTable(),
+		mu:                   sync.Mutex{},
+		snapshots:            make(map[string]map[string][]route.Connection),
+		operations:           nil,
+		blockPublish:         blockPublish,
+		publishStarted:       make(chan struct{}),
+		publishRelease:       make(chan struct{}),
+		publishStartedOnce:   sync.Once{},
+		publishReleaseOnce:   sync.Once{},
+		blockUnpublish:       blockUnpublish,
+		unpublishFailures:    0,
+		unpublishStarted:     make(chan struct{}),
+		unpublishRelease:     make(chan struct{}),
+		unpublishStartedOnce: sync.Once{},
+		unpublishReleaseOnce: sync.Once{},
+		deleteFailures:       0,
+	}
+}
+
+func (s *recordingRouteStore) Publish(ctx context.Context, tunnelID, address string, ttl time.Duration) error {
+	if s.blockPublish {
+		s.publishStartedOnce.Do(func() { close(s.publishStarted) })
+		<-s.publishRelease
+	}
+	if err := s.table.Publish(ctx, tunnelID, address, ttl); err != nil {
+		return err
+	}
+	s.record("publish", tunnelID)
+	return nil
+}
+
+func (s *recordingRouteStore) Candidates(ctx context.Context, tunnelID string) ([]string, error) {
+	return s.table.Candidates(ctx, tunnelID)
+}
+
+func (s *recordingRouteStore) Unpublish(ctx context.Context, tunnelID, address string) error {
+	if s.blockUnpublish {
+		s.unpublishStartedOnce.Do(func() { close(s.unpublishStarted) })
+		<-s.unpublishRelease
+	}
+	s.mu.Lock()
+	if s.unpublishFailures > 0 {
+		s.unpublishFailures--
+		s.operations = append(s.operations, storeOperation{kind: "unpublish_failed", tunnelID: tunnelID, at: time.Now()})
+		s.mu.Unlock()
+		return errors.New("injected unpublish failure")
+	}
+	s.mu.Unlock()
+	if err := s.table.Unpublish(ctx, tunnelID, address); err != nil {
+		return err
+	}
+	s.record("unpublish", tunnelID)
+	return nil
+}
+
+func (s *recordingRouteStore) Delete(ctx context.Context, tunnelID string) error {
+	s.mu.Lock()
+	if s.deleteFailures > 0 {
+		s.deleteFailures--
+		s.operations = append(s.operations, storeOperation{kind: "delete_failed", tunnelID: tunnelID, at: time.Now()})
+		s.mu.Unlock()
+		return errors.New("injected delete failure")
+	}
+	s.mu.Unlock()
+	if err := s.table.Delete(ctx, tunnelID); err != nil {
+		return err
+	}
+	s.record("delete", tunnelID)
+	return nil
+}
+
+func (s *recordingRouteStore) PublishConnections(
+	_ context.Context,
+	tunnelID string,
+	owner string,
+	connections []route.Connection,
+	_ time.Duration,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.snapshots[tunnelID] == nil {
+		s.snapshots[tunnelID] = make(map[string][]route.Connection)
+	}
+	s.snapshots[tunnelID][owner] = append([]route.Connection(nil), connections...)
+	s.operations = append(s.operations, storeOperation{kind: "publish_connections", tunnelID: tunnelID, at: time.Now()})
+	return nil
+}
+
+func (s *recordingRouteStore) Connections(_ context.Context, tunnelID string) ([]route.Connection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var connections []route.Connection
+	for _, ownerConnections := range s.snapshots[tunnelID] {
+		connections = append(connections, ownerConnections...)
+	}
+	return connections, nil
+}
+
+func (s *recordingRouteStore) DeleteConnectionOwner(_ context.Context, tunnelID, owner string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.snapshots[tunnelID], owner)
+	if len(s.snapshots[tunnelID]) == 0 {
+		delete(s.snapshots, tunnelID)
+	}
+	s.operations = append(s.operations, storeOperation{kind: "delete_owner", tunnelID: tunnelID, at: time.Now()})
+	return nil
+}
+
+func (s *recordingRouteStore) DeleteConnections(_ context.Context, tunnelID string) error {
+	s.mu.Lock()
+	delete(s.snapshots, tunnelID)
+	s.operations = append(s.operations, storeOperation{kind: "delete_connections", tunnelID: tunnelID, at: time.Now()})
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *recordingRouteStore) record(kind, tunnelID string) {
+	s.mu.Lock()
+	s.operations = append(s.operations, storeOperation{kind: kind, tunnelID: tunnelID, at: time.Now()})
+	s.mu.Unlock()
+}
+
+func (s *recordingRouteStore) operationsFor(tunnelID string) []storeOperation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var operations []storeOperation
+	for _, operation := range s.operations {
+		if operation.tunnelID == tunnelID {
+			operations = append(operations, operation)
+		}
+	}
+	return operations
+}
+
+func (s *recordingRouteStore) writeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.operations)
+}
+
+func (s *recordingRouteStore) operationCount(tunnelID, kind string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, operation := range s.operations {
+		if operation.tunnelID == tunnelID && operation.kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *recordingRouteStore) hasOwner(tunnelID, owner string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.snapshots[tunnelID][owner]
+	return ok
+}
+
+func (s *recordingRouteStore) releasePublish() {
+	s.publishReleaseOnce.Do(func() { close(s.publishRelease) })
+}
+
+func (s *recordingRouteStore) releaseUnpublish() {
+	s.unpublishReleaseOnce.Do(func() { close(s.unpublishRelease) })
+}
+
+func (s *recordingRouteStore) failNextUnpublish() {
+	s.mu.Lock()
+	s.unpublishFailures++
+	s.mu.Unlock()
+}
+
+func (s *recordingRouteStore) failNextDelete() {
+	s.mu.Lock()
+	s.deleteFailures++
+	s.mu.Unlock()
+}
+
+var _ route.RuntimeStore = (*recordingRouteStore)(nil)
+
+type gatewayHarness struct {
+	gateway *Gateway
+	store   *recordingRouteStore
+	public  *httptest.Server
+	forward *httptest.Server
+	owner   string
+}
+
+func newGatewayHarness(t *testing.T, keys map[string]string, store *recordingRouteStore) *gatewayHarness {
+	t.Helper()
+	return newGatewayHarnessWithResolver(t, NewStaticKeyStore(keys), store, routeTTL/2)
+}
+
+func newGatewayHarnessWithResolver(
+	t *testing.T,
+	keys KeyResolver,
+	store *recordingRouteStore,
+	refreshInterval time.Duration,
+) *gatewayHarness {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw, err := New(Config{ForwardToken: testForwardToken, routeRefreshInterval: refreshInterval}, keys, store, logger)
+	require.NoError(t, err)
+	publicServer := httptest.NewServer(gw.PublicHandler())
+	forwardServer := httptest.NewServer(gw.ForwardHandler())
+	owner := forwardServer.Listener.Addr().String()
+	gw.SetAdvertiseAddr(owner)
+
+	harness := &gatewayHarness{
+		gateway: gw,
+		store:   store,
+		public:  publicServer,
+		forward: forwardServer,
+		owner:   owner,
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		gw.Drain(ctx)
+		gw.CloseSessions(ctx)
+		_ = forwardServer.Config.Shutdown(ctx)
+		_ = publicServer.Config.Shutdown(ctx)
+		forwardServer.Close()
+		publicServer.Close()
+	})
+	return harness
+}
+
+type testAgent struct {
+	session *yamux.Session
+	conn    net.Conn
+	done    chan struct{}
+	close   sync.Once
+}
+
+func dialTestAgent(ctx context.Context, publicURL, key string, handler http.Handler) (*testAgent, *http.Response, error) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+key)
+	headers.Set(wire.HeaderTunnelServiceVersion, "1.0.0")
+	wsURL := "ws" + strings.TrimPrefix(publicURL, "http") + "/connect"
+	ws, response, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: headers})
+	if err != nil {
+		return nil, response, err
+	}
+
+	conn := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+	cfg := yamux.DefaultConfig()
+	cfg.LogOutput = io.Discard
+	session, err := yamux.Server(conn, cfg)
+	if err != nil {
+		_ = conn.Close()
+		return nil, response, err
+	}
+	done := make(chan struct{})
+	server := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second}
+	go func() {
+		_ = server.Serve(session)
+		close(done)
+	}()
+	return &testAgent{session: session, conn: conn, done: done, close: sync.Once{}}, response, nil
+}
+
+func (a *testAgent) Close() {
+	a.close.Do(func() {
+		_ = a.session.Close()
+		_ = a.conn.Close()
+		select {
+		case <-a.done:
+		case <-time.After(time.Second):
+		}
+	})
+}
+
+func successfulAgentHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+type controllableActiveKeyStore struct {
+	*StaticKeyStore
+
+	mu           sync.RWMutex
+	active       bool
+	activeByHash map[string]bool
+	err          error
+}
+
+func newControllableActiveKeyStore(keys map[string]string) *controllableActiveKeyStore {
+	return &controllableActiveKeyStore{
+		StaticKeyStore: NewStaticKeyStore(keys),
+		mu:             sync.RWMutex{},
+		active:         true,
+		activeByHash:   make(map[string]bool),
+		err:            nil,
+	}
+}
+
+func (k *controllableActiveKeyStore) IsActive(_ context.Context, _, keyHash string) (bool, error) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	if active, ok := k.activeByHash[keyHash]; ok {
+		return active, k.err
+	}
+	return k.active, k.err
+}
+
+func (k *controllableActiveKeyStore) setActive(active bool, err error) {
+	k.mu.Lock()
+	k.active = active
+	k.err = err
+	k.mu.Unlock()
+}
+
+func (k *controllableActiveKeyStore) setHashActive(keyHash string, active bool) {
+	k.mu.Lock()
+	k.activeByHash[keyHash] = active
+	k.mu.Unlock()
+}
+
+var _ ActiveTunnelChecker = (*controllableActiveKeyStore)(nil)
+
+type blockingConnectionKeyStore struct {
+	*StaticKeyStore
+
+	markStarted chan struct{}
+	markRelease chan struct{}
+	started     sync.Once
+	released    sync.Once
+}
+
+func newBlockingConnectionKeyStore(keys map[string]string) *blockingConnectionKeyStore {
+	return &blockingConnectionKeyStore{
+		StaticKeyStore: NewStaticKeyStore(keys),
+		markStarted:    make(chan struct{}),
+		markRelease:    make(chan struct{}),
+		started:        sync.Once{},
+		released:       sync.Once{},
+	}
+}
+
+func (k *blockingConnectionKeyStore) MarkConnected(ctx context.Context, _, _, _ string) error {
+	k.started.Do(func() { close(k.markStarted) })
+	select {
+	case <-k.markRelease:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (k *blockingConnectionKeyStore) releaseMarkConnected() {
+	k.released.Do(func() { close(k.markRelease) })
+}
+
+var _ ConnectionRecorder = (*blockingConnectionKeyStore)(nil)
+
+func TestGatewayDrainRemovesRoutesAndSnapshots(t *testing.T) {
+	t.Parallel()
+
+	keys := map[string]string{
+		"tunnel-drain-a": "gram_tunnel_drain_key_a",
+		"tunnel-drain-b": "gram_tunnel_drain_key_b",
+	}
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarness(t, keys, store)
+
+	agents := make([]*testAgent, 0, len(keys))
+	for _, key := range keys {
+		agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+		require.NoError(t, err)
+		agents = append(agents, agent)
+		t.Cleanup(agent.Close)
+	}
+	require.Eventually(t, func() bool {
+		for tunnelID := range keys {
+			candidates, _ := store.Candidates(t.Context(), tunnelID)
+			if len(candidates) != 1 || !store.hasOwner(tunnelID, harness.owner) {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+
+	harness.gateway.Drain(t.Context())
+	for tunnelID := range keys {
+		candidates, err := store.Candidates(t.Context(), tunnelID)
+		require.NoError(t, err)
+		require.Empty(t, candidates)
+		require.False(t, store.hasOwner(tunnelID, harness.owner))
+	}
+	for _, agent := range agents {
+		require.False(t, agent.session.IsClosed())
+	}
+	writesAtDrain := store.writeCount()
+	require.Never(t, func() bool { return store.writeCount() != writesAtDrain }, 100*time.Millisecond, 5*time.Millisecond)
+
+	harness.gateway.CloseSessions(t.Context())
+	require.Eventually(t, func() bool { return harness.gateway.ActiveSessions() == 0 }, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestGatewayRejectsConnectWhileDrainIsInProgress(t *testing.T) {
+	t.Parallel()
+
+	const key = "gram_tunnel_admission_key"
+	store := newRecordingRouteStore(false, true)
+	harness := newGatewayHarness(t, map[string]string{"tunnel-admission": key}, store)
+	t.Cleanup(store.releaseUnpublish)
+	healthResponse, err := http.Get(harness.public.URL + "/healthz")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, healthResponse.StatusCode)
+	require.NoError(t, healthResponse.Body.Close())
+
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), "tunnel-admission")
+		return len(candidates) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	drainDone := make(chan struct{})
+	go func() {
+		harness.gateway.Drain(t.Context())
+		close(drainDone)
+	}()
+	require.Eventually(t, func() bool { return channelClosed(store.unpublishStarted) }, 5*time.Second, 10*time.Millisecond)
+
+	healthResponse, err = http.Get(harness.public.URL + "/healthz")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, healthResponse.StatusCode)
+	require.NoError(t, healthResponse.Body.Close())
+
+	_, response, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.Error(t, err)
+	require.NotNil(t, response)
+	require.Equal(t, http.StatusServiceUnavailable, response.StatusCode)
+	if response.Body != nil {
+		_ = response.Body.Close()
+	}
+
+	store.releaseUnpublish()
+	require.Eventually(t, func() bool { return channelClosed(drainDone) }, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestRouteReconcilerRetriesFailedGlobalRevokeOnTicker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-revoke-retry"
+		key      = "gram_tunnel_revoke_retry_key"
+	)
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(
+		t,
+		NewStaticKeyStore(map[string]string{tunnelID: key}),
+		store,
+		500*time.Millisecond,
+	)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), tunnelID)
+		return len(candidates) == 1
+	}, time.Second, 5*time.Millisecond)
+	require.NoError(t, store.Publish(t.Context(), tunnelID, "other-gateway", routeTTL))
+
+	store.failNextDelete()
+	require.Equal(t, 1, harness.gateway.RevokeTunnel(t.Context(), tunnelID))
+	require.Equal(t, 1, store.operationCount(tunnelID, "delete_failed"))
+	require.Equal(t, 1, store.operationCount(tunnelID, "delete_connections"))
+	require.Eventually(t, func() bool {
+		return store.operationCount(tunnelID, "delete") == 1 &&
+			store.operationCount(tunnelID, "delete_connections") == 2
+	}, 2*time.Second, 5*time.Millisecond)
+	candidates, err := store.Candidates(t.Context(), tunnelID)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}
+
+func TestRouteReconcilerRegistersRevokeWithCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	const tunnelID = "tunnel-canceled-revoke"
+	store := newRecordingRouteStore(false, true)
+	harness := newGatewayHarnessWithResolver(
+		t,
+		NewStaticKeyStore(map[string]string{tunnelID: "gram_tunnel_canceled_revoke_key"}),
+		store,
+		20*time.Millisecond,
+	)
+	t.Cleanup(store.releaseUnpublish)
+	require.NoError(t, store.table.Publish(t.Context(), tunnelID, "stale-owner", routeTTL))
+	store.failNextDelete()
+	harness.gateway.reconciler.nudge("blocked-cleanup")
+	require.Eventually(t, func() bool { return channelClosed(store.unpublishStarted) }, time.Second, 5*time.Millisecond)
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	revokeStarted := make(chan struct{})
+	revokeDone := make(chan struct{})
+	killed := 0
+	go func() {
+		close(revokeStarted)
+		killed = harness.gateway.RevokeTunnel(canceledCtx, tunnelID)
+		close(revokeDone)
+	}()
+	<-revokeStarted
+	require.Never(t, func() bool { return channelClosed(revokeDone) }, 50*time.Millisecond, 5*time.Millisecond)
+	store.releaseUnpublish()
+	require.Eventually(t, func() bool { return channelClosed(revokeDone) }, time.Second, 5*time.Millisecond)
+	require.Zero(t, killed)
+	require.Eventually(t, func() bool {
+		candidates, candidatesErr := store.Candidates(t.Context(), tunnelID)
+		return candidatesErr == nil && len(candidates) == 0 &&
+			store.operationCount(tunnelID, "delete_failed") == 1 &&
+			store.operationCount(tunnelID, "delete") == 1 &&
+			store.operationCount(tunnelID, "delete_connections") == 2
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestRouteReconcilerSuppressesConnectPublishAfterRevoke(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-revoke-connect-race"
+		key      = "gram_tunnel_revoke_connect_race_key"
+	)
+	keys := newBlockingConnectionKeyStore(map[string]string{tunnelID: key})
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(t, keys, store, time.Second)
+	t.Cleanup(keys.releaseMarkConnected)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool { return channelClosed(keys.markStarted) }, time.Second, 5*time.Millisecond)
+
+	require.Zero(t, harness.gateway.RevokeTunnel(t.Context(), tunnelID))
+	keys.releaseMarkConnected()
+	require.Eventually(t, func() bool { return harness.gateway.ActiveSessions() == 1 }, time.Second, 5*time.Millisecond)
+	require.Never(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), tunnelID)
+		return len(candidates) != 0
+	}, 250*time.Millisecond, 5*time.Millisecond)
+	require.Zero(t, store.operationCount(tunnelID, "publish"))
+}
+
+func TestGatewayShutdownLetsInflightForwardFinish(t *testing.T) {
+	t.Parallel()
+
+	const key = "gram_tunnel_inflight_key"
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarness(t, map[string]string{"tunnel-inflight": key}, store)
+	forwardStarted := make(chan struct{})
+	releaseForward := make(chan struct{})
+	var startOnce sync.Once
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseForward) }) })
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/slow" {
+			startOnce.Do(func() { close(forwardStarted) })
+			<-releaseForward
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("complete"))
+	})
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, handler)
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), "tunnel-inflight")
+		return len(candidates) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	type forwardResult struct {
+		status int
+		body   string
+		err    error
+	}
+	forwardDone := make(chan forwardResult, 1)
+	go func() {
+		req, requestErr := http.NewRequestWithContext(t.Context(), http.MethodGet, harness.forward.URL+"/slow", nil)
+		if requestErr != nil {
+			forwardDone <- forwardResult{status: 0, body: "", err: requestErr}
+			return
+		}
+		req.Header.Set(wire.HeaderTunnelID, "tunnel-inflight")
+		req.Header.Set(wire.HeaderTunnelForwardToken, testForwardToken)
+		response, requestErr := http.DefaultClient.Do(req)
+		if requestErr != nil {
+			forwardDone <- forwardResult{status: 0, body: "", err: requestErr}
+			return
+		}
+		defer response.Body.Close()
+		body, requestErr := io.ReadAll(response.Body)
+		forwardDone <- forwardResult{status: response.StatusCode, body: string(body), err: requestErr}
+	}()
+	require.Eventually(t, func() bool { return channelClosed(forwardStarted) }, 5*time.Second, 10*time.Millisecond)
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelShutdown()
+	shutdownDone := make(chan struct{})
+	go func() {
+		harness.gateway.Drain(shutdownCtx)
+		_ = harness.forward.Config.Shutdown(shutdownCtx)
+		harness.gateway.CloseSessions(shutdownCtx)
+		_ = harness.public.Config.Shutdown(shutdownCtx)
+		close(shutdownDone)
+	}()
+	require.Never(t, func() bool { return channelClosed(shutdownDone) }, 50*time.Millisecond, 5*time.Millisecond)
+	releaseOnce.Do(func() { close(releaseForward) })
+
+	select {
+	case result := <-forwardDone:
+		require.NoError(t, result.err)
+		require.Equal(t, http.StatusOK, result.status)
+		require.Equal(t, "complete", result.body)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "forward did not finish")
+	}
+	require.Eventually(t, func() bool { return channelClosed(shutdownDone) }, 5*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return harness.gateway.ActiveSessions() == 0 }, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestGatewayDrainConvergesDuringConcurrentChurn(t *testing.T) {
+	t.Parallel()
+
+	keys := map[string]string{
+		"tunnel-churn-a": "gram_tunnel_churn_key_a",
+		"tunnel-churn-b": "gram_tunnel_churn_key_b",
+		"tunnel-churn-c": "gram_tunnel_churn_key_c",
+		"tunnel-churn-d": "gram_tunnel_churn_key_d",
+	}
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarness(t, keys, store)
+	startChurn := make(chan struct{})
+	ready := make(chan struct{}, len(keys))
+	results := make(chan error, len(keys))
+
+	for tunnelID, key := range keys {
+		go func() {
+			for iteration := range 8 {
+				agent, response, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+				if err != nil {
+					if response != nil && response.StatusCode == http.StatusServiceUnavailable {
+						if response.Body != nil {
+							_ = response.Body.Close()
+						}
+						results <- nil
+						return
+					}
+					results <- fmt.Errorf("dial churn agent: %w", err)
+					return
+				}
+				if iteration == 0 {
+					if !waitUntil(t.Context(), func() bool {
+						connections, _ := store.Connections(t.Context(), tunnelID)
+						return len(connections) > 0
+					}) {
+						agent.Close()
+						results <- fmt.Errorf("initial route for %s was not published", tunnelID)
+						return
+					}
+					ready <- struct{}{}
+					<-startChurn
+				}
+
+				req, requestErr := http.NewRequestWithContext(t.Context(), http.MethodGet, harness.forward.URL+"/churn", nil)
+				if requestErr == nil {
+					req.Header.Set(wire.HeaderTunnelID, tunnelID)
+					req.Header.Set(wire.HeaderTunnelForwardToken, testForwardToken)
+					if forwardResponse, forwardErr := http.DefaultClient.Do(req); forwardErr == nil {
+						_ = forwardResponse.Body.Close()
+					}
+				}
+				agent.Close()
+			}
+			results <- nil
+		}()
+	}
+	for range keys {
+		select {
+		case <-ready:
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "churn worker did not become ready")
+		}
+	}
+	close(startChurn)
+	harness.gateway.Drain(t.Context())
+	writesAtDrain := store.writeCount()
+
+	for range keys {
+		select {
+		case err := <-results:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "churn worker did not finish")
+		}
+	}
+	harness.gateway.CloseSessions(t.Context())
+	for tunnelID := range keys {
+		candidates, err := store.Candidates(t.Context(), tunnelID)
+		require.NoError(t, err)
+		require.Empty(t, candidates)
+		require.False(t, store.hasOwner(tunnelID, harness.owner))
+	}
+	require.Never(t, func() bool { return store.writeCount() != writesAtDrain }, 100*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestRouteReconcilerOrdersFinalCleanupAfterBlockedPublish(t *testing.T) {
+	t.Parallel()
+
+	const key = "gram_tunnel_ordering_key"
+	store := newRecordingRouteStore(true, false)
+	harness := newGatewayHarness(t, map[string]string{"tunnel-ordering": key}, store)
+	t.Cleanup(store.releasePublish)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool { return channelClosed(store.publishStarted) }, 5*time.Second, 10*time.Millisecond)
+
+	drainDone := make(chan struct{})
+	go func() {
+		harness.gateway.Drain(t.Context())
+		close(drainDone)
+	}()
+	require.Never(t, func() bool { return channelClosed(drainDone) }, 50*time.Millisecond, 5*time.Millisecond)
+	store.releasePublish()
+	require.Eventually(t, func() bool { return channelClosed(drainDone) }, 5*time.Second, 10*time.Millisecond)
+
+	operations := store.operationsFor("tunnel-ordering")
+	require.NotEmpty(t, operations)
+	require.Equal(t, "delete_owner", operations[len(operations)-1].kind)
+	var publishAt, cleanupAt time.Time
+	for _, operation := range operations {
+		if operation.kind == "publish" {
+			publishAt = operation.at
+		}
+		if operation.kind == "delete_owner" {
+			cleanupAt = operation.at
+		}
+	}
+	require.False(t, publishAt.IsZero())
+	require.True(t, cleanupAt.After(publishAt) || cleanupAt.Equal(publishAt))
+}
+
+func TestRouteReconcilerRefreshesLiveRouteOnTicker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-refresh"
+		key      = "gram_tunnel_refresh_key"
+	)
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(
+		t,
+		NewStaticKeyStore(map[string]string{tunnelID: key}),
+		store,
+		20*time.Millisecond,
+	)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+
+	require.Eventually(t, func() bool {
+		return store.operationCount(tunnelID, "publish") >= 2
+	}, time.Second, 5*time.Millisecond)
+
+	operations := store.operationsFor(tunnelID)
+	var publishes []time.Time
+	for _, operation := range operations {
+		if operation.kind == "publish" {
+			publishes = append(publishes, operation.at)
+		}
+	}
+	require.GreaterOrEqual(t, len(publishes), 2)
+	require.Less(t, publishes[1].Sub(publishes[0]), routeTTL)
+}
+
+func TestRouteReconcilerGatesRefreshOnActiveState(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-active-gate"
+		key      = "gram_tunnel_active_gate_key"
+	)
+	keys := newControllableActiveKeyStore(map[string]string{tunnelID: key})
+	keys.setActive(true, errors.New("active state unavailable"))
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(t, keys, store, 20*time.Millisecond)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), tunnelID)
+		return len(candidates) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	require.NoError(t, store.Delete(t.Context(), tunnelID))
+	publishesAfterDelete := store.operationCount(tunnelID, "publish")
+	require.Never(t, func() bool {
+		return store.operationCount(tunnelID, "publish") != publishesAfterDelete
+	}, 75*time.Millisecond, 5*time.Millisecond)
+
+	keys.setActive(false, nil)
+	require.Eventually(t, func() bool {
+		return harness.gateway.ActiveSessions() == 0
+	}, time.Second, 5*time.Millisecond)
+	candidates, err := store.Candidates(t.Context(), tunnelID)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}
+
+func TestRouteReconcilerValidatesEachSessionKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-key-rotation"
+		oldKey   = "gram_tunnel_old_rotation_key"
+		newKey   = "gram_tunnel_new_rotation_key"
+	)
+	keys := newControllableActiveKeyStore(map[string]string{tunnelID: oldKey})
+	keys.Add(tunnelID, newKey)
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(t, keys, store, 20*time.Millisecond)
+	oldAgent, _, err := dialTestAgent(t.Context(), harness.public.URL, oldKey, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "old")
+	}))
+	require.NoError(t, err)
+	t.Cleanup(oldAgent.Close)
+	require.Eventually(t, func() bool { return harness.gateway.ActiveSessions() == 1 }, time.Second, 5*time.Millisecond)
+
+	newAgent, _, err := dialTestAgent(t.Context(), harness.public.URL, newKey, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "new")
+	}))
+	require.NoError(t, err)
+	t.Cleanup(newAgent.Close)
+	require.Eventually(t, func() bool { return harness.gateway.ActiveSessions() == 2 }, time.Second, 5*time.Millisecond)
+	keys.setHashActive(wire.HashKey(oldKey), false)
+
+	require.Eventually(t, func() bool {
+		return oldAgent.session.IsClosed() && harness.gateway.ActiveSessions() == 1
+	}, time.Second, 5*time.Millisecond)
+	require.False(t, newAgent.session.IsClosed())
+	candidates, err := store.Candidates(t.Context(), tunnelID)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, harness.forward.URL+"/probe", nil)
+	require.NoError(t, err)
+	request.Header.Set(wire.HeaderTunnelID, tunnelID)
+	request.Header.Set(wire.HeaderTunnelForwardToken, testForwardToken)
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.Equal(t, "new", string(body))
+}
+
+func TestRouteReconcilerRetriesFailedCleanupOnTicker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-cleanup-retry"
+		key      = "gram_tunnel_cleanup_retry_key"
+	)
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarnessWithResolver(
+		t,
+		NewStaticKeyStore(map[string]string{tunnelID: key}),
+		store,
+		20*time.Millisecond,
+	)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), tunnelID)
+		return len(candidates) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	store.failNextUnpublish()
+	agent.Close()
+	require.Eventually(t, func() bool {
+		return harness.gateway.ActiveSessions() == 0 && store.operationCount(tunnelID, "unpublish_failed") == 1
+	}, time.Second, 5*time.Millisecond)
+	require.Eventually(t, func() bool {
+		candidates, candidatesErr := store.Candidates(t.Context(), tunnelID)
+		return candidatesErr == nil && len(candidates) == 0 && store.operationCount(tunnelID, "unpublish") == 1
+	}, time.Second, 5*time.Millisecond)
+
+	writesAfterRetry := store.writeCount()
+	harness.gateway.Drain(t.Context())
+	require.Equal(t, writesAfterRetry, store.writeCount())
+}
+
+func TestGatewayDrainCleanupIgnoresCanceledFirstCaller(t *testing.T) {
+	t.Parallel()
+
+	const (
+		tunnelID = "tunnel-canceled-drain"
+		key      = "gram_tunnel_canceled_drain_key"
+	)
+	store := newRecordingRouteStore(false, false)
+	harness := newGatewayHarness(t, map[string]string{tunnelID: key}, store)
+	agent, _, err := dialTestAgent(t.Context(), harness.public.URL, key, http.HandlerFunc(successfulAgentHandler))
+	require.NoError(t, err)
+	t.Cleanup(agent.Close)
+	require.Eventually(t, func() bool {
+		candidates, _ := store.Candidates(t.Context(), tunnelID)
+		return len(candidates) == 1
+	}, time.Second, 5*time.Millisecond)
+
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	harness.gateway.Drain(canceledCtx)
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), time.Second)
+	defer waitCancel()
+	harness.gateway.Drain(waitCtx)
+
+	candidates, err := store.Candidates(t.Context(), tunnelID)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+}
+
+func waitUntil(ctx context.Context, condition func() bool) bool {
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if condition() {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/tunnel/gateway/registry.go
+++ b/tunnel/gateway/registry.go
@@ -22,10 +22,12 @@ type registry struct {
 	mu       sync.RWMutex
 	sessions map[string][]*sessEntry
 	rr       map[string]uint64 // round-robin cursor per tunnel
+	draining bool
 }
 
 type sessEntry struct {
 	id      string
+	keyHash string
 	session *yamux.Session
 	// proxy is the session-scoped reverse proxy reused across forwards; its
 	// transport dials a fresh yamux substream per request, so sharing the
@@ -36,16 +38,23 @@ type sessEntry struct {
 	consumerSessions map[string]time.Time
 }
 
+type sessionKey struct {
+	id      string
+	keyHash string
+}
+
 func newRegistry() *registry {
 	return &registry{
 		sessions: make(map[string][]*sessEntry),
 		rr:       make(map[string]uint64),
+		draining: false,
 	}
 }
 
-func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.Handler, connection route.Connection) func() {
+func (r *registry) add(tunnelID, sessionID, keyHash string, s *yamux.Session, proxy http.Handler, connection route.Connection) func() {
 	entry := &sessEntry{
 		id:               sessionID,
+		keyHash:          keyHash,
 		session:          s,
 		proxy:            proxy,
 		connection:       connection,
@@ -53,6 +62,11 @@ func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.
 		consumerSessions: make(map[string]time.Time),
 	}
 	r.mu.Lock()
+	if r.draining {
+		r.mu.Unlock()
+		_ = s.Close()
+		return nil
+	}
 	r.sessions[tunnelID] = append(r.sessions[tunnelID], entry)
 	if _, ok := r.rr[tunnelID]; !ok {
 		r.rr[tunnelID] = 0
@@ -76,10 +90,73 @@ func (r *registry) add(tunnelID, sessionID string, s *yamux.Session, proxy http.
 	}
 }
 
-func (r *registry) tunnelSessionCount(tunnelID string) int {
+func (r *registry) sessionKeys(tunnelID string) []sessionKey {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return len(r.sessions[tunnelID])
+
+	keys := make([]sessionKey, 0, len(r.sessions[tunnelID]))
+	for _, entry := range r.sessions[tunnelID] {
+		if !entry.session.IsClosed() {
+			keys = append(keys, sessionKey{id: entry.id, keyHash: entry.keyHash})
+		}
+	}
+	return keys
+}
+
+func (r *registry) killSession(tunnelID, sessionID string) bool {
+	r.mu.Lock()
+	var killed *yamux.Session
+	list := r.sessions[tunnelID]
+	for i, entry := range list {
+		if entry.id != sessionID {
+			continue
+		}
+		killed = entry.session
+		list = append(list[:i], list[i+1:]...)
+		if len(list) == 0 {
+			delete(r.sessions, tunnelID)
+			delete(r.rr, tunnelID)
+		} else {
+			r.sessions[tunnelID] = list
+		}
+		break
+	}
+	r.mu.Unlock()
+
+	if killed == nil {
+		return false
+	}
+	_ = killed.Close()
+	return true
+}
+
+func (r *registry) isDraining() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.draining
+}
+
+func (r *registry) beginDrain() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.draining = true
+
+	tunnelIDs := make([]string, 0, len(r.sessions))
+	for tunnelID := range r.sessions {
+		tunnelIDs = append(tunnelIDs, tunnelID)
+	}
+	return tunnelIDs
+}
+
+func (r *registry) liveTunnelIDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	tunnelIDs := make([]string, 0, len(r.sessions))
+	for tunnelID := range r.sessions {
+		tunnelIDs = append(tunnelIDs, tunnelID)
+	}
+	return tunnelIDs
 }
 
 func (r *registry) connections(tunnelID string, heartbeatAt time.Time) []route.Connection {
@@ -222,6 +299,21 @@ func (r *registry) kill(tunnelID string) int {
 		_ = e.session.Close()
 	}
 	return len(list)
+}
+
+func (r *registry) sessionsSnapshot() []*yamux.Session {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	sessions := make([]*yamux.Session, 0)
+	for _, entries := range r.sessions {
+		for _, entry := range entries {
+			if !entry.session.IsClosed() {
+				sessions = append(sessions, entry.session)
+			}
+		}
+	}
+	return sessions
 }
 
 func (r *registry) activeSessions() int {


### PR DESCRIPTION
## Summary

Introduces a single-writer `routeReconciler`: one per-pod goroutine owns every mutating
route-store call (publish, connection snapshots, unpublish, global revoke). Handlers mark a
tunnel dirty and nudge; the reconciler reads live registry state at write time, batch-refreshes
all live tunnels on one ticker (replacing the per-session refresher goroutines), gates
publishes on `IsActive`, and prunes tracking for cleanly-removed tunnels.

Because all writes are serialized through one goroutine, graceful shutdown becomes the
reconciler's final act: on SIGTERM the registry stops admitting agent connects (checked again
under the lock at registration), the reconciler performs one bounded batched cleanup of every
route this pod may own, the forward server drains in-flight requests, agent sessions close
concurrently, and `main` blocks until the sequence completes — all within the existing 25s
budget. Publish-after-cleanup races are impossible by construction rather than coordinated
away.

Tests are black-box at the gateway boundary (real WebSocket agent + yamux sessions against an
in-memory store): post-drain store emptiness with no writes after drain returns, 503 on
connect during drain, in-flight forwards completing through shutdown, TTL refresh cadence,
revocation across multiple owners, and a concurrent-churn convergence property under the race
detector.

## Motivation

The gateway exited without unpublishing its routes, so every rollout left pod-IP routes in
Redis for up to the 30s TTL while the pod was already gone. gram-server dialed the dead IP and
each affected tunneled request hung ~30s before surfacing a 502, producing an error burst on
every deploy. Draining removes the stale-route window; agents re-home to surviving pods in
~0.5–2s using their existing reconnect backoff. Complements #5888 (fast dial timeout) and
#5930 (dead-route eviction on dial failure), which cover unplanned pod death.

closes AIM-166
