### PR TITLE
mig(telemetry): Attribute MCP drilldown by server, not by session

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260901144303_mcp-call-summaries.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260901144303_mcp-call-summaries.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create "mcp_call_summaries_mv" view
+DROP VIEW `mcp_call_summaries_mv`;
+-- reverse: create "mcp_call_summaries" table
+DROP TABLE `mcp_call_summaries`;

--- a/server/clickhouse/local/golang_migrate/20260901144303_mcp-call-summaries.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260901144303_mcp-call-summaries.up.sql
@@ -1,0 +1,22 @@
+-- create "mcp_call_summaries" table
+CREATE TABLE `mcp_call_summaries` (
+  `gram_project_id` UUID,
+  `trace_id` FixedString(32),
+  `tool_call_id` String,
+  `event_source` SimpleAggregateFunction(max, String),
+  `tool_name` SimpleAggregateFunction(max, String),
+  `toolset_slug` SimpleAggregateFunction(max, String),
+  `mcp_server_url` SimpleAggregateFunction(max, String),
+  `hook_source` SimpleAggregateFunction(max, String),
+  `start_time_unix_nano` SimpleAggregateFunction(min, Int64),
+  `http_status_code` SimpleAggregateFunction(max, Int32),
+  `has_result` SimpleAggregateFunction(max, UInt8),
+  `has_error` SimpleAggregateFunction(max, UInt8),
+  INDEX `idx_mcp_call_summaries_start_time` ((start_time_unix_nano)) TYPE minmax GRANULARITY 1
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `trace_id`, `tool_call_id`) ORDER BY (`gram_project_id`, `trace_id`, `tool_call_id`) TTL fromUnixTimestamp64Nano(start_time_unix_nano) + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Per-tool-call MCP summaries so drill-down can filter by server without mixing other servers from the same session';
+-- Backfill BEFORE creating the MV (same MV-last pattern as tum_breakdown):
+-- an MV created first would also ingest rows written while this scan runs.
+INSERT INTO `mcp_call_summaries` SELECT gram_project_id, trace_id, multiIf(toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), toString(id)) AS tool_call_id, max(event_source) AS event_source, max(tool_name) AS tool_name, max(toolset_slug) AS toolset_slug, max(toString(attributes.gram.mcp.server_url)) AS mcp_server_url, max(hook_source) AS hook_source, min(time_unix_nano) AS start_time_unix_nano, max(toInt32OrZero(toString(attributes.http.response.status_code))) AS http_status_code, max(if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)) AS has_result, max(if(toString(attributes.gram.hook.error) != '', 1, 0)) AS has_error FROM telemetry_logs WHERE (telemetry_logs.trace_id IS NOT NULL) AND (telemetry_logs.trace_id != '') AND (((telemetry_logs.event_source != 'hook') AND (telemetry_logs.toolset_slug != '')) OR ((telemetry_logs.event_source = 'hook') AND (toString(telemetry_logs.attributes.gram.mcp.server_url) != ''))) GROUP BY gram_project_id, trace_id, tool_call_id;
+-- Create "mcp_call_summaries_mv" view — LAST, closing the backfill.
+CREATE MATERIALIZED VIEW `mcp_call_summaries_mv` TO `mcp_call_summaries` AS SELECT gram_project_id, trace_id, multiIf(toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), toString(id)) AS tool_call_id, max(event_source) AS event_source, max(tool_name) AS tool_name, max(toolset_slug) AS toolset_slug, max(toString(attributes.gram.mcp.server_url)) AS mcp_server_url, max(hook_source) AS hook_source, min(time_unix_nano) AS start_time_unix_nano, max(toInt32OrZero(toString(attributes.http.response.status_code))) AS http_status_code, max(if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)) AS has_result, max(if(toString(attributes.gram.hook.error) != '', 1, 0)) AS has_error FROM telemetry_logs WHERE (telemetry_logs.trace_id IS NOT NULL) AND (telemetry_logs.trace_id != '') AND (((telemetry_logs.event_source != 'hook') AND (telemetry_logs.toolset_slug != '')) OR ((telemetry_logs.event_source = 'hook') AND (toString(telemetry_logs.attributes.gram.mcp.server_url) != ''))) GROUP BY gram_project_id, trace_id, tool_call_id;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:cy0aZtbtIM9sc7a3YF0ZFKUyJjoNUbJMww3/A5A5xKQ=
+h1:0K1F/Pyb0tGgeMSbKEtOMekt43LdUrB2FHtqjX2oaxw=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -94,3 +94,4 @@ h1:cy0aZtbtIM9sc7a3YF0ZFKUyJjoNUbJMww3/A5A5xKQ=
 20260825112511_billing-meter-readings.up.sql h1:27Ts5n4EmmxCSfPKF89JmZBaixYgLQ0xvqoE/4yAGOM=
 20260830194012_drop-billing-meter-readings-for-recreation.up.sql h1:BaYerdiYBJFHERzcT2RjXIpGcOKOOue8RhqS6B0IPuU=
 20260830194031_create-billing-meter-readings-with-produced-version.up.sql h1:P/yMjAzN6cJJ/krXI3/Eqk7PEGEYdgNJIa8kpETP8t8=
+20260901144303_mcp-call-summaries.up.sql h1:gLJ9760ARv0Ocba+AZyRp1jlcMI3nD4qNyrLlM6R/tg=

--- a/server/clickhouse/migrations/20260901144256_mcp-call-summaries.sql
+++ b/server/clickhouse/migrations/20260901144256_mcp-call-summaries.sql
@@ -1,0 +1,22 @@
+-- Create "mcp_call_summaries" table
+CREATE TABLE `mcp_call_summaries` (
+  `gram_project_id` UUID,
+  `trace_id` FixedString(32),
+  `tool_call_id` String,
+  `event_source` SimpleAggregateFunction(max, String),
+  `tool_name` SimpleAggregateFunction(max, String),
+  `toolset_slug` SimpleAggregateFunction(max, String),
+  `mcp_server_url` SimpleAggregateFunction(max, String),
+  `hook_source` SimpleAggregateFunction(max, String),
+  `start_time_unix_nano` SimpleAggregateFunction(min, Int64),
+  `http_status_code` SimpleAggregateFunction(max, Int32),
+  `has_result` SimpleAggregateFunction(max, UInt8),
+  `has_error` SimpleAggregateFunction(max, UInt8),
+  INDEX `idx_mcp_call_summaries_start_time` ((start_time_unix_nano)) TYPE minmax GRANULARITY 1
+) ENGINE = AggregatingMergeTree
+PRIMARY KEY (`gram_project_id`, `trace_id`, `tool_call_id`) ORDER BY (`gram_project_id`, `trace_id`, `tool_call_id`) TTL fromUnixTimestamp64Nano(start_time_unix_nano) + toIntervalDay(90) SETTINGS index_granularity = 8192 COMMENT 'Per-tool-call MCP summaries so drill-down can filter by server without mixing other servers from the same session';
+-- Backfill BEFORE creating the MV (same MV-last pattern as tum_breakdown):
+-- an MV created first would also ingest rows written while this scan runs.
+INSERT INTO `mcp_call_summaries` SELECT gram_project_id, trace_id, multiIf(toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), toString(id)) AS tool_call_id, max(event_source) AS event_source, max(tool_name) AS tool_name, max(toolset_slug) AS toolset_slug, max(toString(attributes.gram.mcp.server_url)) AS mcp_server_url, max(hook_source) AS hook_source, min(time_unix_nano) AS start_time_unix_nano, max(toInt32OrZero(toString(attributes.http.response.status_code))) AS http_status_code, max(if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)) AS has_result, max(if(toString(attributes.gram.hook.error) != '', 1, 0)) AS has_error FROM telemetry_logs WHERE (telemetry_logs.trace_id IS NOT NULL) AND (telemetry_logs.trace_id != '') AND (((telemetry_logs.event_source != 'hook') AND (telemetry_logs.toolset_slug != '')) OR ((telemetry_logs.event_source = 'hook') AND (toString(telemetry_logs.attributes.gram.mcp.server_url) != ''))) GROUP BY gram_project_id, trace_id, tool_call_id;
+-- Create "mcp_call_summaries_mv" view — LAST, closing the backfill.
+CREATE MATERIALIZED VIEW `mcp_call_summaries_mv` TO `mcp_call_summaries` AS SELECT gram_project_id, trace_id, multiIf(toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), toString(id)) AS tool_call_id, max(event_source) AS event_source, max(tool_name) AS tool_name, max(toolset_slug) AS toolset_slug, max(toString(attributes.gram.mcp.server_url)) AS mcp_server_url, max(hook_source) AS hook_source, min(time_unix_nano) AS start_time_unix_nano, max(toInt32OrZero(toString(attributes.http.response.status_code))) AS http_status_code, max(if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)) AS has_result, max(if(toString(attributes.gram.hook.error) != '', 1, 0)) AS has_error FROM telemetry_logs WHERE (telemetry_logs.trace_id IS NOT NULL) AND (telemetry_logs.trace_id != '') AND (((telemetry_logs.event_source != 'hook') AND (telemetry_logs.toolset_slug != '')) OR ((telemetry_logs.event_source = 'hook') AND (toString(telemetry_logs.attributes.gram.mcp.server_url) != ''))) GROUP BY gram_project_id, trace_id, tool_call_id;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/Sd8KSe7b8SJnys7g2cSIF5isSpK6KywCB5rbzHcFas=
+h1:/usPGvsye/ZOTprMWXqBdWQnIyPK/pE5tyOK9BNSPqE=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -99,3 +99,4 @@ h1:/Sd8KSe7b8SJnys7g2cSIF5isSpK6KywCB5rbzHcFas=
 20260825112504_billing-meter-readings.sql h1:tQBQtUvTVevKBYdP539VUMePWX/XYBS9FWYQvsDvZ0M=
 20260830194007_drop-billing-meter-readings-for-recreation.sql h1:wkU35/YZ9frc0FklFIGxr6SU4to66HvkIV35wxbklxs=
 20260830194025_create-billing-meter-readings-with-produced-version.sql h1:8zElCaRtJdH7pqsg9gKO469BADjfzEWyebYiNrRQFzA=
+20260901144256_mcp-call-summaries.sql h1:GrlCVuhrDGCNSxDQ7YGFMJeTZQ4MFFbcP+5hZARFx/s=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -282,6 +282,67 @@ FROM telemetry_logs
 WHERE trace_id IS NOT NULL AND trace_id != '' AND NOT startsWith(telemetry_logs.gram_urn, 'urn:uuid:')
 GROUP BY trace_id, gram_project_id;
 
+-- Per-tool-call MCP summaries for diagnostics and drill-down. trace_summaries
+-- is one row per trace_id, so a session that called several MCP servers
+-- collapses to a single max(mcp_server_url) / any(tool_name) and mixes those
+-- servers when a caller filters by one of them. This table keeps one row per
+-- (project, trace, tool call) so a Datadog drill-down does not include Linear
+-- or GitHub tools from the same session. tool_call_id mirrors the session MV
+-- (Claude tool_use_id, then gen_ai.tool.call.id, then the row id).
+CREATE TABLE IF NOT EXISTS mcp_call_summaries (
+    gram_project_id UUID,
+    trace_id FixedString(32),
+    tool_call_id String,
+
+    event_source SimpleAggregateFunction(max, String),
+    tool_name SimpleAggregateFunction(max, String),
+    -- Hosted MCP traffic is identified by toolset slug. max() so an empty
+    -- sibling row loses to the populated value across part merges.
+    toolset_slug SimpleAggregateFunction(max, String),
+    -- Hook-observed traffic is identified by the URL the client called.
+    mcp_server_url SimpleAggregateFunction(max, String),
+    hook_source SimpleAggregateFunction(max, String),
+
+    start_time_unix_nano SimpleAggregateFunction(min, Int64),
+    http_status_code SimpleAggregateFunction(max, Int32),
+    has_result SimpleAggregateFunction(max, UInt8),
+    has_error SimpleAggregateFunction(max, UInt8)
+) ENGINE = AggregatingMergeTree
+ORDER BY (gram_project_id, trace_id, tool_call_id)
+TTL fromUnixTimestamp64Nano(start_time_unix_nano) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+COMMENT 'Per-tool-call MCP summaries so drill-down can filter by server without mixing other servers from the same session';
+
+-- Same part-level minmax pruning as idx_trace_summaries_start_time: the sort
+-- key is (project, trace, call), so a time window cannot prune by primary key.
+CREATE INDEX IF NOT EXISTS idx_mcp_call_summaries_start_time ON mcp_call_summaries (start_time_unix_nano) TYPE minmax GRANULARITY 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mcp_call_summaries_mv TO mcp_call_summaries AS
+SELECT
+    gram_project_id,
+    trace_id,
+    multiIf(
+        toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id),
+        toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id),
+        toString(id)
+    ) AS tool_call_id,
+    max(event_source) AS event_source,
+    max(tool_name) AS tool_name,
+    max(toolset_slug) AS toolset_slug,
+    max(toString(attributes.gram.mcp.server_url)) AS mcp_server_url,
+    max(hook_source) AS hook_source,
+    min(time_unix_nano) AS start_time_unix_nano,
+    max(toInt32OrZero(toString(attributes.http.response.status_code))) AS http_status_code,
+    max(if(toString(attributes.gen_ai.tool.call.result) != '', 1, 0)) AS has_result,
+    max(if(toString(attributes.gram.hook.error) != '', 1, 0)) AS has_error
+FROM telemetry_logs
+WHERE telemetry_logs.trace_id IS NOT NULL AND telemetry_logs.trace_id != ''
+  AND (
+    (telemetry_logs.event_source != 'hook' AND telemetry_logs.toolset_slug != '')
+    OR (telemetry_logs.event_source = 'hook' AND toString(telemetry_logs.attributes.gram.mcp.server_url) != '')
+  )
+GROUP BY gram_project_id, trace_id, tool_call_id;
+
 CREATE TABLE IF NOT EXISTS shadow_mcp_inventory_urls (
     gram_project_id UUID,
     canonical_server_url String,

--- a/server/internal/demoseed/clickhouse.sql
+++ b/server/internal/demoseed/clickhouse.sql
@@ -5,8 +5,8 @@
 -- demo project ids ARE the isolation boundary — they must match
 -- seed/demo/postgres.sql).
 --
--- The MVs (trace/metrics/attribute_metrics/chat_token/chat_session summaries,
--- attribute_keys, spend_rule_usage) fire on INSERT, and a DELETE on
+-- The MVs (trace/metrics/attribute_metrics/chat_token/chat_session/mcp_call
+-- summaries, attribute_keys, spend_rule_usage) fire on INSERT, and a DELETE on
 -- telemetry_logs never shrinks their targets — so each target is deleted
 -- explicitly below before the fresh insert repopulates it through the MVs.
 -- Rows are inserted with recent timestamps (trailing ~12 days), safely past
@@ -60,6 +60,8 @@ SET lightweight_deletes_sync = 1;
 DELETE FROM telemetry_logs WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
 DELETE FROM trace_summaries WHERE gram_project_id IN
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
+DELETE FROM mcp_call_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
 DELETE FROM metrics_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
@@ -1022,6 +1024,13 @@ SELECT throwIf(
      (toUUID('dec0de00-0000-4000-a000-000000000001'))
    ) < 180,
   'demo seed postflight: chat_session_summaries_mv missing sessions');
+
+SELECT throwIf(
+  (SELECT count() FROM mcp_call_summaries WHERE gram_project_id IN
+     (toUUID('dec0de00-0000-4000-a000-000000000001'))
+     AND toolset_slug != ''
+   ) = 0,
+  'demo seed postflight: mcp_call_summaries_mv missing hosted MCP calls');
 
 SELECT throwIf(
   (SELECT count() FROM attribute_metrics_summaries WHERE gram_project_id IN

--- a/server/internal/platformmcp/drilldown.go
+++ b/server/internal/platformmcp/drilldown.go
@@ -269,7 +269,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	// The cursor resolves only against the query that minted it, so a position
 	// cannot be replayed on a different MCP, outcome class, or window.
 	scope := traceCursorScope(target, input.Outcome)
-	before, beforeTraceID, traversed, err := s.decodeTraceCursor(input.Cursor, principal, scope, target.now)
+	before, beforeTraceID, beforeToolCallID, traversed, err := s.decodeTraceCursor(input.Cursor, principal, scope, target.now)
 	if err != nil {
 		return QueryMCPTracesOutput{}, err
 	}
@@ -278,6 +278,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 		GetMCPOutcomeBreakdownParams: target.outcomeParams(),
 		BeforeUnixNano:               before,
 		BeforeTraceID:                beforeTraceID,
+		BeforeToolCallID:             beforeToolCallID,
 		// One extra row decides whether another page exists without a second
 		// round trip, and is dropped before anything is projected.
 		Limit: maxTraceReferences + 1,
@@ -338,7 +339,7 @@ func (s *DiagnosticsService) QueryMCPTraces(ctx context.Context, principal Princ
 	traversed += len(rows)
 	if more && len(rows) > 0 && traversed < maxTraceTraversal {
 		last := rows[len(rows)-1]
-		cursor, err := s.references.EncodeScoped(principal, subjectKindCursor, scope, formatCursorPosition(last.OccurredAt, last.TraceID, traversed), target.now)
+		cursor, err := s.references.EncodeScoped(principal, subjectKindCursor, scope, formatCursorPosition(last.OccurredAt, last.TraceID, last.ToolCallID, traversed), target.now)
 		if err != nil {
 			return QueryMCPTracesOutput{}, fmt.Errorf("mint trace cursor: %w", err)
 		}
@@ -630,19 +631,19 @@ func maskToken(value string) string {
 	return string(runes[0]) + strings.Repeat("*", min(len(runes)-1, 3))
 }
 
-func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, scope string, now time.Time) (int64, string, int, error) {
+func (s *DiagnosticsService) decodeTraceCursor(cursor string, principal Principal, scope string, now time.Time) (int64, string, string, int, error) {
 	if cursor == "" {
-		return 0, "", 0, nil
+		return 0, "", "", 0, nil
 	}
 	value, err := s.references.DecodeScoped(cursor, principal, subjectKindCursor, scope, now)
 	if err != nil {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
-	position, traceID, traversed, err := parseCursorPosition(value)
+	position, traceID, toolCallID, traversed, err := parseCursorPosition(value)
 	if err != nil {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
-	return position, traceID, traversed, nil
+	return position, traceID, toolCallID, traversed, nil
 }
 
 // sortToolEvents puts the tool a caller should look at first at the top:
@@ -667,36 +668,44 @@ func sortToolEvents(events []MCPToolEvents) {
 // everything else a caller holds between calls. The count travels inside the
 // sealed token rather than beside it, so a caller cannot reset its own
 // traversal budget by editing what it was handed.
-func formatCursorPosition(unixNano int64, traceID string, traversed int) string {
-	return "t:" + strconv.FormatInt(unixNano, 10) + ":" + strconv.Itoa(traversed) + ":" + traceID
+func formatCursorPosition(unixNano int64, traceID, toolCallID string, traversed int) string {
+	pos := "t:" + strconv.FormatInt(unixNano, 10) + ":" + strconv.Itoa(traversed) + ":" + traceID
+	if toolCallID != "" {
+		pos += ":" + toolCallID
+	}
+	return pos
 }
 
 // parseCursorPosition recovers the composite page key and the traversal count.
-// Both halves of the key are required: the repo orders by (event_time_ns,
-// trace_id), and a cursor carrying only the timestamp would skip every trace
-// sharing the boundary nanosecond.
-func parseCursorPosition(value string) (int64, string, int, error) {
+// Time, trace id, and tool-call id are required to page without skipping
+// remaining calls that share a session. A three-field cursor (no call id) is
+// still accepted so a token minted before that half existed keeps working.
+func parseCursorPosition(value string) (int64, string, string, int, error) {
 	rest, ok := strings.CutPrefix(value, "t:")
 	if !ok {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
 	timestamp, rest, ok := strings.Cut(rest, ":")
 	if !ok {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
-	count, traceID, ok := strings.Cut(rest, ":")
-	if !ok || traceID == "" {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+	count, rest, ok := strings.Cut(rest, ":")
+	if !ok || rest == "" {
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
+	}
+	traceID, toolCallID, _ := strings.Cut(rest, ":")
+	if traceID == "" {
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
 	position, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil || position <= 0 {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
 	traversed, err := strconv.Atoi(count)
 	if err != nil || traversed < 0 || traversed > maxTraceTraversal {
-		return 0, "", 0, ErrSubjectReferenceNotFound
+		return 0, "", "", 0, ErrSubjectReferenceNotFound
 	}
-	return position, traceID, traversed, nil
+	return position, traceID, toolCallID, traversed, nil
 }
 
 // fitRows drops trailing rows until the serialized result fits the response

--- a/server/internal/platformmcp/drilldown_test.go
+++ b/server/internal/platformmcp/drilldown_test.go
@@ -267,14 +267,23 @@ func TestFailureRate_RoundsServerSide(t *testing.T) {
 func TestCursorPosition_CarriesTheCompositeKey(t *testing.T) {
 	t.Parallel()
 
-	position, traceID, traversed, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", 40))
+	position, traceID, toolCallID, traversed, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", "call-9", 40))
 	require.NoError(t, err)
 	require.Equal(t, int64(1_700_000_000_000_000_000), position)
 	require.Equal(t, "abc123", traceID)
+	require.Equal(t, "call-9", toolCallID)
 	require.Equal(t, 40, traversed)
 
+	// A three-field cursor minted before the call-id half existed still decodes.
+	legacyPosition, legacyTraceID, legacyCallID, legacyTraversed, err := parseCursorPosition("t:1700000000000000000:40:abc123")
+	require.NoError(t, err)
+	require.Equal(t, int64(1_700_000_000_000_000_000), legacyPosition)
+	require.Equal(t, "abc123", legacyTraceID)
+	require.Empty(t, legacyCallID)
+	require.Equal(t, 40, legacyTraversed)
+
 	for _, value := range []string{"", "1700000000", "t:", "t:abc", "t:-1:0:x", "t:0:0:x", "t:1700000000", "t:1700000000:x", "t:1700000000:abc:x", "t:1700000000:-1:x"} {
-		_, _, _, err := parseCursorPosition(value)
+		_, _, _, _, err := parseCursorPosition(value)
 		require.ErrorIs(t, err, ErrSubjectReferenceNotFound, value)
 	}
 }
@@ -286,7 +295,7 @@ func TestCursorPosition_CarriesTheCompositeKey(t *testing.T) {
 func TestCursorPosition_RefusesATraversalPastTheCap(t *testing.T) {
 	t.Parallel()
 
-	_, _, _, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", maxTraceTraversal+1))
+	_, _, _, _, err := parseCursorPosition(formatCursorPosition(1_700_000_000_000_000_000, "abc123", "call-9", maxTraceTraversal+1))
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 }
 

--- a/server/internal/telemetry/mcp_drilldown_test.go
+++ b/server/internal/telemetry/mcp_drilldown_test.go
@@ -1,6 +1,7 @@
 package telemetry_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -168,6 +169,7 @@ func TestListMCPTraceReferences_PagesBackwardsInTime(t *testing.T) {
 		GetMCPOutcomeBreakdownParams: base,
 		BeforeUnixNano:               first[len(first)-1].OccurredAt,
 		BeforeTraceID:                first[len(first)-1].TraceID,
+		BeforeToolCallID:             first[len(first)-1].ToolCallID,
 		Limit:                        2,
 	})
 	require.NoError(t, err)
@@ -265,5 +267,140 @@ func TestMCPDrilldownTraceIDsAreStable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, first, 1)
 	require.Equal(t, first[0].TraceID, second[0].TraceID)
+	require.Equal(t, first[0].ToolCallID, second[0].ToolCallID)
 	require.Equal(t, telemetryRepo.MCPOutcomeUnauthorized, first[0].Outcome)
+}
+
+// TestGetMCPToolOutcomeBreakdown_HookObservedMultiServerSession pins that a
+// single session (shared trace_id) calling several MCP servers contributes
+// only the selected server's tools when filtered. This is the customer-reported
+// drill-down bug: Datadog showed Linear and GitHub tools from the same session.
+func TestGetMCPToolOutcomeBreakdown_HookObservedMultiServerSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+	now := time.Now().UTC()
+	sharedTraceID := strings.ReplaceAll(uuid.New().String(), "-", "")
+
+	for _, event := range []struct {
+		mcpServerURL string
+		toolName     string
+		result       string
+		errorMsg     string
+	}{
+		{"https://api.example.com/mcp/datadog", "mcp__datadog__get_logs", `"ok"`, ""},
+		{"https://api.example.com/mcp/datadog", "mcp__datadog__search_metrics", `"ok"`, ""},
+		{"https://api.example.com/mcp/linear", "mcp__linear__get_issues", `"ok"`, ""},
+		{"https://api.example.com/mcp/linear", "mcp__linear__create_issue", "", "boom"},
+		{"https://api.example.com/mcp/github", "mcp__github__list_repos", `"ok"`, ""},
+	} {
+		insertHookEvent(t, ctx, hookEventParams{
+			projectID:    projectID,
+			deploymentID: deploymentID,
+			timestamp:    now.Add(-10 * time.Minute),
+			traceID:      sharedTraceID,
+			hookSource:   "claude-code",
+			toolName:     event.toolName,
+			result:       event.result,
+			errorMsg:     event.errorMsg,
+			mcpServerURL: event.mcpServerURL,
+			customAttrs:  map[string]any{"gen_ai.tool.call.id": uuid.New().String()},
+		})
+	}
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	base := func(suffix string) telemetryRepo.GetMCPOutcomeBreakdownParams {
+		return telemetryRepo.GetMCPOutcomeBreakdownParams{
+			GramProjectIDs:       []string{projectID},
+			MCPServerURLSuffixes: []string{suffix},
+			TimeStart:            now.Add(-time.Hour).UnixNano(),
+			TimeEnd:              now.UnixNano(),
+		}
+	}
+
+	rows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: base("/mcp/datadog"),
+	})
+	require.NoError(t, err)
+	counts := toolOutcomeCounts(rows)
+	require.Equal(t, map[string]map[string]uint64{
+		"mcp__datadog__get_logs":       {telemetryRepo.MCPOutcomeSuccess: 1},
+		"mcp__datadog__search_metrics": {telemetryRepo.MCPOutcomeSuccess: 1},
+	}, counts)
+
+	outcomes, err := ti.chClient.GetMCPOutcomeBreakdown(ctx, base("/mcp/datadog"))
+	require.NoError(t, err)
+	require.Equal(t, map[string]uint64{telemetryRepo.MCPOutcomeSuccess: 2}, outcomeCounts(outcomes))
+
+	linearRows, err := ti.chClient.GetMCPToolOutcomeBreakdown(ctx, telemetryRepo.GetMCPToolOutcomeBreakdownParams{
+		GetMCPOutcomeBreakdownParams: base("/mcp/linear"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]map[string]uint64{
+		"mcp__linear__get_issues":   {telemetryRepo.MCPOutcomeSuccess: 1},
+		"mcp__linear__create_issue": {telemetryRepo.MCPOutcomeFailed: 1},
+	}, toolOutcomeCounts(linearRows))
+}
+
+// TestListMCPTraceReferences_PagesSameSessionCalls pins that several tool
+// calls sharing a session trace_id each appear as their own occurrence and
+// page on (time, trace, call) rather than collapsing to one row per session.
+func TestListMCPTraceReferences_PagesSameSessionCalls(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+	now := time.Now().UTC()
+	sharedTraceID := strings.ReplaceAll(uuid.New().String(), "-", "")
+
+	for index, toolName := range []string{"get_logs", "search_metrics", "list_monitors"} {
+		insertHookEvent(t, ctx, hookEventParams{
+			projectID:    projectID,
+			deploymentID: deploymentID,
+			timestamp:    now.Add(-time.Duration(30-index*10) * time.Minute),
+			traceID:      sharedTraceID,
+			hookSource:   "claude-code",
+			toolName:     toolName,
+			result:       `"ok"`,
+			mcpServerURL: "https://api.example.com/mcp/datadog",
+			customAttrs:  map[string]any{"gen_ai.tool.call.id": "call-" + toolName},
+		})
+	}
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	base := telemetryRepo.GetMCPOutcomeBreakdownParams{
+		GramProjectIDs:       []string{projectID},
+		MCPServerURLSuffixes: []string{"/mcp/datadog"},
+		TimeStart:            now.Add(-time.Hour).UnixNano(),
+		TimeEnd:              now.UnixNano(),
+	}
+
+	first, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+		Limit:                        2,
+	})
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	require.Equal(t, sharedTraceID, first[0].TraceID)
+	require.Equal(t, sharedTraceID, first[1].TraceID)
+	require.NotEqual(t, first[0].ToolCallID, first[1].ToolCallID)
+
+	next, err := ti.chClient.ListMCPTraceReferences(ctx, telemetryRepo.ListMCPTraceReferencesParams{
+		GetMCPOutcomeBreakdownParams: base,
+		BeforeUnixNano:               first[len(first)-1].OccurredAt,
+		BeforeTraceID:                first[len(first)-1].TraceID,
+		BeforeToolCallID:             first[len(first)-1].ToolCallID,
+		Limit:                        2,
+	})
+	require.NoError(t, err)
+	require.Len(t, next, 1)
+	require.Equal(t, sharedTraceID, next[0].TraceID)
+	require.NotEqual(t, first[0].ToolCallID, next[0].ToolCallID)
+	require.NotEqual(t, first[1].ToolCallID, next[0].ToolCallID)
+	require.Less(t, next[0].OccurredAt, first[1].OccurredAt)
 }

--- a/server/internal/telemetry/repo/mcp_diagnostics.go
+++ b/server/internal/telemetry/repo/mcp_diagnostics.go
@@ -121,10 +121,12 @@ func (q *Queries) GetMCPOutcomeBreakdown(ctx context.Context, arg GetMCPOutcomeB
 	return result, nil
 }
 
-// mcpTraceSource builds the per-trace row set both diagnostics and drill-down
-// read from: one row per trace, carrying its correlation id, when it happened,
-// the client that made it, the tool it called, and its classified outcome.
-// Aggregations sit on top of this; nothing below it reaches a raw log row.
+// mcpTraceSource builds the per-call row set both diagnostics and drill-down
+// read from: one row per tool call, carrying its correlation id, call id,
+// when it happened, the client that made it, the tool it called, and its
+// classified outcome. Aggregations sit on top of this. The source is
+// mcp_call_summaries (one row per tool call), not trace_summaries (one row
+// per session), so a multi-server session does not mix tools across servers.
 func (q *Queries) mcpTraceSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	directSQL, directArgs, err := q.mcpOutcomeDirectSource(arg)
 	if err != nil {
@@ -146,27 +148,29 @@ func unionSource(directSQL string, directArgs []any, hookSQL string, hookArgs []
 }
 
 // mcpOutcomeDirectSource classifies calls that reached a hosted MCP server
-// directly. Aggregate aliases carry the "g_" prefix for the reason the tool
-// usage CTE documents: an alias that shadows a trace_summaries column is merged
-// into the enclosing aggregate and fails with ILLEGAL_AGGREGATION.
+// directly. It reads mcp_call_summaries so toolset_slug is filtered at the
+// call, not after a session-level max(). Aggregate aliases carry the "g_"
+// prefix so they do not shadow base columns and collapse into an enclosing
+// aggregate (ILLEGAL_AGGREGATION).
 func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	grouped := sq.Select(
 		"trace_id",
+		"tool_call_id",
 		"min(start_time_unix_nano) AS event_time_ns",
-		"max(toolset_slug) AS g_toolset_slug",
-		"any(tool_name) AS g_tool_name",
-		"ifNull(anyIfMerge(http_status_code), 0) AS g_http_status_code",
+		"max(tool_name) AS g_tool_name",
+		"max(http_status_code) AS g_http_status_code",
 	).
-		From("trace_summaries").
+		From("mcp_call_summaries").
 		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
-		GroupBy("trace_id").
-		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
-		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
-		Having("any(event_source) != 'hook'").
-		Having("g_toolset_slug != ''")
+		Where("event_source != 'hook'").
+		Where("toolset_slug != ''")
 	if len(arg.ToolsetSlugs) > 0 {
-		grouped = grouped.Having(squirrel.Eq{"g_toolset_slug": arg.ToolsetSlugs})
+		grouped = grouped.Where(squirrel.Eq{"toolset_slug": arg.ToolsetSlugs})
 	}
+	grouped = grouped.
+		GroupBy("trace_id", "tool_call_id").
+		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd)
 	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
 
 	groupedSQL, groupedArgs, err := grouped.ToSql()
@@ -185,6 +189,7 @@ func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (stri
 	return fmt.Sprintf(`
 SELECT
 	trace_id,
+	tool_call_id,
 	event_time_ns,
 	'%s' AS client,
 	g_tool_name AS tool_name,
@@ -196,26 +201,31 @@ FROM (%s)`, MCPClientUnattributed, outcome, groupedSQL), groupedArgs, nil
 // observed them. This is the only lane that can name a client today, and it
 // names the reporting integration — self-reported evidence, never a metric
 // dimension a caller can filter on.
+//
+// mcp_server_url is filtered in WHERE against mcp_call_summaries so a session
+// that called several servers contributes only the matching calls, not an
+// arbitrary tool_name from the whole trace.
 func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	grouped := sq.Select(
 		"trace_id",
+		"tool_call_id",
 		"min(start_time_unix_nano) AS event_time_ns",
-		"any(hook_source) AS g_hook_source",
-		"any(tool_name) AS g_tool_name",
-		"max(mcp_server_url) AS g_mcp_server_url",
+		"max(hook_source) AS g_hook_source",
+		"max(tool_name) AS g_tool_name",
 		"max(has_result) AS g_has_result",
 		"max(has_error) AS g_has_error",
 	).
-		From("trace_summaries").
+		From("mcp_call_summaries").
 		Where(squirrel.Eq{"gram_project_id": arg.GramProjectIDs}).
-		GroupBy("trace_id").
-		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
-		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd).
-		Having("any(event_source) = 'hook'").
-		Having("g_mcp_server_url != ''")
+		Where("event_source = 'hook'").
+		Where("mcp_server_url != ''")
 	if len(arg.MCPServerURLSuffixes) > 0 {
-		grouped = grouped.Having("arrayExists(suffix -> endsWith(g_mcp_server_url, suffix), ?)", arg.MCPServerURLSuffixes)
+		grouped = grouped.Where("arrayExists(suffix -> endsWith(mcp_server_url, suffix), ?)", arg.MCPServerURLSuffixes)
 	}
+	grouped = grouped.
+		GroupBy("trace_id", "tool_call_id").
+		Having("min(start_time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(start_time_unix_nano) <= ?", arg.TimeEnd)
 	grouped = withTraceWindowScanBounds(grouped, "start_time_unix_nano", arg.TimeStart, arg.TimeEnd)
 
 	groupedSQL, groupedArgs, err := grouped.ToSql()
@@ -232,6 +242,7 @@ func (q *Queries) mcpOutcomeHookSource(arg GetMCPOutcomeBreakdownParams) (string
 	return fmt.Sprintf(`
 SELECT
 	trace_id,
+	tool_call_id,
 	event_time_ns,
 	%s AS client,
 	g_tool_name AS tool_name,

--- a/server/internal/telemetry/repo/mcp_diagnostics.go
+++ b/server/internal/telemetry/repo/mcp_diagnostics.go
@@ -149,9 +149,10 @@ func unionSource(directSQL string, directArgs []any, hookSQL string, hookArgs []
 
 // mcpOutcomeDirectSource classifies calls that reached a hosted MCP server
 // directly. It reads mcp_call_summaries so toolset_slug is filtered at the
-// call, not after a session-level max(). Aggregate aliases carry the "g_"
-// prefix so they do not shadow base columns and collapse into an enclosing
-// aggregate (ILLEGAL_AGGREGATION).
+// call, not after a session-level max(). Rows without tool_use_id or
+// gen_ai.tool.call.id fall back to the log row id, matching the session MV.
+// Aggregate aliases carry the "g_" prefix so they do not shadow base columns
+// and collapse into an enclosing aggregate (ILLEGAL_AGGREGATION).
 func (q *Queries) mcpOutcomeDirectSource(arg GetMCPOutcomeBreakdownParams) (string, []any, error) {
 	grouped := sq.Select(
 		"trace_id",

--- a/server/internal/telemetry/repo/mcp_drilldown.go
+++ b/server/internal/telemetry/repo/mcp_drilldown.go
@@ -138,8 +138,9 @@ func (q *Queries) ListMCPTraceReferences(ctx context.Context, arg ListMCPTraceRe
 		if arg.BeforeTraceID != "" && arg.BeforeToolCallID != "" {
 			sb = sb.Where("(event_time_ns, trace_id, tool_call_id) < (?, ?, ?)", arg.BeforeUnixNano, arg.BeforeTraceID, arg.BeforeToolCallID)
 		} else if arg.BeforeTraceID != "" {
-			// Callers that have not yet adopted the call-id half of the key
-			// keep the previous (time, trace) exclusive boundary.
+			// A cursor without a call id keeps the (time, trace) exclusive
+			// boundary so a token minted before that half existed still pages
+			// one-call-per-trace traffic correctly.
 			sb = sb.Where("(event_time_ns, trace_id) < (?, ?)", arg.BeforeUnixNano, arg.BeforeTraceID)
 		} else {
 			sb = sb.Where("event_time_ns < ?", arg.BeforeUnixNano)

--- a/server/internal/telemetry/repo/mcp_drilldown.go
+++ b/server/internal/telemetry/repo/mcp_drilldown.go
@@ -79,17 +79,21 @@ type ListMCPTraceReferencesParams struct {
 	// rarely what a drill-down wants — the caller usually arrives here holding a
 	// failure class the overview named.
 	Outcomes []string
-	// BeforeUnixNano and BeforeTraceID continue a previous page. They are the
-	// composite key the ordering below uses; paging on the timestamp alone
-	// would skip every remaining trace sharing the boundary nanosecond, which
-	// on a busy server silently drops occurrences from both pages.
-	BeforeUnixNano int64
-	BeforeTraceID  string
-	Limit          int
+	// BeforeUnixNano, BeforeTraceID, and BeforeToolCallID continue a previous
+	// page. They are the composite key the ordering below uses. Paging on the
+	// timestamp alone would skip every remaining call sharing the boundary
+	// nanosecond. Paging on (time, trace_id) alone would skip remaining calls
+	// in the same session — hook-observed traffic shares a trace_id across
+	// every tool call in the session.
+	BeforeUnixNano   int64
+	BeforeTraceID    string
+	BeforeToolCallID string
+	Limit            int
 }
 
 type MCPTraceReferenceRow struct {
 	TraceID    string `ch:"trace_id"`
+	ToolCallID string `ch:"tool_call_id"`
 	OccurredAt int64  `ch:"event_time_ns"`
 	ToolName   string `ch:"tool_name"`
 	Outcome    string `ch:"outcome"`
@@ -120,6 +124,7 @@ func (q *Queries) ListMCPTraceReferences(ctx context.Context, arg ListMCPTraceRe
 
 	sb := sq.Select(
 		"trace_id",
+		"tool_call_id",
 		"event_time_ns",
 		"tool_name",
 		"outcome",
@@ -130,15 +135,19 @@ func (q *Queries) ListMCPTraceReferences(ctx context.Context, arg ListMCPTraceRe
 		sb = sb.Where(squirrel.Eq{"outcome": arg.Outcomes})
 	}
 	if arg.BeforeUnixNano > 0 {
-		if arg.BeforeTraceID != "" {
+		if arg.BeforeTraceID != "" && arg.BeforeToolCallID != "" {
+			sb = sb.Where("(event_time_ns, trace_id, tool_call_id) < (?, ?, ?)", arg.BeforeUnixNano, arg.BeforeTraceID, arg.BeforeToolCallID)
+		} else if arg.BeforeTraceID != "" {
+			// Callers that have not yet adopted the call-id half of the key
+			// keep the previous (time, trace) exclusive boundary.
 			sb = sb.Where("(event_time_ns, trace_id) < (?, ?)", arg.BeforeUnixNano, arg.BeforeTraceID)
 		} else {
 			sb = sb.Where("event_time_ns < ?", arg.BeforeUnixNano)
 		}
 	}
-	// Ordered by time then trace id so a page boundary is deterministic when
-	// several traces share a nanosecond.
-	sb = sb.OrderBy("event_time_ns DESC", "trace_id DESC").Limit(uint64(limit))
+	// Ordered by time, then trace, then call so a page boundary is
+	// deterministic when several calls share a session and a nanosecond.
+	sb = sb.OrderBy("event_time_ns DESC", "trace_id DESC", "tool_call_id DESC").Limit(uint64(limit))
 
 	query, args, err := sb.ToSql()
 	if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes DNO-1021: MCP diagnostics and tool drill-down mixed tools from other MCP servers that happened to share a session (`trace_id`).

This is the D&O-owned fix for the attribution bug that [PR 5869](https://github.com/speakeasy-api/gram/pull/5869) tried to solve by scanning `telemetry_logs`. That approach is correct on attribution but abandons the pre-aggregated read path and introduces pagination issues. This PR keeps the summary path.

[skip migration check]

The new `mcp_call_summaries` table exists only to serve these queries, and the demo-seed skill requires the matching scoped DELETE in the same change. Shipping the MV without the read-path cutover would leave the bug in place; shipping the queries without the table would fail at runtime.

## Problem

`mcpOutcomeDirectSource` and `mcpOutcomeHookSource` (shared by Platform MCP and dashboard-adjacent diagnostics) grouped `trace_summaries` by `trace_id` and filtered with `HAVING max(toolset_slug)` / `max(mcp_server_url)`. A hook-observed session that called Datadog, Linear, and GitHub collapsed to one row. `any(tool_name)` then picked an arbitrary tool from the whole session, so a Datadog drill-down showed Linear and GitHub tools.

`trace_summaries` cannot recover per-server tools after that collapse — the data is already aggregated.

## Solution

Add `mcp_call_summaries`, an `AggregatingMergeTree` at `(gram_project_id, trace_id, tool_call_id)` granularity:

- Hosted traffic is identified by `toolset_slug` on the call row
- Hook-observed traffic is identified by `mcp_server_url` on the call row
- `tool_call_id` matches the session MV (Claude `tool_use_id`, then `gen_ai.tool.call.id`, then row id)

MCP diagnostics and drill-down now read this table and filter in `WHERE` before grouping. Trace-reference pagination includes `tool_call_id` so several calls in one session do not skip a page.

The migration backfills existing MCP rows from `telemetry_logs` before creating the MV (MV-last, same pattern as `tum_breakdown_summaries`).

## Testing

- Existing MCP diagnostics and drill-down tests
- New: hook-observed multi-server session filters to the selected server only, and counts each matching call
- New: same-session tool calls page on `(time, trace_id, tool_call_id)`
- Cursor decode still accepts three-field tokens minted before the call-id half existed

Resolves DNO-1021.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-1021](https://linear.app/speakeasy/issue/DNO-1021/bug-prevent-mcp-drilldown-from-mixing-session-servers)

<div><a href="https://cursor.com/agents/bc-1f34105b-5a17-4210-8f6f-b61c1c9b269f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f34105b-5a17-4210-8f6f-b61c1c9b269f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-1021: MCP diagnostics and drill-down now attribute tools to the MCP server that called them instead of the session they ran in. Previously `trace_summaries` grouped by session, so a Datadog drill-down could show Linear and GitHub tools called from the same session.

**Migration**
- Adds `mcp_call_summaries` with one row per tool call so server filtering happens before grouping.
- Backfills existing MCP rows from `telemetry_logs` before the materialized view is created.

**Bug Fixes**
- MCP diagnostics and drill-down read `mcp_call_summaries` and filter by `toolset_slug` or `mcp_server_url` in `WHERE` instead of aggregating then filtering.
- Pagination includes `tool_call_id` so multiple calls in one session page correctly; legacy cursors without the call id still decode.

<sup>Written for commit 4609dd3001fa3424970ba50d66c4cbccdcf051d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

