### PR TITLE
feat(watchdog): add principal dimension to group signals by user

### DIFF
--- a/client/dashboard/src/pages/security/watchdog/SignalsList.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalsList.tsx
@@ -68,6 +68,7 @@ function groupLabel(group: SignalGroup, mode: SignalGroupMode): string {
       return RULE_CATEGORY_META[group.key as RuleCategory]?.label ?? group.key;
     case "team":
     case "app":
+    case "principal":
       return group.key === UNATTRIBUTED_GROUP_KEY ? "Unattributed" : group.key;
   }
 }

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -67,6 +67,7 @@ const GROUP_OPTIONS: { value: SignalGroupMode; label: string }[] = [
   { value: "category", label: "Data type" },
   { value: "team", label: "Team" },
   { value: "app", label: "App" },
+  { value: "principal", label: "User" },
 ];
 
 const GROUP_MODES = new Set<SignalGroupMode>(

--- a/client/dashboard/src/pages/security/watchdog/signals-helpers.test.ts
+++ b/client/dashboard/src/pages/security/watchdog/signals-helpers.test.ts
@@ -111,6 +111,37 @@ describe("groupSignals", () => {
     expect(groups[2]!.signals.map((s) => s.key)).toEqual(["b"]);
   });
 
+  it("sections by principal, treating the unknown-user placeholder as unattributed", () => {
+    const principalSignals = [
+      signal({
+        key: "a",
+        topUsers: [
+          {
+            email: "x@a.com",
+            externalUserId: "x@a.com",
+            team: "",
+            findings: 5,
+          },
+        ],
+      }),
+      signal({
+        key: "b",
+        topUsers: [
+          {
+            email: "Unknown user",
+            externalUserId: "",
+            team: "",
+            findings: 3,
+          },
+        ],
+      }),
+      signal({ key: "c", topUsers: [] }),
+    ];
+    const groups = groupSignals(principalSignals, "principal");
+    expect(groups.map((g) => g.key)).toEqual(["x@a.com", ""]);
+    expect(groups[1]!.signals.map((s) => s.key)).toEqual(["b", "c"]);
+  });
+
   it("sections by first observed app with unattributed last", () => {
     const appSignals = [
       signal({ key: "a", apps: ["codex", "cursor"] }),

--- a/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
+++ b/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
@@ -105,12 +105,20 @@ function dominantApp(signal: RiskSignal): string {
 }
 
 /**
+ * The placeholder email the server emits for findings it cannot attribute to
+ * a user. Treated as no attribution here so those signals land in the
+ * unattributed bucket rather than under an "Unknown user" heading.
+ */
+const UNKNOWN_USER_EMAIL = "Unknown user";
+
+/**
  * The principal (user) a signal is filed under when grouping by principal:
  * the most-affected user by finding count. Returns the user's email for
- * display. Empty when no top user exists.
+ * display. Empty when no top user exists or the user is unattributed.
  */
 function dominantPrincipal(signal: RiskSignal): string {
-  return signal.topUsers[0]?.email ?? "";
+  const email = signal.topUsers[0]?.email ?? "";
+  return email === UNKNOWN_USER_EMAIL ? "" : email;
 }
 
 function groupKeyForMode(signal: RiskSignal, mode: SignalGroupMode): string {

--- a/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
+++ b/client/dashboard/src/pages/security/watchdog/signals-helpers.ts
@@ -33,7 +33,12 @@ export const SEVERITY_ACCENT: Record<SeverityRating, string> = {
 
 /** How the signals list is sectioned. Rows keep the server's risk ranking
  * within every section. */
-export type SignalGroupMode = "severity" | "category" | "team" | "app";
+export type SignalGroupMode =
+  | "severity"
+  | "category"
+  | "team"
+  | "app"
+  | "principal";
 
 /**
  * Group key for signals whose findings carry no team/app attribution (rows
@@ -99,6 +104,15 @@ function dominantApp(signal: RiskSignal): string {
   return signal.apps[0] ?? "";
 }
 
+/**
+ * The principal (user) a signal is filed under when grouping by principal:
+ * the most-affected user by finding count. Returns the user's email for
+ * display. Empty when no top user exists.
+ */
+function dominantPrincipal(signal: RiskSignal): string {
+  return signal.topUsers[0]?.email ?? "";
+}
+
 function groupKeyForMode(signal: RiskSignal, mode: SignalGroupMode): string {
   switch (mode) {
     case "severity":
@@ -109,6 +123,8 @@ function groupKeyForMode(signal: RiskSignal, mode: SignalGroupMode): string {
       return dominantTeam(signal);
     case "app":
       return dominantApp(signal);
+    case "principal":
+      return dominantPrincipal(signal);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "User" (principal) dimension to the Watchdog dimension selector, allowing users to group risk signals by the user/principal who triggered them. This complements the existing Group, Severity, Data Type, Team, and App dimensions.

## Changes

- **`signals-helpers.ts`**:
  - Added `"principal"` to the `SignalGroupMode` type
  - Added `dominantPrincipal()` function that extracts the most-affected user (by finding count) from a signal's `topUsers` array
  - Updated `groupKeyForMode()` to handle the `"principal"` case

- **`SignalsList.tsx`**:
  - Updated `groupLabel()` to handle the `"principal"` mode (displays user email, or "Unattributed" for signals without user attribution)

- **`Watchdog.tsx`**:
  - Added `{ value: "principal", label: "User" }` to `GROUP_OPTIONS`

## Testing

- Type-checking passes: `pnpm -F dashboard type-check`
- All dashboard tests pass: `pnpm -F dashboard test`
- Manual verification: The "User" dimension appears in the Watchdog dimension selector

![Watchdog User Dimension Screenshot](https://cursor.com/artifacts/c/art-26b09bb2-c801-4ac9-b245-7de0fbd887ed)

## Linear

Closes AGE-3367
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3367](https://linear.app/speakeasy/issue/AGE-3367/feat-add-a-principal-dimension-to-watchdog)

<div><a href="https://cursor.com/agents/bc-06306d93-c219-4937-9d46-250845a4a143?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06306d93-c219-4937-9d46-250845a4a143&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a User (principal) dimension to the Watchdog dimension selector so you can group risk signals by the user who triggered them, alongside the existing Severity, Data type, Team, and App dimensions.

**New Features**
- Groups signals by the most-affected user's email using the signal's top users.
- Treats the server's "Unknown user" placeholder as no attribution, so those signals land in the "Unattributed" bucket.

Closes AGE-3367.

<sup>Written for commit acdcb9231d8fe0fe5eb4e3d620060b08933f42e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

