### PR TITLE
fix(dashboard): show redacted risk matches without chat:read

### DIFF
--- a/client/dashboard/src/pages/security/risk-ui.test.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.test.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from "@/components/ui/Tooltip";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { EventMatchDialog, RuleLabel } from "./risk-ui";
+import { EventMatchDialog, MaskedMatch, RuleLabel } from "./risk-ui";
 
 const hasScope = vi.fn<(scope: string) => boolean>();
 
@@ -78,11 +78,46 @@ describe("EventMatchDialog", () => {
     expect(screen.getByRole("img", { name: /chat:read/ })).toBeTruthy();
   });
 
-  it("falls back to visible Hidden text without chat:read and no rationale", () => {
+  it("falls back to the redacted match without chat:read and no rationale", () => {
     hasScope.mockReturnValue(false);
     renderCell(undefined);
 
-    expect(screen.getByText("Hidden")).toBeTruthy();
+    expect(screen.getByText("<redacted len=42 sha=deadbeef>")).toBeTruthy();
+    expect(screen.queryByText("Hidden")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByRole("img", { name: /chat:read/ })).toBeTruthy();
+  });
+});
+
+function renderMasked(matchRedacted = "<redacted len=42 sha=deadbeef>") {
+  render(
+    <TooltipProvider>
+      <MaskedMatch
+        resultId="00000000-0000-0000-0000-000000000001"
+        matchRedacted={matchRedacted}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("MaskedMatch", () => {
+  it("shows the redacted match without chat:read, and offers no reveal", () => {
+    hasScope.mockReturnValue(false);
+    renderMasked();
+
+    expect(screen.getByText("<redacted len=42 sha=deadbeef>")).toBeTruthy();
+    expect(screen.queryByText("Hidden")).toBeNull();
+    expect(screen.queryByText("Click to reveal")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByRole("img", { name: /chat:read/ })).toBeTruthy();
+  });
+
+  it("keeps the reveal affordance when chat:read is granted", () => {
+    hasScope.mockReturnValue(true);
+    renderMasked();
+
+    expect(screen.getByText("Click to reveal")).toBeTruthy();
+    expect(screen.queryByText("<redacted len=42 sha=deadbeef>")).toBeNull();
   });
 });
 

--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -389,7 +389,7 @@ export function EventMatchDialog({
 
   const summary = rationale?.trim() ? rationale.trim() : null;
 
-  if (!resultId || !hasRevealableEvent(matchRedacted)) {
+  if (!resultId || !matchRedacted || !hasRevealableEvent(matchRedacted)) {
     return summary ? <RationaleText text={summary} /> : <span>-</span>;
   }
 

--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -225,21 +225,16 @@ export function MaskedMatch({
 
   if (!resultId || !matchRedacted) return <span>-</span>;
 
-  // Without chat:read the value can never be revealed — render a static,
-  // non-interactive placeholder so reveal-all can't flip it open either.
+  // Without chat:read the plaintext can never be revealed — keep the
+  // fingerprint on screen so a reviewer can still correlate and inspect the
+  // finding before suppressing it. Reveal-all must not flip this open.
   if (!canReveal) {
     return (
-      <SimpleTooltip tooltip={REVEAL_DENIED_REASON}>
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 text-xs",
-            contrast ? "text-background/70" : "text-muted-foreground",
-          )}
-        >
-          <Lock className="h-3 w-3" />
-          <span>Hidden</span>
-        </span>
-      </SimpleTooltip>
+      <LockedRedactedMatch
+        matchRedacted={matchRedacted}
+        contrast={contrast}
+        wrap={wrap}
+      />
     );
   }
 
@@ -317,6 +312,47 @@ function prettyJSON(s: string): string {
   }
 }
 
+// Static fingerprint for callers who lack chat:read. The lock explains why
+// the plaintext stays withheld; the fingerprint itself is the reviewable
+// token the list endpoints already ship as match_redacted.
+function LockedRedactedMatch({
+  matchRedacted,
+  contrast = false,
+  wrap = false,
+}: {
+  matchRedacted: string;
+  contrast?: boolean;
+  wrap?: boolean;
+}): JSX.Element {
+  return (
+    <SimpleTooltip tooltip={REVEAL_DENIED_REASON}>
+      <span
+        className={cn(
+          "inline-flex max-w-full min-w-0 gap-1 text-xs",
+          wrap ? "items-start" : "items-center",
+          contrast ? "text-background/70" : "text-muted-foreground",
+        )}
+      >
+        <Lock
+          role="img"
+          aria-label={REVEAL_DENIED_REASON}
+          className="h-3 w-3 shrink-0"
+        />
+        <span
+          className={cn(
+            "min-w-0 font-mono",
+            wrap
+              ? "break-all whitespace-pre-wrap"
+              : "overflow-x-auto whitespace-nowrap",
+          )}
+        >
+          {matchRedacted}
+        </span>
+      </span>
+    </SimpleTooltip>
+  );
+}
+
 // A judge rationale rendered for a cell that has no reveal affordance. Clamped
 // to two lines rather than one: a rationale is a sentence or two, and a
 // single-line clip leaves only the first few words.
@@ -358,27 +394,24 @@ export function EventMatchDialog({
   }
 
   // Without chat:read the event payload can never be revealed, so there's no
-  // trigger to render. The rationale still stands on its own.
+  // trigger to render. The rationale still stands on its own; with none, the
+  // redacted fingerprint is the reviewable token (same as MaskedMatch).
   if (!canReveal) {
-    return (
-      <span className="flex min-w-0 items-center gap-1.5">
-        <SimpleTooltip tooltip={REVEAL_DENIED_REASON}>
-          <Lock
-            role="img"
-            aria-label={REVEAL_DENIED_REASON}
-            className="text-muted-foreground h-3 w-3 shrink-0"
-          />
-        </SimpleTooltip>
-        {/* The rationale reads as ordinary text, so without a label the lock is
-         * the only signal that the event itself is withheld. With no rationale
-         * to show, fall back to the same "Hidden" text MaskedMatch uses. */}
-        {summary ? (
+    if (summary) {
+      return (
+        <span className="flex min-w-0 items-center gap-1.5">
+          <SimpleTooltip tooltip={REVEAL_DENIED_REASON}>
+            <Lock
+              role="img"
+              aria-label={REVEAL_DENIED_REASON}
+              className="text-muted-foreground h-3 w-3 shrink-0"
+            />
+          </SimpleTooltip>
           <RationaleText text={summary} />
-        ) : (
-          <span className="text-muted-foreground text-xs">Hidden</span>
-        )}
-      </span>
-    );
+        </span>
+      );
+    }
+    return <LockedRedactedMatch matchRedacted={matchRedacted} />;
   }
 
   return (

--- a/client/dashboard/src/pages/security/unmask.ts
+++ b/client/dashboard/src/pages/security/unmask.ts
@@ -16,7 +16,9 @@ export const REVEAL_DENIED_REASON =
 // event behind the reveal, and offering one opens an empty dialog.
 const NO_MATCH_FINGERPRINT = "<redacted len=0>";
 
-export function hasRevealableEvent(matchRedacted: string | undefined): boolean {
+export function hasRevealableEvent(
+  matchRedacted: string | undefined,
+): matchRedacted is string {
   return Boolean(matchRedacted) && matchRedacted !== NO_MATCH_FINGERPRINT;
 }
 

--- a/client/dashboard/src/pages/security/unmask.ts
+++ b/client/dashboard/src/pages/security/unmask.ts
@@ -16,9 +16,7 @@ export const REVEAL_DENIED_REASON =
 // event behind the reveal, and offering one opens an empty dialog.
 const NO_MATCH_FINGERPRINT = "<redacted len=0>";
 
-export function hasRevealableEvent(
-  matchRedacted: string | undefined,
-): matchRedacted is string {
+export function hasRevealableEvent(matchRedacted: string | undefined): boolean {
   return Boolean(matchRedacted) && matchRedacted !== NO_MATCH_FINGERPRINT;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [AIS-672](https://linear.app/speakeasy/issue/AIS-672/feedback-display-redacted-matches-without-chatread-permissions). Reviewers without `chat:read` could suppress a risk finding while seeing only a generic **Hidden** label — the `match_redacted` fingerprint the list API already returns never made it onto the page.

`MaskedMatch` (Watchdog evidence, Risk Events, Risk Overview, exclusion context) and `EventMatchDialog` (judge findings with no rationale) now render that fingerprint as a static, non-interactive token. Reveal stays gated on `chat:read`; reveal-all cannot flip these rows open.

## Test plan

- [x] Unit tests: `MaskedMatch` shows the fingerprint without `chat:read` and no reveal button; with `chat:read` it still offers Click to reveal
- [x] Unit tests: `EventMatchDialog` without rationale falls back to the fingerprint instead of Hidden
- [ ] Confirm on Watchdog / Risk Events that a viewer without `chat:read` sees `<redacted len=N sha=…>` next to Suppress
- [ ] Confirm a viewer with `chat:read` still gets Click to reveal and the audited unmask path

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-672](https://linear.app/speakeasy/issue/AIS-672/feedback-display-redacted-matches-without-chatread-permissions)

<div><a href="https://cursor.com/agents/bc-3c318b5c-c418-4557-8c0d-9bfd9758245b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c318b5c-c418-4557-8c0d-9bfd9758245b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reviewers lacking `chat:read` seeing a generic Hidden label for risk matches, so they can now correlate a finding before suppressing it. The `match_redacted` fingerprint is rendered as a static token in `MaskedMatch` and `EventMatchDialog`, while reveal stays gated on the `chat:read` scope.

- Reveal-all cannot flip locked rows open.
- `hasRevealableEvent` now returns a plain boolean; `EventMatchDialog` narrows `matchRedacted` with an explicit check at the call site.

<sup>Written for commit 0bcb97735fd977cc3eb43f88b5be12afbcc87d79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

