### PR TITLE
fix: match admin organization overview design (AGE-3351)

### DIFF
--- a/client/admin/src/pages/organization/Overview.browser-focus.test.tsx
+++ b/client/admin/src/pages/organization/Overview.browser-focus.test.tsx
@@ -185,7 +185,7 @@ describe("Overview conversion without DialogTrigger restoration", () => {
     );
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: "Active trial" }),
+        screen.queryByRole("heading", { name: "Enterprise trial" }),
       ).toBeNull(),
     );
     expect(announce).not.toHaveBeenCalled();
@@ -220,7 +220,7 @@ describe("Overview conversion without DialogTrigger restoration", () => {
     );
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: "Active trial" }),
+        screen.queryByRole("heading", { name: "Enterprise trial" }),
       ).toBeNull(),
     );
 

--- a/client/admin/src/pages/organization/Overview.browser-focus.test.tsx
+++ b/client/admin/src/pages/organization/Overview.browser-focus.test.tsx
@@ -185,7 +185,7 @@ describe("Overview conversion without DialogTrigger restoration", () => {
     );
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: "Enterprise trial" }),
+        screen.queryByRole("heading", { name: "Active trial" }),
       ).toBeNull(),
     );
     expect(announce).not.toHaveBeenCalled();
@@ -220,7 +220,7 @@ describe("Overview conversion without DialogTrigger restoration", () => {
     );
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: "Enterprise trial" }),
+        screen.queryByRole("heading", { name: "Active trial" }),
       ).toBeNull(),
     );
 

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -159,7 +159,7 @@ afterEach(() => {
 });
 
 describe("Overview", () => {
-  it("shows live trial facts in the Enterprise trial panel", async () => {
+  it("matches the approved active-trial hierarchy", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
@@ -167,21 +167,51 @@ describe("Overview", () => {
     const trialEndsAt = ORG.trial_ends_at;
     if (!trialEndsAt) throw new Error("the record under test needs a trial");
 
-    await screen.findByRole("heading", { name: "Enterprise trial" });
-    const facts = panelNamed("Enterprise trial");
+    await screen.findByRole("heading", { name: "Active trial" });
+    const trial = panelNamed("Active trial");
+    const detailsPanel = panelNamed("Details");
+    const details = within(detailsPanel);
+    expect(within(trial).getByText("RUNNING")).toBeTruthy();
+    expect(within(trial).getByText(/days left$/)).toBeTruthy();
+    expect(trial.textContent).toContain(
+      `End date ${new Date(trialEndsAt).toLocaleDateString()} · Enterprise tier`,
+    );
+    expect(within(trial).queryByText("State")).toBeNull();
     expect(
-      within(facts).getByText("State").nextElementSibling?.textContent,
+      details.getByText("Trial state").nextElementSibling?.textContent,
     ).toBe("Running");
     expect(
-      within(facts).getByText("Tier").nextElementSibling?.textContent,
+      details.getByText("Trial tier").nextElementSibling?.textContent,
     ).toBe("Enterprise");
-    expect(
-      within(facts).getByText("Ends").nextElementSibling?.textContent,
-    ).toBe(new Date(trialEndsAt).toLocaleDateString());
-    expect(screen.getAllByText("State")).toHaveLength(1);
+    expect(details.getByText("End date").nextElementSibling?.textContent).toBe(
+      new Date(trialEndsAt).toLocaleDateString(),
+    );
 
-    // The defaulted pair is gone from the page, not merely unread: an operator
-    // who sees "Free trial ends" reads a date no organization ever earned.
+    const buttons = within(trial).getAllByRole("button");
+    const convert = within(trial).getByRole("button", {
+      name: `Mark ${ORG.name} as converted`,
+    });
+    const extend = within(trial).getByRole("button", {
+      name: `Extend trial for ${ORG.name}`,
+    });
+    expect(buttons.indexOf(convert)).toBeLessThan(buttons.indexOf(extend));
+    expect(convert.className).toContain("w-full");
+    expect(extend.className).toContain("w-full");
+    expect(trial.textContent).toContain(
+      "Converting keeps enterprise access and closes the trial.",
+    );
+    expect(
+      details.getByText(`Updated ${shortDate(ORG.updated_at)}`),
+    ).toBeTruthy();
+    expect(details.getByText("Platform access, no demo gate")).toBeTruthy();
+    expect(details.queryByText("Created")).toBeNull();
+    expect(details.queryByText("Disabled at")).toBeNull();
+    const recordTitle = screen.getByRole("heading", {
+      level: 4,
+      name: ORG.name,
+    });
+    expect(recordTitle.parentElement?.textContent).not.toContain("Running");
+
     expect(screen.queryByText("Free trial started")).toBeNull();
     expect(screen.queryByText("Free trial ends")).toBeNull();
   });
@@ -224,14 +254,13 @@ describe("Overview", () => {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    await screen.findByText("Created");
+    await screen.findByText(`Updated ${shortDate(updated)}`);
     // The zone really moved, and in it this instant is the 15th locally.
     expect(new Date(created).getDate()).toBe(15);
-    // Every date the view renders, not one of them: each row is a separate
-    // call and the rule holds for all of them or for none.
-    expect(valueBeside("Created").textContent).toBe(shortDate(created));
-    expect(valueBeside("Updated").textContent).toBe(shortDate(updated));
-    expect(valueBeside("Disabled at").textContent).toBe(shortDate(disabled));
+    expect(screen.getByText(`Created ${shortDate(created)}`)).toBeTruthy();
+    expect(panelNamed("Danger zone").textContent).toContain(
+      `Disabled ${shortDate(disabled)}`,
+    );
   });
 
   it("leaves the control reading the record while the dialog asks", async () => {
@@ -1149,8 +1178,12 @@ describe("Overview", () => {
         initialPath: `/organizations/${ORG.slug}`,
       });
 
+      const heading =
+        trialState === "running" || trialState === "ending_soon"
+          ? "Active trial"
+          : "Enterprise trial";
       expect(
-        await screen.findByRole("heading", { name: "Enterprise trial" }),
+        await screen.findByRole("heading", { name: heading }),
       ).toBeTruthy();
     },
   );
@@ -1208,7 +1241,7 @@ describe("Overview", () => {
     await screen.findByRole("heading", { name: "Details" });
     const details = panelNamed("Details");
     expect(
-      within(details).getByText("State").nextElementSibling?.textContent,
+      within(details).getByText("Trial state").nextElementSibling?.textContent,
     ).toBe("Converted");
     expect(
       within(details).getByText("Conversion date").nextElementSibling
@@ -1252,8 +1285,8 @@ describe("Overview", () => {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    await screen.findByRole("heading", { name: "Enterprise trial" });
-    const trial = panelNamed("Enterprise trial");
+    await screen.findByRole("heading", { name: "Active trial" });
+    const trial = panelNamed("Active trial");
     const danger = panelNamed("Danger zone");
     expect(
       within(trial).getByRole("button", {
@@ -1309,7 +1342,7 @@ describe("Overview", () => {
     await screen.findByRole("heading", { name: "Details" });
     const details = panelNamed("Details");
     const danger = panelNamed("Danger zone");
-    const trial = panelNamed("Enterprise trial");
+    const trial = panelNamed("Active trial");
     const left = details.parentElement;
     const layout = left?.parentElement;
 
@@ -1326,8 +1359,8 @@ describe("Overview", () => {
     expect(left?.className).toContain("min-w-[min(100%,32rem)]");
     expect(left?.className).toContain("flex-[2_1_32rem]");
     expect(trial.className).toContain("w-full");
-    expect(trial.className).toContain("max-w-80");
-    expect(trial.className).toContain("flex-[1_1_16rem]");
+    expect(trial.className).toContain("max-w-[21rem]");
+    expect(trial.className).toContain("flex-[1_1_18rem]");
   });
 
   it("nests the panel headings under the record's own heading", async () => {
@@ -1338,7 +1371,7 @@ describe("Overview", () => {
     expect(
       await screen.findByRole("heading", { level: 4, name: ORG.name }),
     ).toBeTruthy();
-    for (const panel of ["Details", "Enterprise trial", "Danger zone"]) {
+    for (const panel of ["Details", "Active trial", "Danger zone"]) {
       expect(screen.getByRole("heading", { name: panel }).tagName).toBe("H5");
     }
   });
@@ -1539,8 +1572,8 @@ describe("Overview", () => {
     // belongs to a different field of the same record, which reads as right.
     const rows: [string, string][] = [
       ["Copy Slug", identified.slug],
-      ["Copy Organization id", identified.id],
-      ["Copy WorkOS id", identified.workos_id],
+      ["Copy Organization ID", identified.id],
+      ["Copy WorkOS org ID", identified.workos_id],
     ];
     for (const [name, value] of rows) {
       const control = await screen.findByRole("button", { name });
@@ -1560,24 +1593,26 @@ describe("Overview", () => {
     expect(new Set(rows.map(([, value]) => value)).size).toBe(rows.length);
   });
 
-  it("offers no copy control over an absent WorkOS id", async () => {
+  it("offers no copy control over an absent WorkOS org ID", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    await screen.findByText("WorkOS id");
+    await screen.findByText("WorkOS org ID");
     expect(ORG.workos_id).toBeUndefined();
     // A button that copies "-" is worse than no button.
-    expect(valueBeside("WorkOS id").textContent).toBe("-");
-    expect(screen.queryByRole("button", { name: "Copy WorkOS id" })).toBeNull();
+    expect(valueBeside("WorkOS org ID").textContent).toBe("-");
+    expect(
+      screen.queryByRole("button", { name: "Copy WorkOS org ID" }),
+    ).toBeNull();
   });
 
-  it("renders a dash for a record that was never disabled", async () => {
+  it("keeps disabled status in Danger zone rather than Details", async () => {
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}`,
     });
 
-    await screen.findByText("Disabled at");
-    expect(valueBeside("Disabled at").textContent).toBe("-");
+    await screen.findByRole("heading", { name: "Danger zone" });
+    expect(screen.queryByText("Disabled at")).toBeNull();
   });
 });

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -186,6 +186,10 @@ describe("Overview", () => {
     expect(details.getByText("End date").nextElementSibling?.textContent).toBe(
       new Date(trialEndsAt).toLocaleDateString(),
     );
+    const trialFacts =
+      details.getByText("Trial state").parentElement?.parentElement;
+    expect(trialFacts?.className).toContain("border-t");
+    expect(trialFacts?.className).toContain("mt-5");
 
     const buttons = within(trial).getAllByRole("button");
     const convert = within(trial).getByRole("button", {

--- a/client/admin/src/pages/organization/Overview.tsx
+++ b/client/admin/src/pages/organization/Overview.tsx
@@ -15,7 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { TrialFacts } from "@/pages/organization/TrialFacts";
+import { TrialFacts, TrialSummary } from "@/pages/organization/TrialFacts";
 import { OrganizationActions } from "@/pages/organizations/OrganizationActions";
 import {
   Select,
@@ -68,22 +68,27 @@ function Panel({
   children,
   className,
   headingRef,
+  meta,
 }: {
   title: string;
   children: React.ReactNode;
   className?: string;
   headingRef?: Ref<HTMLHeadingElement>;
+  meta?: React.ReactNode;
 }) {
   return (
     <section className={cn("bg-card rounded-lg border", className)}>
-      {/* h5 follows the record name's h4 in RecordHeader. */}
-      <h5
-        ref={headingRef}
-        tabIndex={headingRef ? -1 : undefined}
-        className="border-b px-5 py-2.5 text-sm font-semibold"
-      >
-        {title}
-      </h5>
+      <div className="flex items-center justify-between gap-4 border-b px-5 py-2.5">
+        {/* h5 follows the record name's h4 in RecordHeader. */}
+        <h5
+          ref={headingRef}
+          tabIndex={headingRef ? -1 : undefined}
+          className="text-sm font-semibold"
+        >
+          {title}
+        </h5>
+        {meta}
+      </div>
       <div className="p-5">{children}</div>
     </section>
   );
@@ -325,44 +330,46 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
   return (
     <div
       data-slot="organization-overview"
-      className="flex flex-wrap items-start gap-4"
+      className="flex flex-wrap items-start gap-6"
     >
       <div
         data-slot="organization-overview-main"
-        className="min-w-[min(100%,32rem)] flex-[2_1_32rem] space-y-4"
+        className="min-w-[min(100%,32rem)] flex-[2_1_32rem] space-y-8"
       >
-        <Panel title="Details" headingRef={detailsHeading}>
+        <Panel
+          title="Details"
+          headingRef={detailsHeading}
+          meta={
+            <span className="text-muted-foreground text-xs">
+              Updated {fmtDateShort(org.updated_at)}
+            </span>
+          }
+        >
           <Row label="Name">
             <span className="text-sm">{org.name}</span>
           </Row>
           <Row label="Slug">
             <CopyValue label="Slug" value={org.slug} className="text-sm" />
           </Row>
-          <Row label="Organization id">
+          <Row label="Organization ID">
             <CopyValue
-              label="Organization id"
+              label="Organization ID"
               value={org.id}
               className="text-sm"
             />
           </Row>
-          <Row label="WorkOS id">
+          <Row label="WorkOS org ID">
             {/* No control over an absent value: a button that copies "-" is
               worse than no button. */}
             {org.workos_id ? (
               <CopyValue
-                label="WorkOS id"
+                label="WorkOS org ID"
                 value={org.workos_id}
                 className="text-sm"
               />
             ) : (
               <span className="text-muted-foreground text-sm">-</span>
             )}
-          </Row>
-          <Row label="Created">
-            <span className="text-sm">{fmtDateShort(org.created_at)}</span>
-          </Row>
-          <Row label="Updated">
-            <span className="text-sm">{fmtDateShort(org.updated_at)}</span>
           </Row>
           <Row label="Account type">
             <Select
@@ -397,39 +404,32 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
             </Select>
           </Row>
           <Row label="Whitelisted">
-            <Switch
-              ref={whitelistedControl}
-              checked={org.whitelisted}
-              disabled={mut.isPending || conversionPending}
-              onCheckedChange={(v) => {
-                void commit(
-                  { whitelisted: v },
-                  `Whitelisted: ${yesNo(org.whitelisted)} → ${yesNo(v)}`,
-                  whitelistedControl,
-                );
-              }}
-            />
+            <div className="flex flex-wrap items-center gap-3">
+              <Switch
+                ref={whitelistedControl}
+                checked={org.whitelisted}
+                disabled={mut.isPending || conversionPending}
+                onCheckedChange={(v) => {
+                  void commit(
+                    { whitelisted: v },
+                    `Whitelisted: ${yesNo(org.whitelisted)} → ${yesNo(v)}`,
+                    whitelistedControl,
+                  );
+                }}
+              />
+              <span className="text-muted-foreground text-sm">
+                {org.whitelisted
+                  ? "Platform access, no demo gate"
+                  : "Demo gate applies"}
+              </span>
+            </div>
           </Row>
-          <Row label="Disabled at">
-            <span
-              className={cn(
-                "text-sm",
-                !org.disabled_at && "text-muted-foreground",
-              )}
-            >
-              {fmtDateShort(org.disabled_at)}
-            </span>
-          </Row>
-          {!showTrialPanel && (
-            <Row label="Trial">
-              <TrialFacts org={org} />
-            </Row>
-          )}
+          <TrialFacts org={org} />
         </Panel>
 
         <Panel
           title="Danger zone"
-          className="border-destructive [&>h5]:text-destructive"
+          className="border-destructive [&_h5]:text-destructive"
         >
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div className="min-w-0 flex-1">
@@ -462,33 +462,39 @@ export function Overview({ org }: { org: AdminOrganization }): JSX.Element {
       {showTrialPanel && (
         <aside
           data-slot="organization-overview-trial"
-          className="bg-card w-full max-w-80 flex-[1_1_16rem] rounded-lg border"
+          className="bg-card w-full max-w-[21rem] flex-[1_1_18rem] rounded-lg border"
         >
-          <h5 className="border-b px-5 py-2.5 text-sm font-semibold">
-            Enterprise trial
-          </h5>
-          <div className="space-y-4 p-5">
-            <TrialFacts org={org} />
-            <OrganizationActions
-              org={org}
-              layout="buttons"
-              actions="trial"
-              focusFallbackRef={detailsHeading}
-            />
+          <div className="space-y-5 p-5">
+            <TrialSummary org={org} />
+            <div className="space-y-2">
+              {canMarkEnterpriseTrialConverted(org) && (
+                <Button
+                  ref={conversionControl}
+                  size="sm"
+                  className="w-full"
+                  disabled={conversionPending}
+                  aria-label={`Mark ${org.name} as converted`}
+                  onClick={() => {
+                    conversionContext.current = org;
+                    setConversionUncertain(false);
+                    setConversionOpen(true);
+                  }}
+                >
+                  Mark as converted
+                </Button>
+              )}
+              <OrganizationActions
+                org={org}
+                layout="buttons"
+                actions="trial"
+                focusFallbackRef={detailsHeading}
+                buttonClassName="h-8 w-full px-3 text-sm"
+              />
+            </div>
             {canMarkEnterpriseTrialConverted(org) && (
-              <Button
-                ref={conversionControl}
-                size="sm"
-                disabled={conversionPending}
-                aria-label={`Mark ${org.name} as converted`}
-                onClick={() => {
-                  conversionContext.current = org;
-                  setConversionUncertain(false);
-                  setConversionOpen(true);
-                }}
-              >
-                Mark as converted
-              </Button>
+              <p className="text-muted-foreground text-xs">
+                Converting keeps enterprise access and closes the trial.
+              </p>
             )}
           </div>
         </aside>

--- a/client/admin/src/pages/organization/RecordHeader.test.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.test.tsx
@@ -2,8 +2,7 @@ import { cleanup, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { badgeTone } from "@/lib/badgeTone";
-import { organizationDashboardUrl, type TrialState } from "@/lib/gramAdminApi";
-import { TRIAL_LABELS } from "@/lib/trialLabels";
+import { organizationDashboardUrl } from "@/lib/gramAdminApi";
 import { fmtDateShort } from "@/lib/utils";
 import { anOrganization } from "@/test/fixtures";
 import { renderWithApp } from "@/test/harness";
@@ -78,66 +77,25 @@ describe("RecordHeader", () => {
     expect(fact?.querySelector('[aria-hidden="true"]')).toBeTruthy();
   });
 
-  it("draws the account type in the neutral tone", async () => {
-    // No trial, so the only badge beside the name is this one.
+  it("draws only the account type in the neutral tone", async () => {
     const org = anOrganization({
       account_type: "enterprise",
-      trial_state: "none",
+      trial_state: "ending_soon",
+      trial_ends_at: "2026-05-06T00:00:00Z",
     });
     await renderWithApp(<RecordHeader org={org} />);
 
-    const badge = screen
+    const badges = screen
       .getByRole("heading", { name: org.name })
-      .parentElement?.querySelector('[data-slot="badge"]');
+      .parentElement?.querySelectorAll('[data-slot="badge"]');
+    expect(badges).toHaveLength(1);
+    const badge = badges?.item(0);
     expect(badge?.textContent).toBe("enterprise");
     // happy-dom lays nothing out, so the class list is the whole account of a
     // colour a unit test can read. `Trial.test.tsx` reads a tone the same way.
     // Without it the account type can take the failure tone and say the record
     // is in trouble when it is not.
     expect(badge?.className).toContain(badgeTone.neutral);
-  });
-
-  it("names the record and its trial state", async () => {
-    const org = anOrganization({
-      trial_state: "ending_soon",
-      trial_ends_at: "2026-05-06T00:00:00Z",
-    });
-    await renderWithApp(<RecordHeader org={org} />);
-
-    expect(screen.getByRole("heading", { name: org.name })).toBeTruthy();
-    expect(screen.getByText(TRIAL_LABELS.ending_soon)).toBeTruthy();
-  });
-
-  it("shows no trial mark on a record with no trial", async () => {
-    // `Trial` renders a bare dash for `none`, which is right in a table cell
-    // and reads as a stray hyphen beside a record name.
-    await renderWithApp(
-      <RecordHeader org={anOrganization({ trial_state: "none" })} />,
-    );
-
-    expect(screen.queryByText("-")).toBeNull();
-    expect(screen.queryByText(TRIAL_LABELS.none)).toBeNull();
-  });
-
-  it("shows no trial mark on a record the server sends no trial state for", async () => {
-    // A gate written as `!== "none"` alone draws the dash here.
-    await renderWithApp(<RecordHeader org={anOrganization()} />);
-
-    expect(screen.queryByText("-")).toBeNull();
-    expect(screen.queryByText(TRIAL_LABELS.none)).toBeNull();
-  });
-
-  it("still shows the dash when the server sends a state the client does not know", async () => {
-    // `Trial` renders the same bare dash for `none` and for an unrecognised
-    // value. Only `none` is "no trial"; an unrecognised state says this build
-    // is behind the server, and hiding it would hide that.
-    await renderWithApp(
-      <RecordHeader
-        org={anOrganization({ trial_state: "paused" as TrialState })}
-      />,
-    );
-
-    expect(screen.getByText("Trial state not recognised")).toBeTruthy();
   });
 
   it("keeps Open in Dashboard but no lifecycle or trial actions", async () => {

--- a/client/admin/src/pages/organization/RecordHeader.tsx
+++ b/client/admin/src/pages/organization/RecordHeader.tsx
@@ -1,6 +1,5 @@
 import type { JSX } from "react";
 
-import { Trial } from "@/components/Trial";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { badgeTone } from "@/lib/badgeTone";
@@ -33,9 +32,6 @@ export function RecordHeader({ org }: { org: AdminOrganization }): JSX.Element {
           <Badge variant="outline" className={badgeTone.neutral}>
             {org.account_type}
           </Badge>
-          {/* Keyed on `none`, never on "would `Trial` draw a dash". An
-              unrecognised state draws the same dash and has to keep it. */}
-          {org.trial_state && org.trial_state !== "none" && <Trial org={org} />}
         </div>
         {/* Two facts and no more. The line grows when the events slice lands;
             it is not padded to fill now. */}

--- a/client/admin/src/pages/organization/TrialFacts.test.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { anOrganization } from "@/test/fixtures";
 
-import { TrialFacts } from "./TrialFacts";
+import { TrialFacts, TrialSummary } from "./TrialFacts";
 
 const END = "2026-05-06T01:01:00Z";
 
@@ -32,18 +32,16 @@ describe("TrialFacts", () => {
       />,
     );
 
-    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
-      stateLabel,
-    );
-    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+    expect(
+      screen.getByText("Trial state").nextElementSibling?.textContent,
+    ).toBe(stateLabel);
+    expect(screen.getByText("Trial tier").nextElementSibling?.textContent).toBe(
       "Enterprise",
     );
-    expect(screen.getByText("Ends").nextElementSibling?.textContent).toBe(
+    expect(screen.getByText("End date").nextElementSibling?.textContent).toBe(
       new Date(END).toLocaleDateString(),
     );
-    expect(screen.getByText("Remaining").nextElementSibling?.textContent).toBe(
-      "1 hour 1 minute",
-    );
+    expect(screen.queryByText("Remaining")).toBeNull();
   });
 
   it("keeps No trial visible", () => {
@@ -66,17 +64,17 @@ describe("TrialFacts", () => {
       />,
     );
 
-    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+    expect(screen.getByText("Trial tier").nextElementSibling?.textContent).toBe(
       "Unknown",
     );
     expect(screen.queryByText("future_internal_tier")).toBeNull();
   });
 
-  it("updates on end-relative minute boundaries and cleans up its timer", () => {
+  it("updates the summary on end-relative boundaries and cleans up its timer", () => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-05-06T00:00:30.500Z");
     const view = render(
-      <TrialFacts
+      <TrialSummary
         org={anOrganization({
           trial_state: "running",
           trial_tier: "enterprise",
@@ -85,54 +83,44 @@ describe("TrialFacts", () => {
       />,
     );
 
-    const remaining = () =>
-      screen.getByText("Remaining").nextElementSibling?.textContent;
-    expect(remaining()).toBe("1 hour 2 minutes");
-
+    expect(screen.getByText("1 hour 2 minutes left")).toBeTruthy();
     act(() => {
-      vi.advanceTimersByTime(14_499);
+      vi.advanceTimersByTime(14_500);
     });
-    expect(remaining()).toBe("1 hour 2 minutes");
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(remaining()).toBe("1 hour 1 minute");
+    expect(screen.getByText("1 hour 1 minute left")).toBeTruthy();
     expect(vi.getTimerCount()).toBe(1);
 
     view.unmount();
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it.each([
-    ["2026-05-09T00:00:30Z", "4 days", "72 hours"],
-    ["2026-05-07T00:00:30Z", "25 hours", "24 hours"],
-  ])("updates at the formatter boundary ending at %s", (end, before, after) => {
+  it("updates Details to expired at the exact end", () => {
     vi.useFakeTimers();
-    vi.setSystemTime("2026-05-06T00:00:00Z");
+    vi.setSystemTime("2026-05-06T00:00:30Z");
     render(
       <TrialFacts
         org={anOrganization({
           trial_state: "running",
-          trial_ends_at: end,
+          trial_ends_at: "2026-05-06T00:01:45Z",
         })}
       />,
     );
 
-    const remaining = () =>
-      screen.getByText("Remaining").nextElementSibling?.textContent;
-    expect(remaining()).toBe(before);
     act(() => {
-      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(75_000);
     });
-    expect(remaining()).toBe(after);
+
+    expect(
+      screen.getByText("Trial state").nextElementSibling?.textContent,
+    ).toBe("Expired");
   });
 
-  it("switches a live trial to expired at its exact end", () => {
+  it("switches the summary to ended at the exact end", () => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-05-06T00:00:30Z");
     const end = "2026-05-06T00:01:45Z";
     render(
-      <TrialFacts
+      <TrialSummary
         org={anOrganization({
           trial_state: "running",
           trial_tier: "enterprise",
@@ -145,39 +133,11 @@ describe("TrialFacts", () => {
       vi.advanceTimersByTime(75_000);
     });
 
-    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
-      "Expired",
-    );
-    expect(screen.queryByText("Remaining")).toBeNull();
-    expect(
-      screen.getByText("Original end").nextElementSibling?.textContent,
-    ).toBe(new Date(end).toLocaleDateString());
-    expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
-      "Enterprise",
+    expect(screen.getByText("Trial ended")).toBeTruthy();
+    expect(screen.getByText(/End date/).textContent).toContain(
+      new Date(end).toLocaleDateString(),
     );
     expect(vi.getTimerCount()).toBe(0);
-  });
-
-  it("refreshes a stale clock when transitioning into a live trial", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime("2026-05-06T00:00:00Z");
-    const view = render(
-      <TrialFacts org={anOrganization({ trial_state: "converted" })} />,
-    );
-    vi.setSystemTime("2026-05-06T00:30:00Z");
-
-    view.rerender(
-      <TrialFacts
-        org={anOrganization({
-          trial_state: "running",
-          trial_ends_at: "2026-05-06T01:00:00Z",
-        })}
-      />,
-    );
-
-    expect(screen.getByText("Remaining").nextElementSibling?.textContent).toBe(
-      "30 minutes",
-    );
   });
 
   it.each([undefined, "not-a-date"])(
@@ -185,20 +145,13 @@ describe("TrialFacts", () => {
     (end) => {
       vi.useFakeTimers();
       render(
-        <TrialFacts
-          org={anOrganization({
-            trial_state: "running",
-            trial_ends_at: end,
-          })}
+        <TrialSummary
+          org={anOrganization({ trial_state: "running", trial_ends_at: end })}
         />,
       );
 
-      expect(screen.getByText("Ends").nextElementSibling?.textContent).toBe(
-        "Unknown",
-      );
-      expect(
-        screen.getByText("Remaining").nextElementSibling?.textContent,
-      ).toBe("Unknown");
+      expect(screen.getByText("Trial status unknown")).toBeTruthy();
+      expect(screen.getByText(/End date/).textContent).toContain("Unknown");
       expect(vi.getTimerCount()).toBe(0);
     },
   );
@@ -210,9 +163,9 @@ describe("TrialFacts", () => {
       />,
     );
 
-    expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
-      "Unknown",
-    );
+    expect(
+      screen.getByText("Trial state").nextElementSibling?.textContent,
+    ).toBe("Unknown");
   });
 
   it.each([
@@ -237,15 +190,15 @@ describe("TrialFacts", () => {
         />,
       );
 
-      expect(screen.getByText("State").nextElementSibling?.textContent).toBe(
-        stateLabel,
-      );
-      expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
-        "Enterprise",
-      );
       expect(
-        screen.getByText("Original end").nextElementSibling?.textContent,
-      ).toBe(new Date(end).toLocaleDateString());
+        screen.getByText("Trial state").nextElementSibling?.textContent,
+      ).toBe(stateLabel);
+      expect(
+        screen.getByText("Trial tier").nextElementSibling?.textContent,
+      ).toBe("Enterprise");
+      expect(screen.getByText("End date").nextElementSibling?.textContent).toBe(
+        new Date(end).toLocaleDateString(),
+      );
 
       if (lifecycleLabel) {
         const lifecycleDate = trialState === "converted" ? converted : demoted;
@@ -268,12 +221,12 @@ describe("TrialFacts", () => {
     (trialState) => {
       render(<TrialFacts org={anOrganization({ trial_state: trialState })} />);
 
-      expect(screen.getByText("Tier").nextElementSibling?.textContent).toBe(
+      expect(
+        screen.getByText("Trial tier").nextElementSibling?.textContent,
+      ).toBe("Unknown");
+      expect(screen.getByText("End date").nextElementSibling?.textContent).toBe(
         "Unknown",
       );
-      expect(
-        screen.getByText("Original end").nextElementSibling?.textContent,
-      ).toBe("Unknown");
       if (trialState !== "expired") {
         expect(
           screen.getByText(

--- a/client/admin/src/pages/organization/TrialFacts.test.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.test.tsx
@@ -94,6 +94,26 @@ describe("TrialFacts", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("refreshes the summary clock when transitioning into a live trial", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-05-06T00:00:00Z");
+    const view = render(
+      <TrialSummary org={anOrganization({ trial_state: "converted" })} />,
+    );
+    vi.setSystemTime("2026-05-06T00:30:00Z");
+
+    view.rerender(
+      <TrialSummary
+        org={anOrganization({
+          trial_state: "running",
+          trial_ends_at: "2026-05-06T01:00:00Z",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("30 minutes left")).toBeTruthy();
+  });
+
   it("updates Details to expired at the exact end", () => {
     vi.useFakeTimers();
     vi.setSystemTime("2026-05-06T00:00:30Z");
@@ -156,17 +176,20 @@ describe("TrialFacts", () => {
     },
   );
 
-  it("labels an unknown future trial state safely", () => {
-    render(
-      <TrialFacts
-        org={anOrganization({ trial_state: "future_state" as "running" })}
-      />,
-    );
+  it.each(["future_state", "constructor", "toString"])(
+    "labels unknown trial state %s safely",
+    (trialState) => {
+      render(
+        <TrialFacts
+          org={anOrganization({ trial_state: trialState as "running" })}
+        />,
+      );
 
-    expect(
-      screen.getByText("Trial state").nextElementSibling?.textContent,
-    ).toBe("Unknown");
-  });
+      expect(
+        screen.getByText("Trial state").nextElementSibling?.textContent,
+      ).toBe("Unknown");
+    },
+  );
 
   it.each([
     ["converted", "Converted", "Conversion date"],

--- a/client/admin/src/pages/organization/TrialFacts.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.tsx
@@ -57,25 +57,85 @@ function Fact({
   children: React.ReactNode;
 }) {
   return (
-    <div className="grid grid-cols-[7rem_1fr] gap-3">
-      <span className="text-muted-foreground">{label}</span>
-      <span>{children}</span>
+    <div className="grid grid-cols-1 gap-1 py-1 sm:grid-cols-[7.5rem_minmax(0,1fr)] sm:items-center sm:gap-3">
+      <span data-slot="field-label" className="text-muted-foreground text-sm">
+        {label}
+      </span>
+      <span className="text-sm">{children}</span>
     </div>
   );
 }
 
-// Detail-only trial facts. List and peek surfaces deliberately keep using the
-// compact Trial component; this view has room for exact and changing facts.
+// Exact trial fields belong in Details. The side card summarizes the same trial
+// for action, rather than replacing these record facts with another table.
 export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
   const live =
     org.trial_state === "running" || org.trial_state === "ending_soon";
   const [now, setNow] = useState(() => new Date());
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const end = new Date(org.trial_ends_at ?? "");
-  const endTime = end.getTime();
+  const endTime = new Date(org.trial_ends_at ?? "").getTime();
+  const attachExpiration = useCallback(
+    (node: HTMLDivElement | null) => {
+      clearTimeout(timer.current);
+      timer.current = undefined;
+      if (!node || !live || Number.isNaN(endTime)) return;
+
+      const tick = () => {
+        const currentTime = Date.now();
+        const remaining = endTime - currentTime;
+        if (remaining <= 0) {
+          setNow(new Date(currentTime));
+          return;
+        }
+        timer.current = setTimeout(tick, Math.min(remaining, MAX_TIMEOUT_MS));
+      };
+
+      tick();
+    },
+    [endTime, live],
+  );
+  useOnUnmount(() => clearTimeout(timer.current));
+  const expired = live && !Number.isNaN(endTime) && endTime <= now.getTime();
+  const lifecycleFact =
+    org.trial_state === "converted"
+      ? { label: "Conversion date", date: org.trial_converted_at }
+      : org.trial_state === "demoted"
+        ? { label: "Demotion date", date: org.trial_demoted_at }
+        : undefined;
+  const state =
+    org.trial_state === "none" || !org.trial_state
+      ? "No trial"
+      : expired
+        ? TRIAL_LABELS.expired
+        : (TRIAL_LABELS[org.trial_state] ?? stateLabel(org.trial_state));
+
+  return (
+    <div ref={attachExpiration}>
+      <Fact label="Trial state">{state}</Fact>
+      {state !== "No trial" && (
+        <>
+          <Fact label="Trial tier">{tierLabel(org.trial_tier)}</Fact>
+          <Fact label="End date">{dateLabel(org.trial_ends_at)}</Fact>
+          {lifecycleFact && (
+            <Fact label={lifecycleFact.label}>
+              {dateLabel(lifecycleFact.date)}
+            </Fact>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function TrialSummary({ org }: { org: AdminOrganization }): JSX.Element {
+  const live =
+    org.trial_state === "running" || org.trial_state === "ending_soon";
+  const [now, setNow] = useState(() => new Date());
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const endTime = new Date(org.trial_ends_at ?? "").getTime();
 
   const attachRemainingTime = useCallback(
-    (node: HTMLSpanElement | null) => {
+    (node: HTMLParagraphElement | null) => {
       clearTimeout(timer.current);
       timer.current = undefined;
       if (!node) return;
@@ -83,16 +143,12 @@ export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
       const tick = () => {
         const currentTime = Date.now();
         setNow(new Date(currentTime));
-
         const remaining = endTime - currentTime;
         if (Number.isNaN(endTime) || remaining <= 0) return;
-
         const delay = remaining - nextRemainingChange(remaining);
         timer.current = setTimeout(tick, Math.min(delay, MAX_TIMEOUT_MS));
       };
 
-      // The component may have spent time in a completed state with no timer.
-      // Refresh before scheduling whenever the countdown is attached.
       tick();
     },
     [endTime],
@@ -100,48 +156,44 @@ export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
 
   useOnUnmount(() => clearTimeout(timer.current));
 
-  if (org.trial_state === "none" || !org.trial_state) {
-    return <span className="text-muted-foreground text-sm">No trial</span>;
-  }
-
   const expired = live && !Number.isNaN(endTime) && endTime <= now.getTime();
-
-  if (!live || expired) {
-    // Keep each lifecycle date beside its state branch. Conversion and demotion
-    // timestamps are both present on the wire, so selecting one generically
-    // would make it too easy to silently show the other event.
-    const lifecycleFact =
-      org.trial_state === "converted"
-        ? { label: "Conversion date", date: org.trial_converted_at }
-        : org.trial_state === "demoted"
-          ? { label: "Demotion date", date: org.trial_demoted_at }
-          : undefined;
-    const label = expired ? TRIAL_LABELS.expired : stateLabel(org.trial_state);
-
-    return (
-      <div className="space-y-1 text-sm">
-        <Fact label="State">{label}</Fact>
-        <Fact label="Tier">{tierLabel(org.trial_tier)}</Fact>
-        {lifecycleFact && (
-          <Fact label={lifecycleFact.label}>
-            {dateLabel(lifecycleFact.date)}
-          </Fact>
-        )}
-        <Fact label="Original end">{dateLabel(org.trial_ends_at)}</Fact>
-      </div>
-    );
-  }
-
-  const remaining = formatTrialTimeRemaining(org.trial_ends_at, now);
+  const remaining =
+    live && !expired
+      ? formatTrialTimeRemaining(org.trial_ends_at, now)
+      : undefined;
+  const hero = remaining
+    ? `${remaining} left`
+    : expired || org.trial_state === "expired"
+      ? "Trial ended"
+      : org.trial_state === "demoted"
+        ? "Trial demoted"
+        : "Trial status unknown";
+  const status = expired
+    ? TRIAL_LABELS.expired
+    : org.trial_state
+      ? (TRIAL_LABELS[org.trial_state] ?? stateLabel(org.trial_state))
+      : stateLabel(org.trial_state);
 
   return (
-    <div className="space-y-1 text-sm">
-      <Fact label="State">{TRIAL_LABELS[org.trial_state] ?? "Unknown"}</Fact>
-      <Fact label="Tier">{tierLabel(org.trial_tier)}</Fact>
-      <Fact label="Ends">{dateLabel(org.trial_ends_at)}</Fact>
-      <Fact label="Remaining">
-        <span ref={attachRemainingTime}>{remaining ?? "Unknown"}</span>
-      </Fact>
+    <div>
+      <div className="flex items-center justify-between gap-3">
+        <h5 className="text-sm font-semibold">
+          {live && !expired ? "Active trial" : "Enterprise trial"}
+        </h5>
+        <span className="text-muted-foreground rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium tracking-wide">
+          {status.toUpperCase()}
+        </span>
+      </div>
+      <p
+        ref={live && !expired ? attachRemainingTime : undefined}
+        className="mt-5 text-2xl font-semibold tracking-tight"
+      >
+        {hero}
+      </p>
+      <p className="text-muted-foreground mt-1 text-xs">
+        End date {dateLabel(org.trial_ends_at)} · {tierLabel(org.trial_tier)}{" "}
+        tier
+      </p>
     </div>
   );
 }

--- a/client/admin/src/pages/organization/TrialFacts.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.tsx
@@ -29,6 +29,14 @@ function stateLabel(state: unknown): string {
   }
 }
 
+const LABEL_BY_STATE: Record<string, string | undefined> = TRIAL_LABELS;
+
+function trialLabel(state: unknown): string {
+  return typeof state === "string" && Object.hasOwn(TRIAL_LABELS, state)
+    ? (LABEL_BY_STATE[state] ?? "Unknown")
+    : stateLabel(state);
+}
+
 function nextRemainingChange(remaining: number): number {
   if (remaining > 72 * HOUR_MS) {
     return Math.max(72 * HOUR_MS, (Math.ceil(remaining / DAY_MS) - 1) * DAY_MS);
@@ -107,7 +115,7 @@ export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
       ? "No trial"
       : expired
         ? TRIAL_LABELS.expired
-        : (TRIAL_LABELS[org.trial_state] ?? stateLabel(org.trial_state));
+        : trialLabel(org.trial_state);
 
   return (
     <div ref={attachExpiration} className="mt-5 border-t pt-5">
@@ -168,11 +176,7 @@ export function TrialSummary({ org }: { org: AdminOrganization }): JSX.Element {
       : org.trial_state === "demoted"
         ? "Trial demoted"
         : "Trial status unknown";
-  const status = expired
-    ? TRIAL_LABELS.expired
-    : org.trial_state
-      ? (TRIAL_LABELS[org.trial_state] ?? stateLabel(org.trial_state))
-      : stateLabel(org.trial_state);
+  const status = expired ? TRIAL_LABELS.expired : trialLabel(org.trial_state);
 
   return (
     <div>

--- a/client/admin/src/pages/organization/TrialFacts.tsx
+++ b/client/admin/src/pages/organization/TrialFacts.tsx
@@ -110,7 +110,7 @@ export function TrialFacts({ org }: { org: AdminOrganization }): JSX.Element {
         : (TRIAL_LABELS[org.trial_state] ?? stateLabel(org.trial_state));
 
   return (
-    <div ref={attachExpiration}>
+    <div ref={attachExpiration} className="mt-5 border-t pt-5">
       <Fact label="Trial state">{state}</Fact>
       {state !== "No trial" && (
         <>


### PR DESCRIPTION
## Summary

- align the organization Details and Active trial panels with the approved AGE-3351 design
- restore the status badge, countdown hierarchy, stacked actions, conversion guidance, and trial facts in Details
- preserve conversion focus behavior and the separate Billing/OpenRouter disable-cause contract

## Verification

- `aube run -F admin lint`
- `aube run -F admin test -- src/pages/organization/Overview.test.tsx src/pages/organization/Overview.browser-focus.test.tsx src/pages/organization/TrialFacts.test.tsx`
- `aube run -F admin build`