### PR TITLE
fix: stop logging inbound request body close errors

### DIFF
--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -734,9 +734,6 @@ func writeOAuthProtectedResourceMetadataResponse(ctx context.Context, logger *sl
 // loadToolset's docstring and TestServePublic_CustomDomain_PlatformDomainStillWorks.
 func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
 
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -34,7 +34,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
@@ -70,9 +69,6 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 	metaServer *metamcprepo.MetaMcpServer,
 ) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, logger, func() error {
-		return r.Body.Close()
-	})
 
 	logger = logger.With(attr.SlogMetaMcpServerID(metaServer.ID.String()))
 

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -45,9 +45,6 @@ const platformToolsetMaxBodyBytes = 1 << 20
 // are intentionally not honored here.
 func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
 
 	slug := chi.URLParam(r, "toolsetSlug")
 	if slug == "" {

--- a/server/internal/mcp/servepublic_credentialspresent_test.go
+++ b/server/internal/mcp/servepublic_credentialspresent_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
+
+type eofCloseBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *eofCloseBody) Close() error {
+	b.closed = true
+	return io.EOF
+}
 
 // ---------------------------------------------------------------------------
 // Tests from servepublic_auth_test.go (all except helpers and BatchRequest)
@@ -106,7 +117,7 @@ func TestServePublicAuth_WithSecurityDefs_WrongMCPHeader_Returns401(t *testing.T
 	require.Contains(t, err.Error(), "unauthorized")
 }
 
-func TestServePublicAuth_PrivateServer_NoToken_Returns401(t *testing.T) {
+func TestServePublicAuth_PrivateServer_NoToken_Returns401WithoutClosingRequestBody(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -127,10 +138,22 @@ func TestServePublicAuth_PrivateServer_NoToken_Returns401(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	unauthCtx := context.Background()
-	_, err = servePublicHTTP(t, unauthCtx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	body := &eofCloseBody{
+		Reader: bytes.NewReader(makeInitializeBody()),
+		closed: false,
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String, body)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	err = ti.service.ServePublic(httptest.NewRecorder(), req)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "expired or invalid access token")
+	require.False(t, body.closed, "the HTTP server owns the inbound request body lifecycle")
 }
 
 // ---------------------------------------------------------------------------

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -938,9 +938,6 @@ func (ic *installContext) organizationID() string {
 
 func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
 
 	mcpSlug := chi.URLParam(r, "mcpSlug")
 	if mcpSlug == "" {
@@ -1571,9 +1568,6 @@ func (s *Service) InstallPageScriptHash() string {
 // ServeInstallPageScript serves the hosted install page JavaScript with immutable cache headers.
 func (s *Service) ServeInstallPageScript(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
 
 	hash := chi.URLParam(r, "hash")
 	if hash != s.installPageScriptHash {

--- a/server/internal/usage/impl.go
+++ b/server/internal/usage/impl.go
@@ -189,9 +189,6 @@ func (s *Service) HandlePolarWebhook(w http.ResponseWriter, r *http.Request) err
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to read request body").LogError(ctx, s.logger)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
 
 	webhookPayload, err := s.billingRepo.ValidateAndParseWebhookEvent(ctx, body, r.Header)
 	if err != nil {

--- a/server/internal/xmcp/handler.go
+++ b/server/internal/xmcp/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -16,11 +15,6 @@ import (
 // gate when applicable, and dispatches to the remote-MCP proxy or the
 // toolset-backed handler.
 func (s *Service) ServeMCP(w http.ResponseWriter, r *http.Request) error {
-	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, func() error {
-		return r.Body.Close()
-	})
-
 	slug := chi.URLParam(r, "slug")
 	if slug == "" {
 		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided")


### PR DESCRIPTION
## Summary

- rely on `net/http` to close inbound request bodies across MCP, MCP metadata, xMCP, and webhook handlers
- remove the deferred close path that promoted request-body `EOF` results to error logs
- add regression coverage proving an unauthorized MCP request leaves body cleanup to the HTTP server

## Motivation

Expected early responses, including authentication challenges, can return before the request body is consumed. Explicitly closing those bodies through `o11y.LogDefer` turns an inconsequential `EOF` into an error log. The Go HTTP server already owns inbound body cleanup, so removing the redundant handler cleanup eliminates the noise without weakening `LogDefer` for resources whose close failures are actionable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops logging `EOF` errors from closing inbound request bodies before the HTTP server has consumed them. Early responses like 401 auth challenges previously promoted the harmless close failure to an error log.

- Removed the deferred `o11y.LogDefer` body-close calls from MCP, MCP metadata, xMCP, and webhook handlers.
- Relies on `net/http` to close inbound request bodies, which it already owns.
- Added a regression test asserting an unauthorized MCP request leaves the request body open for the HTTP server to close.

<sup>Written for commit dae1d26038b266d67f21bc7512d003a98f0e503f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

