### PR TITLE
chore: count Stripe meter reading export dispositions

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -731,6 +731,8 @@ const (
 	ResilienceNamespaceKey              = attribute.Key("gram.resilience.namespace")
 	ResiliencePartitionKey              = attribute.Key("gram.resilience.partition")
 	ResilienceSubsetKey                 = attribute.Key("gram.resilience.subset")
+
+	MeteringStripeExportDispositionKey = attribute.Key("gram.metering.stripe_export.disposition")
 )
 
 const (
@@ -1765,6 +1767,10 @@ func OrganizationInviteRoleSlug(v string) attribute.KeyValue {
 
 func Outcome[V ~string](v V) attribute.KeyValue { return OutcomeKey.String(string(v)) }
 func SlogOutcome(v string) slog.Attr            { return slog.String(string(OutcomeKey), v) }
+
+func MeteringStripeExportDisposition[V ~string](v V) attribute.KeyValue {
+	return MeteringStripeExportDispositionKey.String(string(v))
+}
 
 func PackageName(v string) attribute.KeyValue { return PackageNameKey.String(v) }
 func SlogPackageName(v string) slog.Attr      { return slog.String(string(PackageNameKey), v) }

--- a/server/internal/metering/handler_stripe.go
+++ b/server/internal/metering/handler_stripe.go
@@ -23,10 +23,16 @@ import (
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
 )
 
+type stripeExportOutcome string
+
 const (
 	meterStripeExportErrors    = "gram.metering.stripe_export.errors"
+	meterStripeExportReadings  = "gram.metering.stripe_export.readings"
 	stripeCustomerCacheMaxSize = 4096
 	stripeCustomerCacheTTL     = 10 * time.Minute
+
+	stripeExportOutcomeIneligible stripeExportOutcome = "ineligible"
+	stripeExportOutcomeSent       stripeExportOutcome = "sent"
 )
 
 type stripeCustomerReader interface {
@@ -56,6 +62,7 @@ type MeterReadingStripeExporter struct {
 	customers       *expirable.LRU[string, string]
 	customerLookups singleflight.Group
 	exportErrors    metric.Int64Counter
+	readings        metric.Int64Counter
 }
 
 // NewMeterReadingStripeExporter creates a Stripe meter-reading subscriber.
@@ -67,13 +74,23 @@ func NewMeterReadingStripeExporter(
 	stripeCatalog StripeCatalog,
 	enabled bool,
 ) *MeterReadingStripeExporter {
-	exportErrors, err := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/metering").Int64Counter(
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/metering")
+	exportErrors, err := meter.Int64Counter(
 		meterStripeExportErrors,
 		metric.WithDescription("Stripe meter-reading export failures by classified cause."),
 		metric.WithUnit("{error}"),
 	)
 	if err != nil {
 		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterStripeExportErrors), attr.SlogError(err))
+	}
+
+	readings, err := meter.Int64Counter(
+		meterStripeExportReadings,
+		metric.WithDescription("Stripe meter readings by export disposition: ineligible or sent."),
+		metric.WithUnit("{reading}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterStripeExportReadings), attr.SlogError(err))
 	}
 
 	return &MeterReadingStripeExporter{
@@ -84,6 +101,7 @@ func NewMeterReadingStripeExporter(
 		customers:       expirable.NewLRU[string, string](stripeCustomerCacheMaxSize, nil, stripeCustomerCacheTTL),
 		customerLookups: singleflight.Group{},
 		exportErrors:    exportErrors,
+		readings:        readings,
 	}
 }
 
@@ -96,6 +114,7 @@ func (e *MeterReadingStripeExporter) Handle(ctx context.Context, reading *meteri
 		return nil
 	}
 	if reading.GetKind() == meteringv1.MeterReading_KIND_ADJUSTMENT {
+		e.recordReadingOutcome(ctx, stripeExportOutcomeIneligible)
 		return nil
 	}
 	if reading.GetKind() != meteringv1.MeterReading_KIND_USAGE {
@@ -114,6 +133,7 @@ func (e *MeterReadingStripeExporter) Handle(ctx context.Context, reading *meteri
 		return fmt.Errorf("map meter %q version %d to Stripe: %w", reading.GetMeterId(), reading.GetMeterVersion(), err)
 	}
 	if eventName == "" {
+		e.recordReadingOutcome(ctx, stripeExportOutcomeIneligible)
 		return nil
 	}
 
@@ -127,6 +147,7 @@ func (e *MeterReadingStripeExporter) Handle(ctx context.Context, reading *meteri
 		return fmt.Errorf("look up Stripe customer: %w", err)
 	}
 	if customerID == "" {
+		e.recordReadingOutcome(ctx, stripeExportOutcomeIneligible)
 		return nil
 	}
 
@@ -141,6 +162,7 @@ func (e *MeterReadingStripeExporter) Handle(ctx context.Context, reading *meteri
 		e.recordExportError(ctx, err)
 		return fmt.Errorf("export meter reading to Stripe: %w", err)
 	}
+	e.recordReadingOutcome(ctx, stripeExportOutcomeSent)
 	return nil
 }
 
@@ -176,6 +198,14 @@ func (e *MeterReadingStripeExporter) stripeCustomerID(ctx context.Context, organ
 		return "", fmt.Errorf("unexpected Stripe customer lookup result %T", value)
 	}
 	return customerID, nil
+}
+
+func (e *MeterReadingStripeExporter) recordReadingOutcome(ctx context.Context, outcome stripeExportOutcome) {
+	if e.readings == nil {
+		return
+	}
+
+	e.readings.Add(ctx, 1, metric.WithAttributes(attr.MeteringStripeExportDisposition(outcome)))
 }
 
 func (e *MeterReadingStripeExporter) recordExportError(ctx context.Context, err error) {

--- a/server/internal/metering/handler_stripe_test.go
+++ b/server/internal/metering/handler_stripe_test.go
@@ -10,9 +10,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
@@ -36,14 +39,73 @@ var tumStripeCatalog = metering.StripeCatalogFunc(func(definition metering.Defin
 	return "", nil
 })
 
+const stripeExportReadingsMetric = "gram.metering.stripe_export.readings"
+
+func newStripeExporterMetricReader(t *testing.T) (*sdkmetric.MeterProvider, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	})
+	return meterProvider, reader
+}
+
+func stripeExportReadingOutcomes(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
+
+	outcomes := make(map[string]int64)
+	for _, scope := range resourceMetrics.ScopeMetrics {
+		for _, candidate := range scope.Metrics {
+			if candidate.Name != stripeExportReadingsMetric {
+				continue
+			}
+
+			require.Equal(t, "{reading}", candidate.Unit)
+			sum, ok := candidate.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "Stripe export readings must be an int64 counter")
+			for _, point := range sum.DataPoints {
+				require.Equal(t, 1, point.Attributes.Len())
+				value, ok := point.Attributes.Value(attr.MeteringStripeExportDispositionKey)
+				require.True(t, ok)
+				outcome := value.AsString()
+				require.Contains(t, []string{"ineligible", "sent"}, outcome)
+				outcomes[outcome] += point.Value
+			}
+		}
+	}
+	return outcomes
+}
+
 func TestMeterReadingStripeExporterDisabledAcknowledgesWithoutProcessing(t *testing.T) {
 	t.Parallel()
 
 	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), nil, client, nil, false)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, nil, client, nil, false)
 
 	require.NoError(t, exporter.Handle(t.Context(), new(meteringv1.MeterReading), gcp.MessageMetadata{}))
 	require.Empty(t, client.inputs)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
+}
+
+func TestMeterReadingStripeExporterNacksUnsupportedKindWithoutOutcome(t *testing.T) {
+	t.Parallel()
+
+	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, nil, client, nil, true)
+	reading := new(meteringv1.MeterReading)
+	reading.SetKind(meteringv1.MeterReading_KIND_UNSPECIFIED)
+
+	err := exporter.Handle(t.Context(), reading, gcp.MessageMetadata{})
+	require.ErrorContains(t, err, "unsupported meter reading kind")
+	require.Empty(t, client.inputs)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterTransparentlyAcknowledgesAdjustments(t *testing.T) {
@@ -51,7 +113,8 @@ func TestMeterReadingStripeExporterTransparentlyAcknowledgesAdjustments(t *testi
 
 	conn, _ := newMeteringPostgres(t)
 	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, client, tumStripeCatalog, true)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
 	reading := new(meteringv1.MeterReading)
 	reading.SetKind(meteringv1.MeterReading_KIND_ADJUSTMENT)
 	reading.SetMeterId("unrecognized.meter")
@@ -59,6 +122,7 @@ func TestMeterReadingStripeExporterTransparentlyAcknowledgesAdjustments(t *testi
 
 	require.NoError(t, exporter.Handle(t.Context(), reading, gcp.MessageMetadata{}))
 	require.Empty(t, client.inputs)
+	require.Equal(t, map[string]int64{"ineligible": 1}, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterNacksUnrecognizedMeter(t *testing.T) {
@@ -66,7 +130,8 @@ func TestMeterReadingStripeExporterNacksUnrecognizedMeter(t *testing.T) {
 
 	conn, _ := newMeteringPostgres(t)
 	client := &captureV2MeterEventClient{inputs: nil, err: nil}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, client, tumStripeCatalog, true)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
 	reading := new(meteringv1.MeterReading)
 	reading.SetKind(meteringv1.MeterReading_KIND_USAGE)
 	reading.SetMeterId("unrecognized.meter")
@@ -75,15 +140,17 @@ func TestMeterReadingStripeExporterNacksUnrecognizedMeter(t *testing.T) {
 	err := exporter.Handle(t.Context(), reading, gcp.MessageMetadata{})
 	require.ErrorContains(t, err, "is not registered")
 	require.Empty(t, client.inputs)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterAcknowledgesCatalogMiss(t *testing.T) {
 	t.Parallel()
 
 	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
+	meterProvider, reader := newStripeExporterMetricReader(t)
 	exporter := metering.NewMeterReadingStripeExporter(
 		testenv.NewLogger(t),
-		testenv.NewMeterProvider(t),
+		meterProvider,
 		nil,
 		client,
 		metering.StripeCatalogFunc(func(metering.Definition) (string, error) {
@@ -95,6 +162,7 @@ func TestMeterReadingStripeExporterAcknowledgesCatalogMiss(t *testing.T) {
 
 	require.NoError(t, exporter.Handle(t.Context(), reading, gcp.MessageMetadata{}))
 	require.Empty(t, client.inputs)
+	require.Equal(t, map[string]int64{"ineligible": 1}, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterNacksCatalogError(t *testing.T) {
@@ -102,9 +170,10 @@ func TestMeterReadingStripeExporterNacksCatalogError(t *testing.T) {
 
 	mapErr := errors.New("catalog unavailable")
 	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
+	meterProvider, reader := newStripeExporterMetricReader(t)
 	exporter := metering.NewMeterReadingStripeExporter(
 		testenv.NewLogger(t),
-		testenv.NewMeterProvider(t),
+		meterProvider,
 		nil,
 		client,
 		metering.StripeCatalogFunc(func(metering.Definition) (string, error) {
@@ -117,6 +186,7 @@ func TestMeterReadingStripeExporterNacksCatalogError(t *testing.T) {
 	err := exporter.Handle(t.Context(), reading, gcp.MessageMetadata{})
 	require.ErrorIs(t, err, mapErr)
 	require.Empty(t, client.inputs)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterAcknowledgesOrganizationWithoutStripeCustomer(t *testing.T) {
@@ -124,11 +194,13 @@ func TestMeterReadingStripeExporterAcknowledgesOrganizationWithoutStripeCustomer
 
 	conn, organizationID := newMeteringPostgres(t)
 	client := &captureV2MeterEventClient{inputs: nil, err: nil}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, client, tumStripeCatalog, true)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
 	reading, _ := stripeUsageMessage(t, organizationID, time.Date(2026, time.August, 28, 10, 0, 0, 0, time.UTC), 17)
 
 	require.NoError(t, exporter.Handle(t.Context(), reading, gcp.MessageMetadata{}))
 	require.Empty(t, client.inputs)
+	require.Equal(t, map[string]int64{"ineligible": 1}, stripeExportReadingOutcomes(t, reader))
 
 	require.NoError(t, testrepo.New(conn).CreateStripeBillingMetadataFixture(t.Context(), testrepo.CreateStripeBillingMetadataFixtureParams{
 		OrganizationID:   organizationID,
@@ -136,6 +208,23 @@ func TestMeterReadingStripeExporterAcknowledgesOrganizationWithoutStripeCustomer
 	}))
 	require.NoError(t, exporter.Handle(t.Context(), reading, gcp.MessageMetadata{}))
 	require.Len(t, client.inputs, 1)
+	require.Equal(t, map[string]int64{"ineligible": 1, "sent": 1}, stripeExportReadingOutcomes(t, reader))
+}
+
+func TestMeterReadingStripeExporterNacksCustomerLookupErrorWithoutOutcome(t *testing.T) {
+	t.Parallel()
+
+	conn, organizationID := newMeteringPostgres(t)
+	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
+	conn.Close()
+	reading, _ := stripeUsageMessage(t, organizationID, time.Date(2026, time.August, 28, 10, 0, 0, 0, time.UTC), 17)
+
+	err := exporter.Handle(t.Context(), reading, gcp.MessageMetadata{})
+	require.ErrorContains(t, err, "look up Stripe customer")
+	require.Empty(t, client.inputs)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterSendsMappedUsage(t *testing.T) {
@@ -147,7 +236,8 @@ func TestMeterReadingStripeExporterSendsMappedUsage(t *testing.T) {
 		StripeCustomerID: pgtype.Text{String: "cus_test", Valid: true},
 	}))
 	client := &captureV2MeterEventClient{inputs: nil, err: nil}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, client, tumStripeCatalog, true)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
 	occurredAt := time.Date(2026, time.August, 28, 10, 1, 2, 345, time.UTC)
 	reading, _ := stripeUsageMessage(t, organizationID, occurredAt, 23)
 
@@ -159,6 +249,7 @@ func TestMeterReadingStripeExporterSendsMappedUsage(t *testing.T) {
 		Value:      23,
 		Timestamp:  occurredAt.UTC(),
 	}}, client.inputs)
+	require.Equal(t, map[string]int64{"sent": 1}, stripeExportReadingOutcomes(t, reader))
 }
 
 func TestMeterReadingStripeExporterCachesStripeCustomer(t *testing.T) {
@@ -195,12 +286,14 @@ func TestMeterReadingStripeExporterNacksClassifiedStripeFailure(t *testing.T) {
 		Err:            errors.New("rate limited"),
 	}
 	client := &captureV2MeterEventClient{inputs: nil, err: stripeErr}
-	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, client, tumStripeCatalog, true)
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(testenv.NewLogger(t), meterProvider, conn, client, tumStripeCatalog, true)
 	reading, _ := stripeUsageMessage(t, organizationID, time.Date(2026, time.August, 28, 10, 0, 0, 0, time.UTC), 1)
 
 	err := exporter.Handle(t.Context(), reading, gcp.MessageMetadata{})
 	require.ErrorIs(t, err, stripeErr)
 	require.Len(t, client.inputs, 1)
+	require.Empty(t, stripeExportReadingOutcomes(t, reader))
 }
 
 func stripeUsageMessage(t *testing.T, organizationID string, occurredAt time.Time, value int64) (*meteringv1.MeterReading, metering.Reading) {


### PR DESCRIPTION
## Summary

- Add `gram.metering.stripe_export.readings`, an OpenTelemetry counter with the bounded `gram.metering.stripe_export.disposition` attribute.
- Record `ineligible` for intentionally acknowledged readings that are not sent, and `sent` only after Stripe accepts a meter event.
- Keep disabled processing and retryable errors uncounted while preserving the existing export failure counter.

## Motivation

Stripe meter-reading processing needs to distinguish intentional acknowledgements from successful exports. A metric-specific disposition attribute avoids conflicting with the shared `gram.outcome` convention, whose values are restricted to `success` and `failure`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Stripe meter-reading export disposition counter so intentionally skipped readings can be distinguished from successful exports.

- Records `ineligible` for adjustments, unmapped meters, and missing customers; `sent` only after Stripe accepts a meter event.
- Keeps disabled processing and retryable errors uncounted; the existing export failure counter is unchanged.
- Adds the `gram.metering.stripe_export.disposition` attribute scoped to the new `gram.metering.stripe_export.readings` counter.

<sup>Written for commit 3b33f68e8abdb7b99ae5552626bc893d62676506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

