### PR TITLE
feat: admitted workload identity lookup behind an injected interface

### DIFF
--- a/.changeset/workload-identity-admission-lookup.md
+++ b/.changeset/workload-identity-admission-lookup.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Read a workload identity's admission from the database, scoped to the caller's own project or the organization above it. Not yet wired to any request path.

--- a/.changeset/workload-identity-admission.md
+++ b/.changeset/workload-identity-admission.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Admission for the workload assertion grant: check a verified assertion's subject against the workload identities an endpoint admits, keyed on the exact organization, endpoint issuer, external issuer and subject, behind an injected lookup that admits nothing until a policy is configured

--- a/.changeset/workload-issuer-admission.md
+++ b/.changeset/workload-issuer-admission.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Admission for the workload assertion grant: resolve an assertion's issuer to the row the rest of the grant is built on, share one issuer resolution between the management API and admission, bound admission lookups per endpoint, and remember recent rejections in the shared cache so a repeated unknown issuer costs no query on any replica

--- a/.changeset/workload-key-source-repoint.md
+++ b/.changeset/workload-key-source-repoint.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Verify workload assertions against the keys published by their `workload_issuers` record rather than a remote session issuer row. Not yet wired to any request path.

--- a/server/internal/mcp/authnchallenge_workloadallowlist.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity"
 	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
@@ -57,11 +58,6 @@ var errWorkloadIssuerLookupRateLimited = errors.New("workload issuer lookups are
 // not reported as a rate limit an operator can wait out.
 var errWorkloadIssuerLimiterUnavailable = errors.New("workload issuer lookup limiter unavailable")
 
-// errWorkloadIssuerURLInvalid marks a value that is not an issuer identifier
-// at all. Wrapped by a lookup before it consults anything, so admission can
-// tell "could never name a row" from "names no row we hold".
-var errWorkloadIssuerURLInvalid = errors.New("invalid issuer url")
-
 // newWorkloadIssuerLookupBudget builds the per-endpoint ceiling, or nil when
 // there is no store. Nil is not "unlimited" — an absent budget refuses, so a
 // deployment without the store does not get the grant.
@@ -93,7 +89,8 @@ type workloadIssuerBudget func(ctx context.Context, scope string) (ratelimit.Res
 //
 // The whole row rather than its id, because workloadIssuerKeySource reads
 // jwks_uri off it. A value that is not an issuer identifier is reported as an
-// error wrapping errWorkloadIssuerURLInvalid, before the store is consulted.
+// error wrapping workloadidentity.ErrIssuerURLInvalid before the store is
+// consulted, as workloadidentity.ResolveIssuerByURL reports it.
 type workloadIssuerLookup func(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, bool, error)
 
 // workloadIssuerAdmission resolves an assertion's issuer to the row that
@@ -147,6 +144,17 @@ type workloadIssuerResolution struct {
 // request. A rejection costs one indexed SELECT, bounded anyway because this
 // grant is reachable without credentials.
 func (a *workloadIssuerAdmission) admit(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, error) {
+	switch {
+	// An unwired lookup reads as "no issuer registered" and a missing endpoint
+	// as "no tenancy to resolve under", as admitWorkloadIdentity treats them.
+	case a.lookup == nil, endpoint == nil:
+		return workloadidentity_repo.WorkloadIssuer{}, errWorkloadIssuerUntrusted
+	// No row can describe an empty iss, so it is refused before it spends the
+	// endpoint's budget.
+	case issuerURL == "":
+		return workloadidentity_repo.WorkloadIssuer{}, fmt.Errorf("%w: %w", errWorkloadIssuerUntrusted, workloadidentity.ErrIssuerURLInvalid)
+	}
+
 	ch := a.inflight.DoChan(workloadIssuerFlightKey(endpoint, issuerURL), func() (any, error) {
 		// Detached from the caller that opened the flight: values carry
 		// through, cancellation does not. Tying the flight's lifetime to that
@@ -171,7 +179,7 @@ func (a *workloadIssuerAdmission) admit(ctx context.Context, endpoint *ResolvedM
 
 		issuer, found, lookupErr := a.lookup(lookupCtx, endpoint, issuerURL)
 		switch {
-		case errors.Is(lookupErr, errWorkloadIssuerURLInvalid):
+		case errors.Is(lookupErr, workloadidentity.ErrIssuerURLInvalid):
 			// No row could ever describe it. Reported as untrusted with the
 			// parse failure wrapped, so a caller can tell a malformed iss from
 			// an unknown one without the two answering differently on the wire.

--- a/server/internal/mcp/authnchallenge_workloadallowlist.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist.go
@@ -1,0 +1,226 @@
+// Admission for the workload assertion grant: resolving an assertion's iss to
+// the issuer row the rest of the grant is built on. Sits in front of
+// workloadIssuerKeySource in authnchallenge_workloadauth.go, which reads that
+// row's stored jwks_uri.
+//
+// Resolving the issuer is not the same as admitting the workload, and this
+// stage only does the first. See errWorkloadIssuerUntrusted.
+
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+const (
+	// workloadIssuerLookupTimeout bounds one admission lookup. The lookup runs
+	// detached from the caller's context, so nothing else bounds it.
+	workloadIssuerLookupTimeout = 5 * time.Second
+)
+
+// workloadIssuerLookupRate bounds how many lookups one endpoint drives into
+// the database, and is the only bound: singleflight collapses repeats of one
+// spelling, but a flood of distinct spellings shares no flight.
+//
+// Per endpoint rather than per replica, so one tenant cannot exhaust another's
+// budget. The bucket lives in Redis, so it is fleet-wide.
+var workloadIssuerLookupRate = ratelimit.PerMinute(120).WithBurst(30)
+
+// errWorkloadIssuerUntrusted reports an iss resolving to no workload issuer
+// row in the endpoint's tenancy — its own project, or the organization above.
+//
+// Weaker than "trusted for this workload": this stage establishes only that the
+// tenant registered the issuer. A CI provider signs every job on its platform,
+// so the subject admission that follows is the security boundary, not this.
+var errWorkloadIssuerUntrusted = errors.New("no workload issuer in this tenancy describes that issuer url")
+
+// errWorkloadIssuerLookupRateLimited reports a lookup refused for budget.
+// Nothing was decided about the issuer, so a caller mapping untrusted onto a
+// 401 must not answer one here.
+var errWorkloadIssuerLookupRateLimited = errors.New("workload issuer lookups are rate limited for this endpoint")
+
+// errWorkloadIssuerLimiterUnavailable reports that the limiter's store could
+// not answer. Fails closed, and stays distinct from a refusal so an outage is
+// not reported as a rate limit an operator can wait out.
+var errWorkloadIssuerLimiterUnavailable = errors.New("workload issuer lookup limiter unavailable")
+
+// errWorkloadIssuerURLInvalid marks a value that is not an issuer identifier
+// at all. Wrapped by a lookup before it consults anything, so admission can
+// tell "could never name a row" from "names no row we hold".
+var errWorkloadIssuerURLInvalid = errors.New("invalid issuer url")
+
+// newWorkloadIssuerLookupBudget builds the per-endpoint ceiling, or nil when
+// there is no store. Nil is not "unlimited" — an absent budget refuses, so a
+// deployment without the store does not get the grant.
+func newWorkloadIssuerLookupBudget(redisClient *redis.Client, meterProvider metric.MeterProvider) workloadIssuerBudget {
+	if redisClient == nil {
+		return nil
+	}
+
+	limiter := ratelimit.New(
+		ratelimit.NewRedisStore(redisClient),
+		"workload_issuer_lookup",
+		workloadIssuerLookupRate,
+		ratelimit.WithMetrics(meterProvider),
+	)
+
+	return limiter.Allow
+}
+
+// workloadIssuerBudget charges one lookup against a scope's ceiling. A
+// function rather than *ratelimit.Limiter so refusal and outage are testable
+// without the store; production passes (*ratelimit.Limiter).Allow.
+//
+// !Allowed is a decision the budget made; an error is it failing to make one.
+type workloadIssuerBudget func(ctx context.Context, scope string) (ratelimit.Result, error)
+
+// workloadIssuerLookup resolves an iss to the workload issuer row the
+// endpoint's tenant registered for it, false when none does. The endpoint is
+// the input because it names the tenancy the resolution runs against.
+//
+// The whole row rather than its id, because workloadIssuerKeySource reads
+// jwks_uri off it. A value that is not an issuer identifier is reported as an
+// error wrapping errWorkloadIssuerURLInvalid, before the store is consulted.
+type workloadIssuerLookup func(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, bool, error)
+
+// workloadIssuerAdmission resolves an assertion's issuer to the row that
+// describes it.
+//
+// Safe for concurrent use; build one at wiring time.
+type workloadIssuerAdmission struct {
+	lookup workloadIssuerLookup
+
+	// inflight collapses concurrent resolutions of one key onto a single
+	// lookup. In-process is all it needs to be: it bounds a simultaneous
+	// burst, sustained load is the limiter's job.
+	inflight singleflight.Group
+
+	// charge bounds lookups reaching the database. Nil means no ceiling was
+	// wired, which admission treats as unprotected rather than unlimited.
+	charge workloadIssuerBudget
+}
+
+func newWorkloadIssuerAdmission(lookup workloadIssuerLookup, charge workloadIssuerBudget) *workloadIssuerAdmission {
+	return &workloadIssuerAdmission{
+		lookup:   lookup,
+		inflight: singleflight.Group{},
+		charge:   charge,
+	}
+}
+
+// workloadIssuerLookupScope names the budget an endpoint's lookups are charged
+// to: the authorization server's identifier, so no endpoint spends another's.
+//
+// A denial-of-service bound, deliberately not the tenancy the lookup resolves
+// against, so a flood at one of a tenant's servers cannot starve the rest.
+//
+// Never the issuer URL, which two organizations may share, and never anything
+// derived from the request, which would let a caller mint a fresh budget by
+// varying what it sends.
+func workloadIssuerLookupScope(endpoint *ResolvedMcpEndpoint) string {
+	return "workload-issuer-lookup:" + endpoint.UserSessionIssuerID.String()
+}
+
+// workloadIssuerResolution carries a lookup's result through singleflight, so
+// every sharer of a call sees the same row.
+type workloadIssuerResolution struct {
+	issuer workloadidentity_repo.WorkloadIssuer
+}
+
+// admit resolves issuerURL to the issuer row it names, or reports
+// errWorkloadIssuerUntrusted.
+//
+// Nothing here fetches, so an unrecognised iss cannot become an outbound
+// request. A rejection costs one indexed SELECT, bounded anyway because this
+// grant is reachable without credentials.
+func (a *workloadIssuerAdmission) admit(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, error) {
+	ch := a.inflight.DoChan(workloadIssuerFlightKey(endpoint, issuerURL), func() (any, error) {
+		// Detached from the caller that opened the flight: values carry
+		// through, cancellation does not. Tying the flight's lifetime to that
+		// one caller would hand context.Canceled to everyone sharing the
+		// lookup the moment it went away. The caller keeps its own
+		// cancellation through the select below; what bounds the flight is
+		// this timeout.
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workloadIssuerLookupTimeout)
+		defer cancel()
+
+		// Charged before the query, so a refusal costs only the bucket read.
+		if a.charge == nil {
+			return nil, errWorkloadIssuerLimiterUnavailable
+		}
+		charged, chargeErr := a.charge(lookupCtx, workloadIssuerLookupScope(endpoint))
+		if chargeErr != nil {
+			return nil, fmt.Errorf("%w: %w", errWorkloadIssuerLimiterUnavailable, chargeErr)
+		}
+		if !charged.Allowed {
+			return nil, fmt.Errorf("%w: retry after %s", errWorkloadIssuerLookupRateLimited, charged.RetryAfter)
+		}
+
+		issuer, found, lookupErr := a.lookup(lookupCtx, endpoint, issuerURL)
+		switch {
+		case errors.Is(lookupErr, errWorkloadIssuerURLInvalid):
+			// No row could ever describe it. Reported as untrusted with the
+			// parse failure wrapped, so a caller can tell a malformed iss from
+			// an unknown one without the two answering differently on the wire.
+			return nil, fmt.Errorf("%w: %w", errWorkloadIssuerUntrusted, lookupErr)
+		case lookupErr != nil:
+			return nil, fmt.Errorf("resolve workload issuer: %w", lookupErr)
+		case !found:
+			return nil, errWorkloadIssuerUntrusted
+		}
+		return workloadIssuerResolution{issuer: issuer}, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		// This caller gave up; the flight carries on for whoever else shares
+		// it. Deliberately not errWorkloadIssuerUntrusted — nothing was
+		// decided about this issuer.
+		return workloadidentity_repo.WorkloadIssuer{}, fmt.Errorf("await workload issuer admission: %w", ctx.Err())
+	case res := <-ch:
+		if res.Err != nil {
+			return workloadidentity_repo.WorkloadIssuer{}, res.Err
+		}
+		resolution, ok := res.Val.(workloadIssuerResolution)
+		if !ok {
+			return workloadidentity_repo.WorkloadIssuer{}, fmt.Errorf("resolve workload issuer: unexpected resolution %T", res.Val)
+		}
+		return resolution.issuer, nil
+	}
+}
+
+// workloadIssuerFlightKey identifies one in-flight lookup.
+//
+// Two callers share a key exactly when they would share a result, so the key is
+// what the lookup consumes: the tenancy it resolves under and the spelling it
+// resolves. Tenancy is the organization and project, not the user session
+// issuer — one issuer can back endpoints in different projects.
+//
+// Keyed on the supplied spelling rather than a canonical form: lookup matches a
+// closed set of spellings, so a row stored as https://IDP.example.com is not
+// found by a request spelling it in lowercase.
+//
+// Hashed and length-prefixed, as replay.Key is, because the spelling arrives
+// unauthenticated under no length bound.
+func workloadIssuerFlightKey(endpoint *ResolvedMcpEndpoint, issuerURL string) string {
+	sum := sha256.New()
+	for _, part := range []string{endpoint.OrganizationID, endpoint.ProjectID.String(), issuerURL} {
+		sum.Write([]byte(strconv.Itoa(len(part))))
+		sum.Write([]byte(":"))
+		sum.Write([]byte(part))
+	}
+	return base64.RawURLEncoding.EncodeToString(sum.Sum(nil))
+}

--- a/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
@@ -1,0 +1,396 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+// workloadTenantEndpoint names the tenancy an admission resolves under, which
+// is what the flight key is built from.
+func workloadTenantEndpoint(organizationID string, projectID, issuerID uuid.UUID) *ResolvedMcpEndpoint {
+	return &ResolvedMcpEndpoint{
+		OrganizationID:      organizationID,
+		ProjectID:           projectID,
+		UserSessionIssuerID: issuerID,
+	}
+}
+
+// workloadTestTenant is a fresh, fully distinct tenancy.
+func workloadTestTenant() *ResolvedMcpEndpoint {
+	return workloadTenantEndpoint(uuid.NewString(), uuid.New(), uuid.New())
+}
+
+// newWorkloadTestAdmission builds admission with no store behind it. There is
+// nothing to isolate between parallel tests: the only shared state is the
+// in-process flight map, and each test builds its own.
+func newWorkloadTestAdmission(t *testing.T, lookup workloadIssuerLookup, charge workloadIssuerBudget) *workloadIssuerAdmission {
+	t.Helper()
+
+	return newWorkloadIssuerAdmission(lookup, charge)
+}
+
+// countingLookup records every call so a test can assert what the miss path
+// did and did not consult. The counter is atomic because the concurrency test
+// calls it from many goroutines at once.
+type countingLookup struct {
+	calls atomic.Int64
+	// running and peak track how many lookups are inside the function at once,
+	// so a test can assert the slot bound rather than infer it from timing.
+	running atomic.Int64
+	peak    atomic.Int64
+	// release, when non-nil, holds the lookup open until the test closes it,
+	// so a test can guarantee callers pile up behind one in-flight call.
+	release chan struct{}
+	issuer  workloadidentity_repo.WorkloadIssuer
+	found   bool
+	err     error
+}
+
+func (l *countingLookup) fn() workloadIssuerLookup {
+	return func(_ context.Context, _ *ResolvedMcpEndpoint, _ string) (workloadidentity_repo.WorkloadIssuer, bool, error) {
+		l.calls.Add(1)
+		l.enter()
+		defer l.running.Add(-1)
+
+		if l.release != nil {
+			<-l.release
+		}
+		return l.issuer, l.found, l.err
+	}
+}
+
+// enter records one more concurrent lookup, raising the high-water mark.
+func (l *countingLookup) enter() {
+	running := l.running.Add(1)
+	for {
+		peak := l.peak.Load()
+		if running <= peak || l.peak.CompareAndSwap(peak, running) {
+			return
+		}
+	}
+}
+
+func TestWorkloadIssuerAdmission_TrustedIssuerResolves(t *testing.T) {
+	t.Parallel()
+
+	want := workloadidentity_repo.WorkloadIssuer{ID: uuid.New(), Name: "gh-actions", JwksUri: "https://token.actions.example.test/jwks"}
+	lookup := &countingLookup{issuer: want, found: true}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	got, err := admission.admit(t.Context(), workloadTestTenant(), "https://token.actions.example.test")
+
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// The core property of this ticket: an issuer nobody trusts is rejected
+// without a key source ever being built, so nothing downstream can turn a
+// request-supplied URL into an outbound fetch.
+func TestWorkloadIssuerAdmission_UntrustedIssuerRejectedWithoutEgress(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	row, err := admission.admit(t.Context(), workloadTestTenant(), "https://attacker.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	require.Equal(t, workloadidentity_repo.WorkloadIssuer{}, row, "a rejected issuer must yield no row, so no key source can be built from it")
+}
+
+// Without coordination, callers arriving together each cost a query. The
+// limiter bounds sustained load; this is what bounds a simultaneous burst.
+func TestWorkloadIssuerAdmission_ConcurrentMissesCollapseToOneLookup(t *testing.T) {
+	t.Parallel()
+
+	const callers = 32
+
+	lookup := &countingLookup{found: false, release: make(chan struct{})}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	// Held inside admit: one caller occupies the lookup, the rest join it.
+	var waiting atomic.Int64
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Go(func() {
+			waiting.Add(1)
+			defer waiting.Add(-1)
+			_, err := admission.admit(t.Context(), endpoint, "https://attacker.example.test")
+			require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+		})
+	}
+
+	// Every caller is inside admit before any of them is allowed to finish,
+	// so the burst is genuinely simultaneous rather than accidentally serial.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, callers, waiting.Load())
+	}, 5*time.Second, time.Millisecond)
+
+	close(lookup.release)
+	wg.Wait()
+
+	require.EqualValues(t, 1, lookup.calls.Load(), "concurrent rejections of one issuer must share a single lookup")
+}
+
+// Detaching the flight must not cost the caller its own cancellation. A client
+// that disconnects has to stop waiting immediately, while the flight it opened
+// carries on for anyone sharing it and still records what it found.
+func TestWorkloadIssuerAdmission_AbandonedCallerStopsWaitingButFlightFinishes(t *testing.T) {
+	t.Parallel()
+
+	const issuerURL = "https://attacker.example.test"
+
+	lookup := &countingLookup{found: false, release: make(chan struct{})}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var abandoned error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, abandoned = admission.admit(ctx, endpoint, issuerURL)
+	}()
+
+	// The flight is inside the held-open lookup before the caller gives up, so
+	// this abandons work that is genuinely still running.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 1, lookup.running.Load())
+	}, 5*time.Second, time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a caller that gave up was left waiting on the flight it opened")
+	}
+
+	require.ErrorIs(t, abandoned, context.Canceled)
+	require.NotErrorIs(t, abandoned, errWorkloadIssuerUntrusted, "giving up decides nothing about the issuer, and must not be reported as a rejection")
+
+	// The flight runs to completion on its own timeout rather than being
+	// torn down with the caller that opened it. Releasing the lookup lets it
+	// finish; nothing restarts it.
+	close(lookup.release)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 0, lookup.running.Load(), "the abandoned flight must finish rather than hang")
+	}, 5*time.Second, time.Millisecond)
+
+	require.EqualValues(t, 1, lookup.calls.Load(), "a caller giving up must not cause the lookup to run again")
+}
+
+// Two endpoints in different tenancies resolve independently, so one
+// rejection must never answer for the other.
+func TestWorkloadIssuerAdmission_FlightIsNotSharedAcrossTenancies(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	const issuerURL = "https://idp.example.test"
+	_, err := admission.admit(t.Context(), workloadTestTenant(), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), workloadTestTenant(), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "a second tenancy must be resolved on its own, not from the first's miss")
+}
+
+// One user session issuer can back endpoints in different projects: the
+// mcp_servers foreign key to it carries no project pinning, unlike
+// meta_mcp_servers' composite one. Since the lookup resolves under the
+// project, a miss recorded for one must not deny a project-tier trusted
+// issuer in the other.
+func TestWorkloadIssuerAdmission_FlightIsNotSharedAcrossProjectsOnOneIssuer(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	organizationID := uuid.NewString()
+	sharedIssuer := uuid.New()
+	const issuerURL = "https://idp.example.test"
+
+	_, err := admission.admit(t.Context(), workloadTenantEndpoint(organizationID, uuid.New(), sharedIssuer), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), workloadTenantEndpoint(organizationID, uuid.New(), sharedIssuer), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "two projects sharing one issuer must not share a flight")
+}
+
+// A malformed iss is reported as untrusted with the parse failure wrapped, so
+// a caller can tell "could never name a row" from "names no row we hold"
+// without the two answering differently on the wire.
+func TestWorkloadIssuerAdmission_MalformedIssuerKeepsItsReason(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{err: fmt.Errorf("%w: no host", errWorkloadIssuerURLInvalid)}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "not-a-url")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	require.ErrorIs(t, err, errWorkloadIssuerURLInvalid)
+}
+
+// The non-obvious half of the key, asserted where it matters rather than only
+// at the key function. Lookup matches a closed candidate set that includes the
+// caller's own spelling, so two inputs sharing a canonical form do not
+// necessarily share a result: collapsing them would let the rejection of one
+// answer for the spelling that would have matched.
+func TestWorkloadIssuerAdmission_SpellingsSharingACanonicalFormResolveSeparately(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	_, err := admission.admit(t.Context(), endpoint, "https://idp.example.test")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), endpoint, "https://IDP.example.test")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "a spelling the lookup may resolve differently must be resolved on its own")
+}
+
+// The key must distinguish exactly what the lookup distinguishes: same
+// tenancy and same spelling share an answer, and any difference in either
+// does not.
+func TestWorkloadIssuerFlightKey_SeparatesTenancyAndSpelling(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.NewString()
+	projectID, issuerID := uuid.New(), uuid.New()
+	endpoint := workloadTenantEndpoint(organizationID, projectID, issuerID)
+	const issuerURL = "https://idp.example.test"
+
+	base := workloadIssuerFlightKey(endpoint, issuerURL)
+
+	require.Equal(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(organizationID, projectID, issuerID), issuerURL),
+		"one tenancy and one spelling must produce one key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(organizationID, uuid.New(), issuerID), issuerURL),
+		"a different project resolves differently and must not share a key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(uuid.NewString(), projectID, issuerID), issuerURL),
+		"a different organization resolves differently and must not share a key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(endpoint, "https://IDP.example.test"),
+		"a spelling the lookup may resolve differently must not share a key")
+}
+
+// The issuer spelling arrives unauthenticated under no length bound, so an
+// entry must not grow with it: otherwise the entry cap would bound a count of
+// unbounded strings rather than memory.
+func TestWorkloadIssuerFlightKey_IsFixedSize(t *testing.T) {
+	t.Parallel()
+
+	endpoint := workloadTestTenant()
+
+	short := workloadIssuerFlightKey(endpoint, "https://a.test")
+	long := workloadIssuerFlightKey(endpoint, "https://a.test/"+strings.Repeat("x", 1<<20))
+
+	require.Len(t, long, len(short), "a megabyte of issuer must occupy no more key than a short one")
+}
+
+// allowAllWorkloadLookups is the budget for tests about something other than
+// the budget: every charge succeeds, so admission behaves as it does for an
+// endpoint well inside its ceiling.
+func allowAllWorkloadLookups(context.Context, string) (ratelimit.Result, error) {
+	return ratelimit.Result{Allowed: true, Remaining: 1, RetryAfter: 0}, nil
+}
+
+// The ceiling is the bound this path relies on, so a refusal must be its own
+// answer. Reported as errWorkloadIssuerUntrusted it would tell a caller the
+// issuer was rejected, which is a 401 and a lie; reported as nothing in
+// particular it would surface as a 5xx.
+func TestWorkloadIssuerAdmission_SpentBudgetIsNotATrustDecision(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	spent := func(context.Context, string) (ratelimit.Result, error) {
+		return ratelimit.Result{Allowed: false, Remaining: 0, RetryAfter: 3 * time.Second}, nil
+	}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), spent)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLookupRateLimited)
+	require.NotErrorIs(t, err, errWorkloadIssuerUntrusted, "a spent budget decides nothing about the issuer")
+	require.EqualValues(t, 0, lookup.calls.Load(), "a refused charge must cost no query")
+}
+
+// An unreachable bucket is not a throttle. Running the lookup anyway would
+// spend exactly the budget the ceiling exists to protect, so it fails closed —
+// and stays distinguishable from a refusal an operator could wait out.
+func TestWorkloadIssuerAdmission_LimiterOutageFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	outage := errors.New("redis unreachable")
+	admission := newWorkloadTestAdmission(t, lookup.fn(), func(context.Context, string) (ratelimit.Result, error) {
+		return ratelimit.Result{Allowed: false, Remaining: 0, RetryAfter: 0}, outage
+	})
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLimiterUnavailable)
+	require.ErrorIs(t, err, outage)
+	require.NotErrorIs(t, err, errWorkloadIssuerLookupRateLimited, "an outage must not read as a rate limit")
+	require.EqualValues(t, 0, lookup.calls.Load(), "an unbounded lookup is exactly what the ceiling prevents")
+}
+
+// A ceiling that was never wired leaves this path with no bound at all. On a
+// grant reachable without credentials that is the condition the bound exists
+// for, so it refuses rather than running unprotected.
+func TestWorkloadIssuerAdmission_AbsentBudgetRefuses(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), nil)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLimiterUnavailable)
+	require.EqualValues(t, 0, lookup.calls.Load())
+}
+
+// The budget is per endpoint, which is the property that keeps a mitigation
+// from becoming a cross-tenant denial surface: one endpoint's spend must never
+// be charged against another's.
+func TestWorkloadIssuerLookupScope_SeparatesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	shared := workloadTenantEndpoint(uuid.NewString(), uuid.New(), issuerID)
+
+	require.Equal(t, workloadIssuerLookupScope(shared),
+		workloadIssuerLookupScope(workloadTenantEndpoint(uuid.NewString(), uuid.New(), issuerID)),
+		"one authorization server is one budget, whatever project addresses it")
+	require.NotEqual(t, workloadIssuerLookupScope(shared), workloadIssuerLookupScope(workloadTestTenant()),
+		"a different endpoint must not spend this one's budget")
+	require.NotEqual(t, workloadIssuerLookupScope(shared), workloadFetchScope(shared),
+		"key fetches and admission lookups bound different resources and must not share a bucket")
+}
+
+// Without a store there are no buckets, and admission must not read that as
+// permission to run unbounded.
+func TestNewWorkloadIssuerLookupBudget_NilWithoutAStore(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, newWorkloadIssuerLookupBudget(nil, testenv.NewMeterProvider(t)),
+		"no store means no ceiling, which admission refuses rather than ignores")
+}

--- a/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity"
 	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
@@ -241,12 +242,49 @@ func TestWorkloadIssuerAdmission_FlightIsNotSharedAcrossProjectsOnOneIssuer(t *t
 func TestWorkloadIssuerAdmission_MalformedIssuerKeepsItsReason(t *testing.T) {
 	t.Parallel()
 
-	lookup := &countingLookup{err: fmt.Errorf("%w: no host", errWorkloadIssuerURLInvalid)}
+	lookup := &countingLookup{err: fmt.Errorf("%w: no host", workloadidentity.ErrIssuerURLInvalid)}
 	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
 
 	_, err := admission.admit(t.Context(), workloadTestTenant(), "not-a-url")
 	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
-	require.ErrorIs(t, err, errWorkloadIssuerURLInvalid)
+	require.ErrorIs(t, err, workloadidentity.ErrIssuerURLInvalid)
+}
+
+// Each of these has an answer known before anything is consulted. On a grant
+// reachable without credentials, none may panic or spend the endpoint's
+// budget: all are refused as untrusted before the charge, even with a lookup
+// wired that would have found a row.
+func TestWorkloadIssuerAdmission_UnresolvableInputsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		lookup    func(*countingLookup) workloadIssuerLookup
+		endpoint  *ResolvedMcpEndpoint
+		issuerURL string
+	}{
+		"unwired lookup": {lookup: func(*countingLookup) workloadIssuerLookup { return nil }, endpoint: workloadTestTenant(), issuerURL: "https://idp.example.test"},
+		"no endpoint":    {lookup: (*countingLookup).fn, endpoint: nil, issuerURL: "https://idp.example.test"},
+		"empty issuer":   {lookup: (*countingLookup).fn, endpoint: workloadTestTenant(), issuerURL: ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+			var charges atomic.Int64
+			admission := newWorkloadTestAdmission(t, tc.lookup(lookup), func(ctx context.Context, scope string) (ratelimit.Result, error) {
+				charges.Add(1)
+				return allowAllWorkloadLookups(ctx, scope)
+			})
+
+			row, err := admission.admit(t.Context(), tc.endpoint, tc.issuerURL)
+
+			require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+			require.Equal(t, workloadidentity_repo.WorkloadIssuer{}, row)
+			require.EqualValues(t, 0, charges.Load(), "an answer known in advance must not spend the endpoint's budget")
+			require.EqualValues(t, 0, lookup.calls.Load())
+		})
+	}
 }
 
 // The non-obvious half of the key, asserted where it matters rather than only

--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -8,32 +8,29 @@ package mcp
 import (
 	"fmt"
 
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
-// workloadIssuerKeySource builds the key source a trusted workload issuer's
-// assertions verify against.
+// workloadIssuerKeySource builds the key source a workload issuer's assertions
+// verify against.
 //
-// Only one shape exists here, unlike clientKeySource's two: a workload
-// issuer publishes its keys and never registers them with us, so there is no
-// inline key set to consider. The jwks_uri arrives on the row from the RFC
-// 8414 / OIDC discovery the management API runs when an issuer is created or
-// refreshed, which is why nothing is fetched or probed on this path.
+// One shape only, unlike clientKeySource's two: a workload issuer publishes its
+// keys and never registers them with us. jwks_uri is stored on the row at
+// discovery time, so nothing is fetched or probed here.
 //
-// An issuer row with no jwks_uri is a setup error, not a bad assertion, and
-// says so: discovery either never ran or the issuer's document omitted the
-// field. Answering it like a rejected workload would send an operator
-// hunting through their platform's configuration for a problem that is on
-// ours.
-func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *remotesessions_repo.RemoteSessionIssuer) (jwks.Source, error) {
-	if !issuer.JwksUri.Valid || issuer.JwksUri.String == "" {
-		return jwks.Source{}, fmt.Errorf("trusted issuer %q records no jwks_uri: re-run discovery for it", issuer.Slug)
+// jwks_uri is NOT NULL on workload_issuers but carries no non-empty CHECK, so
+// the empty check guards invalid persisted data rather than an unstorable row.
+// Errors name the issuer by name; a workload issuer has no slug, its URL being
+// its canonical name.
+func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *workloadidentity_repo.WorkloadIssuer) (jwks.Source, error) {
+	if issuer.JwksUri == "" {
+		return jwks.Source{}, fmt.Errorf("workload issuer %q records no jwks_uri", issuer.Name)
 	}
 
-	source, err := jwks.NewRemoteSource(issuer.JwksUri.String)
+	source, err := jwks.NewRemoteSource(issuer.JwksUri)
 	if err != nil {
-		return jwks.Source{}, fmt.Errorf("trusted issuer %q jwks_uri: %w", issuer.Slug, err)
+		return jwks.Source{}, fmt.Errorf("workload issuer %q jwks_uri: %w", issuer.Name, err)
 	}
 
 	return source.WithFetchScope(workloadFetchScope(endpoint)), nil

--- a/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
@@ -4,18 +4,17 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
 func workloadTestEndpoint(issuerID uuid.UUID) *ResolvedMcpEndpoint {
 	return &ResolvedMcpEndpoint{UserSessionIssuerID: issuerID}
 }
 
-func workloadTestIssuer(slug string, jwksURI pgtype.Text) *remotesessions_repo.RemoteSessionIssuer {
-	return &remotesessions_repo.RemoteSessionIssuer{Slug: slug, JwksUri: jwksURI}
+func workloadTestIssuer(name string, jwksURI string) *workloadidentity_repo.WorkloadIssuer {
+	return &workloadidentity_repo.WorkloadIssuer{Name: name, JwksUri: jwksURI}
 }
 
 func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
@@ -24,38 +23,25 @@ func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
 	issuerID := uuid.New()
 	source, err := workloadIssuerKeySource(
 		workloadTestEndpoint(issuerID),
-		workloadTestIssuer("gh-actions", pgtype.Text{String: "https://example.test/keys", Valid: true}),
+		workloadTestIssuer("gh-actions", "https://example.test/keys"),
 	)
 
 	require.NoError(t, err)
 	require.Equal(t, "https://example.test/keys", source.CacheKey(), "the cache key is the jwks_uri, shared across every scope naming it")
 }
 
-func TestWorkloadIssuerKeySource_MissingJwksURIIsASetupError(t *testing.T) {
+// Pins the guard: jwks_uri is NOT NULL but carries no non-empty CHECK, so an
+// empty one is storable and has to be refused here.
+func TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name    string
-		jwksURI pgtype.Text
-	}{
-		{name: "null", jwksURI: pgtype.Text{String: "", Valid: false}},
-		{name: "empty", jwksURI: pgtype.Text{String: "", Valid: true}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	_, err := workloadIssuerKeySource(
+		workloadTestEndpoint(uuid.New()),
+		workloadTestIssuer("gh-actions", ""),
+	)
 
-			_, err := workloadIssuerKeySource(
-				workloadTestEndpoint(uuid.New()),
-				workloadTestIssuer("gh-actions", tt.jwksURI),
-			)
-
-			require.Error(t, err)
-			// The message has to name the issuer and point at discovery: this
-			// is our configuration gap, not the caller's assertion.
-			require.ErrorContains(t, err, "gh-actions")
-			require.ErrorContains(t, err, "re-run discovery")
-		})
-	}
+	require.Error(t, err)
+	require.ErrorContains(t, err, "gh-actions")
 }
 
 func TestWorkloadIssuerKeySource_RejectsUnusableJwksURI(t *testing.T) {
@@ -63,7 +49,7 @@ func TestWorkloadIssuerKeySource_RejectsUnusableJwksURI(t *testing.T) {
 
 	_, err := workloadIssuerKeySource(
 		workloadTestEndpoint(uuid.New()),
-		workloadTestIssuer("gh-actions", pgtype.Text{String: "http://example.test/keys", Valid: true}),
+		workloadTestIssuer("gh-actions", "http://example.test/keys"),
 	)
 
 	require.Error(t, err, "plain http must not become a key source")

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -59,12 +59,11 @@ type workloadIdentity struct {
 // workloadIdentityLookup reports whether an endpoint admits one workload
 // identity.
 //
-// Injected so admission can be exercised without a database, and so the
-// Nigel POC can wire a static policy eight weeks before any table exists. The
-// database-backed implementation lands with the trusted issuer configuration
-// milestone and swaps in here without changing a caller: its query is the same
-// triple against user_session_issuer_workload_identities, filtered to rows
-// that are enabled and not soft-deleted.
+// Injected so that admission can be exercised against a static policy with no
+// database behind it, and so a store can replace that policy without touching
+// a caller. A database-backed implementation is the same triple queried
+// against user_session_issuer_workload_identities, restricted to rows that are
+// enabled and not soft-deleted.
 //
 // Reporting false and reporting an error are different answers. False is a
 // decision — this endpoint does not admit this workload. An error is the
@@ -75,12 +74,11 @@ type workloadIdentityLookup func(ctx context.Context, identity workloadIdentity)
 // newStaticWorkloadIdentityLookup admits exactly the identities given and
 // nothing else.
 //
-// Calling it with no identities is the production wiring: an empty policy
-// admits nothing. That is the whole contract — there is no allow-all here, and
-// no configuration that produces one, because the grant this serves is
-// reachable without credentials and a policy that fails open on a
-// misconfiguration would admit every machine its issuers ever mint a token
-// for.
+// Calling it with no identities admits nothing, which is the safe default and
+// the whole contract: there is no allow-all here and no configuration that
+// produces one. The grant this serves is reachable without credentials, so a
+// policy that failed open on a misconfiguration would admit every machine its
+// issuers ever mint a token for.
 func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdentityLookup {
 	set := make(map[workloadIdentity]struct{}, len(admitted))
 	for _, identity := range admitted {
@@ -108,14 +106,6 @@ func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdent
 // unconfigured lookup, a subject the assertion never carried, and an issuer
 // that resolved to nothing are all non-admission rather than a reason to skip
 // the check.
-//
-// Nothing calls this yet, and that is the milestone's shape rather than an
-// omission: the token endpoint grant that verifies a workload assertion is
-// what creates a caller, and it does not exist. Its siblings on this path —
-// workloadIssuerKeySource and the workload expectation on clientauth.Verify —
-// shipped the same way, exercised by tests until the grant arrives to use
-// them. The order is deliberate, because the grant must not be the change that
-// also introduces the boundary it depends on.
 func admitWorkloadIdentity(
 	ctx context.Context,
 	lookup workloadIdentityLookup,

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -1,0 +1,154 @@
+// Admission for the workload assertion grant: deciding whether a verified
+// assertion's subject names a workload this endpoint admits. Runs after
+// workloadIssuerKeySource in authnchallenge_workloadauth.go has resolved the
+// keys an assertion verifies against, and after that verification succeeds.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// errWorkloadNotAdmitted reports a genuine assertion whose subject names no
+// workload identity this endpoint admits.
+//
+// Distinct from errWorkloadIssuerUntrusted, which rejects the issuer before
+// anything is verified. Reaching this error means the assertion is real and
+// its issuer is trusted — the remaining question is whether the machine it
+// vouches for is one of ours.
+var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by this endpoint")
+
+// workloadIdentity names one admitted workload: the exact triple the admission
+// index is keyed on, plus the organization the row belongs to.
+//
+// Every field is part of the key, and the struct is comparable so that
+// "exact match" is a property of the type rather than a convention a caller
+// has to keep. There is deliberately no pattern, prefix, or wildcard field:
+// these platforms put declared, bounded resources in sub — a service account,
+// a registered workload, a repository and environment pairing — and
+// wildcarding a CI subject is the misconfiguration that hands production
+// credentials to anyone able to push a branch. Widening this is an additive
+// match_kind column when a customer needs it, not a shape to leave open now.
+//
+// OrganizationID is part of the key even though the database's unique index is
+// the three columns after it. remote_session_issuers holds global-tier rows
+// with organization_id IS NULL that any organization may reference, so that
+// table's tenancy is application-enforced by design (AIM-143). Carrying the
+// organization here is that enforcement at this layer: a lookup cannot answer
+// for a tenancy it was not asked about.
+type workloadIdentity struct {
+	// OrganizationID owns the admission.
+	OrganizationID string
+	// UserSessionIssuerID is the Gram endpoint issuer this identity may
+	// obtain a session against.
+	UserSessionIssuerID uuid.UUID
+	// RemoteSessionIssuerID is the external issuer that vouches for it.
+	RemoteSessionIssuerID uuid.UUID
+	// ExternalSubject is the sub claim that issuer must assert. Named to stay
+	// distinct from urn.SessionSubject, which is the Gram-side identity
+	// derived from it rather than the value the platform put in the token.
+	ExternalSubject string
+}
+
+// workloadIdentityLookup reports whether an endpoint admits one workload
+// identity.
+//
+// Injected so admission can be exercised without a database, and so the
+// Nigel POC can wire a static policy eight weeks before any table exists. The
+// database-backed implementation lands with the trusted issuer configuration
+// milestone and swaps in here without changing a caller: its query is the same
+// triple against user_session_issuer_workload_identities, filtered to rows
+// that are enabled and not soft-deleted.
+//
+// Reporting false and reporting an error are different answers. False is a
+// decision — this endpoint does not admit this workload. An error is the
+// absence of one, and callers must never read it as a rejection, or a store
+// outage would start denying workloads that are in fact admitted.
+type workloadIdentityLookup func(ctx context.Context, identity workloadIdentity) (bool, error)
+
+// newStaticWorkloadIdentityLookup admits exactly the identities given and
+// nothing else.
+//
+// Calling it with no identities is the production wiring: an empty policy
+// admits nothing. That is the whole contract — there is no allow-all here, and
+// no configuration that produces one, because the grant this serves is
+// reachable without credentials and a policy that fails open on a
+// misconfiguration would admit every machine its issuers ever mint a token
+// for.
+func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdentityLookup {
+	set := make(map[workloadIdentity]struct{}, len(admitted))
+	for _, identity := range admitted {
+		set[identity] = struct{}{}
+	}
+
+	return func(_ context.Context, identity workloadIdentity) (bool, error) {
+		_, ok := set[identity]
+		return ok, nil
+	}
+}
+
+// admitWorkloadIdentity reports nil when endpoint admits externalSubject from
+// issuer, and errWorkloadNotAdmitted when it does not.
+//
+// This is the security boundary of the feature, and it is a separate question
+// from the one the signature answered. A CI provider's issuer mints valid,
+// correctly signed assertions for every job on its platform — every one of
+// that provider's own customers included. Trusting the issuer establishes that
+// an assertion is genuine; only naming the subject establishes that the
+// machine is ours. Without this step, trusting GitHub Actions would admit
+// anybody's GitHub Actions.
+//
+// Fails closed at every step that could otherwise be read as permission: an
+// unconfigured lookup, a subject the assertion never carried, and an issuer
+// that resolved to nothing are all non-admission rather than a reason to skip
+// the check.
+func admitWorkloadIdentity(
+	ctx context.Context,
+	lookup workloadIdentityLookup,
+	endpoint *ResolvedMcpEndpoint,
+	issuer *remotesessions_repo.RemoteSessionIssuer,
+	externalSubject string,
+) error {
+	switch {
+	case lookup == nil:
+		// Nothing is configured, so nothing is admitted. Deliberately not a
+		// programming error: an unwired policy is the production default until
+		// a store is configured, and the safe reading of "no policy" is "no
+		// admissions" rather than a panic that takes the endpoint down or a
+		// skip that lets everything through.
+		return errWorkloadNotAdmitted
+	case endpoint == nil || issuer == nil:
+		// The tenancy or the issuer the admission would be keyed on is
+		// missing, so no key can be built and no row could answer for it.
+		return errWorkloadNotAdmitted
+	case externalSubject == "":
+		// An assertion carrying no subject names no workload. Rejected here
+		// rather than looked up, so an empty string can never match a row that
+		// happens to hold one.
+		return errWorkloadNotAdmitted
+	}
+
+	admitted, err := lookup(ctx, workloadIdentity{
+		OrganizationID:        endpoint.OrganizationID,
+		UserSessionIssuerID:   endpoint.UserSessionIssuerID,
+		RemoteSessionIssuerID: issuer.ID,
+		ExternalSubject:       externalSubject,
+	})
+	if err != nil {
+		// Never reported as a rejection: the store failed to answer, which is
+		// not evidence that this workload is unadmitted. A caller mapping
+		// non-admission onto a 403 must not turn an outage into one.
+		return fmt.Errorf("resolve admitted workload identity: %w", err)
+	}
+	if !admitted {
+		return errWorkloadNotAdmitted
+	}
+
+	return nil
+}

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -108,6 +108,14 @@ func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdent
 // unconfigured lookup, a subject the assertion never carried, and an issuer
 // that resolved to nothing are all non-admission rather than a reason to skip
 // the check.
+//
+// Nothing calls this yet, and that is the milestone's shape rather than an
+// omission: the token endpoint grant that verifies a workload assertion is
+// what creates a caller, and it does not exist. Its siblings on this path —
+// workloadIssuerKeySource and the workload expectation on clientauth.Verify —
+// shipped the same way, exercised by tests until the grant arrives to use
+// them. The order is deliberate, because the grant must not be the change that
+// also introduces the boundary it depends on.
 func admitWorkloadIdentity(
 	ctx context.Context,
 	lookup workloadIdentityLookup,

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
 // errWorkloadNotAdmitted reports a genuine assertion whose subject names no
@@ -37,19 +35,22 @@ var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by th
 // match_kind column when a customer needs it, not a shape to leave open now.
 //
 // OrganizationID is part of the key even though the database's unique index is
-// the three columns after it. remote_session_issuers holds global-tier rows
-// with organization_id IS NULL that any organization may reference, so that
-// table's tenancy is application-enforced by design (AIM-143). Carrying the
-// organization here is that enforcement at this layer: a lookup cannot answer
-// for a tenancy it was not asked about.
+// the three columns after it, and even though workload issuers are themselves
+// tenant-scoped with no global tier. Carrying it here means a lookup cannot
+// answer for a tenancy it was not asked about, whatever the store behind it
+// enforces — the key names the whole question rather than trusting the caller
+// to have scoped it already.
 type workloadIdentity struct {
 	// OrganizationID owns the admission.
 	OrganizationID string
 	// UserSessionIssuerID is the Gram endpoint issuer this identity may
 	// obtain a session against.
 	UserSessionIssuerID uuid.UUID
-	// RemoteSessionIssuerID is the external issuer that vouches for it.
-	RemoteSessionIssuerID uuid.UUID
+	// WorkloadIssuerID is the external issuer that vouches for it, named by
+	// its workload issuer row rather than by URL: re-registering an issuer is
+	// deliberately a new identity, and a discovery refresh or an in-place URL
+	// edit must not silently repoint an existing admission.
+	WorkloadIssuerID uuid.UUID
 	// ExternalSubject is the sub claim that issuer must assert. Named to stay
 	// distinct from urn.SessionSubject, which is the Gram-side identity
 	// derived from it rather than the value the platform put in the token.
@@ -62,8 +63,8 @@ type workloadIdentity struct {
 // Injected so that admission can be exercised against a static policy with no
 // database behind it, and so a store can replace that policy without touching
 // a caller. A database-backed implementation is the same triple queried
-// against user_session_issuer_workload_identities, restricted to rows that are
-// enabled and not soft-deleted.
+// against the workload identity admission table, restricted to rows that are
+// not soft-deleted.
 //
 // Reporting false and reporting an error are different answers. False is a
 // decision — this endpoint does not admit this workload. An error is the
@@ -110,7 +111,7 @@ func admitWorkloadIdentity(
 	ctx context.Context,
 	lookup workloadIdentityLookup,
 	endpoint *ResolvedMcpEndpoint,
-	issuer *remotesessions_repo.RemoteSessionIssuer,
+	workloadIssuerID uuid.UUID,
 	externalSubject string,
 ) error {
 	switch {
@@ -121,7 +122,7 @@ func admitWorkloadIdentity(
 		// admissions" rather than a panic that takes the endpoint down or a
 		// skip that lets everything through.
 		return errWorkloadNotAdmitted
-	case endpoint == nil || issuer == nil:
+	case endpoint == nil || workloadIssuerID == uuid.Nil:
 		// The tenancy or the issuer the admission would be keyed on is
 		// missing, so no key can be built and no row could answer for it.
 		return errWorkloadNotAdmitted
@@ -133,10 +134,10 @@ func admitWorkloadIdentity(
 	}
 
 	admitted, err := lookup(ctx, workloadIdentity{
-		OrganizationID:        endpoint.OrganizationID,
-		UserSessionIssuerID:   endpoint.UserSessionIssuerID,
-		RemoteSessionIssuerID: issuer.ID,
-		ExternalSubject:       externalSubject,
+		OrganizationID:      endpoint.OrganizationID,
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		WorkloadIssuerID:    workloadIssuerID,
+		ExternalSubject:     externalSubject,
 	})
 	if err != nil {
 		// Never reported as a rejection: the store failed to answer, which is

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -40,7 +40,7 @@ type workloadIdentity struct {
 	// workloadidentity.ResolveIssuerParams.ProjectID, so the two reads on this
 	// path scope alike.
 	//
-	// Still deliberately no endpoint here. Which MCP server is asking must not
+	// Deliberately no endpoint here. Which MCP server is asking must not
 	// change the answer — what a recognised machine may then reach is an
 	// authorization question RBAC answers per toolset. A project is coarser
 	// than that and is a tier of the admission itself: workload_identity_

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -1,7 +1,7 @@
 // Admission for the workload assertion grant: deciding whether a verified
 // assertion's subject names a workload this endpoint admits. Runs after
 // workloadIssuerKeySource in authnchallenge_workloadauth.go has resolved the
-// keys an assertion verifies against, and after that verification succeeds.
+// keys, and after verification against them succeeds.
 
 package mcp
 
@@ -17,69 +17,52 @@ import (
 // workload identity this endpoint admits.
 //
 // Distinct from errWorkloadIssuerUntrusted, which rejects the issuer before
-// anything is verified. Reaching this error means the assertion is real and
-// its issuer is trusted — the remaining question is whether the machine it
-// vouches for is one of ours.
+// anything is verified. Reaching this one means the assertion is real and its
+// issuer is trusted; the remaining question is whether the machine is ours.
 var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by this endpoint")
 
-// workloadIdentity names one admitted workload: the exact triple the admission
-// index is keyed on, plus the organization the row belongs to.
+// workloadIdentity names one admitted workload. Every field is part of the
+// key, and the struct is comparable so exact match is a property of the type
+// rather than a convention each caller has to keep.
 //
-// Every field is part of the key, and the struct is comparable so that
-// "exact match" is a property of the type rather than a convention a caller
-// has to keep. There is deliberately no pattern, prefix, or wildcard field:
-// these platforms put declared, bounded resources in sub — a service account,
-// a registered workload, a repository and environment pairing — and
-// wildcarding a CI subject is the misconfiguration that hands production
-// credentials to anyone able to push a branch. Widening this is an additive
-// match_kind column when a customer needs it, not a shape to leave open now.
-//
-// OrganizationID is part of the key even though the database's unique index is
-// the three columns after it, and even though workload issuers are themselves
-// tenant-scoped with no global tier. Carrying it here means a lookup cannot
-// answer for a tenancy it was not asked about, whatever the store behind it
-// enforces — the key names the whole question rather than trusting the caller
-// to have scoped it already.
+// There is deliberately no pattern, prefix, or wildcard field: these platforms
+// put declared, bounded resources in sub — a service account, a repository and
+// environment pairing — and wildcarding a CI subject is the misconfiguration
+// that hands production credentials to anyone able to push a branch. Widening
+// this is an additive match_kind column if a customer ever needs it.
 type workloadIdentity struct {
-	// OrganizationID owns the admission.
+	// OrganizationID owns the admission. It is in the key so a lookup cannot
+	// answer for a tenancy it was not asked about, whatever the store behind
+	// it enforces.
 	OrganizationID string
 	// UserSessionIssuerID is the Gram endpoint issuer this identity may
 	// obtain a session against.
 	UserSessionIssuerID uuid.UUID
 	// WorkloadIssuerID is the external issuer that vouches for it, named by
-	// its workload issuer row rather than by URL: re-registering an issuer is
-	// deliberately a new identity, and a discovery refresh or an in-place URL
-	// edit must not silently repoint an existing admission.
+	// row rather than by URL so a discovery refresh or an in-place URL edit
+	// cannot silently repoint an existing admission.
 	WorkloadIssuerID uuid.UUID
 	// ExternalSubject is the sub claim that issuer must assert. Named to stay
-	// distinct from urn.SessionSubject, which is the Gram-side identity
-	// derived from it rather than the value the platform put in the token.
+	// distinct from urn.SessionSubject, the Gram-side identity derived from it.
 	ExternalSubject string
 }
 
 // workloadIdentityLookup reports whether an endpoint admits one workload
-// identity.
+// identity. Injected so admission can be exercised against a static policy
+// with no database behind it, and so a store can replace that policy without
+// touching a caller.
 //
-// Injected so that admission can be exercised against a static policy with no
-// database behind it, and so a store can replace that policy without touching
-// a caller. A database-backed implementation is the same triple queried
-// against the workload identity admission table, restricted to rows that are
-// not soft-deleted.
-//
-// Reporting false and reporting an error are different answers. False is a
-// decision — this endpoint does not admit this workload. An error is the
-// absence of one, and callers must never read it as a rejection, or a store
-// outage would start denying workloads that are in fact admitted.
+// False and an error are different answers. False is a decision. An error is
+// the absence of one, and callers must never read it as a rejection, or a
+// store outage would start denying workloads that are in fact admitted.
 type workloadIdentityLookup func(ctx context.Context, identity workloadIdentity) (bool, error)
 
-// newStaticWorkloadIdentityLookup admits exactly the identities given and
-// nothing else.
+// newStaticWorkloadIdentityLookup admits exactly the identities given.
 //
-// Calling it with no identities admits nothing, which is the safe default and
-// the whole contract: there is no allow-all here and no configuration that
-// produces one. The grant this serves is reachable without credentials, so a
-// policy that failed open on a misconfiguration would admit every machine its
-// issuers ever mint a token for.
+// With none, it admits nothing. There is no allow-all and no configuration
+// that produces one: the grant this serves is reachable without credentials,
+// so a policy that failed open would admit every machine its issuers ever mint
+// a token for.
 func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdentityLookup {
 	set := make(map[workloadIdentity]struct{}, len(admitted))
 	for _, identity := range admitted {
@@ -93,20 +76,15 @@ func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdent
 }
 
 // admitWorkloadIdentity reports nil when endpoint admits externalSubject from
-// issuer, and errWorkloadNotAdmitted when it does not.
+// the given workload issuer, and errWorkloadNotAdmitted when it does not.
 //
-// This is the security boundary of the feature, and it is a separate question
-// from the one the signature answered. A CI provider's issuer mints valid,
-// correctly signed assertions for every job on its platform — every one of
-// that provider's own customers included. Trusting the issuer establishes that
-// an assertion is genuine; only naming the subject establishes that the
-// machine is ours. Without this step, trusting GitHub Actions would admit
+// This is the security boundary of the feature, and a separate question from
+// the one the signature answered. A CI provider's issuer mints valid, signed
+// assertions for every job on its platform, that provider's other customers
+// included — so trusting GitHub Actions without naming the subject would admit
 // anybody's GitHub Actions.
 //
-// Fails closed at every step that could otherwise be read as permission: an
-// unconfigured lookup, a subject the assertion never carried, and an issuer
-// that resolved to nothing are all non-admission rather than a reason to skip
-// the check.
+// Every case that could otherwise be read as permission fails closed.
 func admitWorkloadIdentity(
 	ctx context.Context,
 	lookup workloadIdentityLookup,
@@ -116,20 +94,16 @@ func admitWorkloadIdentity(
 ) error {
 	switch {
 	case lookup == nil:
-		// Nothing is configured, so nothing is admitted. Deliberately not a
-		// programming error: an unwired policy is the production default until
-		// a store is configured, and the safe reading of "no policy" is "no
-		// admissions" rather than a panic that takes the endpoint down or a
-		// skip that lets everything through.
+		// An unwired policy is the production default until a store is
+		// configured, and "no policy" reads as "no admissions" rather than a
+		// panic or a skip.
 		return errWorkloadNotAdmitted
 	case endpoint == nil || workloadIssuerID == uuid.Nil:
-		// The tenancy or the issuer the admission would be keyed on is
-		// missing, so no key can be built and no row could answer for it.
+		// No key can be built, so no row could answer for it.
 		return errWorkloadNotAdmitted
 	case externalSubject == "":
-		// An assertion carrying no subject names no workload. Rejected here
-		// rather than looked up, so an empty string can never match a row that
-		// happens to hold one.
+		// Rejected rather than looked up, so an empty string can never match a
+		// row that happens to hold one.
 		return errWorkloadNotAdmitted
 	}
 
@@ -140,9 +114,9 @@ func admitWorkloadIdentity(
 		ExternalSubject:     externalSubject,
 	})
 	if err != nil {
-		// Never reported as a rejection: the store failed to answer, which is
-		// not evidence that this workload is unadmitted. A caller mapping
-		// non-admission onto a 403 must not turn an outage into one.
+		// Never a rejection: the store failed to answer, which is not evidence
+		// that this workload is unadmitted. A caller mapping non-admission
+		// onto a 403 must not turn an outage into one.
 		return fmt.Errorf("resolve admitted workload identity: %w", err)
 	}
 	if !admitted {

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -50,7 +50,7 @@ type workloadIdentity struct {
 	ExternalSubject string
 }
 
-// workloadIdentityLookup reports whether an endpoint admits one workload
+// workloadIdentityLookup reports whether an organization admits one workload
 // identity. Injected so admission can be exercised against a static policy
 // with no database behind it, and so a store can replace that policy without
 // touching a caller.

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -1,7 +1,5 @@
-// Admission for the workload assertion grant: deciding whether a verified
-// assertion's subject names a workload this organization recognises. Runs after
-// workloadIssuerKeySource in authnchallenge_workloadauth.go has resolved the
-// keys, and after verification against them succeeds.
+// Admission for the workload assertion grant: whether a verified assertion's
+// subject names a workload this tenant recognises. Runs after verification.
 
 package mcp
 
@@ -13,59 +11,40 @@ import (
 	"github.com/google/uuid"
 )
 
-// errWorkloadNotAdmitted reports a genuine assertion whose subject names no
-// workload identity this organization has admitted.
-//
-// Distinct from errWorkloadIssuerUntrusted, which rejects the issuer before
-// anything is verified. Reaching this one means the assertion is real and its
-// issuer is trusted; the remaining question is whether the machine is ours.
+// errWorkloadNotAdmitted reports a genuine assertion from a trusted issuer
+// whose subject nobody admitted. Distinct from errWorkloadIssuerUntrusted,
+// which rejects the issuer before anything is verified.
 var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by this organization")
 
-// workloadIdentity names one admitted workload. Every field is part of the
-// key, and the struct is comparable so exact match is a property of the type
-// rather than a convention each caller has to keep.
+// workloadIdentity is one admission query. Every field is part of the key.
 //
-// There is deliberately no pattern, prefix, or wildcard field: these platforms
-// put declared, bounded resources in sub — a service account, a repository and
-// environment pairing — and wildcarding a CI subject is the misconfiguration
-// that hands production credentials to anyone able to push a branch. Widening
-// this is an additive match_kind column if a customer ever needs it.
+// No pattern, prefix or wildcard field: wildcarding a CI subject is the
+// misconfiguration that hands production credentials to anyone able to push a
+// branch. Widening it later is an additive match_kind column.
 type workloadIdentity struct {
-	// OrganizationID scopes every admission that could answer. No arm reads
-	// outside it.
+	// OrganizationID scopes every admission that could answer.
 	OrganizationID string
-	// ProjectID selects the project tier when set. Unset is an
-	// organization-scoped caller, which sees only organization-tier
-	// admissions. Same shape and same meaning as
-	// workloadidentity.ResolveIssuerParams.ProjectID, so the two reads on this
+	// ProjectID is the project asking. Unset is an organization-scoped caller,
+	// which sees only organization-tier admissions. Matches
+	// workloadidentity.ResolveIssuerParams.ProjectID so both reads on this
 	// path scope alike.
 	//
-	// Deliberately no endpoint here. Which MCP server is asking must not
-	// change the answer — what a recognised machine may then reach is an
-	// authorization question RBAC answers per toolset. A project is coarser
-	// than that and is a tier of the admission itself: workload_identity_
-	// admissions rows sit either in one project or at the organization above
-	// them, so a team can recognise its own workload without an organization
-	// administrator admitting it for them.
+	// No endpoint: which MCP server is asking must not change the answer. What
+	// a recognised machine may then reach is RBAC's question, per toolset.
 	ProjectID uuid.NullUUID
-	// WorkloadIssuerID is the external issuer that vouches for it, named by
-	// row rather than by URL so a discovery refresh or an in-place URL edit
-	// cannot silently repoint an existing admission.
+	// WorkloadIssuerID names the issuer by row rather than by URL, so a
+	// discovery refresh cannot silently repoint an existing admission.
 	WorkloadIssuerID uuid.UUID
-	// ExternalSubject is the sub claim that issuer must assert. Named to stay
-	// distinct from urn.SessionSubject, the Gram-side identity derived from it.
+	// ExternalSubject is the sub claim the issuer asserted. Named to stay
+	// distinct from urn.SessionSubject, the Gram identity derived from it.
 	ExternalSubject string
 }
 
-// workloadAdmission is one stored admission: what a policy holds, as opposed
-// to workloadIdentity, which is what a caller asks about.
-//
-// They are separate types because the project field does not mean the same
-// thing on each. On a query it is the project asking and is always set; on a
-// row it is the tier, and an unset one is the organization tier that every
-// project in that organization sees. Collapsing them into one struct would
-// make an org-tier row indistinguishable from a query with no project, which
-// is the confusion that lets a project-tier admission leak organization-wide.
+// workloadAdmission is one stored admission, kept separate from
+// workloadIdentity because the project field differs: on a query it is the
+// project asking, on a row it is the tier. One struct for both would make an
+// organization-tier row indistinguishable from a query naming no project,
+// which is what lets a project's admission leak organization-wide.
 type workloadAdmission struct {
 	OrganizationID string
 	// ProjectID unset is the organization tier. Set is that project alone.
@@ -74,18 +53,12 @@ type workloadAdmission struct {
 	ExternalSubject  string
 }
 
-// admits reports whether this row answers a query, matching the tiers the way
-// the table's indexes do: every other component by exact equality, and the
-// project by tier, so an organization-tier row answers any project in its
-// organization and a project-tier row answers only its own.
+// admits matches every component by equality and the project by tier: an
+// unset row is the organization tier and answers everyone, an unset query is
+// an organization-scoped caller a project-tier row must not answer.
 //
-// Both sides are nullable and the nulls mean different things, which is the
-// whole reason the two types are separate. An unset row is the organization
-// tier and answers everyone; an unset query is an organization-scoped caller,
-// which a project-tier row must not answer. SQL gets this for free — the
-// project arm of `project_id = @project_id OR project_id IS NULL` is simply
-// not true when the parameter is NULL — and this mirrors it rather than
-// inventing a second rule.
+// Mirrors what `project_id = @project_id OR project_id IS NULL` does in SQL,
+// where the project arm is not true for a NULL parameter.
 func (a workloadAdmission) admits(identity workloadIdentity) bool {
 	if a.OrganizationID != identity.OrganizationID ||
 		a.WorkloadIssuerID != identity.WorkloadIssuerID ||
@@ -99,22 +72,17 @@ func (a workloadAdmission) admits(identity workloadIdentity) bool {
 	return identity.ProjectID.Valid && a.ProjectID.UUID == identity.ProjectID.UUID
 }
 
-// workloadIdentityLookup reports whether an organization admits one workload
-// identity. Injected so admission can be exercised against a static policy
-// with no database behind it, and so a store can replace that policy without
-// touching a caller.
+// workloadIdentityLookup reports whether a tenant admits one workload.
+// Injected so admission is testable without a database.
 //
-// False and an error are different answers. False is a decision. An error is
-// the absence of one, and callers must never read it as a rejection, or a
-// store outage would start denying workloads that are in fact admitted.
+// False and an error are different answers: false is a decision, an error is
+// the absence of one. Reading an error as a rejection would turn a store
+// outage into denials for workloads that are in fact admitted.
 type workloadIdentityLookup func(ctx context.Context, identity workloadIdentity) (bool, error)
 
-// newStaticWorkloadIdentityLookup admits exactly the identities given.
-//
-// With none, it admits nothing. There is no allow-all and no configuration
-// that produces one: the grant this serves is reachable without credentials,
-// so a policy that failed open would admit every machine its issuers ever mint
-// a token for.
+// newStaticWorkloadIdentityLookup admits exactly the rows given, and with none
+// admits nothing. There is no allow-all: this grant is reachable without
+// credentials, so failing open would admit every machine its issuers serve.
 func newStaticWorkloadIdentityLookup(admitted ...workloadAdmission) workloadIdentityLookup {
 	rows := make([]workloadAdmission, len(admitted))
 	copy(rows, admitted)
@@ -130,17 +98,13 @@ func newStaticWorkloadIdentityLookup(admitted ...workloadAdmission) workloadIden
 	}
 }
 
-// admitWorkloadIdentity reports nil when the endpoint's organization admits
-// externalSubject from the given workload issuer, and errWorkloadNotAdmitted
-// when it does not.
+// admitWorkloadIdentity reports nil when the endpoint's tenant admits
+// externalSubject from this issuer, errWorkloadNotAdmitted when it does not.
 //
-// This is the security boundary of the feature, and a separate question from
-// the one the signature answered. A CI provider's issuer mints valid, signed
-// assertions for every job on its platform, that provider's other customers
-// included — so trusting GitHub Actions without naming the subject would admit
-// anybody's GitHub Actions.
-//
-// Every case that could otherwise be read as permission fails closed.
+// The security boundary, and a different question from the one the signature
+// answered: a CI provider signs valid assertions for every job on its
+// platform, so trusting the issuer without naming the subject would admit
+// anybody's. Every ambiguous case fails closed.
 func admitWorkloadIdentity(
 	ctx context.Context,
 	lookup workloadIdentityLookup,
@@ -149,34 +113,25 @@ func admitWorkloadIdentity(
 	externalSubject string,
 ) error {
 	switch {
-	case lookup == nil:
-		// An unwired policy is the production default until a store is
-		// configured, and "no policy" reads as "no admissions" rather than a
-		// panic or a skip.
-		return errWorkloadNotAdmitted
-	case endpoint == nil || workloadIssuerID == uuid.Nil:
-		// No key can be built, so no row could answer for it.
-		return errWorkloadNotAdmitted
-	case externalSubject == "":
-		// Rejected rather than looked up, so an empty string can never match a
-		// row that happens to hold one.
+	// An unwired policy reads as "no admissions", an unbuildable key as "no
+	// row could answer", and an empty subject is refused rather than looked up
+	// so it can never match a row holding one.
+	case lookup == nil, endpoint == nil, workloadIssuerID == uuid.Nil, externalSubject == "":
 		return errWorkloadNotAdmitted
 	}
 
 	admitted, err := lookup(ctx, workloadIdentity{
 		OrganizationID: endpoint.OrganizationID,
-		// A zero project is an endpoint that names none, which asks as an
-		// organization-scoped caller rather than as project uuid.Nil — no row
-		// carries that id, but a sentinel comparing equal by accident is not a
-		// property worth relying on at a security boundary.
+		// A zero project asks as an organization-scoped caller rather than as
+		// project uuid.Nil: a sentinel comparing equal by accident is not a
+		// property to rely on at a security boundary.
 		ProjectID:        uuid.NullUUID{UUID: endpoint.ProjectID, Valid: endpoint.ProjectID != uuid.Nil},
 		WorkloadIssuerID: workloadIssuerID,
 		ExternalSubject:  externalSubject,
 	})
 	if err != nil {
-		// Never a rejection: the store failed to answer, which is not evidence
-		// that this workload is unadmitted. A caller mapping non-admission
-		// onto a 403 must not turn an outage into one.
+		// Never a rejection: a caller mapping non-admission onto a 403 must
+		// not turn a store outage into one.
 		return fmt.Errorf("resolve admitted workload identity: %w", err)
 	}
 	if !admitted {

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -34,8 +34,11 @@ type workloadIdentity struct {
 	// OrganizationID scopes every admission that could answer. No arm reads
 	// outside it.
 	OrganizationID string
-	// ProjectID is the project asking, which is always known: an MCP endpoint
-	// lives in exactly one project.
+	// ProjectID selects the project tier when set. Unset is an
+	// organization-scoped caller, which sees only organization-tier
+	// admissions. Same shape and same meaning as
+	// workloadidentity.ResolveIssuerParams.ProjectID, so the two reads on this
+	// path scope alike.
 	//
 	// Still deliberately no endpoint here. Which MCP server is asking must not
 	// change the answer — what a recognised machine may then reach is an
@@ -44,7 +47,7 @@ type workloadIdentity struct {
 	// admissions rows sit either in one project or at the organization above
 	// them, so a team can recognise its own workload without an organization
 	// administrator admitting it for them.
-	ProjectID uuid.UUID
+	ProjectID uuid.NullUUID
 	// WorkloadIssuerID is the external issuer that vouches for it, named by
 	// row rather than by URL so a discovery refresh or an in-place URL edit
 	// cannot silently repoint an existing admission.
@@ -75,6 +78,14 @@ type workloadAdmission struct {
 // the table's indexes do: every other component by exact equality, and the
 // project by tier, so an organization-tier row answers any project in its
 // organization and a project-tier row answers only its own.
+//
+// Both sides are nullable and the nulls mean different things, which is the
+// whole reason the two types are separate. An unset row is the organization
+// tier and answers everyone; an unset query is an organization-scoped caller,
+// which a project-tier row must not answer. SQL gets this for free — the
+// project arm of `project_id = @project_id OR project_id IS NULL` is simply
+// not true when the parameter is NULL — and this mirrors it rather than
+// inventing a second rule.
 func (a workloadAdmission) admits(identity workloadIdentity) bool {
 	if a.OrganizationID != identity.OrganizationID ||
 		a.WorkloadIssuerID != identity.WorkloadIssuerID ||
@@ -85,7 +96,7 @@ func (a workloadAdmission) admits(identity workloadIdentity) bool {
 		return true
 	}
 
-	return a.ProjectID.UUID == identity.ProjectID
+	return identity.ProjectID.Valid && a.ProjectID.UUID == identity.ProjectID.UUID
 }
 
 // workloadIdentityLookup reports whether an organization admits one workload
@@ -153,8 +164,12 @@ func admitWorkloadIdentity(
 	}
 
 	admitted, err := lookup(ctx, workloadIdentity{
-		OrganizationID:   endpoint.OrganizationID,
-		ProjectID:        endpoint.ProjectID,
+		OrganizationID: endpoint.OrganizationID,
+		// A zero project is an endpoint that names none, which asks as an
+		// organization-scoped caller rather than as project uuid.Nil — no row
+		// carries that id, but a sentinel comparing equal by accident is not a
+		// property worth relying on at a security boundary.
+		ProjectID:        uuid.NullUUID{UUID: endpoint.ProjectID, Valid: endpoint.ProjectID != uuid.Nil},
 		WorkloadIssuerID: workloadIssuerID,
 		ExternalSubject:  externalSubject,
 	})

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -31,16 +31,20 @@ var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by th
 // that hands production credentials to anyone able to push a branch. Widening
 // this is an additive match_kind column if a customer ever needs it.
 type workloadIdentity struct {
-	// OrganizationID owns the admission, and is the whole of its tenancy.
-	//
-	// Deliberately no endpoint here. This answers "is this machine one of
-	// ours", which does not change depending on which MCP server is asking;
-	// what a recognised machine may reach is an authorization question that
-	// RBAC answers per toolset. Keying an endpoint in as well would ask the
-	// same question twice at two granularities, and leave this key disagreeing
-	// with the workload principal it produces, which is organization-scoped on
-	// exactly (issuer, subject).
+	// OrganizationID scopes every admission that could answer. No arm reads
+	// outside it.
 	OrganizationID string
+	// ProjectID is the project asking, which is always known: an MCP endpoint
+	// lives in exactly one project.
+	//
+	// Still deliberately no endpoint here. Which MCP server is asking must not
+	// change the answer — what a recognised machine may then reach is an
+	// authorization question RBAC answers per toolset. A project is coarser
+	// than that and is a tier of the admission itself: workload_identity_
+	// admissions rows sit either in one project or at the organization above
+	// them, so a team can recognise its own workload without an organization
+	// administrator admitting it for them.
+	ProjectID uuid.UUID
 	// WorkloadIssuerID is the external issuer that vouches for it, named by
 	// row rather than by URL so a discovery refresh or an in-place URL edit
 	// cannot silently repoint an existing admission.
@@ -48,6 +52,40 @@ type workloadIdentity struct {
 	// ExternalSubject is the sub claim that issuer must assert. Named to stay
 	// distinct from urn.SessionSubject, the Gram-side identity derived from it.
 	ExternalSubject string
+}
+
+// workloadAdmission is one stored admission: what a policy holds, as opposed
+// to workloadIdentity, which is what a caller asks about.
+//
+// They are separate types because the project field does not mean the same
+// thing on each. On a query it is the project asking and is always set; on a
+// row it is the tier, and an unset one is the organization tier that every
+// project in that organization sees. Collapsing them into one struct would
+// make an org-tier row indistinguishable from a query with no project, which
+// is the confusion that lets a project-tier admission leak organization-wide.
+type workloadAdmission struct {
+	OrganizationID string
+	// ProjectID unset is the organization tier. Set is that project alone.
+	ProjectID        uuid.NullUUID
+	WorkloadIssuerID uuid.UUID
+	ExternalSubject  string
+}
+
+// admits reports whether this row answers a query, matching the tiers the way
+// the table's indexes do: every other component by exact equality, and the
+// project by tier, so an organization-tier row answers any project in its
+// organization and a project-tier row answers only its own.
+func (a workloadAdmission) admits(identity workloadIdentity) bool {
+	if a.OrganizationID != identity.OrganizationID ||
+		a.WorkloadIssuerID != identity.WorkloadIssuerID ||
+		a.ExternalSubject != identity.ExternalSubject {
+		return false
+	}
+	if !a.ProjectID.Valid {
+		return true
+	}
+
+	return a.ProjectID.UUID == identity.ProjectID
 }
 
 // workloadIdentityLookup reports whether an organization admits one workload
@@ -66,15 +104,18 @@ type workloadIdentityLookup func(ctx context.Context, identity workloadIdentity)
 // that produces one: the grant this serves is reachable without credentials,
 // so a policy that failed open would admit every machine its issuers ever mint
 // a token for.
-func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdentityLookup {
-	set := make(map[workloadIdentity]struct{}, len(admitted))
-	for _, identity := range admitted {
-		set[identity] = struct{}{}
-	}
+func newStaticWorkloadIdentityLookup(admitted ...workloadAdmission) workloadIdentityLookup {
+	rows := make([]workloadAdmission, len(admitted))
+	copy(rows, admitted)
 
 	return func(_ context.Context, identity workloadIdentity) (bool, error) {
-		_, ok := set[identity]
-		return ok, nil
+		for _, row := range rows {
+			if row.admits(identity) {
+				return true, nil
+			}
+		}
+
+		return false, nil
 	}
 }
 
@@ -113,6 +154,7 @@ func admitWorkloadIdentity(
 
 	admitted, err := lookup(ctx, workloadIdentity{
 		OrganizationID:   endpoint.OrganizationID,
+		ProjectID:        endpoint.ProjectID,
 		WorkloadIssuerID: workloadIssuerID,
 		ExternalSubject:  externalSubject,
 	})

--- a/server/internal/mcp/authnchallenge_workloadidentity.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity.go
@@ -1,5 +1,5 @@
 // Admission for the workload assertion grant: deciding whether a verified
-// assertion's subject names a workload this endpoint admits. Runs after
+// assertion's subject names a workload this organization recognises. Runs after
 // workloadIssuerKeySource in authnchallenge_workloadauth.go has resolved the
 // keys, and after verification against them succeeds.
 
@@ -14,12 +14,12 @@ import (
 )
 
 // errWorkloadNotAdmitted reports a genuine assertion whose subject names no
-// workload identity this endpoint admits.
+// workload identity this organization has admitted.
 //
 // Distinct from errWorkloadIssuerUntrusted, which rejects the issuer before
 // anything is verified. Reaching this one means the assertion is real and its
 // issuer is trusted; the remaining question is whether the machine is ours.
-var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by this endpoint")
+var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by this organization")
 
 // workloadIdentity names one admitted workload. Every field is part of the
 // key, and the struct is comparable so exact match is a property of the type
@@ -31,13 +31,16 @@ var errWorkloadNotAdmitted = errors.New("workload identity is not admitted by th
 // that hands production credentials to anyone able to push a branch. Widening
 // this is an additive match_kind column if a customer ever needs it.
 type workloadIdentity struct {
-	// OrganizationID owns the admission. It is in the key so a lookup cannot
-	// answer for a tenancy it was not asked about, whatever the store behind
-	// it enforces.
+	// OrganizationID owns the admission, and is the whole of its tenancy.
+	//
+	// Deliberately no endpoint here. This answers "is this machine one of
+	// ours", which does not change depending on which MCP server is asking;
+	// what a recognised machine may reach is an authorization question that
+	// RBAC answers per toolset. Keying an endpoint in as well would ask the
+	// same question twice at two granularities, and leave this key disagreeing
+	// with the workload principal it produces, which is organization-scoped on
+	// exactly (issuer, subject).
 	OrganizationID string
-	// UserSessionIssuerID is the Gram endpoint issuer this identity may
-	// obtain a session against.
-	UserSessionIssuerID uuid.UUID
 	// WorkloadIssuerID is the external issuer that vouches for it, named by
 	// row rather than by URL so a discovery refresh or an in-place URL edit
 	// cannot silently repoint an existing admission.
@@ -75,8 +78,9 @@ func newStaticWorkloadIdentityLookup(admitted ...workloadIdentity) workloadIdent
 	}
 }
 
-// admitWorkloadIdentity reports nil when endpoint admits externalSubject from
-// the given workload issuer, and errWorkloadNotAdmitted when it does not.
+// admitWorkloadIdentity reports nil when the endpoint's organization admits
+// externalSubject from the given workload issuer, and errWorkloadNotAdmitted
+// when it does not.
 //
 // This is the security boundary of the feature, and a separate question from
 // the one the signature answered. A CI provider's issuer mints valid, signed
@@ -108,10 +112,9 @@ func admitWorkloadIdentity(
 	}
 
 	admitted, err := lookup(ctx, workloadIdentity{
-		OrganizationID:      endpoint.OrganizationID,
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		WorkloadIssuerID:    workloadIssuerID,
-		ExternalSubject:     externalSubject,
+		OrganizationID:   endpoint.OrganizationID,
+		WorkloadIssuerID: workloadIssuerID,
+		ExternalSubject:  externalSubject,
 	})
 	if err != nil {
 		// Never a rejection: the store failed to answer, which is not evidence

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -1,0 +1,210 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// workloadIdentityFixture is one admitted workload and the endpoint and issuer
+// it was admitted against, so a test can vary exactly one part of the key.
+type workloadIdentityFixture struct {
+	endpoint *ResolvedMcpEndpoint
+	issuer   *remotesessions_repo.RemoteSessionIssuer
+	subject  string
+}
+
+func newWorkloadIdentityFixture() workloadIdentityFixture {
+	return workloadIdentityFixture{
+		endpoint: &ResolvedMcpEndpoint{
+			OrganizationID:      uuid.NewString(),
+			ProjectID:           uuid.New(),
+			UserSessionIssuerID: uuid.New(),
+		},
+		issuer:  &remotesessions_repo.RemoteSessionIssuer{ID: uuid.New(), Slug: "gh-actions"},
+		subject: "repo:acme/payments-api:ref:refs/heads/main",
+	}
+}
+
+// identity is the admission this fixture stands for.
+func (f workloadIdentityFixture) identity() workloadIdentity {
+	return workloadIdentity{
+		OrganizationID:        f.endpoint.OrganizationID,
+		UserSessionIssuerID:   f.endpoint.UserSessionIssuerID,
+		RemoteSessionIssuerID: f.issuer.ID,
+		ExternalSubject:       f.subject,
+	}
+}
+
+// admit runs the admission this fixture describes against lookup.
+func (f workloadIdentityFixture) admit(t *testing.T, lookup workloadIdentityLookup) error {
+	t.Helper()
+	return admitWorkloadIdentity(t.Context(), lookup, f.endpoint, f.issuer, f.subject)
+}
+
+// The ticket's central case: a static policy naming exactly one subject admits
+// that subject.
+func TestAdmitWorkloadIdentity_AdmittedSubjectPasses(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	lookup := newStaticWorkloadIdentityLookup(fixture.identity())
+
+	require.NoError(t, fixture.admit(t, lookup))
+}
+
+// The security boundary. A CI provider's issuer mints genuine assertions for
+// every job on its platform, so an assertion that verifies against a trusted
+// issuer must still be rejected when its subject names a workload nobody
+// admitted.
+func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	// Somebody else's job on the same trusted issuer.
+	lookup := newStaticWorkloadIdentityLookup(workloadIdentity{
+		OrganizationID:        fixture.endpoint.OrganizationID,
+		UserSessionIssuerID:   fixture.endpoint.UserSessionIssuerID,
+		RemoteSessionIssuerID: fixture.issuer.ID,
+		ExternalSubject:       "repo:someone-else/their-api:ref:refs/heads/main",
+	})
+
+	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
+}
+
+// An empty policy is the production wiring, so it has to admit nothing rather
+// than fall through to an allow-all.
+func TestAdmitWorkloadIdentity_EmptyPolicyAdmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+
+	require.ErrorIs(t, fixture.admit(t, newStaticWorkloadIdentityLookup()), errWorkloadNotAdmitted)
+}
+
+// An unwired policy is the state production is in until a store is configured.
+// It must read as "no admissions", never as "no check to run".
+func TestAdmitWorkloadIdentity_UnconfiguredLookupAdmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+
+	require.ErrorIs(t, fixture.admit(t, nil), errWorkloadNotAdmitted)
+}
+
+// Every part of the key is load-bearing: sub is unique within an issuer and
+// never across, one Gram issuer's admission must not answer for another's, and
+// remote_session_issuers tenancy is application-enforced because its
+// global-tier rows are shared. Varying one field at a time proves no part of
+// the triple is being ignored.
+func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	admitted := fixture.identity()
+
+	for name, mutate := range map[string]func(workloadIdentity) workloadIdentity{
+		"a different organization": func(i workloadIdentity) workloadIdentity {
+			i.OrganizationID = uuid.NewString()
+			return i
+		},
+		"a different endpoint issuer": func(i workloadIdentity) workloadIdentity {
+			i.UserSessionIssuerID = uuid.New()
+			return i
+		},
+		"a different external issuer": func(i workloadIdentity) workloadIdentity {
+			i.RemoteSessionIssuerID = uuid.New()
+			return i
+		},
+		"a different subject": func(i workloadIdentity) workloadIdentity {
+			i.ExternalSubject = "repo:acme/payments-api:ref:refs/heads/other"
+			return i
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// The policy admits the mutated identity; the request presents the
+			// original. Only an exact match on all four may pass.
+			lookup := newStaticWorkloadIdentityLookup(mutate(admitted))
+
+			require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted,
+				"%s must not be admitted by the original's entry", name)
+		})
+	}
+}
+
+// The same sub from two different issuers is two different workloads. Keying
+// on the subject alone would let one issuer's admission answer for the other,
+// which is the collision the identity is keyed on the pair to avoid.
+func TestAdmitWorkloadIdentity_OneSubjectFromTwoIssuersDoesNotShareAnAdmission(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	lookup := newStaticWorkloadIdentityLookup(fixture.identity())
+
+	// A second trusted issuer — one the organization runs itself, so it
+	// controls every claim in it — asserting a byte-identical subject.
+	staging := &remotesessions_repo.RemoteSessionIssuer{ID: uuid.New(), Slug: "staging-idp"}
+
+	err := admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, staging, fixture.subject)
+
+	require.ErrorIs(t, err, errWorkloadNotAdmitted, "an identical sub from another issuer is another workload")
+}
+
+// A subject the assertion never carried names no workload, and must not be
+// able to match a row holding an empty string.
+func TestAdmitWorkloadIdentity_EmptySubjectIsNeverAdmitted(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	empty := fixture.identity()
+	empty.ExternalSubject = ""
+
+	// Even with the empty subject explicitly in the policy.
+	lookup := newStaticWorkloadIdentityLookup(empty)
+
+	err := admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, fixture.issuer, "")
+
+	require.ErrorIs(t, err, errWorkloadNotAdmitted)
+}
+
+// A store that fails to answer has not decided anything. Reporting it as
+// non-admission would turn an outage into a rejection and deny workloads that
+// are in fact admitted.
+func TestAdmitWorkloadIdentity_LookupFailureIsNotARejection(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	outage := errors.New("connection refused")
+	lookup := func(context.Context, workloadIdentity) (bool, error) { return false, outage }
+
+	err := fixture.admit(t, lookup)
+
+	require.ErrorIs(t, err, outage)
+	require.NotErrorIs(t, err, errWorkloadNotAdmitted, "an outage is not an admission decision")
+}
+
+// A missing endpoint or issuer leaves the key unbuildable. It must fail closed
+// rather than reach the lookup with a zero-valued tenancy, which could match a
+// zero-valued entry.
+func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+
+	consulted := false
+	lookup := func(context.Context, workloadIdentity) (bool, error) {
+		consulted = true
+		return true, nil
+	}
+
+	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, nil, fixture.issuer, fixture.subject), errWorkloadNotAdmitted)
+	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, nil, fixture.subject), errWorkloadNotAdmitted)
+	require.False(t, consulted, "an unbuildable key must never reach the lookup")
+}

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -47,8 +47,7 @@ func (f workloadIdentityFixture) admit(t *testing.T, lookup workloadIdentityLook
 	return admitWorkloadIdentity(t.Context(), lookup, f.endpoint, f.issuer, f.subject)
 }
 
-// The ticket's central case: a static policy naming exactly one subject admits
-// that subject.
+// A static policy naming exactly one subject admits that subject.
 func TestAdmitWorkloadIdentity_AdmittedSubjectPasses(t *testing.T) {
 	t.Parallel()
 
@@ -77,8 +76,8 @@ func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing
 	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
 }
 
-// An empty policy is the production wiring, so it has to admit nothing rather
-// than fall through to an allow-all.
+// An empty policy has to admit nothing rather than fall through to an
+// allow-all.
 func TestAdmitWorkloadIdentity_EmptyPolicyAdmitsNothing(t *testing.T) {
 	t.Parallel()
 
@@ -87,8 +86,9 @@ func TestAdmitWorkloadIdentity_EmptyPolicyAdmitsNothing(t *testing.T) {
 	require.ErrorIs(t, fixture.admit(t, newStaticWorkloadIdentityLookup()), errWorkloadNotAdmitted)
 }
 
-// An unwired policy is the state production is in until a store is configured.
-// It must read as "no admissions", never as "no check to run".
+// An unwired policy must read as "no admissions", never as "no check to run":
+// a lookup nobody supplied is the absence of permission, not the absence of a
+// rule to apply.
 func TestAdmitWorkloadIdentity_UnconfiguredLookupAdmitsNothing(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -28,13 +28,33 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 	}
 }
 
-// identity is the admission this fixture stands for.
+// identity is the query this fixture's endpoint makes.
 func (f workloadIdentityFixture) identity() workloadIdentity {
 	return workloadIdentity{
 		OrganizationID:   f.endpoint.OrganizationID,
+		ProjectID:        f.endpoint.ProjectID,
 		WorkloadIssuerID: f.issuerID,
 		ExternalSubject:  f.subject,
 	}
+}
+
+// organizationTier is the stored admission this fixture stands for, held above
+// every project in the organization.
+func (f workloadIdentityFixture) organizationTier() workloadAdmission {
+	return workloadAdmission{
+		OrganizationID:   f.endpoint.OrganizationID,
+		ProjectID:        uuid.NullUUID{},
+		WorkloadIssuerID: f.issuerID,
+		ExternalSubject:  f.subject,
+	}
+}
+
+// projectTier is the same admission held by one project alone.
+func (f workloadIdentityFixture) projectTier(projectID uuid.UUID) workloadAdmission {
+	row := f.organizationTier()
+	row.ProjectID = uuid.NullUUID{UUID: projectID, Valid: true}
+
+	return row
 }
 
 // admit runs the admission this fixture describes against lookup.
@@ -48,7 +68,7 @@ func TestAdmitWorkloadIdentity_AdmittedSubjectPasses(t *testing.T) {
 	t.Parallel()
 
 	fixture := newWorkloadIdentityFixture()
-	lookup := newStaticWorkloadIdentityLookup(fixture.identity())
+	lookup := newStaticWorkloadIdentityLookup(fixture.organizationTier())
 
 	require.NoError(t, fixture.admit(t, lookup))
 }
@@ -61,7 +81,7 @@ func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing
 
 	fixture := newWorkloadIdentityFixture()
 	// Somebody else's job on the same trusted issuer.
-	lookup := newStaticWorkloadIdentityLookup(workloadIdentity{
+	lookup := newStaticWorkloadIdentityLookup(workloadAdmission{
 		OrganizationID:   fixture.endpoint.OrganizationID,
 		WorkloadIssuerID: fixture.issuerID,
 		ExternalSubject:  "repo:someone-else/their-api:ref:refs/heads/main",
@@ -96,20 +116,24 @@ func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 	t.Parallel()
 
 	fixture := newWorkloadIdentityFixture()
-	admitted := fixture.identity()
+	admitted := fixture.organizationTier()
 
-	for name, mutate := range map[string]func(workloadIdentity) workloadIdentity{
-		"a different organization": func(i workloadIdentity) workloadIdentity {
-			i.OrganizationID = uuid.NewString()
-			return i
+	for name, mutate := range map[string]func(workloadAdmission) workloadAdmission{
+		"a different organization": func(a workloadAdmission) workloadAdmission {
+			a.OrganizationID = uuid.NewString()
+			return a
 		},
-		"a different external issuer": func(i workloadIdentity) workloadIdentity {
-			i.WorkloadIssuerID = uuid.New()
-			return i
+		"a different external issuer": func(a workloadAdmission) workloadAdmission {
+			a.WorkloadIssuerID = uuid.New()
+			return a
 		},
-		"a different subject": func(i workloadIdentity) workloadIdentity {
-			i.ExternalSubject = "repo:acme/payments-api:ref:refs/heads/other"
-			return i
+		"a different subject": func(a workloadAdmission) workloadAdmission {
+			a.ExternalSubject = "repo:acme/payments-api:ref:refs/heads/other"
+			return a
+		},
+		"another project's admission": func(a workloadAdmission) workloadAdmission {
+			a.ProjectID = uuid.NullUUID{UUID: uuid.New(), Valid: true}
+			return a
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -132,7 +156,7 @@ func TestAdmitWorkloadIdentity_OneSubjectFromTwoIssuersDoesNotShareAnAdmission(t
 	t.Parallel()
 
 	fixture := newWorkloadIdentityFixture()
-	lookup := newStaticWorkloadIdentityLookup(fixture.identity())
+	lookup := newStaticWorkloadIdentityLookup(fixture.organizationTier())
 
 	// A second trusted issuer — one the organization runs itself, so it
 	// controls every claim in it — asserting a byte-identical subject.
@@ -149,7 +173,7 @@ func TestAdmitWorkloadIdentity_EmptySubjectIsNeverAdmitted(t *testing.T) {
 	t.Parallel()
 
 	fixture := newWorkloadIdentityFixture()
-	empty := fixture.identity()
+	empty := fixture.organizationTier()
 	empty.ExternalSubject = ""
 
 	// Even with the empty subject explicitly in the policy.
@@ -193,4 +217,44 @@ func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T)
 	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, nil, fixture.issuerID, fixture.subject), errWorkloadNotAdmitted)
 	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, uuid.Nil, fixture.subject), errWorkloadNotAdmitted)
 	require.False(t, consulted, "an unbuildable key must never reach the lookup")
+}
+
+// The organization tier is visible to every project beneath it, which is what
+// makes an administrator's admission worth making once.
+func TestAdmitWorkloadIdentity_OrganizationTierAdmitsAnyProjectInIt(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	lookup := newStaticWorkloadIdentityLookup(fixture.organizationTier())
+
+	// A second server in the same organization, in a different project.
+	elsewhere := &ResolvedMcpEndpoint{OrganizationID: fixture.endpoint.OrganizationID, ProjectID: uuid.New()}
+
+	require.NoError(t, admitWorkloadIdentity(t.Context(), lookup, elsewhere, fixture.issuerID, fixture.subject))
+}
+
+// A project-tier admission answers for its own project, which is the point of
+// the tier: a team recognises its own workload without an organization
+// administrator admitting it for them.
+func TestAdmitWorkloadIdentity_ProjectTierAdmitsItsOwnProject(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	lookup := newStaticWorkloadIdentityLookup(fixture.projectTier(fixture.endpoint.ProjectID))
+
+	require.NoError(t, fixture.admit(t, lookup))
+}
+
+// TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit is the
+// isolation the project tier exists for, and the one a lookup keyed on the
+// organization alone would silently lose: one team's decision to trust a
+// workload must not admit it across the whole organization.
+func TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	sibling := uuid.New()
+	lookup := newStaticWorkloadIdentityLookup(fixture.projectTier(sibling))
+
+	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
 }

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -7,15 +7,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
 // workloadIdentityFixture is one admitted workload and the endpoint and issuer
 // it was admitted against, so a test can vary exactly one part of the key.
 type workloadIdentityFixture struct {
 	endpoint *ResolvedMcpEndpoint
-	issuer   *remotesessions_repo.RemoteSessionIssuer
+	issuerID uuid.UUID
 	subject  string
 }
 
@@ -26,25 +24,25 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 			ProjectID:           uuid.New(),
 			UserSessionIssuerID: uuid.New(),
 		},
-		issuer:  &remotesessions_repo.RemoteSessionIssuer{ID: uuid.New(), Slug: "gh-actions"},
-		subject: "repo:acme/payments-api:ref:refs/heads/main",
+		issuerID: uuid.New(),
+		subject:  "repo:acme/payments-api:ref:refs/heads/main",
 	}
 }
 
 // identity is the admission this fixture stands for.
 func (f workloadIdentityFixture) identity() workloadIdentity {
 	return workloadIdentity{
-		OrganizationID:        f.endpoint.OrganizationID,
-		UserSessionIssuerID:   f.endpoint.UserSessionIssuerID,
-		RemoteSessionIssuerID: f.issuer.ID,
-		ExternalSubject:       f.subject,
+		OrganizationID:      f.endpoint.OrganizationID,
+		UserSessionIssuerID: f.endpoint.UserSessionIssuerID,
+		WorkloadIssuerID:    f.issuerID,
+		ExternalSubject:     f.subject,
 	}
 }
 
 // admit runs the admission this fixture describes against lookup.
 func (f workloadIdentityFixture) admit(t *testing.T, lookup workloadIdentityLookup) error {
 	t.Helper()
-	return admitWorkloadIdentity(t.Context(), lookup, f.endpoint, f.issuer, f.subject)
+	return admitWorkloadIdentity(t.Context(), lookup, f.endpoint, f.issuerID, f.subject)
 }
 
 // A static policy naming exactly one subject admits that subject.
@@ -67,10 +65,10 @@ func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing
 	fixture := newWorkloadIdentityFixture()
 	// Somebody else's job on the same trusted issuer.
 	lookup := newStaticWorkloadIdentityLookup(workloadIdentity{
-		OrganizationID:        fixture.endpoint.OrganizationID,
-		UserSessionIssuerID:   fixture.endpoint.UserSessionIssuerID,
-		RemoteSessionIssuerID: fixture.issuer.ID,
-		ExternalSubject:       "repo:someone-else/their-api:ref:refs/heads/main",
+		OrganizationID:      fixture.endpoint.OrganizationID,
+		UserSessionIssuerID: fixture.endpoint.UserSessionIssuerID,
+		WorkloadIssuerID:    fixture.issuerID,
+		ExternalSubject:     "repo:someone-else/their-api:ref:refs/heads/main",
 	})
 
 	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
@@ -118,7 +116,7 @@ func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 			return i
 		},
 		"a different external issuer": func(i workloadIdentity) workloadIdentity {
-			i.RemoteSessionIssuerID = uuid.New()
+			i.WorkloadIssuerID = uuid.New()
 			return i
 		},
 		"a different subject": func(i workloadIdentity) workloadIdentity {
@@ -150,7 +148,7 @@ func TestAdmitWorkloadIdentity_OneSubjectFromTwoIssuersDoesNotShareAnAdmission(t
 
 	// A second trusted issuer — one the organization runs itself, so it
 	// controls every claim in it — asserting a byte-identical subject.
-	staging := &remotesessions_repo.RemoteSessionIssuer{ID: uuid.New(), Slug: "staging-idp"}
+	staging := uuid.New()
 
 	err := admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, staging, fixture.subject)
 
@@ -169,7 +167,7 @@ func TestAdmitWorkloadIdentity_EmptySubjectIsNeverAdmitted(t *testing.T) {
 	// Even with the empty subject explicitly in the policy.
 	lookup := newStaticWorkloadIdentityLookup(empty)
 
-	err := admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, fixture.issuer, "")
+	err := admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, fixture.issuerID, "")
 
 	require.ErrorIs(t, err, errWorkloadNotAdmitted)
 }
@@ -204,7 +202,7 @@ func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T)
 		return true, nil
 	}
 
-	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, nil, fixture.issuer, fixture.subject), errWorkloadNotAdmitted)
-	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, nil, fixture.subject), errWorkloadNotAdmitted)
+	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, nil, fixture.issuerID, fixture.subject), errWorkloadNotAdmitted)
+	require.ErrorIs(t, admitWorkloadIdentity(t.Context(), lookup, fixture.endpoint, uuid.Nil, fixture.subject), errWorkloadNotAdmitted)
 	require.False(t, consulted, "an unbuildable key must never reach the lookup")
 }

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// workloadIdentityFixture is one admitted workload and the endpoint and issuer
-// it was admitted against, so a test can vary exactly one part of the key.
+// workloadIdentityFixture is one workload plus the endpoint and issuer it was
+// admitted against, so a test can vary exactly one part of the key.
 type workloadIdentityFixture struct {
 	endpoint *ResolvedMcpEndpoint
 	issuerID uuid.UUID
@@ -28,8 +28,7 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 	}
 }
 
-// organizationTier is the stored admission this fixture stands for, held above
-// every project in the organization.
+// organizationTier is this fixture's admission, held above every project.
 func (f workloadIdentityFixture) organizationTier() workloadAdmission {
 	return workloadAdmission{
 		OrganizationID:   f.endpoint.OrganizationID,
@@ -63,9 +62,8 @@ func TestAdmitWorkloadIdentity_AdmittedSubjectPasses(t *testing.T) {
 	require.NoError(t, fixture.admit(t, lookup))
 }
 
-// The security boundary. A CI provider's issuer mints genuine assertions for
-// every job on its platform, so verifying against a trusted issuer is not
-// enough: an unadmitted subject must still be rejected.
+// The security boundary: a trusted issuer signs every job on its platform, so
+// an unadmitted subject must still be rejected.
 func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing.T) {
 	t.Parallel()
 
@@ -99,9 +97,7 @@ func TestAdmitWorkloadIdentity_UnconfiguredLookupAdmitsNothing(t *testing.T) {
 	require.ErrorIs(t, fixture.admit(t, nil), errWorkloadNotAdmitted)
 }
 
-// Every part of the key is load-bearing: sub is unique within an issuer and
-// never across, and one Gram issuer's admission must not answer for another's.
-// Varying one field at a time proves no part is being ignored.
+// Varying one field at a time proves no part of the key is ignored.
 func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 	t.Parallel()
 
@@ -139,9 +135,7 @@ func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 	}
 }
 
-// The same sub from two different issuers is two different workloads. Keying
-// on the subject alone would let one issuer's admission answer for the other,
-// which is the collision the identity is keyed on the pair to avoid.
+// The same sub from two issuers is two workloads.
 func TestAdmitWorkloadIdentity_OneSubjectFromTwoIssuersDoesNotShareAnAdmission(t *testing.T) {
 	t.Parallel()
 
@@ -157,8 +151,7 @@ func TestAdmitWorkloadIdentity_OneSubjectFromTwoIssuersDoesNotShareAnAdmission(t
 	require.ErrorIs(t, err, errWorkloadNotAdmitted, "an identical sub from another issuer is another workload")
 }
 
-// A subject the assertion never carried names no workload, and must not be
-// able to match a row holding an empty string.
+// An empty subject must not match a row holding one.
 func TestAdmitWorkloadIdentity_EmptySubjectIsNeverAdmitted(t *testing.T) {
 	t.Parallel()
 
@@ -174,9 +167,8 @@ func TestAdmitWorkloadIdentity_EmptySubjectIsNeverAdmitted(t *testing.T) {
 	require.ErrorIs(t, err, errWorkloadNotAdmitted)
 }
 
-// A store that fails to answer has not decided anything. Reporting it as
-// non-admission would turn an outage into a rejection and deny workloads that
-// are in fact admitted.
+// A store that fails to answer has decided nothing; an outage is not a
+// rejection.
 func TestAdmitWorkloadIdentity_LookupFailureIsNotARejection(t *testing.T) {
 	t.Parallel()
 
@@ -190,9 +182,8 @@ func TestAdmitWorkloadIdentity_LookupFailureIsNotARejection(t *testing.T) {
 	require.NotErrorIs(t, err, errWorkloadNotAdmitted, "an outage is not an admission decision")
 }
 
-// A missing endpoint or issuer leaves the key unbuildable. It fails closed
-// rather than reaching the lookup with a zero-valued tenancy, which could
-// match a zero-valued entry.
+// An unbuildable key fails closed rather than reaching the lookup with a
+// zero-valued tenancy.
 func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T) {
 	t.Parallel()
 
@@ -209,8 +200,7 @@ func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T)
 	require.False(t, consulted, "an unbuildable key must never reach the lookup")
 }
 
-// The organization tier is visible to every project beneath it, which is what
-// makes an administrator's admission worth making once.
+// The organization tier is visible to every project beneath it.
 func TestAdmitWorkloadIdentity_OrganizationTierAdmitsAnyProjectInIt(t *testing.T) {
 	t.Parallel()
 
@@ -223,9 +213,7 @@ func TestAdmitWorkloadIdentity_OrganizationTierAdmitsAnyProjectInIt(t *testing.T
 	require.NoError(t, admitWorkloadIdentity(t.Context(), lookup, elsewhere, fixture.issuerID, fixture.subject))
 }
 
-// A project-tier admission answers for its own project, which is the point of
-// the tier: a team recognises its own workload without an organization
-// administrator admitting it for them.
+// A project admits its own workload without an organization administrator.
 func TestAdmitWorkloadIdentity_ProjectTierAdmitsItsOwnProject(t *testing.T) {
 	t.Parallel()
 
@@ -235,10 +223,8 @@ func TestAdmitWorkloadIdentity_ProjectTierAdmitsItsOwnProject(t *testing.T) {
 	require.NoError(t, fixture.admit(t, lookup))
 }
 
-// TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit is the
-// isolation the project tier exists for, and the one a lookup keyed on the
-// organization alone would silently lose: one team's decision to trust a
-// workload must not admit it across the whole organization.
+// The isolation the tier exists for, and the one a lookup keyed on the
+// organization alone silently loses.
 func TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit(t *testing.T) {
 	t.Parallel()
 
@@ -249,10 +235,8 @@ func TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit(t *testing.
 	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
 }
 
-// An organization-scoped caller names no project, and a project-tier admission
-// must not answer it. The nulls on the two sides are not the same null: an
-// unset row is the organization tier and answers everyone, an unset query is a
-// caller with no project and may only be answered by that tier.
+// The two nulls differ: an unset row answers everyone, an unset query is a
+// caller with no project that only the organization tier may answer.
 func TestAdmitWorkloadIdentity_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *testing.T) {
 	t.Parallel()
 
@@ -271,12 +255,9 @@ func TestAdmitWorkloadIdentity_AnOrganizationScopedCallerSeesOnlyTheOrganization
 		admitWorkloadIdentity(t.Context(), organizationTier, organizationScoped, fixture.issuerID, fixture.subject))
 }
 
-// A row claiming the project tier while carrying the zero uuid must not answer
-// an organization-scoped caller, whose unset project also reads as zero. No
-// such row can come from the table — a project id is generated, never zero —
-// so this pins the guard rather than a reachable state: at a security
-// boundary, two different meanings must not compare equal just because their
-// zero values do.
+// Pins the guard, not a reachable state: no table row carries a zero project
+// id, but two different meanings must not compare equal at a security boundary
+// just because their zero values do.
 func TestAdmitWorkloadIdentity_AZeroProjectTierRowAnswersNobody(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -32,7 +32,7 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 func (f workloadIdentityFixture) identity() workloadIdentity {
 	return workloadIdentity{
 		OrganizationID:   f.endpoint.OrganizationID,
-		ProjectID:        f.endpoint.ProjectID,
+		ProjectID:        uuid.NullUUID{UUID: f.endpoint.ProjectID, Valid: true},
 		WorkloadIssuerID: f.issuerID,
 		ExternalSubject:  f.subject,
 	}
@@ -257,4 +257,47 @@ func TestAdmitWorkloadIdentity_ASiblingProjectsAdmissionDoesNotAdmit(t *testing.
 	lookup := newStaticWorkloadIdentityLookup(fixture.projectTier(sibling))
 
 	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
+}
+
+// An organization-scoped caller names no project, and a project-tier admission
+// must not answer it. The nulls on the two sides are not the same null: an
+// unset row is the organization tier and answers everyone, an unset query is a
+// caller with no project and may only be answered by that tier.
+func TestAdmitWorkloadIdentity_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	// An endpoint naming no project asks as the organization.
+	organizationScoped := &ResolvedMcpEndpoint{OrganizationID: fixture.endpoint.OrganizationID}
+
+	projectTier := newStaticWorkloadIdentityLookup(fixture.projectTier(fixture.endpoint.ProjectID))
+	require.ErrorIs(t,
+		admitWorkloadIdentity(t.Context(), projectTier, organizationScoped, fixture.issuerID, fixture.subject),
+		errWorkloadNotAdmitted,
+		"a project's admission must not answer a caller that named no project")
+
+	organizationTier := newStaticWorkloadIdentityLookup(fixture.organizationTier())
+	require.NoError(t,
+		admitWorkloadIdentity(t.Context(), organizationTier, organizationScoped, fixture.issuerID, fixture.subject))
+}
+
+// A row claiming the project tier while carrying the zero uuid must not answer
+// an organization-scoped caller, whose unset project also reads as zero. No
+// such row can come from the table — a project id is generated, never zero —
+// so this pins the guard rather than a reachable state: at a security
+// boundary, two different meanings must not compare equal just because their
+// zero values do.
+func TestAdmitWorkloadIdentity_AZeroProjectTierRowAnswersNobody(t *testing.T) {
+	t.Parallel()
+
+	fixture := newWorkloadIdentityFixture()
+	malformed := fixture.organizationTier()
+	malformed.ProjectID = uuid.NullUUID{UUID: uuid.Nil, Valid: true}
+	lookup := newStaticWorkloadIdentityLookup(malformed)
+
+	organizationScoped := &ResolvedMcpEndpoint{OrganizationID: fixture.endpoint.OrganizationID}
+
+	require.ErrorIs(t,
+		admitWorkloadIdentity(t.Context(), lookup, organizationScoped, fixture.issuerID, fixture.subject),
+		errWorkloadNotAdmitted)
 }

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -28,16 +28,6 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 	}
 }
 
-// identity is the query this fixture's endpoint makes.
-func (f workloadIdentityFixture) identity() workloadIdentity {
-	return workloadIdentity{
-		OrganizationID:   f.endpoint.OrganizationID,
-		ProjectID:        uuid.NullUUID{UUID: f.endpoint.ProjectID, Valid: true},
-		WorkloadIssuerID: f.issuerID,
-		ExternalSubject:  f.subject,
-	}
-}
-
 // organizationTier is the stored admission this fixture stands for, held above
 // every project in the organization.
 func (f workloadIdentityFixture) organizationTier() workloadAdmission {

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -56,9 +56,8 @@ func TestAdmitWorkloadIdentity_AdmittedSubjectPasses(t *testing.T) {
 }
 
 // The security boundary. A CI provider's issuer mints genuine assertions for
-// every job on its platform, so an assertion that verifies against a trusted
-// issuer must still be rejected when its subject names a workload nobody
-// admitted.
+// every job on its platform, so verifying against a trusted issuer is not
+// enough: an unadmitted subject must still be rejected.
 func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing.T) {
 	t.Parallel()
 
@@ -84,9 +83,7 @@ func TestAdmitWorkloadIdentity_EmptyPolicyAdmitsNothing(t *testing.T) {
 	require.ErrorIs(t, fixture.admit(t, newStaticWorkloadIdentityLookup()), errWorkloadNotAdmitted)
 }
 
-// An unwired policy must read as "no admissions", never as "no check to run":
-// a lookup nobody supplied is the absence of permission, not the absence of a
-// rule to apply.
+// An unwired policy reads as "no admissions", never as "no check to run".
 func TestAdmitWorkloadIdentity_UnconfiguredLookupAdmitsNothing(t *testing.T) {
 	t.Parallel()
 
@@ -96,10 +93,8 @@ func TestAdmitWorkloadIdentity_UnconfiguredLookupAdmitsNothing(t *testing.T) {
 }
 
 // Every part of the key is load-bearing: sub is unique within an issuer and
-// never across, one Gram issuer's admission must not answer for another's, and
-// remote_session_issuers tenancy is application-enforced because its
-// global-tier rows are shared. Varying one field at a time proves no part of
-// the triple is being ignored.
+// never across, and one Gram issuer's admission must not answer for another's.
+// Varying one field at a time proves no part is being ignored.
 func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 	t.Parallel()
 
@@ -188,9 +183,9 @@ func TestAdmitWorkloadIdentity_LookupFailureIsNotARejection(t *testing.T) {
 	require.NotErrorIs(t, err, errWorkloadNotAdmitted, "an outage is not an admission decision")
 }
 
-// A missing endpoint or issuer leaves the key unbuildable. It must fail closed
-// rather than reach the lookup with a zero-valued tenancy, which could match a
-// zero-valued entry.
+// A missing endpoint or issuer leaves the key unbuildable. It fails closed
+// rather than reaching the lookup with a zero-valued tenancy, which could
+// match a zero-valued entry.
 func TestAdmitWorkloadIdentity_MissingTenancyOrIssuerAdmitsNothing(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadidentity_internal_test.go
@@ -20,9 +20,8 @@ type workloadIdentityFixture struct {
 func newWorkloadIdentityFixture() workloadIdentityFixture {
 	return workloadIdentityFixture{
 		endpoint: &ResolvedMcpEndpoint{
-			OrganizationID:      uuid.NewString(),
-			ProjectID:           uuid.New(),
-			UserSessionIssuerID: uuid.New(),
+			OrganizationID: uuid.NewString(),
+			ProjectID:      uuid.New(),
 		},
 		issuerID: uuid.New(),
 		subject:  "repo:acme/payments-api:ref:refs/heads/main",
@@ -32,10 +31,9 @@ func newWorkloadIdentityFixture() workloadIdentityFixture {
 // identity is the admission this fixture stands for.
 func (f workloadIdentityFixture) identity() workloadIdentity {
 	return workloadIdentity{
-		OrganizationID:      f.endpoint.OrganizationID,
-		UserSessionIssuerID: f.endpoint.UserSessionIssuerID,
-		WorkloadIssuerID:    f.issuerID,
-		ExternalSubject:     f.subject,
+		OrganizationID:   f.endpoint.OrganizationID,
+		WorkloadIssuerID: f.issuerID,
+		ExternalSubject:  f.subject,
 	}
 }
 
@@ -64,10 +62,9 @@ func TestAdmitWorkloadIdentity_VerifiedButUnadmittedSubjectIsRejected(t *testing
 	fixture := newWorkloadIdentityFixture()
 	// Somebody else's job on the same trusted issuer.
 	lookup := newStaticWorkloadIdentityLookup(workloadIdentity{
-		OrganizationID:      fixture.endpoint.OrganizationID,
-		UserSessionIssuerID: fixture.endpoint.UserSessionIssuerID,
-		WorkloadIssuerID:    fixture.issuerID,
-		ExternalSubject:     "repo:someone-else/their-api:ref:refs/heads/main",
+		OrganizationID:   fixture.endpoint.OrganizationID,
+		WorkloadIssuerID: fixture.issuerID,
+		ExternalSubject:  "repo:someone-else/their-api:ref:refs/heads/main",
 	})
 
 	require.ErrorIs(t, fixture.admit(t, lookup), errWorkloadNotAdmitted)
@@ -104,10 +101,6 @@ func TestAdmitWorkloadIdentity_EveryPartOfTheKeyMustMatch(t *testing.T) {
 	for name, mutate := range map[string]func(workloadIdentity) workloadIdentity{
 		"a different organization": func(i workloadIdentity) workloadIdentity {
 			i.OrganizationID = uuid.NewString()
-			return i
-		},
-		"a different endpoint issuer": func(i workloadIdentity) workloadIdentity {
-			i.UserSessionIssuerID = uuid.New()
 			return i
 		},
 		"a different external issuer": func(i workloadIdentity) workloadIdentity {

--- a/server/internal/workloadidentity/admissionlookup.go
+++ b/server/internal/workloadidentity/admissionlookup.go
@@ -1,0 +1,56 @@
+package workloadidentity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+// AdmissionParams addresses one admission check. Every field is part of the
+// key; omitting one never widens the search.
+type AdmissionParams struct {
+	// OrganizationID scopes every row considered. Empty admits nothing.
+	OrganizationID string
+	// ProjectID selects the project tier when set. Unset is an
+	// organization-scoped caller, which a project's own admission never
+	// answers. Same shape as ResolveIssuerParams.ProjectID.
+	ProjectID uuid.NullUUID
+	// WorkloadIssuerID is the row that vouches for the subject, never the
+	// issuer URL: a discovery refresh must not repoint an existing admission.
+	WorkloadIssuerID uuid.UUID
+	// Subject is the sub claim the issuer asserted, exactly as it arrived.
+	Subject string
+}
+
+// IsAdmitted reports whether a tenant recognises one workload as its own.
+//
+// The security boundary of the grant. A CI provider signs genuine assertions
+// for every job on its platform, its other customers included, so a verified
+// assertion says only that the platform minted it. Presence here is what makes
+// the machine ours.
+//
+// False and an error must never be collapsed: false is a decision, an error is
+// the absence of one.
+func IsAdmitted(ctx context.Context, db repo.DBTX, params AdmissionParams) (bool, error) {
+	// Checked before the store, like ResolveIssuerByURL's organization: a
+	// tenancy hole should not depend on a data property a seed could break.
+	switch {
+	case params.OrganizationID == "", params.WorkloadIssuerID == uuid.Nil, params.Subject == "":
+		return false, nil
+	}
+
+	admitted, err := repo.New(db).WorkloadIdentityIsAdmitted(ctx, repo.WorkloadIdentityIsAdmittedParams{
+		OrganizationID:   params.OrganizationID,
+		ProjectID:        params.ProjectID,
+		WorkloadIssuerID: params.WorkloadIssuerID,
+		Subject:          params.Subject,
+	})
+	if err != nil {
+		return false, fmt.Errorf("check workload identity admission: %w", err)
+	}
+
+	return admitted, nil
+}

--- a/server/internal/workloadidentity/admissionlookup_test.go
+++ b/server/internal/workloadidentity/admissionlookup_test.go
@@ -1,0 +1,238 @@
+package workloadidentity_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity"
+)
+
+const testSubject = "repo:acme/payments-api:ref:refs/heads/main"
+
+// seedAdmission writes one workload_identity_admissions row directly. Raw SQL
+// for the same reason seedIssuer uses it: writes are the management API's job,
+// and this package is read-only by design.
+func seedAdmission(t *testing.T, conn *pgxpool.Pool, organizationID string, projectID uuid.NullUUID, issuerID uuid.UUID, subject string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	err := conn.QueryRow( //nolint:glint // notestingrawsql: no create query exists yet; writes belong to the management API milestone
+		t.Context(), `
+		INSERT INTO workload_identity_admissions
+		  (organization_id, project_id, workload_issuer_id, subject)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, organizationID, projectID, issuerID, subject).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+func withdraw(t *testing.T, conn *pgxpool.Pool, id uuid.UUID) {
+	t.Helper()
+
+	_, err := conn.Exec( //nolint:glint // notestingrawsql: see seedAdmission
+		t.Context(), `UPDATE workload_identity_admissions SET deleted_at = clock_timestamp() WHERE id = $1`, id)
+	require.NoError(t, err)
+}
+
+// admissionFixture is one tenant with one issuer.
+type admissionFixture struct {
+	tenant   tenant
+	issuerID uuid.UUID
+}
+
+func newAdmissionFixture(t *testing.T, conn *pgxpool.Pool) admissionFixture {
+	t.Helper()
+
+	tenant := newTenant(t, conn)
+
+	return admissionFixture{
+		tenant:   tenant,
+		issuerID: seedIssuer(t, conn, tenant.organizationID, organizationTier(), "gh-actions", testIssuerURL, epoch),
+	}
+}
+
+func (f admissionFixture) params() workloadidentity.AdmissionParams {
+	return workloadidentity.AdmissionParams{
+		OrganizationID:   f.tenant.organizationID,
+		ProjectID:        projectTier(f.tenant.projectID),
+		WorkloadIssuerID: f.issuerID,
+		Subject:          testSubject,
+	}
+}
+
+func TestIsAdmitted_AnAdmittedSubjectResolves(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// A verified assertion proves the platform minted it, not that it is ours.
+func TestIsAdmitted_AnUnadmittedSubjectDoesNot(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	// Somebody else's job on the same trusted issuer.
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, "repo:someone-else/their-api:ref:refs/heads/main")
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}
+
+// Changing any single component must not resolve.
+func TestIsAdmitted_EveryComponentOfTheKeyMustMatch(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	other := newTenant(t, conn)
+	otherIssuer := seedIssuer(t, conn, fixture.tenant.organizationID, organizationTier(), "staging", "https://staging.example.test", epoch)
+
+	for name, mutate := range map[string]func(workloadidentity.AdmissionParams) workloadidentity.AdmissionParams{
+		"another organization": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.OrganizationID = other.organizationID
+			return p
+		},
+		"another issuer": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.WorkloadIssuerID = otherIssuer
+			return p
+		},
+		"another subject": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.Subject = testSubject + ":other"
+			return p
+		},
+		"an empty organization": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.OrganizationID = ""
+			return p
+		},
+		"an empty subject": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.Subject = ""
+			return p
+		},
+		"no issuer": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.WorkloadIssuerID = uuid.Nil
+			return p
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, mutate(fixture.params()))
+
+			require.NoError(t, err)
+			require.False(t, admitted, "%s must not resolve against the admitted row", name)
+		})
+	}
+}
+
+// The organization tier is visible to every project beneath it.
+func TestIsAdmitted_TheOrganizationTierAnswersEveryProject(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	elsewhere := fixture.params()
+	elsewhere.ProjectID = projectTier(newProject(t, conn, fixture.tenant.organizationID))
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, elsewhere)
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// A project admits its own workload without an organization administrator.
+func TestIsAdmitted_TheProjectTierAnswersItsOwnProject(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(fixture.tenant.projectID), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// The isolation the tier exists for, and the case a lookup keyed on the
+// organization alone silently loses.
+func TestIsAdmitted_ASiblingProjectsAdmissionDoesNot(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	sibling := newProject(t, conn, fixture.tenant.organizationID)
+	seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(sibling), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}
+
+// A project's private admission must not answer a caller naming no project.
+func TestIsAdmitted_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	projectRow := seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(fixture.tenant.projectID), fixture.issuerID, testSubject)
+
+	organizationScoped := fixture.params()
+	organizationScoped.ProjectID = organizationTier()
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, organizationScoped)
+	require.NoError(t, err)
+	require.False(t, admitted, "a project's admission must not answer a caller that named no project")
+
+	// The same caller, once the organization itself admits the subject.
+	withdraw(t, conn, projectRow)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	admitted, err = workloadidentity.IsAdmitted(t.Context(), conn, organizationScoped)
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// Withdrawal is a soft delete; ignoring it would keep admitting a workload an
+// administrator believes they have removed.
+func TestIsAdmitted_AWithdrawnAdmissionDoesNotResolve(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	id := seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	withdraw(t, conn, id)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}

--- a/server/internal/workloadidentity/queries.sql
+++ b/server/internal/workloadidentity/queries.sql
@@ -31,3 +31,27 @@ WHERE issuer = ANY(@issuers::text[])
   AND (project_id = @project_id OR project_id IS NULL)
   AND deleted IS FALSE
 ORDER BY created_at ASC, id ASC;
+
+-- name: WorkloadIdentityIsAdmitted :one
+-- Whether this tenant recognises one workload: a subject vouched for by one
+-- issuer row, admitted in the caller's own project or the organization above.
+--
+-- EXISTS rather than the row, so a caller cannot read anything else off it and
+-- widen the security boundary by accident.
+--
+-- Tenancy matches ListWorkloadIssuersByIssuerURL: organization_id
+-- unconditionally, so a project-tier row cannot answer outside its
+-- organization, and the project arm is not true for a NULL @project_id, so an
+-- organization-scoped caller sees only organization-tier rows.
+--
+-- Exact equality on subject, compared as the platform minted it. No expression
+-- around the column, which would make the lookup index unusable.
+SELECT EXISTS (
+  SELECT 1
+  FROM workload_identity_admissions
+  WHERE organization_id = @organization_id
+    AND workload_issuer_id = @workload_issuer_id
+    AND subject = @subject
+    AND (project_id = @project_id OR project_id IS NULL)
+    AND deleted IS FALSE
+);

--- a/server/internal/workloadidentity/repo/queries.sql.go
+++ b/server/internal/workloadidentity/repo/queries.sql.go
@@ -84,3 +84,47 @@ func (q *Queries) ListWorkloadIssuersByIssuerURL(ctx context.Context, arg ListWo
 	}
 	return items, nil
 }
+
+const workloadIdentityIsAdmitted = `-- name: WorkloadIdentityIsAdmitted :one
+SELECT EXISTS (
+  SELECT 1
+  FROM workload_identity_admissions
+  WHERE organization_id = $1
+    AND workload_issuer_id = $2
+    AND subject = $3
+    AND (project_id = $4 OR project_id IS NULL)
+    AND deleted IS FALSE
+)
+`
+
+type WorkloadIdentityIsAdmittedParams struct {
+	OrganizationID   string
+	WorkloadIssuerID uuid.UUID
+	Subject          string
+	ProjectID        uuid.NullUUID
+}
+
+// Whether this tenant recognises one workload: a subject vouched for by one
+// issuer row, admitted in the caller's own project or the organization above.
+//
+// EXISTS rather than the row, so a caller cannot read anything else off it and
+// widen the security boundary by accident.
+//
+// Tenancy matches ListWorkloadIssuersByIssuerURL: organization_id
+// unconditionally, so a project-tier row cannot answer outside its
+// organization, and the project arm is not true for a NULL @project_id, so an
+// organization-scoped caller sees only organization-tier rows.
+//
+// Exact equality on subject, compared as the platform minted it. No expression
+// around the column, which would make the lookup index unusable.
+func (q *Queries) WorkloadIdentityIsAdmitted(ctx context.Context, arg WorkloadIdentityIsAdmittedParams) (bool, error) {
+	row := q.db.QueryRow(ctx, workloadIdentityIsAdmitted,
+		arg.OrganizationID,
+		arg.WorkloadIssuerID,
+		arg.Subject,
+		arg.ProjectID,
+	)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}


### PR DESCRIPTION
AIM-149

## Summary

The admission probe for the workload assertion grant: an injected lookup answering whether a tenant admits one workload identity, a static implementation, and `admitWorkloadIdentity` over both.

Two types, because the project field means different things on each. `workloadIdentity` is the query — organization, the project asking, workload issuer row, external subject. `workloadAdmission` is the stored row, where an unset project is the organization tier. One struct for both would make an organization-tier row indistinguishable from a query naming no project, which is what lets a project's admission leak organization-wide.

Matching is exact on every component and by tier on the project: an organization-tier admission answers every project beneath it, a project-tier one answers only its own, and an organization-scoped caller sees only the organization tier. That mirrors `project_id = @project_id OR project_id IS NULL` rather than inventing a second rule.

Everything ambiguous fails closed — unconfigured lookup, empty policy, no subject, missing endpoint or issuer. A lookup that errors stays distinct from one returning false: the first is the absence of a decision, and reading it as a rejection would let a store outage deny workloads that are in fact admitted.

No schema, no wiring. The store is #6285 and the grant handler is AIM-259, so there is no live call site and `NewService` gains no parameter.

## Motivation

Verifying a signature proves an assertion is genuine, not that the machine it vouches for is ours. A CI provider signs valid assertions for every job on its platform, its other customers included, so trusting GitHub Actions without naming the subject would admit anybody's.

Exact match with no patterns is deliberate: these platforms put bounded resources in `sub`, and wildcarding a CI subject is the misconfiguration that hands production credentials to anyone able to push a branch. An additive `match_kind` column covers it later.

The project tier came from review feedback on the table — a team should be able to recognise its own workload without an organization administrator doing it for them.
