### PR TITLE
fix: test fixtures stop sharing one toolset across live wrappers

### DIFF
--- a/.changeset/wrapper-fixture-prep.md
+++ b/.changeset/wrapper-fixture-prep.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Test fixtures stop sharing one toolset across live mcp_servers wrappers.

--- a/server/internal/admin/listorganizationprojects_test.go
+++ b/server/internal/admin/listorganizationprojects_test.go
@@ -114,8 +114,9 @@ func TestListOrganizationProjects_CountsMCPServerRows(t *testing.T) {
 	seedOrg(t, ctx, conn, orgFixture{id: "org_one", name: "One", slug: "one"})
 	projectID := seedProject(t, ctx, conn, "org_one", "new-model")
 	backing := seedToolset(t, ctx, conn, "org_one", projectID, "backing", false)
+	backingTwo := seedToolset(t, ctx, conn, "org_one", projectID, "backing-two", false)
 	seedMCPServer(t, ctx, conn, projectID, backing, "one")
-	seedMCPServer(t, ctx, conn, projectID, backing, "two")
+	seedMCPServer(t, ctx, conn, projectID, backingTwo, "two")
 
 	require.Equal(t, map[string]int{"new-model": 2}, listProjects(t, ctx, svc, "org_one"))
 }

--- a/server/internal/metamcp/addmetamcpmember_test.go
+++ b/server/internal/metamcp/addmetamcpmember_test.go
@@ -150,10 +150,8 @@ func TestAddMetaMcpMember_RejectsSecondServerOnSameBackend(t *testing.T) {
 			name:    "tunnel",
 			backend: mcpserversrepo.CreateMCPServerParams{TunneledMcpServerID: conv.ToNullUUID(seedTunnelBackend(t, ctx, ti.conn, *authCtx.ProjectID))},
 		},
-		{
-			name:    "toolset",
-			backend: mcpserversrepo.CreateMCPServerParams{ToolsetID: conv.ToNullUUID(seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID))},
-		},
+		// No toolset case: mcp_servers_toolset_id_key forbids two live wrappers
+		// over one toolset.
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Precursor to #5951 (one-wrapper-per-toolset unique index).

## Summary

- The admin project-count test seeds a distinct backing toolset per `mcp_servers` row instead of two wrappers over one toolset; count and intent unchanged.
- The meta-MCP shared-backend rejection test drops its toolset case: two live wrappers over one toolset is the state the upcoming index forbids, so the case can no longer be represented (the remote and tunnel cases still pin the member-level rejection).

## Motivation

PR #5951 adds a partial unique index enforcing at most one live wrapper per toolset. These two fixtures relied on the now-forbidden state and fail under the index; migration PRs must not carry code changes, so the fixture updates land first. Both changes are compatible with the current schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCzhsvUYz5VMieXYaQUC2Z


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates test fixtures that relied on two live wrappers sharing one toolset, a state that PR #5951's partial unique index will forbid. The fixture updates land first because migration PRs must not carry code changes, and both changes are compatible with the current schema.

- The admin project-count test seeds a distinct backing toolset per `mcp_servers` row, leaving the count and test intent unchanged.
- The meta-MCP shared-backend rejection test drops its toolset case; the remote and tunnel cases still validate the member-level rejection.

<sup>Written for commit 2cea6bd72fe2aedf5045af5694f50f60e7fd5e5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

