### PR TITLE
feat: serve direct upstream authorization on MCP servers

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -66346,11 +66346,12 @@ components:
           format: uuid
         visibility:
           type: string
-          description: The visibility of an MCP server
+          description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
           enum:
             - disabled
             - private
             - public
+            - upstream
       description: Form for creating a new MCP server. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, or unproxied_mcp_server_id must be provided.
       required:
         - name
@@ -74892,11 +74893,12 @@ components:
           format: uuid
         visibility:
           type: string
-          description: The visibility of an MCP server
+          description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
           enum:
             - disabled
             - private
             - public
+            - upstream
       description: 'An MCP server configuration: authentication, environment, and backend selection for an MCP server.'
       required:
         - id
@@ -86078,11 +86080,12 @@ components:
           format: uuid
         visibility:
           type: string
-          description: The visibility of an MCP server
+          description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
           enum:
             - disabled
             - private
             - public
+            - upstream
       description: 'Form for updating an MCP server. This is a full-record replace: fields omitted from the request become null on the stored record. The user session issuer cannot be changed after create. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, or unproxied_mcp_server_id must be provided. Omit name to leave the existing display name unchanged; the slug is recomputed server-side from the resulting name.'
       required:
         - id

--- a/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
+++ b/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
@@ -39,8 +39,8 @@ function getStatusConfig(
   // the server is reachable without a Gram credential, but it is not open.
   if (mcpIsUpstream) {
     return {
-      color: "bg-info-default",
-      pulseColor: "bg-info-default",
+      color: "bg-information-default",
+      pulseColor: "bg-information-default",
       label: "Upstream auth",
       animate: true,
     };

--- a/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
+++ b/client/dashboard/src/components/mcp/MCPStatusIndicator.tsx
@@ -4,6 +4,13 @@ import { cn } from "@/lib/utils";
 interface MCPStatusIndicatorProps {
   mcpEnabled: boolean | undefined;
   mcpIsPublic: boolean | undefined;
+  /**
+   * The server authenticates its clients against its own upstream
+   * authorization server. Optional because the toolset-backed callers have no
+   * such state; without it an upstream server reads as "Private", which is
+   * the one thing it is not.
+   */
+  mcpIsUpstream?: boolean;
   size?: "sm" | "md";
   className?: string;
 }
@@ -18,6 +25,7 @@ interface StatusConfig {
 function getStatusConfig(
   mcpEnabled: boolean | undefined,
   mcpIsPublic: boolean | undefined,
+  mcpIsUpstream: boolean | undefined,
 ): StatusConfig {
   if (!mcpEnabled) {
     return {
@@ -25,6 +33,16 @@ function getStatusConfig(
       pulseColor: "bg-destructive/60",
       label: "Disabled",
       animate: false,
+    };
+  }
+  // Checked before the public/private split, which this axis does not sit on:
+  // the server is reachable without a Gram credential, but it is not open.
+  if (mcpIsUpstream) {
+    return {
+      color: "bg-info-default",
+      pulseColor: "bg-info-default",
+      label: "Upstream auth",
+      animate: true,
     };
   }
   if (!mcpIsPublic) {
@@ -83,12 +101,13 @@ function StatusDotLabel({
 export function MCPStatusIndicator({
   mcpEnabled,
   mcpIsPublic,
+  mcpIsUpstream,
   size = "md",
   className,
 }: MCPStatusIndicatorProps): JSX.Element {
   return (
     <StatusDotLabel
-      status={getStatusConfig(mcpEnabled, mcpIsPublic)}
+      status={getStatusConfig(mcpEnabled, mcpIsPublic, mcpIsUpstream)}
       size={size}
       className={className}
     />

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantMCPServersSection.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantMCPServersSection.tsx
@@ -355,6 +355,12 @@ function AddServersDialog({
           !!server.slug &&
           !server.tunneledMcpServerId &&
           server.visibility !== "disabled" &&
+          // Rejected by resolveMcpServerRefsForWrite for the same reason
+          // tunneled servers are: the assistant runtime sends only
+          // Gram-Environment and no Authorization header, so an upstream
+          // server would 401 on every turn. Offering it here would surface
+          // that as a validation error after the user picked it.
+          server.visibility !== "upstream" &&
           serverIdsWithGramEndpoint.has(server.id),
       )
       .map((server): AttachedRef => ({

--- a/client/dashboard/src/pages/mcp/mcp-filter-schema.ts
+++ b/client/dashboard/src/pages/mcp/mcp-filter-schema.ts
@@ -24,6 +24,7 @@ export const MCP_FILTER_OPTIONS: OptionsById = {
   status: [
     { value: "public", label: "Public" },
     { value: "private", label: "Private" },
+    { value: "upstream", label: "Upstream auth" },
     { value: "disabled", label: "Disabled" },
   ],
   source: [
@@ -40,7 +41,7 @@ export const MCP_FILTER_OPTIONS: OptionsById = {
 
 export interface McpFacets {
   /** Absent for gateways, which have no visibility; an active status filter excludes them. */
-  status?: "public" | "private" | "disabled";
+  status?: "public" | "private" | "upstream" | "disabled";
   source:
     | "catalog"
     | "custom"
@@ -110,12 +111,18 @@ export function mcpServerFacets(
   server: McpServer,
   membership: PluginMembership,
 ): McpFacets {
-  const status =
+  // Mapped explicitly rather than defaulting the tail to "disabled": that
+  // default filed every value it did not recognise under Disabled, so an
+  // upstream server would have been hidden from every other status filter
+  // while showing up under one that says it is not served at all.
+  const status: McpFacets["status"] =
     server.visibility === "public"
       ? "public"
       : server.visibility === "private"
         ? "private"
-        : "disabled";
+        : server.visibility === "upstream"
+          ? "upstream"
+          : "disabled";
   const source = server.unproxiedMcpServerId
     ? "unproxied"
     : server.tunneledMcpServerId

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -324,12 +324,19 @@ export function MCPServerStatusDropdown({
     });
   };
 
+  // Mapped explicitly rather than defaulting the tail to "Private". Upstream
+  // servers are the one thing that default got exactly backwards: they are not
+  // private, and they are not selectable from the dropdown below either (the
+  // mode selector is AIM-27), so this is read-only display for a value only
+  // the API can currently set.
   const currentLabel =
     server.visibility === "disabled"
       ? "Disabled"
       : server.visibility === "public"
         ? "Public"
-        : "Private";
+        : server.visibility === "upstream"
+          ? "Upstream auth"
+          : "Private";
 
   const isTunneled = Boolean(server.tunneledMcpServerId);
   const { data: tunneledSource } = useGetTunneledMcpServer(
@@ -343,9 +350,12 @@ export function MCPServerStatusDropdown({
     ? [...VISIBILITY_OPTIONS, PUBLIC_VISIBILITY_OPTION]
     : VISIBILITY_OPTIONS;
 
+  // A value with no option — today only "upstream" — must not inherit green,
+  // which this file assigns to Public ("anyone can connect anonymously"). That
+  // is the opposite of what an upstream server does.
   const currentDotClass =
     options.find((option) => option.value === server.visibility)?.dotClass ??
-    "bg-green-400";
+    "bg-muted-foreground/60";
 
   // Unproxied servers have no Gram-hosted endpoint for disabled/private to
   // gate — the vendor's own server is reachable regardless of this setting —

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -357,12 +357,18 @@ export function MCPServerStatusDropdown({
     options.find((option) => option.value === server.visibility)?.dotClass ??
     "bg-muted-foreground/60";
 
+  // Upstream is not one of the options, so every entry in this dropdown would
+  // silently convert the server away from it, and there is no way back: the
+  // mode selector that can set it is AIM-27. Render the status without a
+  // trigger until that exists.
+  const readOnly = server.visibility === "upstream";
+
   // Unproxied servers have no Gram-hosted endpoint for disabled/private to
   // gate — the vendor's own server is reachable regardless of this setting —
   // so there's nothing to toggle. Still show the record's actual stored
   // value (not a hardcoded "Public") so this can't drift from what Settings
   // and the readiness checklist report for the same server.
-  if (server.unproxiedMcpServerId) {
+  if (server.unproxiedMcpServerId || readOnly) {
     return (
       <span className="text-foreground border-border flex w-fit items-center gap-2 border px-3 py-1.5 text-sm font-medium">
         <span

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
@@ -53,6 +53,11 @@ function mcpServerVisibilityToast(visibility: McpServerVisibility) {
       return "MCP server enabled";
     case "public":
       return "MCP server set to public";
+    case "upstream":
+      // Not reachable from this section, which only toggles enabled and
+      // public. Named so the switch stays exhaustive and so a future control
+      // that can set it does not fall through to a generic message.
+      return "MCP server set to upstream authorization";
     default:
       return "MCP server updated";
   }

--- a/client/dashboard/src/sdk/src/models/components/createmcpserverform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createmcpserverform.ts
@@ -20,15 +20,16 @@ export const NetworkAccessMode = {
 export type NetworkAccessMode = ClosedEnum<typeof NetworkAccessMode>;
 
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export const CreateMcpServerFormVisibility = {
   Disabled: "disabled",
   Private: "private",
   Public: "public",
+  Upstream: "upstream",
 } as const;
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export type CreateMcpServerFormVisibility = ClosedEnum<
   typeof CreateMcpServerFormVisibility
@@ -71,7 +72,7 @@ export type CreateMcpServerForm = {
    */
   unproxiedMcpServerId?: string | undefined;
   /**
-   * The visibility of an MCP server
+   * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
    */
   visibility: CreateMcpServerFormVisibility;
 };

--- a/client/dashboard/src/sdk/src/models/components/mcpserver.ts
+++ b/client/dashboard/src/sdk/src/models/components/mcpserver.ts
@@ -25,15 +25,16 @@ export type McpServerNetworkAccessMode = ClosedEnum<
 >;
 
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export const McpServerVisibility = {
   Disabled: "disabled",
   Private: "private",
   Public: "public",
+  Upstream: "upstream",
 } as const;
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export type McpServerVisibility = ClosedEnum<typeof McpServerVisibility>;
 
@@ -98,7 +99,7 @@ export type McpServer = {
    */
   userSessionIssuerId?: string | undefined;
   /**
-   * The visibility of an MCP server
+   * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
    */
   visibility: McpServerVisibility;
 };

--- a/client/dashboard/src/sdk/src/models/components/updatemcpserverform.ts
+++ b/client/dashboard/src/sdk/src/models/components/updatemcpserverform.ts
@@ -22,15 +22,16 @@ export type UpdateMcpServerFormNetworkAccessMode = ClosedEnum<
 >;
 
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export const UpdateMcpServerFormVisibility = {
   Disabled: "disabled",
   Private: "private",
   Public: "public",
+  Upstream: "upstream",
 } as const;
 /**
- * The visibility of an MCP server
+ * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
  */
 export type UpdateMcpServerFormVisibility = ClosedEnum<
   typeof UpdateMcpServerFormVisibility
@@ -77,7 +78,7 @@ export type UpdateMcpServerForm = {
    */
   unproxiedMcpServerId?: string | undefined;
   /**
-   * The visibility of an MCP server
+   * Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.
    */
   visibility: UpdateMcpServerFormVisibility;
 };

--- a/server/design/mcpservers/design.go
+++ b/server/design/mcpservers/design.go
@@ -368,8 +368,8 @@ var _ = Service("mcpServers", func() {
 })
 
 var McpServerVisibility = Type("McpServerVisibility", String, func() {
-	Description("The visibility of an MCP server")
-	Enum("disabled", "private", "public")
+	Description("Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server's own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.")
+	Enum("disabled", "private", "public", "upstream")
 	Meta("struct:pkg:path", "types")
 })
 

--- a/server/gen/http/mcp_servers/client/cli.go
+++ b/server/gen/http/mcp_servers/client/cli.go
@@ -45,8 +45,8 @@ func BuildCreateMcpServerPayload(mcpServersCreateMcpServerBody string, mcpServer
 		if body.ToolVariationsGroupID != nil {
 			err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 		}
-		if !(body.Visibility == "disabled" || body.Visibility == "private" || body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", body.Visibility, []any{"disabled", "private", "public"}))
+		if !(body.Visibility == "disabled" || body.Visibility == "private" || body.Visibility == "public" || body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 		if body.NetworkAccessMode != nil {
 			if !(*body.NetworkAccessMode == "public_only" || *body.NetworkAccessMode == "dual" || *body.NetworkAccessMode == "private_only") {
@@ -262,8 +262,8 @@ func BuildUpdateMcpServerPayload(mcpServersUpdateMcpServerBody string, mcpServer
 		if body.ToolVariationsGroupID != nil {
 			err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 		}
-		if !(body.Visibility == "disabled" || body.Visibility == "private" || body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", body.Visibility, []any{"disabled", "private", "public"}))
+		if !(body.Visibility == "disabled" || body.Visibility == "private" || body.Visibility == "public" || body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 		if body.NetworkAccessMode != nil {
 			if !(*body.NetworkAccessMode == "public_only" || *body.NetworkAccessMode == "dual" || *body.NetworkAccessMode == "private_only") {

--- a/server/gen/http/mcp_servers/client/types.go
+++ b/server/gen/http/mcp_servers/client/types.go
@@ -4792,8 +4792,8 @@ func ValidateCreateMcpServerResponseBody(body *CreateMcpServerResponseBody) (err
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {
@@ -4859,8 +4859,8 @@ func ValidateGetMcpServerResponseBody(body *GetMcpServerResponseBody) (err error
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {
@@ -4958,8 +4958,8 @@ func ValidateUpdateMcpServerResponseBody(body *UpdateMcpServerResponseBody) (err
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {
@@ -8018,8 +8018,8 @@ func ValidateMcpServerResponseBody(body *McpServerResponseBody) (err error) {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {

--- a/server/gen/http/mcp_servers/server/types.go
+++ b/server/gen/http/mcp_servers/server/types.go
@@ -4831,8 +4831,8 @@ func ValidateCreateMcpServerRequestBody(body *CreateMcpServerRequestBody) (err e
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {
@@ -4874,8 +4874,8 @@ func ValidateUpdateMcpServerRequestBody(body *UpdateMcpServerRequestBody) (err e
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -69090,11 +69090,12 @@ components:
                     format: uuid
                 visibility:
                     type: string
-                    description: The visibility of an MCP server
+                    description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
                     enum:
                         - disabled
                         - private
                         - public
+                        - upstream
             description: Form for creating a new MCP server. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, or unproxied_mcp_server_id must be provided.
             required:
                 - name
@@ -78108,11 +78109,12 @@ components:
                     format: uuid
                 visibility:
                     type: string
-                    description: The visibility of an MCP server
+                    description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
                     enum:
                         - disabled
                         - private
                         - public
+                        - upstream
             description: 'An MCP server configuration: authentication, environment, and backend selection for an MCP server.'
             required:
                 - id
@@ -89804,11 +89806,12 @@ components:
                     format: uuid
                 visibility:
                     type: string
-                    description: The visibility of an MCP server
+                    description: 'Who authenticates an inbound MCP client, and therefore whether and how the server is served. `disabled`: nothing is served. `private`: Gram, against a Gram API key, dashboard session, or user session issuer, with mcp:connect enforced. `public`: nobody, so the server is served anonymously. `upstream`: the server''s own upstream authorization server, whose metadata Gram advertises and to which the inbound bearer is forwarded unchanged; Gram validates nothing and mints no session. `upstream` requires a hosted (toolset) backend, a remote session issuer, and no user session issuer.'
                     enum:
                         - disabled
                         - private
                         - public
+                        - upstream
             description: 'Form for updating an MCP server. This is a full-record replace: fields omitted from the request become null on the stored record. The user session issuer cannot be changed after create. Exactly one of remote_mcp_server_id, tunneled_mcp_server_id, toolset_id, or unproxied_mcp_server_id must be provided. Omit name to leave the existing display name unchanged; the slug is recomputed server-side from the resulting name.'
             required:
                 - id

--- a/server/gen/http/remote_mcp/client/types.go
+++ b/server/gen/http/remote_mcp/client/types.go
@@ -8537,8 +8537,8 @@ func ValidateMcpServerResponseBody(body *McpServerResponseBody) (err error) {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.tool_variations_group_id", *body.ToolVariationsGroupID, goa.FormatUUID))
 	}
 	if body.Visibility != nil {
-		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public"}))
+		if !(*body.Visibility == "disabled" || *body.Visibility == "private" || *body.Visibility == "public" || *body.Visibility == "upstream") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.visibility", *body.Visibility, []any{"disabled", "private", "public", "upstream"}))
 		}
 	}
 	if body.NetworkAccessMode != nil {

--- a/server/gen/types/mcp_server_visibility.go
+++ b/server/gen/types/mcp_server_visibility.go
@@ -7,5 +7,12 @@
 
 package types
 
-// The visibility of an MCP server
+// Who authenticates an inbound MCP client, and therefore whether and how the
+// server is served. `disabled`: nothing is served. `private`: Gram, against a
+// Gram API key, dashboard session, or user session issuer, with mcp:connect
+// enforced. `public`: nobody, so the server is served anonymously. `upstream`:
+// the server's own upstream authorization server, whose metadata Gram
+// advertises and to which the inbound bearer is forwarded unchanged; Gram
+// validates nothing and mints no session. `upstream` requires a hosted
+// (toolset) backend, a remote session issuer, and no user session issuer.
 type McpServerVisibility string

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -899,12 +899,18 @@ func (s *ServiceCore) resolveMcpServerRefsForWrite(
 		// Reject servers the runtime cannot reach so a bad attach fails the
 		// write instead of silently vanishing from reads and dispatch:
 		// tunnelled backends have no /mcp serving path, disabled servers 404
-		// there, and without a Gram-hosted endpoint there is no URL to build.
+		// there, upstream servers authenticate inbound clients against their
+		// own authorization server and the runtime sends no Authorization
+		// header at all (see the dispatch loop below, which sets only
+		// Gram-Environment), so every call would 401, and without a
+		// Gram-hosted endpoint there is no URL to build.
 		switch {
 		case row.Tunneled:
 			return nil, assistantValidationError("mcp server %q is tunnel-backed and cannot be attached to an assistant", row.Slug.String)
 		case row.Visibility == visibility.Disabled:
 			return nil, assistantValidationError("mcp server %q is disabled", row.Slug.String)
+		case row.Visibility == visibility.Upstream:
+			return nil, assistantValidationError("mcp server %q requires upstream authorization and cannot be attached to an assistant", row.Slug.String)
 		case !row.HasGramEndpoint:
 			return nil, assistantValidationError("mcp server %q has no Gram-hosted MCP endpoint", row.Slug.String)
 		}
@@ -3204,6 +3210,15 @@ func resolveAssistantMCPServers(ctx context.Context, logger *slog.Logger, server
 		}
 		if m.Visibility == visibility.Disabled {
 			logger.WarnContext(ctx, "skipping disabled assistant mcp server",
+				attr.SlogMcpServerID(m.MCPServerID.String()),
+			)
+			continue
+		}
+		// Attach rejects these, but visibility is mutable afterwards, so a
+		// server can become upstream while already attached. Dispatch sends no
+		// Authorization header, so dialling it would 401 every turn.
+		if m.Visibility == visibility.Upstream {
+			logger.WarnContext(ctx, "skipping assistant mcp server that requires upstream authorization",
 				attr.SlogMcpServerID(m.MCPServerID.String()),
 			)
 			continue

--- a/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
+++ b/server/internal/mcp/authnchallenge_consent_mcp_endpoint.go
@@ -322,8 +322,19 @@ func (s *Service) serveConsentProxiedMCP(
 	}
 
 	subject := *challengeState.Subject
-	if serverRow.Visibility == mcpservers.VisibilityPrivate && subject.Kind == urn.SessionSubjectKindAnonymous {
-		return oops.E(oops.CodeUnauthorized, nil, "anonymous subject cannot enumerate a private MCP server").LogWarn(ctx, logger)
+	// Switched rather than compared against private, so a visibility this
+	// path has no rule for cannot inherit public's "anonymous is fine".
+	// Unreachable for upstream today (that mode is hosted-only and the
+	// backend check above already rejected non-proxied servers), but the
+	// fall-through is what would make the next value a hole.
+	switch serverRow.Visibility {
+	case mcpservers.VisibilityPublic:
+	case mcpservers.VisibilityPrivate:
+		if subject.Kind == urn.SessionSubjectKindAnonymous {
+			return oops.E(oops.CodeUnauthorized, nil, "anonymous subject cannot enumerate a private MCP server").LogWarn(ctx, logger)
+		}
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", serverRow.Visibility).LogError(ctx, logger)
 	}
 	tokens, err := s.remoteChallengeMgr.ResolveAccessTokens(ctx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID, subject)
 	if err != nil {
@@ -346,10 +357,14 @@ func (s *Service) serveConsentProxiedMCP(
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "stamp consent subject context").LogError(ctx, logger)
 	}
-	if serverRow.Visibility == mcpservers.VisibilityPrivate {
+	switch serverRow.Visibility {
+	case mcpservers.VisibilityPublic:
+	case mcpservers.VisibilityPrivate:
 		if _, ok := contextvalues.GetAuthContext(ctx); !ok {
 			return oops.E(oops.CodeUnauthorized, nil, "consent subject has no authenticated context").LogWarn(ctx, logger)
 		}
+	default:
+		return oops.E(oops.CodeUnexpected, nil, "unrecognized mcp server visibility %q", serverRow.Visibility).LogError(ctx, logger)
 	}
 	ctx, err = s.authorizeProxyBackendAccess(ctx, logger, endpoint.ProjectID, serverRow)
 	if err != nil {

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -424,14 +424,17 @@ func (s *Service) serveUpstreamAuthorizationServer(ctx context.Context, w http.R
 	}
 
 	result, fromSnapshot, err := wellknown.ResolveOAuthServerMetadataFromRemoteSessionIssuer(wellknown.RemoteSessionIssuerMetadata{
-		AuthorizationEndpoint:         conv.FromPGTextOrEmpty[string](issuer.AuthorizationEndpoint),
-		TokenEndpoint:                 conv.FromPGTextOrEmpty[string](issuer.TokenEndpoint),
-		RegistrationEndpoint:          conv.FromPGTextOrEmpty[string](issuer.RegistrationEndpoint),
-		ScopesSupported:               issuer.ScopesSupported,
-		ResponseTypesSupported:        issuer.ResponseTypesSupported,
-		GrantTypesSupported:           issuer.GrantTypesSupported,
-		CodeChallengeMethodsSupported: issuer.CodeChallengeMethodsSupported,
-		Snapshot:                      issuer.Metadata,
+		AuthorizationEndpoint:             conv.FromPGTextOrEmpty[string](issuer.AuthorizationEndpoint),
+		TokenEndpoint:                     conv.FromPGTextOrEmpty[string](issuer.TokenEndpoint),
+		RegistrationEndpoint:              conv.FromPGTextOrEmpty[string](issuer.RegistrationEndpoint),
+		RevocationEndpoint:                conv.FromPGTextOrEmpty[string](issuer.RevocationEndpoint),
+		JwksURI:                           conv.FromPGTextOrEmpty[string](issuer.JwksUri),
+		ScopesSupported:                   issuer.ScopesSupported,
+		ResponseTypesSupported:            issuer.ResponseTypesSupported,
+		GrantTypesSupported:               issuer.GrantTypesSupported,
+		TokenEndpointAuthMethodsSupported: issuer.TokenEndpointAuthMethodsSupported,
+		CodeChallengeMethodsSupported:     issuer.CodeChallengeMethodsSupported,
+		Snapshot:                          issuer.Metadata,
 	}, resourceURL)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve upstream OAuth server metadata").LogError(ctx, logger)

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -255,21 +255,24 @@ func (s *Service) ServeWellKnownProtectedResourceForServer(
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 	}
 
-	if mcpServer.UserSessionIssuerID.Valid {
-		endpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, routeBase)
-		if err != nil {
-			return fmt.Errorf("build resolved mcp endpoint: %w", err)
-		}
-		return s.ServeGetProtectedResource(w, r, endpoint)
-	}
-
-	// Upstream servers advertise the Gram URL the request arrived at, exactly as
-	// the toolset external-OAuth branch does. The authorization-server document
-	// served from that URL is the upstream's, so a client following this
-	// pointer lands on the upstream's endpoints. Taken before the backend
-	// switch, and before the legacy toolset resolver, which keys on
-	// external_oauth_server_id and would 404 a converted server.
-	if authMode, _ := mcpservers.ResolveAuthorizationMode(mcpServer); authMode == mcpservers.AuthorizationModeUpstream {
+	// Consulted before the issuer-gated branch below. An upstream row that also
+	// carries a user session issuer is one ResolveAuthorizationMode refuses, and
+	// the runtime serves it as not found; reaching the issuer-gated branch here
+	// would advertise Gram as its authorization server instead, which is the
+	// exact split brain between what Gram serves and what Gram advertises that
+	// the mode exists to prevent. Non-hosted upstream rows land here too, rather
+	// than falling through to the backend switch's unexpected-error arm.
+	switch authMode, reason := mcpservers.ResolveAuthorizationMode(mcpServer); authMode {
+	case mcpservers.AuthorizationModeInvalid:
+		logger.ErrorContext(ctx, "refusing well-known metadata for an mcp server with an incoherent authorization configuration",
+			attr.SlogError(errors.New(reason)),
+		)
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	case mcpservers.AuthorizationModeUpstream:
+		// Upstream servers advertise the Gram URL the request arrived at,
+		// exactly as the toolset external-OAuth branch does. The
+		// authorization-server document served from that URL is the upstream's,
+		// so a client following this pointer lands on the upstream's endpoints.
 		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
@@ -281,6 +284,19 @@ func (s *Service) ServeWellKnownProtectedResourceForServer(
 			BearerMethodsSupported: supportedBearerMethods,
 			ResourceDocumentation:  "",
 		})
+	case mcpservers.AuthorizationModeDisabled, mcpservers.AuthorizationModeGram, mcpservers.AuthorizationModeIssuerGated:
+		// Handled below: disabled never reaches here (resolution filters it),
+		// and the other two take the issuer-gated or legacy toolset branches,
+		// which is where their metadata has always come from. Listed rather
+		// than defaulted so a new mode is a compile-time decision here.
+	}
+
+	if mcpServer.UserSessionIssuerID.Valid {
+		endpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, routeBase)
+		if err != nil {
+			return fmt.Errorf("build resolved mcp endpoint: %w", err)
+		}
+		return s.ServeGetProtectedResource(w, r, endpoint)
 	}
 
 	switch {
@@ -321,25 +337,41 @@ func (s *Service) ServeWellKnownAuthorizationServerForServer(
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 	}
 
+	// Consulted before the issuer-gated branch below. An upstream row that also
+	// carries a user session issuer is one ResolveAuthorizationMode refuses, and
+	// the runtime serves it as not found; reaching the issuer-gated branch here
+	// would advertise Gram as its authorization server instead, which is the
+	// exact split brain between what Gram serves and what Gram advertises that
+	// the mode exists to prevent. Non-hosted upstream rows land here too, rather
+	// than falling through to the backend switch's unexpected-error arm.
+	switch authMode, reason := mcpservers.ResolveAuthorizationMode(mcpServer); authMode {
+	case mcpservers.AuthorizationModeInvalid:
+		logger.ErrorContext(ctx, "refusing well-known metadata for an mcp server with an incoherent authorization configuration",
+			attr.SlogError(errors.New(reason)),
+		)
+		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
+	case mcpservers.AuthorizationModeUpstream:
+		// An upstream server's authorization server is its own, named by
+		// remote_session_issuer_id: which backend fronts it does not change
+		// whose metadata is served.
+		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
+		}
+		return s.serveUpstreamAuthorizationServer(ctx, w, r, logger, mcpEndpoint.ProjectID, mcpServer.RemoteSessionIssuerID.UUID, resourceURL)
+	case mcpservers.AuthorizationModeDisabled, mcpservers.AuthorizationModeGram, mcpservers.AuthorizationModeIssuerGated:
+		// Handled below: disabled never reaches here (resolution filters it),
+		// and the other two take the issuer-gated or legacy toolset branches,
+		// which is where their metadata has always come from. Listed rather
+		// than defaulted so a new mode is a compile-time decision here.
+	}
+
 	if mcpServer.UserSessionIssuerID.Valid {
 		endpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, routeBase)
 		if err != nil {
 			return fmt.Errorf("build resolved mcp endpoint: %w", err)
 		}
 		return s.ServeGetAuthorizationServer(w, r, endpoint)
-	}
-
-	// An upstream server's authorization server is its own, named by
-	// remote_session_issuer_id, so this branch is taken before the backend
-	// switch: which backend fronts it does not change whose metadata is served.
-	// ResolveAuthorizationMode has already refused an upstream row that is not
-	// hosted or that carries a user session issuer.
-	if authMode, _ := mcpservers.ResolveAuthorizationMode(mcpServer); authMode == mcpservers.AuthorizationModeUpstream {
-		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
-		}
-		return s.serveUpstreamAuthorizationServer(ctx, w, r, logger, mcpEndpoint.ProjectID, mcpServer.RemoteSessionIssuerID.UUID, resourceURL)
 	}
 
 	switch {
@@ -434,9 +466,18 @@ func (s *Service) serveUpstreamAuthorizationServer(ctx context.Context, w http.R
 		GrantTypesSupported:               issuer.GrantTypesSupported,
 		TokenEndpointAuthMethodsSupported: issuer.TokenEndpointAuthMethodsSupported,
 		CodeChallengeMethodsSupported:     issuer.CodeChallengeMethodsSupported,
+		ServiceDocumentation:              conv.FromPGTextOrEmpty[string](issuer.ServiceDocumentation),
+		OpPolicyURI:                       conv.FromPGTextOrEmpty[string](issuer.OpPolicyUri),
+		OpTosURI:                          conv.FromPGTextOrEmpty[string](issuer.OpTosUri),
+		ClientIDMetadataDocumentSupported: issuer.ClientIDMetadataDocumentSupported,
 		Snapshot:                          issuer.Metadata,
 	}, resourceURL)
-	if err != nil {
+	switch {
+	case errors.Is(err, wellknown.ErrIncompleteIssuerMetadata):
+		// Nothing usable to advertise, so say so rather than hand a client a
+		// document it cannot start a flow from.
+		return oops.E(oops.CodeNotFound, err, "no OAuth configuration found").LogWarn(ctx, logger)
+	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve upstream OAuth server metadata").LogError(ctx, logger)
 	}
 	if !fromSnapshot {

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -30,10 +30,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth/wellknown"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd/admission"
@@ -260,6 +263,26 @@ func (s *Service) ServeWellKnownProtectedResourceForServer(
 		return s.ServeGetProtectedResource(w, r, endpoint)
 	}
 
+	// Upstream servers advertise the Gram URL the request arrived at, exactly as
+	// the toolset external-OAuth branch does. The authorization-server document
+	// served from that URL is the upstream's, so a client following this
+	// pointer lands on the upstream's endpoints. Taken before the backend
+	// switch, and before the legacy toolset resolver, which keys on
+	// external_oauth_server_id and would 404 a converted server.
+	if authMode, _ := mcpservers.ResolveAuthorizationMode(mcpServer); authMode == mcpservers.AuthorizationModeUpstream {
+		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
+		}
+		return writeOAuthProtectedResourceMetadataResponse(ctx, logger, w, r, &wellknown.OAuthProtectedResourceMetadata{
+			Resource:               resourceURL,
+			AuthorizationServers:   []string{resourceURL},
+			ScopesSupported:        nil,
+			BearerMethodsSupported: supportedBearerMethods,
+			ResourceDocumentation:  "",
+		})
+	}
+
 	switch {
 	case mcpServer.RemoteMcpServerID.Valid:
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
@@ -306,6 +329,19 @@ func (s *Service) ServeWellKnownAuthorizationServerForServer(
 		return s.ServeGetAuthorizationServer(w, r, endpoint)
 	}
 
+	// An upstream server's authorization server is its own, named by
+	// remote_session_issuer_id, so this branch is taken before the backend
+	// switch: which backend fronts it does not change whose metadata is served.
+	// ResolveAuthorizationMode has already refused an upstream row that is not
+	// hosted or that carries a user session issuer.
+	if authMode, _ := mcpservers.ResolveAuthorizationMode(mcpServer); authMode == mcpservers.AuthorizationModeUpstream {
+		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
+		}
+		return s.serveUpstreamAuthorizationServer(ctx, w, r, logger, mcpEndpoint.ProjectID, mcpServer.RemoteSessionIssuerID.UUID, resourceURL)
+	}
+
 	switch {
 	case mcpServer.RemoteMcpServerID.Valid:
 		return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
@@ -348,6 +384,66 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 		return nil, oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 	}
 	return &toolset, nil
+}
+
+// serveUpstreamAuthorizationServer writes the RFC 8414 document for an
+// `upstream` MCP server: the authorization server it names in
+// remote_session_issuer_id, re-served from Gram's URL.
+//
+// The caller has already established the mode, so a missing or unreadable
+// issuer row here is a broken invariant rather than a configuration the client
+// should be told about, and it 404s.
+func (s *Service) serveUpstreamAuthorizationServer(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, projectID, remoteSessionIssuerID uuid.UUID, resourceURL string) error {
+	logger = logger.With(attr.SlogRemoteSessionIssuerID(remoteSessionIssuerID.String()))
+
+	// The FK cannot qualify tenancy, so the read must. An mcp_server may name a
+	// project, organization, or platform issuer, and all three tiers are opened
+	// here because any of them is a legitimate choice for this server; the
+	// project and organization arms are what stop it resolving another tenant's
+	// row that happens to share the id.
+	project, err := projectsrepo.New(s.db).GetProjectByID(ctx, projectID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, err, "no OAuth configuration found").LogWarn(ctx, logger)
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "load mcp server project").LogError(ctx, logger)
+	}
+
+	issuer, err := remotesessions_repo.New(s.db).GetRemoteSessionIssuerByID(ctx, remotesessions_repo.GetRemoteSessionIssuerByIDParams{
+		ID:                    remoteSessionIssuerID,
+		ProjectID:             uuid.NullUUID{UUID: projectID, Valid: true},
+		IncludeOrganizational: true,
+		OrganizationID:        conv.ToPGText(project.OrganizationID),
+		IncludeGlobal:         true,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, err, "no OAuth configuration found").LogWarn(ctx, logger)
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "load remote session issuer").LogError(ctx, logger)
+	}
+
+	result, fromSnapshot, err := wellknown.ResolveOAuthServerMetadataFromRemoteSessionIssuer(wellknown.RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:         conv.FromPGTextOrEmpty[string](issuer.AuthorizationEndpoint),
+		TokenEndpoint:                 conv.FromPGTextOrEmpty[string](issuer.TokenEndpoint),
+		RegistrationEndpoint:          conv.FromPGTextOrEmpty[string](issuer.RegistrationEndpoint),
+		ScopesSupported:               issuer.ScopesSupported,
+		ResponseTypesSupported:        issuer.ResponseTypesSupported,
+		GrantTypesSupported:           issuer.GrantTypesSupported,
+		CodeChallengeMethodsSupported: issuer.CodeChallengeMethodsSupported,
+		Snapshot:                      issuer.Metadata,
+	}, resourceURL)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to resolve upstream OAuth server metadata").LogError(ctx, logger)
+	}
+	if !fromSnapshot {
+		// Serviceable but degraded: the reconstruction drops whatever OIDC
+		// extension fields this issuer advertises that Gram does not model.
+		// Refreshing the issuer captures a snapshot and resolves it.
+		logger.WarnContext(ctx, "serving upstream authorization server metadata reconstructed from typed columns; issuer has no captured discovery document")
+	}
+
+	return writeOAuthServerMetadataResponse(ctx, logger, w, r, result)
 }
 
 // serveLegacyToolsetProtectedResource resolves and writes RFC 9728

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1337,6 +1337,20 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 		return false, oops.E(oops.CodeUnexpected, err, "failed to describe toolset for security check").LogError(ctx, s.logger)
 	}
 
+	// upstreamAuthorized deliberately governs only the no-schemes arm below.
+	//
+	// When the toolset declares per-tool security, a scheme satisfied from the
+	// system environment or an MCP-* request header dispatches the call without
+	// an inbound bearer. That reads like a hole in "upstream requires the
+	// upstream's bearer", and reviewers have filed it as one, but it is the
+	// environment-to-header credential override customers depend on: those
+	// credentials are what authorize the call Gram makes to the tool, while
+	// visibility governs who Gram admits. Requiring a bearer here would break
+	// that override for every upstream server whose toolset carries schemes.
+	//
+	// The behavior is also unchanged from the toolset external-OAuth branch
+	// this mode replaces, which gates identically. Revisit with AIM-25, when
+	// that branch and its assumptions go away together.
 	schemes := describeToolSecurity(described.SecurityVariables)
 	if len(schemes) == 0 {
 		// No per-tool security annotations, but the toolset may still require

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -838,6 +838,13 @@ type hostedServing struct {
 	// the legacy path.
 	isPublic bool
 
+	// upstreamAuthorized: wrapper visibility == 'upstream'. The server's own
+	// upstream authorization server authenticates inbound clients, so Gram
+	// forwards the bearer without validating it, mints no session, and holds
+	// no grants to enforce. Never set on the legacy path, which has no wrapper
+	// to say so.
+	upstreamAuthorized bool
+
 	// runInToolsetGate: run the in-toolset issuer gate (legacy path only; the
 	// wrapper path gates pre-dispatch).
 	runInToolsetGate bool
@@ -864,6 +871,7 @@ type hostedServing struct {
 func hostedServingFromToolset(toolset *toolsets_repo.Toolset) *hostedServing {
 	return &hostedServing{
 		isPublic:              toolset.McpIsPublic,
+		upstreamAuthorized:    false,
 		runInToolsetGate:      toolset.UserSessionIssuerID.Valid,
 		callerGated:           false,
 		rbacResourceID:        toolset.ID,
@@ -891,6 +899,11 @@ func hostedServingFromToolset(toolset *toolsets_repo.Toolset) *hostedServing {
 // carries no policy; the in-toolset gate below populates it for legacy-path
 // callers.
 func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, cfg *hostedServing, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, pendingIssuerGate *issuerGateAuthentication) error {
+	// The wrapper's own authorization server authenticates the caller, so every
+	// gate below that keys on the toolset's OAuth columns yields to it. This is
+	// orthogonal to cfg.isPublic: an upstream server is not open, it simply
+	// does not authenticate anyone against Gram.
+	upstreamAuthorized := cfg.upstreamAuthorized
 	ctx := r.Context()
 	var err error
 
@@ -923,7 +936,10 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	//
 	// Private MCPs still enforce identity auth at this level since that's user
 	// identity, not per-tool security.
-	oauthRequired := toolset.ExternalOauthServerID.Valid
+	// Sole input to whether the 401 below carries WWW-Authenticate. False for an
+	// upstream server would mean a bare 401, leaving an MCP client with no way
+	// to discover the authorization server it is meant to authenticate against.
+	oauthRequired := toolset.ExternalOauthServerID.Valid || upstreamAuthorized
 
 	// Issuer-gated path is fully separate from the legacy switch below: try
 	// validating a user-session JWT; on success stamp ctx and skip the legacy
@@ -984,6 +1000,19 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 
 	if !runInToolsetGate && !callerAlreadyGated {
 		switch {
+		case upstreamAuthorized:
+			// Identical to the external-OAuth branch below, and deliberately
+			// not gated on cfg.isPublic: the fronting server's
+			// visibility already decided that nobody authenticates against
+			// Gram here, and a backing toolset left non-public would otherwise
+			// fall through to the 404 further down.
+			if authToken != "" {
+				tokenInputs = append(tokenInputs, oauthTokenInputs{
+					securityKeys:          []string{},
+					remoteSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+					Token:                 authToken,
+				})
+			}
 		case cfg.isPublic && toolset.ExternalOauthServerID.Valid:
 			// External OAuth server flow — collect token if present
 			if authToken != "" {
@@ -1035,15 +1064,21 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		// so they get public access without environment/secrets
 	}
 
-	if !cfg.isPublic && !authenticated {
+	// An upstream server's callers are authenticated by the upstream, so they
+	// are legitimately unauthenticated as far as Gram is concerned. Without the
+	// guard a server served as non-public 404s them, which reads to an MCP
+	// client as "no such server" rather than "authenticate first".
+	if !upstreamAuthorized && !cfg.isPublic && !authenticated {
 		return oops.C(oops.CodeNotFound)
 	}
 
 	if authenticated {
 		// Private MCPs require mcp:connect on the specific server (the
 		// wrapper's id when one fronts the request, else the toolset's).
-		// Public MCPs are open to everyone — no RBAC enforcement.
-		if !cfg.isPublic {
+		// Public MCPs are open to everyone — no RBAC enforcement, and neither
+		// are upstream ones: Gram holds no grants for a principal it never
+		// authenticated.
+		if !upstreamAuthorized && !cfg.isPublic {
 			// Ensure grants are loaded — not all auth strategies in authenticateToken
 			// go through auth.Authorize (which calls PrepareContext). This is a no-op
 			// if grants are already in context.
@@ -1197,7 +1232,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	// Check security schemes before dispatching any RPC — including initialize.
 	// Some MCP clients (e.g. Claude Desktop) require 401 on initialize to trigger
 	// their OAuth flow, so we can't defer this to individual RPC handlers.
-	satisfied, err := s.checkToolsetSecurity(ctx, toolset, cfg.isPublic, mcpInputs)
+	satisfied, err := s.checkToolsetSecurity(ctx, toolset, cfg.isPublic, upstreamAuthorized, mcpInputs)
 	if err != nil {
 		return err
 	}
@@ -1288,8 +1323,10 @@ func (s *Service) respondMCPError(ctx context.Context, w http.ResponseWriter, id
 // request environment satisfies at least one scheme. Returns true if satisfied
 // (or if the toolset has no security requirements). isPublic is the effective
 // publicness the request is served under (wrapper visibility when a wrapper
-// fronts it), not necessarily the toolset's own flag.
-func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_repo.Toolset, isPublic bool, payload *mcpInputs) (bool, error) {
+// fronts it), not necessarily the toolset's own flag. upstreamAuthorized is
+// the wrapper serving direct upstream authorization, which is neither public
+// nor Gram-authenticated.
+func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_repo.Toolset, isPublic, upstreamAuthorized bool, payload *mcpInputs) (bool, error) {
 	projectID := mv.ProjectID(payload.projectID)
 	// Security-scheme detection must see the full, unfiltered toolset, so this
 	// always uses the project-default variation group (nil) regardless of any
@@ -1306,7 +1343,10 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 		// OAuth at the server level (proxy or external). If so, require the
 		// user to have provided a token — otherwise the 401 + WWW-Authenticate
 		// must be sent so MCP clients can initiate the OAuth flow.
-		oauthRequired := isPublic && (toolset.ExternalOauthServerID.Valid || toolset.OauthProxyServerID.Valid)
+		// upstreamAuthorized stands alone rather than being conjoined with
+		// isPublic: the fronting wrapper already answered who authenticates the
+		// caller, and neither flag below gets to veto it.
+		oauthRequired := upstreamAuthorized || (isPublic && (toolset.ExternalOauthServerID.Valid || toolset.OauthProxyServerID.Valid))
 		if oauthRequired {
 			for _, t := range payload.oauthTokenInputs {
 				if t.Token != "" {

--- a/server/internal/mcp/serve_meta_members.go
+++ b/server/internal/mcp/serve_meta_members.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp/metamcp"
@@ -144,6 +145,15 @@ func (s *Service) resolveMetaMemberSnapshot(
 				return ctx, nil, oops.E(oops.CodeUnexpected, err, "check member authz").LogError(ctx, logger)
 			}
 		default:
+			// Fail closed, but say so. metamcp.AddMetaMcpMember refuses these
+			// at attach, yet visibility is mutable afterwards, so a member can
+			// arrive here by being flipped later. Without a line the member's
+			// tools simply disappear from the gateway with nothing anywhere to
+			// explain it, and the gateway's own member list still reports it
+			// healthy.
+			logger.WarnContext(ctx, "filtering meta mcp member whose visibility the gateway cannot front",
+				attr.SlogMcpServerID(row.McpServerID.String()),
+			)
 			continue
 		}
 

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -233,8 +233,10 @@ func (s *Service) handleMetaExecuteToolCall(
 	// Pre-dispatch security check so an unsatisfied member surfaces as a
 	// member-scoped result (as in serveToolsetResolved). Members keep the
 	// toolset's own publicness; the meta surface is outside wrapper
-	// governance.
-	satisfied, err := s.checkToolsetSecurity(ctx, toolset, toolset.McpIsPublic, inputs)
+	// governance. Never upstream: metamcp.AddMetaMcpMember refuses such a
+	// member, because a Gram-authenticated gateway cannot present a member's
+	// own authorization server to the caller.
+	satisfied, err := s.checkToolsetSecurity(ctx, toolset, toolset.McpIsPublic, false, inputs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -163,7 +163,23 @@ func (s *Service) serveResolvedMCPEndpoint(
 
 	logger = logger.With(attr.SlogMcpServerID(mcpServer.ID.String()))
 
-	issuerGated := mcpServer.UserSessionIssuerID.Valid
+	// Derived before any dispatch so an incoherent row is refused once, here,
+	// rather than reaching a backend that would have to decide what it meant.
+	authMode, authModeRejection := mcpservers.ResolveAuthorizationMode(mcpServer)
+	if authMode == mcpservers.AuthorizationModeInvalid {
+		// Not found rather than a code that distinguishes the cause: an
+		// unauthenticated caller learns nothing about a misconfigured server,
+		// and the operator's signal is the log line, not the response.
+		logger.ErrorContext(ctx, "refusing to serve mcp server with an incoherent authorization configuration",
+			attr.SlogError(errors.New(authModeRejection)),
+		)
+		return oops.E(oops.CodeNotFound, nil, "mcp server not found")
+	}
+	if authMode == mcpservers.AuthorizationModeUpstream {
+		logger = logger.With(attr.SlogRemoteSessionIssuerID(mcpServer.RemoteSessionIssuerID.UUID.String()))
+	}
+
+	issuerGated := authMode == mcpservers.AuthorizationModeIssuerGated
 
 	// Public tunneled servers serve anonymously: no OAuth handshake, so the
 	// issuer gate is skipped even though the issuer column is populated.
@@ -253,7 +269,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			return oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 		}
 
-		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, hostedServingFromWrapper(mcpServer, issuerGated), nil, sessionToolSelection, pendingIssuerGate); err != nil {
+		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, hostedServingFromWrapper(mcpServer, issuerGated, authMode), nil, sessionToolSelection, pendingIssuerGate); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil
@@ -270,7 +286,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 // callerGated reports whether the caller already ran the issuer gate keyed on
 // mcp_servers.user_session_issuer_id; the in-toolset gate never runs on this
 // path regardless.
-func hostedServingFromWrapper(mcpServer *mcpserversrepo.McpServer, callerGated bool) *hostedServing {
+func hostedServingFromWrapper(mcpServer *mcpserversrepo.McpServer, callerGated bool, authMode mcpservers.AuthorizationMode) *hostedServing {
 	var groupID *uuid.UUID
 	if mcpServer.ToolVariationsGroupID.Valid {
 		id := mcpServer.ToolVariationsGroupID.UUID
@@ -278,7 +294,12 @@ func hostedServingFromWrapper(mcpServer *mcpserversrepo.McpServer, callerGated b
 	}
 	serverID := mcpServer.ID
 	return &hostedServing{
-		isPublic:              mcpServer.Visibility == mcpservers.VisibilityPublic,
+		isPublic: mcpServer.Visibility == mcpservers.VisibilityPublic,
+		// Deliberately separate from isPublic. An upstream server is not open:
+		// it requires a bearer, Gram just does not validate one. Folding it
+		// into isPublic would skip the challenge that tells a client where to
+		// authenticate.
+		upstreamAuthorized:    authMode == mcpservers.AuthorizationModeUpstream,
 		runInToolsetGate:      false,
 		callerGated:           callerGated,
 		rbacResourceID:        mcpServer.ID,
@@ -480,7 +501,16 @@ func (s *Service) LoadResolvedMcpEndpointBySlug(ctx context.Context, logger *slo
 		// surface: every issuer-gated handler resolving through here
 		// (authorize, token, register, revoke, consent) must 404 even
 		// though the issuer column is populated.
-		if !mcpServer.UserSessionIssuerID.Valid || isTunneledPublic(mcpServer) {
+		//
+		// Upstream servers expose none of it either, and are refused by name
+		// rather than left to fall out of the NULL issuer column. Their
+		// well-known documents point clients at the upstream's authorization
+		// server, so a Gram /authorize for them would be an endpoint nothing
+		// advertises; reaching it would mean redirecting the caller to the
+		// Speakeasy IDP, since ResolvedMcpEndpoint.IsPublic is false for
+		// upstream and forceIDP follows from that.
+		upstreamAuthorized := mcpServer.Visibility == mcpservers.VisibilityUpstream
+		if !mcpServer.UserSessionIssuerID.Valid || isTunneledPublic(mcpServer) || upstreamAuthorized {
 			return nil, oops.E(oops.CodeNotFound, nil, "not found")
 		}
 		return s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)

--- a/server/internal/mcpendpoints/resolve.go
+++ b/server/internal/mcpendpoints/resolve.go
@@ -177,7 +177,10 @@ func Resolve(ctx context.Context, db *pgxpool.Pool, logger *slog.Logger, input R
 		return deniedResult(&endpoint, &server, nil, networkaccess.ModePrivateOnly), nil
 	}
 	switch server.Visibility {
-	case mcpservers.VisibilityPublic, mcpservers.VisibilityPrivate:
+	// Upstream serves like the others; what differs is who authenticates the
+	// caller, which the serve path decides. ResolveAuthorizationMode still
+	// refuses an upstream row whose columns do not describe a servable server.
+	case mcpservers.VisibilityPublic, mcpservers.VisibilityPrivate, mcpservers.VisibilityUpstream:
 		// Known serving states continue to network-surface policy below.
 	default:
 		// Disabled and unrecognized values fail closed. An endpoint row owns

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1708,6 +1708,13 @@ func (s *Service) resolveSecurityMode(toolset *toolsets_repo.Toolset, server *mc
 		switch {
 		case sessionGated:
 			return securityModeOAuth
+		case server.Visibility == mcpservers.VisibilityUpstream:
+			// Also OAuth, but against the upstream's authorization server
+			// rather than one of Gram's, which is why it is not folded into
+			// sessionGated: no Gram session exists here. Without this arm the
+			// install page tells the user to paste a Gram API key for a server
+			// whose only accepted credential is an upstream bearer.
+			return securityModeOAuth
 		case server.Visibility == mcpservers.VisibilityPublic:
 			return securityModePublic
 		default:

--- a/server/internal/mcpservers/authorizationmode.go
+++ b/server/internal/mcpservers/authorizationmode.go
@@ -1,0 +1,107 @@
+package mcpservers
+
+import (
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+)
+
+// AuthorizationMode answers one question about an mcp_server: which authority
+// authenticates the inbound MCP client.
+//
+// It is deliberately not a restatement of mcp_servers.visibility. Visibility
+// answers that question for three of its values but also carries an access
+// control meaning (private enforces mcp:connect, public does not) that survives
+// independently, and user_session_issuer_id answers it for a server of any
+// visibility. Reading the two columns separately at each consumer is what let
+// the two axes blur together; deriving the mode once keeps "who authenticates
+// the caller" separate from "what may they reach".
+//
+// The mode is derived from the mcp_servers row alone. It is deliberately not
+// derived for toolset-backed serving from toolsets.mcp_is_public or
+// toolsets.external_oauth_server_id: those columns are the pre-mcp_servers way
+// of saying the same thing, and teaching this type to speak both would
+// entrench exactly the conflation AIM-25 exists to delete.
+type AuthorizationMode string
+
+const (
+	// AuthorizationModeDisabled serves nothing.
+	AuthorizationModeDisabled AuthorizationMode = "disabled"
+
+	// AuthorizationModeGram makes Gram the authority: the caller presents a
+	// Gram API key, dashboard session, or chat session. Private servers
+	// require it; public servers probe for it and continue without.
+	AuthorizationModeGram AuthorizationMode = "gram"
+
+	// AuthorizationModeIssuerGated makes a Gram-hosted authorization server
+	// bound to user_session_issuer_id the authority. The caller presents a
+	// user-session JWT that Gram minted and validates.
+	AuthorizationModeIssuerGated AuthorizationMode = "issuer-gated"
+
+	// AuthorizationModeUpstream makes the server's own upstream authorization
+	// server the authority. Gram advertises that server in its well-known
+	// documents and forwards the inbound bearer unchanged, validating nothing
+	// and minting no session.
+	AuthorizationModeUpstream AuthorizationMode = "upstream"
+
+	// AuthorizationModeInvalid is a row whose columns do not describe a
+	// servable server. Callers must refuse to serve it. It is a state the
+	// management API prevents rather than one the runtime trusts it to.
+	AuthorizationModeInvalid AuthorizationMode = "invalid"
+)
+
+// ResolveAuthorizationMode derives the mode for an mcp_server row.
+//
+// The three states an `upstream` row may not hold are refused here rather than
+// at each consumer, so a caller that forgets one cannot serve a row Gram has no
+// coherent story for:
+//
+//   - No remote_session_issuer_id names no authorization server, so there is no
+//     metadata to advertise and nothing for a client to authenticate against.
+//   - A user_session_issuer_id would make ResyncMCPServerRemoteSessionIssuers
+//     match the row on its next remote-session client attach or detach and
+//     recompute the very issuer whose document is being served, leaving the
+//     server advertising one authorization server while forwarding bearers to
+//     another.
+//   - Only the hosted (toolset) serve path forwards the inbound bearer as a
+//     token input. Proxied backends resolve their upstream credential from a
+//     remote session instead, so upstream there would silently serve
+//     unauthenticated.
+//
+// The second return value explains an Invalid result and is for logs only. It
+// must not reach a caller: an unauthenticated client learns nothing useful from
+// a misconfigured server, and the operator's signal is the log line.
+func ResolveAuthorizationMode(server *repo.McpServer) (AuthorizationMode, string) {
+	if server == nil {
+		return AuthorizationModeInvalid, "no mcp server row"
+	}
+
+	switch server.Visibility {
+	case VisibilityDisabled:
+		return AuthorizationModeDisabled, ""
+
+	case VisibilityUpstream:
+		switch {
+		case !server.RemoteSessionIssuerID.Valid:
+			return AuthorizationModeInvalid, "upstream authorization needs a remote_session_issuer_id naming the authorization server to advertise"
+		case server.UserSessionIssuerID.Valid:
+			return AuthorizationModeInvalid, "upstream authorization requires user_session_issuer_id to be NULL, or the remote session issuer resync would reassign the issuer being advertised"
+		case !server.ToolsetID.Valid:
+			return AuthorizationModeInvalid, "upstream authorization is served for hosted (toolset) backends only"
+		default:
+			return AuthorizationModeUpstream, ""
+		}
+
+	case VisibilityPrivate, VisibilityPublic:
+		// Public tunneled servers carry an issuer because the schema forces one
+		// on every tunneled backend, but they serve anonymously once the tunnel
+		// owner has opted in, so the gate does not run for them. Consent itself
+		// is checked at dispatch, not here.
+		tunneledPublic := server.TunneledMcpServerID.Valid && server.Visibility == VisibilityPublic
+		if server.UserSessionIssuerID.Valid && !tunneledPublic {
+			return AuthorizationModeIssuerGated, ""
+		}
+		return AuthorizationModeGram, ""
+
+	default:
+		return AuthorizationModeInvalid, "unrecognized mcp server visibility"
+	}
+}

--- a/server/internal/mcpservers/authorizationmode_test.go
+++ b/server/internal/mcpservers/authorizationmode_test.go
@@ -1,0 +1,136 @@
+package mcpservers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+)
+
+func TestResolveAuthorizationMode(t *testing.T) {
+	t.Parallel()
+
+	set := func() uuid.NullUUID { return uuid.NullUUID{UUID: uuid.New(), Valid: true} }
+	unset := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+
+	tests := []struct {
+		name       string
+		server     *repo.McpServer
+		want       AuthorizationMode
+		wantReason string
+	}{
+		{
+			name:       "no row",
+			server:     nil,
+			want:       AuthorizationModeInvalid,
+			wantReason: "no mcp server row",
+		},
+		{
+			name:       "disabled serves nothing",
+			server:     &repo.McpServer{Visibility: VisibilityDisabled, ToolsetID: set()},
+			want:       AuthorizationModeDisabled,
+			wantReason: "",
+		},
+		{
+			name:       "private without an issuer authenticates against Gram",
+			server:     &repo.McpServer{Visibility: VisibilityPrivate, ToolsetID: set()},
+			want:       AuthorizationModeGram,
+			wantReason: "",
+		},
+		{
+			name:       "public without an issuer authenticates against Gram",
+			server:     &repo.McpServer{Visibility: VisibilityPublic, ToolsetID: set()},
+			want:       AuthorizationModeGram,
+			wantReason: "",
+		},
+		{
+			// Orthogonal to visibility: an issuer gates a server of either
+			// visibility, which is why the mode is not a restatement of the
+			// visibility column.
+			name:       "private with an issuer is issuer-gated",
+			server:     &repo.McpServer{Visibility: VisibilityPrivate, ToolsetID: set(), UserSessionIssuerID: set()},
+			want:       AuthorizationModeIssuerGated,
+			wantReason: "",
+		},
+		{
+			name:       "public with an issuer is issuer-gated",
+			server:     &repo.McpServer{Visibility: VisibilityPublic, ToolsetID: set(), UserSessionIssuerID: set()},
+			want:       AuthorizationModeIssuerGated,
+			wantReason: "",
+		},
+		{
+			// The schema forces an issuer on every tunneled backend, but a
+			// public tunnel serves anonymously, so the gate must not run.
+			name:       "public tunneled serves anonymously despite its forced issuer",
+			server:     &repo.McpServer{Visibility: VisibilityPublic, TunneledMcpServerID: set(), UserSessionIssuerID: set()},
+			want:       AuthorizationModeGram,
+			wantReason: "",
+		},
+		{
+			name:       "private tunneled is still gated",
+			server:     &repo.McpServer{Visibility: VisibilityPrivate, TunneledMcpServerID: set(), UserSessionIssuerID: set()},
+			want:       AuthorizationModeIssuerGated,
+			wantReason: "",
+		},
+		{
+			name:       "upstream on a hosted backend naming an issuer",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, ToolsetID: set(), RemoteSessionIssuerID: set()},
+			want:       AuthorizationModeUpstream,
+			wantReason: "",
+		},
+		{
+			name:       "upstream naming no issuer has no metadata to advertise",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, ToolsetID: set(), RemoteSessionIssuerID: unset},
+			want:       AuthorizationModeInvalid,
+			wantReason: "remote_session_issuer_id",
+		},
+		{
+			name:       "upstream that is also issuer-gated would have its issuer resynced away",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, ToolsetID: set(), RemoteSessionIssuerID: set(), UserSessionIssuerID: set()},
+			want:       AuthorizationModeInvalid,
+			wantReason: "user_session_issuer_id to be NULL",
+		},
+		{
+			name:       "upstream on a remote backend is not served",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, RemoteMcpServerID: set(), RemoteSessionIssuerID: set()},
+			want:       AuthorizationModeInvalid,
+			wantReason: "hosted (toolset) backends only",
+		},
+		{
+			name:       "upstream on a tunneled backend is not served",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, TunneledMcpServerID: set(), RemoteSessionIssuerID: set()},
+			want:       AuthorizationModeInvalid,
+			wantReason: "hosted (toolset) backends only",
+		},
+		{
+			name:       "upstream on an unproxied backend is not served",
+			server:     &repo.McpServer{Visibility: VisibilityUpstream, UnproxiedMcpServerID: set(), RemoteSessionIssuerID: set()},
+			want:       AuthorizationModeInvalid,
+			wantReason: "hosted (toolset) backends only",
+		},
+		{
+			// The reason a fifth value cannot quietly inherit public's
+			// treatment: it lands here rather than in any serving arm.
+			name:       "an unrecognized visibility fails closed",
+			server:     &repo.McpServer{Visibility: "something-new", ToolsetID: set()},
+			want:       AuthorizationModeInvalid,
+			wantReason: "unrecognized mcp server visibility",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, reason := ResolveAuthorizationMode(tt.server)
+			require.Equal(t, tt.want, got)
+			if tt.wantReason == "" {
+				require.Empty(t, reason)
+				return
+			}
+			require.Contains(t, reason, tt.wantReason)
+		})
+	}
+}

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -182,6 +182,12 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
+	// Create never writes a user session issuer, so the NULL half of the rule
+	// holds by construction here; the backend half does not.
+	if err := verifyUpstreamAuthorization(string(payload.Visibility), ids.ToolsetID, uuid.NullUUID{UUID: uuid.Nil, Valid: false}); err != nil {
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
+	}
+
 	server, err := CreateMCPServerInTransaction(ctx, dbtx, s.audit, MCPServerTransactionInput{
 		OrganizationID:        authCtx.ActiveOrganizationID,
 		ProjectID:             *authCtx.ProjectID,
@@ -753,6 +759,13 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
+	// Same reason as the consent check above: the update query COALESCEs unset
+	// references, so only the post-update row says which backend and issuer the
+	// server actually ended up with.
+	if err := verifyUpstreamAuthorization(updated.Visibility, updated.ToolsetID, updated.UserSessionIssuerID); err != nil {
+		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
+	}
+
 	afterView := mv.BuildMcpServerView(updated)
 
 	// A server that was just enabled is publishable if it already has an
@@ -1269,6 +1282,37 @@ func verifyTunneledPublicConsent(ctx context.Context, dbtx pgx.Tx, projectID uui
 	}
 	if !source.AllowPublic {
 		return fmt.Errorf("tunneled MCP servers cannot be public until the tunnel source enables public serving")
+	}
+	return nil
+}
+
+// verifyUpstreamAuthorization enforces the two states an `upstream` server may
+// not hold. Both are checked here rather than by a CHECK constraint, because
+// mcp_servers_remote_session_issuer_id_fkey is ON DELETE SET NULL and the
+// project/organization cascades that hard-delete remote_session_issuers would
+// trip such a constraint mid-teardown.
+//
+// Hosted (toolset) backend only: the serve path forwards the inbound bearer as
+// a token input, which only the hosted path does. Proxied backends fail closed
+// at dispatch, but rejecting the write is the smaller and clearer failure.
+//
+// user_session_issuer_id must be NULL, and this is load-bearing rather than
+// stylistic. ResyncMCPServerRemoteSessionIssuers matches
+// `WHERE s.user_session_issuer_id = resolved.user_session_issuer_id`, and SQL
+// NULL never equals anything, so a NULL there is the only thing that keeps the
+// resync from silently reassigning or nulling the remote_session_issuer_id
+// naming the issuer whose metadata the well-known documents serve. A server
+// that was both `upstream` and issuer-gated would advertise one authorization
+// server while forwarding bearers to another.
+func verifyUpstreamAuthorization(visibility string, toolsetID, userSessionIssuerID uuid.NullUUID) error {
+	if visibility != VisibilityUpstream {
+		return nil
+	}
+	if !toolsetID.Valid {
+		return fmt.Errorf("only toolset-backed MCP servers can serve direct upstream authorization")
+	}
+	if userSessionIssuerID.Valid {
+		return fmt.Errorf("MCP servers serving direct upstream authorization cannot also be gated by a user session issuer")
 	}
 	return nil
 }

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -182,9 +182,9 @@ func (s *Service) CreateMcpServer(ctx context.Context, payload *gen.CreateMcpSer
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
-	// Create never writes a user session issuer, so the NULL half of the rule
-	// holds by construction here; the backend half does not.
-	if err := verifyUpstreamAuthorization(string(payload.Visibility), ids.ToolsetID, uuid.NullUUID{UUID: uuid.Nil, Valid: false}); err != nil {
+	// Create writes neither issuer column, so the NULL-user-session half holds
+	// by construction and the remote-session half can never be satisfied here.
+	if err := verifyUpstreamAuthorization(string(payload.Visibility), ids.ToolsetID, uuid.NullUUID{UUID: uuid.Nil, Valid: false}, uuid.NullUUID{UUID: uuid.Nil, Valid: false}); err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
@@ -762,7 +762,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// Same reason as the consent check above: the update query COALESCEs unset
 	// references, so only the post-update row says which backend and issuer the
 	// server actually ended up with.
-	if err := verifyUpstreamAuthorization(updated.Visibility, updated.ToolsetID, updated.UserSessionIssuerID); err != nil {
+	if err := verifyUpstreamAuthorization(updated.Visibility, updated.ToolsetID, updated.UserSessionIssuerID, updated.RemoteSessionIssuerID); err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid mcp server").LogWarn(ctx, logger)
 	}
 
@@ -1304,7 +1304,7 @@ func verifyTunneledPublicConsent(ctx context.Context, dbtx pgx.Tx, projectID uui
 // naming the issuer whose metadata the well-known documents serve. A server
 // that was both `upstream` and issuer-gated would advertise one authorization
 // server while forwarding bearers to another.
-func verifyUpstreamAuthorization(visibility string, toolsetID, userSessionIssuerID uuid.NullUUID) error {
+func verifyUpstreamAuthorization(visibility string, toolsetID, userSessionIssuerID, remoteSessionIssuerID uuid.NullUUID) error {
 	if visibility != VisibilityUpstream {
 		return nil
 	}
@@ -1313,6 +1313,18 @@ func verifyUpstreamAuthorization(visibility string, toolsetID, userSessionIssuer
 	}
 	if userSessionIssuerID.Valid {
 		return fmt.Errorf("MCP servers serving direct upstream authorization cannot also be gated by a user session issuer")
+	}
+	// Refused at the write rather than left to fail at request time. Without an
+	// issuer there is no authorization server to advertise, so
+	// ResolveAuthorizationMode returns Invalid and every request 404s with only
+	// a log line to explain it — an operator flipping a working server to
+	// upstream would take it offline with no visible cause. Nothing can set
+	// this column yet (AIM-27 adds the management surface; the resync that
+	// derives it cannot match a row whose user_session_issuer_id is NULL, which
+	// upstream requires), so this makes upstream unreachable through the API
+	// until that lands, which is the honest state.
+	if !remoteSessionIssuerID.Valid {
+		return fmt.Errorf("MCP servers serving direct upstream authorization must name the remote session issuer whose authorization server clients authenticate against")
 	}
 	return nil
 }

--- a/server/internal/mcpservers/setup_test.go
+++ b/server/internal/mcpservers/setup_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	tunneledmcprepo "github.com/speakeasy-api/gram/server/internal/tunneledmcp/repo"
 	unproxiedmcprepo "github.com/speakeasy-api/gram/server/internal/unproxiedmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -171,6 +172,25 @@ func seedTunneledMcpServer(t *testing.T, ctx context.Context, conn *pgxpool.Pool
 	require.NoError(t, err)
 
 	return server.ID
+}
+
+// seedToolsetBackend inserts a toolsets row so we have a valid hosted backend
+// FK for mcp_servers tests.
+func seedToolsetBackend(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID) uuid.UUID {
+	t.Helper()
+
+	slug := "toolset-" + uuid.NewString()[:8]
+	toolset, err := toolsetsrepo.New(conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		McpSlug:        pgtype.Text{String: slug, Valid: true},
+		McpEnabled:     true,
+	})
+	require.NoError(t, err)
+
+	return toolset.ID
 }
 
 // seedUnproxiedMcpServer inserts an unproxied_mcp_servers row directly

--- a/server/internal/mcpservers/upstreamauthorization_test.go
+++ b/server/internal/mcpservers/upstreamauthorization_test.go
@@ -14,65 +14,84 @@ func TestVerifyUpstreamAuthorization(t *testing.T) {
 	unset := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 
 	tests := []struct {
-		name                string
-		visibility          string
-		toolsetID           uuid.NullUUID
-		userSessionIssuerID uuid.NullUUID
-		wantErr             string
+		name                  string
+		visibility            string
+		toolsetID             uuid.NullUUID
+		userSessionIssuerID   uuid.NullUUID
+		remoteSessionIssuerID uuid.NullUUID
+		wantErr               string
 	}{
 		{
-			name:                "upstream on a hosted backend with no issuer is the only accepted shape",
-			visibility:          VisibilityUpstream,
-			toolsetID:           set,
-			userSessionIssuerID: unset,
-			wantErr:             "",
+			name:                  "upstream on a hosted backend naming an issuer and no user session issuer is the only accepted shape",
+			visibility:            VisibilityUpstream,
+			toolsetID:             set,
+			userSessionIssuerID:   unset,
+			remoteSessionIssuerID: set,
+			wantErr:               "",
 		},
 		{
-			name:                "upstream without a toolset backend is rejected",
-			visibility:          VisibilityUpstream,
-			toolsetID:           unset,
-			userSessionIssuerID: unset,
-			wantErr:             "only toolset-backed MCP servers can serve direct upstream authorization",
+			name:                  "upstream without a toolset backend is rejected",
+			visibility:            VisibilityUpstream,
+			toolsetID:             unset,
+			userSessionIssuerID:   unset,
+			remoteSessionIssuerID: set,
+			wantErr:               "only toolset-backed MCP servers can serve direct upstream authorization",
 		},
 		{
-			name:                "upstream gated by a user session issuer is rejected",
-			visibility:          VisibilityUpstream,
-			toolsetID:           set,
-			userSessionIssuerID: set,
-			wantErr:             "cannot also be gated by a user session issuer",
+			name:                  "upstream gated by a user session issuer is rejected",
+			visibility:            VisibilityUpstream,
+			toolsetID:             set,
+			userSessionIssuerID:   set,
+			remoteSessionIssuerID: set,
+			wantErr:               "cannot also be gated by a user session issuer",
 		},
 		{
 			// Both violations at once still reports the backend one; the
 			// message only has to name a reason the write cannot proceed.
-			name:                "upstream violating both rules is rejected",
-			visibility:          VisibilityUpstream,
-			toolsetID:           unset,
-			userSessionIssuerID: set,
-			wantErr:             "only toolset-backed MCP servers can serve direct upstream authorization",
+			name:                  "upstream violating several rules is rejected",
+			visibility:            VisibilityUpstream,
+			toolsetID:             unset,
+			userSessionIssuerID:   set,
+			remoteSessionIssuerID: unset,
+			wantErr:               "only toolset-backed MCP servers can serve direct upstream authorization",
 		},
 		{
-			// The other visibilities own neither rule: a private or public
+			// Without this the runtime resolves the row Invalid and 404s every
+			// request, so an operator flipping a live server to upstream would
+			// take it offline with only a log line to explain it.
+			name:                  "upstream naming no issuer is rejected",
+			visibility:            VisibilityUpstream,
+			toolsetID:             set,
+			userSessionIssuerID:   unset,
+			remoteSessionIssuerID: unset,
+			wantErr:               "must name the remote session issuer",
+		},
+		{
+			// The other visibilities own none of these rules: a private or public
 			// server is routinely both issuer-gated and proxied, so the check
 			// must not leak onto them.
-			name:                "private is unconstrained",
-			visibility:          VisibilityPrivate,
-			toolsetID:           unset,
-			userSessionIssuerID: set,
-			wantErr:             "",
+			name:                  "private is unconstrained",
+			visibility:            VisibilityPrivate,
+			toolsetID:             unset,
+			userSessionIssuerID:   set,
+			remoteSessionIssuerID: unset,
+			wantErr:               "",
 		},
 		{
-			name:                "public is unconstrained",
-			visibility:          VisibilityPublic,
-			toolsetID:           unset,
-			userSessionIssuerID: set,
-			wantErr:             "",
+			name:                  "public is unconstrained",
+			visibility:            VisibilityPublic,
+			toolsetID:             unset,
+			userSessionIssuerID:   set,
+			remoteSessionIssuerID: unset,
+			wantErr:               "",
 		},
 		{
-			name:                "disabled is unconstrained",
-			visibility:          VisibilityDisabled,
-			toolsetID:           unset,
-			userSessionIssuerID: set,
-			wantErr:             "",
+			name:                  "disabled is unconstrained",
+			visibility:            VisibilityDisabled,
+			toolsetID:             unset,
+			userSessionIssuerID:   set,
+			remoteSessionIssuerID: unset,
+			wantErr:               "",
 		},
 	}
 
@@ -80,7 +99,7 @@ func TestVerifyUpstreamAuthorization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := verifyUpstreamAuthorization(tt.visibility, tt.toolsetID, tt.userSessionIssuerID)
+			err := verifyUpstreamAuthorization(tt.visibility, tt.toolsetID, tt.userSessionIssuerID, tt.remoteSessionIssuerID)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return

--- a/server/internal/mcpservers/upstreamauthorization_test.go
+++ b/server/internal/mcpservers/upstreamauthorization_test.go
@@ -1,0 +1,91 @@
+package mcpservers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyUpstreamAuthorization(t *testing.T) {
+	t.Parallel()
+
+	set := uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	unset := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
+
+	tests := []struct {
+		name                string
+		visibility          string
+		toolsetID           uuid.NullUUID
+		userSessionIssuerID uuid.NullUUID
+		wantErr             string
+	}{
+		{
+			name:                "upstream on a hosted backend with no issuer is the only accepted shape",
+			visibility:          VisibilityUpstream,
+			toolsetID:           set,
+			userSessionIssuerID: unset,
+			wantErr:             "",
+		},
+		{
+			name:                "upstream without a toolset backend is rejected",
+			visibility:          VisibilityUpstream,
+			toolsetID:           unset,
+			userSessionIssuerID: unset,
+			wantErr:             "only toolset-backed MCP servers can serve direct upstream authorization",
+		},
+		{
+			name:                "upstream gated by a user session issuer is rejected",
+			visibility:          VisibilityUpstream,
+			toolsetID:           set,
+			userSessionIssuerID: set,
+			wantErr:             "cannot also be gated by a user session issuer",
+		},
+		{
+			// Both violations at once still reports the backend one; the
+			// message only has to name a reason the write cannot proceed.
+			name:                "upstream violating both rules is rejected",
+			visibility:          VisibilityUpstream,
+			toolsetID:           unset,
+			userSessionIssuerID: set,
+			wantErr:             "only toolset-backed MCP servers can serve direct upstream authorization",
+		},
+		{
+			// The other visibilities own neither rule: a private or public
+			// server is routinely both issuer-gated and proxied, so the check
+			// must not leak onto them.
+			name:                "private is unconstrained",
+			visibility:          VisibilityPrivate,
+			toolsetID:           unset,
+			userSessionIssuerID: set,
+			wantErr:             "",
+		},
+		{
+			name:                "public is unconstrained",
+			visibility:          VisibilityPublic,
+			toolsetID:           unset,
+			userSessionIssuerID: set,
+			wantErr:             "",
+		},
+		{
+			name:                "disabled is unconstrained",
+			visibility:          VisibilityDisabled,
+			toolsetID:           unset,
+			userSessionIssuerID: set,
+			wantErr:             "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyUpstreamAuthorization(tt.visibility, tt.toolsetID, tt.userSessionIssuerID)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/server/internal/mcpservers/upstreamvisibility_test.go
+++ b/server/internal/mcpservers/upstreamvisibility_test.go
@@ -16,8 +16,12 @@ import (
 // API refuses the other backends rather than leaving them to fail closed at
 // dispatch, where the operator would see a 500 with no explanation.
 //
-// These call the service directly, so they reach the check without going
-// through the design enum — which deliberately does not accept 'upstream' yet.
+// The API cannot yet produce a servable upstream server: nothing outside tests
+// writes remote_session_issuer_id (AIM-27 adds the management surface, and the
+// resync that derives it cannot match a row whose user_session_issuer_id is
+// NULL, which upstream requires). So every write below is rejected, and that is
+// the point — the alternative is accepting a row the runtime answers 404 for,
+// with only a log line to explain why a working server went dark.
 
 func TestCreateMcpServer_UpstreamRejectsRemoteBackend(t *testing.T) {
 	t.Parallel()
@@ -73,7 +77,7 @@ func TestCreateMcpServer_UpstreamRejectsTunneledBackend(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
 
-func TestCreateMcpServer_UpstreamAllowsToolsetBackend(t *testing.T) {
+func TestCreateMcpServer_UpstreamRejectedWithoutAnIssuer(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -83,7 +87,9 @@ func TestCreateMcpServer_UpstreamAllowsToolsetBackend(t *testing.T) {
 
 	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).String()
 
-	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+	// The backend is right and no user session issuer is written, so the only
+	// unsatisfied rule is the issuer the server would advertise.
+	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
@@ -91,59 +97,13 @@ func TestCreateMcpServer_UpstreamAllowsToolsetBackend(t *testing.T) {
 		EnvironmentID:    nil,
 		ToolsetID:        &toolsetID,
 		Visibility:       types.McpServerVisibility("upstream"),
-	})
-	require.NoError(t, err)
-	require.Equal(t, types.McpServerVisibility("upstream"), created.Visibility)
-	// Create never writes a user session issuer, and the upstream rule depends
-	// on that staying true: a non-NULL value here would let
-	// ResyncMCPServerRemoteSessionIssuers reassign the server's issuer.
-	require.Nil(t, created.UserSessionIssuerID)
-}
-
-// Repointing an upstream server onto a proxied backend is the same violation
-// arriving by a different route, and the update path checks the post-update row
-// because the query COALESCEs unset references.
-func TestUpdateMcpServer_UpstreamRejectsBackendSwitchToRemote(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).String()
-
-	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
-		Name:             "upstream on toolset",
-		EnvironmentID:    nil,
-		ToolsetID:        &toolsetID,
-		Visibility:       types.McpServerVisibility("upstream"),
-	})
-	require.NoError(t, err)
-
-	remoteID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
-
-	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
-		SessionToken:      nil,
-		ApikeyToken:       nil,
-		ProjectSlugInput:  nil,
-		ID:                created.ID,
-		EnvironmentID:     nil,
-		RemoteMcpServerID: &remoteID,
-		ToolsetID:         nil,
-		Visibility:        types.McpServerVisibility("upstream"),
 	})
 	// oops redacts the cause, so the reason is asserted in the unit test on
 	// verifyUpstreamAuthorization; here the code is what the API contract owns.
 	requireOopsCode(t, err, oops.CodeInvalid)
 }
 
-// A toolset-backed server may be moved into and back out of upstream freely;
-// the rule constrains the backend and the issuer, not the transition.
-func TestUpdateMcpServer_UpstreamOnToolsetBackendRoundTrips(t *testing.T) {
+func TestUpdateMcpServer_UpstreamRejectedWithoutAnIssuer(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -164,7 +124,7 @@ func TestUpdateMcpServer_UpstreamOnToolsetBackendRoundTrips(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	updated, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
@@ -173,18 +133,72 @@ func TestUpdateMcpServer_UpstreamOnToolsetBackendRoundTrips(t *testing.T) {
 		ToolsetID:        &toolsetID,
 		Visibility:       types.McpServerVisibility("upstream"),
 	})
-	require.NoError(t, err)
-	require.Equal(t, types.McpServerVisibility("upstream"), updated.Visibility)
+	requireOopsCode(t, err, oops.CodeInvalid)
 
-	reverted, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+	// The rejected write must leave the server serving as it was, not half
+	// applied: this is an operator flipping a live server, and the failure mode
+	// the rule exists to prevent is exactly "it went dark".
+	after, err := ti.service.GetMcpServer(ctx, &gen.GetMcpServerPayload{
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
-		ID:               created.ID,
-		EnvironmentID:    nil,
-		ToolsetID:        &toolsetID,
-		Visibility:       types.McpServerVisibility("public"),
+		ID:               &created.ID,
+		Slug:             nil,
 	})
 	require.NoError(t, err)
-	require.Equal(t, types.McpServerVisibility("public"), reverted.Visibility)
+	require.Equal(t, types.McpServerVisibility("public"), after.Visibility)
+}
+
+// The update path checks the post-update row rather than the payload, because
+// the query COALESCEs unset references, so a single request that both switches
+// the backend and sets upstream must be judged on where it lands.
+//
+// Starting from a public remote-backed server rather than an upstream one: an
+// upstream server is not constructible through the API today, and the point
+// here is the update-path check, not the starting state.
+func TestUpdateMcpServer_UpstreamRejectsRemoteBackendOnTheSameRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	remoteID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "remote server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("upstream"),
+	})
+	// oops redacts the cause, so the reason is asserted in the unit test on
+	// verifyUpstreamAuthorization; here the code is what the API contract owns.
+	requireOopsCode(t, err, oops.CodeInvalid)
+
+	after, err := ti.service.GetMcpServer(ctx, &gen.GetMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		ID:               &created.ID,
+		Slug:             nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.McpServerVisibility("public"), after.Visibility, "a rejected write must leave the server serving as it was")
 }

--- a/server/internal/mcpservers/upstreamvisibility_test.go
+++ b/server/internal/mcpservers/upstreamvisibility_test.go
@@ -1,0 +1,190 @@
+package mcpservers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// visibility = 'upstream' forwards the inbound bearer to the upstream as a
+// token input, which only the hosted (toolset) serve path does. The management
+// API refuses the other backends rather than leaving them to fail closed at
+// dispatch, where the operator would see a 500 with no explanation.
+//
+// These call the service directly, so they reach the check without going
+// through the design enum — which deliberately does not accept 'upstream' yet.
+
+func TestCreateMcpServer_UpstreamRejectsRemoteBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	serverID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "upstream on remote",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &serverID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("upstream"),
+	})
+	// oops redacts the cause, so the reason is asserted in the unit test on
+	// verifyUpstreamAuthorization; here the code is what the API contract owns.
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+func TestCreateMcpServer_UpstreamRejectsTunneledBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	tunneledID := seedTunneledMcpServer(t, ctx, ti.conn, *authCtx.ProjectID)
+	// Grant the anonymous-serving consent a public tunnel would need, so the
+	// rejection can only be coming from the upstream rule.
+	enableTunneledPublicConsent(t, ctx, ti.conn, *authCtx.ProjectID, tunneledID)
+	tunneled := tunneledID.String()
+
+	_, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:        nil,
+		ApikeyToken:         nil,
+		ProjectSlugInput:    nil,
+		Name:                "upstream on tunnel",
+		EnvironmentID:       nil,
+		TunneledMcpServerID: &tunneled,
+		ToolsetID:           nil,
+		Visibility:          types.McpServerVisibility("upstream"),
+	})
+	// oops redacts the cause, so the reason is asserted in the unit test on
+	// verifyUpstreamAuthorization; here the code is what the API contract owns.
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+func TestCreateMcpServer_UpstreamAllowsToolsetBackend(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).String()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "upstream on toolset",
+		EnvironmentID:    nil,
+		ToolsetID:        &toolsetID,
+		Visibility:       types.McpServerVisibility("upstream"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.McpServerVisibility("upstream"), created.Visibility)
+	// Create never writes a user session issuer, and the upstream rule depends
+	// on that staying true: a non-NULL value here would let
+	// ResyncMCPServerRemoteSessionIssuers reassign the server's issuer.
+	require.Nil(t, created.UserSessionIssuerID)
+}
+
+// Repointing an upstream server onto a proxied backend is the same violation
+// arriving by a different route, and the update path checks the post-update row
+// because the query COALESCEs unset references.
+func TestUpdateMcpServer_UpstreamRejectsBackendSwitchToRemote(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).String()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "upstream on toolset",
+		EnvironmentID:    nil,
+		ToolsetID:        &toolsetID,
+		Visibility:       types.McpServerVisibility("upstream"),
+	})
+	require.NoError(t, err)
+
+	remoteID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+
+	_, err = ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		ID:                created.ID,
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &remoteID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("upstream"),
+	})
+	// oops redacts the cause, so the reason is asserted in the unit test on
+	// verifyUpstreamAuthorization; here the code is what the API contract owns.
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+// A toolset-backed server may be moved into and back out of upstream freely;
+// the rule constrains the backend and the issuer, not the transition.
+func TestUpdateMcpServer_UpstreamOnToolsetBackendRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID).String()
+
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Name:             "toolset server",
+		EnvironmentID:    nil,
+		ToolsetID:        &toolsetID,
+		Visibility:       types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+
+	updated, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		ID:               created.ID,
+		EnvironmentID:    nil,
+		ToolsetID:        &toolsetID,
+		Visibility:       types.McpServerVisibility("upstream"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.McpServerVisibility("upstream"), updated.Visibility)
+
+	reverted, err := ti.service.UpdateMcpServer(ctx, &gen.UpdateMcpServerPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		ID:               created.ID,
+		EnvironmentID:    nil,
+		ToolsetID:        &toolsetID,
+		Visibility:       types.McpServerVisibility("public"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.McpServerVisibility("public"), reverted.Visibility)
+}

--- a/server/internal/mcpservers/visibility.go
+++ b/server/internal/mcpservers/visibility.go
@@ -10,4 +10,5 @@ const (
 	VisibilityPublic   = visibility.Public
 	VisibilityPrivate  = visibility.Private
 	VisibilityDisabled = visibility.Disabled
+	VisibilityUpstream = visibility.Upstream
 )

--- a/server/internal/mcpservers/visibility/visibility.go
+++ b/server/internal/mcpservers/visibility/visibility.go
@@ -1,4 +1,22 @@
 // Package visibility declares the mcp_servers.visibility enum values.
+//
+// The column answers one question: who authenticates an inbound MCP client,
+// and therefore whether and how the server is served.
+//
+//   - Disabled: nothing is served.
+//   - Private: Gram, against a Gram API key, dashboard session, or user
+//     session issuer, with mcp:connect enforced.
+//   - Public: nobody, so the server is served anonymously.
+//   - Upstream: the server's own upstream authorization server, whose metadata
+//     Gram advertises and to which the inbound bearer is forwarded unchanged.
+//
+// "The visibility of an MCP server" is what this used to say, which is why the
+// axis kept getting confused with access control and with which authorization
+// server issued an upstream's credential. Neither is what it means. Public is
+// not renamed to match, because a rename would cost a data migration, a
+// breaking SDK enum change, and dashboard updates for clarity this comment
+// already carries.
+//
 // It mirrors the enum in the design package (design/mcpservers/design.go)
 // and is a leaf package so that packages mcpservers itself depends on
 // (e.g. plugins) can reference the values without an import cycle. Most
@@ -18,8 +36,8 @@ const (
 	// session, and runs no consent, so it is not an authorization server for
 	// these clients at all.
 	//
-	// Deliberately absent from the design enum until every site that would
-	// mishandle it is fixed, so no operator can write the value early. The
-	// serve path is hosted-backend only; every other backend fails closed.
+	// The serve path is hosted-backend only; every other backend fails closed,
+	// in the management API at write time and in ResolveAuthorizationMode at
+	// request time.
 	Upstream = "upstream"
 )

--- a/server/internal/mcpservers/visibility/visibility.go
+++ b/server/internal/mcpservers/visibility/visibility.go
@@ -9,4 +9,17 @@ const (
 	Public   = "public"
 	Private  = "private"
 	Disabled = "disabled"
+
+	// Upstream serves the MCP server's own upstream authorization server as
+	// the authority for inbound clients: the well-known documents advertise
+	// that server, taken from the remote_session_issuers.metadata snapshot
+	// named by mcp_servers.remote_session_issuer_id, and the inbound bearer
+	// is forwarded upstream unchanged. Gram validates nothing, mints no
+	// session, and runs no consent, so it is not an authorization server for
+	// these clients at all.
+	//
+	// Deliberately absent from the design enum until every site that would
+	// mishandle it is fixed, so no operator can write the value early. The
+	// serve path is hosted-backend only; every other backend fails closed.
+	Upstream = "upstream"
 )

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -646,6 +646,14 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 	if server.UnproxiedMcpServerID.Valid {
 		return nil, oops.E(oops.CodeInvalid, nil, "unproxied mcp servers cannot be meta mcp members").LogError(ctx, logger)
 	}
+	// A meta gateway is Gram-authenticated (meta_mcp_servers.visibility is only
+	// disabled or private), so it cannot present an upstream member's own
+	// authorization server to the caller. serve_meta_members already filters
+	// unrecognised visibilities, but silently: without this the member would be
+	// accepted here and then simply never appear in tools/list.
+	if server.Visibility == mcpservers.VisibilityUpstream {
+		return nil, oops.E(oops.CodeInvalid, nil, "mcp servers requiring upstream authorization cannot be meta mcp members").LogError(ctx, logger)
+	}
 
 	// The meta lock above serializes concurrent adds, so this sees every
 	// committed member.

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -22,6 +22,7 @@ package wellknown
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -78,6 +79,13 @@ type OAuthServerMetadata struct {
 	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
+	ServiceDocumentation              string   `json:"service_documentation,omitempty"`
+	OpPolicyURI                       string   `json:"op_policy_uri,omitempty"`
+	OpTosURI                          string   `json:"op_tos_uri,omitempty"`
+	// Pointer so the CIMD draft's member is advertised only when the issuer
+	// actually supports it; false and absent mean the same thing to a client,
+	// and emitting false on every reconstruction would be noise.
+	ClientIDMetadataDocumentSupported *bool `json:"client_id_metadata_document_supported,omitempty"`
 }
 
 type OAuthServerMetadataResultKind string
@@ -168,6 +176,20 @@ func ResolveOAuthServerMetadataFromToolset(
 	return nil, nil
 }
 
+// cimdSupported returns a pointer only when the issuer advertises CIMD, so the
+// member is omitted rather than emitted as false.
+func cimdSupported(supported bool) *bool {
+	if !supported {
+		return nil
+	}
+	return &supported
+}
+
+// ErrIncompleteIssuerMetadata is a reconstruction that cannot describe a usable
+// authorization server, because the issuer has no captured snapshot and no
+// stored authorization or token endpoint either.
+var ErrIncompleteIssuerMetadata = errors.New("issuer has no authorization or token endpoint to advertise")
+
 // RemoteSessionIssuerMetadata is the part of a remote_session_issuers row the
 // well-known surface needs to describe an upstream authorization server. It is
 // a plain struct rather than the repo row so this package stays independent of
@@ -183,6 +205,10 @@ type RemoteSessionIssuerMetadata struct {
 	GrantTypesSupported               []string
 	TokenEndpointAuthMethodsSupported []string
 	CodeChallengeMethodsSupported     []string
+	ServiceDocumentation              string
+	OpPolicyURI                       string
+	OpTosURI                          string
+	ClientIDMetadataDocumentSupported bool
 
 	// Snapshot is remote_session_issuers.metadata: the discovery document as
 	// the issuer served it, filtered to what Gram will republish. Empty for a
@@ -219,6 +245,15 @@ func ResolveOAuthServerMetadataFromRemoteSessionIssuer(issuer RemoteSessionIssue
 		}, true, nil
 	}
 
+	// RFC 8414 makes both of these REQUIRED, and a client cannot start a flow
+	// without them. An issuer that has neither a snapshot nor endpoints is a
+	// row discovery never completed for, so serving 200 with empty strings
+	// would advertise a broken authorization server rather than admit there is
+	// nothing to advertise. The caller turns this into a not-found.
+	if issuer.AuthorizationEndpoint == "" || issuer.TokenEndpoint == "" {
+		return nil, false, ErrIncompleteIssuerMetadata
+	}
+
 	return &OAuthServerMetadataResult{
 		Kind: OAuthServerMetadataResultKindStatic,
 		Static: &OAuthServerMetadata{
@@ -238,6 +273,10 @@ func ResolveOAuthServerMetadataFromRemoteSessionIssuer(issuer RemoteSessionIssue
 			GrantTypesSupported:               issuer.GrantTypesSupported,
 			TokenEndpointAuthMethodsSupported: issuer.TokenEndpointAuthMethodsSupported,
 			CodeChallengeMethodsSupported:     issuer.CodeChallengeMethodsSupported,
+			ServiceDocumentation:              issuer.ServiceDocumentation,
+			OpPolicyURI:                       issuer.OpPolicyURI,
+			OpTosURI:                          issuer.OpTosURI,
+			ClientIDMetadataDocumentSupported: cimdSupported(issuer.ClientIDMetadataDocumentSupported),
 		},
 		Raw:      nil,
 		ProxyURL: "",

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -58,15 +58,26 @@ type OAuthProtectedResourceMetadata struct {
 }
 
 // OAuthServerMetadata represents OAuth 2.0 Authorization Server Metadata (RFC 8414).
+//
+// Every optional member is omitempty. A nil slice would otherwise marshal to
+// `null`, which clients modelling these as optional arrays reject outright, and
+// an empty slice asserts "supports none of these" rather than "not stated" —
+// for response_types_supported that means a client refuses `code`, and for
+// registration_endpoint an empty string is not the URL RFC 8414 promises. When
+// a value is genuinely unknown, saying nothing lets the client apply the RFC's
+// defaults; saying `[]` or `""` does not.
 type OAuthServerMetadata struct {
-	Issuer                        string   `json:"issuer"`
-	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
-	TokenEndpoint                 string   `json:"token_endpoint"`
-	RegistrationEndpoint          string   `json:"registration_endpoint"`
-	ScopesSupported               []string `json:"scopes_supported,omitempty"`
-	ResponseTypesSupported        []string `json:"response_types_supported"`
-	GrantTypesSupported           []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	RevocationEndpoint                string   `json:"revocation_endpoint,omitempty"`
+	JwksURI                           string   `json:"jwks_uri,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported            []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
 }
 
 type OAuthServerMetadataResultKind string
@@ -162,13 +173,16 @@ func ResolveOAuthServerMetadataFromToolset(
 // a plain struct rather than the repo row so this package stays independent of
 // the remote sessions schema.
 type RemoteSessionIssuerMetadata struct {
-	AuthorizationEndpoint         string
-	TokenEndpoint                 string
-	RegistrationEndpoint          string
-	ScopesSupported               []string
-	ResponseTypesSupported        []string
-	GrantTypesSupported           []string
-	CodeChallengeMethodsSupported []string
+	AuthorizationEndpoint             string
+	TokenEndpoint                     string
+	RegistrationEndpoint              string
+	RevocationEndpoint                string
+	JwksURI                           string
+	ScopesSupported                   []string
+	ResponseTypesSupported            []string
+	GrantTypesSupported               []string
+	TokenEndpointAuthMethodsSupported []string
+	CodeChallengeMethodsSupported     []string
 
 	// Snapshot is remote_session_issuers.metadata: the discovery document as
 	// the issuer served it, filtered to what Gram will republish. Empty for a
@@ -208,14 +222,22 @@ func ResolveOAuthServerMetadataFromRemoteSessionIssuer(issuer RemoteSessionIssue
 	return &OAuthServerMetadataResult{
 		Kind: OAuthServerMetadataResultKindStatic,
 		Static: &OAuthServerMetadata{
-			Issuer:                        resourceURL,
-			AuthorizationEndpoint:         issuer.AuthorizationEndpoint,
-			TokenEndpoint:                 issuer.TokenEndpoint,
-			RegistrationEndpoint:          issuer.RegistrationEndpoint,
-			ScopesSupported:               issuer.ScopesSupported,
-			ResponseTypesSupported:        issuer.ResponseTypesSupported,
-			GrantTypesSupported:           issuer.GrantTypesSupported,
-			CodeChallengeMethodsSupported: issuer.CodeChallengeMethodsSupported,
+			Issuer:                resourceURL,
+			AuthorizationEndpoint: issuer.AuthorizationEndpoint,
+			TokenEndpoint:         issuer.TokenEndpoint,
+			RegistrationEndpoint:  issuer.RegistrationEndpoint,
+			// Modelled by remote_session_issuers and therefore reconstructable.
+			// Omitting token_endpoint_auth_methods_supported in particular is
+			// not harmless: RFC 8414 makes its absence mean client_secret_basic,
+			// so a public client issuer advertising `none` would fail token
+			// exchange on this path while working on the snapshot path.
+			RevocationEndpoint:                issuer.RevocationEndpoint,
+			JwksURI:                           issuer.JwksURI,
+			ScopesSupported:                   issuer.ScopesSupported,
+			ResponseTypesSupported:            issuer.ResponseTypesSupported,
+			GrantTypesSupported:               issuer.GrantTypesSupported,
+			TokenEndpointAuthMethodsSupported: issuer.TokenEndpointAuthMethodsSupported,
+			CodeChallengeMethodsSupported:     issuer.CodeChallengeMethodsSupported,
 		},
 		Raw:      nil,
 		ProxyURL: "",

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -157,6 +157,71 @@ func ResolveOAuthServerMetadataFromToolset(
 	return nil, nil
 }
 
+// RemoteSessionIssuerMetadata is the part of a remote_session_issuers row the
+// well-known surface needs to describe an upstream authorization server. It is
+// a plain struct rather than the repo row so this package stays independent of
+// the remote sessions schema.
+type RemoteSessionIssuerMetadata struct {
+	AuthorizationEndpoint         string
+	TokenEndpoint                 string
+	RegistrationEndpoint          string
+	ScopesSupported               []string
+	ResponseTypesSupported        []string
+	GrantTypesSupported           []string
+	CodeChallengeMethodsSupported []string
+
+	// Snapshot is remote_session_issuers.metadata: the discovery document as
+	// the issuer served it, filtered to what Gram will republish. Empty for a
+	// row that predates capture or was configured by hand.
+	Snapshot json.RawMessage
+}
+
+// ResolveOAuthServerMetadataFromRemoteSessionIssuer builds the RFC 8414
+// authorization-server document an `upstream` MCP server serves, describing the
+// issuer's own authorization server rather than Gram's.
+//
+// resourceURL is the Gram URL the document is fetched from, and becomes the
+// served `issuer`. RFC 8414 §3.3 requires the two to be equal, so a
+// spec-compliant MCP client does not reject the metadata; the upstream's own
+// authorization, token, and registration endpoints are carried through
+// unchanged, which the RFC does not require to share the issuer's origin.
+//
+// The second return value reports whether the document came from the captured
+// snapshot. When it did not, the document was reconstructed from the typed
+// columns and is missing whatever OIDC extension fields the upstream advertises
+// that Gram does not model, which callers should log: it is serviceable but
+// degraded, and it resolves itself the next time the issuer is refreshed.
+func ResolveOAuthServerMetadataFromRemoteSessionIssuer(issuer RemoteSessionIssuerMetadata, resourceURL string) (*OAuthServerMetadataResult, bool, error) {
+	if len(issuer.Snapshot) > 0 {
+		rewritten, err := rewriteMetadataIssuer(issuer.Snapshot, resourceURL)
+		if err != nil {
+			return nil, false, fmt.Errorf("rewrite remote session issuer metadata: %w", err)
+		}
+		return &OAuthServerMetadataResult{
+			Kind:     OAuthServerMetadataResultKindRaw,
+			Static:   nil,
+			Raw:      rewritten,
+			ProxyURL: "",
+		}, true, nil
+	}
+
+	return &OAuthServerMetadataResult{
+		Kind: OAuthServerMetadataResultKindStatic,
+		Static: &OAuthServerMetadata{
+			Issuer:                        resourceURL,
+			AuthorizationEndpoint:         issuer.AuthorizationEndpoint,
+			TokenEndpoint:                 issuer.TokenEndpoint,
+			RegistrationEndpoint:          issuer.RegistrationEndpoint,
+			ScopesSupported:               issuer.ScopesSupported,
+			ResponseTypesSupported:        issuer.ResponseTypesSupported,
+			GrantTypesSupported:           issuer.GrantTypesSupported,
+			CodeChallengeMethodsSupported: issuer.CodeChallengeMethodsSupported,
+		},
+		Raw:      nil,
+		ProxyURL: "",
+	}, false, nil
+}
+
 // rewriteMetadataIssuer returns raw with its top-level "issuer" field set to
 // issuer, leaving every other field untouched. Used to reconcile a captured
 // upstream OAuth authorization-server metadata document with the Gram URL it

--- a/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
+++ b/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
@@ -1,0 +1,125 @@
+package wellknown
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const upstreamResourceURL = "https://app.getgram.ai/mcp/example"
+
+// The snapshot path must behave exactly like the toolset external-OAuth branch
+// it replaces: re-serve the captured document with only `issuer` rewritten, so
+// upstream extension fields survive.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_FromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	snapshot := json.RawMessage(`{
+		"issuer": "https://idp.example.com",
+		"authorization_endpoint": "https://idp.example.com/authorize",
+		"token_endpoint": "https://idp.example.com/token",
+		"userinfo_endpoint": "https://idp.example.com/userinfo",
+		"claims_supported": ["sub", "email"],
+		"id_token_signing_alg_values_supported": ["RS256"]
+	}`)
+
+	result, fromSnapshot, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:         "https://idp.example.com/authorize",
+		TokenEndpoint:                 "https://idp.example.com/token",
+		RegistrationEndpoint:          "",
+		ScopesSupported:               nil,
+		ResponseTypesSupported:        nil,
+		GrantTypesSupported:           nil,
+		CodeChallengeMethodsSupported: nil,
+		Snapshot:                      snapshot,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+	require.True(t, fromSnapshot)
+	require.Equal(t, OAuthServerMetadataResultKindRaw, result.Kind)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(result.Raw, &got))
+
+	// RFC 8414 3.3: the served issuer must equal the URL the client fetched the
+	// document from, which is Gram's, not the upstream's.
+	require.Equal(t, upstreamResourceURL, got["issuer"])
+
+	// The upstream's own endpoints are carried through unchanged. The RFC does
+	// not require them to share the issuer's origin, and rewriting them would
+	// send the client to Gram for a flow Gram does not host.
+	require.Equal(t, "https://idp.example.com/authorize", got["authorization_endpoint"])
+	require.Equal(t, "https://idp.example.com/token", got["token_endpoint"])
+
+	// The whole reason the snapshot exists: fields the typed columns do not
+	// model survive into the served document.
+	require.Equal(t, "https://idp.example.com/userinfo", got["userinfo_endpoint"])
+	require.Equal(t, []any{"sub", "email"}, got["claims_supported"])
+	require.Equal(t, []any{"RS256"}, got["id_token_signing_alg_values_supported"])
+}
+
+// An issuer that predates capture, or was configured by hand, still serves a
+// usable document. It is missing only the extension fields, and refreshing the
+// issuer resolves that.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_ReconstructsWithoutSnapshot(t *testing.T) {
+	t.Parallel()
+
+	result, fromSnapshot, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:         "https://idp.example.com/authorize",
+		TokenEndpoint:                 "https://idp.example.com/token",
+		RegistrationEndpoint:          "https://idp.example.com/register",
+		ScopesSupported:               []string{"openid"},
+		ResponseTypesSupported:        []string{"code"},
+		GrantTypesSupported:           []string{"authorization_code"},
+		CodeChallengeMethodsSupported: []string{"S256"},
+		Snapshot:                      nil,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+	require.False(t, fromSnapshot, "the caller logs a warning on this path")
+	require.Equal(t, OAuthServerMetadataResultKindStatic, result.Kind)
+
+	require.Equal(t, upstreamResourceURL, result.Static.Issuer)
+	require.Equal(t, "https://idp.example.com/authorize", result.Static.AuthorizationEndpoint)
+	require.Equal(t, "https://idp.example.com/token", result.Static.TokenEndpoint)
+	require.Equal(t, "https://idp.example.com/register", result.Static.RegistrationEndpoint)
+	require.Equal(t, []string{"S256"}, result.Static.CodeChallengeMethodsSupported)
+}
+
+// An empty JSON object is a captured snapshot, not an absent one, so it takes
+// the snapshot path rather than silently reconstructing.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_EmptyObjectIsASnapshot(t *testing.T) {
+	t.Parallel()
+
+	result, fromSnapshot, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:         "https://idp.example.com/authorize",
+		TokenEndpoint:                 "https://idp.example.com/token",
+		RegistrationEndpoint:          "",
+		ScopesSupported:               nil,
+		ResponseTypesSupported:        nil,
+		GrantTypesSupported:           nil,
+		CodeChallengeMethodsSupported: nil,
+		Snapshot:                      json.RawMessage(`{}`),
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+	require.True(t, fromSnapshot)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(result.Raw, &got))
+	require.Equal(t, map[string]any{"issuer": upstreamResourceURL}, got)
+}
+
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_RejectsUnparseableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:         "https://idp.example.com/authorize",
+		TokenEndpoint:                 "https://idp.example.com/token",
+		RegistrationEndpoint:          "",
+		ScopesSupported:               nil,
+		ResponseTypesSupported:        nil,
+		GrantTypesSupported:           nil,
+		CodeChallengeMethodsSupported: nil,
+		Snapshot:                      json.RawMessage(`["not an object"]`),
+	}, upstreamResourceURL)
+	require.ErrorContains(t, err, "rewrite remote session issuer metadata")
+}

--- a/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
+++ b/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
@@ -123,3 +123,73 @@ func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_RejectsUnparseableSna
 	}, upstreamResourceURL)
 	require.ErrorContains(t, err, "rewrite remote session issuer metadata")
 }
+
+// The shape an issuer that was hand-configured, or created before capture
+// existed, actually has: nullable PKCE column NULL, optional endpoints empty,
+// capability arrays empty. Every other reconstruction test seeds them non-nil,
+// so this is the one that sees what a real degraded row serves.
+//
+// Emitting these would break clients rather than merely under-inform them:
+// `"code_challenge_methods_supported": null` fails an optional-array schema
+// outright, `"registration_endpoint": ""` is not the URL RFC 8414 promises,
+// and `"response_types_supported": []` asserts the server supports no response
+// types at all, so a strict client refuses `code`.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_OmitsUnknownMembers(t *testing.T) {
+	t.Parallel()
+
+	result, fromSnapshot, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:             "https://idp.example.com/authorize",
+		TokenEndpoint:                     "https://idp.example.com/token",
+		RegistrationEndpoint:              "",
+		RevocationEndpoint:                "",
+		JwksURI:                           "",
+		ScopesSupported:                   []string{},
+		ResponseTypesSupported:            []string{},
+		GrantTypesSupported:               []string{},
+		TokenEndpointAuthMethodsSupported: []string{},
+		CodeChallengeMethodsSupported:     nil,
+		Snapshot:                          nil,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+	require.False(t, fromSnapshot)
+
+	encoded, err := json.Marshal(result.Static)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &got))
+
+	// The two members RFC 8414 always requires, plus the rewritten issuer.
+	require.Equal(t, map[string]any{
+		"issuer":                 upstreamResourceURL,
+		"authorization_endpoint": "https://idp.example.com/authorize",
+		"token_endpoint":         "https://idp.example.com/token",
+	}, got, "an unknown member must be absent, not null or empty")
+}
+
+// The counterpart: a member Gram does know is served, including the three the
+// first version of this reconstruction dropped despite modelling them.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_ServesEveryModelledMember(t *testing.T) {
+	t.Parallel()
+
+	result, _, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:             "https://idp.example.com/authorize",
+		TokenEndpoint:                     "https://idp.example.com/token",
+		RegistrationEndpoint:              "https://idp.example.com/register",
+		RevocationEndpoint:                "https://idp.example.com/revoke",
+		JwksURI:                           "https://idp.example.com/jwks",
+		ScopesSupported:                   []string{"openid"},
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		Snapshot:                          nil,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+
+	require.Equal(t, "https://idp.example.com/revoke", result.Static.RevocationEndpoint)
+	require.Equal(t, "https://idp.example.com/jwks", result.Static.JwksURI)
+	// RFC 8414 reads an absent value here as client_secret_basic, so dropping
+	// it would break a public client that authenticates with `none`.
+	require.Equal(t, []string{"none"}, result.Static.TokenEndpointAuthMethodsSupported)
+}

--- a/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
+++ b/server/internal/oauth/wellknown/wellknown_remote_session_issuer_test.go
@@ -193,3 +193,66 @@ func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_ServesEveryModelledMe
 	// it would break a public client that authenticates with `none`.
 	require.Equal(t, []string{"none"}, result.Static.TokenEndpointAuthMethodsSupported)
 }
+
+// An issuer with neither a snapshot nor endpoints has nothing to advertise.
+// Serving 200 with empty required members would hand a client a document it
+// cannot start a flow from and no signal that the server knows it.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_RefusesIncompleteReconstruction(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		authorization string
+		token         string
+	}{
+		{name: "no endpoints at all", authorization: "", token: ""},
+		{name: "no token endpoint", authorization: "https://idp.example.com/authorize", token: ""},
+		{name: "no authorization endpoint", authorization: "", token: "https://idp.example.com/token"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+				AuthorizationEndpoint: tt.authorization,
+				TokenEndpoint:         tt.token,
+				Snapshot:              nil,
+			}, upstreamResourceURL)
+			require.ErrorIs(t, err, ErrIncompleteIssuerMetadata)
+		})
+	}
+}
+
+// The documentation and CIMD members the first reconstruction dropped despite
+// remote_session_issuers modelling them.
+func TestResolveOAuthServerMetadataFromRemoteSessionIssuer_ServesDocumentationAndCIMD(t *testing.T) {
+	t.Parallel()
+
+	result, _, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint:             "https://idp.example.com/authorize",
+		TokenEndpoint:                     "https://idp.example.com/token",
+		ServiceDocumentation:              "https://idp.example.com/docs",
+		OpPolicyURI:                       "https://idp.example.com/policy",
+		OpTosURI:                          "https://idp.example.com/tos",
+		ClientIDMetadataDocumentSupported: true,
+		Snapshot:                          nil,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+
+	require.Equal(t, "https://idp.example.com/docs", result.Static.ServiceDocumentation)
+	require.Equal(t, "https://idp.example.com/policy", result.Static.OpPolicyURI)
+	require.Equal(t, "https://idp.example.com/tos", result.Static.OpTosURI)
+	require.NotNil(t, result.Static.ClientIDMetadataDocumentSupported)
+	require.True(t, *result.Static.ClientIDMetadataDocumentSupported)
+
+	// An issuer that does not support CIMD omits the member rather than
+	// advertising false, which means the same thing and is noise.
+	plain, _, err := ResolveOAuthServerMetadataFromRemoteSessionIssuer(RemoteSessionIssuerMetadata{
+		AuthorizationEndpoint: "https://idp.example.com/authorize",
+		TokenEndpoint:         "https://idp.example.com/token",
+		Snapshot:              nil,
+	}, upstreamResourceURL)
+	require.NoError(t, err)
+	encoded, err := json.Marshal(plain.Static)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "client_id_metadata_document_supported")
+}

--- a/server/internal/platformmcp/catalog_identity_provider_attachment.go
+++ b/server/internal/platformmcp/catalog_identity_provider_attachment.go
@@ -272,6 +272,11 @@ func (s *CatalogIdentityProviderAttachmentService) ensureIssuer(ctx context.Cont
 		ClientIDMetadataDocumentSupported: metadata.ClientIDMetadataDocumentSupported,
 		Oidc:                              false,
 		Passthrough:                       false,
+		// The endpoints above come from this same document, so the snapshot
+		// cannot disagree with them, and it carries the OIDC extension fields
+		// the typed columns drop. Nil is fine: the issuer reconstructs its
+		// well-known document from those columns until a refresh captures one.
+		Metadata: metadata.Metadata,
 	})
 	if err != nil {
 		return remotesessionsrepo.RemoteSessionIssuer{}, fmt.Errorf("create discovered identity provider: %w", err)

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -428,7 +428,12 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.mcp_server_id,
 	(s.visibility = 'public')::bool AS mcp_server_is_public,
-	(s.user_session_issuer_id IS NOT NULL)::bool AS mcp_server_is_oauth,
+	-- Upstream servers are OAuth-protected even though they carry no
+	-- user_session_issuer_id: the authorization server is the upstream's, not
+	-- Gram's. Without this they read as neither public nor OAuth, and
+	-- plugins/generate.go emits a Gram API key config for a server whose only
+	-- accepted credential is an upstream bearer.
+	(s.user_session_issuer_id IS NOT NULL OR s.visibility = 'upstream')::bool AS mcp_server_is_oauth,
   COALESCE(ep.slug, '') AS endpoint_slug,
   ep.custom_domain AS endpoint_custom_domain,
   ump.url AS unproxied_url
@@ -453,7 +458,12 @@ LEFT JOIN LATERAL (
 ) ep ON TRUE
 LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
 LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
-LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
+-- The visibility predicates gate anonymous serving: 'public' needs the tunnel
+-- owner's allow_public consent, and 'upstream' is not servable on a tunneled
+-- backend at all, so neither may resolve a tunnel here. Written as an explicit
+-- exclusion rather than leaning on `<> 'public'`, which admits every value the
+-- consent rule was never written for.
+LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND s.visibility <> 'upstream' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
 LEFT JOIN toolsets mts ON mts.id = s.toolset_id AND mts.project_id = p.project_id AND mts.deleted IS FALSE AND mts.mcp_enabled IS TRUE
 WHERE p.project_id = @project_id
   AND p.deleted IS FALSE
@@ -493,6 +503,12 @@ WITH intended AS (
       WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
       WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
       WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'disabled' THEN 'mcp_server_disabled'
+      -- Direct upstream authorization is served for hosted (toolset) backends
+      -- only. mcpservers.verifyUpstreamAuthorization rejects the other
+      -- backends at write time; this keeps an already-attached server that
+      -- somehow reaches that state off the marketplace rather than
+      -- advertising it as installable.
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.toolset_id IS NULL THEN 'upstream_backend_unsupported'
       WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -456,8 +456,13 @@ LEFT JOIN LATERAL (
   ORDER BY (e.custom_domain_id IS NULL) ASC, e.created_at ASC
   LIMIT 1
 ) ep ON TRUE
-LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
-LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
+LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE AND s.visibility <> 'upstream'
+-- The upstream exclusions mirror the tunneled join below: direct upstream
+-- authorization is served for hosted (toolset) backends only, so a remote or
+-- unproxied row carrying it resolves no backend here. Without them
+-- resolvePluginInfos emits a server that ResolveAuthorizationMode refuses as
+-- not found, so the generated package points at a dead endpoint.
+LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse') AND s.visibility <> 'upstream'
 -- The visibility predicates gate anonymous serving: 'public' needs the tunnel
 -- owner's allow_public consent, and 'upstream' is not servable on a tunneled
 -- backend at all, so neither may resolve a tunnel here. Written as an explicit
@@ -509,6 +514,11 @@ WITH intended AS (
       -- somehow reaches that state off the marketplace rather than
       -- advertising it as installable.
       WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.toolset_id IS NULL THEN 'upstream_backend_unsupported'
+      -- The other two invariants ResolveAuthorizationMode enforces. Without
+      -- them a malformed hosted row produces no compatibility issue at all,
+      -- so the plugin stays eligible while every request to it 404s.
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.remote_session_issuer_id IS NULL THEN 'upstream_issuer_missing'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.user_session_issuer_id IS NOT NULL THEN 'upstream_user_session_issuer_conflict'
       WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -759,6 +759,11 @@ WITH intended AS (
       -- somehow reaches that state off the marketplace rather than
       -- advertising it as installable.
       WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.toolset_id IS NULL THEN 'upstream_backend_unsupported'
+      -- The other two invariants ResolveAuthorizationMode enforces. Without
+      -- them a malformed hosted row produces no compatibility issue at all,
+      -- so the plugin stays eligible while every request to it 404s.
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.remote_session_issuer_id IS NULL THEN 'upstream_issuer_missing'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.user_session_issuer_id IS NOT NULL THEN 'upstream_user_session_issuer_conflict'
       WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (
@@ -1405,8 +1410,8 @@ LEFT JOIN LATERAL (
   ORDER BY (e.custom_domain_id IS NULL) ASC, e.created_at ASC
   LIMIT 1
 ) ep ON TRUE
-LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
-LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
+LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE AND s.visibility <> 'upstream'
+LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse') AND s.visibility <> 'upstream'
 LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND s.visibility <> 'upstream' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
 LEFT JOIN toolsets mts ON mts.id = s.toolset_id AND mts.project_id = p.project_id AND mts.deleted IS FALSE AND mts.mcp_enabled IS TRUE
 WHERE p.project_id = $1
@@ -1457,6 +1462,11 @@ type ListPluginsWithMcpServersForProjectRow struct {
 // usable endpoint nor an unproxied backing are dropped.
 // Scoped to project_id; the mcp_server must live in the same project as the
 // plugin, and disabled servers are excluded.
+// The upstream exclusions mirror the tunneled join below: direct upstream
+// authorization is served for hosted (toolset) backends only, so a remote or
+// unproxied row carrying it resolves no backend here. Without them
+// resolvePluginInfos emits a server that ResolveAuthorizationMode refuses as
+// not found, so the generated package points at a dead endpoint.
 // The visibility predicates gate anonymous serving: 'public' needs the tunnel
 // owner's allow_public consent, and 'upstream' is not servable on a tunneled
 // backend at all, so neither may resolve a tunnel here. Written as an explicit

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -753,6 +753,12 @@ WITH intended AS (
       WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
       WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
       WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'disabled' THEN 'mcp_server_disabled'
+      -- Direct upstream authorization is served for hosted (toolset) backends
+      -- only. mcpservers.verifyUpstreamAuthorization rejects the other
+      -- backends at write time; this keeps an already-attached server that
+      -- somehow reaches that state off the marketplace rather than
+      -- advertising it as installable.
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'upstream' AND s.toolset_id IS NULL THEN 'upstream_backend_unsupported'
       WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
 	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (
@@ -1371,7 +1377,12 @@ SELECT
   ps.sort_order AS server_sort_order,
   ps.mcp_server_id,
 	(s.visibility = 'public')::bool AS mcp_server_is_public,
-	(s.user_session_issuer_id IS NOT NULL)::bool AS mcp_server_is_oauth,
+	-- Upstream servers are OAuth-protected even though they carry no
+	-- user_session_issuer_id: the authorization server is the upstream's, not
+	-- Gram's. Without this they read as neither public nor OAuth, and
+	-- plugins/generate.go emits a Gram API key config for a server whose only
+	-- accepted credential is an upstream bearer.
+	(s.user_session_issuer_id IS NOT NULL OR s.visibility = 'upstream')::bool AS mcp_server_is_oauth,
   COALESCE(ep.slug, '') AS endpoint_slug,
   ep.custom_domain AS endpoint_custom_domain,
   ump.url AS unproxied_url
@@ -1396,7 +1407,7 @@ LEFT JOIN LATERAL (
 ) ep ON TRUE
 LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
 LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
-LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
+LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND s.visibility <> 'upstream' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
 LEFT JOIN toolsets mts ON mts.id = s.toolset_id AND mts.project_id = p.project_id AND mts.deleted IS FALSE AND mts.mcp_enabled IS TRUE
 WHERE p.project_id = $1
   AND p.deleted IS FALSE
@@ -1446,6 +1457,11 @@ type ListPluginsWithMcpServersForProjectRow struct {
 // usable endpoint nor an unproxied backing are dropped.
 // Scoped to project_id; the mcp_server must live in the same project as the
 // plugin, and disabled servers are excluded.
+// The visibility predicates gate anonymous serving: 'public' needs the tunnel
+// owner's allow_public consent, and 'upstream' is not servable on a tunneled
+// backend at all, so neither may resolve a tunnel here. Written as an explicit
+// exclusion rather than leaning on `<> 'public'`, which admits every value the
+// consent rule was never written for.
 func (q *Queries) ListPluginsWithMcpServersForProject(ctx context.Context, arg ListPluginsWithMcpServersForProjectParams) ([]ListPluginsWithMcpServersForProjectRow, error) {
 	rows, err := q.db.Query(ctx, listPluginsWithMcpServersForProject, arg.ProjectID, arg.PluginIds)
 	if err != nil {

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -244,8 +244,29 @@ func (f *ProxyManager) BuildTarget(
 	// private — because the property is Gram's own envelope rather than
 	// anything scoped to an identity or a risk policy. It is a no-op for
 	// the arguments that don't carry it.
+	// Whether server-level RBAC applies, decided once by switch rather than by
+	// four separate comparisons against private. The comparisons read as "not
+	// private, so skip RBAC", which silently grants any future visibility the
+	// public treatment. BuildTarget cannot return an error, so an unrecognised
+	// value takes the deny-by-default arm: attaching the interceptors makes a
+	// caller with no grants unable to invoke anything, which is the safe way to
+	// be wrong here.
+	//
+	// Upstream skips RBAC deliberately, not by fall-through: its callers
+	// authenticate against the upstream authorization server, so Gram holds no
+	// grants to consult and the tools/list filter would empty the catalog.
+	// Unreachable today — upstream is hosted-only and this manager serves
+	// proxied backends — so this is defense in depth.
+	enforceServerRBAC := true
+	switch visibility {
+	case mcpservers.VisibilityPrivate:
+		enforceServerRBAC = true
+	case mcpservers.VisibilityPublic, mcpservers.VisibilityUpstream:
+		enforceServerRBAC = false
+	}
+
 	toolsCallPreForwardInterceptors := []proxy.ToolsCallRequestInterceptor(nil)
-	if visibility == mcpservers.VisibilityPrivate {
+	if enforceServerRBAC {
 		// Private calls use a method-level preflight so even malformed params
 		// reach the checkpoint before any downstream typed or upstream work.
 		checkpoint := f.killswitchCheckpoint
@@ -263,14 +284,14 @@ func (f *ProxyManager) BuildTarget(
 		NewToolsCallStripToolsetIDInterceptor(logger),
 		clickHouseLogInterceptor,
 	}
-	if visibility == mcpservers.VisibilityPrivate {
+	if enforceServerRBAC {
 		toolsCallReqInterceptors = append(toolsCallReqInterceptors,
 			NewToolsCallAuthzInterceptor(f.authz, f.toolDispositions, identity.McpServerID, projectID, logger),
 		)
 	}
 
 	toolsListRespInterceptors := []proxy.ToolsListResponseInterceptor{}
-	if visibility == mcpservers.VisibilityPrivate {
+	if enforceServerRBAC {
 		toolsListRespInterceptors = append(toolsListRespInterceptors,
 			NewToolsListMCPConnectFilterInterceptor(f.authz, f.toolDispositions, identity.McpServerID, projectID, logger),
 		)
@@ -290,7 +311,7 @@ func (f *ProxyManager) BuildTarget(
 	// the proxy interceptor surface is in place so they can attach later
 	// without touching the proxy package again.
 	userRequestObservationInterceptors := make([]proxy.UserRequestInterceptor, 0, 3)
-	if options.recordIdentityCoverage && visibility != mcpservers.VisibilityPrivate {
+	if options.recordIdentityCoverage && !enforceServerRBAC {
 		userRequestObservationInterceptors = append(userRequestObservationInterceptors, NewToolsCallIdentityCoverageInterceptor(f.identityCoverage, identity, organizationID))
 	}
 	userRequestObservationInterceptors = append(userRequestObservationInterceptors,

--- a/server/internal/remotesessions/adminhandlers.go
+++ b/server/internal/remotesessions/adminhandlers.go
@@ -142,6 +142,10 @@ func (s *Service) CreateGlobalIssuer(ctx context.Context, payload *adminrsgen.Cr
 		ClientIDMetadataDocumentSupported: conv.PtrValOr(payload.ClientIDMetadataDocumentSupported, false),
 		Oidc:                              conv.PtrValOr(payload.Oidc, false),
 		Passthrough:                       conv.PtrValOr(payload.Passthrough, false),
+		// Create does not discover, so it has no document to snapshot. The
+		// column is filled by the first refresh, and by callers that already
+		// hold a discovery document (see platformmcp's attachment).
+		Metadata: nil,
 	})
 	if err != nil {
 		if isGlobalRemoteSessionIssuerSlugConflict(err) {
@@ -487,7 +491,7 @@ func (s *Service) FetchGlobalIssuerMetadata(ctx context.Context, payload *adminr
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid issuer url").LogError(ctx, logger)
 	}
 
-	doc, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
+	doc, _, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
 	if err != nil {
 		return nil, mapDiscoveryError(ctx, logger, err, oops.CodeBadRequest)
 	}

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -97,7 +97,7 @@ func (s *Service) FetchRemoteSessionIssuerMetadata(ctx context.Context, payload 
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid issuer url").LogError(ctx, logger)
 	}
 
-	doc, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
+	doc, _, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
 	if err != nil {
 		return nil, mapDiscoveryError(ctx, logger, err, oops.CodeBadRequest)
 	}
@@ -296,6 +296,10 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 		ClientIDMetadataDocumentSupported: conv.PtrValOr(payload.ClientIDMetadataDocumentSupported, false),
 		Oidc:                              conv.PtrValOr(payload.Oidc, false),
 		Passthrough:                       conv.PtrValOr(payload.Passthrough, false),
+		// Create does not discover, so it has no document to snapshot. The
+		// column is filled by the first refresh, and by callers that already
+		// hold a discovery document (see platformmcp's attachment).
+		Metadata: nil,
 	})
 	if err != nil {
 		if isRemoteSessionIssuerSlugConflict(err) {
@@ -879,6 +883,18 @@ type DiscoveredIssuerMetadata struct {
 	CodeChallengeMethodsSupported []string
 
 	ClientIDMetadataDocumentSupported bool
+
+	// Metadata is the discovery document these fields were projected from,
+	// filtered to what Gram is willing to re-publish, ready to store in
+	// remote_session_issuers.metadata. Callers that persist an issuer from this
+	// value should store it: they write the endpoints above from the same
+	// document, so the snapshot cannot disagree with them, and it carries the
+	// OIDC extension fields the typed columns do not model.
+	//
+	// Nil when the document could not be reduced to a storable snapshot, which
+	// is not an error: the issuer simply reconstructs its well-known document
+	// from the typed columns until a refresh captures one.
+	Metadata []byte
 }
 
 // DiscoverIssuerMetadata performs issuer metadata discovery through Guardian's
@@ -886,11 +902,17 @@ type DiscoveredIssuerMetadata struct {
 // Platform MCP provider attachment; browser and MCP callers must never supply
 // an issuer URL to it.
 func DiscoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (DiscoveredIssuerMetadata, error) {
-	doc, _, err := discoverIssuerMetadata(ctx, policy, issuerURL)
+	doc, raw, _, err := discoverIssuerMetadata(ctx, policy, issuerURL)
 	if err != nil {
 		return DiscoveredIssuerMetadata{}, err
 	}
+	// A document that cannot be reduced to a storable snapshot still yields
+	// usable typed values, so the projection continues with a nil snapshot
+	// rather than failing the caller's attachment over it.
+	snapshot, _ := sanitizeDiscoverySnapshot(raw)
 	return DiscoveredIssuerMetadata{
+		Metadata: snapshot,
+
 		Issuer:                            doc.Issuer,
 		AuthorizationEndpoint:             doc.AuthorizationEndpoint,
 		TokenEndpoint:                     doc.TokenEndpoint,
@@ -911,10 +933,24 @@ func DiscoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	}, nil
 }
 
-func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (rfc8414Document, []string, error) {
+// discoveredDocument pairs a parsed metadata document with the exact bytes it
+// was parsed from.
+//
+// They travel as one value rather than as two variables because
+// discoverIssuerMetadata may return a document remembered from an earlier probe
+// candidate after later candidates fail. A `raw` tracked alongside the loop
+// would then hold the last probe's body while the returned document came from
+// an earlier one, and the snapshot persisted for the issuer would describe an
+// authorization server Gram never adopted.
+type discoveredDocument struct {
+	doc rfc8414Document
+	raw []byte
+}
+
+func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuerURL string) (rfc8414Document, []byte, []string, error) {
 	candidates, err := IssuerMetadataProbeCandidates(issuerURL)
 	if err != nil {
-		return rfc8414Document{}, nil, &discoveryError{
+		return rfc8414Document{}, nil, nil, &discoveryError{
 			WellKnownURL: "",
 			Status:       0,
 			cause:        fmt.Errorf("compute well-known url: %w", err),
@@ -935,10 +971,10 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 	}
 
 	var firstErr *discoveryError
-	var fallbackDoc rfc8414Document
+	var fallback discoveredDocument
 	haveFallback := false
 	for _, wellKnown := range candidates {
-		doc, attemptErr := attemptIssuerProbe(reqCtx, client, wellKnown)
+		found, attemptErr := attemptIssuerProbe(reqCtx, client, wellKnown)
 		if attemptErr != nil {
 			if firstErr == nil {
 				firstErr = attemptErr
@@ -950,31 +986,39 @@ func discoverIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer
 		// always a catch-all answering our speculative candidate, not real
 		// metadata. Remember the first such document but keep probing — a later
 		// candidate (e.g. the origin-style fallback) may carry the real one.
-		if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
+		if found.doc.AuthorizationEndpoint == "" || found.doc.TokenEndpoint == "" {
 			if !haveFallback {
-				fallbackDoc = doc
+				fallback = found
 				haveFallback = true
 			}
 			continue
 		}
 
-		return doc, collectDiscoveryWarnings(issuerURL, doc), nil
+		return found.doc, found.raw, collectDiscoveryWarnings(issuerURL, found.doc), nil
 	}
 
 	if haveFallback {
-		return fallbackDoc, collectDiscoveryWarnings(issuerURL, fallbackDoc), nil
+		return fallback.doc, fallback.raw, collectDiscoveryWarnings(issuerURL, fallback.doc), nil
 	}
 
-	return rfc8414Document{}, nil, firstErr
+	return rfc8414Document{}, nil, nil, firstErr
 }
 
 // attemptIssuerProbe issues a single GET against an issuer well-known URL and
-// returns either the parsed RFC 8414 / OIDC document or a typed error annotated
-// with the probed URL and upstream status.
-func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKnown string) (rfc8414Document, *discoveryError) {
+// returns either the parsed RFC 8414 / OIDC document, paired with the bytes it
+// was parsed from, or a typed error annotated with the probed URL and upstream
+// status.
+//
+// The raw body is returned so callers can persist a snapshot of what the issuer
+// actually advertised: the typed columns model only the fields Gram acts on, so
+// re-serving from them would drop the OIDC extension fields an MCP client may
+// rely on. It is only ever returned alongside a document that parsed and passed
+// validateIssuerMetadataEndpoints, so a stored snapshot has cleared the same
+// gate as the typed values beside it.
+func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKnown string) (discoveredDocument, *discoveryError) {
 	requestURL, err := url.Parse(wellKnown)
 	if err != nil || !validIssuerDiscoveryURL(requestURL) {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       0,
 			cause:        errors.New("issuer discovery URL must use HTTPS outside local loopback"),
@@ -982,7 +1026,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wellKnown, nil)
 	if err != nil {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       0,
 			cause:        fmt.Errorf("build discovery request: %w", err),
@@ -992,7 +1036,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       0,
 			cause:        fmt.Errorf("fetch discovery document: %w", err),
@@ -1001,7 +1045,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("discovery returned status %d", resp.StatusCode),
@@ -1010,7 +1054,7 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("read discovery body: %w", err),
@@ -1019,21 +1063,21 @@ func attemptIssuerProbe(ctx context.Context, client *guardian.HTTPClient, wellKn
 
 	var doc rfc8414Document
 	if err := json.Unmarshal(body, &doc); err != nil {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        fmt.Errorf("decode discovery document: %w", err),
 		}
 	}
 	if err := validateIssuerMetadataEndpoints(doc, requestURL); err != nil {
-		return rfc8414Document{}, &discoveryError{
+		return discoveredDocument{}, &discoveryError{
 			WellKnownURL: wellKnown,
 			Status:       resp.StatusCode,
 			cause:        err,
 		}
 	}
 
-	return doc, nil
+	return discoveredDocument{doc: doc, raw: body}, nil
 }
 
 // IssuerMetadataProbeCandidates returns the ordered list of well-known metadata URLs to

--- a/server/internal/remotesessions/issuerrefresh.go
+++ b/server/internal/remotesessions/issuerrefresh.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -106,14 +107,22 @@ func sanitizeDiscoverySnapshot(raw []byte) ([]byte, error) {
 		return nil, errors.New("decode discovery document: expected a JSON object")
 	}
 
+	// Matched case-insensitively, and every variant is dropped together.
+	// encoding/json resolves a struct field case-insensitively, so
+	// attemptIssuerProbe validated whichever spelling the upstream sent, while
+	// this map preserves them all verbatim. Filtering only the canonical
+	// spelling therefore republished the exact variants validation had already
+	// looked at: a document carrying REVOCATION_ENDPOINT over plaintext http
+	// passed the probe and survived into the served snapshot untouched.
 	dropUnless := func(key string, allowed func(string) bool) {
-		encoded, ok := fields[key]
-		if !ok {
-			return
-		}
-		var value string
-		if err := json.Unmarshal(encoded, &value); err != nil || !allowed(value) {
-			delete(fields, key)
+		for name, encoded := range fields {
+			if !strings.EqualFold(name, key) {
+				continue
+			}
+			var value string
+			if err := json.Unmarshal(encoded, &value); err != nil || !allowed(value) {
+				delete(fields, name)
+			}
 		}
 	}
 

--- a/server/internal/remotesessions/issuerrefresh.go
+++ b/server/internal/remotesessions/issuerrefresh.go
@@ -2,6 +2,7 @@ package remotesessions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -75,6 +76,59 @@ func buildIssuerDraft(doc rfc8414Document, issuerURL string, warnings []string) 
 	}
 }
 
+// sanitizeDiscoverySnapshot filters a discovery document down to what Gram is
+// willing to re-publish from its own origin, returning the JSON to store in
+// remote_session_issuers.metadata.
+//
+// The snapshot exists to preserve the OIDC extension fields the typed columns
+// do not model, so everything unrecognised is kept verbatim. What it must not
+// do is republish values the typed columns deliberately drop: buildIssuerDraft
+// and refreshIssuerMetadata discard a non-HTTPS revocation_endpoint (tokens are
+// credentials and must not be sent in the clear) and a service_documentation,
+// op_policy_uri or op_tos_uri that is not an absolute http(s) URL (downstream
+// surfaces render them as links). Storing them unfiltered would make the
+// snapshot laxer than the columns beside it, and the reconstruction fallback
+// stricter than the primary path, so the document a client received would
+// depend on whether the issuer had been refreshed yet.
+//
+// Key order is normalised by the map round trip, matching what
+// wellknown.rewriteMetadataIssuer already does to this document on the way out.
+func sanitizeDiscoverySnapshot(raw []byte) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("decode discovery document: %w", err)
+	}
+	if fields == nil {
+		return nil, errors.New("decode discovery document: expected a JSON object")
+	}
+
+	dropUnless := func(key string, allowed func(string) bool) {
+		encoded, ok := fields[key]
+		if !ok {
+			return
+		}
+		var value string
+		if err := json.Unmarshal(encoded, &value); err != nil || !allowed(value) {
+			delete(fields, key)
+		}
+	}
+
+	dropUnless("revocation_endpoint", urls.IsAbsoluteHTTPSOrLoopback)
+	for _, key := range []string{"service_documentation", "op_policy_uri", "op_tos_uri"} {
+		dropUnless(key, urls.IsAbsoluteHTTP)
+	}
+
+	out, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("encode discovery document: %w", err)
+	}
+	return out, nil
+}
+
 // issuerOrigin reduces an issuer URL to its scheme and host. Returns the input
 // unchanged when it does not parse as an absolute URL, so a caller comparing
 // against it simply finds no match rather than matching everything.
@@ -137,7 +191,7 @@ func mapDiscoveryError(ctx context.Context, logger *slog.Logger, err error, unre
 func refreshIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer repo.RemoteSessionIssuer) (repo.UpdateRemoteSessionIssuerDiscoveredMetadataParams, []string, error) {
 	var zero repo.UpdateRemoteSessionIssuerDiscoveredMetadataParams
 
-	doc, warnings, err := discoverIssuerMetadata(ctx, policy, issuer.Issuer)
+	doc, raw, warnings, err := discoverIssuerMetadata(ctx, policy, issuer.Issuer)
 	if err != nil {
 		return zero, nil, err
 	}
@@ -186,7 +240,21 @@ func refreshIssuerMetadata(ctx context.Context, policy *guardian.Policy, issuer 
 		}
 	}
 
+	// Runs only after the distrust gate above, so a document Gram refuses to
+	// adopt never replaces a snapshot that currently serves. The snapshot and
+	// the typed columns below are written from this one document in one
+	// statement, which is what keeps the served well-known document consistent
+	// with the endpoints Gram itself dials.
+	snapshot, err := sanitizeDiscoverySnapshot(raw)
+	if err != nil {
+		return zero, nil, &untrustedDocumentError{
+			reason: fmt.Sprintf("metadata document at %s could not be stored: %s", issuer.Issuer, err),
+		}
+	}
+
 	return repo.UpdateRemoteSessionIssuerDiscoveredMetadataParams{
+		Metadata: snapshot,
+
 		// An endpoint the issuer has stopped advertising arrives here as an
 		// empty string, which the query clears to NULL. Manual endpoint
 		// overrides are not preserved: they are rare to nonexistent, and

--- a/server/internal/remotesessions/issuersnapshot_internal_test.go
+++ b/server/internal/remotesessions/issuersnapshot_internal_test.go
@@ -1,0 +1,146 @@
+package remotesessions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The snapshot exists so the well-known surface can re-serve fields the typed
+// columns do not model, so anything unrecognised must survive verbatim. What it
+// must not do is republish values refreshIssuerMetadata deliberately drops,
+// which would make the snapshot laxer than the columns beside it.
+func TestSanitizeDiscoverySnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    map[string]any
+		wantErr string
+	}{
+		{
+			name: "preserves fields the typed columns do not model",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"authorization_endpoint": "https://idp.example.com/authorize",
+				"token_endpoint": "https://idp.example.com/token",
+				"userinfo_endpoint": "https://idp.example.com/userinfo",
+				"introspection_endpoint": "https://idp.example.com/introspect",
+				"claims_supported": ["sub", "email"],
+				"subject_types_supported": ["public"],
+				"id_token_signing_alg_values_supported": ["RS256"]
+			}`,
+			want: map[string]any{
+				"issuer":                                "https://idp.example.com",
+				"authorization_endpoint":                "https://idp.example.com/authorize",
+				"token_endpoint":                        "https://idp.example.com/token",
+				"userinfo_endpoint":                     "https://idp.example.com/userinfo",
+				"introspection_endpoint":                "https://idp.example.com/introspect",
+				"claims_supported":                      []any{"sub", "email"},
+				"subject_types_supported":               []any{"public"},
+				"id_token_signing_alg_values_supported": []any{"RS256"},
+			},
+			wantErr: "",
+		},
+		{
+			name: "drops a plaintext revocation endpoint",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"revocation_endpoint": "http://idp.example.com/revoke"
+			}`,
+			want:    map[string]any{"issuer": "https://idp.example.com"},
+			wantErr: "",
+		},
+		{
+			name: "keeps an https revocation endpoint",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"revocation_endpoint": "https://idp.example.com/revoke"
+			}`,
+			want: map[string]any{
+				"issuer":              "https://idp.example.com",
+				"revocation_endpoint": "https://idp.example.com/revoke",
+			},
+			wantErr: "",
+		},
+		{
+			name: "keeps a loopback revocation endpoint, matching the typed column rule",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"revocation_endpoint": "http://127.0.0.1:8080/revoke"
+			}`,
+			want: map[string]any{
+				"issuer":              "https://idp.example.com",
+				"revocation_endpoint": "http://127.0.0.1:8080/revoke",
+			},
+			wantErr: "",
+		},
+		{
+			name: "drops documentation URLs that are not absolute http(s)",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"service_documentation": "javascript:alert(1)",
+				"op_policy_uri": "/relative/policy",
+				"op_tos_uri": "https://idp.example.com/tos"
+			}`,
+			want: map[string]any{
+				"issuer":     "https://idp.example.com",
+				"op_tos_uri": "https://idp.example.com/tos",
+			},
+			wantErr: "",
+		},
+		{
+			// A field whose type is wrong is a document Gram cannot reason
+			// about, so it is dropped rather than re-served to clients.
+			name: "drops a filtered field carrying a non-string value",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"revocation_endpoint": {"url": "https://idp.example.com/revoke"}
+			}`,
+			want:    map[string]any{"issuer": "https://idp.example.com"},
+			wantErr: "",
+		},
+		{
+			name:    "an empty body yields no snapshot rather than an error",
+			raw:     "",
+			want:    nil,
+			wantErr: "",
+		},
+		{
+			name:    "a JSON null is not an object",
+			raw:     "null",
+			want:    nil,
+			wantErr: "expected a JSON object",
+		},
+		{
+			name:    "a JSON array is not an object",
+			raw:     `["not", "an", "object"]`,
+			want:    nil,
+			wantErr: "decode discovery document",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := sanitizeDiscoverySnapshot([]byte(tt.raw))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			if tt.want == nil {
+				require.Nil(t, got)
+				return
+			}
+
+			decoded := map[string]any{}
+			require.NoError(t, json.Unmarshal(got, &decoded))
+			require.Equal(t, tt.want, decoded)
+		})
+	}
+}

--- a/server/internal/remotesessions/issuersnapshot_internal_test.go
+++ b/server/internal/remotesessions/issuersnapshot_internal_test.go
@@ -92,6 +92,32 @@ func TestSanitizeDiscoverySnapshot(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			// encoding/json matches struct fields case-insensitively, so
+			// attemptIssuerProbe validated this member and let it through;
+			// filtering only the canonical spelling then republished the exact
+			// value validation had rejected, over plaintext, from Gram's origin.
+			name: "drops a filtered field under any capitalization",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"REVOCATION_ENDPOINT": "http://idp.example.com/revoke",
+				"Service_Documentation": "javascript:alert(1)"
+			}`,
+			want:    map[string]any{"issuer": "https://idp.example.com"},
+			wantErr: "",
+		},
+		{
+			name: "keeps a safe value under a non-canonical capitalization",
+			raw: `{
+				"issuer": "https://idp.example.com",
+				"Revocation_Endpoint": "https://idp.example.com/revoke"
+			}`,
+			want: map[string]any{
+				"issuer":              "https://idp.example.com",
+				"Revocation_Endpoint": "https://idp.example.com/revoke",
+			},
+			wantErr: "",
+		},
+		{
 			// A field whose type is wrong is a document Gram cannot reason
 			// about, so it is dropped rather than re-served to clients.
 			name: "drops a filtered field carrying a non-string value",

--- a/server/internal/remotesessions/issuersnapshot_test.go
+++ b/server/internal/remotesessions/issuersnapshot_test.go
@@ -1,0 +1,139 @@
+package remotesessions_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/remote_session_issuers"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// storedSnapshot returns the decoded remote_session_issuers.metadata for an
+// issuer, or nil when the row has never captured one.
+func storedSnapshot(t *testing.T, ctx context.Context, ti *testInstance, created *types.RemoteSessionIssuer) map[string]any {
+	t.Helper()
+
+	stored, err := repo.New(ti.conn).GetRemoteSessionIssuerByIDProjectOwned(ctx, repo.GetRemoteSessionIssuerByIDProjectOwnedParams{
+		ID:        uuid.MustParse(created.ID),
+		ProjectID: uuid.NullUUID{UUID: uuid.MustParse(created.ProjectID), Valid: true},
+	})
+	require.NoError(t, err)
+
+	if len(stored.Metadata) == 0 {
+		return nil
+	}
+
+	decoded := map[string]any{}
+	require.NoError(t, json.Unmarshal(stored.Metadata, &decoded))
+	return decoded
+}
+
+// A refresh writes the snapshot and the typed columns from one document in one
+// statement, so the two can never disagree about which authorization server the
+// issuer is.
+func TestRefreshRemoteSessionIssuerMetadata_CapturesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	upstream := fakeIssuerServer(t, func(doc map[string]any) {
+		// Fields the typed columns do not model. They are the whole reason the
+		// snapshot exists, so they must survive into it.
+		doc["userinfo_endpoint"] = "https://idp.example.com/userinfo"
+		doc["claims_supported"] = []string{"sub", "email"}
+	})
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayloadForURL("idp-snapshot-refresh", upstream.URL))
+	require.NoError(t, err)
+	require.Nil(t, storedSnapshot(t, ctx, ti, created), "create stores no snapshot; refresh is the capture event")
+
+	_, err = ti.service.RefreshRemoteSessionIssuerMetadata(ctx, &gen.RefreshRemoteSessionIssuerMetadataPayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	snapshot := storedSnapshot(t, ctx, ti, created)
+	require.NotNil(t, snapshot, "refresh is the capture event")
+	require.Equal(t, upstream.URL, snapshot["issuer"])
+	require.Equal(t, upstream.URL+"/authorize", snapshot["authorization_endpoint"])
+	require.Equal(t, "https://idp.example.com/userinfo", snapshot["userinfo_endpoint"])
+	require.Equal(t, []any{"sub", "email"}, snapshot["claims_supported"])
+}
+
+// The snapshot is re-served from Gram's origin, so it must not carry values the
+// typed columns drop. Otherwise a client's view of the issuer would depend on
+// whether the row had been refreshed yet.
+func TestRefreshRemoteSessionIssuerMetadata_SnapshotDropsUnsafeURLs(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	upstream := fakeIssuerServer(t, func(doc map[string]any) {
+		doc["revocation_endpoint"] = "http://idp.example.com/revoke"
+		doc["service_documentation"] = "javascript:alert(1)"
+	})
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayloadForURL("idp-snapshot-unsafe", upstream.URL))
+	require.NoError(t, err)
+
+	_, err = ti.service.RefreshRemoteSessionIssuerMetadata(ctx, &gen.RefreshRemoteSessionIssuerMetadataPayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	snapshot := storedSnapshot(t, ctx, ti, created)
+	require.NotNil(t, snapshot)
+	require.NotContains(t, snapshot, "revocation_endpoint", "a plaintext revocation endpoint is dropped from the typed column too")
+	require.NotContains(t, snapshot, "service_documentation")
+}
+
+// Create persists an operator-submitted form and deliberately does no
+// discovery of its own: the snapshot is only needed by direct upstream
+// authorization, and that project is responsible for ensuring an issuer has one
+// before allowing an MCP server to depend on it. Optimistically fetching a
+// document on every issuer create is not worth the round trip.
+//
+// The counter is the assertion. A create that quietly probes the upstream is
+// exactly the regression this guards, and it would otherwise be invisible.
+func TestCreateRemoteSessionIssuer_DoesNotDiscover(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	var probes atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probes.Add(1)
+		http.NotFound(w, nil)
+	}))
+	t.Cleanup(upstream.Close)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayloadForURL("idp-snapshot-nocapture", upstream.URL))
+	require.NoError(t, err)
+
+	require.Zero(t, probes.Load(), "create must not reach out to the issuer")
+	require.Nil(t, storedSnapshot(t, ctx, ti, created), "no document was fetched, so there is nothing to snapshot")
+}
+
+// An issuer whose upstream is unreachable is created exactly as before: there
+// was never a fetch to fail.
+func TestCreateRemoteSessionIssuer_UnreachableUpstreamStillCreates(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-snapshot-unreachable"))
+	require.NoError(t, err)
+	require.Nil(t, storedSnapshot(t, ctx, ti, created))
+}

--- a/server/internal/remotesessions/organizationissuerhandlers.go
+++ b/server/internal/remotesessions/organizationissuerhandlers.go
@@ -145,6 +145,10 @@ func (s *Service) CreateIssuer(ctx context.Context, payload *orgissuersgen.Creat
 		ClientIDMetadataDocumentSupported: conv.PtrValOr(payload.ClientIDMetadataDocumentSupported, false),
 		Oidc:                              conv.PtrValOr(payload.Oidc, false),
 		Passthrough:                       conv.PtrValOr(payload.Passthrough, false),
+		// Create does not discover, so it has no document to snapshot. The
+		// column is filled by the first refresh, and by callers that already
+		// hold a discovery document (see platformmcp's attachment).
+		Metadata: nil,
 	})
 	if err != nil {
 		if isRemoteSessionIssuerSlugConflict(err) || isGlobalRemoteSessionIssuerSlugConflict(err) {
@@ -557,7 +561,7 @@ func (s *Service) FetchIssuerMetadata(ctx context.Context, payload *orgissuersge
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid issuer url").LogError(ctx, logger)
 	}
 
-	doc, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
+	doc, _, warnings, err := discoverIssuerMetadata(ctx, s.policy, issuerURL)
 	if err != nil {
 		return nil, mapDiscoveryError(ctx, logger, err, oops.CodeBadRequest)
 	}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -28,7 +28,8 @@ INSERT INTO remote_session_issuers (
     code_challenge_methods_supported,
     client_id_metadata_document_supported,
     oidc,
-    passthrough
+    passthrough,
+    metadata
 )
 VALUES (
     @project_id,
@@ -56,7 +57,14 @@ VALUES (
     @code_challenge_methods_supported,
     @client_id_metadata_document_supported,
     @oidc,
-    @passthrough
+    @passthrough,
+    -- The issuer's own discovery document, for callers that already hold one.
+    -- The create handlers do not: they persist an operator-submitted form and
+    -- deliberately do no discovery of their own, so they pass NULL and the
+    -- well-known surface reconstructs from the typed columns above until a
+    -- refresh captures a document. Platform MCP's identity-provider attachment
+    -- does discover, and supplies it here.
+    sqlc.narg('metadata')::jsonb
 )
 RETURNING *;
 
@@ -384,6 +392,13 @@ SET
     token_endpoint_auth_methods_supported = @token_endpoint_auth_methods_supported::text[],
     code_challenge_methods_supported = @code_challenge_methods_supported::text[],
     client_id_metadata_document_supported = @client_id_metadata_document_supported::boolean,
+    -- The document the typed columns above were derived from, so the well-known
+    -- surface can re-serve the OIDC extension fields they do not model. Written
+    -- in the same statement from the same document, which is what keeps what
+    -- Gram advertises consistent with what Gram dials. NULL only when the
+    -- caller could not produce a storable snapshot; the column is nullable
+    -- because rows created before capture existed have never had one.
+    metadata = sqlc.narg('metadata')::jsonb,
     updated_at = clock_timestamp()
 WHERE id = @id
   AND issuer = @issuer::text

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -327,15 +327,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN sqlc.narg('issuer')::text IS NOT NULL
+            OR sqlc.narg('authorization_endpoint')::text IS NOT NULL
+            OR sqlc.narg('token_endpoint')::text IS NOT NULL
+            OR sqlc.narg('revocation_endpoint')::text IS NOT NULL
+            OR sqlc.narg('registration_endpoint')::text IS NOT NULL
+            OR sqlc.narg('jwks_uri')::text IS NOT NULL
+            OR sqlc.narg('service_documentation')::text IS NOT NULL
+            OR sqlc.narg('op_policy_uri')::text IS NOT NULL
+            OR sqlc.narg('op_tos_uri')::text IS NOT NULL
+            OR sqlc.narg('scopes_supported')::text[] IS NOT NULL
+            OR sqlc.narg('grant_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('response_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('token_endpoint_auth_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('code_challenge_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('client_id_metadata_document_supported')::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()
@@ -1692,15 +1715,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN sqlc.narg('issuer')::text IS NOT NULL
+            OR sqlc.narg('authorization_endpoint')::text IS NOT NULL
+            OR sqlc.narg('token_endpoint')::text IS NOT NULL
+            OR sqlc.narg('revocation_endpoint')::text IS NOT NULL
+            OR sqlc.narg('registration_endpoint')::text IS NOT NULL
+            OR sqlc.narg('jwks_uri')::text IS NOT NULL
+            OR sqlc.narg('service_documentation')::text IS NOT NULL
+            OR sqlc.narg('op_policy_uri')::text IS NOT NULL
+            OR sqlc.narg('op_tos_uri')::text IS NOT NULL
+            OR sqlc.narg('scopes_supported')::text[] IS NOT NULL
+            OR sqlc.narg('grant_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('response_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('token_endpoint_auth_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('code_challenge_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('client_id_metadata_document_supported')::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()
@@ -2211,15 +2257,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN sqlc.narg('issuer')::text IS NOT NULL
+            OR sqlc.narg('authorization_endpoint')::text IS NOT NULL
+            OR sqlc.narg('token_endpoint')::text IS NOT NULL
+            OR sqlc.narg('revocation_endpoint')::text IS NOT NULL
+            OR sqlc.narg('registration_endpoint')::text IS NOT NULL
+            OR sqlc.narg('jwks_uri')::text IS NOT NULL
+            OR sqlc.narg('service_documentation')::text IS NOT NULL
+            OR sqlc.narg('op_policy_uri')::text IS NOT NULL
+            OR sqlc.narg('op_tos_uri')::text IS NOT NULL
+            OR sqlc.narg('scopes_supported')::text[] IS NOT NULL
+            OR sqlc.narg('grant_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('response_types_supported')::text[] IS NOT NULL
+            OR sqlc.narg('token_endpoint_auth_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('code_challenge_methods_supported')::text[] IS NOT NULL
+            OR sqlc.narg('client_id_metadata_document_supported')::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -327,6 +327,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()
@@ -1683,6 +1692,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()
@@ -2193,6 +2211,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE(sqlc.narg('token_endpoint_auth_methods_supported')::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE(sqlc.narg('code_challenge_methods_supported')::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE(sqlc.narg('client_id_metadata_document_supported'), client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE(sqlc.narg('oidc'), oidc),
     passthrough = COALESCE(sqlc.narg('passthrough'), passthrough),
     updated_at = clock_timestamp()

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -5284,15 +5284,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN $2::text IS NOT NULL
+            OR $6::text IS NOT NULL
+            OR $7::text IS NOT NULL
+            OR $8::text IS NOT NULL
+            OR $9::text IS NOT NULL
+            OR $10::text IS NOT NULL
+            OR $11::text IS NOT NULL
+            OR $12::text IS NOT NULL
+            OR $13::text IS NOT NULL
+            OR $14::text[] IS NOT NULL
+            OR $15::text[] IS NOT NULL
+            OR $16::text[] IS NOT NULL
+            OR $17::text[] IS NOT NULL
+            OR $18::text[] IS NOT NULL
+            OR $19::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()
@@ -5511,15 +5534,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN $2::text IS NOT NULL
+            OR $6::text IS NOT NULL
+            OR $7::text IS NOT NULL
+            OR $8::text IS NOT NULL
+            OR $9::text IS NOT NULL
+            OR $10::text IS NOT NULL
+            OR $11::text IS NOT NULL
+            OR $12::text IS NOT NULL
+            OR $13::text IS NOT NULL
+            OR $14::text[] IS NOT NULL
+            OR $15::text[] IS NOT NULL
+            OR $16::text[] IS NOT NULL
+            OR $17::text[] IS NOT NULL
+            OR $18::text[] IS NOT NULL
+            OR $19::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()
@@ -5769,15 +5815,38 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
-    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
-    -- clients; the columns this statement rewrites are what Gram dials. An
-    -- operator correcting an endpoint, or repointing issuer entirely, would
-    -- otherwise leave Gram serving a document naming the old authorization
-    -- server while every remote session flow used the new one. Refresh keeps
-    -- the two coupled by writing both from one document; a manual edit has no
-    -- document to write, so it drops the snapshot and the well-known surface
-    -- reconstructs from these columns until the next refresh recaptures it.
-    metadata = NULL,
+    -- Cleared only when this edit actually moves a discovery-derived value.
+    -- The snapshot is what Gram advertises to MCP clients; the columns above
+    -- are what Gram dials, so an operator correcting an endpoint or repointing
+    -- issuer would otherwise leave Gram serving a document naming the old
+    -- authorization server while every remote session flow used the new one.
+    -- Refresh keeps the two coupled by writing both from one document; a manual
+    -- edit has no document to write, so it drops the snapshot and the
+    -- well-known surface reconstructs until the next refresh recaptures one.
+    --
+    -- Renaming an issuer, or changing its logo or setup documentation, moves
+    -- nothing the snapshot describes, so those edits keep it. Dropping it there
+    -- would silently degrade the served document to the typed columns for a
+    -- change that has nothing to do with them.
+    metadata = CASE
+        WHEN $2::text IS NOT NULL
+            OR $6::text IS NOT NULL
+            OR $7::text IS NOT NULL
+            OR $8::text IS NOT NULL
+            OR $9::text IS NOT NULL
+            OR $10::text IS NOT NULL
+            OR $11::text IS NOT NULL
+            OR $12::text IS NOT NULL
+            OR $13::text IS NOT NULL
+            OR $14::text[] IS NOT NULL
+            OR $15::text[] IS NOT NULL
+            OR $16::text[] IS NOT NULL
+            OR $17::text[] IS NOT NULL
+            OR $18::text[] IS NOT NULL
+            OR $19::boolean IS NOT NULL
+        THEN NULL
+        ELSE metadata
+    END,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -688,7 +688,8 @@ INSERT INTO remote_session_issuers (
     code_challenge_methods_supported,
     client_id_metadata_document_supported,
     oidc,
-    passthrough
+    passthrough,
+    metadata
 )
 VALUES (
     $1,
@@ -716,7 +717,12 @@ VALUES (
     $20,
     $21,
     $22,
-    $23
+    $23,
+    -- Best-effort snapshot of the issuer's own discovery document. NULL is the
+    -- normal outcome for a hand-configured issuer or an unreachable upstream:
+    -- the well-known surface reconstructs from the typed columns above until
+    -- the first refresh captures one.
+    $24::jsonb
 )
 RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, revocation_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, code_challenge_methods_supported, client_id_metadata_document_supported, oidc, passthrough, tunneled_mcp_server_id, name, logo_asset_id, client_setup_documentation_url, metadata, created_at, updated_at, deleted_at, deleted
 `
@@ -745,6 +751,7 @@ type CreateRemoteSessionIssuerParams struct {
 	ClientIDMetadataDocumentSupported bool
 	Oidc                              bool
 	Passthrough                       bool
+	Metadata                          []byte
 }
 
 // Remote session issuers — upstream Authorization Server identity records
@@ -777,6 +784,7 @@ func (q *Queries) CreateRemoteSessionIssuer(ctx context.Context, arg CreateRemot
 		arg.ClientIDMetadataDocumentSupported,
 		arg.Oidc,
 		arg.Passthrough,
+		arg.Metadata,
 	)
 	var i RemoteSessionIssuer
 	err := row.Scan(
@@ -5862,11 +5870,18 @@ SET
     token_endpoint_auth_methods_supported = $12::text[],
     code_challenge_methods_supported = $13::text[],
     client_id_metadata_document_supported = $14::boolean,
+    -- The document the typed columns above were derived from, so the well-known
+    -- surface can re-serve the OIDC extension fields they do not model. Written
+    -- in the same statement from the same document, which is what keeps what
+    -- Gram advertises consistent with what Gram dials. NULL only when the
+    -- caller could not produce a storable snapshot; the column is nullable
+    -- because rows created before capture existed have never had one.
+    metadata = $15::jsonb,
     updated_at = clock_timestamp()
-WHERE id = $15
-  AND issuer = $16::text
-  AND project_id IS NOT DISTINCT FROM $17::uuid
-  AND organization_id IS NOT DISTINCT FROM $18::text
+WHERE id = $16
+  AND issuer = $17::text
+  AND project_id IS NOT DISTINCT FROM $18::uuid
+  AND organization_id IS NOT DISTINCT FROM $19::text
   AND deleted IS FALSE
 RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, revocation_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, code_challenge_methods_supported, client_id_metadata_document_supported, oidc, passthrough, tunneled_mcp_server_id, name, logo_asset_id, client_setup_documentation_url, metadata, created_at, updated_at, deleted_at, deleted
 `
@@ -5886,6 +5901,7 @@ type UpdateRemoteSessionIssuerDiscoveredMetadataParams struct {
 	TokenEndpointAuthMethodsSupported []string
 	CodeChallengeMethodsSupported     []string
 	ClientIDMetadataDocumentSupported bool
+	Metadata                          []byte
 	ID                                uuid.UUID
 	Issuer                            string
 	ProjectID                         uuid.NullUUID
@@ -5950,6 +5966,7 @@ func (q *Queries) UpdateRemoteSessionIssuerDiscoveredMetadata(ctx context.Contex
 		arg.TokenEndpointAuthMethodsSupported,
 		arg.CodeChallengeMethodsSupported,
 		arg.ClientIDMetadataDocumentSupported,
+		arg.Metadata,
 		arg.ID,
 		arg.Issuer,
 		arg.ProjectID,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -718,10 +718,12 @@ VALUES (
     $21,
     $22,
     $23,
-    -- Best-effort snapshot of the issuer's own discovery document. NULL is the
-    -- normal outcome for a hand-configured issuer or an unreachable upstream:
-    -- the well-known surface reconstructs from the typed columns above until
-    -- the first refresh captures one.
+    -- The issuer's own discovery document, for callers that already hold one.
+    -- The create handlers do not: they persist an operator-submitted form and
+    -- deliberately do no discovery of their own, so they pass NULL and the
+    -- well-known surface reconstructs from the typed columns above until a
+    -- refresh captures a document. Platform MCP's identity-provider attachment
+    -- does discover, and supplies it here.
     $24::jsonb
 )
 RETURNING id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, revocation_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, code_challenge_methods_supported, client_id_metadata_document_supported, oidc, passthrough, tunneled_mcp_server_id, name, logo_asset_id, client_setup_documentation_url, metadata, created_at, updated_at, deleted_at, deleted
@@ -5282,6 +5284,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()
@@ -5500,6 +5511,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()
@@ -5749,6 +5769,15 @@ SET
     token_endpoint_auth_methods_supported = COALESCE($17::text[], token_endpoint_auth_methods_supported),
     code_challenge_methods_supported = COALESCE($18::text[], code_challenge_methods_supported),
     client_id_metadata_document_supported = COALESCE($19, client_id_metadata_document_supported),
+    -- Cleared, not preserved. The snapshot is what Gram advertises to MCP
+    -- clients; the columns this statement rewrites are what Gram dials. An
+    -- operator correcting an endpoint, or repointing issuer entirely, would
+    -- otherwise leave Gram serving a document naming the old authorization
+    -- server while every remote session flow used the new one. Refresh keeps
+    -- the two coupled by writing both from one document; a manual edit has no
+    -- document to write, so it drops the snapshot and the well-known surface
+    -- reconstructs from these columns until the next refresh recaptures it.
+    metadata = NULL,
     oidc = COALESCE($20, oidc),
     passthrough = COALESCE($21, passthrough),
     updated_at = clock_timestamp()

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -860,6 +860,21 @@ UPDATE remote_session_issuers
 SET deleted_at = clock_timestamp()
 WHERE id = @id;
 
+-- name: SetMCPServerUserSessionIssuerFixture :execrows
+-- Test-only fixture: attaches a user session issuer to an existing MCP server.
+-- UpdateMCPServer COALESCEs this column and the management API refuses the
+-- combination outright, so this is the only way to build a row that is both
+-- upstream and issuer-gated — the state the runtime must refuse to serve
+-- because ResyncMCPServerRemoteSessionIssuers would reassign the issuer being
+-- advertised.
+--
+-- Returns the row count so the caller can insist the stamp landed.
+UPDATE mcp_servers
+SET user_session_issuer_id = @user_session_issuer_id
+WHERE id = @id
+  AND project_id = @project_id
+  AND deleted IS FALSE;
+
 -- name: SetMCPServerRemoteSessionIssuerFixture :execrows
 -- Test-only fixture: stamps the denormalised upstream authorization server on
 -- an MCP server. Server creation cannot set it — no client bindings exist yet —

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -2583,6 +2583,36 @@ func (q *Queries) SetMCPServerRemoteSessionIssuerFixture(ctx context.Context, ar
 	return result.RowsAffected(), nil
 }
 
+const setMCPServerUserSessionIssuerFixture = `-- name: SetMCPServerUserSessionIssuerFixture :execrows
+UPDATE mcp_servers
+SET user_session_issuer_id = $1
+WHERE id = $2
+  AND project_id = $3
+  AND deleted IS FALSE
+`
+
+type SetMCPServerUserSessionIssuerFixtureParams struct {
+	UserSessionIssuerID uuid.NullUUID
+	ID                  uuid.UUID
+	ProjectID           uuid.UUID
+}
+
+// Test-only fixture: attaches a user session issuer to an existing MCP server.
+// UpdateMCPServer COALESCEs this column and the management API refuses the
+// combination outright, so this is the only way to build a row that is both
+// upstream and issuer-gated — the state the runtime must refuse to serve
+// because ResyncMCPServerRemoteSessionIssuers would reassign the issuer being
+// advertised.
+//
+// Returns the row count so the caller can insist the stamp landed.
+func (q *Queries) SetMCPServerUserSessionIssuerFixture(ctx context.Context, arg SetMCPServerUserSessionIssuerFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setMCPServerUserSessionIssuerFixture, arg.UserSessionIssuerID, arg.ID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const setMetaMCPServerNetworkAccessModeFixture = `-- name: SetMetaMCPServerNetworkAccessModeFixture :execrows
 UPDATE meta_mcp_servers
 SET network_access_mode = $1

--- a/server/internal/xmcp/upstream_authorization_test.go
+++ b/server/internal/xmcp/upstream_authorization_test.go
@@ -1,0 +1,295 @@
+// upstream_authorization_test.go covers mcp_servers.visibility = 'upstream':
+// the server advertises its own upstream authorization server in the well-known
+// documents and forwards the inbound bearer to it unchanged.
+//
+// The interesting cases are all about the fronting mcp_servers row overriding
+// the backing toolset. A converted server keeps a toolset whose mcp_is_public
+// is false and whose external_oauth_server_id is NULL, and every gate on the
+// toolset-backed serve path keys on exactly those two columns, so a test that
+// seeded an already-public toolset would pass without proving anything.
+package xmcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/xmcp"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+const upstreamIssuerURL = "https://idp.example.com"
+
+// upstreamDiscoveryDocument is what an issuer's own well-known endpoint served,
+// including fields remote_session_issuers has no column for. Those are the
+// reason the snapshot exists, so they are what the assertions look for.
+func upstreamDiscoveryDocument() json.RawMessage {
+	return json.RawMessage(`{
+		"issuer": "https://idp.example.com",
+		"authorization_endpoint": "https://idp.example.com/authorize",
+		"token_endpoint": "https://idp.example.com/token",
+		"registration_endpoint": "https://idp.example.com/register",
+		"response_types_supported": ["code"],
+		"grant_types_supported": ["authorization_code", "refresh_token"],
+		"code_challenge_methods_supported": ["S256"],
+		"userinfo_endpoint": "https://idp.example.com/userinfo",
+		"introspection_endpoint": "https://idp.example.com/introspect",
+		"claims_supported": ["sub", "email"],
+		"id_token_signing_alg_values_supported": ["RS256"]
+	}`)
+}
+
+func seedRemoteSessionIssuer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID, organizationID string, snapshot json.RawMessage) uuid.UUID {
+	t.Helper()
+
+	issuer, err := remotesessionsrepo.New(ti.conn).CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{UUID: projectID, Valid: true},
+		OrganizationID:                    conv.ToPGText(organizationID),
+		Slug:                              "upstream-idp-" + uuid.NewString()[:8],
+		Issuer:                            upstreamIssuerURL,
+		Name:                              conv.ToPGText("Upstream IdP"),
+		AuthorizationEndpoint:             conv.ToPGText(upstreamIssuerURL + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(upstreamIssuerURL + "/token"),
+		RegistrationEndpoint:              conv.ToPGText(upstreamIssuerURL + "/register"),
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		Metadata:                          snapshot,
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
+// seedUpstreamToolsetMCPEndpoint wires a full /x/mcp resolution chain for a
+// hosted server serving direct upstream authorization. The backing toolset is
+// left non-public on purpose, which is the state a converted server is in.
+//
+// The issuer id is stamped after creation the way the binding resync does it,
+// because a fresh server has no client bindings to derive it from.
+func seedUpstreamToolsetMCPEndpoint(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	projectID uuid.UUID,
+	organizationID string,
+	snapshot json.RawMessage,
+) (slug string, mcpServer mcpserversrepo.McpServer, issuerID uuid.UUID) {
+	t.Helper()
+
+	issuerID = seedRemoteSessionIssuer(t, ctx, ti, projectID, organizationID, snapshot)
+
+	toolset := seedBareToolset(t, ctx, ti, projectID, organizationID, "ts-upstream-"+uuid.NewString()[:8])
+	slug, mcpServer = seedToolsetMCPEndpoint(t, ctx, ti, projectID, toolset, mcpservers.VisibilityUpstream)
+
+	stamped, err := testrepo.New(ti.conn).SetMCPServerRemoteSessionIssuerFixture(ctx, testrepo.SetMCPServerRemoteSessionIssuerFixtureParams{
+		RemoteSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+		ID:                    mcpServer.ID,
+		ProjectID:             projectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stamped, "the issuer stamp must land on exactly one live server")
+
+	return slug, mcpServer, issuerID
+}
+
+// The document a client fetches is the upstream's, with only `issuer` rewritten
+// to the Gram URL it was fetched from (RFC 8414 3.3). This is the behavior the
+// toolset external-OAuth branch had, now keyed on mcp_servers.
+func TestUpstream_WellKnownAuthorizationServerServesTheIssuerSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, 200, w.Code)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+
+	issuer, isString := got["issuer"].(string)
+	require.True(t, isString)
+	require.Contains(t, issuer, "/x/mcp/"+slug, "the served issuer must be the Gram URL the client fetched this from")
+
+	require.Equal(t, upstreamIssuerURL+"/authorize", got["authorization_endpoint"])
+	require.Equal(t, upstreamIssuerURL+"/token", got["token_endpoint"])
+
+	// Fields no remote_session_issuers column models. Reconstructing from the
+	// typed columns would silently drop these.
+	require.Equal(t, upstreamIssuerURL+"/userinfo", got["userinfo_endpoint"])
+	require.Equal(t, upstreamIssuerURL+"/introspect", got["introspection_endpoint"])
+	require.Equal(t, []any{"sub", "email"}, got["claims_supported"])
+	require.Equal(t, []any{"RS256"}, got["id_token_signing_alg_values_supported"])
+}
+
+// An issuer that has not been refreshed since the snapshot column existed still
+// serves a spec-valid document, built from the typed columns.
+func TestUpstream_WellKnownAuthorizationServerReconstructsWithoutASnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, nil)
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, 200, w.Code)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+
+	issuer, isString := got["issuer"].(string)
+	require.True(t, isString)
+	require.Contains(t, issuer, "/x/mcp/"+slug)
+	require.Equal(t, upstreamIssuerURL+"/authorize", got["authorization_endpoint"])
+	require.Equal(t, upstreamIssuerURL+"/token", got["token_endpoint"])
+
+	// The degradation this path costs, asserted so the difference from the
+	// snapshot path stays visible rather than being assumed.
+	require.NotContains(t, got, "userinfo_endpoint")
+	require.NotContains(t, got, "claims_supported")
+}
+
+// The protected-resource document points a client at the Gram URL it arrived
+// at, whose authorization-server document is the upstream's. The legacy toolset
+// resolver would 404 here, since a converted server's toolset has no
+// external_oauth_server_id.
+func TestUpstream_WellKnownProtectedResourceAdvertisesTheGramURL(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, 200, w.Code)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+
+	resource, isString := got["resource"].(string)
+	require.True(t, isString)
+	require.Contains(t, resource, "/x/mcp/"+slug)
+	require.Equal(t, []any{resource}, got["authorization_servers"])
+}
+
+// A row that names no issuer has no authorization server to advertise, so it is
+// not served at all rather than served as something else.
+func TestUpstream_WithoutAnIssuerIsNotServed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := seedBareToolset(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, "ts-upstream-noissuer-"+uuid.NewString()[:8])
+	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, toolset, mcpservers.VisibilityUpstream)
+
+	_, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.Error(t, err)
+}
+
+// A tokenless call must be challenged, not refused. Two separate bugs produce a
+// response that looks almost right here: without oauthRequired the 401 carries
+// no WWW-Authenticate, leaving a client with no way to discover the
+// authorization server, and without the upstream guard on the toolset gate the
+// non-public backing toolset answers 404, which reads as "no such server"
+// rather than "authenticate first".
+func TestUpstream_RuntimeChallengesATokenlessCall(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, "", []byte(initializeBody))
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "body=%s", rr.Body.String())
+
+	challenge := rr.Header().Get("WWW-Authenticate")
+	require.NotEmpty(t, challenge, "a tokenless call must be told where to authenticate")
+	require.Contains(t, challenge, "resource_metadata=")
+	require.Contains(t, challenge, "/x/mcp/"+slug)
+}
+
+// The bearer is forwarded verbatim: Gram validates nothing, so any bearer gets
+// past the gate. What this pins is that neither the non-public backing toolset
+// nor the mcp:connect RBAC check refuses a caller Gram never authenticated.
+func TestUpstream_RuntimeAcceptsAnInboundBearer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer("upstream-issued-token"), []byte(initializeBody))
+	require.NotEqual(t, http.StatusNotFound, rr.Code, "a non-public backing toolset must not 404 an upstream server; body=%s", rr.Body.String())
+	require.NotEqual(t, http.StatusUnauthorized, rr.Code, "Gram must not validate a bearer it forwards; body=%s", rr.Body.String())
+	require.Equal(t, http.StatusOK, rr.Code, "body=%s", rr.Body.String())
+}
+
+// Gram is not the authorization server for these clients, so it must not offer
+// an authorize endpoint they could be redirected to. ResolvedMcpEndpoint.IsPublic
+// is false for upstream, so reaching it would send the caller to the Speakeasy
+// IDP for a server whose well-known documents point somewhere else entirely.
+func TestUpstream_ExposesNoGramAuthorizeSurface(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", "some-client")
+	q.Set("redirect_uri", "https://client.example.com/callback")
+	q.Set("code_challenge", "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", "upstream-authorize-state")
+
+	mux := goahttp.NewMuxer()
+	xmcp.Attach(mux, ti.service, nil)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/x/mcp/"+slug+"/authorize?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "upstream servers must expose no Gram authorize endpoint; body=%s", w.Body.String())
+	require.NotContains(t, w.Header().Get("Location"), "/connect", "a redirect here would send the caller into a Gram consent flow")
+}

--- a/server/internal/xmcp/upstream_authorization_test.go
+++ b/server/internal/xmcp/upstream_authorization_test.go
@@ -201,7 +201,13 @@ func TestUpstream_WellKnownProtectedResourceAdvertisesTheGramURL(t *testing.T) {
 }
 
 // A row that names no issuer has no authorization server to advertise, so it is
-// not served at all rather than served as something else.
+// not served at all rather than served as something else. Asserted on the
+// runtime path, not the well-known path: a well-known 404 proves nothing here,
+// since a toolset with no external OAuth config 404s there regardless of
+// visibility, so that version of this test passed with the feature reverted.
+//
+// This is the branch that actually executes in production today, because
+// nothing outside tests can set remote_session_issuer_id yet.
 func TestUpstream_WithoutAnIssuerIsNotServed(t *testing.T) {
 	t.Parallel()
 
@@ -213,8 +219,40 @@ func TestUpstream_WithoutAnIssuerIsNotServed(t *testing.T) {
 	toolset := seedBareToolset(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, "ts-upstream-noissuer-"+uuid.NewString()[:8])
 	slug, _ := seedToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, toolset, mcpservers.VisibilityUpstream)
 
+	// Not 401: an incoherent row must not challenge a client into a handshake
+	// it can never complete. Not 200: it must certainly not serve.
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer("upstream-issued-token"), []byte(initializeBody))
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
+
 	_, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
 	require.Error(t, err)
+}
+
+// An upstream row carrying a user session issuer would have its advertised
+// issuer reassigned by the remote-session resync, leaving it advertising one
+// authorization server while forwarding bearers to another. The runtime does
+// not trust the management API to have prevented that.
+func TestUpstream_WithAUserSessionIssuerIsNotServed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, mcpServer, _ := seedUpstreamToolsetMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, upstreamDiscoveryDocument())
+
+	userIssuerID := seedUserSessionIssuer(t, ctx, ti, *authCtx.ProjectID)
+	stamped, err := testrepo.New(ti.conn).SetMCPServerUserSessionIssuerFixture(ctx, testrepo.SetMCPServerUserSessionIssuerFixtureParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: userIssuerID, Valid: true},
+		ID:                  mcpServer.ID,
+		ProjectID:           *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stamped)
+
+	rr := runHandler(t, ctx, ti, http.MethodPost, slug, bearer("upstream-issued-token"), []byte(initializeBody))
+	require.Equal(t, http.StatusNotFound, rr.Code, "body=%s", rr.Body.String())
 }
 
 // A tokenless call must be challenged, not refused. Two separate bugs produce a


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-28/feat-serve-direct-upstream-authorization-on-visibility-upstream

## Summary

Adds `upstream` as a fourth `mcp_servers.visibility` value. A server in this mode does not authenticate its inbound MCP clients against Gram at all: the well-known documents advertise the server's **own** upstream authorization server, and the inbound bearer is forwarded upstream unchanged, with no validation, no session minted, and no consent recorded. It is the `mcp_servers`-keyed replacement for the toolset `external_oauth_server_id` branch and is indistinguishable from it to an MCP client.

`mcpservers.ResolveAuthorizationMode` derives, once per request, which authority authenticates the caller. It is deliberately not a restatement of `visibility`, which also carries an access control meaning that survives independently, and it is derived from the `mcp_servers` row alone rather than from `toolsets.mcp_is_public`, which would entrench the conflation AIM-25 exists to delete. An `upstream` row must be toolset-backed, must name a `remote_session_issuer_id`, and must have `user_session_issuer_id IS NULL`; a row violating any of these resolves `Invalid` and is served as not found with the reason logged rather than returned.

**Serve path.** `upstream` forwards the bearer as a token input exactly as the toolset branch does, carried through `hostedServing.upstreamAuthorized` alongside the existing `isPublic`. It is deliberately separate from `isPublic`, because an upstream server is not open: it requires a bearer, Gram just does not validate one. Five gates on the hosted path needed it. Without them the 401 carries no `WWW-Authenticate` (no client can discover the authorization server), the caller is challenged against Gram, a tokenless call answers 404 rather than 401, and `mcp:connect` is enforced against a principal Gram never authenticated.

**Well-known.** The authorization-server document is the issuer's captured discovery snapshot with only `issuer` rewritten to the Gram URL it is fetched from, per RFC 8414 §3.3, preserving the OIDC extension fields the typed columns do not model. An issuer with no snapshot is reconstructed from those columns and logged; every optional member is omitted when unknown rather than emitted as `null`, `""` or `[]`, which clients reject. The protected-resource document advertises the Gram URL the request arrived at, taken before the legacy toolset resolver, which would 404 a converted server.

**Snapshot capture.** `remote_session_issuers.metadata` has existed since AIM-29 but nothing wrote it. It is now captured wherever a discovery document is already in hand, and never by fetching one for its own sake: on refresh, which writes the snapshot and the typed columns from one document in one statement so they cannot disagree, and on Platform MCP's identity-provider attachment, which already discovers. The create handlers store NULL, and an operator edit that rewrites endpoints clears the snapshot so Gram never advertises a server it no longer dials.

**Write side.** Every site that decided behavior by comparing against `VisibilityPublic` or `VisibilityPrivate` rather than switching is fixed, so a fourth value cannot inherit public's treatment by fall-through. `upstream` is rejected at assistant attach (dispatch sends no `Authorization` header, so every call would 401) and at meta MCP attach (a Gram-authenticated gateway cannot present a member's own authorization server).

**Clients.** Goa, the TypeScript SDK, and the Go CLI client are regenerated together. Both clients validate this enum when **decoding a response**, not only when encoding a request, so a pinned build of either fails on a server carrying the new value.

## Motivation

The issue originally selected this behavior with `remote_session_issuer_id IS NOT NULL AND visibility = 'public'`. That rule does not work: `remote_session_issuer_id` is a derived column recomputed by `ResyncMCPServerRemoteSessionIssuers` on every remote-session client attach and detach, recording which authorization server issued the **upstream's** credential. It says nothing about whether Gram should stop being the authorization server for inbound clients, and applied as written it would have flipped most public remote servers into bearer passthrough. `visibility` already owns that axis, so `upstream` is a fourth answer to the question it already asks.

The `user_session_issuer_id IS NULL` requirement is load-bearing rather than stylistic. The resync matches `WHERE s.user_session_issuer_id = resolved.user_session_issuer_id`, and SQL NULL never equals anything, so a NULL there is the only thing keeping the resync from reassigning the very issuer whose metadata is being advertised, which would leave a server advertising one authorization server while forwarding bearers to another.

No migration. `mcp_servers.visibility` is `CHECK (visibility <> '')` with no enum constraint, so accepting the value needs no schema change. A CHECK enforcing the two invariants was considered and rejected: `mcp_servers_remote_session_issuer_id_fkey` is `ON DELETE SET NULL`, so the project and organization cascades that hard-delete `remote_session_issuers` would null the column and trip the constraint mid-teardown, making the outcome depend on cascade ordering. Both bad states are already inert because the serve path refuses them, which makes this an availability invariant rather than a security one.

`upstream` is not yet reachable through the API, by design. Nothing outside tests writes `remote_session_issuer_id`; AIM-27 adds that management surface, and the resync that derives it cannot match a row whose `user_session_issuer_id` is NULL, which `upstream` requires. Rather than accept a configuration the runtime answers 404 for, the management API refuses `upstream` without an issuer, which is AIM-27's own first rule arriving early. The runtime path is exercised by seeding the column directly through the existing test fixture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `upstream` as a fourth `mcp_servers.visibility` value so a server can authenticate clients against its own upstream authorization server instead of Gram. The well-known documents advertise the upstream's OAuth metadata and the inbound bearer is forwarded unchanged; Gram validates nothing, mints no session, and records no consent.

The original plan (`visibility = 'public'` plus `remote_session_issuer_id`) was dropped because that column is derived from live client bindings and would have flipped most public remote servers into bearer passthrough.

**Serving**
- `mcpservers.ResolveAuthorizationMode` derives once per request which authority authenticates the caller, from the `mcp_servers` row alone.
- An `upstream` row must be hosted, name a `remote_session_issuer_id`, and have `user_session_issuer_id IS NULL`; anything else resolves `Invalid` and is served as not found.
- The authorization-server document is the issuer's discovery snapshot with only `issuer` rewritten; snapshots are captured on refresh and Platform MCP attach, never fetched for their own sake, and cleared when an edit moves a discovery-derived value.
- The snapshot sanitizer matches case-variant JSON keys, and an issuer with neither a snapshot nor endpoints fails closed rather than advertising an unusable server.
- The well-known handlers resolve the authorization mode first, so Gram never advertises a server it serves as not found.
- Five toolset-path gates are fixed so 401s carry `WWW-Authenticate`, tokenless calls answer 401 rather than 404, and `mcp:connect` is not enforced against a principal Gram never authenticated; a public backing toolset no longer renders an upstream server's install page as open.
- `upstream` is rejected at assistant and meta MCP attach and on non-hosted backends, which also stops the plugin marketplace resolving such rows.
- Per-tool security schemes on the backing toolset can still be satisfied from the environment or an `MCP-*` header without an inbound bearer, matching the external-OAuth branch this mode replaces.

**Adoption**
- No migration; the column has no enum constraint.
- The management API refuses `upstream` without an issuer, so the value is unreachable through the API until AIM-27 lands; tests seed rows directly.
- Goa, the TypeScript SDK, and the Go CLI client are regenerated, and both clients validate the enum on response decode.
- Dashboard read side renders the value as "Upstream auth" with a read-only status dropdown and exhaustive switches across status, detail, and toast surfaces.

<sup>Written for commit e4a72ed400b76d00e27668894ad09c4833122e4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

