### PR TITLE
feat: add a permanent demo org link to the account menu

### DIFF
--- a/.changeset/demo-org-account-menu.md
+++ b/.changeset/demo-org-account-menu.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Keep Explore demo org reachable from the account menu after the trial welcome banner no longer shows it.

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -7,9 +7,13 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const orgSlug = vi.hoisted(() => ({ current: "acme" }));
+const exploreDemoGoTo = vi.hoisted(() => vi.fn());
+
 vi.mock("@/contexts/Auth", () => ({
   useUser: () => ({ displayName: "Sagar", email: "s@x.dev", photoUrl: "" }),
   useSession: () => ({ organizations: [{ id: "o1" }] }),
+  useOrganization: () => ({ slug: orgSlug.current }),
 }));
 vi.mock("@/contexts/Sdk", () => ({
   useSlugs: () => ({ projectSlug: "proj" }),
@@ -19,7 +23,10 @@ vi.mock("@/hooks/useRBAC", () => ({
   useRBAC: () => ({ hasAnyScope: () => true }),
 }));
 vi.mock("@/routes", () => ({
-  useRoutes: () => ({ settings: { goTo: vi.fn() } }),
+  useRoutes: () => ({
+    settings: { goTo: vi.fn() },
+    exploreDemo: { goTo: exploreDemoGoTo },
+  }),
   useOrgRoutes: () => ({
     billing: { goTo: vi.fn() },
   }),
@@ -69,6 +76,7 @@ vi.mock("@/components/ui/ThemeSwitcher", () => ({
   ThemeSwitcher: () => <div data-testid="theme-switcher" />,
 }));
 
+import { DEMO_ORG_SLUG } from "@/lib/demo";
 import { isPylonChatOpen, togglePylonChat } from "@/lib/pylon";
 import { installMockPylon } from "@/lib/pylon-test-mock";
 
@@ -80,6 +88,8 @@ afterEach(() => {
   }
   cleanup();
   Reflect.deleteProperty(window, "Pylon");
+  orgSlug.current = "acme";
+  exploreDemoGoTo.mockReset();
 });
 
 describe("SidebarUserMenu", () => {
@@ -130,5 +140,21 @@ describe("SidebarUserMenu", () => {
 
     expect(screen.getByText("Get Support")).toBeTruthy();
     expect(screen.queryByText("Close Support")).toBeNull();
+  });
+
+  it("always offers Explore demo org outside the demo org", () => {
+    render(<SidebarUserMenu />);
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+
+    fireEvent.click(screen.getByText("Explore demo org"));
+    expect(exploreDemoGoTo).toHaveBeenCalledOnce();
+  });
+
+  it("hides Explore demo org while already in the demo org", () => {
+    orgSlug.current = DEMO_ORG_SLUG;
+    render(<SidebarUserMenu />);
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+
+    expect(screen.queryByText("Explore demo org")).toBeNull();
   });
 });

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -1,6 +1,7 @@
-import { useSession, useUser } from "@/contexts/Auth";
+import { useOrganization, useSession, useUser } from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
+import { DEMO_ORG_SLUG } from "@/lib/demo";
 import { useOrgRoutes, useRoutes } from "@/routes";
 import {
   DropdownMenu,
@@ -16,6 +17,7 @@ import {
   ActivityIcon,
   BookOpenIcon,
   BuildingIcon,
+  CompassIcon,
   CreditCardIcon,
   LogOutIcon,
   MailIcon,
@@ -37,6 +39,7 @@ import {
 export function SidebarUserMenu(): JSX.Element {
   const user = useUser();
   const session = useSession();
+  const organization = useOrganization();
   const navigate = useNavigate();
   const routes = useRoutes();
   const orgRoutes = useOrgRoutes();
@@ -46,6 +49,7 @@ export function SidebarUserMenu(): JSX.Element {
 
   const canAccessOrgRoutes = hasAnyScope(["org:read", "org:admin"]);
   const isMultiOrg = session.organizations.length > 1;
+  const isDemoOrg = organization.slug === DEMO_ORG_SLUG;
 
   const [menuOpen, setMenuOpen] = useState(false);
   const pylonOpen = useSyncExternalStore(
@@ -155,6 +159,12 @@ export function SidebarUserMenu(): JSX.Element {
               >
                 <BuildingIcon className="mr-2 h-4 w-4" />
                 Switch Organization
+              </DropdownMenuItem>
+            )}
+            {!isDemoOrg && (
+              <DropdownMenuItem onClick={() => routes.exploreDemo.goTo()}>
+                <CompassIcon className="mr-2 h-4 w-4" />
+                Explore demo org
               </DropdownMenuItem>
             )}
           </DropdownMenuGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The org-home welcome banner only offers **Explore demo org** while the org is on trial. After that card drops, there is no durable in-app path into `/explore-demo`.

This adds the same destination to the sidebar account menu so it stays reachable from any project or org page. The item is hidden while already inside the demo org (Exit demo remains on the banner).

## Testing
- Unit tests for `SidebarUserMenu` cover showing the item, navigating to `/explore-demo`, and hiding it in the demo org.
- Manual: open the account menu on a non-demo org, click **Explore demo org**, land in the demo org; reopen the menu and confirm the item is gone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d6f015-103e-4359-a270-369616b4187f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d6f015-103e-4359-a270-369616b4187f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permanent **Explore demo org** entry to the sidebar account menu so the demo org stays reachable after the trial welcome banner disappears. The item is hidden when already inside the demo org.

- The menu item navigates to `/explore-demo` from any project or org page.
- New unit tests cover showing the item, navigating to the demo org, and hiding it inside the demo org.

<sup>Written for commit 78ac277200c849ade8e9cf5f8e6b36c6a22cdd51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

