### PR TITLE
fix: keep demo Cal branding on its embed namespace

### DIFF
--- a/.changeset/demo-booking-embed-fallback.md
+++ b/.changeset/demo-booking-embed-fallback.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The demo booking calendar uses a dedicated Cal.com namespace so its branding instructions target the same embed instance.

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
-import { CAL_DEMO_LINK } from "./demo-booking";
+import { CAL_DEMO_LINK, CAL_DEMO_NAMESPACE } from "./demo-booking";
 
 type MockSession = {
   user: { email: string; displayName?: string };
@@ -16,19 +16,23 @@ const { captureMock, sessionHolder, calUiMock } = vi.hoisted(() => ({
     } as MockSession,
   },
 }));
+const calNamespaces = vi.hoisted(() => [] as (string | undefined)[]);
 
 // Replace the Cal embed with a probe that exposes the props it received.
 vi.mock("@calcom/embed-react", () => ({
   default: ({
     calLink,
+    namespace,
     config,
   }: {
     calLink: string;
+    namespace?: string;
     config?: Record<string, string | undefined>;
   }) => (
     <div
       data-testid="cal-embed"
       data-cal-link={calLink}
+      data-cal-namespace={namespace ?? ""}
       data-cal-name={config?.name ?? ""}
       data-cal-email={config?.email ?? ""}
       // Keyed by the booking question's identifier on the Cal event, which is
@@ -38,7 +42,10 @@ vi.mock("@calcom/embed-react", () => ({
       data-cal-notes={config?.notes ?? ""}
     />
   ),
-  getCalApi: () => Promise.resolve(calUiMock),
+  getCalApi: (options?: { namespace?: string }) => {
+    calNamespaces.push(options?.namespace);
+    return Promise.resolve(calUiMock);
+  },
 }));
 
 vi.mock("@/contexts/Auth", () => ({
@@ -57,9 +64,16 @@ vi.mock("@/components/billing/lockout-payg-checkout-panel", () => ({
 
 import { DemoBookingFlow } from "./DemoBookingFlow";
 
+/** Renders, then settles the promise `getCalApi` returns. */
+async function renderConfigured(ui: React.ReactElement = <DemoBookingFlow />) {
+  render(ui);
+  await waitFor(() => expect(calUiMock).toHaveBeenCalled());
+}
+
 beforeEach(() => {
   captureMock.mockClear();
   calUiMock.mockClear();
+  calNamespaces.length = 0;
   sessionHolder.current = {
     user: { email: "jane@acme.com", displayName: "Jane Smith" },
     organization: { name: "Acme Inc" },
@@ -141,9 +155,7 @@ describe("DemoBookingFlow", () => {
   // hideEventTypeDetails and cssVarsPerTheme are UiConfig, not prefill config;
   // passing them via the `config` prop silently does nothing.
   it("brands the embed through the ui instruction, not the config prop", async () => {
-    render(<DemoBookingFlow />);
-
-    await waitFor(() => expect(calUiMock).toHaveBeenCalled());
+    await renderConfigured();
 
     const [instruction, uiConfig] = calUiMock.mock.calls[0] as [
       string,
@@ -158,6 +170,15 @@ describe("DemoBookingFlow", () => {
       "light",
       "dark",
     ]);
+  });
+
+  it("uses one Cal namespace for the embed and its instructions", async () => {
+    await renderConfigured();
+
+    expect(calNamespaces).toEqual([CAL_DEMO_NAMESPACE]);
+    expect(
+      screen.getByTestId("cal-embed").getAttribute("data-cal-namespace"),
+    ).toBe(CAL_DEMO_NAMESPACE);
   });
 
   it("footnotes the details it handed the embed", () => {

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -3,7 +3,11 @@ import _Cal, { getCalApi } from "@calcom/embed-react";
 import { LockoutPaygCheckoutPanel } from "@/components/billing/lockout-payg-checkout-panel";
 import { useSessionData } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
-import { CAL_DEMO_LINK, splitDisplayName } from "./demo-booking";
+import {
+  CAL_DEMO_LINK,
+  CAL_DEMO_NAMESPACE,
+  splitDisplayName,
+} from "./demo-booking";
 
 // Cal's .d.ts returns the legacy global `JSX.Element`, incompatible with
 // react-jsx/TS5. Widen only the return type; keep prop types intact so a
@@ -43,7 +47,7 @@ function useCalBranding() {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const cal = await getCalApi();
+      const cal = await getCalApi({ namespace: CAL_DEMO_NAMESPACE });
       if (cancelled) return;
       cal("ui", {
         theme: "light",
@@ -51,6 +55,7 @@ function useCalBranding() {
         cssVarsPerTheme: { light: CAL_BRAND_VARS, dark: CAL_BRAND_VARS },
       });
     })();
+
     return () => {
       cancelled = true;
     };
@@ -153,6 +158,7 @@ export function DemoBookingFlow({
             capped so the card still clears the fold on a laptop viewport. */}
         <div className="h-[clamp(500px,54vh,600px)] w-full overflow-auto">
           <Cal
+            namespace={CAL_DEMO_NAMESPACE}
             calLink={CAL_DEMO_LINK}
             config={{
               // Caller defaults go first so the identity below wins: the type

--- a/client/dashboard/src/pages/demo/components/demo-booking.ts
+++ b/client/dashboard/src/pages/demo/components/demo-booking.ts
@@ -2,6 +2,9 @@
 // embedded directly (no routing form). Rotate here if the Cal event changes.
 export const CAL_DEMO_LINK = "team/speakeasy-com/ai-transformation";
 
+// Keep the branding instruction and inline embed on the same Cal instance.
+export const CAL_DEMO_NAMESPACE = "gram-demo";
+
 export function splitDisplayName(displayName?: string): {
   firstName: string;
   lastName: string;


### PR DESCRIPTION
## Summary

Use one explicit Cal.com namespace for the demo booking embed and its branding instruction:

- Pass `CAL_DEMO_NAMESPACE` to both `<Cal>` and `getCalApi`.
- Keep the hosted Cal.com inline embed, prefilled attendee details, branding, and existing booking-success telemetry.
- Remove app-level embed readiness and failure handling: loading overlay, timeout fallback, direct booking and email links, `linkReady`/`linkFailed` listeners, and failure/load telemetry.
- Add focused coverage for the hosted embed configuration and namespace wiring.

## Motivation

Cal embed calls use the same namespace as the iframe they configure. Sharing the namespace keeps the `cal("ui", ...)` branding instruction attached to the intended embed. The change stays limited to the Cal integration and does not introduce a second application-level failure state machine around Cal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the demo booking Cal embed so its branding instruction targets the same embed instance instead of the default namespace.

- Adds `CAL_DEMO_NAMESPACE` and passes it to both `<Cal>` and `getCalApi`.
- Adds a test asserting both calls use the same namespace.

<sup>Written for commit 13a73d7f10dc3848a5ac5f5ac32c3a98836cc750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

