### PR TITLE
feat: add AI platform push integration admin toggle

### DIFF
--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -14,7 +14,6 @@ import {
 import {
   getOrganization,
   getOrganizationChatAnalysisSettings,
-  getOrganizationFeatures,
   getOrganizationStats,
   getInferenceKeys,
   getInferenceSpendHistory,
@@ -31,7 +30,6 @@ import {
   type AdminInferenceSpendMonth,
   type AdminOrganization,
   type AdminOrganizationChatAnalysisSettings,
-  type AdminOrganizationFeatures,
   type AdminProjectDetail,
   type AdminPaygBillingSummary,
   type AdminStripeSubscription,
@@ -126,18 +124,6 @@ export function invalidateOrganizationActivity(
 ): void {
   void qc.invalidateQueries({
     queryKey: organizationActivityQuery(organizationID).queryKey,
-  });
-}
-
-export function organizationFeaturesQuery(
-  organizationID: string,
-): AdminQuery<
-  AdminOrganizationFeatures,
-  readonly ["gram-admin-organization-features", string]
-> {
-  return queryOptions({
-    queryKey: ["gram-admin-organization-features", organizationID] as const,
-    queryFn: () => getOrganizationFeatures(organizationID),
   });
 }
 

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -547,55 +547,6 @@ export type AdminInferenceKey = Omit<
   disable_causes: string[] | null;
 };
 
-export type AdminOrganizationFeatures = {
-  authz_challenge_logging_enabled: boolean;
-  customer_managed_encryption_keys_enabled: boolean;
-  custom_model_keys_enabled: boolean;
-  platform_mcp_enabled: boolean;
-  remote_session_auto_refresh_enabled: boolean;
-  session_portability_enabled: boolean;
-  sso_enabled: boolean;
-  scim_enabled: boolean;
-};
-
-export type AdminOrganizationFeatureName =
-  | "authz_challenge_logging"
-  | "customer_managed_encryption_keys"
-  | "custom_model_keys"
-  | "platform_mcp"
-  | "remote_session_auto_refresh"
-  | "session_portability"
-  | "sso"
-  | "scim";
-
-export function getOrganizationFeatures(
-  organizationID: string,
-): Promise<AdminOrganizationFeatures> {
-  const qs = toSearchParams({ organization_id: organizationID });
-  return gramAdminFetch<AdminOrganizationFeatures>(
-    `/admin/organization.features?${qs}`,
-  );
-}
-
-export function setOrganizationFeature(input: {
-  organizationID: string;
-  featureName: AdminOrganizationFeatureName;
-  enabled: boolean;
-}): Promise<AdminOrganizationFeatures> {
-  return gramAdminMutation<AdminOrganizationFeatures>(
-    "/admin/organization.features",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        organization_id: input.organizationID,
-        feature_name: input.featureName,
-        enabled: input.enabled,
-      }),
-    },
-  );
-}
-
 export type AdminChatAnalysisJudge = "work_units" | "business_memory";
 
 export type AdminOrganizationChatAnalysisSettings = {

--- a/client/admin/src/pages/organization/Features.test.tsx
+++ b/client/admin/src/pages/organization/Features.test.tsx
@@ -121,20 +121,17 @@ const TOGGLE_FEATURES = [
 
 type ToggleFeatureName = (typeof TOGGLE_FEATURES)[number]["featureName"];
 
-const MANAGED_FEATURES = {
-  logs: "managed-elsewhere",
-  tool_io_logs: "managed-elsewhere",
-  session_capture: "managed-elsewhere",
-  hooks_browser_login: "managed-elsewhere",
-  hooks_fail_open: "managed-elsewhere",
-  skills: "managed-elsewhere",
-  skill_capture_metadata_only: "managed-elsewhere",
-  remote_session_auto_refresh_enforced: "managed-elsewhere",
-  consent_tool_filtering: "managed-elsewhere",
-} as const satisfies Record<
-  Exclude<FeatureName, ToggleFeatureName>,
-  "managed-elsewhere"
->;
+const OMITTED_FEATURES = {
+  logs: "omitted",
+  tool_io_logs: "omitted",
+  session_capture: "omitted",
+  hooks_browser_login: "omitted",
+  hooks_fail_open: "omitted",
+  skills: "omitted",
+  skill_capture_metadata_only: "omitted",
+  remote_session_auto_refresh_enforced: "omitted",
+  consent_tool_filtering: "omitted",
+} as const satisfies Record<Exclude<FeatureName, ToggleFeatureName>, "omitted">;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -210,8 +207,8 @@ describe("Features", () => {
       ),
     ).toEqual(switches);
     expect(
-      Object.values(MANAGED_FEATURES).filter(
-        (classification) => classification === "managed-elsewhere",
+      Object.values(OMITTED_FEATURES).filter(
+        (classification) => classification === "omitted",
       ),
     ).toHaveLength(9);
   });

--- a/client/admin/src/pages/organization/Features.test.tsx
+++ b/client/admin/src/pages/organization/Features.test.tsx
@@ -2,18 +2,17 @@ import { QueryClient } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { organizationFeaturesQuery } from "@/lib/adminQueries";
-import type {
-  AdminOrganizationChatAnalysisSettings,
-  AdminOrganizationFeatures,
-} from "@/lib/gramAdminApi";
+import { organizationFeaturesQuery } from "@/lib/gramAdminClient";
+import type { AdminOrganizationChatAnalysisSettings } from "@/lib/gramAdminApi";
+import type { ProductFeatures } from "@gram/admin-client/models/components/productfeatures";
+import type { FeatureName } from "@gram/admin-client/models/components/setorganizationfeaturerequestbody";
+import { queryKeyAdminOrganizationFeatures } from "@gram/admin-client/react-query/adminOrganizationFeatures.core";
 import { Features } from "@/pages/organization/Features";
 import { anOrganization } from "@/test/fixtures";
 import { renderWithApp } from "@/test/harness";
 
 const mocks = vi.hoisted(() => ({
-  getOrganizationFeatures: vi.fn(),
-  setOrganizationFeature: vi.fn(),
+  featureFetch: vi.fn(),
   getOrganizationChatAnalysisSettings: vi.fn(),
   setOrganizationChatAnalysisSetting: vi.fn(),
   triggerOrganizationChatAnalysis: vi.fn(),
@@ -23,8 +22,6 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
   return {
     ...actual,
-    getOrganizationFeatures: mocks.getOrganizationFeatures,
-    setOrganizationFeature: mocks.setOrganizationFeature,
     getOrganizationChatAnalysisSettings:
       mocks.getOrganizationChatAnalysisSettings,
     setOrganizationChatAnalysisSetting:
@@ -34,16 +31,131 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
 });
 
 const ORG = anOrganization();
-const FEATURES: AdminOrganizationFeatures = {
+const FEATURES: ProductFeatures = {
+  aiPlatformPushIntegrationsEnabled: false,
+  authzChallengeLoggingEnabled: true,
+  consentToolFilteringEnabled: false,
+  customModelKeysEnabled: true,
+  customerManagedEncryptionKeysEnabled: false,
+  deviceAgent: false,
+  hooksBrowserLoginEnabled: false,
+  hooksFailOpenEnabled: false,
+  logsEnabled: true,
+  platformMcpEnabled: true,
+  remoteSessionAutoRefreshEnabled: false,
+  remoteSessionAutoRefreshEnforcedEnabled: false,
+  scimEnabled: false,
+  sessionCaptureEnabled: false,
+  sessionPortabilityEnabled: false,
+  skillCaptureMetadataOnly: false,
+  skillsEnabled: true,
+  ssoEnabled: true,
+  toolIoLogsEnabled: true,
+};
+
+const FEATURES_RESPONSE = {
+  ai_platform_push_integrations_enabled: false,
   authz_challenge_logging_enabled: true,
-  customer_managed_encryption_keys_enabled: false,
+  consent_tool_filtering_enabled: false,
   custom_model_keys_enabled: true,
+  customer_managed_encryption_keys_enabled: false,
+  device_agent: false,
+  hooks_browser_login_enabled: false,
+  hooks_fail_open_enabled: false,
+  logs_enabled: true,
   platform_mcp_enabled: true,
   remote_session_auto_refresh_enabled: false,
-  session_portability_enabled: false,
-  sso_enabled: true,
+  remote_session_auto_refresh_enforced_enabled: false,
   scim_enabled: false,
+  session_capture_enabled: false,
+  session_portability_enabled: false,
+  skill_capture_metadata_only: false,
+  skills_enabled: true,
+  sso_enabled: true,
+  tool_io_logs_enabled: true,
 };
+
+const TOGGLE_FEATURES = [
+  {
+    featureName: "ai_platform_push_integrations",
+    enabledKey: "aiPlatformPushIntegrationsEnabled",
+    label: "AI Platform Push Integrations",
+  },
+  {
+    featureName: "authz_challenge_logging",
+    enabledKey: "authzChallengeLoggingEnabled",
+    label: "Authz Challenge Logging",
+  },
+  {
+    featureName: "customer_managed_encryption_keys",
+    enabledKey: "customerManagedEncryptionKeysEnabled",
+    label: "Customer-Managed Encryption Keys",
+  },
+  {
+    featureName: "custom_model_keys",
+    enabledKey: "customModelKeysEnabled",
+    label: "Custom Model Provider Keys",
+  },
+  {
+    featureName: "platform_mcp",
+    enabledKey: "platformMcpEnabled",
+    label: "Platform MCP access",
+  },
+  {
+    featureName: "remote_session_auto_refresh",
+    enabledKey: "remoteSessionAutoRefreshEnabled",
+    label: "Automatic Remote Session Refresh",
+  },
+  {
+    featureName: "session_portability",
+    enabledKey: "sessionPortabilityEnabled",
+    label: "Session Portability",
+  },
+  { featureName: "sso", enabledKey: "ssoEnabled", label: "SSO" },
+  { featureName: "scim", enabledKey: "scimEnabled", label: "SCIM" },
+] as const satisfies readonly {
+  featureName: FeatureName;
+  enabledKey: keyof ProductFeatures;
+  label: string;
+}[];
+
+type ToggleFeatureName = (typeof TOGGLE_FEATURES)[number]["featureName"];
+
+const MANAGED_FEATURES = {
+  logs: "managed-elsewhere",
+  tool_io_logs: "managed-elsewhere",
+  session_capture: "managed-elsewhere",
+  hooks_browser_login: "managed-elsewhere",
+  hooks_fail_open: "managed-elsewhere",
+  skills: "managed-elsewhere",
+  skill_capture_metadata_only: "managed-elsewhere",
+  remote_session_auto_refresh_enforced: "managed-elsewhere",
+  consent_tool_filtering: "managed-elsewhere",
+} as const satisfies Record<
+  Exclude<FeatureName, ToggleFeatureName>,
+  "managed-elsewhere"
+>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function serviceError(message: string, status: number): Response {
+  return jsonResponse(
+    {
+      fault: status >= 500,
+      id: "placeholder",
+      message,
+      name: status >= 500 ? "internal_error" : "invalid_request",
+      temporary: false,
+      timeout: false,
+    },
+    status,
+  );
+}
 const CHAT_ANALYSIS: AdminOrganizationChatAnalysisSettings = {
   organization_id: ORG.id,
   work_units_enabled: true,
@@ -55,14 +167,20 @@ const CHAT_ANALYSIS: AdminOrganizationChatAnalysisSettings = {
 
 beforeEach(() => {
   for (const mock of Object.values(mocks)) mock.mockReset();
-  mocks.getOrganizationFeatures.mockResolvedValue(FEATURES);
-  mocks.setOrganizationFeature.mockImplementation(
-    ({ featureName, enabled }: { featureName: string; enabled: boolean }) =>
-      Promise.resolve({
-        ...FEATURES,
-        [`${featureName}_enabled`]: enabled,
-      }),
-  );
+  mocks.featureFetch.mockImplementation(async (input: RequestInfo | URL) => {
+    const request = input as Request;
+    if (request.method === "GET") return jsonResponse(FEATURES_RESPONSE);
+
+    const body = (await request.clone().json()) as {
+      enabled: boolean;
+      feature_name: string;
+    };
+    return jsonResponse({
+      ...FEATURES_RESPONSE,
+      [`${body.feature_name}_enabled`]: body.enabled,
+    });
+  });
+  vi.stubGlobal("fetch", mocks.featureFetch);
   mocks.getOrganizationChatAnalysisSettings.mockResolvedValue(CHAT_ANALYSIS);
   mocks.setOrganizationChatAnalysisSetting.mockResolvedValue(CHAT_ANALYSIS);
   mocks.triggerOrganizationChatAnalysis.mockResolvedValue({
@@ -70,30 +188,83 @@ beforeEach(() => {
   });
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 async function renderFeatures(queryClient?: QueryClient): Promise<void> {
   await renderWithApp(<Features org={ORG} />, { queryClient });
 }
 
 describe("Features", () => {
-  it("matches the dashboard platform-admin product feature list", async () => {
+  it("renders exactly the nine typed direct toggles", async () => {
     await renderFeatures();
 
-    for (const label of [
-      "Authz Challenge Logging",
-      "Customer-Managed Encryption Keys",
-      "Custom Model Provider Keys",
-      "Platform MCP access",
-      "Automatic Remote Session Refresh",
-      "SSO",
-      "SCIM",
-    ]) {
-      expect(await screen.findByText(label)).toBeTruthy();
-    }
-    expect(screen.queryByText("Consent tool filtering")).toBeNull();
-    expect(mocks.getOrganizationFeatures).toHaveBeenCalledWith(ORG.id);
+    const switches = await screen.findAllByRole("switch");
+    expect(switches).toHaveLength(TOGGLE_FEATURES.length);
+    expect(
+      TOGGLE_FEATURES.map(({ label }) =>
+        screen.getByRole("switch", { name: `Toggle ${label}` }),
+      ),
+    ).toEqual(switches);
+    expect(
+      Object.values(MANAGED_FEATURES).filter(
+        (classification) => classification === "managed-elsewhere",
+      ),
+    ).toHaveLength(9);
   });
+
+  it("uses an organization-scoped generated query", async () => {
+    await renderFeatures();
+
+    await screen.findAllByRole("switch");
+    const request = mocks.featureFetch.mock.calls[0]?.[0] as Request;
+    const url = new URL(request.url);
+    expect(url.pathname).toBe("/admin/organization.features");
+    expect(url.searchParams.get("organization_id")).toBe(ORG.id);
+    expect(organizationFeaturesQuery(ORG.id).queryKey).toEqual(
+      queryKeyAdminOrganizationFeatures({ organizationId: ORG.id }),
+    );
+  });
+
+  it.each(TOGGLE_FEATURES)(
+    "maps $featureName to $enabledKey and emits its generated name",
+    async ({ featureName, enabledKey, label }) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      queryClient.setQueryData(organizationFeaturesQuery(ORG.id).queryKey, {
+        ...FEATURES,
+        ...Object.fromEntries(
+          TOGGLE_FEATURES.map((feature) => [feature.enabledKey, true]),
+        ),
+        [enabledKey]: false,
+      });
+      await renderFeatures(queryClient);
+
+      const control = screen.getByRole("switch", { name: `Toggle ${label}` });
+      expect(control.getAttribute("data-state")).toBe("unchecked");
+      fireEvent.click(control);
+
+      await waitFor(() => {
+        expect(
+          mocks.featureFetch.mock.calls.some(
+            ([input]) => (input as Request).method === "POST",
+          ),
+        ).toBe(true);
+      });
+      const request = mocks.featureFetch.mock.calls
+        .map(([input]) => input as Request)
+        .find((input) => input.method === "POST");
+      expect(await request?.clone().json()).toEqual({
+        organization_id: ORG.id,
+        feature_name: featureName,
+        enabled: true,
+      });
+    },
+  );
 
   it("shows chat analysis controls beneath product features", async () => {
     await renderFeatures();
@@ -229,27 +400,126 @@ describe("Features", () => {
     expect(screen.getByText("Enabled")).toBeTruthy();
   });
 
-  it("updates an organization feature from its switch", async () => {
-    await renderFeatures();
+  it("cancels an in-flight refresh before the optimistic generated-key update", async () => {
+    let getCount = 0;
+    let finishRefresh!: (response: Response) => void;
+    let finishMutation!: (response: Response) => void;
+    mocks.featureFetch.mockImplementation((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === "POST") {
+        return new Promise<Response>((resolve) => {
+          finishMutation = resolve;
+        });
+      }
+      getCount += 1;
+      if (getCount === 1)
+        return Promise.resolve(jsonResponse(FEATURES_RESPONSE));
+      return new Promise<Response>((resolve) => {
+        finishRefresh = resolve;
+      });
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    await renderFeatures(queryClient);
 
     const control = await screen.findByRole("switch", {
       name: "Toggle Customer-Managed Encryption Keys",
     });
-    expect(control.getAttribute("data-state")).toBe("unchecked");
+    void queryClient.invalidateQueries(organizationFeaturesQuery(ORG.id));
+    await waitFor(() => expect(getCount).toBe(2));
     fireEvent.click(control);
 
     await waitFor(() => {
-      expect(mocks.setOrganizationFeature).toHaveBeenCalledWith({
-        organizationID: ORG.id,
-        featureName: "customer_managed_encryption_keys",
-        enabled: true,
-      });
+      expect(control.getAttribute("data-state")).toBe("checked");
+      for (const item of screen.getAllByRole("switch")) {
+        expect((item as HTMLButtonElement).disabled).toBe(true);
+      }
     });
-    expect(control.getAttribute("data-state")).toBe("checked");
+    const request = mocks.featureFetch.mock.calls
+      .map(([input]) => input as Request)
+      .find((input) => input.method === "POST");
+    expect(new URL(request!.url).pathname).toBe("/admin/organization.features");
+    expect(await request?.clone().json()).toEqual({
+      organization_id: ORG.id,
+      feature_name: "customer_managed_encryption_keys",
+      enabled: true,
+    });
+
+    finishRefresh(jsonResponse(FEATURES_RESPONSE));
+    await waitFor(() => {
+      expect(control.getAttribute("data-state")).toBe("checked");
+    });
+    finishMutation(
+      jsonResponse({
+        ...FEATURES_RESPONSE,
+        customer_managed_encryption_keys_enabled: true,
+      }),
+    );
+    await waitFor(() => {
+      expect((control as HTMLButtonElement).disabled).toBe(false);
+    });
   });
 
-  it("restores the previous state and reports a mutation failure", async () => {
-    mocks.setOrganizationFeature.mockRejectedValue(new Error("write failed"));
+  it("replaces the full snapshot from success without refetching", async () => {
+    mocks.featureFetch.mockImplementation((input: RequestInfo | URL) => {
+      const request = input as Request;
+      return Promise.resolve(
+        jsonResponse(
+          request.method === "GET"
+            ? FEATURES_RESPONSE
+            : {
+                ...FEATURES_RESPONSE,
+                customer_managed_encryption_keys_enabled: true,
+                sso_enabled: false,
+              },
+        ),
+      );
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    await renderFeatures(queryClient);
+
+    fireEvent.click(
+      await screen.findByRole("switch", {
+        name: "Toggle Customer-Managed Encryption Keys",
+      }),
+    );
+
+    const sso = screen.getByRole("switch", { name: "Toggle SSO" });
+    await waitFor(() => {
+      expect(sso.getAttribute("data-state")).toBe("unchecked");
+    });
+    expect(
+      queryClient.getQueryData(organizationFeaturesQuery(ORG.id).queryKey),
+    ).toEqual({
+      ...FEATURES,
+      customerManagedEncryptionKeysEnabled: true,
+      ssoEnabled: false,
+    });
+    expect(
+      mocks.featureFetch.mock.calls.filter(
+        ([input]) => (input as Request).method === "GET",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("restores the previous state before refreshing and reports a 4xx on its row", async () => {
+    let getCount = 0;
+    let finishRefresh!: (response: Response) => void;
+    mocks.featureFetch.mockImplementation((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === "POST") {
+        return Promise.resolve(serviceError("write failed", 422));
+      }
+      getCount += 1;
+      if (getCount === 1)
+        return Promise.resolve(jsonResponse(FEATURES_RESPONSE));
+      return new Promise<Response>((resolve) => {
+        finishRefresh = resolve;
+      });
+    });
     await renderFeatures();
 
     const control = await screen.findByRole("switch", {
@@ -257,20 +527,70 @@ describe("Features", () => {
     });
     fireEvent.click(control);
 
+    await waitFor(() => {
+      expect(control.getAttribute("data-state")).toBe("unchecked");
+    });
+    finishRefresh(jsonResponse(FEATURES_RESPONSE));
     expect(await screen.findByText("write failed")).toBeTruthy();
+    expect(control.parentElement?.textContent).toContain("write failed");
+    expect(
+      screen.getByRole("switch", { name: "Toggle SSO" }).parentElement
+        ?.textContent,
+    ).not.toContain("write failed");
     expect(control.getAttribute("data-state")).toBe("unchecked");
   });
 
+  it("does not expose a generated 5xx body", async () => {
+    mocks.featureFetch.mockImplementation((input: RequestInfo | URL) => {
+      const request = input as Request;
+      return Promise.resolve(
+        request.method === "GET"
+          ? jsonResponse(FEATURES_RESPONSE)
+          : serviceError("sensitive internal detail", 500),
+      );
+    });
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("switch", { name: "Toggle SCIM" }));
+
+    expect(
+      await screen.findByText("gram admin 500 Internal Server Error"),
+    ).toBeTruthy();
+    expect(screen.queryByText("sensitive internal detail")).toBeNull();
+  });
+
+  it("surfaces a mutation 401 without redirecting or refreshing", async () => {
+    let getCount = 0;
+    mocks.featureFetch.mockImplementation((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.method === "POST") {
+        return Promise.resolve(serviceError("unauthorized", 401));
+      }
+      getCount += 1;
+      return Promise.resolve(
+        getCount === 1
+          ? jsonResponse(FEATURES_RESPONSE)
+          : serviceError("unauthorized", 401),
+      );
+    });
+    const href = vi.spyOn(window.location, "href", "set");
+    await renderFeatures();
+
+    fireEvent.click(await screen.findByRole("switch", { name: "Toggle SCIM" }));
+
+    expect(await screen.findByText("unauthorized")).toBeTruthy();
+    expect(getCount).toBe(1);
+    expect(href).not.toHaveBeenCalled();
+  });
+
   it("shows a loading state while the query is pending", async () => {
-    mocks.getOrganizationFeatures.mockImplementation(
-      () => new Promise(() => {}),
-    );
+    mocks.featureFetch.mockImplementation(() => new Promise(() => {}));
     await renderFeatures();
     expect(screen.getByText("Loading...")).toBeTruthy();
   });
 
   it("shows a load failure message when the query fails", async () => {
-    mocks.getOrganizationFeatures.mockRejectedValue(new Error("boom"));
+    mocks.featureFetch.mockResolvedValue(serviceError("boom", 500));
     await renderFeatures();
     expect(await screen.findByText("Unable to load features")).toBeTruthy();
   });
@@ -282,7 +602,7 @@ describe("Features", () => {
     await renderFeatures(queryClient);
     expect(await screen.findByText("Authz Challenge Logging")).toBeTruthy();
 
-    mocks.getOrganizationFeatures.mockRejectedValue(new Error("boom"));
+    mocks.featureFetch.mockRejectedValue(new Error("boom"));
     await queryClient.invalidateQueries(organizationFeaturesQuery(ORG.id));
 
     expect(
@@ -291,5 +611,10 @@ describe("Features", () => {
       ),
     ).toBeTruthy();
     expect(screen.getByText("Authz Challenge Logging")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("switch", { name: "Toggle Authz Challenge Logging" })
+        .getAttribute("data-state"),
+    ).toBe("checked");
   });
 });

--- a/client/admin/src/pages/organization/Features.tsx
+++ b/client/admin/src/pages/organization/Features.tsx
@@ -8,84 +8,131 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
   organizationChatAnalysisSettingsQuery,
-  organizationFeaturesQuery,
   organizationQuery,
 } from "@/lib/adminQueries";
 import {
+  organizationFeaturesQuery,
+  useSetAdminOrganizationFeatureMutation,
+} from "@/lib/gramAdminClient";
+import {
   errorMessage,
   setOrganizationChatAnalysisSetting,
-  setOrganizationFeature,
   triggerOrganizationChatAnalysis,
   type AdminChatAnalysisJudge,
   type AdminOrganization,
   type AdminOrganizationChatAnalysisSettings,
-  type AdminOrganizationFeatureName,
-  type AdminOrganizationFeatures,
 } from "@/lib/gramAdminApi";
+import type { ProductFeatures } from "@gram/admin-client/models/components/productfeatures";
+import type { FeatureName } from "@gram/admin-client/models/components/setorganizationfeaturerequestbody";
 
-type FeatureDefinition = {
-  featureName: AdminOrganizationFeatureName;
-  enabledKey: keyof AdminOrganizationFeatures;
-  label: string;
-  description: string;
-};
+type ProductFeatureEntry =
+  | {
+      kind: "toggle";
+      enabledKey: keyof ProductFeatures;
+      label: string;
+      description: string;
+    }
+  | { kind: "managed-elsewhere"; where: string };
 
-const PRODUCT_FEATURES: FeatureDefinition[] = [
-  {
-    featureName: "authz_challenge_logging",
-    enabledKey: "authz_challenge_logging_enabled",
+const PRODUCT_FEATURES: Record<FeatureName, ProductFeatureEntry> = {
+  ai_platform_push_integrations: {
+    kind: "toggle",
+    enabledKey: "aiPlatformPushIntegrationsEnabled",
+    label: "AI Platform Push Integrations",
+    description:
+      "Allows this organization to provision push integrations for AI platforms.",
+  },
+  authz_challenge_logging: {
+    kind: "toggle",
+    enabledKey: "authzChallengeLoggingEnabled",
     label: "Authz Challenge Logging",
     description:
       'Log every authorization decision (allow/deny) to ClickHouse. Powers auditing of "why did X have access to Y?"',
   },
-  {
-    featureName: "customer_managed_encryption_keys",
-    enabledKey: "customer_managed_encryption_keys_enabled",
+  customer_managed_encryption_keys: {
+    kind: "toggle",
+    enabledKey: "customerManagedEncryptionKeysEnabled",
     label: "Customer-Managed Encryption Keys",
     description:
       "Unlocks encryption key management for an organization, enabling external service credential, external encryption key, and asymmetric signing functionality.",
   },
-  {
-    featureName: "custom_model_keys",
-    enabledKey: "custom_model_keys_enabled",
+  custom_model_keys: {
+    kind: "toggle",
+    enabledKey: "customModelKeysEnabled",
     label: "Custom Model Provider Keys",
     description:
       "Allows projects in this organization to store OpenRouter API keys for model completions.",
   },
-  {
-    featureName: "platform_mcp",
-    enabledKey: "platform_mcp_enabled",
+  platform_mcp: {
+    kind: "toggle",
+    enabledKey: "platformMcpEnabled",
     label: "Platform MCP access",
     description:
       "Allows this organization to authenticate to and use Platform MCP, including manual setup. Disabling it denies runtime access without removing existing setup records.",
   },
-  {
-    featureName: "remote_session_auto_refresh",
-    enabledKey: "remote_session_auto_refresh_enabled",
+  remote_session_auto_refresh: {
+    kind: "toggle",
+    enabledKey: "remoteSessionAutoRefreshEnabled",
     label: "Automatic Remote Session Refresh",
     description:
       "Shows the Auto refresh opt-in on remote-session consent screens.",
   },
-  {
-    featureName: "session_portability",
-    enabledKey: "session_portability_enabled",
+  session_portability: {
+    kind: "toggle",
+    enabledKey: "sessionPortabilityEnabled",
     label: "Session Portability",
     description:
       "Enables agent session portability for the device agent: session sharing links, move reporting with lineage, and picker title enrichment.",
   },
-  {
-    featureName: "sso",
-    enabledKey: "sso_enabled",
+  sso: {
+    kind: "toggle",
+    enabledKey: "ssoEnabled",
     label: "SSO",
     description: "Enables WorkOS portal link creation for managing SSO.",
   },
-  {
-    featureName: "scim",
-    enabledKey: "scim_enabled",
+  scim: {
+    kind: "toggle",
+    enabledKey: "scimEnabled",
     label: "SCIM",
     description: "Enables WorkOS portal link creation for managing SCIM.",
   },
-];
+  logs: {
+    kind: "managed-elsewhere",
+    where: "Dashboard log settings",
+  },
+  tool_io_logs: {
+    kind: "managed-elsewhere",
+    where: "Dashboard log settings",
+  },
+  session_capture: {
+    kind: "managed-elsewhere",
+    where: "Dashboard session capture settings",
+  },
+  hooks_browser_login: {
+    kind: "managed-elsewhere",
+    where: "Dashboard hook settings",
+  },
+  hooks_fail_open: {
+    kind: "managed-elsewhere",
+    where: "Dashboard hook settings",
+  },
+  skills: {
+    kind: "managed-elsewhere",
+    where: "Dashboard Skills settings",
+  },
+  skill_capture_metadata_only: {
+    kind: "managed-elsewhere",
+    where: "Dashboard Skills settings",
+  },
+  remote_session_auto_refresh_enforced: {
+    kind: "managed-elsewhere",
+    where: "Dashboard remote session settings",
+  },
+  consent_tool_filtering: {
+    kind: "managed-elsewhere",
+    where: "Dashboard consent settings",
+  },
+};
 
 export function FeaturesRoute(): JSX.Element | null {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });
@@ -103,6 +150,30 @@ export function Features({ org }: { org: AdminOrganization }): JSX.Element {
   );
 }
 
+function productFeatureStatusCode(error: unknown): number | undefined {
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+  return undefined;
+}
+
+function productFeatureErrorMessage(error: unknown): string {
+  const statusCode = productFeatureStatusCode(error);
+  if (statusCode !== undefined && statusCode >= 500 && error instanceof Error) {
+    const statusText =
+      "rawResponse" in error && error.rawResponse instanceof Response
+        ? error.rawResponse.statusText
+        : "";
+    return `gram admin ${statusCode} ${statusText || "Internal Server Error"}`;
+  }
+  return errorMessage(error);
+}
+
 function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
   const queryClient = useQueryClient();
   const query = organizationFeaturesQuery(org.id);
@@ -110,56 +181,30 @@ function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
     ...query,
     enabled: !!org.id,
   });
-  const mutation = useMutation({
-    mutationFn: ({
-      featureName,
-      enabled,
-    }: {
-      featureName: AdminOrganizationFeatureName;
-      enabled: boolean;
-    }) =>
-      setOrganizationFeature({
-        organizationID: org.id,
-        featureName,
-        enabled,
-      }),
+  const mutation = useSetAdminOrganizationFeatureMutation({
     onMutate: async ({ featureName, enabled }) => {
       await queryClient.cancelQueries({ queryKey: query.queryKey });
-      const previous = queryClient.getQueryData<AdminOrganizationFeatures>(
+      const previous = queryClient.getQueryData<ProductFeatures>(
         query.queryKey,
       );
-      const definition = PRODUCT_FEATURES.find(
-        (feature) => feature.featureName === featureName,
-      );
-      if (previous && definition) {
-        queryClient.setQueryData<AdminOrganizationFeatures>(query.queryKey, {
+      const feature = PRODUCT_FEATURES[featureName];
+      if (previous && feature.kind === "toggle") {
+        queryClient.setQueryData<ProductFeatures>(query.queryKey, {
           ...previous,
-          [definition.enabledKey]: enabled,
+          [feature.enabledKey]: enabled,
         });
       }
-      return {
-        enabledKey: definition?.enabledKey,
-        previousEnabled: definition
-          ? previous?.[definition.enabledKey]
-          : undefined,
-      };
+      return { previous };
     },
-    onError: async (_error, _variables, context) => {
-      const enabledKey = context?.enabledKey;
-      const previousEnabled = context?.previousEnabled;
-      if (enabledKey && previousEnabled !== undefined) {
-        queryClient.setQueryData<AdminOrganizationFeatures>(
-          query.queryKey,
-          (current) =>
-            current
-              ? {
-                  ...current,
-                  [enabledKey]: previousEnabled,
-                }
-              : current,
-        );
+    onError: async (error, _variables, context) => {
+      const previous = (context as { previous?: ProductFeatures } | undefined)
+        ?.previous;
+      if (previous) {
+        queryClient.setQueryData(query.queryKey, previous);
       }
-      await queryClient.invalidateQueries({ queryKey: query.queryKey });
+      if (productFeatureStatusCode(error) !== 401) {
+        await queryClient.invalidateQueries({ queryKey: query.queryKey });
+      }
     },
     onSuccess: (updated) => {
       queryClient.setQueryData(query.queryKey, updated);
@@ -193,16 +238,18 @@ function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
           </p>
         </div>
         <div className="divide-border divide-y">
-          {PRODUCT_FEATURES.map((feature) => {
+          {Object.entries(PRODUCT_FEATURES).map(([featureName, feature]) => {
+            if (feature.kind === "managed-elsewhere") return null;
+            const typedFeatureName = featureName as FeatureName;
             const rowError =
               mutation.isError &&
-              mutation.variables.featureName === feature.featureName
-                ? errorMessage(mutation.error)
+              mutation.variables.featureName === typedFeatureName
+                ? productFeatureErrorMessage(mutation.error)
                 : undefined;
             return (
               <div
                 className="grid grid-cols-[1fr_auto] items-center gap-4 px-4 py-3"
-                key={feature.featureName}
+                key={typedFeatureName}
               >
                 <div>
                   <p className="text-sm font-medium">{feature.label}</p>
@@ -218,7 +265,8 @@ function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
                   disabled={mutation.isPending}
                   onCheckedChange={(enabled) =>
                     mutation.mutate({
-                      featureName: feature.featureName,
+                      organizationId: org.id,
+                      featureName: typedFeatureName,
                       enabled,
                     })
                   }

--- a/client/admin/src/pages/organization/Features.tsx
+++ b/client/admin/src/pages/organization/Features.tsx
@@ -25,16 +25,21 @@ import {
 import type { ProductFeatures } from "@gram/admin-client/models/components/productfeatures";
 import type { FeatureName } from "@gram/admin-client/models/components/setorganizationfeaturerequestbody";
 
-type ProductFeatureEntry =
+type EnabledProductFeatureKey = Extract<
+  keyof ProductFeatures,
+  `${string}Enabled`
+>;
+
+type ProductFeatureDecision =
   | {
       kind: "toggle";
-      enabledKey: keyof ProductFeatures;
+      enabledKey: EnabledProductFeatureKey;
       label: string;
       description: string;
     }
   | { kind: "managed-elsewhere"; where: string };
 
-const PRODUCT_FEATURES: Record<FeatureName, ProductFeatureEntry> = {
+const PRODUCT_FEATURES = {
   ai_platform_push_integrations: {
     kind: "toggle",
     enabledKey: "aiPlatformPushIntegrationsEnabled",
@@ -96,43 +101,52 @@ const PRODUCT_FEATURES: Record<FeatureName, ProductFeatureEntry> = {
     label: "SCIM",
     description: "Enables WorkOS portal link creation for managing SCIM.",
   },
+  // reason: managed in dashboard log settings
   logs: {
     kind: "managed-elsewhere",
     where: "Dashboard log settings",
   },
+  // reason: managed in dashboard log settings
   tool_io_logs: {
     kind: "managed-elsewhere",
     where: "Dashboard log settings",
   },
+  // reason: managed in dashboard session capture settings
   session_capture: {
     kind: "managed-elsewhere",
     where: "Dashboard session capture settings",
   },
+  // reason: managed in dashboard hook settings
   hooks_browser_login: {
     kind: "managed-elsewhere",
     where: "Dashboard hook settings",
   },
+  // reason: managed in dashboard hook settings
   hooks_fail_open: {
     kind: "managed-elsewhere",
     where: "Dashboard hook settings",
   },
+  // reason: managed in dashboard Skills settings
   skills: {
     kind: "managed-elsewhere",
     where: "Dashboard Skills settings",
   },
+  // reason: managed in dashboard Skills settings
   skill_capture_metadata_only: {
     kind: "managed-elsewhere",
     where: "Dashboard Skills settings",
   },
+  // reason: managed in dashboard remote session settings
   remote_session_auto_refresh_enforced: {
     kind: "managed-elsewhere",
     where: "Dashboard remote session settings",
   },
+  // reason: managed in dashboard consent settings
   consent_tool_filtering: {
     kind: "managed-elsewhere",
     where: "Dashboard consent settings",
   },
-};
+} satisfies Record<FeatureName, ProductFeatureDecision>;
 
 export function FeaturesRoute(): JSX.Element | null {
   const { idOrSlug } = useParams({ from: "/organizations/$idOrSlug" });

--- a/client/admin/src/pages/organization/Features.tsx
+++ b/client/admin/src/pages/organization/Features.tsx
@@ -37,7 +37,7 @@ type ProductFeatureDecision =
       label: string;
       description: string;
     }
-  | { kind: "managed-elsewhere"; where: string };
+  | { kind: "omitted"; where: string };
 
 const PRODUCT_FEATURES = {
   ai_platform_push_integrations: {
@@ -103,47 +103,47 @@ const PRODUCT_FEATURES = {
   },
   // reason: managed in dashboard log settings
   logs: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard log settings",
   },
   // reason: managed in dashboard log settings
   tool_io_logs: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard log settings",
   },
   // reason: managed in dashboard session capture settings
   session_capture: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard session capture settings",
   },
   // reason: managed in dashboard hook settings
   hooks_browser_login: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard hook settings",
   },
   // reason: managed in dashboard hook settings
   hooks_fail_open: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard hook settings",
   },
   // reason: managed in dashboard Skills settings
   skills: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard Skills settings",
   },
   // reason: managed in dashboard Skills settings
   skill_capture_metadata_only: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard Skills settings",
   },
   // reason: managed in dashboard remote session settings
   remote_session_auto_refresh_enforced: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard remote session settings",
   },
   // reason: managed in dashboard consent settings
   consent_tool_filtering: {
-    kind: "managed-elsewhere",
+    kind: "omitted",
     where: "Dashboard consent settings",
   },
 } satisfies Record<FeatureName, ProductFeatureDecision>;
@@ -253,7 +253,7 @@ function ProductFeatures({ org }: { org: AdminOrganization }): JSX.Element {
         </div>
         <div className="divide-border divide-y">
           {Object.entries(PRODUCT_FEATURES).map(([featureName, feature]) => {
-            if (feature.kind === "managed-elsewhere") return null;
+            if (feature.kind === "omitted") return null;
             const typedFeatureName = featureName as FeatureName;
             const rowError =
               mutation.isError &&


### PR DESCRIPTION
## Stack context

This PR is the third part of a four-PR stack that moves organization product-feature management from the legacy Dashboard Platform Admin surface into the standalone Admin application.

PR #6036 establishes the shared product-feature API and isolated Admin contract, and #6000 generates the private same-origin Admin SDK from it. This PR applies those foundations to the Admin Features page: it uses the generated contract for exhaustive feature classification and closes the remaining parity gap by adding AI Platform Push Integrations. The final PR can then remove the superseded Dashboard feature-management route.

## What this PR does

- migrates Admin feature reads and mutations onto the private generated Admin client
- classifies the generated feature contract exhaustively so new features require an explicit UI decision
- adds AI Platform Push Integrations to the organization Features page
- preserves cache updates, rollback behavior, unauthorized redirects, pending state, and canonical organization lookup
