### PR TITLE
feat: bring admin activity to dashboard parity

### DIFF
--- a/client/admin/src/components/app-sidebar.test.tsx
+++ b/client/admin/src/components/app-sidebar.test.tsx
@@ -15,7 +15,6 @@ const mocks = vi.hoisted(() => ({
   getProject: vi.fn(),
   listOrganizationProjects: vi.fn(),
   listOrganizationMembers: vi.fn(),
-  listOrganizationActivity: vi.fn(),
 }));
 
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
@@ -28,7 +27,6 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     getProject: mocks.getProject,
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizationMembers: mocks.listOrganizationMembers,
-    listOrganizationActivity: mocks.listOrganizationActivity,
   };
 });
 
@@ -77,11 +75,21 @@ beforeEach(() => {
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.listOrganizationMembers.mockReset();
   mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
-  mocks.listOrganizationActivity.mockReset();
-  mocks.listOrganizationActivity.mockResolvedValue({ logs: [] });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ logs: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 // The breadcrumb names the same views the nav does, so every link query here
 // has to say which of the two it means.

--- a/client/admin/src/components/site-header.test.tsx
+++ b/client/admin/src/components/site-header.test.tsx
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
   getProject: vi.fn(),
   listOrganizationProjects: vi.fn(),
   listOrganizationMembers: vi.fn(),
-  listOrganizationActivity: vi.fn(),
 }));
 
 vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
@@ -33,7 +32,6 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     getProject: mocks.getProject,
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizationMembers: mocks.listOrganizationMembers,
-    listOrganizationActivity: mocks.listOrganizationActivity,
   };
 });
 
@@ -86,11 +84,21 @@ beforeEach(() => {
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.listOrganizationMembers.mockReset();
   mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
-  mocks.listOrganizationActivity.mockReset();
-  mocks.listOrganizationActivity.mockResolvedValue({ logs: [] });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ logs: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 function bar(): HTMLElement {
   return screen.getByRole("navigation", { name: "breadcrumb" });

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
   cancelOrganizationFetches,
+  invalidateOrganizationActivity,
   invalidateOrganizationStats,
-  organizationActivityQuery,
   organizationQuery,
   organizationsListQuery,
   organizationsStatsQuery,
   projectQuery,
   writeOrganizationToCache,
 } from "@/lib/adminQueries";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
 import type {
   AdminOrganization,
   AdminProjectDetail,
@@ -54,45 +55,19 @@ describe("organizationsListQuery", () => {
   });
 });
 
-describe("organizationActivityQuery", () => {
-  it("uses one organization-scoped key and forwards opaque cursors", async () => {
-    const fetch = vi.fn().mockImplementation(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ logs: [], next_cursor: "next" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      ),
-    );
-    vi.stubGlobal("fetch", fetch);
-    const first = organizationActivityQuery("org_1");
-    const second = organizationActivityQuery("org_2");
+describe("invalidateOrganizationActivity", () => {
+  it("invalidates only the generated query for the changed organization", () => {
+    const qc = new QueryClient();
+    const invalidate = vi
+      .spyOn(qc, "invalidateQueries")
+      .mockResolvedValue(undefined);
 
-    expect(first.queryKey).not.toEqual(second.queryKey);
-    expect(first.initialPageParam).toBeUndefined();
-    if (typeof first.queryFn !== "function") {
-      throw new Error("activity query has no query function");
-    }
-    await first.queryFn({ pageParam: undefined } as never);
-    expect(fetch.mock.calls[0]?.[0]).toContain("organization_id=org_1");
-    expect(fetch.mock.calls[0]?.[0]).not.toContain("cursor=");
+    invalidateOrganizationActivity(qc, "org_1");
 
-    await first.queryFn({ pageParam: "opaque+/=" } as never);
-    expect(fetch.mock.calls[1]?.[0]).toContain(
-      "organization_id=org_1&cursor=opaque%2B%2F%3D",
-    );
-    expect(
-      first.getNextPageParam?.(
-        { logs: [], next_cursor: "next" },
-        [],
-        undefined,
-        [],
-      ),
-    ).toBe("next");
-    expect(
-      first.getNextPageParam?.({ logs: [] }, [], undefined, []),
-    ).toBeUndefined();
-    vi.unstubAllGlobals();
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: organizationActivityQuery("org_1").queryKey,
+      exact: true,
+    });
   });
 });
 

--- a/client/admin/src/lib/adminQueries.ts
+++ b/client/admin/src/lib/adminQueries.ts
@@ -5,9 +5,7 @@
 // mutation that updates the server and leaves the table showing the old row.
 
 import {
-  infiniteQueryOptions,
   queryOptions,
-  type InfiniteData,
   type QueryClient,
   type QueryKey,
 } from "@tanstack/react-query";
@@ -21,7 +19,6 @@ import {
   getStripeSubscription,
   getProject,
   getSession,
-  listOrganizationActivity,
   listOrganizationMembers,
   listOrganizationProjects,
   listOrganizations,
@@ -33,12 +30,12 @@ import {
   type AdminProjectDetail,
   type AdminPaygBillingSummary,
   type AdminStripeSubscription,
-  type ListOrganizationActivityResult,
   type ListOrganizationMembersResult,
   type ListOrganizationProjectsResult,
   type ListOrganizationsParams,
   type ListOrganizationsResult,
 } from "@/lib/gramAdminApi";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
 
 // What queryOptions infers, named so the exports can carry the return type that
 // `typescript/explicit-module-boundary-types` demands. Writing the shape out by
@@ -96,34 +93,13 @@ export function organizationQuery(
   });
 }
 
-type OrganizationActivityQuery = ReturnType<
-  typeof infiniteQueryOptions<
-    ListOrganizationActivityResult,
-    Error,
-    InfiniteData<ListOrganizationActivityResult, string | undefined>,
-    readonly ["gram-admin-organization-activity", string],
-    string | undefined
-  >
->;
-
-export function organizationActivityQuery(
-  organizationID: string,
-): OrganizationActivityQuery {
-  return infiniteQueryOptions({
-    queryKey: ["gram-admin-organization-activity", organizationID] as const,
-    initialPageParam: undefined as string | undefined,
-    queryFn: ({ pageParam }) =>
-      listOrganizationActivity(organizationID, pageParam),
-    getNextPageParam: (lastPage) => lastPage.next_cursor,
-  });
-}
-
 export function invalidateOrganizationActivity(
   qc: QueryClient,
   organizationID: string,
 ): void {
   void qc.invalidateQueries({
     queryKey: organizationActivityQuery(organizationID).queryKey,
+    exact: true,
   });
 }
 

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -12,7 +12,6 @@ import {
   getPaygBillingSummary,
   getStripeSubscription,
   getProject,
-  listOrganizationActivity,
   listOrganizations,
   logout,
   markEnterpriseTrialConverted,
@@ -62,69 +61,6 @@ describe("toSearchParams", () => {
 // has to arrive as one key per value. A comma-joined `account_types=free,pro`
 // parses on the server as a single account type named "free,pro", which matches
 // no organization: the browser would show an empty list and no error.
-describe("listOrganizationActivity", () => {
-  afterEach(() => vi.unstubAllGlobals());
-
-  it("encodes the explicit organization ID and omits an absent cursor", async () => {
-    const payload = {
-      logs: [
-        {
-          id: "event_2",
-          project_id: "project_1",
-          project_slug: "fictional-project",
-          actor_id: "user_1",
-          actor_type: "user",
-          actor_display_name: "Example Operator",
-          actor_slug: "example-operator",
-          action: "organization:settings_updated",
-          acting_surface: "dashboard",
-          acting_client_id: "client_1",
-          subject_id: "org_1",
-          subject_type: "organization",
-          subject_display_name: "Test Org",
-          subject_slug: "test-org",
-          before_snapshot: { enabled: false },
-          after_snapshot: { enabled: true },
-          metadata: { source: "test" },
-          created_at: "2026-01-15T12:30:00Z",
-        },
-        {
-          id: "event_1",
-          actor_id: "system",
-          actor_type: "system",
-          action: "organization:sync_completed",
-          acting_surface: "unknown",
-          subject_id: "org_1",
-          subject_type: "organization",
-          created_at: "2026-01-15T12:00:00Z",
-        },
-      ],
-      next_cursor: "opaque+/=",
-    };
-    const fetch = vi.fn().mockImplementation(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(payload), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      ),
-    );
-    vi.stubGlobal("fetch", fetch);
-
-    await expect(listOrganizationActivity("org explicit")).resolves.toEqual(
-      payload,
-    );
-    expect(fetch.mock.calls[0]?.[0]).toBe(
-      "/admin/organization.activity?organization_id=org+explicit",
-    );
-
-    await listOrganizationActivity("org explicit", "opaque+/=");
-    expect(fetch.mock.calls[1]?.[0]).toBe(
-      "/admin/organization.activity?organization_id=org+explicit&cursor=opaque%2B%2F%3D",
-    );
-  });
-});
-
 describe("listOrganizations", () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -220,42 +220,6 @@ export type ListOrganizationsResult = {
   next_cursor?: string;
 };
 
-export type AdminAuditLog = {
-  id: string;
-  project_id?: string;
-  project_slug?: string;
-  actor_id: string;
-  actor_type: string;
-  actor_display_name?: string;
-  actor_slug?: string;
-  action: string;
-  acting_surface: string;
-  acting_client_id?: string;
-  subject_id: string;
-  subject_type: string;
-  subject_display_name?: string;
-  subject_slug?: string;
-  before_snapshot?: unknown;
-  after_snapshot?: unknown;
-  metadata?: Record<string, unknown>;
-  created_at: string;
-};
-
-export type ListOrganizationActivityResult = {
-  logs: AdminAuditLog[];
-  next_cursor?: string;
-};
-
-export function listOrganizationActivity(
-  organizationID: string,
-  cursor?: string,
-): Promise<ListOrganizationActivityResult> {
-  const qs = toSearchParams({ organization_id: organizationID, cursor });
-  return gramAdminFetch<ListOrganizationActivityResult>(
-    `/admin/organization.activity?${qs.toString()}`,
-  );
-}
-
 // Each filter is a repeated parameter the server reads as a set, and an absent
 // one means no filter of that kind: no account_types is every type, no
 // trial_states is every state, no disabled_states is active organizations only.

--- a/client/admin/src/lib/gramAdminClient.test.ts
+++ b/client/admin/src/lib/gramAdminClient.test.ts
@@ -12,6 +12,7 @@ vi.mock("@tanstack/react-query", async (importOriginal) => {
 });
 
 import type { SetOrganizationFeatureRequestBody } from "@gram/admin-client/models/components/setorganizationfeaturerequestbody";
+import { queryKeyAdminListOrganizationActivityInfinite } from "@gram/admin-client/react-query/adminListOrganizationActivity.core";
 
 import { isRedirectingToLogin as predecessorLatch } from "@/lib/gramAdminApi";
 import * as boundary from "@/lib/gramAdminClient";
@@ -36,6 +37,7 @@ describe("generated admin boundary", () => {
     expect(Object.keys(boundary).sort()).toEqual([
       "adminSessionQuery",
       "isRedirectingToLogin",
+      "organizationActivityQuery",
       "organizationFeaturesQuery",
       "redirectOnUnauthorized",
       "setAdminOrganizationFeature",
@@ -86,6 +88,59 @@ describe("generated admin boundary", () => {
     expect(request.mode).toBe("cors");
     expect(request.headers.has("Authorization")).toBe(false);
     expect(request.headers.has("Cookie")).toBe(false);
+  });
+
+  it("uses the guarded generated infinite activity operation and exposes its page shape", async () => {
+    const fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            logs: [
+              {
+                acting_surface: "platform_mcp",
+                action: "organization:settings_updated",
+                actor_id: "actor_1",
+                actor_type: "user",
+                created_at: "2026-03-12T15:30:00Z",
+                id: "log_1",
+                subject_id: "org_1",
+                subject_type: "organization",
+              },
+            ],
+            next_cursor: "opaque+/=",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const query = boundary.organizationActivityQuery("org explicit");
+    const firstPage = await query.queryFn?.({
+      pageParam: undefined,
+      signal: new AbortController().signal,
+    } as never);
+
+    expect(query.queryKey).toEqual(
+      queryKeyAdminListOrganizationActivityInfinite({
+        organizationId: "org explicit",
+      }),
+    );
+    expect(firstPage?.result.logs[0]?.createdAt).toEqual(
+      new Date("2026-03-12T15:30:00Z"),
+    );
+    expect(firstPage?.["~next"]).toEqual({ cursor: "opaque+/=" });
+    let url = new URL((fetch.mock.calls[0]?.[0] as Request).url);
+    expect(url.pathname).toBe("/admin/organization.activity");
+    expect(url.searchParams.get("organization_id")).toBe("org explicit");
+    expect(url.searchParams.has("cursor")).toBe(false);
+
+    await query.queryFn?.({
+      pageParam: firstPage?.["~next"],
+      signal: new AbortController().signal,
+    } as never);
+    url = new URL((fetch.mock.calls[1]?.[0] as Request).url);
+    expect(url.searchParams.get("cursor")).toBe("opaque+/=");
   });
 
   it("redirects a generated read before parsing a malformed 401 body", async () => {

--- a/client/admin/src/lib/gramAdminClient.test.ts
+++ b/client/admin/src/lib/gramAdminClient.test.ts
@@ -82,7 +82,7 @@ describe("generated admin boundary", () => {
     const query = boundary.adminSessionQuery();
     await query.queryFn?.({ signal: new AbortController().signal } as never);
 
-    const request = fetch.mock.calls[0]?.[0] as Request;
+    const request = fetch.mock.calls[0]![0] as Request;
     expect(new URL(request.url).origin).toBe(window.location.origin);
     expect(request.credentials).toBe("same-origin");
     expect(request.mode).toBe("cors");
@@ -130,7 +130,7 @@ describe("generated admin boundary", () => {
       new Date("2026-03-12T15:30:00Z"),
     );
     expect(firstPage?.["~next"]).toEqual({ cursor: "opaque+/=" });
-    let url = new URL((fetch.mock.calls[0]?.[0] as Request).url);
+    let url = new URL((fetch.mock.calls[0]![0] as Request).url);
     expect(url.pathname).toBe("/admin/organization.activity");
     expect(url.searchParams.get("organization_id")).toBe("org explicit");
     expect(url.searchParams.has("cursor")).toBe(false);
@@ -139,7 +139,7 @@ describe("generated admin boundary", () => {
       pageParam: firstPage?.["~next"],
       signal: new AbortController().signal,
     } as never);
-    url = new URL((fetch.mock.calls[1]?.[0] as Request).url);
+    url = new URL((fetch.mock.calls[1]![0] as Request).url);
     expect(url.searchParams.get("cursor")).toBe("opaque+/=");
   });
 

--- a/client/admin/src/lib/gramAdminClient.ts
+++ b/client/admin/src/lib/gramAdminClient.ts
@@ -1,4 +1,5 @@
 import {
+  infiniteQueryOptions,
   queryOptions,
   useMutation,
   type UseMutationOptions,
@@ -8,6 +9,10 @@ import {
 import { GramCore } from "@gram/admin-client/core";
 import { HTTPClient } from "@gram/admin-client/lib/http";
 import { buildAdminGetSessionQuery } from "@gram/admin-client/react-query/adminGetSession.core";
+import {
+  buildAdminListOrganizationActivityInfiniteQuery,
+  type AdminListOrganizationActivityPageParams,
+} from "@gram/admin-client/react-query/adminListOrganizationActivity.core";
 import { buildAdminOrganizationFeaturesQuery } from "@gram/admin-client/react-query/adminOrganizationFeatures.core";
 import { buildSetAdminOrganizationFeatureMutation } from "@gram/admin-client/react-query/setAdminOrganizationFeature";
 import type { ProductFeatures } from "@gram/admin-client/models/components/productfeatures";
@@ -101,6 +106,25 @@ export function organizationFeaturesQuery(
   organizationId: string,
 ): ReturnType<typeof createOrganizationFeaturesQuery> {
   return createOrganizationFeaturesQuery(organizationId);
+}
+
+function createOrganizationActivityQuery(organizationId: string) {
+  const generated = buildAdminListOrganizationActivityInfiniteQuery(
+    redirectingClient,
+    { organizationId },
+  );
+  return infiniteQueryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+    initialPageParam: undefined as AdminListOrganizationActivityPageParams,
+    getNextPageParam: (lastPage) => lastPage["~next"],
+  });
+}
+
+export function organizationActivityQuery(
+  organizationId: string,
+): ReturnType<typeof createOrganizationActivityQuery> {
+  return createOrganizationActivityQuery(organizationId);
 }
 
 // Feature writes preserve their predecessor's in-place 401 behavior. No raw

--- a/client/admin/src/pages/organization/Activity.test.tsx
+++ b/client/admin/src/pages/organization/Activity.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { infiniteQueryOptions, QueryClient } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -681,6 +682,50 @@ describe("Activity", () => {
     expect(screen.getAllByRole("listitem")).toHaveLength(2);
     expect(screen.getByText("first-seen")).toBeTruthy();
     expect(screen.queryByText("duplicate")).toBeNull();
+  });
+
+  it("paginates a new organization while the previous page is still pending", async () => {
+    const page = deferred<{ logs: ReturnType<typeof anActivityLog>[] }>();
+    const otherOrg = anOrganization({ id: "other-org" });
+    mocks.listOrganizationActivity
+      .mockResolvedValueOnce({
+        logs: [anActivityLog({ action: "old-event" })],
+        nextCursor: "old-next",
+      })
+      .mockReturnValueOnce(page.promise)
+      .mockResolvedValueOnce({
+        logs: [anActivityLog({ action: "new-event" })],
+        nextCursor: "new-next",
+      })
+      .mockResolvedValueOnce({
+        logs: [anActivityLog({ id: "next-event", action: "next-event" })],
+      });
+    function SwitchOrganization() {
+      const [org, setOrg] = useState(ORG);
+      return (
+        <>
+          <button onClick={() => setOrg(otherOrg)}>Switch organization</button>
+          <Activity org={org} />
+        </>
+      );
+    }
+    await renderWithApp(<SwitchOrganization />);
+    fireEvent.click(await screen.findByRole("button", { name: "Load more" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Switch organization" }),
+    );
+    await screen.findByText("new-event");
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    try {
+      await screen.findByText("next-event");
+      expect(mocks.listOrganizationActivity).toHaveBeenLastCalledWith(
+        otherOrg.id,
+        "new-next",
+      );
+      expect(screen.queryByText("old-event")).toBeNull();
+    } finally {
+      page.resolve({ logs: [] });
+    }
   });
 
   it("guards load-more synchronously, handles rejection, and safely settles after unmount", async () => {

--- a/client/admin/src/pages/organization/Activity.test.tsx
+++ b/client/admin/src/pages/organization/Activity.test.tsx
@@ -1,30 +1,49 @@
-import { QueryClient } from "@tanstack/react-query";
+import { infiniteQueryOptions, QueryClient } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { organizationActivityQuery } from "@/lib/adminQueries";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
 import { Activity } from "@/pages/organization/Activity";
 import { anActivityLog, anOrganization } from "@/test/fixtures";
 import { renderWithApp } from "@/test/harness";
 
 const mocks = vi.hoisted(() => ({ listOrganizationActivity: vi.fn() }));
 
-vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/gramAdminApi")>();
-  return {
-    ...actual,
-    listOrganizationActivity: mocks.listOrganizationActivity,
-  };
-});
+vi.mock("@/lib/gramAdminClient", () => ({
+  organizationActivityQuery: (organizationId: string) =>
+    infiniteQueryOptions({
+      queryKey: ["activity", organizationId],
+      initialPageParam: undefined as { cursor: string } | undefined,
+      queryFn: async ({ pageParam }) => {
+        const result = await mocks.listOrganizationActivity(
+          organizationId,
+          pageParam?.cursor,
+        );
+        return {
+          result,
+          "~next": result.nextCursor
+            ? { cursor: result.nextCursor }
+            : undefined,
+        };
+      },
+      getNextPageParam: (page) => page["~next"],
+    }),
+}));
 
 const ORG = anOrganization();
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
     resolve = settle;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 beforeEach(() => mocks.listOrganizationActivity.mockReset());
@@ -32,45 +51,45 @@ afterEach(cleanup);
 
 describe("Activity", () => {
   it("renders every event field and the display, slug, and ID fallbacks", async () => {
-    const createdAt = "2026-01-15T12:30:00Z";
+    const createdAt = new Date("2026-01-15T12:30:00Z");
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
           id: "event-display",
-          created_at: createdAt,
-          actor_id: "actor-display-id",
-          actor_type: "staff",
-          actor_display_name: "Actor Display",
-          actor_slug: "actor-display-slug",
-          subject_id: "subject-display-id",
-          subject_type: "organization",
-          subject_display_name: "Subject Display",
-          subject_slug: "subject-display-slug",
-          project_id: "project-id",
-          project_slug: "project-slug",
-          acting_surface: "platform_mcp",
-          acting_client_id: "client-id",
-          before_snapshot: { days: 7 },
-          after_snapshot: { days: 14 },
+          createdAt: createdAt,
+          actorId: "actor-display-id",
+          actorType: "staff",
+          actorDisplayName: "Actor Display",
+          actorSlug: "actor-display-slug",
+          subjectId: "subject-display-id",
+          subjectType: "organization",
+          subjectDisplayName: "Subject Display",
+          subjectSlug: "subject-display-slug",
+          projectId: "project-id",
+          projectSlug: "project-slug",
+          actingSurface: "platform_mcp",
+          actingClientId: "client-id",
+          beforeSnapshot: { days: 7 },
+          afterSnapshot: { days: 14 },
           metadata: { approved: true },
         }),
         anActivityLog({
           id: "event-slug",
-          actor_id: "actor-slug-id",
-          actor_display_name: undefined,
-          actor_slug: "actor-slug",
-          subject_id: "subject-slug-id",
-          subject_display_name: undefined,
-          subject_slug: "subject-slug",
+          actorId: "actor-slug-id",
+          actorDisplayName: undefined,
+          actorSlug: "actor-slug",
+          subjectId: "subject-slug-id",
+          subjectDisplayName: undefined,
+          subjectSlug: "subject-slug",
         }),
         anActivityLog({
           id: "event-id",
-          actor_id: "actor-id-fallback",
-          actor_display_name: undefined,
-          actor_slug: undefined,
-          subject_id: "subject-id-fallback",
-          subject_display_name: undefined,
-          subject_slug: undefined,
+          actorId: "actor-id-fallback",
+          actorDisplayName: undefined,
+          actorSlug: undefined,
+          subjectId: "subject-id-fallback",
+          subjectDisplayName: undefined,
+          subjectSlug: undefined,
         }),
       ],
     });
@@ -94,7 +113,7 @@ describe("Activity", () => {
     expect(list.textContent).toContain("via platform_mcp");
 
     const time = list.querySelector("time");
-    expect(time?.getAttribute("datetime")).toBe(createdAt);
+    expect(time?.getAttribute("datetime")).toBe(createdAt.toISOString());
     expect(time?.textContent).toBe(
       "Thursday, January 15, 2026 at 12:30:00 PM UTC",
     );
@@ -122,13 +141,13 @@ describe("Activity", () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
-          before_snapshot: {
+          beforeSnapshot: {
             zeta: "before",
             removed: "gone",
             complex: { nested: ["old"] },
             alpha: null,
           },
-          after_snapshot: {
+          afterSnapshot: {
             zeta: "after",
             added: true,
             complex: { nested: ["new"] },
@@ -186,12 +205,28 @@ describe("Activity", () => {
     expect(rows[3]?.textContent).toBe('removed"gone"→(none)');
   });
 
+  it("uses the legacy system actor ID fallback", async () => {
+    mocks.listOrganizationActivity.mockResolvedValue({
+      logs: [
+        anActivityLog({
+          actorId: "system",
+          actorType: "staff",
+          actorDisplayName: undefined,
+          actorSlug: undefined,
+        }),
+      ],
+    });
+
+    await renderWithApp(<Activity org={ORG} />);
+    expect((await screen.findByRole("list")).textContent).toContain("System");
+  });
+
   it("renders an empty string as a visible JSON string in a changed field", async () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
-          before_snapshot: { value: "before" },
-          after_snapshot: { value: "" },
+          beforeSnapshot: { value: "before" },
+          afterSnapshot: { value: "" },
         }),
       ],
     });
@@ -209,8 +244,8 @@ describe("Activity", () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
-          before_snapshot: { value: true },
-          after_snapshot: { value: "true" },
+          beforeSnapshot: { value: true },
+          afterSnapshot: { value: "true" },
         }),
       ],
     });
@@ -228,8 +263,8 @@ describe("Activity", () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
-          before_snapshot: { days: 7 },
-          after_snapshot: { days: 14 },
+          beforeSnapshot: { days: 7 },
+          afterSnapshot: { days: 14 },
         }),
       ],
     });
@@ -255,8 +290,8 @@ describe("Activity", () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [
         anActivityLog({
-          before_snapshot: snapshot,
-          after_snapshot: snapshot,
+          beforeSnapshot: snapshot,
+          afterSnapshot: snapshot,
           metadata: { request_id: "request-placeholder" },
         }),
       ],
@@ -305,6 +340,17 @@ describe("Activity", () => {
     expect(screen.queryByText("Loading activity...")).toBeNull();
     expect(screen.queryByRole("list")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not claim the feed is empty while another page is available", async () => {
+    mocks.listOrganizationActivity.mockResolvedValue({
+      logs: [],
+      nextCursor: "next-page",
+    });
+
+    await renderWithApp(<Activity org={ORG} />);
+    await screen.findByRole("button", { name: "Load more" });
+    expect(screen.queryByText("No activity for this organization")).toBeNull();
   });
 
   it("keeps the empty state and shows only the refresh error after a failed refetch", async () => {
@@ -417,7 +463,7 @@ describe("Activity", () => {
           anActivityLog({ id: "event-4", action: "event-4" }),
           anActivityLog({ id: "event-3", action: "event-3" }),
         ],
-        next_cursor: "cursor-2",
+        nextCursor: "cursor-2",
       })
       .mockReturnValueOnce(secondPage.promise);
     await renderWithApp(<Activity org={ORG} />);
@@ -453,12 +499,227 @@ describe("Activity", () => {
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
   });
 
+  it("humanizes trial actions and interprets Stripe checkout conversion", async () => {
+    mocks.listOrganizationActivity.mockResolvedValue({
+      logs: [
+        anActivityLog({
+          id: "armed",
+          action: "organization:enterprise_trial_armed",
+          createdAt: new Date("2026-08-01T12:00:00Z"),
+          afterSnapshot: {
+            trial: { tier: "enterprise", ends_at: "2026-08-15T12:00:00Z" },
+          },
+        }),
+        anActivityLog({
+          id: "extended",
+          action: "organization:enterprise_trial_extended",
+          beforeSnapshot: { trial: { ends_at: "2026-08-15T12:00:00Z" } },
+          afterSnapshot: {
+            trial: { tier: "enterprise", ends_at: "2026-08-29T12:00:00Z" },
+          },
+        }),
+        anActivityLog({
+          id: "rearmed",
+          action: "organization:enterprise_trial_rearmed",
+        }),
+        anActivityLog({
+          id: "demoted",
+          action: "organization:enterprise_trial_demoted",
+          metadata: { previous_account_type: "enterprise" },
+        }),
+        anActivityLog({
+          id: "converted",
+          action: "organization:enterprise_trial_converted",
+          metadata: {
+            conversion_source: "stripe_checkout",
+            key_access_changed: true,
+          },
+          beforeSnapshot: {
+            keys: [{ key_type: "chat", effective_disabled: true }],
+          },
+          afterSnapshot: {
+            trial: { converted_at: "2026-08-20T12:00:00Z", tier: "enterprise" },
+            keys: [{ key_type: "chat", effective_disabled: false }],
+          },
+        }),
+      ],
+    });
+
+    await renderWithApp(<Activity org={ORG} />);
+
+    for (const phrase of [
+      "started enterprise trial",
+      "extended enterprise trial",
+      "rearmed enterprise trial",
+      "demoted enterprise trial",
+      "converted enterprise trial through checkout",
+    ]) {
+      expect(await screen.findByText(phrase)).toBeTruthy();
+    }
+    const checkout = screen
+      .getByText("converted enterprise trial through checkout")
+      .closest("li");
+    expect(checkout?.textContent).toContain("Stripe");
+    expect(checkout?.textContent).toContain("Enterprise trial converted");
+    expect(checkout?.textContent).toContain("Conversion methodStripe checkout");
+    expect(checkout?.textContent).toContain("Tierenterprise");
+    expect(checkout?.textContent).toContain("OpenRouter key access changedYes");
+    expect(checkout?.textContent).toContain(
+      "OpenRouter chat keyDisabled → Enabled",
+    );
+    expect(
+      screen.getByRole("region", { name: "Enterprise trial started" })
+        .textContent,
+    ).toContain("Trial end");
+    expect(
+      screen.getByRole("region", { name: "Enterprise trial extended" })
+        .textContent,
+    ).toContain("Previous trial end");
+    expect(
+      screen.getByRole("region", { name: "Enterprise trial ended" })
+        .textContent,
+    ).toContain("Tierenterprise");
+  });
+
+  it("renders malformed trial dates without breaking the feed", async () => {
+    mocks.listOrganizationActivity.mockResolvedValue({
+      logs: [
+        anActivityLog({
+          action: "organization:enterprise_trial_rearmed",
+          createdAt: new Date("not-a-date"),
+        }),
+      ],
+    });
+
+    await renderWithApp(<Activity org={ORG} />);
+    expect(await screen.findByText("rearmed enterprise trial")).toBeTruthy();
+    expect(screen.getAllByText("Unknown time").length).toBeGreaterThan(0);
+  });
+
+  it("adds labeled nested trial, organization, and key diffs without losing Admin details", async () => {
+    mocks.listOrganizationActivity.mockResolvedValue({
+      logs: [
+        anActivityLog({
+          id: "nested",
+          action: "organization:enterprise_trial_converted",
+          actorId: "actor-id",
+          actorSlug: "actor-slug",
+          subjectId: "subject-id",
+          projectId: "project-id",
+          actingClientId: "client-id",
+          metadata: { conversion_source: "manual", extra: { retained: true } },
+          beforeSnapshot: {
+            organization: { account_type: "free", whitelisted: false },
+            trial: { status: "running", tier: "enterprise" },
+            trial_ends_at: "2026-08-20T12:00:00Z",
+            keys: [{ key_type: "chat", effective_disabled: false }],
+            generic_extra: { value: "before" },
+          },
+          afterSnapshot: {
+            organization: { account_type: "enterprise", whitelisted: true },
+            trial: { status: "converted", tier: "enterprise" },
+            trial_ends_at: "2026-08-27T12:00:00Z",
+            keys: [{ key_type: "chat", effective_disabled: true }],
+            generic_extra: { value: "after" },
+          },
+        }),
+      ],
+    });
+
+    await renderWithApp(<Activity org={ORG} />);
+    fireEvent.click(await screen.findByRole("button", { name: "Show diff ▾" }));
+    const diff = screen.getByRole("region", { name: "Changed fields" });
+    for (const label of [
+      "Account type",
+      "Whitelisted",
+      "Trial status",
+      "Trial end",
+      "OpenRouter effective disabled (chat)",
+      "generic_extra",
+    ]) {
+      expect(within(diff).getByText(label)).toBeTruthy();
+    }
+
+    fireEvent.click(screen.getByText(/Event details for/));
+    for (const value of [
+      "actor-id",
+      "actor-slug",
+      "subject-id",
+      "project-id",
+      "client-id",
+    ]) {
+      expect(screen.getAllByText(value).length).toBeGreaterThan(0);
+    }
+    expect(screen.getByText(/"retained": true/)).toBeTruthy();
+    fireEvent.click(
+      within(diff).getByRole("button", { name: "View raw diff" }),
+    );
+    expect(screen.getAllByText(/"generic_extra"/)).toHaveLength(2);
+  });
+
+  it("deduplicates IDs at page boundaries and announces incremental loading", async () => {
+    const secondPage = deferred<{ logs: ReturnType<typeof anActivityLog>[] }>();
+    mocks.listOrganizationActivity
+      .mockResolvedValueOnce({
+        logs: [anActivityLog({ id: "same", action: "first-seen" })],
+        nextCursor: "next",
+      })
+      .mockReturnValueOnce(secondPage.promise);
+    await renderWithApp(<Activity org={ORG} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Load more" }));
+    expect((await screen.findByRole("status")).textContent).toBe(
+      "Loading more activity",
+    );
+    secondPage.resolve({
+      logs: [
+        anActivityLog({ id: "same", action: "duplicate" }),
+        anActivityLog({ id: "new", action: "new" }),
+      ],
+    });
+    await screen.findByText("new");
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("first-seen")).toBeTruthy();
+    expect(screen.queryByText("duplicate")).toBeNull();
+  });
+
+  it("guards load-more synchronously, handles rejection, and safely settles after unmount", async () => {
+    const page = deferred<{ logs: ReturnType<typeof anActivityLog>[] }>();
+    mocks.listOrganizationActivity
+      .mockResolvedValueOnce({
+        logs: [anActivityLog({ id: "current" })],
+        nextCursor: "next",
+      })
+      .mockReturnValueOnce(page.promise);
+    const mounted = await renderWithApp(<Activity org={ORG} />);
+    const loadMore = await screen.findByRole("button", { name: "Load more" });
+
+    fireEvent.click(loadMore);
+    fireEvent.click(loadMore);
+    expect(mocks.listOrganizationActivity).toHaveBeenCalledTimes(2);
+
+    mounted.unmount();
+    page.reject(new Error("offline"));
+    await page.promise.catch(() => undefined);
+  });
+
+  it("exposes the initial loading message as a polite status", async () => {
+    const pending = deferred<{ logs: ReturnType<typeof anActivityLog>[] }>();
+    mocks.listOrganizationActivity.mockReturnValue(pending.promise);
+    const mounted = await renderWithApp(<Activity org={ORG} />);
+    const status = await screen.findByRole("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toContain("Loading activity");
+    mounted.unmount();
+    pending.resolve({ logs: [] });
+  });
+
   it("keeps rows and prevents repeated activation while retrying a later page", async () => {
     const retry = deferred<{ logs: ReturnType<typeof anActivityLog>[] }>();
     mocks.listOrganizationActivity
       .mockResolvedValueOnce({
         logs: [anActivityLog({ id: "event-2", action: "event-2" })],
-        next_cursor: "retry-cursor",
+        nextCursor: "retry-cursor",
       })
       .mockRejectedValueOnce(new Error("offline"))
       .mockReturnValueOnce(retry.promise);

--- a/client/admin/src/pages/organization/Activity.test.tsx
+++ b/client/admin/src/pages/organization/Activity.test.tsx
@@ -582,6 +582,57 @@ describe("Activity", () => {
     ).toContain("Tierenterprise");
   });
 
+  it.each([
+    [
+      "trial tier object",
+      { trial: { tier: { name: "enterprise" } } },
+      {},
+      '{"name":"enterprise"}',
+    ],
+    [
+      "trial tier array",
+      { trial: { tier: ["enterprise"] } },
+      {},
+      '["enterprise"]',
+    ],
+    [
+      "account type object",
+      {},
+      { account_type: { name: "enterprise" } },
+      '{"name":"enterprise"}',
+    ],
+    [
+      "account type array",
+      {},
+      { account_type: ["enterprise"] },
+      '["enterprise"]',
+    ],
+    ["missing tier", {}, {}, "Not recorded"],
+    ["null tier", { trial: { tier: null } }, {}, "Not recorded"],
+    ["empty tier", { trial: { tier: "" } }, {}, "Not recorded"],
+  ])(
+    "renders %s in trial facts",
+    async (_name, afterSnapshot, metadata, expected) => {
+      mocks.listOrganizationActivity.mockResolvedValue({
+        logs: [
+          anActivityLog({
+            action: "organization:enterprise_trial_armed",
+            afterSnapshot,
+            metadata,
+          }),
+        ],
+      });
+
+      await renderWithApp(<Activity org={ORG} />);
+      const facts = await screen.findByRole("region", {
+        name: "Enterprise trial started",
+      });
+      expect(
+        within(facts).getByText("Tier").nextElementSibling?.textContent,
+      ).toBe(expected);
+    },
+  );
+
   it("renders malformed trial dates without breaking the feed", async () => {
     mocks.listOrganizationActivity.mockResolvedValue({
       logs: [

--- a/client/admin/src/pages/organization/Activity.tsx
+++ b/client/admin/src/pages/organization/Activity.tsx
@@ -316,7 +316,7 @@ function recorded(value: unknown): string {
         typeof value === "number" ||
         typeof value === "boolean"
       ? String(value)
-      : "Not recorded";
+      : (JSON.stringify(value) ?? "Not recorded");
 }
 
 function snapshotKeys(

--- a/client/admin/src/pages/organization/Activity.tsx
+++ b/client/admin/src/pages/organization/Activity.tsx
@@ -1,13 +1,28 @@
-import { useMemo, useState, type JSX, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode,
+} from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
-import {
-  organizationActivityQuery,
-  organizationQuery,
-} from "@/lib/adminQueries";
-import type { AdminAuditLog, AdminOrganization } from "@/lib/gramAdminApi";
+import { organizationQuery } from "@/lib/adminQueries";
+import type { AdminOrganization } from "@/lib/gramAdminApi";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
+import type { AuditLog } from "@gram/admin-client/models/components/auditlog";
+
+const TRIAL_ACTIONS = new Set([
+  "organization:enterprise_trial_armed",
+  "organization:enterprise_trial_extended",
+  "organization:enterprise_trial_rearmed",
+  "organization:enterprise_trial_demoted",
+  "organization:enterprise_trial_converted",
+]);
 
 const UTC_DATE_TIME = new Intl.DateTimeFormat("en-US", {
   dateStyle: "full",
@@ -15,17 +30,50 @@ const UTC_DATE_TIME = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-function actorName(log: AdminAuditLog): string {
+function conversionSource(log: AuditLog): string | undefined {
+  return typeof log.metadata?.conversion_source === "string"
+    ? log.metadata.conversion_source
+    : undefined;
+}
+
+function actorName(log: AuditLog): string {
+  if (
+    log.action === "organization:enterprise_trial_converted" &&
+    conversionSource(log) === "stripe_checkout"
+  ) {
+    return "Stripe";
+  }
   return (
-    log.actor_display_name ??
-    (log.actor_type === "system" ? "System" : undefined) ??
-    log.actor_slug ??
-    log.actor_id
+    log.actorDisplayName ??
+    (log.actorType === "system" || log.actorId === "system"
+      ? "System"
+      : undefined) ??
+    log.actorSlug ??
+    log.actorId
   );
 }
 
-function subjectName(log: AdminAuditLog): string {
-  return log.subject_display_name ?? log.subject_slug ?? log.subject_id;
+function activityAction(log: AuditLog): string {
+  switch (log.action) {
+    case "organization:enterprise_trial_armed":
+      return "started enterprise trial";
+    case "organization:enterprise_trial_extended":
+      return "extended enterprise trial";
+    case "organization:enterprise_trial_rearmed":
+      return "rearmed enterprise trial";
+    case "organization:enterprise_trial_demoted":
+      return "demoted enterprise trial";
+    case "organization:enterprise_trial_converted":
+      return conversionSource(log) === "stripe_checkout"
+        ? "converted enterprise trial through checkout"
+        : "marked enterprise trial converted";
+    default:
+      return log.action;
+  }
+}
+
+function subjectName(log: AuditLog): string {
+  return log.subjectDisplayName ?? log.subjectSlug ?? log.subjectId;
 }
 
 function Detail({ label, children }: { label: string; children: ReactNode }) {
@@ -54,6 +102,82 @@ type ChangedField = {
   newValue: unknown;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nestedValue(snapshot: unknown, group: string, field: string): unknown {
+  if (!isRecord(snapshot) || !isRecord(snapshot[group])) return undefined;
+  return snapshot[group][field];
+}
+
+function trialEnd(snapshot: unknown): unknown {
+  const nested = nestedValue(snapshot, "trial", "ends_at");
+  return nested ?? (isRecord(snapshot) ? snapshot.trial_ends_at : undefined);
+}
+
+function keyValue(snapshot: unknown, keyType: string, field: string): unknown {
+  if (!isRecord(snapshot) || !Array.isArray(snapshot.keys)) return undefined;
+  const key = snapshot.keys.find(
+    (candidate) => isRecord(candidate) && candidate.key_type === keyType,
+  );
+  return isRecord(key) ? key[field] : undefined;
+}
+
+function specializedChangedFields(
+  before: unknown,
+  after: unknown,
+): ChangedField[] {
+  const changes: ChangedField[] = [];
+  const add = (field: string, oldValue: unknown, newValue: unknown) => {
+    if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+      changes.push({ field, oldValue, newValue });
+    }
+  };
+  for (const [label, group, field] of [
+    ["Account type", "organization", "account_type"],
+    ["Whitelisted", "organization", "whitelisted"],
+    ["Disabled", "organization", "disabled"],
+    ["Trial status", "trial", "status"],
+    ["Trial tier", "trial", "tier"],
+    ["Converted at", "trial", "converted_at"],
+    ["Demoted at", "trial", "demoted_at"],
+  ] as const) {
+    const oldValue = nestedValue(before, group, field);
+    const newValue = nestedValue(after, group, field);
+    if (oldValue !== undefined || newValue !== undefined)
+      add(label, oldValue, newValue);
+  }
+  const oldTrialEnd = trialEnd(before);
+  const newTrialEnd = trialEnd(after);
+  if (oldTrialEnd !== undefined || newTrialEnd !== undefined) {
+    add("Trial end", oldTrialEnd, newTrialEnd);
+  }
+  const keyTypes = new Set<string>();
+  for (const snapshot of [before, after]) {
+    if (!isRecord(snapshot) || !Array.isArray(snapshot.keys)) continue;
+    for (const key of snapshot.keys) {
+      if (isRecord(key) && typeof key.key_type === "string")
+        keyTypes.add(key.key_type);
+    }
+  }
+  for (const keyType of [...keyTypes].sort()) {
+    for (const [label, field] of [
+      ["OpenRouter stored disabled", "stored_disabled"],
+      ["OpenRouter effective disabled", "effective_disabled"],
+      ["OpenRouter key access changed", "key_access_changed"],
+      ["OpenRouter monthly cap", "monthly_credits"],
+    ] as const) {
+      const oldValue = keyValue(before, keyType, field);
+      const newValue = keyValue(after, keyType, field);
+      if (oldValue !== undefined || newValue !== undefined) {
+        add(`${label} (${keyType})`, oldValue, newValue);
+      }
+    }
+  }
+  return changes;
+}
+
 function computeChangedFields(before: unknown, after: unknown): ChangedField[] {
   const beforeObject =
     before != null && typeof before === "object"
@@ -68,7 +192,7 @@ function computeChangedFields(before: unknown, after: unknown): ChangedField[] {
     ...Object.keys(afterObject),
   ]);
 
-  return [...fields]
+  const generic = [...fields]
     .filter(
       (field) =>
         JSON.stringify(beforeObject[field]) !==
@@ -80,6 +204,7 @@ function computeChangedFields(before: unknown, after: unknown): ChangedField[] {
       newValue: afterObject[field],
     }))
     .sort((left, right) => left.field.localeCompare(right.field));
+  return [...specializedChangedFields(before, after), ...generic];
 }
 
 function formatChangedValue(value: unknown): string {
@@ -166,11 +291,211 @@ function ActivityDiff({
   );
 }
 
-function ActivityItem({ log }: { log: AdminAuditLog }): JSX.Element {
+function firstRecorded(...values: unknown[]): unknown {
+  return values.find(
+    (value) => value !== undefined && value !== null && value !== "",
+  );
+}
+
+function formatDate(value: Date): string {
+  return Number.isNaN(value.valueOf())
+    ? "Unknown time"
+    : UTC_DATE_TIME.format(value);
+}
+
+function factDate(value: unknown): string {
+  if (value instanceof Date) return formatDate(value);
+  return typeof value === "string"
+    ? formatDate(new Date(value))
+    : "Not recorded";
+}
+
+function recorded(value: unknown): string {
+  return value === undefined || value === null || value === ""
+    ? "Not recorded"
+    : String(value);
+}
+
+function snapshotKeys(
+  snapshot: Record<string, unknown>,
+): Record<string, unknown>[] {
+  return Array.isArray(snapshot.keys) ? snapshot.keys.filter(isRecord) : [];
+}
+
+function keyTypes(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): string[] {
+  return [
+    ...new Set(
+      [...snapshotKeys(before), ...snapshotKeys(after)]
+        .map((key) => key.key_type)
+        .filter((value): value is string => typeof value === "string"),
+    ),
+  ];
+}
+
+function keyAccess(snapshot: Record<string, unknown>, keyType: string): string {
+  const key = snapshotKeys(snapshot).find((item) => item.key_type === keyType);
+  return typeof key?.effective_disabled === "boolean"
+    ? key.effective_disabled
+      ? "Disabled"
+      : "Enabled"
+    : "Not recorded";
+}
+
+function snapshotKeyAccessChanged(
+  snapshot: Record<string, unknown>,
+): boolean | undefined {
+  const values = snapshotKeys(snapshot)
+    .map((key) => key.key_access_changed)
+    .filter((value): value is boolean => typeof value === "boolean");
+  return values.length === 0 ? undefined : values.some(Boolean);
+}
+
+function TrialFacts({ log }: { log: AuditLog }): JSX.Element {
+  const before = isRecord(log.beforeSnapshot) ? log.beforeSnapshot : {};
+  const after = isRecord(log.afterSnapshot) ? log.afterSnapshot : {};
+  const beforeEnd = firstRecorded(
+    nestedValue(before, "trial", "ends_at"),
+    before.trial_ends_at,
+    log.metadata?.previous_trial_ends_at,
+  );
+  const afterEnd = firstRecorded(
+    nestedValue(after, "trial", "ends_at"),
+    after.trial_ends_at,
+    log.metadata?.trial_ends_at,
+  );
+  const tier = firstRecorded(
+    nestedValue(after, "trial", "tier"),
+    nestedValue(before, "trial", "tier"),
+    log.metadata?.tier,
+    log.metadata?.account_type,
+    log.metadata?.previous_account_type,
+  );
+  const facts: Array<[string, string]> = [];
+  let title = "Enterprise trial updated";
+  switch (log.action) {
+    case "organization:enterprise_trial_armed":
+      title = "Enterprise trial started";
+      facts.push(
+        ["Started", factDate(log.createdAt)],
+        ["Trial end", factDate(afterEnd)],
+        ["Tier", recorded(tier)],
+      );
+      break;
+    case "organization:enterprise_trial_extended":
+      title = "Enterprise trial extended";
+      facts.push(
+        ["Previous trial end", factDate(beforeEnd)],
+        ["New trial end", factDate(afterEnd)],
+        ["Tier", recorded(tier)],
+      );
+      break;
+    case "organization:enterprise_trial_rearmed":
+      title = "Enterprise trial restarted";
+      facts.push(
+        ["Restarted", factDate(log.createdAt)],
+        ["Trial end", factDate(afterEnd)],
+        ["Tier", recorded(tier)],
+      );
+      break;
+    case "organization:enterprise_trial_demoted":
+      title = "Enterprise trial ended";
+      facts.push(
+        [
+          "Ended",
+          factDate(
+            firstRecorded(
+              nestedValue(after, "trial", "demoted_at"),
+              log.createdAt,
+            ),
+          ),
+        ],
+        ["Trial end", factDate(afterEnd)],
+        ["Tier", recorded(tier)],
+      );
+      break;
+    case "organization:enterprise_trial_converted":
+      title = "Enterprise trial converted";
+      facts.push(
+        [
+          "Converted",
+          factDate(
+            firstRecorded(
+              nestedValue(after, "trial", "converted_at"),
+              log.createdAt,
+            ),
+          ),
+        ],
+        [
+          "Conversion method",
+          conversionSource(log) === "stripe_checkout"
+            ? "Stripe checkout"
+            : conversionSource(log) === "platform_admin" ||
+                conversionSource(log) === "admin"
+              ? "Manual"
+              : recorded(conversionSource(log)),
+        ],
+        ["Tier", recorded(tier)],
+      );
+      break;
+  }
+  const keyAccessChanged = firstRecorded(
+    log.metadata?.key_access_changed,
+    snapshotKeyAccessChanged(after),
+    snapshotKeyAccessChanged(before),
+  );
+  if (
+    [
+      "organization:enterprise_trial_rearmed",
+      "organization:enterprise_trial_demoted",
+      "organization:enterprise_trial_converted",
+    ].includes(log.action)
+  ) {
+    facts.push([
+      "OpenRouter key access changed",
+      keyAccessChanged === undefined
+        ? "Not recorded"
+        : keyAccessChanged
+          ? "Yes"
+          : "No",
+    ]);
+  }
+  for (const keyType of keyTypes(before, after)) {
+    const oldAccess = keyAccess(before, keyType);
+    const newAccess = keyAccess(after, keyType);
+    facts.push([
+      `OpenRouter ${keyType} key`,
+      oldAccess === newAccess || oldAccess === "Not recorded"
+        ? newAccess
+        : `${oldAccess} → ${newAccess}`,
+    ]);
+  }
+  return (
+    <section
+      className="bg-muted mt-2 rounded-md px-3 py-2 text-xs"
+      aria-label={title}
+      role="region"
+    >
+      <h3 className="mb-1 font-medium">{title}</h3>
+      <dl className="grid gap-x-4 gap-y-1 sm:grid-cols-2">
+        {facts.map(([label, value]) => (
+          <div className="contents" key={label}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function ActivityItem({ log }: { log: AuditLog }): JSX.Element {
   const [diffExpanded, setDiffExpanded] = useState(false);
   const changes = useMemo(
-    () => computeChangedFields(log.before_snapshot, log.after_snapshot),
-    [log.before_snapshot, log.after_snapshot],
+    () => computeChangedFields(log.beforeSnapshot, log.afterSnapshot),
+    [log.beforeSnapshot, log.afterSnapshot],
   );
   const showDiff = changes.length > 0;
   const diffId = `activity-diff-${log.id}`;
@@ -178,14 +503,21 @@ function ActivityItem({ log }: { log: AdminAuditLog }): JSX.Element {
   return (
     <li className="rounded-lg border p-3">
       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
-        <time className="text-muted-foreground" dateTime={log.created_at}>
-          {UTC_DATE_TIME.format(new Date(log.created_at))}
+        <time
+          className="text-muted-foreground"
+          dateTime={
+            Number.isNaN(log.createdAt.valueOf())
+              ? undefined
+              : log.createdAt.toISOString()
+          }
+        >
+          {formatDate(log.createdAt)}
         </time>
-        <strong className="font-medium">{log.action}</strong>
+        <strong className="font-medium">{activityAction(log)}</strong>
         <span>{actorName(log)}</span>
         <span className="text-muted-foreground">→</span>
         <span>{subjectName(log)}</span>
-        <span className="text-muted-foreground">via {log.acting_surface}</span>
+        <span className="text-muted-foreground">via {log.actingSurface}</span>
         {showDiff && (
           <button
             type="button"
@@ -198,11 +530,12 @@ function ActivityItem({ log }: { log: AdminAuditLog }): JSX.Element {
           </button>
         )}
       </div>
+      {TRIAL_ACTIONS.has(log.action) && <TrialFacts log={log} />}
       {showDiff && diffExpanded && (
         <div id={diffId} className="pt-2">
           <ActivityDiff
-            before={log.before_snapshot}
-            after={log.after_snapshot}
+            before={log.beforeSnapshot}
+            after={log.afterSnapshot}
             changes={changes}
           />
         </div>
@@ -212,24 +545,20 @@ function ActivityItem({ log }: { log: AdminAuditLog }): JSX.Element {
           Event details for {log.action}
         </summary>
         <dl className="mt-2 grid gap-2 sm:grid-cols-2">
-          {log.project_id && (
-            <Detail label="Project ID">{log.project_id}</Detail>
+          {log.projectId && <Detail label="Project ID">{log.projectId}</Detail>}
+          {log.projectSlug && (
+            <Detail label="Project slug">{log.projectSlug}</Detail>
           )}
-          {log.project_slug && (
-            <Detail label="Project slug">{log.project_slug}</Detail>
+          <Detail label="Actor type">{log.actorType}</Detail>
+          <Detail label="Actor ID">{log.actorId}</Detail>
+          {log.actorSlug && <Detail label="Actor slug">{log.actorSlug}</Detail>}
+          <Detail label="Subject type">{log.subjectType}</Detail>
+          <Detail label="Subject ID">{log.subjectId}</Detail>
+          {log.subjectSlug && (
+            <Detail label="Subject slug">{log.subjectSlug}</Detail>
           )}
-          <Detail label="Actor type">{log.actor_type}</Detail>
-          <Detail label="Actor ID">{log.actor_id}</Detail>
-          {log.actor_slug && (
-            <Detail label="Actor slug">{log.actor_slug}</Detail>
-          )}
-          <Detail label="Subject type">{log.subject_type}</Detail>
-          <Detail label="Subject ID">{log.subject_id}</Detail>
-          {log.subject_slug && (
-            <Detail label="Subject slug">{log.subject_slug}</Detail>
-          )}
-          {log.acting_client_id && (
-            <Detail label="Acting client ID">{log.acting_client_id}</Detail>
+          {log.actingClientId && (
+            <Detail label="Acting client ID">{log.actingClientId}</Detail>
           )}
           <JsonDetail label="Metadata" value={log.metadata} />
         </dl>
@@ -247,13 +576,47 @@ export function ActivityRoute(): JSX.Element | null {
 
 export function Activity({ org }: { org: AdminOrganization }): JSX.Element {
   const query = useInfiniteQuery(organizationActivityQuery(org.id));
-  const logs = query.data?.pages.flatMap((page) => page.logs) ?? [];
+  const fetchInFlight = useRef(false);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  const fetchNextPage = query.fetchNextPage;
+  const fetchMore = useCallback(async () => {
+    if (fetchInFlight.current) return;
+    fetchInFlight.current = true;
+    try {
+      await fetchNextPage({ cancelRefetch: false });
+    } catch {
+      // React Query exposes the incremental error below.
+    } finally {
+      if (mounted.current) fetchInFlight.current = false;
+    }
+  }, [fetchNextPage]);
+  const logs = useMemo(() => {
+    const byID = new Map<string, AuditLog>();
+    for (const page of query.data?.pages ?? []) {
+      for (const log of page.result.logs) {
+        if (!byID.has(log.id)) byID.set(log.id, log);
+      }
+    }
+    return [...byID.values()];
+  }, [query.data?.pages]);
 
   return (
     <section className="flex flex-col gap-3">
       <h2 className="text-lg font-semibold">Activity</h2>
       {query.isPending ? (
-        <p className="text-muted-foreground text-sm">Loading activity...</p>
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-muted-foreground text-sm"
+        >
+          Loading activity...
+        </p>
       ) : query.isError && query.data === undefined ? (
         <div role="alert" className="flex items-center gap-2">
           <p className="text-destructive text-sm">Unable to load activity</p>
@@ -265,7 +628,7 @@ export function Activity({ org }: { org: AdminOrganization }): JSX.Element {
             Retry
           </Button>
         </div>
-      ) : logs.length === 0 ? (
+      ) : logs.length === 0 && !query.hasNextPage ? (
         <p className="text-muted-foreground text-sm">
           No activity for this organization
         </p>
@@ -298,21 +661,28 @@ export function Activity({ org }: { org: AdminOrganization }): JSX.Element {
             variant="outline"
             size="sm"
             disabled={query.isFetchingNextPage}
-            onClick={() => void query.fetchNextPage()}
+            onClick={() => void fetchMore()}
           >
             {query.isFetchingNextPage ? "Retrying..." : "Retry loading more"}
           </Button>
         </div>
       ) : query.hasNextPage ? (
-        <Button
-          className="self-start"
-          variant="outline"
-          size="sm"
-          disabled={query.isFetchingNextPage}
-          onClick={() => void query.fetchNextPage()}
-        >
-          {query.isFetchingNextPage ? "Loading..." : "Load more"}
-        </Button>
+        <>
+          {query.isFetchingNextPage && (
+            <span role="status" aria-live="polite" className="sr-only">
+              Loading more activity
+            </span>
+          )}
+          <Button
+            className="self-start"
+            variant="outline"
+            size="sm"
+            disabled={query.isFetchingNextPage}
+            onClick={() => void fetchMore()}
+          >
+            {query.isFetchingNextPage ? "Loading..." : "Load more"}
+          </Button>
+        </>
       ) : null}
     </section>
   );

--- a/client/admin/src/pages/organization/Activity.tsx
+++ b/client/admin/src/pages/organization/Activity.tsx
@@ -1,6 +1,5 @@
 import {
   useCallback,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -313,7 +312,11 @@ function factDate(value: unknown): string {
 function recorded(value: unknown): string {
   return value === undefined || value === null || value === ""
     ? "Not recorded"
-    : String(value);
+    : typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ? String(value)
+      : "Not recorded";
 }
 
 function snapshotKeys(
@@ -575,15 +578,16 @@ export function ActivityRoute(): JSX.Element | null {
 }
 
 export function Activity({ org }: { org: AdminOrganization }): JSX.Element {
+  return <OrganizationActivity key={org.id} org={org} />;
+}
+
+function OrganizationActivity({
+  org,
+}: {
+  org: AdminOrganization;
+}): JSX.Element {
   const query = useInfiniteQuery(organizationActivityQuery(org.id));
   const fetchInFlight = useRef(false);
-  const mounted = useRef(true);
-  useEffect(() => {
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
   const fetchNextPage = query.fetchNextPage;
   const fetchMore = useCallback(async () => {
     if (fetchInFlight.current) return;
@@ -593,7 +597,7 @@ export function Activity({ org }: { org: AdminOrganization }): JSX.Element {
     } catch {
       // React Query exposes the incremental error below.
     } finally {
-      if (mounted.current) fetchInFlight.current = false;
+      fetchInFlight.current = false;
     }
   }, [fetchNextPage]);
   const logs = useMemo(() => {

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -9,12 +9,12 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  organizationActivityQuery,
   organizationQuery,
   organizationsListQuery,
   organizationsStatsQuery,
 } from "@/lib/adminQueries";
 import { GramAdminError, type AdminOrganization } from "@/lib/gramAdminApi";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
 import { routeTree } from "@/routeTree.gen";
 import { anOrganization } from "@/test/fixtures";
 import { renderRouteTree } from "@/test/harness";

--- a/client/admin/src/pages/organization/RecordLayout.test.tsx
+++ b/client/admin/src/pages/organization/RecordLayout.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
   getOrganization: vi.fn(),
   listOrganizationProjects: vi.fn(),
   listOrganizationMembers: vi.fn(),
-  listOrganizationActivity: vi.fn(),
+  activityFetch: vi.fn(),
   enableOrganization: vi.fn(),
 }));
 
@@ -27,7 +27,6 @@ vi.mock("@/lib/gramAdminApi", async (importOriginal) => {
     getOrganization: mocks.getOrganization,
     listOrganizationProjects: mocks.listOrganizationProjects,
     listOrganizationMembers: mocks.listOrganizationMembers,
-    listOrganizationActivity: mocks.listOrganizationActivity,
     enableOrganization: mocks.enableOrganization,
   };
 });
@@ -52,12 +51,23 @@ beforeEach(() => {
   mocks.listOrganizationProjects.mockResolvedValue({ projects: [] });
   mocks.listOrganizationMembers.mockReset();
   mocks.listOrganizationMembers.mockResolvedValue({ members: [] });
-  mocks.listOrganizationActivity.mockReset();
-  mocks.listOrganizationActivity.mockResolvedValue({ logs: [] });
+  mocks.activityFetch.mockReset();
+  mocks.activityFetch.mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ logs: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  vi.stubGlobal("fetch", mocks.activityFetch);
   mocks.enableOrganization.mockReset();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 // The one region a screen reader hears a write through. Read as a node rather
 // than by its text, because what this is about is the text changing.
@@ -84,15 +94,6 @@ describe("RecordLayout", () => {
   });
 
   it("keeps record context around the activity view and requests by explicit ID", async () => {
-    mocks.listOrganizationActivity.mockImplementation(
-      (organizationID: string) =>
-        organizationID === ORG.id
-          ? Promise.resolve({ logs: [] })
-          : Promise.reject(
-              new Error(`unexpected organization ${organizationID}`),
-            ),
-    );
-
     await renderRouteTree(routeTree, {
       initialPath: `/organizations/${ORG.slug}/activity`,
     });
@@ -102,10 +103,10 @@ describe("RecordLayout", () => {
     expect(
       screen.getByRole("button", { name: /Open in Dashboard/ }),
     ).toBeTruthy();
-    expect(mocks.listOrganizationActivity).toHaveBeenCalledTimes(1);
-    expect(mocks.listOrganizationActivity).toHaveBeenCalledWith(
+    expect(mocks.activityFetch).toHaveBeenCalledTimes(1);
+    const request = mocks.activityFetch.mock.calls[0]?.[0] as Request;
+    expect(new URL(request.url).searchParams.get("organization_id")).toBe(
       ORG.id,
-      undefined,
     );
   });
 
@@ -129,7 +130,7 @@ describe("RecordLayout", () => {
       expect(
         await screen.findByRole("button", { name: /Open in Dashboard/ }),
       ).toBeTruthy();
-      expect(screen.queryByRole("status")).toBeNull();
+      await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
     },
   );
 

--- a/client/admin/src/pages/organizations/rowActions.test.tsx
+++ b/client/admin/src/pages/organizations/rowActions.test.tsx
@@ -3,11 +3,8 @@ import { renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  organizationActivityQuery,
-  organizationQuery,
-  organizationsListQuery,
-} from "@/lib/adminQueries";
+import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
+import { organizationActivityQuery } from "@/lib/gramAdminClient";
 import {
   TRIAL_STATES,
   type AdminOrganization,
@@ -132,9 +129,9 @@ describe("audited organization lifecycle mutations", () => {
       const detail = organizationQuery(DEMOTED_ORG.slug);
       qc.setQueryData(detail.queryKey, DEMOTED_ORG);
       qc.setQueryData(activity.queryKey, {
-        pages: [{ logs: [] }],
+        pages: [{ result: { logs: [] } }],
         pageParams: [undefined],
-      });
+      } as never);
       const { result } = renderHook(
         () => ({
           disable: useDisableOrganization(),

--- a/client/admin/src/test/fixtures.ts
+++ b/client/admin/src/test/fixtures.ts
@@ -4,27 +4,26 @@
 // Invented names throughout. This repository is public, so no fixture ever
 // carries a real organization, project or person.
 
+import type { AuditLog } from "@gram/admin-client/models/components/auditlog";
+
 import type {
-  AdminAuditLog,
   AdminOrganization,
   AdminOrganizationMember,
   AdminProject,
 } from "@/lib/gramAdminApi";
 
-export function anActivityLog(
-  overrides: Partial<AdminAuditLog> = {},
-): AdminAuditLog {
+export function anActivityLog(overrides: Partial<AuditLog> = {}): AuditLog {
   return {
     id: "event_1",
-    actor_id: "user_1",
-    actor_type: "user",
-    actor_display_name: "Example Operator",
+    actorId: "user_1",
+    actorType: "user",
+    actorDisplayName: "Example Operator",
     action: "organization:settings_updated",
-    acting_surface: "dashboard",
-    subject_id: "org_1",
-    subject_type: "organization",
-    subject_display_name: "Test Org",
-    created_at: "2026-01-15T12:30:00Z",
+    actingSurface: "dashboard",
+    subjectId: "org_1",
+    subjectType: "organization",
+    subjectDisplayName: "Test Org",
+    createdAt: new Date("2026-01-15T12:30:00Z"),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- adds enterprise-trial lifecycle summaries, facts, and nested field interpretation to the standalone Admin activity feed
- identifies checkout-driven conversions and preserves the feed's complete generic audit details
- consumes the generated Admin SDK for activity models, pagination, transport, and scoped cache invalidation
- deduplicates paginated events and guards repeated load-more requests while improving loading announcements

## Motivation

The standalone Admin activity feed should retain its role as the general organization audit log while providing the useful trial-specific interpretation previously available only in Dashboard Platform Admin. Keeping this behavior on the Admin-authenticated surface avoids relying on an incompatible Dashboard session and now uses the generated SDK boundary shared by standalone Admin operations.
