### PR TITLE
fix: drain tunnel gateways and retry stale routes

### DIFF
--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -106,7 +106,7 @@ func (m *tunnelManager) buildProxy(
 		selection,
 		options...,
 	)
-	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
+	p.UpstreamRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
 	// Redirects won't work across a tunnel boundary; disable.
 	p.DisableRedirects = true
 	p.GuardianClientOptions = m.guardianClientOptions()

--- a/server/internal/mcp/tunnelrouting/routing.go
+++ b/server/internal/mcp/tunnelrouting/routing.go
@@ -6,14 +6,13 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math/big"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/tunnel/route"
@@ -106,8 +105,7 @@ func SelectRoute(clientAffinityKey string, candidates []string, exclude map[stri
 func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forwardToken string) proxy.UpstreamRetryer {
 	return func(ctx context.Context, resp *http.Response, forwardErr error) (*proxy.UpstreamRetry, error) {
 		if forwardErr != nil {
-			var opErr *net.OpError
-			if ctx.Err() != nil || !errors.As(forwardErr, &opErr) || opErr.Op != "dial" {
+			if ctx.Err() != nil || !guardian.IsDeadPeerDialError(forwardErr) {
 				return nil, nil
 			}
 			if err := unpublishSelected(ctx, routes, tunnelID, selectedAddr); err != nil {

--- a/server/internal/mcp/tunnelrouting/routing.go
+++ b/server/internal/mcp/tunnelrouting/routing.go
@@ -6,8 +6,10 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,8 +103,18 @@ func SelectRoute(clientAffinityKey string, candidates []string, exclude map[stri
 }
 
 // Retryer returns the tunnel-specific proxy retry policy.
-func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forwardToken string) proxy.UpstreamResponseRetryer {
-	return func(ctx context.Context, resp *http.Response) (*proxy.UpstreamResponseRetry, error) {
+func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forwardToken string) proxy.UpstreamRetryer {
+	return func(ctx context.Context, resp *http.Response, forwardErr error) (*proxy.UpstreamRetry, error) {
+		if forwardErr != nil {
+			var opErr *net.OpError
+			if ctx.Err() != nil || !errors.As(forwardErr, &opErr) || opErr.Op != "dial" {
+				return nil, nil
+			}
+			if err := unpublishSelected(ctx, routes, tunnelID, selectedAddr); err != nil {
+				return nil, err
+			}
+			return retryTarget(ctx, routes, tunnelID, selectedAddr, clientAffinityKey, forwardToken)
+		}
 		if resp == nil || resp.StatusCode != http.StatusBadGateway {
 			return nil, nil
 		}
@@ -110,10 +122,8 @@ func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forw
 		tunnelErr := resp.Header.Get(ErrorHeader)
 		switch tunnelErr {
 		case wire.TunnelErrorNoLiveSession:
-			if selectedAddr != "" {
-				if err := routes.Unpublish(ctx, tunnelID, selectedAddr); err != nil {
-					return nil, fmt.Errorf("unpublish stale tunnel route: %w", err)
-				}
+			if err := unpublishSelected(ctx, routes, tunnelID, selectedAddr); err != nil {
+				return nil, err
 			}
 		case wire.TunnelErrorTunnelBusy:
 			// The gateway is healthy but at its substream cap: keep its route
@@ -134,27 +144,45 @@ func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forw
 			return nil, nil
 		}
 
-		candidates, err := routes.Candidates(ctx, tunnelID)
-		if err != nil {
-			return nil, fmt.Errorf("list tunnel retry routes: %w", err)
-		}
-		exclude := map[string]struct{}{selectedAddr: {}}
+		excludedAddr := selectedAddr
 		if tunnelErr == wire.TunnelErrorSubstreamFailed {
-			exclude = nil
+			excludedAddr = ""
 		}
-		addr, ok := SelectRoute(clientAffinityKey, candidates, exclude)
-		if !ok {
-			return nil, nil
-		}
-		gatewayURL, err := GatewayURL(addr)
-		if err != nil {
-			return nil, fmt.Errorf("build tunnel retry route URL: %w", err)
-		}
-		return &proxy.UpstreamResponseRetry{
-			RemoteURL: gatewayURL,
-			Headers:   Headers(tunnelID, forwardToken, clientAffinityKey),
-		}, nil
+		return retryTarget(ctx, routes, tunnelID, excludedAddr, clientAffinityKey, forwardToken)
 	}
+}
+
+func unpublishSelected(ctx context.Context, routes route.Store, tunnelID, selectedAddr string) error {
+	if selectedAddr == "" {
+		return nil
+	}
+	if err := routes.Unpublish(ctx, tunnelID, selectedAddr); err != nil {
+		return fmt.Errorf("unpublish stale tunnel route: %w", err)
+	}
+	return nil
+}
+
+func retryTarget(ctx context.Context, routes route.Store, tunnelID, excludedAddr, clientAffinityKey, forwardToken string) (*proxy.UpstreamRetry, error) {
+	candidates, err := routes.Candidates(ctx, tunnelID)
+	if err != nil {
+		return nil, fmt.Errorf("list tunnel retry routes: %w", err)
+	}
+	var exclude map[string]struct{}
+	if excludedAddr != "" {
+		exclude = map[string]struct{}{excludedAddr: {}}
+	}
+	addr, ok := SelectRoute(clientAffinityKey, candidates, exclude)
+	if !ok {
+		return nil, nil
+	}
+	gatewayURL, err := GatewayURL(addr)
+	if err != nil {
+		return nil, fmt.Errorf("build tunnel retry route URL: %w", err)
+	}
+	return &proxy.UpstreamRetry{
+		RemoteURL: gatewayURL,
+		Headers:   Headers(tunnelID, forwardToken, clientAffinityKey),
+	}, nil
 }
 
 // GatewayURL normalizes a route store address into the proxy's upstream URL.

--- a/server/internal/mcp/tunnelrouting/routing_test.go
+++ b/server/internal/mcp/tunnelrouting/routing_test.go
@@ -3,6 +3,8 @@ package tunnelrouting
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -45,7 +47,7 @@ func TestRetryerNoLiveSessionUnpublishesAndFailsOver(t *testing.T) {
 
 	resp := tunnelErrorResponse("no-live-session")
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.NotNil(t, retry)
 	require.Equal(t, "http://127.0.0.1:1002", retry.RemoteURL)
@@ -58,6 +60,43 @@ func TestRetryerNoLiveSessionUnpublishesAndFailsOver(t *testing.T) {
 	require.Equal(t, []string{"127.0.0.1:1002"}, candidates)
 }
 
+func TestRetryerDialFailureUnpublishesAndFailsOver(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1002", time.Minute))
+
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")}
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, nil, dialErr)
+	require.NoError(t, err)
+	require.NotNil(t, retry)
+	require.Equal(t, "http://127.0.0.1:1002", retry.RemoteURL)
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"127.0.0.1:1002"}, candidates)
+}
+
+func TestRetryerDoesNotReplayAfterConnectedTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1002", time.Minute))
+
+	readErr := &net.OpError{Op: "read", Net: "tcp", Err: errors.New("connection reset")}
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, nil, readErr)
+	require.NoError(t, err)
+	require.Nil(t, retry)
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"127.0.0.1:1001", "127.0.0.1:1002"}, candidates)
+}
+
 func TestRetryerSubstreamFailedRetriesSameRouteWithoutUnpublish(t *testing.T) {
 	t.Parallel()
 
@@ -67,7 +106,7 @@ func TestRetryerSubstreamFailedRetriesSameRouteWithoutUnpublish(t *testing.T) {
 
 	resp := tunnelErrorResponse("substream-failed")
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.NotNil(t, retry)
 	require.Equal(t, "http://127.0.0.1:1001", retry.RemoteURL)
@@ -91,7 +130,7 @@ func TestRetryerTunnelBusyFailsOverWithoutUnpublish(t *testing.T) {
 
 	resp := tunnelErrorResponseForMethod(wire.TunnelErrorTunnelBusy, http.MethodPost)
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.NotNil(t, retry)
 	require.Equal(t, "http://127.0.0.1:1002", retry.RemoteURL)
@@ -111,7 +150,7 @@ func TestRetryerTunnelBusySingleCandidateDoesNotRetry(t *testing.T) {
 
 	resp := tunnelErrorResponseForMethod(wire.TunnelErrorTunnelBusy, http.MethodPost)
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.Nil(t, retry)
 
@@ -134,7 +173,7 @@ func TestRetryerSubstreamFailedDoesNotReplayPost(t *testing.T) {
 
 	resp := tunnelErrorResponseForMethod("substream-failed", http.MethodPost)
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.Nil(t, retry)
 
@@ -156,7 +195,7 @@ func TestRetryerSubstreamFailedNilRequestDoesNotRetry(t *testing.T) {
 	resp := tunnelErrorResponse("substream-failed")
 	resp.Request = nil
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.Nil(t, retry)
 }
@@ -174,7 +213,7 @@ func TestRetryerPlainBadGatewayDoesNotRetry(t *testing.T) {
 		Body:       http.NoBody,
 	}
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.Nil(t, retry)
 
@@ -192,7 +231,7 @@ func TestRetryerNoLiveSessionSingleCandidateDoesNotRetry(t *testing.T) {
 
 	resp := tunnelErrorResponse("no-live-session")
 	defer func() { require.NoError(t, resp.Body.Close()) }()
-	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp)
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, resp, nil)
 	require.NoError(t, err)
 	require.Nil(t, retry)
 

--- a/server/internal/mcp/tunnelrouting/routing_test.go
+++ b/server/internal/mcp/tunnelrouting/routing_test.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/tunnel/route"
 	"github.com/speakeasy-api/gram/tunnel/wire"
@@ -68,7 +70,7 @@ func TestRetryerDialFailureUnpublishesAndFailsOver(t *testing.T) {
 	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
 	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1002", time.Minute))
 
-	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("i/o timeout")}
+	dialErr := &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ETIMEDOUT}
 	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, nil, dialErr)
 	require.NoError(t, err)
 	require.NotNil(t, retry)
@@ -77,6 +79,24 @@ func TestRetryerDialFailureUnpublishesAndFailsOver(t *testing.T) {
 	candidates, err := routes.Candidates(ctx, "tunnel-1")
 	require.NoError(t, err)
 	require.Equal(t, []string{"127.0.0.1:1002"}, candidates)
+}
+
+func TestRetryerGuardianPolicyFailurePreservesRoute(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	routes := route.NewRouteTable()
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1001", time.Minute))
+	require.NoError(t, routes.Publish(ctx, "tunnel-1", "127.0.0.1:1002", time.Minute))
+
+	blockedErr := &net.OpError{Op: "dial", Net: "tcp", Err: guardian.ErrBlockedIP}
+	retry, err := Retryer(routes, "tunnel-1", "127.0.0.1:1001", "auth:stable", "forward-token")(ctx, nil, blockedErr)
+	require.NoError(t, err)
+	require.Nil(t, retry)
+
+	candidates, err := routes.Candidates(ctx, "tunnel-1")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"127.0.0.1:1001", "127.0.0.1:1002"}, candidates)
 }
 
 func TestRetryerDoesNotReplayAfterConnectedTransportFailure(t *testing.T) {

--- a/server/internal/remotemcp/proxy/errors.go
+++ b/server/internal/remotemcp/proxy/errors.go
@@ -29,6 +29,22 @@ var ErrUndecodableJSONRPCBody = errors.New("upstream response is not a json-rpc 
 // supported") rather than a generic decode failure.
 var ErrBatchRequest = errors.New("batch requests are not supported")
 
+type forwardTransportError struct {
+	cause    error
+	timedOut bool
+}
+
+func (e *forwardTransportError) Error() string { return e.cause.Error() }
+func (e *forwardTransportError) Unwrap() error { return e.cause }
+
+func (p *Proxy) classifyForwardResultError(ctx context.Context, err error) error {
+	var forwardErr *forwardTransportError
+	if !errors.As(err, &forwardErr) {
+		return err
+	}
+	return p.classifyForwardError(ctx, forwardErr.cause, forwardErr.timedOut)
+}
+
 // classifyForwardError maps a [http.Client.Do] failure into a typed proxy
 // error. timedOut is true when the failure was caused by the proxy's own
 // phase-1 timer firing (vs. a parent-context cancellation from the user

--- a/server/internal/remotemcp/proxy/forward_retry_internal_test.go
+++ b/server/internal/remotemcp/proxy/forward_retry_internal_test.go
@@ -51,7 +51,7 @@ func TestForwardRequestWithRetryClosesBodyOnRetryerError(t *testing.T) {
 		RemoteURL:             upstream.URL,
 		Headers:               nil,
 		AuthorizationOverride: "",
-		UpstreamResponseRetryer: func(_ context.Context, _ *http.Response) (*UpstreamResponseRetry, error) {
+		UpstreamRetryer: func(_ context.Context, _ *http.Response, _ error) (*UpstreamRetry, error) {
 			return nil, retryerErr
 		},
 		UserRequestObservationInterceptors: nil,

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -129,12 +129,12 @@ func (i ServerIdentity) AppendAttributes(attrs []attribute.KeyValue) []attribute
 	return attrs
 }
 
-type UpstreamResponseRetry struct {
+type UpstreamRetry struct {
 	RemoteURL string
 	Headers   []ConfiguredHeader
 }
 
-type UpstreamResponseRetryer func(ctx context.Context, resp *http.Response) (*UpstreamResponseRetry, error)
+type UpstreamRetryer func(ctx context.Context, resp *http.Response, forwardErr error) (*UpstreamRetry, error)
 
 // Proxy is a one-request handler that forwards inbound MCP client requests
 // to a configured Remote MCP Server. A fresh value is expected per inbound
@@ -220,10 +220,11 @@ type Proxy struct {
 	// Leave empty (default) to send no Authorization upstream.
 	AuthorizationOverride string
 
-	// UpstreamResponseRetryer may replace the upstream target once after
-	// response headers arrive but before any response is relayed to the user.
-	// It is used by tunneled MCP to fail over stale gateway owners.
-	UpstreamResponseRetryer UpstreamResponseRetryer
+	// UpstreamRetryer may replace the upstream target once before anything is
+	// relayed to the user. It receives either a response or an error; tunneled
+	// MCP uses the error path only for failures proven to have happened while
+	// dialing, before an HTTP request could reach the agent.
+	UpstreamRetryer UpstreamRetryer
 
 	// UpstreamResponseInterceptor, when set, runs once against the final
 	// upstream response — after any retry, before any header or body byte is
@@ -928,10 +929,12 @@ func (p *Proxy) forwardRequest(
 		// timer.Stop() returns false if the timer has already fired;
 		// that's how we distinguish a phase-1 timeout from a parent
 		// cancellation when both surface as the same context error
-		// inside the http.Client error chain.
+		// inside the http.Client error chain. Classification is deferred
+		// until the retry policy has had a chance to fail over a dial that
+		// never reached the selected gateway.
 		timedOut := !phaseTimer.Stop()
 		forwardCancel()
-		return nil, nil, p.classifyForwardError(ctx, err, timedOut)
+		return upstreamReq, nil, &forwardTransportError{cause: err, timedOut: timedOut}
 	}
 
 	// Atomically transition out of the headers-phase window. Stop returning
@@ -942,7 +945,7 @@ func (p *Proxy) forwardRequest(
 	if !phaseTimer.Stop() {
 		_ = resp.Body.Close()
 		forwardCancel()
-		return nil, nil, p.classifyForwardError(ctx, context.DeadlineExceeded, true)
+		return upstreamReq, nil, &forwardTransportError{cause: context.DeadlineExceeded, timedOut: true}
 	}
 
 	if isEventStream(resp.Header) {
@@ -981,27 +984,32 @@ func (p *Proxy) forwardRequestWithRetry(
 	validate func(*http.Request) error,
 ) (*http.Request, *http.Response, error) {
 	upstreamReq, upstreamResp, err := p.forwardRequest(ctx, r, body(), validate)
-	if err != nil || p.UpstreamResponseRetryer == nil {
-		return upstreamReq, upstreamResp, err
+	if p.UpstreamRetryer == nil {
+		return upstreamReq, upstreamResp, p.classifyForwardResultError(ctx, err)
 	}
 
-	retry, err := p.UpstreamResponseRetryer(ctx, upstreamResp)
-	if err != nil {
+	retry, retryErr := p.UpstreamRetryer(ctx, upstreamResp, err)
+	if retryErr != nil {
 		// Callers bail on err before they register their Body.Close defer,
 		// so an open response returned alongside an error is leaked — it
 		// would pin the upstream connection until the phase timer fires.
 		// Close it here and return no response.
-		o11y.NoLogDefer(upstreamResp.Body.Close)
-		return upstreamReq, nil, err
+		if upstreamResp != nil {
+			o11y.NoLogDefer(upstreamResp.Body.Close)
+		}
+		return upstreamReq, nil, retryErr
 	}
 	if retry == nil {
-		return upstreamReq, upstreamResp, nil
+		return upstreamReq, upstreamResp, p.classifyForwardResultError(ctx, err)
 	}
-	o11y.NoLogDefer(upstreamResp.Body.Close)
+	if upstreamResp != nil {
+		o11y.NoLogDefer(upstreamResp.Body.Close)
+	}
 
 	p.RemoteURL = retry.RemoteURL
 	p.Headers = retry.Headers
-	return p.forwardRequest(ctx, r, body(), validate)
+	upstreamReq, upstreamResp, err = p.forwardRequest(ctx, r, body(), validate)
+	return upstreamReq, upstreamResp, p.classifyForwardResultError(ctx, err)
 }
 
 // relaySSEStream parses Server-Sent Events from the upstream body, relays

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -70,7 +71,7 @@ func newProxyForTest(t *testing.T, upstreamURL string) *proxy.Proxy {
 		RemoteURL:                          upstreamURL,
 		Headers:                            nil,
 		AuthorizationOverride:              "",
-		UpstreamResponseRetryer:            nil,
+		UpstreamRetryer:                    nil,
 		UpstreamResponseInterceptor:        nil,
 		UserRequestObservationInterceptors: nil,
 		UserRequestInterceptors:            nil,
@@ -186,11 +187,12 @@ func TestProxy_Post_RetriesUpstreamResponseBeforeRelay(t *testing.T) {
 	t.Cleanup(first.Close)
 
 	p := newProxyForTest(t, first.URL)
-	p.UpstreamResponseRetryer = func(_ context.Context, resp *http.Response) (*proxy.UpstreamResponseRetry, error) {
+	p.UpstreamRetryer = func(_ context.Context, resp *http.Response, forwardErr error) (*proxy.UpstreamRetry, error) {
+		require.NoError(t, forwardErr)
 		if resp.Header.Get("X-Gram-Tunnel-Error") != "no-live-session" {
 			return nil, nil
 		}
-		return &proxy.UpstreamResponseRetry{RemoteURL: second.URL, Headers: nil}, nil
+		return &proxy.UpstreamRetry{RemoteURL: second.URL, Headers: nil}, nil
 	}
 
 	rr := httptest.NewRecorder()
@@ -205,6 +207,46 @@ func TestProxy_Post_RetriesUpstreamResponseBeforeRelay(t *testing.T) {
 	require.Equal(t, int64(1), secondRequests.Load())
 	require.JSONEq(t, initializeRequest, secondBody)
 	require.Contains(t, rr.Body.String(), `"protocolVersion":"2025-06-18"`)
+}
+
+func TestProxy_Post_RetriesDialFailureBeforeRelay(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	staleURL := "http://" + listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	var retryCalls atomic.Int64
+	var secondBody string
+	var secondReadErr error
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body []byte
+		body, secondReadErr = io.ReadAll(r.Body)
+		secondBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+	}))
+	t.Cleanup(second.Close)
+
+	p := newProxyForTest(t, staleURL)
+	p.UpstreamRetryer = func(_ context.Context, resp *http.Response, forwardErr error) (*proxy.UpstreamRetry, error) {
+		retryCalls.Add(1)
+		require.Nil(t, resp)
+		require.Error(t, forwardErr)
+		return &proxy.UpstreamRetry{RemoteURL: second.URL, Headers: nil}, nil
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/mcp", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, int64(1), retryCalls.Load())
+	require.NoError(t, secondReadErr)
+	require.JSONEq(t, initializeRequest, secondBody)
 }
 
 func TestProxy_Post_StripsAuthorizationHeader(t *testing.T) {

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -309,7 +309,7 @@ func (f *ProxyManager) BuildTarget(
 		RemoteURL:                   upstreamURL,
 		Headers:                     headers,
 		AuthorizationOverride:       upstreamAuth,
-		UpstreamResponseRetryer:     nil,
+		UpstreamRetryer:             nil,
 		UpstreamResponseInterceptor: nil,
 		DisableRedirects:            false,
 		StrictToolSelection:         selection != nil,

--- a/tunnel/cmd/tunnel-gateway/main.go
+++ b/tunnel/cmd/tunnel-gateway/main.go
@@ -94,16 +94,27 @@ func main() {
 		slog.String("public_addr", publicListenAddr),
 		slog.String("forward_addr", forwardListenAddr),
 		slog.String("advertise", advertiseAddr))
+	var serverErr error
 	for range 2 {
-		if err := <-errCh; err != nil {
+		if err := <-errCh; err != nil && serverErr == nil {
+			serverErr = err
 			stop()
 			shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 			_ = publicSrv.Shutdown(shutCtx)
 			_ = forwardSrv.Shutdown(shutCtx)
 			cancel()
-			logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", err))
-			os.Exit(1)
 		}
+	}
+
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), 25*time.Second)
+	if err := gw.Shutdown(drainCtx); err != nil {
+		logger.ErrorContext(context.Background(), "tunnel-gateway session drain failed", slog.Any("error", err))
+	}
+	cancelDrain()
+
+	if serverErr != nil {
+		logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", serverErr))
+		os.Exit(1)
 	}
 }
 

--- a/tunnel/cmd/tunnel-gateway/main.go
+++ b/tunnel/cmd/tunnel-gateway/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -78,12 +79,31 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdownDone := make(chan struct{})
 	go func() {
+		defer close(shutdownDone)
 		<-ctx.Done()
+
 		shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
 		defer cancel()
-		_ = publicSrv.Shutdown(shutCtx)
-		_ = forwardSrv.Shutdown(shutCtx)
+
+		var shutdowns sync.WaitGroup
+		shutdowns.Go(func() {
+			if err := publicSrv.Shutdown(shutCtx); err != nil {
+				logger.ErrorContext(shutCtx, "tunnel-gateway public listener shutdown failed", slog.Any("error", err))
+			}
+		})
+		shutdowns.Go(func() {
+			if err := forwardSrv.Shutdown(shutCtx); err != nil {
+				logger.ErrorContext(shutCtx, "tunnel-gateway forward listener shutdown failed", slog.Any("error", err))
+			}
+		})
+		shutdowns.Go(func() {
+			if err := gw.Shutdown(shutCtx); err != nil {
+				logger.ErrorContext(shutCtx, "tunnel-gateway session drain failed", slog.Any("error", err))
+			}
+		})
+		shutdowns.Wait()
 	}()
 
 	errCh := make(chan error, 2)
@@ -99,18 +119,10 @@ func main() {
 		if err := <-errCh; err != nil && serverErr == nil {
 			serverErr = err
 			stop()
-			shutCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
-			_ = publicSrv.Shutdown(shutCtx)
-			_ = forwardSrv.Shutdown(shutCtx)
-			cancel()
 		}
 	}
-
-	drainCtx, cancelDrain := context.WithTimeout(context.Background(), 25*time.Second)
-	if err := gw.Shutdown(drainCtx); err != nil {
-		logger.ErrorContext(context.Background(), "tunnel-gateway session drain failed", slog.Any("error", err))
-	}
-	cancelDrain()
+	stop()
+	<-shutdownDone
 
 	if serverErr != nil {
 		logger.ErrorContext(context.Background(), "tunnel-gateway server error", slog.Any("error", serverErr))

--- a/tunnel/gateway/gateway.go
+++ b/tunnel/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket"
@@ -56,6 +57,10 @@ type Gateway struct {
 	routes route.Store
 	reg    *registry
 	logger *slog.Logger
+
+	lifecycleMu sync.Mutex
+	draining    bool
+	handlers    sync.WaitGroup
 }
 
 func New(cfg Config, keys KeyResolver, routes route.Store, logger *slog.Logger) (*Gateway, error) {
@@ -102,7 +107,45 @@ func (g *Gateway) ActiveSessions() int { return g.reg.activeSessions() }
 // SetAdvertiseAddr lets tests publish listener addresses known only after bind.
 func (g *Gateway) SetAdvertiseAddr(addr string) { g.cfg.AdvertiseAddr = addr }
 
+// Shutdown rejects new agent connections, closes every hijacked WebSocket
+// session, and waits for their handlers to withdraw route state.
+func (g *Gateway) Shutdown(ctx context.Context) error {
+	g.lifecycleMu.Lock()
+	g.draining = true
+	g.lifecycleMu.Unlock()
+
+	g.reg.closeAll()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		g.handlers.Wait()
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g *Gateway) beginConnect() bool {
+	g.lifecycleMu.Lock()
+	defer g.lifecycleMu.Unlock()
+	if g.draining {
+		return false
+	}
+	g.handlers.Add(1)
+	return true
+}
+
 func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
+	if !g.beginConnect() {
+		http.Error(w, "tunnel gateway is shutting down", http.StatusServiceUnavailable)
+		return
+	}
+	defer g.handlers.Done()
+
 	// Shed before key lookup so a connect storm cannot load the key resolver.
 	if g.reg.activeSessions() >= g.cfg.MaxSessions {
 		g.logger.WarnContext(r.Context(), "tunnel connect rejected",
@@ -163,23 +206,16 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 		_ = conn.Close()
 		return
 	}
-	defer conn.Close()
-
-	// Record durable activation only after the session is actually live: a
-	// valid-key plain-HTTP probe (no upgrade) must not flip status to active
-	// or advance last_seen_at for a tunnel that never connected. On failure,
-	// close the session — the agent retries and re-activates.
-	if recorder, ok := g.keys.(ConnectionRecorder); ok {
-		if err := recorder.MarkConnected(r.Context(), tunnelID, presentedKeyHash, agentVersion); err != nil {
-			g.logger.ErrorContext(r.Context(), "tunnel connect activation failed",
-				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
-			_ = session.Close()
-			return
-		}
-	}
+	defer func() { _ = conn.Close() }()
 
 	sessionID := uuid.NewString()
 	now := time.Now().UTC()
+	g.lifecycleMu.Lock()
+	if g.draining {
+		g.lifecycleMu.Unlock()
+		_ = session.Close()
+		return
+	}
 	remove := g.reg.add(tunnelID, sessionID, session, g.newSessionProxy(tunnelID, session), route.Connection{
 		GatewaySessionID:       sessionID,
 		ServiceVersion:         serviceVersion,
@@ -191,6 +227,25 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 		ActiveConsumerSessions: 0,
 		Metadata:               metadata,
 	})
+	g.lifecycleMu.Unlock()
+
+	// Record durable activation only after the session is actually live: a
+	// valid-key plain-HTTP probe (no upgrade) must not flip status to active
+	// or advance last_seen_at for a tunnel that never connected. On failure,
+	// remove and close the session — the agent retries and re-activates.
+	if recorder, ok := g.keys.(ConnectionRecorder); ok {
+		if err := recorder.MarkConnected(r.Context(), tunnelID, presentedKeyHash, agentVersion); err != nil {
+			g.logger.ErrorContext(r.Context(), "tunnel connect activation failed",
+				slog.String("tunnel_id", tunnelID), slog.Any("error", err))
+			remove()
+			_ = session.Close()
+			return
+		}
+	}
+	if session.IsClosed() {
+		remove()
+		return
+	}
 	stateCtx, cancelState := routeOperationContext(r.Context())
 	if err := g.routes.Publish(stateCtx, tunnelID, g.cfg.AdvertiseAddr, routeTTL); err != nil {
 		g.logger.WarnContext(r.Context(), "tunnel route publish failed", slog.Any("error", err))
@@ -204,10 +259,15 @@ func (g *Gateway) handleConnect(w http.ResponseWriter, r *http.Request) {
 	go g.sayHello(session, tunnelID, sessionID)
 
 	stop := make(chan struct{})
-	go g.refreshSessionState(tunnelID, presentedKeyHash, session, stop)
+	refreshDone := make(chan struct{})
+	go func() {
+		defer close(refreshDone)
+		g.refreshSessionState(tunnelID, presentedKeyHash, session, stop)
+	}()
 
 	<-session.CloseChan()
 	close(stop)
+	<-refreshDone
 	remove()
 	g.cleanupSessionState(tunnelID)
 	g.logger.InfoContext(context.Background(), "tunnel disconnected",

--- a/tunnel/gateway/gateway_test.go
+++ b/tunnel/gateway/gateway_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/tunnel/route"
@@ -45,6 +47,51 @@ func TestNewRejectsMissingForwardToken(t *testing.T) {
 	_, err := New(Config{}, NewStaticKeyStore(map[string]string{}), route.NewRouteTable(), slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	require.ErrorIs(t, err, errMissingForwardToken)
+}
+
+func TestShutdownClosesSessionsAndWithdrawsRoutes(t *testing.T) {
+	table := route.NewRouteTable()
+	gw, err := New(
+		Config{AdvertiseAddr: "gw-1:8091", ForwardToken: "s3cret"},
+		NewStaticKeyStore(map[string]string{"tunnel-1": "gram_tunnel_testkey"}),
+		table,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	require.NoError(t, err)
+
+	public := httptest.NewServer(gw.PublicHandler())
+	t.Cleanup(public.Close)
+
+	headers := http.Header{
+		"Authorization":                 []string{"Bearer gram_tunnel_testkey"},
+		wire.HeaderTunnelServiceVersion: []string{"1.0.0"},
+	}
+	ws, _, err := websocket.Dial(t.Context(), "ws"+strings.TrimPrefix(public.URL, "http")+"/connect", &websocket.DialOptions{HTTPHeader: headers})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ws.CloseNow() })
+
+	conn := websocket.NetConn(t.Context(), ws, websocket.MessageBinary)
+	session, err := yamux.Server(conn, yamux.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Close() })
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		candidates, candidateErr := table.Candidates(t.Context(), "tunnel-1")
+		assert.NoError(c, candidateErr)
+		assert.Equal(c, []string{"gw-1:8091"}, candidates)
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, gw.Shutdown(t.Context()))
+	require.True(t, session.IsClosed())
+
+	candidates, err := table.Candidates(t.Context(), "tunnel-1")
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/connect", nil)
+	gw.PublicHandler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 func TestForwardHandlerRejectsMissingOrWrongToken(t *testing.T) {

--- a/tunnel/gateway/registry.go
+++ b/tunnel/gateway/registry.go
@@ -224,12 +224,31 @@ func (r *registry) kill(tunnelID string) int {
 	return len(list)
 }
 
-func (r *registry) activeSessions() int {
+func (r *registry) closeAll() {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	sessions := make([]*yamux.Session, 0, r.activeSessionsLocked())
+	for _, list := range r.sessions {
+		for _, entry := range list {
+			sessions = append(sessions, entry.session)
+		}
+	}
+	r.mu.RUnlock()
+
+	for _, session := range sessions {
+		_ = session.Close()
+	}
+}
+
+func (r *registry) activeSessionsLocked() int {
 	n := 0
 	for _, list := range r.sessions {
 		n += len(list)
 	}
 	return n
+}
+
+func (r *registry) activeSessions() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.activeSessionsLocked()
 }


### PR DESCRIPTION
Closes AIM-166

## Summary

- Drain active WebSocket and yamux sessions during tunnel-gateway shutdown, wait for connection handlers, and withdraw route state before process exit.
- Retry tunneled MCP requests against another gateway only when the original transport failure is proven to have occurred during dialing, before the request could reach an agent.
- Evict stale gateway routes on dial failure while preserving existing safeguards against replaying requests after connected transport failures.
- Cover shutdown route withdrawal, dial failover, request-body replay, and non-dial rejection with regression tests.

## Motivation

HTTP server shutdown does not wait for hijacked WebSocket connections. During gateway replacement, the process could exit before tunnel session cleanup removed its Redis route, leaving affinity routing pointed at an unreachable pod until the route TTL elapsed. Those dial failures also bypassed the existing response-based failover policy. Draining owned sessions and adding strictly pre-connect failover closes that rollout window without risking duplicate tool execution.
