### PR TITLE
feat: enforce ai_access before Gram-hosted inference

### DIFF
--- a/.changeset/enforce-hosted-ai-access.md
+++ b/.changeset/enforce-hosted-ai-access.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Gram-hosted inference now enforces active `ai_access` prescriptions for validated current-user sessions before provider egress, while explicitly excluding unattributed, assistant, internal, and background model calls. Matched denials preserve the administrator-selected safe note in supported chat and dashboard surfaces.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -10149,6 +10149,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - project_slug_header_Gram-Project: []
           session_header_Gram-Session: []
@@ -11577,6 +11583,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - project_slug_header_Gram-Project: []
           session_header_Gram-Session: []
@@ -11673,6 +11685,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - project_slug_header_Gram-Project: []
           session_header_Gram-Session: []
@@ -40945,6 +40963,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - apikey_header_Gram-Key: []
           project_slug_header_Gram-Project: []
@@ -44424,6 +44448,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - apikey_header_Gram-Key: []
           project_slug_header_Gram-Project: []
@@ -44531,6 +44561,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - apikey_header_Gram-Key: []
           project_slug_header_Gram-Project: []
@@ -45269,6 +45305,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'gateway_error: an unexpected error occurred'
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'unavailable: service temporarily unavailable'
       security:
         - apikey_header_Gram-Key: []
           project_slug_header_Gram-Project: []

--- a/client/dashboard/src/elements/contexts/ElementsProvider.tsx
+++ b/client/dashboard/src/elements/contexts/ElementsProvider.tsx
@@ -26,8 +26,9 @@ import {
 import { compactForModel } from "@/elements/lib/contextCompaction";
 import { dictationAdapter } from "@/elements/lib/dictation";
 import {
-  describeStreamError,
+  describeStreamErrorForUI,
   sanitizeStreamErrorForTelemetry,
+  toElementsUIMessageStream,
 } from "@/elements/lib/streamErrorMessage";
 import { cn } from "@/lib/utils";
 import { recommended } from "@/elements/plugins";
@@ -56,7 +57,6 @@ import {
   isStepCount,
   streamText,
   ToolSet,
-  toUIMessageStream,
   type ChatTransport,
   type UIMessage,
 } from "ai";
@@ -514,16 +514,17 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           // prior assistant message's id, so useChat pushes a new UIMessage carrying the snapshot
           // of the prior turn's parts — duplicating text and tool_calls into storage.
           //
-          // onError: AI SDK masks errors by default; surface the friendly
-          // credits prompt for 402, otherwise keep the masking intact.
+          // AI SDK masks model error chunks at the conversion boundary by
+          // default. The wrapper surfaces only selected safe messages, while
+          // this outer handler covers errors thrown during stream execution.
           return createUIMessageStream({
             execute: ({ writer }) => {
-              writer.merge(toUIMessageStream({ stream: result.stream, tools }));
+              writer.merge(
+                toElementsUIMessageStream({ stream: result.stream, tools }),
+              );
             },
             originalMessages: messages,
-            onError: (error) =>
-              describeStreamError(error) ??
-              "An error occurred while generating a response.",
+            onError: describeStreamErrorForUI,
           });
         } catch (error) {
           reportStreamError(error, "stream-creation", "Error creating stream:");

--- a/client/dashboard/src/elements/contexts/ElementsProvider.tsx
+++ b/client/dashboard/src/elements/contexts/ElementsProvider.tsx
@@ -25,7 +25,10 @@ import {
 } from "@/elements/lib/tools";
 import { compactForModel } from "@/elements/lib/contextCompaction";
 import { dictationAdapter } from "@/elements/lib/dictation";
-import { describeStreamError } from "@/elements/lib/streamErrorMessage";
+import {
+  describeStreamError,
+  sanitizeStreamErrorForTelemetry,
+} from "@/elements/lib/streamErrorMessage";
 import { cn } from "@/lib/utils";
 import { recommended } from "@/elements/plugins";
 import elementsSystemPrompt from "@/elements/prompts/system.txt?raw";
@@ -430,6 +433,27 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
           ? config.languageModel
           : (openRouterModel!.chat(model) as LanguageModel);
 
+        const reportStreamError = (
+          error: unknown,
+          source: "streaming" | "stream-creation",
+          label: string,
+        ) => {
+          const telemetryError = sanitizeStreamErrorForTelemetry(error);
+          console.error(label, telemetryError);
+          trackError(telemetryError, { source });
+
+          const isNetworkError =
+            error instanceof TypeError ||
+            (error instanceof Error &&
+              (error.message.includes("fetch") ||
+                error.message.includes("network") ||
+                error.message.includes("Failed to fetch") ||
+                error.message.includes("NetworkError") ||
+                error.message.includes("ECONNREFUSED") ||
+                error.message.includes("ETIMEDOUT")));
+          if (isNetworkError) connectionStatus?.markDisconnected();
+        };
+
         try {
           // This works around AI SDK bug where these fields cause validation failures
           const cleanedMessages = cleanMessagesForModel(messages);
@@ -473,25 +497,12 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
             stopWhen: isStepCount(10),
             experimental_transform: smoothStream({ delayInMs: 15 }),
             abortSignal,
-            onError: ({ error }) => {
-              console.error("Stream error in onError callback:", error);
-              trackError(error, { source: "streaming" });
-
-              // Check if this is a network/connection error
-              const isNetworkError =
-                error instanceof TypeError ||
-                (error instanceof Error &&
-                  (error.message.includes("fetch") ||
-                    error.message.includes("network") ||
-                    error.message.includes("Failed to fetch") ||
-                    error.message.includes("NetworkError") ||
-                    error.message.includes("ECONNREFUSED") ||
-                    error.message.includes("ETIMEDOUT")));
-
-              if (isNetworkError) {
-                connectionStatus?.markDisconnected();
-              }
-            },
+            onError: ({ error }) =>
+              reportStreamError(
+                error,
+                "streaming",
+                "Stream error in onError callback:",
+              ),
           });
 
           // Mark as connected when stream starts successfully
@@ -515,24 +526,7 @@ const ElementsProviderInner = ({ children, config }: ElementsProviderProps) => {
               "An error occurred while generating a response.",
           });
         } catch (error) {
-          console.error("Error creating stream:", error);
-          trackError(error, { source: "stream-creation" });
-
-          // Check if this is a network/connection error
-          const isNetworkError =
-            error instanceof TypeError ||
-            (error instanceof Error &&
-              (error.message.includes("fetch") ||
-                error.message.includes("network") ||
-                error.message.includes("Failed to fetch") ||
-                error.message.includes("NetworkError") ||
-                error.message.includes("ECONNREFUSED") ||
-                error.message.includes("ETIMEDOUT")));
-
-          if (isNetworkError) {
-            connectionStatus?.markDisconnected();
-          }
-
+          reportStreamError(error, "stream-creation", "Error creating stream:");
           throw error;
         }
       },

--- a/client/dashboard/src/elements/lib/streamErrorMessage.integration.test.ts
+++ b/client/dashboard/src/elements/lib/streamErrorMessage.integration.test.ts
@@ -1,0 +1,55 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { createUIMessageStream, streamText } from "ai";
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeStreamErrorForTelemetry,
+  toElementsUIMessageStream,
+} from "./streamErrorMessage";
+
+describe("Elements AI SDK stream error propagation", () => {
+  it("renders a production-shaped AI access denial without reporting its note", async () => {
+    const note =
+      "AI access is paused while this workspace completes its security review.";
+    const reportedErrors: unknown[] = [];
+    const model = createOpenRouter({
+      baseURL: "https://gram.example.test",
+      apiKey: "unused",
+      fetch: async () =>
+        new Response(
+          JSON.stringify({ name: "ai_access_denied", message: note }),
+          {
+            status: 403,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    }).chat("openai/gpt-4o-mini");
+
+    const result = streamText({
+      model,
+      messages: [{ role: "user", content: "Hello" }],
+      maxRetries: 0,
+      onError: ({ error }) => {
+        // ElementsProvider sends this sanitized value to both console.error and
+        // telemetry. Preserve the same boundary in this integration test.
+        reportedErrors.push(sanitizeStreamErrorForTelemetry(error));
+      },
+    });
+    const uiStream = createUIMessageStream({
+      execute: ({ writer }) => {
+        writer.merge(toElementsUIMessageStream({ stream: result.stream }));
+      },
+    });
+
+    const chunks = [];
+    for await (const chunk of uiStream) chunks.push(chunk);
+
+    expect(chunks).toContainEqual({ type: "error", errorText: note });
+    expect(chunks).not.toContainEqual({
+      type: "error",
+      errorText: "An error occurred.",
+    });
+    expect(reportedErrors).toHaveLength(1);
+    expect(String(reportedErrors[0])).toBe("Error: ai_access_denied");
+    expect(JSON.stringify(reportedErrors)).not.toContain(note);
+  });
+});

--- a/client/dashboard/src/elements/lib/streamErrorMessage.test.ts
+++ b/client/dashboard/src/elements/lib/streamErrorMessage.test.ts
@@ -2,9 +2,51 @@ import { describe, expect, it } from "vitest";
 import {
   CREDITS_EXHAUSTED_MESSAGE,
   describeStreamError,
+  sanitizeStreamErrorForTelemetry,
 } from "./streamErrorMessage";
 
 describe("describeStreamError", () => {
+  it("renders the exact dedicated AI access denial note", () => {
+    const note =
+      "Access paused by your organization. <script>ignored as markup</script>";
+    const error = {
+      responseBody: JSON.stringify({ name: "ai_access_denied", message: note }),
+    };
+    expect(describeStreamError(error)).toBe(note);
+
+    const sanitized = sanitizeStreamErrorForTelemetry(error);
+    expect(sanitized).toBeInstanceOf(Error);
+    expect((sanitized as Error).message).toBe("ai_access_denied");
+    expect(JSON.stringify(sanitized)).not.toContain(note);
+    expect(String(sanitized)).not.toContain(note);
+  });
+
+  it("sanitizes a dedicated denial envelope even when it has no renderable note", () => {
+    const error = {
+      name: "ai_access_denied",
+      message: "",
+      secret: "tenant text",
+    };
+    expect(describeStreamError(error)).toBeUndefined();
+    expect(String(sanitizeStreamErrorForTelemetry(error))).toBe(
+      "Error: ai_access_denied",
+    );
+  });
+
+  it("does not render evaluator-unavailable or free-text denial messages", () => {
+    expect(
+      describeStreamError({
+        name: "unavailable",
+        message: "evaluator unavailable",
+      }),
+    ).toBeUndefined();
+    expect(
+      describeStreamError({
+        message: "ai_access_denied: tenant-authored text",
+      }),
+    ).toBeUndefined();
+  });
+
   it("matches Gram goa 402 with name=insufficient_credits at top-level", () => {
     const error = {
       name: "insufficient_credits",

--- a/client/dashboard/src/elements/lib/streamErrorMessage.ts
+++ b/client/dashboard/src/elements/lib/streamErrorMessage.ts
@@ -45,65 +45,100 @@ type ErrorBag = {
   response?: unknown;
 };
 
+const AI_ACCESS_DENIED = "ai_access_denied";
+
 const CHILD_FIELDS: ReadonlyArray<keyof ErrorBag> = [
   "error",
   "cause",
   "lastError",
 ];
 
-// Tracks objects already visited so circular references (`err.cause === err`)
-// don't recurse forever. WeakSet so we don't pin the error tree alive.
-const walk = (error: unknown, seen: WeakSet<object>): boolean => {
-  if (!error) return false;
+type ErrorTreeVisitor<T> = (value: unknown) => T | undefined;
 
-  if (typeof error === "string") return hasCreditHint(error);
-  if (typeof error !== "object") return false;
-  if (seen.has(error)) return false;
+// Visit every normalized error node once. responseBody is visited both as raw
+// text and, when valid JSON, as a nested error envelope.
+const visitErrorTree = <T>(
+  error: unknown,
+  visitor: ErrorTreeVisitor<T>,
+  seen = new WeakSet<object>(),
+): T | undefined => {
+  const result = visitor(error);
+  if (result !== undefined) return result;
+  if (!error || typeof error !== "object" || seen.has(error)) return undefined;
   seen.add(error);
 
   const obj = error as ErrorBag;
-
-  if (obj.name === "insufficient_credits") return true;
-
-  const status =
-    typeof obj.statusCode === "number"
-      ? obj.statusCode
-      : typeof obj.status === "number"
-        ? obj.status
-        : undefined;
-  if (status === 402) return true;
-
-  if (
-    obj.response &&
-    typeof obj.response === "object" &&
-    (obj.response as { status?: unknown }).status === 402
-  ) {
-    return true;
-  }
-
-  if (typeof obj.message === "string" && hasCreditHint(obj.message))
-    return true;
-
   if (typeof obj.responseBody === "string") {
-    if (hasCreditHint(obj.responseBody)) return true;
-    const parsed = tryParseJson(obj.responseBody);
-    if (parsed && walk(parsed, seen)) return true;
+    const rawResult = visitor(obj.responseBody);
+    if (rawResult !== undefined) return rawResult;
+    const parsedResult = visitErrorTree(
+      tryParseJson(obj.responseBody),
+      visitor,
+      seen,
+    );
+    if (parsedResult !== undefined) return parsedResult;
   }
-
   for (const field of CHILD_FIELDS) {
-    if (walk(obj[field], seen)) return true;
+    const childResult = visitErrorTree(obj[field], visitor, seen);
+    if (childResult !== undefined) return childResult;
   }
-
   if (Array.isArray(obj.errors)) {
     for (const inner of obj.errors) {
-      if (walk(inner, seen)) return true;
+      const childResult = visitErrorTree(inner, visitor, seen);
+      if (childResult !== undefined) return childResult;
     }
   }
-
-  return false;
+  return undefined;
 };
 
+// Extract only the server-authored dedicated denial envelope. Never render a
+// message from an unavailable/generic error, or from an object that merely
+// mentions the code in free text. React renders the returned string as text.
+const findAIAccessDenial = (error: unknown): ErrorBag | undefined =>
+  visitErrorTree(error, (value) => {
+    if (!value || typeof value !== "object") return undefined;
+    const obj = value as ErrorBag;
+    return obj.name === AI_ACCESS_DENIED ? obj : undefined;
+  });
+
+const findAIAccessDenialNote = (error: unknown): string | undefined => {
+  const denial = findAIAccessDenial(error);
+  if (typeof denial?.message !== "string") return undefined;
+  return denial.message.trim() ? denial.message : undefined;
+};
+
+const hasCreditsError = (error: unknown): boolean =>
+  visitErrorTree(error, (value) => {
+    if (typeof value === "string") return hasCreditHint(value) || undefined;
+    if (!value || typeof value !== "object") return undefined;
+
+    const obj = value as ErrorBag;
+    if (obj.name === "insufficient_credits") return true;
+    const status =
+      typeof obj.statusCode === "number"
+        ? obj.statusCode
+        : typeof obj.status === "number"
+          ? obj.status
+          : undefined;
+    if (status === 402) return true;
+    if (
+      obj.response &&
+      typeof obj.response === "object" &&
+      (obj.response as { status?: unknown }).status === 402
+    )
+      return true;
+    if (typeof obj.message === "string" && hasCreditHint(obj.message))
+      return true;
+    return undefined;
+  }) === true;
+
+// Tenant-authored denial notes are display content, never telemetry content.
+export const sanitizeStreamErrorForTelemetry = (error: unknown): unknown =>
+  findAIAccessDenial(error) ? new Error(AI_ACCESS_DENIED) : error;
+
 export const describeStreamError = (error: unknown): string | undefined => {
-  if (walk(error, new WeakSet())) return CREDITS_EXHAUSTED_MESSAGE;
+  const denialNote = findAIAccessDenialNote(error);
+  if (denialNote) return denialNote;
+  if (hasCreditsError(error)) return CREDITS_EXHAUSTED_MESSAGE;
   return undefined;
 };

--- a/client/dashboard/src/elements/lib/streamErrorMessage.ts
+++ b/client/dashboard/src/elements/lib/streamErrorMessage.ts
@@ -1,3 +1,5 @@
+import { toUIMessageStream, type TextStreamPart, type ToolSet } from "ai";
+
 // Shown verbatim in the chat thread when the gateway rejects a request for
 // lack of chat credits. The "Get Support" wording matches the dashboard's
 // top-header button label so the prompt is directly actionable.
@@ -142,3 +144,25 @@ export const describeStreamError = (error: unknown): string | undefined => {
   if (hasCreditsError(error)) return CREDITS_EXHAUSTED_MESSAGE;
   return undefined;
 };
+
+export const describeStreamErrorForUI = (error: unknown): string =>
+  describeStreamError(error) ??
+  "An error occurred while generating a response.";
+
+// `toUIMessageStream` masks model errors unless its own onError callback is
+// provided. createUIMessageStream's onError only handles errors thrown while
+// executing/merging streams, so configuring it alone cannot replace an error
+// chunk already emitted by this converter. Keep this wrapper on the actual
+// conversion boundary so selected safe messages survive into the rendered UI.
+export const toElementsUIMessageStream = <TOOLS extends ToolSet>({
+  stream,
+  tools,
+}: {
+  stream: ReadableStream<TextStreamPart<TOOLS>>;
+  tools?: TOOLS;
+}) =>
+  toUIMessageStream({
+    stream,
+    tools,
+    onError: describeStreamErrorForUI,
+  });

--- a/client/dashboard/src/elements/lib/streamErrorMessage.ts
+++ b/client/dashboard/src/elements/lib/streamErrorMessage.ts
@@ -1,4 +1,9 @@
-import { toUIMessageStream, type TextStreamPart, type ToolSet } from "ai";
+import {
+  toUIMessageStream,
+  type TextStreamPart,
+  type ToolSet,
+  type UIMessageChunk,
+} from "ai";
 
 // Shown verbatim in the chat thread when the gateway rejects a request for
 // lack of chat credits. The "Get Support" wording matches the dashboard's
@@ -160,7 +165,7 @@ export const toElementsUIMessageStream = <TOOLS extends ToolSet>({
 }: {
   stream: ReadableStream<TextStreamPart<TOOLS>>;
   tools?: TOOLS;
-}) =>
+}): ReadableStream<UIMessageChunk> =>
   toUIMessageStream({
     stream,
     tools,

--- a/client/dashboard/src/sdk/src/funcs/businessMemoriesSearch.ts
+++ b/client/dashboard/src/sdk/src/funcs/businessMemoriesSearch.ts
@@ -196,7 +196,7 @@ async function $do(
   >(
     M.json(200, SearchBusinessMemoriesResponseBody$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/chatSummarize.ts
+++ b/client/dashboard/src/sdk/src/funcs/chatSummarize.ts
@@ -196,7 +196,7 @@ async function $do(
   >(
     M.json(200, SummarizeChatResult$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/chatSummarizeToolCall.ts
+++ b/client/dashboard/src/sdk/src/funcs/chatSummarizeToolCall.ts
@@ -196,7 +196,7 @@ async function $do(
   >(
     M.json(200, SummarizeToolCallResult$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/riskCustomRulesSuggest.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskCustomRulesSuggest.ts
@@ -214,7 +214,7 @@ async function $do(
   >(
     M.json(200, SuggestCustomDetectionRuleResult$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/riskExclusionsSuggest.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskExclusionsSuggest.ts
@@ -212,7 +212,7 @@ async function $do(
   >(
     M.json(200, SuggestExclusionResult$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/riskPoliciesCreate.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskPoliciesCreate.ts
@@ -212,7 +212,7 @@ async function $do(
   >(
     M.json(200, RiskPolicy$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/client/dashboard/src/sdk/src/funcs/riskPoliciesUpdate.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskPoliciesUpdate.ts
@@ -212,7 +212,7 @@ async function $do(
   >(
     M.json(200, RiskPolicy$inboundSchema),
     M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
-    M.jsonErr([500, 502], ServiceError$inboundSchema),
+    M.jsonErr([500, 502, 503], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),
   )(response, req, { extraFields: responseFields });

--- a/server/cmd/gram/hosted_inference.go
+++ b/server/cmd/gram/hosted_inference.go
@@ -1,0 +1,39 @@
+package gram
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+)
+
+type aiAccessEnforcement struct {
+	registry        *killswitches.Registry
+	evaluator       *killswitches.Evaluator
+	hostedInference *hostedinference.Checkpoint
+}
+
+// newAIAccessEnforcement constructs one code-owned registry and evaluator per
+// production process. Hooks, LiteLLM, and hosted inference share these exact
+// instances; checkpoints add only surface-specific adapters and timeouts.
+func newAIAccessEnforcement(db *pgxpool.Pool, meterProvider metric.MeterProvider, logger *slog.Logger) (*aiAccessEnforcement, error) {
+	registry, err := mcptoolexecution.NewRegistry(db)
+	if err != nil {
+		return nil, fmt.Errorf("create ai_access registry: %w", err)
+	}
+	evaluator, err := killswitches.NewEvaluator(db, registry, hooks.AIAccessEvaluationTimeout, meterProvider, logger)
+	if err != nil {
+		return nil, fmt.Errorf("create ai_access evaluator: %w", err)
+	}
+	checkpoint, err := hostedinference.NewCheckpoint(registry, evaluator, hostedinference.DefaultEvaluationTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("create hosted-inference checkpoint: %w", err)
+	}
+	return &aiAccessEnforcement{registry: registry, evaluator: evaluator, hostedInference: checkpoint}, nil
+}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -988,7 +988,7 @@ func newStartCommand() *cli.Command {
 				return err
 			}
 
-			completionsClient := openrouter.NewUnifiedClient(
+			completionsClient, err := openrouter.NewUnifiedClient(
 				logger,
 				guardianPolicy,
 				openRouter,
@@ -997,8 +997,11 @@ func newStartCommand() *cli.Command {
 				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
 				telemLogger,
+				aiAccess.hostedInference,
 			)
-			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
+			if err != nil {
+				return err
+			}
 
 			memorySvc := memory.NewMemoryService(
 				logger,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -983,6 +983,11 @@ func newStartCommand() *cli.Command {
 			)
 			chatWriter.AddObserver(analysis.NewObserver(logger, chatAnalysisSignaler))
 
+			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
+			if err != nil {
+				return err
+			}
+
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
 				guardianPolicy,
@@ -993,6 +998,7 @@ func newStartCommand() *cli.Command {
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
 				telemLogger,
 			)
+			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
 
 			memorySvc := memory.NewMemoryService(
 				logger,
@@ -1154,7 +1160,7 @@ func newStartCommand() *cli.Command {
 				completionsClient,
 				mcpclient.NewInternalMCPClient(mcpService),
 			)
-			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
+			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient), aiAccess.hostedInference)
 			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo, auditLogger).
 				WithTurnStream(turnStream)
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver, auditLogger)
@@ -1375,15 +1381,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("create hooks acting-user signer: %w", err)
 			}
-			killswitchRegistry, err := mcptoolexecution.NewRegistry(db)
-			if err != nil {
-				return fmt.Errorf("create hooks kill-switch registry: %w", err)
-			}
-			killswitchEvaluator, err := killswitches.NewEvaluator(db, killswitchRegistry, hooks.AIAccessEvaluationTimeout, meterProvider, logger)
-			if err != nil {
-				return fmt.Errorf("create hooks kill-switch evaluator: %w", err)
-			}
-			hookAIAccess, err := hooks.NewHookAIAccessCheckpoint(killswitchRegistry, killswitchEvaluator, hookActingSigner)
+			hookAIAccess, err := hooks.NewHookAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator, hookActingSigner)
 			if err != nil {
 				return fmt.Errorf("create hooks ai_access checkpoint: %w", err)
 			}
@@ -1391,7 +1389,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("create LiteLLM acting-principal signer: %w", err)
 			}
-			litellmAIAccess, err := litellm.NewLiteLLMAIAccessCheckpoint(killswitchRegistry, killswitchEvaluator, litellmActingSigner)
+			litellmAIAccess, err := litellm.NewLiteLLMAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator, litellmActingSigner)
 			if err != nil {
 				return fmt.Errorf("create LiteLLM ai_access checkpoint: %w", err)
 			}

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1000,7 +1000,7 @@ func newStartCommand() *cli.Command {
 				aiAccess.hostedInference,
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("create hosted inference client: %w", err)
 			}
 
 			memorySvc := memory.NewMemoryService(

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -395,7 +395,11 @@ func newStreamsCommand() *cli.Command {
 				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker, encryptionClient)
 			}
 
-			completionsClient := openrouter.NewUnifiedClient(
+			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
+			if err != nil {
+				return err
+			}
+			completionsClient, err := openrouter.NewUnifiedClient(
 				logger,
 				guardianPolicy,
 				openRouter,
@@ -404,12 +408,11 @@ func newStreamsCommand() *cli.Command {
 				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
 				nil,
 				nil,
+				aiAccess.hostedInference,
 			)
-			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
 			if err != nil {
 				return err
 			}
-			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
 			judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))
 
 			_, psbroker, pubsubShutdown, err := newPubSubClient(ctx, c, logger)

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -405,6 +405,11 @@ func newStreamsCommand() *cli.Command {
 				nil,
 				nil,
 			)
+			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
+			if err != nil {
+				return err
+			}
+			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
 			judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))
 
 			_, psbroker, pubsubShutdown, err := newPubSubClient(ctx, c, logger)

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -411,7 +411,7 @@ func newStreamsCommand() *cli.Command {
 				aiAccess.hostedInference,
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("create hosted inference client: %w", err)
 			}
 			judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -702,7 +702,7 @@ func newWorkerCommand() *cli.Command {
 				aiAccess.hostedInference,
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("create hosted inference client: %w", err)
 			}
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -696,6 +696,11 @@ func newWorkerCommand() *cli.Command {
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
 				telemetryLogger,
 			)
+			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
+			if err != nil {
+				return err
+			}
+			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)
 			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, guardianPolicy, mcpRegistryClientOptions{
@@ -849,7 +854,7 @@ func newWorkerCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
+			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient), aiAccess.hostedInference)
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemetryLogger, contextWindowResolver, auditLogger)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -686,7 +686,11 @@ func newWorkerCommand() *cli.Command {
 			)
 			telemetryLogger.AddObserver(spendUsageTrigger)
 
-			completionsClient := openrouter.NewUnifiedClient(
+			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
+			if err != nil {
+				return err
+			}
+			completionsClient, err := openrouter.NewUnifiedClient(
 				logger,
 				guardianPolicy,
 				openRouter,
@@ -695,12 +699,11 @@ func newWorkerCommand() *cli.Command {
 				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
 				telemetryLogger,
+				aiAccess.hostedInference,
 			)
-			aiAccess, err := newAIAccessEnforcement(db, meterProvider, logger)
 			if err != nil {
 				return err
 			}
-			completionsClient = completionsClient.WithHostedInferenceCheckpoint(aiAccess.hostedInference)
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)
 			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, guardianPolicy, mcpRegistryClientOptions{

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -709,7 +709,7 @@ func newOpenRouterClient(apiKey string) openrouter.CompletionClient {
 	logger := slog.New(slog.DiscardHandler)
 	policy := guardian.NewDefaultPolicy(tracenoop.NewTracerProvider())
 	prov := &devProvisioner{apiKey: apiKey}
-	return openrouter.NewUnifiedClient(
+	return openrouter.NewUncheckedUnifiedClient(
 		logger,
 		policy,
 		prov,

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -2,7 +2,7 @@
 // ("LLM-judge") risk policy evaluation in the promptpolicy OpenRouter evaluator.
 //
 // Unlike a hand-rolled HTTP client, this drives the REAL production
-// openrouter.ChatClient (NewUnifiedClient to GetObjectCompletion), so every
+// openrouter.ChatClient (NewUncheckedUnifiedClient to GetObjectCompletion), so every
 // model runs under prod-equivalent conditions:
 //   - reasoning disabled (Effort:"none"), as the object-completion path forces,
 //   - the production model allowlist + ResolveModel fallback,
@@ -144,7 +144,7 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	policy := guardian.NewDefaultPolicy(tracenoop.NewTracerProvider())
 	prov := &devProvisioner{apiKey: apiKey} // returns the dev key for any org
-	client := openrouter.NewUnifiedClient(
+	client := openrouter.NewUncheckedUnifiedClient(
 		logger,
 		policy,
 		prov,

--- a/server/cmd/skillefficacybench/main.go
+++ b/server/cmd/skillefficacybench/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	provisioner := openrouter.NewDevelopment(apiKey)
-	client := openrouter.NewUnifiedClient(
+	client := openrouter.NewUncheckedUnifiedClient(
 		logger,
 		guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()),
 		provisioner,

--- a/server/cmd/skillsuggestbench/main.go
+++ b/server/cmd/skillsuggestbench/main.go
@@ -164,7 +164,7 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	provisioner := openrouter.NewDevelopment(apiKey)
-	client := openrouter.NewUnifiedClient(
+	client := openrouter.NewUncheckedUnifiedClient(
 		logger,
 		guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()),
 		provisioner,

--- a/server/design/businessmemories/design.go
+++ b/server/design/businessmemories/design.go
@@ -118,6 +118,7 @@ var _ = Service("businessMemories", func() {
 
 	Method("searchBusinessMemories", func() {
 		Description("Run semantic search over active memories in the active project. Requires organization admin.")
+		shared.DeclareHostedInferenceErrors()
 		Payload(func() {
 			Attribute("query", String, "Natural-language semantic search query.", func() {
 				MinLength(1)
@@ -139,6 +140,7 @@ var _ = Service("businessMemories", func() {
 		})
 		HTTP(func() {
 			POST("/rpc/businessMemories.search")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.SessionHeader()
 			security.ProjectHeader()
 			Response(StatusOK)

--- a/server/design/chat/design.go
+++ b/server/design/chat/design.go
@@ -343,6 +343,7 @@ var _ = Service("chat", func() {
 
 	Method("summarize", func() {
 		Description("Generate or return a persisted LLM summary of a chat session transcript. When a summary already exists and regenerate is false, returns the cached summary without calling the model.")
+		shared.DeclareHostedInferenceErrors()
 
 		Security(security.Session, security.ProjectSlug)
 
@@ -362,6 +363,7 @@ var _ = Service("chat", func() {
 
 		HTTP(func() {
 			POST("/rpc/chat.summarize")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.SessionHeader()
 			security.ProjectHeader()
 			Response(StatusOK)
@@ -374,6 +376,7 @@ var _ = Service("chat", func() {
 
 	Method("summarizeToolCall", func() {
 		Description("Generate or return a persisted two-sentence summary of one tool call. Concurrent requests share the same cached result.")
+		shared.DeclareHostedInferenceErrors()
 
 		Security(security.Session, security.ProjectSlug)
 
@@ -390,6 +393,7 @@ var _ = Service("chat", func() {
 
 		HTTP(func() {
 			POST("/rpc/chat.summarizeToolCall")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.SessionHeader()
 			security.ProjectHeader()
 			Response(StatusOK)

--- a/server/design/risk/design.go
+++ b/server/design/risk/design.go
@@ -15,6 +15,7 @@ var _ = Service("risk", func() {
 	shared.DeclareErrorResponses()
 
 	Method("createRiskPolicy", func() {
+		shared.DeclareHostedInferenceErrors()
 		Description("Create a new risk analysis policy for the current project.")
 
 		Payload(func() {
@@ -76,6 +77,7 @@ var _ = Service("risk", func() {
 
 		HTTP(func() {
 			POST("/rpc/risk.createPolicy")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.ByKeyHeader()
 			security.SessionHeader()
 			security.ProjectHeader()
@@ -168,6 +170,7 @@ var _ = Service("risk", func() {
 	})
 
 	Method("updateRiskPolicy", func() {
+		shared.DeclareHostedInferenceErrors()
 		Description("Update a risk analysis policy.")
 
 		Payload(func() {
@@ -229,6 +232,7 @@ var _ = Service("risk", func() {
 
 		HTTP(func() {
 			PUT("/rpc/risk.updatePolicy")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.ByKeyHeader()
 			security.SessionHeader()
 			security.ProjectHeader()
@@ -1468,6 +1472,7 @@ var _ = Service("risk", func() {
 	})
 
 	Method("suggestCustomDetectionRule", func() {
+		shared.DeclareHostedInferenceErrors()
 		Description("Suggest a custom detection rule (rule_id, title, description, regex, severity) from a natural-language prompt. Calls the configured LLM with a JSON-schema constrained response so the dashboard can prefill the create form.")
 
 		Payload(func() {
@@ -1486,6 +1491,7 @@ var _ = Service("risk", func() {
 
 		HTTP(func() {
 			POST("/rpc/risk.suggestCustomRules")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.ByKeyHeader()
 			security.SessionHeader()
 			security.ProjectHeader()
@@ -1499,6 +1505,7 @@ var _ = Service("risk", func() {
 	})
 
 	Method("suggestExclusion", func() {
+		shared.DeclareHostedInferenceErrors()
 		Description("Suggest a risk exclusion (match_type, match_value, filters) from a natural-language prompt, a batch of example findings, or both. Calls the configured LLM with a JSON-schema constrained response so the dashboard can prefill the create exclusion form. At least one of prompt or finding_ids is required.")
 
 		Payload(func() {
@@ -1519,6 +1526,7 @@ var _ = Service("risk", func() {
 
 		HTTP(func() {
 			POST("/rpc/risk.suggestExclusion")
+			shared.DeclareHTTPHostedInferenceErrorResponses()
 			security.ByKeyHeader()
 			security.SessionHeader()
 			security.ProjectHeader()

--- a/server/design/shared/errors.go
+++ b/server/design/shared/errors.go
@@ -32,6 +32,28 @@ func DeclareErrorResponses() {
 	HTTP(DeclareHTTPErrorResponses)
 }
 
+// DeclareHostedInferenceErrors declares fail-closed hosted-inference errors for
+// services whose methods can perform governed provider egress.
+func DeclareHostedInferenceErrors() {
+	Error(string(oops.CodeUnavailable), func() {
+		Description(oops.CodeUnavailable.UserMessage())
+		Fault()
+	})
+	Error(string(oops.CodeAIAccessDenied), func() {
+		Description(oops.CodeAIAccessDenied.UserMessage())
+	})
+}
+
+// DeclareHTTPHostedInferenceErrorResponses maps hosted-inference errors to HTTP.
+func DeclareHTTPHostedInferenceErrorResponses() {
+	Response(string(oops.CodeUnavailable), StatusServiceUnavailable, func() {
+		ContentType("application/json")
+	})
+	Response(string(oops.CodeAIAccessDenied), StatusForbidden, func() {
+		ContentType("application/json")
+	})
+}
+
 // DeclareHTTPErrorResponses maps the shared service errors to HTTP responses.
 // Call it from a service's final HTTP block when extending the shared mappings.
 func DeclareHTTPErrorResponses() {

--- a/server/gen/business_memories/client.go
+++ b/server/gen/business_memories/client.go
@@ -79,6 +79,8 @@ func (c *Client) ListBusinessMemoryContentScopes(ctx context.Context, p *ListBus
 // SearchBusinessMemories calls the "searchBusinessMemories" endpoint of the
 // "businessMemories" service.
 // SearchBusinessMemories may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid

--- a/server/gen/business_memories/service.go
+++ b/server/gen/business_memories/service.go
@@ -197,3 +197,13 @@ func MakeUnexpected(err error) *goa.ServiceError {
 func MakeGatewayError(err error) *goa.ServiceError {
 	return goa.NewServiceError(err, "gateway_error", false, false, true)
 }
+
+// MakeUnavailable builds a goa.ServiceError from an error.
+func MakeUnavailable(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "unavailable", false, false, true)
+}
+
+// MakeAiAccessDenied builds a goa.ServiceError from an error.
+func MakeAiAccessDenied(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "ai_access_denied", false, false, false)
+}

--- a/server/gen/chat/client.go
+++ b/server/gen/chat/client.go
@@ -221,6 +221,8 @@ func (c *Client) SetPinned(ctx context.Context, p *SetPinnedPayload) (err error)
 
 // Summarize calls the "summarize" endpoint of the "chat" service.
 // Summarize may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid
@@ -244,6 +246,8 @@ func (c *Client) Summarize(ctx context.Context, p *SummarizePayload) (res *Summa
 // SummarizeToolCall calls the "summarizeToolCall" endpoint of the "chat"
 // service.
 // SummarizeToolCall may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid

--- a/server/gen/chat/service.go
+++ b/server/gen/chat/service.go
@@ -806,3 +806,13 @@ func MakeUnexpected(err error) *goa.ServiceError {
 func MakeGatewayError(err error) *goa.ServiceError {
 	return goa.NewServiceError(err, "gateway_error", false, false, true)
 }
+
+// MakeUnavailable builds a goa.ServiceError from an error.
+func MakeUnavailable(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "unavailable", false, false, true)
+}
+
+// MakeAiAccessDenied builds a goa.ServiceError from an error.
+func MakeAiAccessDenied(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "ai_access_denied", false, false, false)
+}

--- a/server/gen/http/business_memories/client/encode_decode.go
+++ b/server/gen/http/business_memories/client/encode_decode.go
@@ -548,8 +548,10 @@ func EncodeSearchBusinessMemoriesRequest(encoder func(*http.Request) goahttp.Enc
 // restoreBody controls whether the response body should be restored after
 // having been read.
 // DecodeSearchBusinessMemoriesResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -589,6 +591,55 @@ func DecodeSearchBusinessMemoriesResponse(decoder func(*http.Response) goahttp.D
 			}
 			res := NewSearchBusinessMemoriesResultOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body SearchBusinessMemoriesUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("businessMemories", "searchBusinessMemories", err)
+			}
+			err = ValidateSearchBusinessMemoriesUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("businessMemories", "searchBusinessMemories", err)
+			}
+			return nil, NewSearchBusinessMemoriesUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body SearchBusinessMemoriesAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("businessMemories", "searchBusinessMemories", err)
+				}
+				err = ValidateSearchBusinessMemoriesAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("businessMemories", "searchBusinessMemories", err)
+				}
+				return nil, NewSearchBusinessMemoriesAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body SearchBusinessMemoriesForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("businessMemories", "searchBusinessMemories", err)
+				}
+				err = ValidateSearchBusinessMemoriesForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("businessMemories", "searchBusinessMemories", err)
+				}
+				return nil, NewSearchBusinessMemoriesForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("businessMemories", "searchBusinessMemories", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body SearchBusinessMemoriesUnauthorizedResponseBody
@@ -603,20 +654,6 @@ func DecodeSearchBusinessMemoriesResponse(decoder func(*http.Response) goahttp.D
 				return nil, goahttp.ErrValidationError("businessMemories", "searchBusinessMemories", err)
 			}
 			return nil, NewSearchBusinessMemoriesUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body SearchBusinessMemoriesForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("businessMemories", "searchBusinessMemories", err)
-			}
-			err = ValidateSearchBusinessMemoriesForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("businessMemories", "searchBusinessMemories", err)
-			}
-			return nil, NewSearchBusinessMemoriesForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body SearchBusinessMemoriesBadRequestResponseBody

--- a/server/gen/http/business_memories/client/types.go
+++ b/server/gen/http/business_memories/client/types.go
@@ -428,10 +428,29 @@ type ListBusinessMemoryContentScopesGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// SearchBusinessMemoriesUnauthorizedResponseBody is the type of the
+// SearchBusinessMemoriesUnavailableResponseBody is the type of the
 // "businessMemories" service "searchBusinessMemories" endpoint HTTP response
-// body for the "unauthorized" error.
-type SearchBusinessMemoriesUnauthorizedResponseBody struct {
+// body for the "unavailable" error.
+type SearchBusinessMemoriesUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SearchBusinessMemoriesAiAccessDeniedResponseBody is the type of the
+// "businessMemories" service "searchBusinessMemories" endpoint HTTP response
+// body for the "ai_access_denied" error.
+type SearchBusinessMemoriesAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -451,6 +470,25 @@ type SearchBusinessMemoriesUnauthorizedResponseBody struct {
 // "businessMemories" service "searchBusinessMemories" endpoint HTTP response
 // body for the "forbidden" error.
 type SearchBusinessMemoriesForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SearchBusinessMemoriesUnauthorizedResponseBody is the type of the
+// "businessMemories" service "searchBusinessMemories" endpoint HTTP response
+// body for the "unauthorized" error.
+type SearchBusinessMemoriesUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1033,9 +1071,24 @@ func NewSearchBusinessMemoriesResultOK(body *SearchBusinessMemoriesResponseBody)
 	return v
 }
 
-// NewSearchBusinessMemoriesUnauthorized builds a businessMemories service
-// searchBusinessMemories endpoint unauthorized error.
-func NewSearchBusinessMemoriesUnauthorized(body *SearchBusinessMemoriesUnauthorizedResponseBody) *goa.ServiceError {
+// NewSearchBusinessMemoriesUnavailable builds a businessMemories service
+// searchBusinessMemories endpoint unavailable error.
+func NewSearchBusinessMemoriesUnavailable(body *SearchBusinessMemoriesUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSearchBusinessMemoriesAiAccessDenied builds a businessMemories service
+// searchBusinessMemories endpoint ai_access_denied error.
+func NewSearchBusinessMemoriesAiAccessDenied(body *SearchBusinessMemoriesAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -1051,6 +1104,21 @@ func NewSearchBusinessMemoriesUnauthorized(body *SearchBusinessMemoriesUnauthori
 // NewSearchBusinessMemoriesForbidden builds a businessMemories service
 // searchBusinessMemories endpoint forbidden error.
 func NewSearchBusinessMemoriesForbidden(body *SearchBusinessMemoriesForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSearchBusinessMemoriesUnauthorized builds a businessMemories service
+// searchBusinessMemories endpoint unauthorized error.
+func NewSearchBusinessMemoriesUnauthorized(body *SearchBusinessMemoriesUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -1722,9 +1790,33 @@ func ValidateListBusinessMemoryContentScopesGatewayErrorResponseBody(body *ListB
 	return
 }
 
-// ValidateSearchBusinessMemoriesUnauthorizedResponseBody runs the validations
-// defined on searchBusinessMemories_unauthorized_response_body
-func ValidateSearchBusinessMemoriesUnauthorizedResponseBody(body *SearchBusinessMemoriesUnauthorizedResponseBody) (err error) {
+// ValidateSearchBusinessMemoriesUnavailableResponseBody runs the validations
+// defined on searchBusinessMemories_unavailable_response_body
+func ValidateSearchBusinessMemoriesUnavailableResponseBody(body *SearchBusinessMemoriesUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSearchBusinessMemoriesAiAccessDeniedResponseBody runs the
+// validations defined on searchBusinessMemories_ai_access_denied_response_body
+func ValidateSearchBusinessMemoriesAiAccessDeniedResponseBody(body *SearchBusinessMemoriesAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -1749,6 +1841,30 @@ func ValidateSearchBusinessMemoriesUnauthorizedResponseBody(body *SearchBusiness
 // ValidateSearchBusinessMemoriesForbiddenResponseBody runs the validations
 // defined on searchBusinessMemories_forbidden_response_body
 func ValidateSearchBusinessMemoriesForbiddenResponseBody(body *SearchBusinessMemoriesForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSearchBusinessMemoriesUnauthorizedResponseBody runs the validations
+// defined on searchBusinessMemories_unauthorized_response_body
+func ValidateSearchBusinessMemoriesUnauthorizedResponseBody(body *SearchBusinessMemoriesUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/business_memories/server/encode_decode.go
+++ b/server/gen/http/business_memories/server/encode_decode.go
@@ -555,7 +555,7 @@ func EncodeSearchBusinessMemoriesError(encoder func(context.Context, http.Respon
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -564,10 +564,24 @@ func EncodeSearchBusinessMemoriesError(encoder func(context.Context, http.Respon
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewSearchBusinessMemoriesUnauthorizedResponseBody(res)
+				body = NewSearchBusinessMemoriesUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSearchBusinessMemoriesAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -582,6 +596,20 @@ func EncodeSearchBusinessMemoriesError(encoder func(context.Context, http.Respon
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSearchBusinessMemoriesUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError

--- a/server/gen/http/business_memories/server/types.go
+++ b/server/gen/http/business_memories/server/types.go
@@ -430,10 +430,29 @@ type ListBusinessMemoryContentScopesGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// SearchBusinessMemoriesUnauthorizedResponseBody is the type of the
+// SearchBusinessMemoriesUnavailableResponseBody is the type of the
 // "businessMemories" service "searchBusinessMemories" endpoint HTTP response
-// body for the "unauthorized" error.
-type SearchBusinessMemoriesUnauthorizedResponseBody struct {
+// body for the "unavailable" error.
+type SearchBusinessMemoriesUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SearchBusinessMemoriesAiAccessDeniedResponseBody is the type of the
+// "businessMemories" service "searchBusinessMemories" endpoint HTTP response
+// body for the "ai_access_denied" error.
+type SearchBusinessMemoriesAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -453,6 +472,25 @@ type SearchBusinessMemoriesUnauthorizedResponseBody struct {
 // "businessMemories" service "searchBusinessMemories" endpoint HTTP response
 // body for the "forbidden" error.
 type SearchBusinessMemoriesForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SearchBusinessMemoriesUnauthorizedResponseBody is the type of the
+// "businessMemories" service "searchBusinessMemories" endpoint HTTP response
+// body for the "unauthorized" error.
+type SearchBusinessMemoriesUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1026,11 +1064,26 @@ func NewListBusinessMemoryContentScopesGatewayErrorResponseBody(res *goa.Service
 	return body
 }
 
-// NewSearchBusinessMemoriesUnauthorizedResponseBody builds the HTTP response
+// NewSearchBusinessMemoriesUnavailableResponseBody builds the HTTP response
 // body from the result of the "searchBusinessMemories" endpoint of the
 // "businessMemories" service.
-func NewSearchBusinessMemoriesUnauthorizedResponseBody(res *goa.ServiceError) *SearchBusinessMemoriesUnauthorizedResponseBody {
-	body := &SearchBusinessMemoriesUnauthorizedResponseBody{
+func NewSearchBusinessMemoriesUnavailableResponseBody(res *goa.ServiceError) *SearchBusinessMemoriesUnavailableResponseBody {
+	body := &SearchBusinessMemoriesUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSearchBusinessMemoriesAiAccessDeniedResponseBody builds the HTTP response
+// body from the result of the "searchBusinessMemories" endpoint of the
+// "businessMemories" service.
+func NewSearchBusinessMemoriesAiAccessDeniedResponseBody(res *goa.ServiceError) *SearchBusinessMemoriesAiAccessDeniedResponseBody {
+	body := &SearchBusinessMemoriesAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -1046,6 +1099,21 @@ func NewSearchBusinessMemoriesUnauthorizedResponseBody(res *goa.ServiceError) *S
 // "businessMemories" service.
 func NewSearchBusinessMemoriesForbiddenResponseBody(res *goa.ServiceError) *SearchBusinessMemoriesForbiddenResponseBody {
 	body := &SearchBusinessMemoriesForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSearchBusinessMemoriesUnauthorizedResponseBody builds the HTTP response
+// body from the result of the "searchBusinessMemories" endpoint of the
+// "businessMemories" service.
+func NewSearchBusinessMemoriesUnauthorizedResponseBody(res *goa.ServiceError) *SearchBusinessMemoriesUnauthorizedResponseBody {
+	body := &SearchBusinessMemoriesUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/server/gen/http/chat/client/encode_decode.go
+++ b/server/gen/http/chat/client/encode_decode.go
@@ -2008,8 +2008,10 @@ func EncodeSummarizeRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 // summarize endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
 // DecodeSummarizeResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -2049,6 +2051,55 @@ func DecodeSummarizeResponse(decoder func(*http.Response) goahttp.Decoder, resto
 			}
 			res := NewSummarizeChatResultOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body SummarizeUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("chat", "summarize", err)
+			}
+			err = ValidateSummarizeUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("chat", "summarize", err)
+			}
+			return nil, NewSummarizeUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body SummarizeAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("chat", "summarize", err)
+				}
+				err = ValidateSummarizeAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("chat", "summarize", err)
+				}
+				return nil, NewSummarizeAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body SummarizeForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("chat", "summarize", err)
+				}
+				err = ValidateSummarizeForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("chat", "summarize", err)
+				}
+				return nil, NewSummarizeForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("chat", "summarize", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body SummarizeUnauthorizedResponseBody
@@ -2063,20 +2114,6 @@ func DecodeSummarizeResponse(decoder func(*http.Response) goahttp.Decoder, resto
 				return nil, goahttp.ErrValidationError("chat", "summarize", err)
 			}
 			return nil, NewSummarizeUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body SummarizeForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("chat", "summarize", err)
-			}
-			err = ValidateSummarizeForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("chat", "summarize", err)
-			}
-			return nil, NewSummarizeForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body SummarizeBadRequestResponseBody
@@ -2246,8 +2283,10 @@ func EncodeSummarizeToolCallRequest(encoder func(*http.Request) goahttp.Encoder)
 // the chat summarizeToolCall endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeSummarizeToolCallResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -2287,6 +2326,55 @@ func DecodeSummarizeToolCallResponse(decoder func(*http.Response) goahttp.Decode
 			}
 			res := NewSummarizeToolCallResultOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body SummarizeToolCallUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("chat", "summarizeToolCall", err)
+			}
+			err = ValidateSummarizeToolCallUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("chat", "summarizeToolCall", err)
+			}
+			return nil, NewSummarizeToolCallUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body SummarizeToolCallAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("chat", "summarizeToolCall", err)
+				}
+				err = ValidateSummarizeToolCallAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("chat", "summarizeToolCall", err)
+				}
+				return nil, NewSummarizeToolCallAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body SummarizeToolCallForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("chat", "summarizeToolCall", err)
+				}
+				err = ValidateSummarizeToolCallForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("chat", "summarizeToolCall", err)
+				}
+				return nil, NewSummarizeToolCallForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("chat", "summarizeToolCall", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body SummarizeToolCallUnauthorizedResponseBody
@@ -2301,20 +2389,6 @@ func DecodeSummarizeToolCallResponse(decoder func(*http.Response) goahttp.Decode
 				return nil, goahttp.ErrValidationError("chat", "summarizeToolCall", err)
 			}
 			return nil, NewSummarizeToolCallUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body SummarizeToolCallForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("chat", "summarizeToolCall", err)
-			}
-			err = ValidateSummarizeToolCallForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("chat", "summarizeToolCall", err)
-			}
-			return nil, NewSummarizeToolCallForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body SummarizeToolCallBadRequestResponseBody

--- a/server/gen/http/chat/client/types.go
+++ b/server/gen/http/chat/client/types.go
@@ -1709,9 +1709,27 @@ type SetPinnedGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// SummarizeUnauthorizedResponseBody is the type of the "chat" service
-// "summarize" endpoint HTTP response body for the "unauthorized" error.
-type SummarizeUnauthorizedResponseBody struct {
+// SummarizeUnavailableResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "unavailable" error.
+type SummarizeUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SummarizeAiAccessDeniedResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "ai_access_denied" error.
+type SummarizeAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1730,6 +1748,24 @@ type SummarizeUnauthorizedResponseBody struct {
 // SummarizeForbiddenResponseBody is the type of the "chat" service "summarize"
 // endpoint HTTP response body for the "forbidden" error.
 type SummarizeForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SummarizeUnauthorizedResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "unauthorized" error.
+type SummarizeUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1889,9 +1925,28 @@ type SummarizeGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// SummarizeToolCallUnauthorizedResponseBody is the type of the "chat" service
-// "summarizeToolCall" endpoint HTTP response body for the "unauthorized" error.
-type SummarizeToolCallUnauthorizedResponseBody struct {
+// SummarizeToolCallUnavailableResponseBody is the type of the "chat" service
+// "summarizeToolCall" endpoint HTTP response body for the "unavailable" error.
+type SummarizeToolCallUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SummarizeToolCallAiAccessDeniedResponseBody is the type of the "chat"
+// service "summarizeToolCall" endpoint HTTP response body for the
+// "ai_access_denied" error.
+type SummarizeToolCallAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1910,6 +1965,24 @@ type SummarizeToolCallUnauthorizedResponseBody struct {
 // SummarizeToolCallForbiddenResponseBody is the type of the "chat" service
 // "summarizeToolCall" endpoint HTTP response body for the "forbidden" error.
 type SummarizeToolCallForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SummarizeToolCallUnauthorizedResponseBody is the type of the "chat" service
+// "summarizeToolCall" endpoint HTTP response body for the "unauthorized" error.
+type SummarizeToolCallUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -4295,9 +4368,24 @@ func NewSummarizeChatResultOK(body *SummarizeResponseBody) *chat.SummarizeChatRe
 	return v
 }
 
-// NewSummarizeUnauthorized builds a chat service summarize endpoint
-// unauthorized error.
-func NewSummarizeUnauthorized(body *SummarizeUnauthorizedResponseBody) *goa.ServiceError {
+// NewSummarizeUnavailable builds a chat service summarize endpoint unavailable
+// error.
+func NewSummarizeUnavailable(body *SummarizeUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSummarizeAiAccessDenied builds a chat service summarize endpoint
+// ai_access_denied error.
+func NewSummarizeAiAccessDenied(body *SummarizeAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -4313,6 +4401,21 @@ func NewSummarizeUnauthorized(body *SummarizeUnauthorizedResponseBody) *goa.Serv
 // NewSummarizeForbidden builds a chat service summarize endpoint forbidden
 // error.
 func NewSummarizeForbidden(body *SummarizeForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSummarizeUnauthorized builds a chat service summarize endpoint
+// unauthorized error.
+func NewSummarizeUnauthorized(body *SummarizeUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -4455,9 +4558,24 @@ func NewSummarizeToolCallResultOK(body *SummarizeToolCallResponseBody) *chat.Sum
 	return v
 }
 
-// NewSummarizeToolCallUnauthorized builds a chat service summarizeToolCall
-// endpoint unauthorized error.
-func NewSummarizeToolCallUnauthorized(body *SummarizeToolCallUnauthorizedResponseBody) *goa.ServiceError {
+// NewSummarizeToolCallUnavailable builds a chat service summarizeToolCall
+// endpoint unavailable error.
+func NewSummarizeToolCallUnavailable(body *SummarizeToolCallUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSummarizeToolCallAiAccessDenied builds a chat service summarizeToolCall
+// endpoint ai_access_denied error.
+func NewSummarizeToolCallAiAccessDenied(body *SummarizeToolCallAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -4473,6 +4591,21 @@ func NewSummarizeToolCallUnauthorized(body *SummarizeToolCallUnauthorizedRespons
 // NewSummarizeToolCallForbidden builds a chat service summarizeToolCall
 // endpoint forbidden error.
 func NewSummarizeToolCallForbidden(body *SummarizeToolCallForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSummarizeToolCallUnauthorized builds a chat service summarizeToolCall
+// endpoint unauthorized error.
+func NewSummarizeToolCallUnauthorized(body *SummarizeToolCallUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -7256,9 +7389,33 @@ func ValidateSetPinnedGatewayErrorResponseBody(body *SetPinnedGatewayErrorRespon
 	return
 }
 
-// ValidateSummarizeUnauthorizedResponseBody runs the validations defined on
-// summarize_unauthorized_response_body
-func ValidateSummarizeUnauthorizedResponseBody(body *SummarizeUnauthorizedResponseBody) (err error) {
+// ValidateSummarizeUnavailableResponseBody runs the validations defined on
+// summarize_unavailable_response_body
+func ValidateSummarizeUnavailableResponseBody(body *SummarizeUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSummarizeAiAccessDeniedResponseBody runs the validations defined on
+// summarize_ai_access_denied_response_body
+func ValidateSummarizeAiAccessDeniedResponseBody(body *SummarizeAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -7283,6 +7440,30 @@ func ValidateSummarizeUnauthorizedResponseBody(body *SummarizeUnauthorizedRespon
 // ValidateSummarizeForbiddenResponseBody runs the validations defined on
 // summarize_forbidden_response_body
 func ValidateSummarizeForbiddenResponseBody(body *SummarizeForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSummarizeUnauthorizedResponseBody runs the validations defined on
+// summarize_unauthorized_response_body
+func ValidateSummarizeUnauthorizedResponseBody(body *SummarizeUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -7496,9 +7677,33 @@ func ValidateSummarizeGatewayErrorResponseBody(body *SummarizeGatewayErrorRespon
 	return
 }
 
-// ValidateSummarizeToolCallUnauthorizedResponseBody runs the validations
-// defined on summarizeToolCall_unauthorized_response_body
-func ValidateSummarizeToolCallUnauthorizedResponseBody(body *SummarizeToolCallUnauthorizedResponseBody) (err error) {
+// ValidateSummarizeToolCallUnavailableResponseBody runs the validations
+// defined on summarizeToolCall_unavailable_response_body
+func ValidateSummarizeToolCallUnavailableResponseBody(body *SummarizeToolCallUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSummarizeToolCallAiAccessDeniedResponseBody runs the validations
+// defined on summarizeToolCall_ai_access_denied_response_body
+func ValidateSummarizeToolCallAiAccessDeniedResponseBody(body *SummarizeToolCallAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -7523,6 +7728,30 @@ func ValidateSummarizeToolCallUnauthorizedResponseBody(body *SummarizeToolCallUn
 // ValidateSummarizeToolCallForbiddenResponseBody runs the validations defined
 // on summarizeToolCall_forbidden_response_body
 func ValidateSummarizeToolCallForbiddenResponseBody(body *SummarizeToolCallForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSummarizeToolCallUnauthorizedResponseBody runs the validations
+// defined on summarizeToolCall_unauthorized_response_body
+func ValidateSummarizeToolCallUnauthorizedResponseBody(body *SummarizeToolCallUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/chat/server/encode_decode.go
+++ b/server/gen/http/chat/server/encode_decode.go
@@ -2137,7 +2137,7 @@ func EncodeSummarizeError(encoder func(context.Context, http.ResponseWriter) goa
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -2146,10 +2146,24 @@ func EncodeSummarizeError(encoder func(context.Context, http.ResponseWriter) goa
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewSummarizeUnauthorizedResponseBody(res)
+				body = NewSummarizeUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSummarizeAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -2164,6 +2178,20 @@ func EncodeSummarizeError(encoder func(context.Context, http.ResponseWriter) goa
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSummarizeUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError
@@ -2362,7 +2390,7 @@ func EncodeSummarizeToolCallError(encoder func(context.Context, http.ResponseWri
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -2371,10 +2399,24 @@ func EncodeSummarizeToolCallError(encoder func(context.Context, http.ResponseWri
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewSummarizeToolCallUnauthorizedResponseBody(res)
+				body = NewSummarizeToolCallUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSummarizeToolCallAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -2389,6 +2431,20 @@ func EncodeSummarizeToolCallError(encoder func(context.Context, http.ResponseWri
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSummarizeToolCallUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError

--- a/server/gen/http/chat/server/types.go
+++ b/server/gen/http/chat/server/types.go
@@ -1710,9 +1710,27 @@ type SetPinnedGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// SummarizeUnauthorizedResponseBody is the type of the "chat" service
-// "summarize" endpoint HTTP response body for the "unauthorized" error.
-type SummarizeUnauthorizedResponseBody struct {
+// SummarizeUnavailableResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "unavailable" error.
+type SummarizeUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SummarizeAiAccessDeniedResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "ai_access_denied" error.
+type SummarizeAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1731,6 +1749,24 @@ type SummarizeUnauthorizedResponseBody struct {
 // SummarizeForbiddenResponseBody is the type of the "chat" service "summarize"
 // endpoint HTTP response body for the "forbidden" error.
 type SummarizeForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SummarizeUnauthorizedResponseBody is the type of the "chat" service
+// "summarize" endpoint HTTP response body for the "unauthorized" error.
+type SummarizeUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1890,9 +1926,28 @@ type SummarizeGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// SummarizeToolCallUnauthorizedResponseBody is the type of the "chat" service
-// "summarizeToolCall" endpoint HTTP response body for the "unauthorized" error.
-type SummarizeToolCallUnauthorizedResponseBody struct {
+// SummarizeToolCallUnavailableResponseBody is the type of the "chat" service
+// "summarizeToolCall" endpoint HTTP response body for the "unavailable" error.
+type SummarizeToolCallUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SummarizeToolCallAiAccessDeniedResponseBody is the type of the "chat"
+// service "summarizeToolCall" endpoint HTTP response body for the
+// "ai_access_denied" error.
+type SummarizeToolCallAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1911,6 +1966,24 @@ type SummarizeToolCallUnauthorizedResponseBody struct {
 // SummarizeToolCallForbiddenResponseBody is the type of the "chat" service
 // "summarizeToolCall" endpoint HTTP response body for the "forbidden" error.
 type SummarizeToolCallForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SummarizeToolCallUnauthorizedResponseBody is the type of the "chat" service
+// "summarizeToolCall" endpoint HTTP response body for the "unauthorized" error.
+type SummarizeToolCallUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -4243,10 +4316,24 @@ func NewSetPinnedGatewayErrorResponseBody(res *goa.ServiceError) *SetPinnedGatew
 	return body
 }
 
-// NewSummarizeUnauthorizedResponseBody builds the HTTP response body from the
+// NewSummarizeUnavailableResponseBody builds the HTTP response body from the
 // result of the "summarize" endpoint of the "chat" service.
-func NewSummarizeUnauthorizedResponseBody(res *goa.ServiceError) *SummarizeUnauthorizedResponseBody {
-	body := &SummarizeUnauthorizedResponseBody{
+func NewSummarizeUnavailableResponseBody(res *goa.ServiceError) *SummarizeUnavailableResponseBody {
+	body := &SummarizeUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSummarizeAiAccessDeniedResponseBody builds the HTTP response body from
+// the result of the "summarize" endpoint of the "chat" service.
+func NewSummarizeAiAccessDeniedResponseBody(res *goa.ServiceError) *SummarizeAiAccessDeniedResponseBody {
+	body := &SummarizeAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -4261,6 +4348,20 @@ func NewSummarizeUnauthorizedResponseBody(res *goa.ServiceError) *SummarizeUnaut
 // result of the "summarize" endpoint of the "chat" service.
 func NewSummarizeForbiddenResponseBody(res *goa.ServiceError) *SummarizeForbiddenResponseBody {
 	body := &SummarizeForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSummarizeUnauthorizedResponseBody builds the HTTP response body from the
+// result of the "summarize" endpoint of the "chat" service.
+func NewSummarizeUnauthorizedResponseBody(res *goa.ServiceError) *SummarizeUnauthorizedResponseBody {
+	body := &SummarizeUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -4383,10 +4484,24 @@ func NewSummarizeGatewayErrorResponseBody(res *goa.ServiceError) *SummarizeGatew
 	return body
 }
 
-// NewSummarizeToolCallUnauthorizedResponseBody builds the HTTP response body
+// NewSummarizeToolCallUnavailableResponseBody builds the HTTP response body
 // from the result of the "summarizeToolCall" endpoint of the "chat" service.
-func NewSummarizeToolCallUnauthorizedResponseBody(res *goa.ServiceError) *SummarizeToolCallUnauthorizedResponseBody {
-	body := &SummarizeToolCallUnauthorizedResponseBody{
+func NewSummarizeToolCallUnavailableResponseBody(res *goa.ServiceError) *SummarizeToolCallUnavailableResponseBody {
+	body := &SummarizeToolCallUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSummarizeToolCallAiAccessDeniedResponseBody builds the HTTP response body
+// from the result of the "summarizeToolCall" endpoint of the "chat" service.
+func NewSummarizeToolCallAiAccessDeniedResponseBody(res *goa.ServiceError) *SummarizeToolCallAiAccessDeniedResponseBody {
+	body := &SummarizeToolCallAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -4401,6 +4516,20 @@ func NewSummarizeToolCallUnauthorizedResponseBody(res *goa.ServiceError) *Summar
 // the result of the "summarizeToolCall" endpoint of the "chat" service.
 func NewSummarizeToolCallForbiddenResponseBody(res *goa.ServiceError) *SummarizeToolCallForbiddenResponseBody {
 	body := &SummarizeToolCallForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSummarizeToolCallUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "summarizeToolCall" endpoint of the "chat" service.
+func NewSummarizeToolCallUnauthorizedResponseBody(res *goa.ServiceError) *SummarizeToolCallUnauthorizedResponseBody {
+	body := &SummarizeToolCallUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -12024,6 +12024,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - project_slug_header_Gram-Project: []
                   session_header_Gram-Session: []
@@ -13440,6 +13446,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - project_slug_header_Gram-Project: []
                   session_header_Gram-Session: []
@@ -13535,6 +13547,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - project_slug_header_Gram-Project: []
                   session_header_Gram-Session: []
@@ -42529,6 +42547,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - apikey_header_Gram-Key: []
                   project_slug_header_Gram-Project: []
@@ -45977,6 +46001,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - apikey_header_Gram-Key: []
                   project_slug_header_Gram-Project: []
@@ -46083,6 +46113,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - apikey_header_Gram-Key: []
                   project_slug_header_Gram-Project: []
@@ -46814,6 +46850,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'gateway_error: an unexpected error occurred'
+                "503":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'unavailable: service temporarily unavailable'
             security:
                 - apikey_header_Gram-Key: []
                   project_slug_header_Gram-Project: []

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -67,8 +67,10 @@ func EncodeCreateRiskPolicyRequest(encoder func(*http.Request) goahttp.Encoder) 
 // the risk createRiskPolicy endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeCreateRiskPolicyResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -108,6 +110,55 @@ func DecodeCreateRiskPolicyResponse(decoder func(*http.Response) goahttp.Decoder
 			}
 			res := NewCreateRiskPolicyRiskPolicyOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body CreateRiskPolicyUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("risk", "createRiskPolicy", err)
+			}
+			err = ValidateCreateRiskPolicyUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("risk", "createRiskPolicy", err)
+			}
+			return nil, NewCreateRiskPolicyUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body CreateRiskPolicyAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "createRiskPolicy", err)
+				}
+				err = ValidateCreateRiskPolicyAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "createRiskPolicy", err)
+				}
+				return nil, NewCreateRiskPolicyAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body CreateRiskPolicyForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "createRiskPolicy", err)
+				}
+				err = ValidateCreateRiskPolicyForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "createRiskPolicy", err)
+				}
+				return nil, NewCreateRiskPolicyForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("risk", "createRiskPolicy", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body CreateRiskPolicyUnauthorizedResponseBody
@@ -122,20 +173,6 @@ func DecodeCreateRiskPolicyResponse(decoder func(*http.Response) goahttp.Decoder
 				return nil, goahttp.ErrValidationError("risk", "createRiskPolicy", err)
 			}
 			return nil, NewCreateRiskPolicyUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body CreateRiskPolicyForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("risk", "createRiskPolicy", err)
-			}
-			err = ValidateCreateRiskPolicyForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("risk", "createRiskPolicy", err)
-			}
-			return nil, NewCreateRiskPolicyForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body CreateRiskPolicyBadRequestResponseBody
@@ -1027,8 +1064,10 @@ func EncodeUpdateRiskPolicyRequest(encoder func(*http.Request) goahttp.Encoder) 
 // the risk updateRiskPolicy endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeUpdateRiskPolicyResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -1068,6 +1107,55 @@ func DecodeUpdateRiskPolicyResponse(decoder func(*http.Response) goahttp.Decoder
 			}
 			res := NewUpdateRiskPolicyRiskPolicyOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body UpdateRiskPolicyUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("risk", "updateRiskPolicy", err)
+			}
+			err = ValidateUpdateRiskPolicyUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("risk", "updateRiskPolicy", err)
+			}
+			return nil, NewUpdateRiskPolicyUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body UpdateRiskPolicyAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "updateRiskPolicy", err)
+				}
+				err = ValidateUpdateRiskPolicyAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "updateRiskPolicy", err)
+				}
+				return nil, NewUpdateRiskPolicyAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body UpdateRiskPolicyForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "updateRiskPolicy", err)
+				}
+				err = ValidateUpdateRiskPolicyForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "updateRiskPolicy", err)
+				}
+				return nil, NewUpdateRiskPolicyForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("risk", "updateRiskPolicy", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body UpdateRiskPolicyUnauthorizedResponseBody
@@ -1082,20 +1170,6 @@ func DecodeUpdateRiskPolicyResponse(decoder func(*http.Response) goahttp.Decoder
 				return nil, goahttp.ErrValidationError("risk", "updateRiskPolicy", err)
 			}
 			return nil, NewUpdateRiskPolicyUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body UpdateRiskPolicyForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("risk", "updateRiskPolicy", err)
-			}
-			err = ValidateUpdateRiskPolicyForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("risk", "updateRiskPolicy", err)
-			}
-			return nil, NewUpdateRiskPolicyForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body UpdateRiskPolicyBadRequestResponseBody
@@ -10212,8 +10286,10 @@ func EncodeSuggestCustomDetectionRuleRequest(encoder func(*http.Request) goahttp
 // returned by the risk suggestCustomDetectionRule endpoint. restoreBody
 // controls whether the response body should be restored after having been read.
 // DecodeSuggestCustomDetectionRuleResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -10253,6 +10329,55 @@ func DecodeSuggestCustomDetectionRuleResponse(decoder func(*http.Response) goaht
 			}
 			res := NewSuggestCustomDetectionRuleResultOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body SuggestCustomDetectionRuleUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("risk", "suggestCustomDetectionRule", err)
+			}
+			err = ValidateSuggestCustomDetectionRuleUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("risk", "suggestCustomDetectionRule", err)
+			}
+			return nil, NewSuggestCustomDetectionRuleUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body SuggestCustomDetectionRuleAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "suggestCustomDetectionRule", err)
+				}
+				err = ValidateSuggestCustomDetectionRuleAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "suggestCustomDetectionRule", err)
+				}
+				return nil, NewSuggestCustomDetectionRuleAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body SuggestCustomDetectionRuleForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "suggestCustomDetectionRule", err)
+				}
+				err = ValidateSuggestCustomDetectionRuleForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "suggestCustomDetectionRule", err)
+				}
+				return nil, NewSuggestCustomDetectionRuleForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("risk", "suggestCustomDetectionRule", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body SuggestCustomDetectionRuleUnauthorizedResponseBody
@@ -10267,20 +10392,6 @@ func DecodeSuggestCustomDetectionRuleResponse(decoder func(*http.Response) goaht
 				return nil, goahttp.ErrValidationError("risk", "suggestCustomDetectionRule", err)
 			}
 			return nil, NewSuggestCustomDetectionRuleUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body SuggestCustomDetectionRuleForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("risk", "suggestCustomDetectionRule", err)
-			}
-			err = ValidateSuggestCustomDetectionRuleForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("risk", "suggestCustomDetectionRule", err)
-			}
-			return nil, NewSuggestCustomDetectionRuleForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body SuggestCustomDetectionRuleBadRequestResponseBody
@@ -10454,8 +10565,10 @@ func EncodeSuggestExclusionRequest(encoder func(*http.Request) goahttp.Encoder) 
 // the risk suggestExclusion endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeSuggestExclusionResponse may return the following errors:
-//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "unavailable" (type *goa.ServiceError): http.StatusServiceUnavailable
+//   - "ai_access_denied" (type *goa.ServiceError): http.StatusForbidden
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
 //   - "not_found" (type *goa.ServiceError): http.StatusNotFound
 //   - "conflict" (type *goa.ServiceError): http.StatusConflict
@@ -10495,6 +10608,55 @@ func DecodeSuggestExclusionResponse(decoder func(*http.Response) goahttp.Decoder
 			}
 			res := NewSuggestExclusionResultOK(&body)
 			return res, nil
+		case http.StatusServiceUnavailable:
+			var (
+				body SuggestExclusionUnavailableResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("risk", "suggestExclusion", err)
+			}
+			err = ValidateSuggestExclusionUnavailableResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("risk", "suggestExclusion", err)
+			}
+			return nil, NewSuggestExclusionUnavailable(&body)
+		case http.StatusForbidden:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "ai_access_denied":
+				var (
+					body SuggestExclusionAiAccessDeniedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "suggestExclusion", err)
+				}
+				err = ValidateSuggestExclusionAiAccessDeniedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "suggestExclusion", err)
+				}
+				return nil, NewSuggestExclusionAiAccessDenied(&body)
+			case "forbidden":
+				var (
+					body SuggestExclusionForbiddenResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("risk", "suggestExclusion", err)
+				}
+				err = ValidateSuggestExclusionForbiddenResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("risk", "suggestExclusion", err)
+				}
+				return nil, NewSuggestExclusionForbidden(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("risk", "suggestExclusion", resp.StatusCode, string(body))
+			}
 		case http.StatusUnauthorized:
 			var (
 				body SuggestExclusionUnauthorizedResponseBody
@@ -10509,20 +10671,6 @@ func DecodeSuggestExclusionResponse(decoder func(*http.Response) goahttp.Decoder
 				return nil, goahttp.ErrValidationError("risk", "suggestExclusion", err)
 			}
 			return nil, NewSuggestExclusionUnauthorized(&body)
-		case http.StatusForbidden:
-			var (
-				body SuggestExclusionForbiddenResponseBody
-				err  error
-			)
-			err = decoder(resp).Decode(&body)
-			if err != nil {
-				return nil, goahttp.ErrDecodingError("risk", "suggestExclusion", err)
-			}
-			err = ValidateSuggestExclusionForbiddenResponseBody(&body)
-			if err != nil {
-				return nil, goahttp.ErrValidationError("risk", "suggestExclusion", err)
-			}
-			return nil, NewSuggestExclusionForbidden(&body)
 		case http.StatusBadRequest:
 			var (
 				body SuggestExclusionBadRequestResponseBody

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -1398,9 +1398,28 @@ type ListRiskEvalReviewsResponseBody struct {
 	Reviews []*RiskPolicyEvalReviewResponseBody `form:"reviews,omitempty" json:"reviews,omitempty" xml:"reviews,omitempty"`
 }
 
-// CreateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
-// "createRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
-type CreateRiskPolicyUnauthorizedResponseBody struct {
+// CreateRiskPolicyUnavailableResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "unavailable" error.
+type CreateRiskPolicyUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// CreateRiskPolicyAiAccessDeniedResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type CreateRiskPolicyAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1419,6 +1438,24 @@ type CreateRiskPolicyUnauthorizedResponseBody struct {
 // CreateRiskPolicyForbiddenResponseBody is the type of the "risk" service
 // "createRiskPolicy" endpoint HTTP response body for the "forbidden" error.
 type CreateRiskPolicyForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// CreateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
+type CreateRiskPolicyUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2132,9 +2169,28 @@ type GetRiskPolicyGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// UpdateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
-// "updateRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
-type UpdateRiskPolicyUnauthorizedResponseBody struct {
+// UpdateRiskPolicyUnavailableResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "unavailable" error.
+type UpdateRiskPolicyUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// UpdateRiskPolicyAiAccessDeniedResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type UpdateRiskPolicyAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2153,6 +2209,24 @@ type UpdateRiskPolicyUnauthorizedResponseBody struct {
 // UpdateRiskPolicyForbiddenResponseBody is the type of the "risk" service
 // "updateRiskPolicy" endpoint HTTP response body for the "forbidden" error.
 type UpdateRiskPolicyForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// UpdateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
+type UpdateRiskPolicyUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9236,10 +9310,29 @@ type DeleteRiskExclusionGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// SuggestCustomDetectionRuleUnauthorizedResponseBody is the type of the "risk"
+// SuggestCustomDetectionRuleUnavailableResponseBody is the type of the "risk"
 // service "suggestCustomDetectionRule" endpoint HTTP response body for the
-// "unauthorized" error.
-type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
+// "unavailable" error.
+type SuggestCustomDetectionRuleUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SuggestCustomDetectionRuleAiAccessDeniedResponseBody is the type of the
+// "risk" service "suggestCustomDetectionRule" endpoint HTTP response body for
+// the "ai_access_denied" error.
+type SuggestCustomDetectionRuleAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9259,6 +9352,25 @@ type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
 // service "suggestCustomDetectionRule" endpoint HTTP response body for the
 // "forbidden" error.
 type SuggestCustomDetectionRuleForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SuggestCustomDetectionRuleUnauthorizedResponseBody is the type of the "risk"
+// service "suggestCustomDetectionRule" endpoint HTTP response body for the
+// "unauthorized" error.
+type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9426,9 +9538,28 @@ type SuggestCustomDetectionRuleGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
-// SuggestExclusionUnauthorizedResponseBody is the type of the "risk" service
-// "suggestExclusion" endpoint HTTP response body for the "unauthorized" error.
-type SuggestExclusionUnauthorizedResponseBody struct {
+// SuggestExclusionUnavailableResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "unavailable" error.
+type SuggestExclusionUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SuggestExclusionAiAccessDeniedResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type SuggestExclusionAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9447,6 +9578,24 @@ type SuggestExclusionUnauthorizedResponseBody struct {
 // SuggestExclusionForbiddenResponseBody is the type of the "risk" service
 // "suggestExclusion" endpoint HTTP response body for the "forbidden" error.
 type SuggestExclusionForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// SuggestExclusionUnauthorizedResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "unauthorized" error.
+type SuggestExclusionUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -11842,9 +11991,24 @@ func NewCreateRiskPolicyRiskPolicyOK(body *CreateRiskPolicyResponseBody) *types.
 	return v
 }
 
-// NewCreateRiskPolicyUnauthorized builds a risk service createRiskPolicy
-// endpoint unauthorized error.
-func NewCreateRiskPolicyUnauthorized(body *CreateRiskPolicyUnauthorizedResponseBody) *goa.ServiceError {
+// NewCreateRiskPolicyUnavailable builds a risk service createRiskPolicy
+// endpoint unavailable error.
+func NewCreateRiskPolicyUnavailable(body *CreateRiskPolicyUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewCreateRiskPolicyAiAccessDenied builds a risk service createRiskPolicy
+// endpoint ai_access_denied error.
+func NewCreateRiskPolicyAiAccessDenied(body *CreateRiskPolicyAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -11860,6 +12024,21 @@ func NewCreateRiskPolicyUnauthorized(body *CreateRiskPolicyUnauthorizedResponseB
 // NewCreateRiskPolicyForbidden builds a risk service createRiskPolicy endpoint
 // forbidden error.
 func NewCreateRiskPolicyForbidden(body *CreateRiskPolicyForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewCreateRiskPolicyUnauthorized builds a risk service createRiskPolicy
+// endpoint unauthorized error.
+func NewCreateRiskPolicyUnauthorized(body *CreateRiskPolicyUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -12648,9 +12827,24 @@ func NewUpdateRiskPolicyRiskPolicyOK(body *UpdateRiskPolicyResponseBody) *types.
 	return v
 }
 
-// NewUpdateRiskPolicyUnauthorized builds a risk service updateRiskPolicy
-// endpoint unauthorized error.
-func NewUpdateRiskPolicyUnauthorized(body *UpdateRiskPolicyUnauthorizedResponseBody) *goa.ServiceError {
+// NewUpdateRiskPolicyUnavailable builds a risk service updateRiskPolicy
+// endpoint unavailable error.
+func NewUpdateRiskPolicyUnavailable(body *UpdateRiskPolicyUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewUpdateRiskPolicyAiAccessDenied builds a risk service updateRiskPolicy
+// endpoint ai_access_denied error.
+func NewUpdateRiskPolicyAiAccessDenied(body *UpdateRiskPolicyAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -12666,6 +12860,21 @@ func NewUpdateRiskPolicyUnauthorized(body *UpdateRiskPolicyUnauthorizedResponseB
 // NewUpdateRiskPolicyForbidden builds a risk service updateRiskPolicy endpoint
 // forbidden error.
 func NewUpdateRiskPolicyForbidden(body *UpdateRiskPolicyForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewUpdateRiskPolicyUnauthorized builds a risk service updateRiskPolicy
+// endpoint unauthorized error.
+func NewUpdateRiskPolicyUnauthorized(body *UpdateRiskPolicyUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -18986,9 +19195,24 @@ func NewSuggestCustomDetectionRuleResultOK(body *SuggestCustomDetectionRuleRespo
 	return v
 }
 
-// NewSuggestCustomDetectionRuleUnauthorized builds a risk service
-// suggestCustomDetectionRule endpoint unauthorized error.
-func NewSuggestCustomDetectionRuleUnauthorized(body *SuggestCustomDetectionRuleUnauthorizedResponseBody) *goa.ServiceError {
+// NewSuggestCustomDetectionRuleUnavailable builds a risk service
+// suggestCustomDetectionRule endpoint unavailable error.
+func NewSuggestCustomDetectionRuleUnavailable(body *SuggestCustomDetectionRuleUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSuggestCustomDetectionRuleAiAccessDenied builds a risk service
+// suggestCustomDetectionRule endpoint ai_access_denied error.
+func NewSuggestCustomDetectionRuleAiAccessDenied(body *SuggestCustomDetectionRuleAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -19004,6 +19228,21 @@ func NewSuggestCustomDetectionRuleUnauthorized(body *SuggestCustomDetectionRuleU
 // NewSuggestCustomDetectionRuleForbidden builds a risk service
 // suggestCustomDetectionRule endpoint forbidden error.
 func NewSuggestCustomDetectionRuleForbidden(body *SuggestCustomDetectionRuleForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSuggestCustomDetectionRuleUnauthorized builds a risk service
+// suggestCustomDetectionRule endpoint unauthorized error.
+func NewSuggestCustomDetectionRuleUnauthorized(body *SuggestCustomDetectionRuleUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -19149,9 +19388,24 @@ func NewSuggestExclusionResultOK(body *SuggestExclusionResponseBody) *risk.Sugge
 	return v
 }
 
-// NewSuggestExclusionUnauthorized builds a risk service suggestExclusion
-// endpoint unauthorized error.
-func NewSuggestExclusionUnauthorized(body *SuggestExclusionUnauthorizedResponseBody) *goa.ServiceError {
+// NewSuggestExclusionUnavailable builds a risk service suggestExclusion
+// endpoint unavailable error.
+func NewSuggestExclusionUnavailable(body *SuggestExclusionUnavailableResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSuggestExclusionAiAccessDenied builds a risk service suggestExclusion
+// endpoint ai_access_denied error.
+func NewSuggestExclusionAiAccessDenied(body *SuggestExclusionAiAccessDeniedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -19167,6 +19421,21 @@ func NewSuggestExclusionUnauthorized(body *SuggestExclusionUnauthorizedResponseB
 // NewSuggestExclusionForbidden builds a risk service suggestExclusion endpoint
 // forbidden error.
 func NewSuggestExclusionForbidden(body *SuggestExclusionForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewSuggestExclusionUnauthorized builds a risk service suggestExclusion
+// endpoint unauthorized error.
+func NewSuggestExclusionUnauthorized(body *SuggestExclusionUnauthorizedResponseBody) *goa.ServiceError {
 	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
@@ -21623,9 +21892,33 @@ func ValidateListRiskEvalReviewsResponseBody(body *ListRiskEvalReviewsResponseBo
 	return
 }
 
-// ValidateCreateRiskPolicyUnauthorizedResponseBody runs the validations
-// defined on createRiskPolicy_unauthorized_response_body
-func ValidateCreateRiskPolicyUnauthorizedResponseBody(body *CreateRiskPolicyUnauthorizedResponseBody) (err error) {
+// ValidateCreateRiskPolicyUnavailableResponseBody runs the validations defined
+// on createRiskPolicy_unavailable_response_body
+func ValidateCreateRiskPolicyUnavailableResponseBody(body *CreateRiskPolicyUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateCreateRiskPolicyAiAccessDeniedResponseBody runs the validations
+// defined on createRiskPolicy_ai_access_denied_response_body
+func ValidateCreateRiskPolicyAiAccessDeniedResponseBody(body *CreateRiskPolicyAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -21650,6 +21943,30 @@ func ValidateCreateRiskPolicyUnauthorizedResponseBody(body *CreateRiskPolicyUnau
 // ValidateCreateRiskPolicyForbiddenResponseBody runs the validations defined
 // on createRiskPolicy_forbidden_response_body
 func ValidateCreateRiskPolicyForbiddenResponseBody(body *CreateRiskPolicyForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateCreateRiskPolicyUnauthorizedResponseBody runs the validations
+// defined on createRiskPolicy_unauthorized_response_body
+func ValidateCreateRiskPolicyUnauthorizedResponseBody(body *CreateRiskPolicyUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -22584,9 +22901,33 @@ func ValidateGetRiskPolicyGatewayErrorResponseBody(body *GetRiskPolicyGatewayErr
 	return
 }
 
-// ValidateUpdateRiskPolicyUnauthorizedResponseBody runs the validations
-// defined on updateRiskPolicy_unauthorized_response_body
-func ValidateUpdateRiskPolicyUnauthorizedResponseBody(body *UpdateRiskPolicyUnauthorizedResponseBody) (err error) {
+// ValidateUpdateRiskPolicyUnavailableResponseBody runs the validations defined
+// on updateRiskPolicy_unavailable_response_body
+func ValidateUpdateRiskPolicyUnavailableResponseBody(body *UpdateRiskPolicyUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateUpdateRiskPolicyAiAccessDeniedResponseBody runs the validations
+// defined on updateRiskPolicy_ai_access_denied_response_body
+func ValidateUpdateRiskPolicyAiAccessDeniedResponseBody(body *UpdateRiskPolicyAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -22611,6 +22952,30 @@ func ValidateUpdateRiskPolicyUnauthorizedResponseBody(body *UpdateRiskPolicyUnau
 // ValidateUpdateRiskPolicyForbiddenResponseBody runs the validations defined
 // on updateRiskPolicy_forbidden_response_body
 func ValidateUpdateRiskPolicyForbiddenResponseBody(body *UpdateRiskPolicyForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateUpdateRiskPolicyUnauthorizedResponseBody runs the validations
+// defined on updateRiskPolicy_unauthorized_response_body
+func ValidateUpdateRiskPolicyUnauthorizedResponseBody(body *UpdateRiskPolicyUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -31765,9 +32130,34 @@ func ValidateDeleteRiskExclusionGatewayErrorResponseBody(body *DeleteRiskExclusi
 	return
 }
 
-// ValidateSuggestCustomDetectionRuleUnauthorizedResponseBody runs the
-// validations defined on suggestCustomDetectionRule_unauthorized_response_body
-func ValidateSuggestCustomDetectionRuleUnauthorizedResponseBody(body *SuggestCustomDetectionRuleUnauthorizedResponseBody) (err error) {
+// ValidateSuggestCustomDetectionRuleUnavailableResponseBody runs the
+// validations defined on suggestCustomDetectionRule_unavailable_response_body
+func ValidateSuggestCustomDetectionRuleUnavailableResponseBody(body *SuggestCustomDetectionRuleUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSuggestCustomDetectionRuleAiAccessDeniedResponseBody runs the
+// validations defined on
+// suggestCustomDetectionRule_ai_access_denied_response_body
+func ValidateSuggestCustomDetectionRuleAiAccessDeniedResponseBody(body *SuggestCustomDetectionRuleAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -31792,6 +32182,30 @@ func ValidateSuggestCustomDetectionRuleUnauthorizedResponseBody(body *SuggestCus
 // ValidateSuggestCustomDetectionRuleForbiddenResponseBody runs the validations
 // defined on suggestCustomDetectionRule_forbidden_response_body
 func ValidateSuggestCustomDetectionRuleForbiddenResponseBody(body *SuggestCustomDetectionRuleForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSuggestCustomDetectionRuleUnauthorizedResponseBody runs the
+// validations defined on suggestCustomDetectionRule_unauthorized_response_body
+func ValidateSuggestCustomDetectionRuleUnauthorizedResponseBody(body *SuggestCustomDetectionRuleUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -32007,9 +32421,33 @@ func ValidateSuggestCustomDetectionRuleGatewayErrorResponseBody(body *SuggestCus
 	return
 }
 
-// ValidateSuggestExclusionUnauthorizedResponseBody runs the validations
-// defined on suggestExclusion_unauthorized_response_body
-func ValidateSuggestExclusionUnauthorizedResponseBody(body *SuggestExclusionUnauthorizedResponseBody) (err error) {
+// ValidateSuggestExclusionUnavailableResponseBody runs the validations defined
+// on suggestExclusion_unavailable_response_body
+func ValidateSuggestExclusionUnavailableResponseBody(body *SuggestExclusionUnavailableResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSuggestExclusionAiAccessDeniedResponseBody runs the validations
+// defined on suggestExclusion_ai_access_denied_response_body
+func ValidateSuggestExclusionAiAccessDeniedResponseBody(body *SuggestExclusionAiAccessDeniedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -32034,6 +32472,30 @@ func ValidateSuggestExclusionUnauthorizedResponseBody(body *SuggestExclusionUnau
 // ValidateSuggestExclusionForbiddenResponseBody runs the validations defined
 // on suggestExclusion_forbidden_response_body
 func ValidateSuggestExclusionForbiddenResponseBody(body *SuggestExclusionForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateSuggestExclusionUnauthorizedResponseBody runs the validations
+// defined on suggestExclusion_unauthorized_response_body
+func ValidateSuggestExclusionUnauthorizedResponseBody(body *SuggestExclusionUnauthorizedResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -112,7 +112,7 @@ func EncodeCreateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -121,10 +121,24 @@ func EncodeCreateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewCreateRiskPolicyUnauthorizedResponseBody(res)
+				body = NewCreateRiskPolicyUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewCreateRiskPolicyAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -139,6 +153,20 @@ func EncodeCreateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewCreateRiskPolicyUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError
@@ -1010,7 +1038,7 @@ func EncodeUpdateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -1019,10 +1047,24 @@ func EncodeUpdateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewUpdateRiskPolicyUnauthorizedResponseBody(res)
+				body = NewUpdateRiskPolicyUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewUpdateRiskPolicyAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -1037,6 +1079,20 @@ func EncodeUpdateRiskPolicyError(encoder func(context.Context, http.ResponseWrit
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewUpdateRiskPolicyUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError
@@ -9961,7 +10017,7 @@ func EncodeSuggestCustomDetectionRuleError(encoder func(context.Context, http.Re
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -9970,10 +10026,24 @@ func EncodeSuggestCustomDetectionRuleError(encoder func(context.Context, http.Re
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewSuggestCustomDetectionRuleUnauthorizedResponseBody(res)
+				body = NewSuggestCustomDetectionRuleUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSuggestCustomDetectionRuleAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -9988,6 +10058,20 @@ func EncodeSuggestCustomDetectionRuleError(encoder func(context.Context, http.Re
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSuggestCustomDetectionRuleUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError
@@ -10198,7 +10282,7 @@ func EncodeSuggestExclusionError(encoder func(context.Context, http.ResponseWrit
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
-		case "unauthorized":
+		case "unavailable":
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
@@ -10207,10 +10291,24 @@ func EncodeSuggestExclusionError(encoder func(context.Context, http.ResponseWrit
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
-				body = NewSuggestExclusionUnauthorizedResponseBody(res)
+				body = NewSuggestExclusionUnavailableResponseBody(res)
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
-			w.WriteHeader(http.StatusUnauthorized)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return enc.Encode(body)
+		case "ai_access_denied":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSuggestExclusionAiAccessDeniedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
 			return enc.Encode(body)
 		case "forbidden":
 			var res *goa.ServiceError
@@ -10225,6 +10323,20 @@ func EncodeSuggestExclusionError(encoder func(context.Context, http.ResponseWrit
 			}
 			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewSuggestExclusionUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
 			return enc.Encode(body)
 		case "bad_request":
 			var res *goa.ServiceError

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -1400,9 +1400,28 @@ type ListRiskEvalReviewsResponseBody struct {
 	Reviews []*RiskPolicyEvalReviewResponseBody `form:"reviews" json:"reviews" xml:"reviews"`
 }
 
-// CreateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
-// "createRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
-type CreateRiskPolicyUnauthorizedResponseBody struct {
+// CreateRiskPolicyUnavailableResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "unavailable" error.
+type CreateRiskPolicyUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// CreateRiskPolicyAiAccessDeniedResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type CreateRiskPolicyAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -1421,6 +1440,24 @@ type CreateRiskPolicyUnauthorizedResponseBody struct {
 // CreateRiskPolicyForbiddenResponseBody is the type of the "risk" service
 // "createRiskPolicy" endpoint HTTP response body for the "forbidden" error.
 type CreateRiskPolicyForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// CreateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
+// "createRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
+type CreateRiskPolicyUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2134,9 +2171,28 @@ type GetRiskPolicyGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// UpdateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
-// "updateRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
-type UpdateRiskPolicyUnauthorizedResponseBody struct {
+// UpdateRiskPolicyUnavailableResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "unavailable" error.
+type UpdateRiskPolicyUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// UpdateRiskPolicyAiAccessDeniedResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type UpdateRiskPolicyAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -2155,6 +2211,24 @@ type UpdateRiskPolicyUnauthorizedResponseBody struct {
 // UpdateRiskPolicyForbiddenResponseBody is the type of the "risk" service
 // "updateRiskPolicy" endpoint HTTP response body for the "forbidden" error.
 type UpdateRiskPolicyForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// UpdateRiskPolicyUnauthorizedResponseBody is the type of the "risk" service
+// "updateRiskPolicy" endpoint HTTP response body for the "unauthorized" error.
+type UpdateRiskPolicyUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9238,10 +9312,29 @@ type DeleteRiskExclusionGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// SuggestCustomDetectionRuleUnauthorizedResponseBody is the type of the "risk"
+// SuggestCustomDetectionRuleUnavailableResponseBody is the type of the "risk"
 // service "suggestCustomDetectionRule" endpoint HTTP response body for the
-// "unauthorized" error.
-type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
+// "unavailable" error.
+type SuggestCustomDetectionRuleUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SuggestCustomDetectionRuleAiAccessDeniedResponseBody is the type of the
+// "risk" service "suggestCustomDetectionRule" endpoint HTTP response body for
+// the "ai_access_denied" error.
+type SuggestCustomDetectionRuleAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9261,6 +9354,25 @@ type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
 // service "suggestCustomDetectionRule" endpoint HTTP response body for the
 // "forbidden" error.
 type SuggestCustomDetectionRuleForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SuggestCustomDetectionRuleUnauthorizedResponseBody is the type of the "risk"
+// service "suggestCustomDetectionRule" endpoint HTTP response body for the
+// "unauthorized" error.
+type SuggestCustomDetectionRuleUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9428,9 +9540,28 @@ type SuggestCustomDetectionRuleGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
-// SuggestExclusionUnauthorizedResponseBody is the type of the "risk" service
-// "suggestExclusion" endpoint HTTP response body for the "unauthorized" error.
-type SuggestExclusionUnauthorizedResponseBody struct {
+// SuggestExclusionUnavailableResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "unavailable" error.
+type SuggestExclusionUnavailableResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SuggestExclusionAiAccessDeniedResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "ai_access_denied"
+// error.
+type SuggestExclusionAiAccessDeniedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -9449,6 +9580,24 @@ type SuggestExclusionUnauthorizedResponseBody struct {
 // SuggestExclusionForbiddenResponseBody is the type of the "risk" service
 // "suggestExclusion" endpoint HTTP response body for the "forbidden" error.
 type SuggestExclusionForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// SuggestExclusionUnauthorizedResponseBody is the type of the "risk" service
+// "suggestExclusion" endpoint HTTP response body for the "unauthorized" error.
+type SuggestExclusionUnauthorizedResponseBody struct {
 	// Name is the name of this class of errors.
 	Name string `form:"name" json:"name" xml:"name"`
 	// ID is a unique identifier for this particular occurrence of the problem.
@@ -12317,10 +12466,24 @@ func NewListRiskEvalReviewsResponseBody(res *risk.ListRiskEvalReviewsResult) *Li
 	return body
 }
 
-// NewCreateRiskPolicyUnauthorizedResponseBody builds the HTTP response body
+// NewCreateRiskPolicyUnavailableResponseBody builds the HTTP response body
 // from the result of the "createRiskPolicy" endpoint of the "risk" service.
-func NewCreateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *CreateRiskPolicyUnauthorizedResponseBody {
-	body := &CreateRiskPolicyUnauthorizedResponseBody{
+func NewCreateRiskPolicyUnavailableResponseBody(res *goa.ServiceError) *CreateRiskPolicyUnavailableResponseBody {
+	body := &CreateRiskPolicyUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewCreateRiskPolicyAiAccessDeniedResponseBody builds the HTTP response body
+// from the result of the "createRiskPolicy" endpoint of the "risk" service.
+func NewCreateRiskPolicyAiAccessDeniedResponseBody(res *goa.ServiceError) *CreateRiskPolicyAiAccessDeniedResponseBody {
+	body := &CreateRiskPolicyAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -12335,6 +12498,20 @@ func NewCreateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *CreateR
 // the result of the "createRiskPolicy" endpoint of the "risk" service.
 func NewCreateRiskPolicyForbiddenResponseBody(res *goa.ServiceError) *CreateRiskPolicyForbiddenResponseBody {
 	body := &CreateRiskPolicyForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewCreateRiskPolicyUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "createRiskPolicy" endpoint of the "risk" service.
+func NewCreateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *CreateRiskPolicyUnauthorizedResponseBody {
+	body := &CreateRiskPolicyUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -12891,10 +13068,24 @@ func NewGetRiskPolicyGatewayErrorResponseBody(res *goa.ServiceError) *GetRiskPol
 	return body
 }
 
-// NewUpdateRiskPolicyUnauthorizedResponseBody builds the HTTP response body
+// NewUpdateRiskPolicyUnavailableResponseBody builds the HTTP response body
 // from the result of the "updateRiskPolicy" endpoint of the "risk" service.
-func NewUpdateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *UpdateRiskPolicyUnauthorizedResponseBody {
-	body := &UpdateRiskPolicyUnauthorizedResponseBody{
+func NewUpdateRiskPolicyUnavailableResponseBody(res *goa.ServiceError) *UpdateRiskPolicyUnavailableResponseBody {
+	body := &UpdateRiskPolicyUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewUpdateRiskPolicyAiAccessDeniedResponseBody builds the HTTP response body
+// from the result of the "updateRiskPolicy" endpoint of the "risk" service.
+func NewUpdateRiskPolicyAiAccessDeniedResponseBody(res *goa.ServiceError) *UpdateRiskPolicyAiAccessDeniedResponseBody {
+	body := &UpdateRiskPolicyAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -12909,6 +13100,20 @@ func NewUpdateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *UpdateR
 // the result of the "updateRiskPolicy" endpoint of the "risk" service.
 func NewUpdateRiskPolicyForbiddenResponseBody(res *goa.ServiceError) *UpdateRiskPolicyForbiddenResponseBody {
 	body := &UpdateRiskPolicyForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewUpdateRiskPolicyUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "updateRiskPolicy" endpoint of the "risk" service.
+func NewUpdateRiskPolicyUnauthorizedResponseBody(res *goa.ServiceError) *UpdateRiskPolicyUnauthorizedResponseBody {
+	body := &UpdateRiskPolicyUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -18449,11 +18654,26 @@ func NewDeleteRiskExclusionGatewayErrorResponseBody(res *goa.ServiceError) *Dele
 	return body
 }
 
-// NewSuggestCustomDetectionRuleUnauthorizedResponseBody builds the HTTP
+// NewSuggestCustomDetectionRuleUnavailableResponseBody builds the HTTP
 // response body from the result of the "suggestCustomDetectionRule" endpoint
 // of the "risk" service.
-func NewSuggestCustomDetectionRuleUnauthorizedResponseBody(res *goa.ServiceError) *SuggestCustomDetectionRuleUnauthorizedResponseBody {
-	body := &SuggestCustomDetectionRuleUnauthorizedResponseBody{
+func NewSuggestCustomDetectionRuleUnavailableResponseBody(res *goa.ServiceError) *SuggestCustomDetectionRuleUnavailableResponseBody {
+	body := &SuggestCustomDetectionRuleUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSuggestCustomDetectionRuleAiAccessDeniedResponseBody builds the HTTP
+// response body from the result of the "suggestCustomDetectionRule" endpoint
+// of the "risk" service.
+func NewSuggestCustomDetectionRuleAiAccessDeniedResponseBody(res *goa.ServiceError) *SuggestCustomDetectionRuleAiAccessDeniedResponseBody {
+	body := &SuggestCustomDetectionRuleAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -18469,6 +18689,21 @@ func NewSuggestCustomDetectionRuleUnauthorizedResponseBody(res *goa.ServiceError
 // "risk" service.
 func NewSuggestCustomDetectionRuleForbiddenResponseBody(res *goa.ServiceError) *SuggestCustomDetectionRuleForbiddenResponseBody {
 	body := &SuggestCustomDetectionRuleForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSuggestCustomDetectionRuleUnauthorizedResponseBody builds the HTTP
+// response body from the result of the "suggestCustomDetectionRule" endpoint
+// of the "risk" service.
+func NewSuggestCustomDetectionRuleUnauthorizedResponseBody(res *goa.ServiceError) *SuggestCustomDetectionRuleUnauthorizedResponseBody {
+	body := &SuggestCustomDetectionRuleUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -18599,10 +18834,24 @@ func NewSuggestCustomDetectionRuleGatewayErrorResponseBody(res *goa.ServiceError
 	return body
 }
 
-// NewSuggestExclusionUnauthorizedResponseBody builds the HTTP response body
+// NewSuggestExclusionUnavailableResponseBody builds the HTTP response body
 // from the result of the "suggestExclusion" endpoint of the "risk" service.
-func NewSuggestExclusionUnauthorizedResponseBody(res *goa.ServiceError) *SuggestExclusionUnauthorizedResponseBody {
-	body := &SuggestExclusionUnauthorizedResponseBody{
+func NewSuggestExclusionUnavailableResponseBody(res *goa.ServiceError) *SuggestExclusionUnavailableResponseBody {
+	body := &SuggestExclusionUnavailableResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSuggestExclusionAiAccessDeniedResponseBody builds the HTTP response body
+// from the result of the "suggestExclusion" endpoint of the "risk" service.
+func NewSuggestExclusionAiAccessDeniedResponseBody(res *goa.ServiceError) *SuggestExclusionAiAccessDeniedResponseBody {
+	body := &SuggestExclusionAiAccessDeniedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,
@@ -18617,6 +18866,20 @@ func NewSuggestExclusionUnauthorizedResponseBody(res *goa.ServiceError) *Suggest
 // the result of the "suggestExclusion" endpoint of the "risk" service.
 func NewSuggestExclusionForbiddenResponseBody(res *goa.ServiceError) *SuggestExclusionForbiddenResponseBody {
 	body := &SuggestExclusionForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewSuggestExclusionUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "suggestExclusion" endpoint of the "risk" service.
+func NewSuggestExclusionUnauthorizedResponseBody(res *goa.ServiceError) *SuggestExclusionUnauthorizedResponseBody {
+	body := &SuggestExclusionUnauthorizedResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/server/gen/risk/client.go
+++ b/server/gen/risk/client.go
@@ -124,6 +124,8 @@ func NewClient(createRiskPolicy, listRiskPolicies, listBuiltinExclusions, getRis
 
 // CreateRiskPolicy calls the "createRiskPolicy" endpoint of the "risk" service.
 // CreateRiskPolicy may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid
@@ -213,6 +215,8 @@ func (c *Client) GetRiskPolicy(ctx context.Context, p *GetRiskPolicyPayload) (re
 
 // UpdateRiskPolicy calls the "updateRiskPolicy" endpoint of the "risk" service.
 // UpdateRiskPolicy may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid
@@ -1056,6 +1060,8 @@ func (c *Client) DeleteRiskExclusion(ctx context.Context, p *DeleteRiskExclusion
 // SuggestCustomDetectionRule calls the "suggestCustomDetectionRule" endpoint
 // of the "risk" service.
 // SuggestCustomDetectionRule may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid
@@ -1078,6 +1084,8 @@ func (c *Client) SuggestCustomDetectionRule(ctx context.Context, p *SuggestCusto
 
 // SuggestExclusion calls the "suggestExclusion" endpoint of the "risk" service.
 // SuggestExclusion may return the following errors:
+//   - "unavailable" (type *goa.ServiceError): service temporarily unavailable
+//   - "ai_access_denied" (type *goa.ServiceError): AI access denied
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid

--- a/server/gen/risk/service.go
+++ b/server/gen/risk/service.go
@@ -1643,3 +1643,13 @@ func MakeUnexpected(err error) *goa.ServiceError {
 func MakeGatewayError(err error) *goa.ServiceError {
 	return goa.NewServiceError(err, "gateway_error", false, false, true)
 }
+
+// MakeUnavailable builds a goa.ServiceError from an error.
+func MakeUnavailable(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "unavailable", false, false, true)
+}
+
+// MakeAiAccessDenied builds a goa.ServiceError from an error.
+func MakeAiAccessDenied(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "ai_access_denied", false, false, false)
+}

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -618,8 +618,7 @@ func TestRearmTrial_OrganizationWithNoKeysSucceeds(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err, "an organization with no key of a type must still be re-armable")
 
-	//nolint:exhaustive // the absent key type is the assertion: it must not appear
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeChat: conv.PtrEmpty(50)}, provisioner.revivedLimits(),
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeChat: conv.PtrEmpty(50)}, provisioner.revivedLimits(), //nolint:exhaustive // missing type is the assertion
 		"a key type the organization has no row for must not be refreshed")
 
 	state := readOrgState(t, ctx, conn, orgID)
@@ -644,8 +643,7 @@ func TestRearmTrial_OrganizationWithOnlyAnInternalKeySucceeds(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err)
 
-	//nolint:exhaustive // the absent key type is the assertion: it must not appear
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(), //nolint:exhaustive // missing type is the assertion
 		"a key that follows an absent one must still come back up")
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)
 }
@@ -667,8 +665,7 @@ func TestRearmTrial_AlreadyEnabledKeyIsLeftAlone(t *testing.T) {
 	_, err := svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
 	require.NoError(t, err)
 
-	//nolint:exhaustive // the omitted key type is the assertion: it was already live
-	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(),
+	require.Equal(t, map[openrouter.KeyType]*int{openrouter.KeyTypeInternal: conv.PtrEmpty(37)}, provisioner.revivedLimits(), //nolint:exhaustive // missing type is the assertion
 		"an already-enabled key needs no upstream round trip")
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).Disabled)
 	require.False(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).Disabled)

--- a/server/internal/auth/chatsessions/jwt.go
+++ b/server/internal/auth/chatsessions/jwt.go
@@ -9,6 +9,15 @@ import (
 	"github.com/google/uuid"
 )
 
+// GramSessionActingUserClaim binds a chat JWT to the ordinary validated Gram
+// session that minted it. Its values must match the token's ordinary identity
+// claims before authorization stamps governed acting-user provenance.
+type GramSessionActingUserClaim struct {
+	OrgID     string `json:"org_id"`
+	UserID    string `json:"user_id"`
+	SessionID string `json:"session_id"`
+}
+
 // ChatSessionClaims represents the custom claims for a chat session JWT
 type ChatSessionClaims struct {
 	OrgID            string  `json:"org_id"`
@@ -26,6 +35,9 @@ type ChatSessionClaims struct {
 	// AccountType is the organization's billing tier (e.g. "enterprise").
 	// It is carried as session metadata and does not control RBAC enforcement.
 	AccountType string `json:"account_type,omitempty"`
+	// GramSessionActingUser is present only when chatsessions.Create ran with
+	// immutable ordinary validated Gram-session provenance.
+	GramSessionActingUser *GramSessionActingUserClaim `json:"gram_session_acting_user,omitempty"`
 	jwt.RegisteredClaims
 }
 

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -126,5 +126,15 @@ func (m *Manager) Authorize(ctx context.Context, token string) (context.Context,
 		SupportOrganizationID: "",
 	}
 
-	return contextvalues.SetAuthContext(ctx, authCtx), nil
+	authorizedCtx := contextvalues.SetAuthContext(ctx, authCtx)
+	if provenance := claims.GramSessionActingUser; provenance != nil &&
+		provenance.OrgID != "" && provenance.OrgID == claims.OrgID &&
+		provenance.UserID != "" && provenance.UserID == claims.UserID &&
+		provenance.SessionID != "" && claims.SessionID != nil && provenance.SessionID == *claims.SessionID {
+		authorizedCtx = contextvalues.WithValidatedChatSessionActingUser(
+			authorizedCtx, provenance.OrgID, provenance.UserID, provenance.SessionID,
+		)
+	}
+
+	return authorizedCtx, nil
 }

--- a/server/internal/auth/chatsessions/manager_test.go
+++ b/server/internal/auth/chatsessions/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -22,6 +23,16 @@ func testClaims() chatsessions.ChatSessionClaims {
 		ProjectSlug:      "test-project",
 		UserID:           "user-123",
 	}
+}
+
+func governedTestClaims() chatsessions.ChatSessionClaims {
+	claims := testClaims()
+	sessionID := "session-123"
+	claims.SessionID = &sessionID
+	claims.GramSessionActingUser = &chatsessions.GramSessionActingUserClaim{
+		OrgID: claims.OrgID, UserID: claims.UserID, SessionID: sessionID,
+	}
+	return claims
 }
 
 func requireUnauthorized(t *testing.T, err error) {
@@ -70,13 +81,15 @@ func TestManagerAuthorize_RevokedToken(t *testing.T) {
 	ctx := t.Context()
 	mgr := newTestManager(t)
 
-	token, jti, err := mgr.GenerateToken(ctx, testClaims(), "https://example.com", 3600)
+	token, jti, err := mgr.GenerateToken(ctx, governedTestClaims(), "https://example.com", 3600)
 	require.NoError(t, err)
 
 	require.NoError(t, mgr.RevokeToken(ctx, jti))
 
-	_, err = mgr.Authorize(ctx, token)
+	authorizedCtx, err := mgr.Authorize(ctx, token)
 	requireUnauthorized(t, err)
+	_, stamped := contextvalues.ValidatedChatSessionActingUser(authorizedCtx)
+	require.False(t, stamped)
 }
 
 func TestManagerAuthorize_RevocationCheckUnavailable(t *testing.T) {
@@ -124,4 +137,54 @@ func TestManagerAuthorize_ValidToken(t *testing.T) {
 	require.Equal(t, claims.OrgID, authCtx.ActiveOrganizationID)
 	require.Equal(t, claims.ProjectID, authCtx.ProjectID.String())
 	require.Equal(t, claims.UserID, authCtx.UserID)
+	_, governed := contextvalues.ValidatedChatSessionActingUser(authorizedCtx)
+	require.False(t, governed, "old and unstamped chat JWTs remain unsupported")
+}
+
+func TestManagerAuthorize_StampsMatchingOrdinarySessionClaim(t *testing.T) {
+	t.Parallel()
+
+	mgr := newTestManager(t)
+	claims := governedTestClaims()
+	token, _, err := mgr.GenerateToken(t.Context(), claims, "https://example.com", 3600)
+	require.NoError(t, err)
+
+	authorizedCtx, err := mgr.Authorize(t.Context(), token)
+	require.NoError(t, err)
+	provenance, ok := contextvalues.ValidatedChatSessionActingUser(authorizedCtx)
+	require.True(t, ok)
+	require.Equal(t, claims.OrgID, provenance.OrganizationID())
+	require.Equal(t, claims.UserID, provenance.UserID())
+	require.Equal(t, *claims.SessionID, provenance.SessionID())
+}
+
+func TestManagerAuthorize_DoesNotStampMismatchedOrIncompleteClaim(t *testing.T) {
+	t.Parallel()
+
+	for name, mutate := range map[string]func(*chatsessions.ChatSessionClaims){
+		"organization mismatch": func(c *chatsessions.ChatSessionClaims) { c.GramSessionActingUser.OrgID = "org-other" },
+		"user mismatch":         func(c *chatsessions.ChatSessionClaims) { c.GramSessionActingUser.UserID = "owner-substitute" },
+		"session mismatch":      func(c *chatsessions.ChatSessionClaims) { c.GramSessionActingUser.SessionID = "session-other" },
+		"missing marker":        func(c *chatsessions.ChatSessionClaims) { c.GramSessionActingUser = nil },
+		"missing user":          func(c *chatsessions.ChatSessionClaims) { c.GramSessionActingUser.UserID = "" },
+		"missing claim session": func(c *chatsessions.ChatSessionClaims) { c.SessionID = nil },
+		"shared demo": func(c *chatsessions.ChatSessionClaims) {
+			c.OrgID = constants.DemoOrganizationID
+			c.GramSessionActingUser.OrgID = constants.DemoOrganizationID
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			mgr := newTestManager(t)
+			claims := governedTestClaims()
+			mutate(&claims)
+			token, _, err := mgr.GenerateToken(t.Context(), claims, "https://example.com", 3600)
+			require.NoError(t, err)
+
+			authorizedCtx, err := mgr.Authorize(t.Context(), token)
+			require.NoError(t, err, "legacy token authorization remains compatible")
+			_, ok := contextvalues.ValidatedChatSessionActingUser(authorizedCtx)
+			require.False(t, ok)
+		})
+	}
 }

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -320,6 +321,10 @@ If there are no tool calls, return an empty array.`, userPromptText)
 		Strict:      nil,
 	}
 
+	analysisCtx, err := hostedinference.WithBackground(analysisCtx, hostedinference.CallCategoryChatResolution)
+	if err != nil {
+		return nil, fmt.Errorf("classify chat-resolution analysis: %w", err)
+	}
 	response, err := a.chatClient.GetObjectCompletion(
 		analysisCtx,
 		openrouter.ObjectCompletionRequest{

--- a/server/internal/background/activities/chat_resolutions/segment_chat.go
+++ b/server/internal/background/activities/chat_resolutions/segment_chat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
@@ -175,6 +176,10 @@ There are %d messages total (indices 0-%d).%s`, conversationText, numMessages, n
 	}
 
 	// Use Haiku (cheaper model) for segmentation
+	analysisCtx, err := hostedinference.WithBackground(analysisCtx, hostedinference.CallCategoryChatResolution)
+	if err != nil {
+		return nil, fmt.Errorf("classify chat-resolution segmentation: %w", err)
+	}
 	response, err := s.chatClient.GetObjectCompletion(
 		analysisCtx,
 		openrouter.ObjectCompletionRequest{

--- a/server/internal/background/activities/generate_chat_title.go
+++ b/server/internal/background/activities/generate_chat_title.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
@@ -158,6 +159,10 @@ func (g *GenerateChatTitle) generateTitle(ctx context.Context, orgID, projectID 
 		"Do NOT expand, interpret, or replace abbreviations or acronyms — use the user's exact terminology. " +
 		"If the conversation is a greeting, vague, or lacks a clear topic, return exactly: " + defaultChatTitle
 
+	titleCtx, err := hostedinference.WithBackground(titleCtx, hostedinference.CallCategoryAutomaticChatTitle)
+	if err != nil {
+		return defaultChatTitle
+	}
 	response, err := g.chatClient.GetCompletion(titleCtx, openrouter.CompletionRequest{
 		OrgID:     orgID,
 		ProjectID: projectID,

--- a/server/internal/businessmemory/hosted_inference_service_test.go
+++ b/server/internal/businessmemory/hosted_inference_service_test.go
@@ -1,0 +1,128 @@
+package businessmemory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/business_memories"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+const businessMemoryDenialNote = "Hosted inference is paused for this account."
+
+type businessMemoryEvaluator struct {
+	result killswitches.EvaluationResult
+	calls  int
+}
+
+func (e *businessMemoryEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+	e.calls++
+	return e.result
+}
+
+type businessMemoryCompletionClient struct {
+	checkpoint hostedinference.AttemptCheckpoint
+}
+
+func (c *businessMemoryCompletionClient) check(ctx context.Context, organizationID string) error {
+	if err := c.checkpoint.Check(ctx, organizationID); err != nil {
+		return fmt.Errorf("check hosted inference: %w", err)
+	}
+	return nil
+}
+
+func (c *businessMemoryCompletionClient) GetCompletion(ctx context.Context, request openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *businessMemoryCompletionClient) GetCompletionStream(ctx context.Context, request openrouter.CompletionRequest) (openrouter.StreamReader, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *businessMemoryCompletionClient) GetObjectCompletion(ctx context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *businessMemoryCompletionClient) CreateEmbeddings(ctx context.Context, orgID string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
+	return nil, c.check(ctx, orgID)
+}
+
+func (c *businessMemoryCompletionClient) ResolveKey(context.Context, string, string, billing.ModelUsageSource, openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	return openrouter.PlatformKey(), nil
+}
+
+func TestSearchBusinessMemoriesPreservesGovernedClassificationThroughAgenticClient(t *testing.T) {
+	t.Parallel()
+
+	infra, cleanup, err := testenv.Launch(t.Context(), testenv.LaunchOptions{Postgres: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+	conn, err := infra.CloneTestDatabase(t, "business_memory_hosted_inference")
+	require.NoError(t, err)
+
+	const organizationID = "org_test"
+	const userID = "user_test"
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID: organizationID, Name: "Test Organization", Slug: "test-organization", WorkosID: conv.ToPGText(organizationID), Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = usersrepo.New(conn).UpsertUser(t.Context(), usersrepo.UpsertUserParams{
+		ID: userID, Email: "user@example.invalid", DisplayName: "Test User", PhotoUrl: pgtype.Text{}, Admin: false,
+	})
+	require.NoError(t, err)
+	_, err = orgrepo.New(conn).UpsertOrganizationUserRelationship(t.Context(), orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID, UserID: conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	project, err := projectsrepo.New(conn).CreateProject(t.Context(), projectsrepo.CreateProjectParams{
+		Name: "Test Project", Slug: "test-project", OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+
+	registry, err := mcptoolexecution.NewRegistry(conn)
+	require.NoError(t, err)
+	result, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", businessMemoryDenialNote)
+	require.NoError(t, err)
+	evaluator := &businessMemoryEvaluator{result: result}
+	checkpoint, err := hostedinference.NewCheckpoint(registry, evaluator, time.Second)
+	require.NoError(t, err)
+	gate := &businessMemoryCompletionClient{checkpoint: checkpoint}
+	logger := testenv.NewLogger(t)
+	client := chat.NewAgenticChatClient(logger, nil, nil, nil, gate, nil)
+	service := &Service{
+		logger: logger, db: conn, completions: client,
+		authz: authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()),
+	}
+	sessionID := "session_test"
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: organizationID, UserID: userID, SessionID: &sessionID, ProjectID: &project.ID,
+	}, false)
+	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource))
+
+	_, err = service.SearchBusinessMemories(ctx, &gen.SearchBusinessMemoriesPayload{Query: "placeholder query", Limit: 10})
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeAIAccessDenied, shareable.Code)
+	require.Equal(t, businessMemoryDenialNote, shareable.Error())
+	require.Equal(t, 1, evaluator.calls)
+}

--- a/server/internal/businessmemory/impl.go
+++ b/server/internal/businessmemory/impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/businessmemory/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -205,6 +206,10 @@ func (s *Service) SearchBusinessMemories(ctx context.Context, payload *gen.Searc
 		return nil, oops.E(oops.CodeBadRequest, nil, "query is required")
 	}
 
+	ctx, err = hostedinference.WithGovernedUserOrUnsupported(ctx, hostedinference.CallCategoryBusinessMemorySearchEmbedding, hostedinference.CallCategoryAPIKeyBusinessMemorySearch, hostedinference.CallCategoryNonOrdinarySessionMemorySearch)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "classify business memory search inference").LogError(ctx, s.logger)
+	}
 	vectors, err := s.completions.CreateEmbeddings(
 		ctx,
 		authCtx.ActiveOrganizationID,
@@ -214,6 +219,10 @@ func (s *Service) SearchBusinessMemories(ctx context.Context, payload *gen.Searc
 		openrouter.WithEmbeddingKeyType(openrouter.KeyTypeInternal),
 	)
 	if err != nil {
+		//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+		if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+			return nil, mapped
+		}
 		return nil, oops.E(oops.CodeUnexpected, err, "create business memory search embedding").LogError(ctx, s.logger)
 	}
 	if len(vectors) != 1 {

--- a/server/internal/businessmemory/judge.go
+++ b/server/internal/businessmemory/judge.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/businessmemory/repo"
 	"github.com/speakeasy-api/gram/server/internal/chat/analysis"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
@@ -301,9 +302,12 @@ func (j *Judge) persist(
 	}
 	var vectors [][]float32
 	if len(inputs) > 0 {
-		var err error
+		callCtx, err := hostedinference.WithBackground(ctx, hostedinference.CallCategoryBusinessMemoryJudge)
+		if err != nil {
+			return nil, fmt.Errorf("classify business-memory judge inference: %w", err)
+		}
 		vectors, err = j.client.CreateEmbeddings(
-			ctx,
+			callCtx,
 			in.OrgID,
 			embeddingModel,
 			inputs,

--- a/server/internal/chat/agent_client.go
+++ b/server/internal/chat/agent_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -145,6 +146,10 @@ func (c *Client) AgentChat(
 	prompt string,
 	opts AgentChatOptions,
 ) (string, error) {
+	ctx, err := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantChat)
+	if err != nil {
+		return "", fmt.Errorf("classify assistant chat: %w", err)
+	}
 	if opts.AgentTimeout != nil {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, *opts.AgentTimeout)

--- a/server/internal/chat/agent_client_forwarding_test.go
+++ b/server/internal/chat/agent_client_forwarding_test.go
@@ -1,0 +1,113 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+type forwardingCompletionClient struct {
+	t       *testing.T
+	wantCtx context.Context //nolint:containedctx // This test spy verifies that the exact context is forwarded.
+	calls   map[string]int
+}
+
+func (c *forwardingCompletionClient) record(ctx context.Context, method string) {
+	c.t.Helper()
+	require.Equal(c.t, c.wantCtx, ctx)
+	c.calls[method]++
+}
+
+func (c *forwardingCompletionClient) GetCompletion(ctx context.Context, _ openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+	c.record(ctx, "GetCompletion")
+	return &openrouter.CompletionResponse{}, nil
+}
+
+func (c *forwardingCompletionClient) GetCompletionStream(ctx context.Context, _ openrouter.CompletionRequest) (openrouter.StreamReader, error) {
+	c.record(ctx, "GetCompletionStream")
+	return nil, nil
+}
+
+func (c *forwardingCompletionClient) GetObjectCompletion(ctx context.Context, _ openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+	c.record(ctx, "GetObjectCompletion")
+	return &openrouter.CompletionResponse{}, nil
+}
+
+func (c *forwardingCompletionClient) CreateEmbeddings(ctx context.Context, _ string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
+	c.record(ctx, "CreateEmbeddings")
+	return [][]float32{{1}}, nil
+}
+
+func (c *forwardingCompletionClient) ResolveKey(ctx context.Context, _ string, _ string, _ billing.ModelUsageSource, _ openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	c.record(ctx, "ResolveKey")
+	return openrouter.ResolvedKey{}, nil
+}
+
+func TestAgenticClientGenericMethodsPreserveCallerClassification(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := hostedinference.WithUnsupported(context.Background(), hostedinference.CallCategoryAPIKeyChat)
+	require.NoError(t, err)
+	underlying := &forwardingCompletionClient{t: t, wantCtx: ctx, calls: map[string]int{}}
+	client := &Client{completionClient: underlying}
+
+	_, err = client.GetCompletion(ctx, openrouter.CompletionRequest{})
+	require.NoError(t, err)
+	_, err = client.GetCompletionStream(ctx, openrouter.CompletionRequest{})
+	require.NoError(t, err)
+	_, err = client.GetObjectCompletion(ctx, openrouter.ObjectCompletionRequest{})
+	require.NoError(t, err)
+	_, err = client.CreateEmbeddings(ctx, "org", "model", []string{"input"})
+	require.NoError(t, err)
+	_, err = client.ResolveKey(ctx, "org", "project", billing.ModelUsageSourceGram, openrouter.KeyTypeChat)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]int{
+		"GetCompletion":       1,
+		"GetCompletionStream": 1,
+		"GetObjectCompletion": 1,
+		"CreateEmbeddings":    1,
+		"ResolveKey":          1,
+	}, underlying.calls)
+}
+
+func TestChatInferenceExclusionsRemainUnsupported(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		authCtx *contextvalues.AuthContext
+		keySlot billing.ModelUsageSource
+		prepare func(context.Context) context.Context
+	}{
+		"api key":             {authCtx: &contextvalues.AuthContext{APIKeyID: "key"}},
+		"nonordinary session": {authCtx: &contextvalues.AuthContext{}},
+		"chat-session jwt":    {authCtx: &contextvalues.AuthContext{}, keySlot: billing.ModelUsageSourceElements},
+		"assistant": {
+			authCtx: &contextvalues.AuthContext{},
+			prepare: func(ctx context.Context) context.Context {
+				return contextvalues.SetAssistantPrincipal(ctx, contextvalues.AssistantPrincipal{AssistantID: uuid.New()})
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := contextvalues.SetAuthContext(t.Context(), tt.authCtx)
+			if tt.prepare != nil {
+				ctx = tt.prepare(ctx)
+			}
+			classified, err := classifyChatInference(ctx, tt.keySlot)
+			require.NoError(t, err)
+			// Unsupported classes bypass before a checkpoint needs any injected
+			// principal, resource, evaluator, or transport dependency.
+			require.NoError(t, (&hostedinference.Checkpoint{}).Check(classified, "org"))
+		})
+	}
+}

--- a/server/internal/chat/analysis/judge.go
+++ b/server/internal/chat/analysis/judge.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -157,6 +158,10 @@ type StructuredCall struct {
 // returns the raw response text plus the model that produced it. Errors wrap
 // ErrModelFailure or ErrRetryable exactly as the publisher expects.
 func CallStructured(ctx context.Context, logger *slog.Logger, client openrouter.CompletionClient, limiter *ratelimit.Limiter, in JudgeInput, call StructuredCall) (string, string, error) {
+	ctx, classifyErr := hostedinference.WithInternal(ctx, hostedinference.CallCategoryChatAnalysis)
+	if classifyErr != nil {
+		return "", "", fmt.Errorf("classify chat analysis: %w", classifyErr)
+	}
 	// A Store outage is not a throttle: proceed rather than stall the pipeline on
 	// limiter infrastructure. A real throttle is retryable — the unit keeps its
 	// reservation and its attempt budget.
@@ -186,7 +191,6 @@ func CallStructured(ctx context.Context, logger *slog.Logger, client openrouter.
 
 	callCtx, cancel := context.WithTimeout(ctx, call.Timeout)
 	defer cancel()
-
 	response, err := client.GetObjectCompletion(callCtx, openrouter.ObjectCompletionRequest{
 		OrgID:        in.OrgID,
 		ProjectID:    in.ProjectID,

--- a/server/internal/chat/hosted_inference.go
+++ b/server/internal/chat/hosted_inference.go
@@ -1,0 +1,46 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+)
+
+func classifyChatInference(ctx context.Context, keySlot billing.ModelUsageSource) (context.Context, error) {
+	if _, ok := contextvalues.GetAssistantPrincipal(ctx); ok {
+		return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantChat))
+	}
+	if keySlot == billing.ModelUsageSourceElements {
+		if _, ok := contextvalues.ValidatedHostedInferenceActingUser(ctx); ok {
+			return wrapHostedInferenceClassification(hostedinference.WithGovernedUser(ctx, hostedinference.CallCategoryUserChatCompletion))
+		}
+		return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryChatSessionChat))
+	}
+	return wrapHostedInferenceClassification(hostedinference.WithGovernedUserOrUnsupported(
+		ctx,
+		hostedinference.CallCategoryUserChatCompletion,
+		hostedinference.CallCategoryAPIKeyChat,
+		hostedinference.CallCategoryNonOrdinaryGramSessionChat,
+	))
+}
+
+func classifySessionInference(ctx context.Context, governed, apiKey, nonOrdinary hostedinference.CallCategory) (context.Context, error) {
+	if _, ok := contextvalues.ValidatedGramSessionActingUser(ctx); ok {
+		return wrapHostedInferenceClassification(hostedinference.WithGovernedUser(ctx, governed))
+	}
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	if authCtx != nil && authCtx.APIKeyID != "" {
+		return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, apiKey))
+	}
+	return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, nonOrdinary))
+}
+
+func wrapHostedInferenceClassification(classified context.Context, err error) (context.Context, error) {
+	if err != nil {
+		return classified, fmt.Errorf("classify hosted inference: %w", err)
+	}
+	return classified, nil
+}

--- a/server/internal/chat/hosted_inference.go
+++ b/server/internal/chat/hosted_inference.go
@@ -27,15 +27,22 @@ func classifyChatInference(ctx context.Context, keySlot billing.ModelUsageSource
 	))
 }
 
-func classifySessionInference(ctx context.Context, governed, apiKey, nonOrdinary hostedinference.CallCategory) (context.Context, error) {
-	if _, ok := contextvalues.ValidatedGramSessionActingUser(ctx); ok {
-		return wrapHostedInferenceClassification(hostedinference.WithGovernedUser(ctx, governed))
-	}
-	authCtx, _ := contextvalues.GetAuthContext(ctx)
-	if authCtx != nil && authCtx.APIKeyID != "" {
-		return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, apiKey))
-	}
-	return wrapHostedInferenceClassification(hostedinference.WithUnsupported(ctx, nonOrdinary))
+func classifyChatSummaryInference(ctx context.Context) (context.Context, error) {
+	return wrapHostedInferenceClassification(hostedinference.WithGovernedUserOrUnsupported(
+		ctx,
+		hostedinference.CallCategoryChatSummary,
+		hostedinference.CallCategoryAPIKeyChatSummary,
+		hostedinference.CallCategoryNonOrdinarySessionChatSummary,
+	))
+}
+
+func classifyToolCallSummaryInference(ctx context.Context) (context.Context, error) {
+	return wrapHostedInferenceClassification(hostedinference.WithGovernedUserOrUnsupported(
+		ctx,
+		hostedinference.CallCategoryToolCallSummary,
+		hostedinference.CallCategoryAPIKeyToolCallSummary,
+		hostedinference.CallCategoryNonOrdinarySessionToolSummary,
+	))
 }
 
 func wrapHostedInferenceClassification(classified context.Context, err error) (context.Context, error) {

--- a/server/internal/chat/hosted_inference_service_test.go
+++ b/server/internal/chat/hosted_inference_service_test.go
@@ -1,0 +1,380 @@
+package chat_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/chat"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/auth"
+	authchatsessions "github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const hostedInferenceDenialNote = "Hosted inference is paused for this account."
+
+type fixedHostedInferenceEvaluator struct {
+	result  killswitches.EvaluationResult
+	results []killswitches.EvaluationResult
+	calls   int
+}
+
+func (e *fixedHostedInferenceEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+	result := e.result
+	if e.calls < len(e.results) {
+		result = e.results[e.calls]
+	}
+	e.calls++
+	return result
+}
+
+type checkpointCompletionClient struct {
+	checkpoint       hostedinference.AttemptCheckpoint
+	completionCalls  int
+	streamCalls      int
+	providerAttempts int
+}
+
+func (c *checkpointCompletionClient) check(ctx context.Context, organizationID string) error {
+	if err := c.checkpoint.Check(ctx, organizationID); err != nil {
+		return fmt.Errorf("check hosted inference: %w", err)
+	}
+	return nil
+}
+
+func (c *checkpointCompletionClient) GetCompletion(ctx context.Context, request openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+	c.completionCalls++
+	if err := c.check(ctx, request.OrgID); err != nil {
+		return nil, err
+	}
+	c.providerAttempts++
+	return assistantTextResponse("unused"), nil
+}
+
+func (c *checkpointCompletionClient) GetCompletionStream(ctx context.Context, request openrouter.CompletionRequest) (openrouter.StreamReader, error) {
+	c.streamCalls++
+	if err := c.check(ctx, request.OrgID); err != nil {
+		return nil, err
+	}
+	c.providerAttempts++
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (c *checkpointCompletionClient) GetObjectCompletion(ctx context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+	if err := c.check(ctx, request.OrgID); err != nil {
+		return nil, err
+	}
+	return assistantTextResponse("unused"), nil
+}
+
+func (c *checkpointCompletionClient) CreateEmbeddings(ctx context.Context, orgID string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
+	if err := c.check(ctx, orgID); err != nil {
+		return nil, err
+	}
+	return [][]float32{{1}}, nil
+}
+
+func (c *checkpointCompletionClient) ResolveKey(context.Context, string, string, billing.ModelUsageSource, openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	return openrouter.PlatformKey(), nil
+}
+
+func newChatServiceWithEvaluation(t *testing.T, result killswitches.EvaluationResult) (*chatTestInstance, *fixedHostedInferenceEvaluator, *checkpointCompletionClient) {
+	t.Helper()
+
+	gate := &checkpointCompletionClient{}
+	client := chat.NewAgenticChatClient(testenv.NewLogger(t), nil, nil, nil, gate, nil)
+	ti := newTestChatServiceWithCompletion(t, client)
+	registry, err := mcptoolexecution.NewRegistry(ti.conn)
+	require.NoError(t, err)
+	evaluator := &fixedHostedInferenceEvaluator{result: result}
+	gate.checkpoint, err = hostedinference.NewCheckpoint(registry, evaluator, time.Second)
+	require.NoError(t, err)
+	return ti, evaluator, gate
+}
+
+func newDeniedChatService(t *testing.T) (*chatTestInstance, *fixedHostedInferenceEvaluator) {
+	t.Helper()
+	result, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", hostedInferenceDenialNote)
+	require.NoError(t, err)
+	ti, evaluator, _ := newChatServiceWithEvaluation(t, result)
+	return ti, evaluator
+}
+
+func requireHostedInferenceDenial(t *testing.T, err error) {
+	t.Helper()
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeAIAccessDenied, shareable.Code)
+	require.Equal(t, hostedInferenceDenialNote, shareable.Error())
+}
+
+func completionRequest(t *testing.T, ti *chatTestInstance, sessionToken, chatToken, projectSlug, query string, stream bool) *http.Request {
+	t.Helper()
+	ctx := initSessionCtx(t, ti)
+	if projectSlug == "" {
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok)
+		require.NotNil(t, authCtx.ProjectSlug)
+		projectSlug = *authCtx.ProjectSlug
+	}
+
+	body := []byte(`{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}],"stream":` + fmt.Sprint(stream) + `}`)
+	req := httptest.NewRequest(http.MethodPost, "/chat/completions"+query, bytes.NewReader(body)).WithContext(ctx)
+	req.Header.Set(constants.ProjectHeader, projectSlug)
+	if sessionToken != "" {
+		req.Header.Set(constants.SessionHeader, sessionToken)
+	}
+	if chatToken != "" {
+		req.Header.Set(constants.ChatSessionsTokenHeader, chatToken)
+	}
+	return req
+}
+
+func serveCompletion(t *testing.T, ti *chatTestInstance, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	oops.ErrHandle(testenv.NewLogger(t), ti.service.HandleCompletion).ServeHTTP(recorder, req)
+	return recorder
+}
+
+func requireCompletionError(t *testing.T, recorder *httptest.ResponseRecorder, status int, code oops.Code, message string) {
+	t.Helper()
+	require.Equal(t, status, recorder.Code, recorder.Body.String())
+	require.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	require.NotEqual(t, "text/event-stream", recorder.Header().Get("Content-Type"))
+	var payload struct {
+		Name    string `json:"name"`
+		Message string `json:"message"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+	require.Equal(t, string(code), payload.Name)
+	require.Equal(t, message, payload.Message)
+}
+
+func mintRouteChatToken(t *testing.T, ti *chatTestInstance, governed bool) (string, string) {
+	t.Helper()
+	ctx := testenv.InitAuthContext(t, t.Context(), ti.conn, ti.sessions)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.SessionID)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.ProjectSlug)
+
+	selectors, err := authz.NewSelector(authz.ScopeProjectRead, authCtx.ProjectID.String()).MarshalJSON()
+	require.NoError(t, err)
+	_, err = accessrepo.New(ti.conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		Scope:          string(authz.ScopeProjectRead),
+		Selectors:      selectors,
+	})
+	require.NoError(t, err)
+	claims := authchatsessions.ChatSessionClaims{
+		OrgID: authCtx.ActiveOrganizationID, ProjectID: authCtx.ProjectID.String(),
+		OrganizationSlug: authCtx.OrganizationSlug, ProjectSlug: *authCtx.ProjectSlug,
+		UserID: authCtx.UserID, SessionID: authCtx.SessionID, AccountType: authCtx.AccountType,
+	}
+	if governed {
+		claims.GramSessionActingUser = &authchatsessions.GramSessionActingUserClaim{
+			OrgID: claims.OrgID, UserID: claims.UserID, SessionID: *claims.SessionID,
+		}
+	}
+	token, _, err := ti.chatSessions.GenerateToken(ctx, claims, "https://example.com", 3600)
+	require.NoError(t, err)
+	_, err = ti.chatSessions.Authorize(ctx, token)
+	require.NoError(t, err)
+	return token, *authCtx.ProjectSlug
+}
+
+func mintRouteAPIKey(t *testing.T, ti *chatTestInstance) (string, string) {
+	t.Helper()
+	ctx := testenv.InitAuthContext(t, t.Context(), ti.conn, ti.sessions)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.ProjectSlug)
+
+	key := "gram_local_" + uuid.NewString()
+	hash, err := auth.GetAPIKeyHash(key)
+	require.NoError(t, err)
+	_, err = keysrepo.New(ti.conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: authCtx.UserID, Name: "route-test-key", KeyPrefix: key[:16], KeyHash: hash, Scopes: []string{"chat"},
+	})
+	require.NoError(t, err)
+	return key, *authCtx.ProjectSlug
+}
+
+func TestHandleCompletionGovernedSessionDenialWithOptionalContextWindow(t *testing.T) {
+	t.Parallel()
+
+	for _, includeContextWindow := range []bool{false, true} {
+		t.Run(fmt.Sprintf("include context window %t", includeContextWindow), func(t *testing.T) {
+			t.Parallel()
+			result, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", hostedInferenceDenialNote)
+			require.NoError(t, err)
+			ti, evaluator, gate := newChatServiceWithEvaluation(t, result)
+			ctx := initSessionCtx(t, ti)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			query := ""
+			if includeContextWindow {
+				query = "?includeContextWindow=1"
+			}
+			req := completionRequest(t, ti, *authCtx.SessionID, "", "", query, true)
+			recorder := serveCompletion(t, ti, req)
+
+			requireCompletionError(t, recorder, http.StatusForbidden, oops.CodeAIAccessDenied, hostedInferenceDenialNote)
+			require.Equal(t, 1, evaluator.calls)
+			require.Zero(t, gate.providerAttempts)
+			require.Equal(t, 1, gate.streamCalls, "the completion client's common checkpoint owns the denial")
+		})
+	}
+}
+
+func TestHandleCompletionEmptyStreamFallbackRechecksHostedInference(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
+	require.NoError(t, err)
+	denied, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", hostedInferenceDenialNote)
+	require.NoError(t, err)
+	ti, evaluator, gate := newChatServiceWithEvaluation(t, denied)
+	evaluator.results = []killswitches.EvaluationResult{allowed, denied}
+
+	ctx := initSessionCtx(t, ti)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	req := completionRequest(t, ti, *authCtx.SessionID, "", "", "", false)
+	req.Header.Set("Gram-Chat-ID", uuid.NewString())
+	recorder := serveCompletion(t, ti, req)
+
+	requireCompletionError(t, recorder, http.StatusForbidden, oops.CodeAIAccessDenied, hostedInferenceDenialNote)
+	require.Equal(t, 2, evaluator.calls, "the empty stream is allowed before the fallback is denied")
+	require.Equal(t, 1, gate.streamCalls)
+	require.Equal(t, 1, gate.completionCalls)
+	require.Equal(t, 1, gate.providerAttempts, "the denied plain fallback must not reach its provider delegate")
+}
+
+func TestHandleCompletionSessionBackedChatJWTAndLegacyJWTClassification(t *testing.T) {
+	t.Parallel()
+
+	result, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", hostedInferenceDenialNote)
+	require.NoError(t, err)
+
+	t.Run("matching ordinary-session claim is governed", func(t *testing.T) {
+		t.Parallel()
+		ti, evaluator, gate := newChatServiceWithEvaluation(t, result)
+		token, projectSlug := mintRouteChatToken(t, ti, true)
+		req := completionRequest(t, ti, "", token, projectSlug, "", true)
+		recorder := serveCompletion(t, ti, req)
+		requireCompletionError(t, recorder, http.StatusForbidden, oops.CodeAIAccessDenied, hostedInferenceDenialNote)
+		require.Equal(t, 1, evaluator.calls)
+		require.Zero(t, gate.providerAttempts)
+	})
+
+	t.Run("old unstamped token remains unsupported", func(t *testing.T) {
+		t.Parallel()
+		ti, evaluator, gate := newChatServiceWithEvaluation(t, result)
+		token, projectSlug := mintRouteChatToken(t, ti, false)
+		req := completionRequest(t, ti, "", token, projectSlug, "", false)
+		recorder := serveCompletion(t, ti, req)
+		require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+		require.Zero(t, evaluator.calls)
+		require.Equal(t, 1, gate.providerAttempts)
+	})
+
+	t.Run("API key creator remains unsupported", func(t *testing.T) {
+		t.Parallel()
+		ti, evaluator, gate := newChatServiceWithEvaluation(t, result)
+		key, projectSlug := mintRouteAPIKey(t, ti)
+		req := completionRequest(t, ti, "", "", projectSlug, "", false)
+		req.Header.Set(constants.APIKeyHeader, key)
+		recorder := serveCompletion(t, ti, req)
+		require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+		require.Zero(t, evaluator.calls)
+		require.Equal(t, 1, gate.providerAttempts)
+	})
+}
+
+func TestHandleCompletionEvaluatorUnavailableIsGeneric503(t *testing.T) {
+	t.Parallel()
+
+	result, err := killswitches.NewInfrastructureFailureResult(errors.New("private evaluator detail"))
+	require.NoError(t, err)
+	ti, evaluator, gate := newChatServiceWithEvaluation(t, result)
+	ctx := initSessionCtx(t, ti)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	req := completionRequest(t, ti, *authCtx.SessionID, "", "", "", true)
+	recorder := serveCompletion(t, ti, req)
+	requireCompletionError(t, recorder, http.StatusServiceUnavailable, oops.CodeUnavailable, oops.CodeUnavailable.UserMessage())
+	require.NotContains(t, recorder.Body.String(), "private evaluator detail")
+	require.Equal(t, 1, evaluator.calls)
+	require.Zero(t, gate.providerAttempts)
+}
+
+func TestServiceSummarizePreservesGovernedClassificationThroughAgenticClient(t *testing.T) {
+	t.Parallel()
+
+	ti, evaluator := newDeniedChatService(t)
+	ctx := initSessionCtx(t, ti)
+	chatID := seedChat(t, ctx, ti, "", "external-user", "Denied summary")
+	seedMessageContent(t, ctx, ti, chatID, "summarize this")
+
+	_, err := ti.service.Summarize(ctx, &gen.SummarizePayload{ID: chatID.String()})
+	requireHostedInferenceDenial(t, err)
+	require.Equal(t, 1, evaluator.calls)
+}
+
+func TestServiceSummarizeToolCallPreservesGovernedClassificationThroughAgenticClient(t *testing.T) {
+	t.Parallel()
+
+	ti, evaluator := newDeniedChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+	chatID := seedChat(t, ctx, ti, "", "external-user", "Denied tool summary")
+	toolCallID := "call_test"
+	queries := repo.New(ti.conn)
+	messageID, err := queries.CreateChatMessageReturningID(ctx, repo.CreateChatMessageReturningIDParams{
+		ChatID: chatID, ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true}, Role: "assistant", Content: "",
+		ToolCalls: []byte(`[{"id":"call_test","type":"function","function":{"name":"lookup","arguments":{}}}]`),
+	})
+	require.NoError(t, err)
+	_, err = queries.CreateChatMessageReturningID(ctx, repo.CreateChatMessageReturningIDParams{
+		ChatID: chatID, ProjectID: uuid.NullUUID{UUID: ti.projectID, Valid: true}, Role: "tool", Content: "result",
+		ToolCallID: pgtype.Text{String: toolCallID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.SummarizeToolCall(ctx, &gen.SummarizeToolCallPayload{
+		ID: chatID.String(), MessageID: messageID.String(), ToolCallID: toolCallID,
+	})
+	requireHostedInferenceDenial(t, err)
+	require.Equal(t, 1, evaluator.calls)
+}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -50,6 +50,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -1468,6 +1469,10 @@ func IsHistoryCorrupted(err error) bool {
 // completion client into the oops code that should flow back to the caller
 // (and through the runner to the assistant runtime).
 func (s *Service) classifyCompletionError(ctx context.Context, label string, err error) error {
+	//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+	if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+		return mapped
+	}
 	switch {
 	case openrouter.IsPlatformKeyDisabled(err):
 		return oops.C(oops.CodeInferenceDisabled).LogError(ctx, s.logger)
@@ -1591,6 +1596,11 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 		keySlot = billing.ModelUsageSourceAssistants
 	}
 	sourceName := string(source)
+
+	ctx, err = classifyChatInference(ctx, keySlot)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "classify hosted inference").LogError(ctx, s.logger)
+	}
 
 	eventProperties := map[string]any{
 		"action":            "chat_request_received",
@@ -1761,8 +1771,14 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	// (and its OpenRouter round trip on cache miss) is never called.
 	getContextWindow := func() int { return 0 }
 	if r.URL.Query().Get("includeContextWindow") == "1" {
+		// Metadata lookup starts concurrently with the provider call. The
+		// resolver's checkpoint-aware Guardian transport evaluates immediately
+		// before every OpenRouter attempt and retry.
 		resolved := sync.OnceValue(func() int {
-			return s.resolveContextWindow(ctx, completionReq.Model)
+			if s.contextWindow == nil {
+				return 0
+			}
+			return s.resolveContextWindow(ctx, orgID, completionReq.Model)
 		})
 		go resolved()
 		getContextWindow = resolved
@@ -1861,7 +1877,7 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	return nil
 }
 
-func (s *Service) resolveContextWindow(ctx context.Context, requestedModel string) int {
+func (s *Service) resolveContextWindow(ctx context.Context, organizationID, requestedModel string) int {
 	model := requestedModel
 	if model == "" {
 		model = openrouter.DefaultChatModel
@@ -1870,7 +1886,7 @@ func (s *Service) resolveContextWindow(ctx context.Context, requestedModel strin
 		model = resolved
 	}
 
-	tokens, err := s.contextWindow.Resolve(ctx, model)
+	tokens, err := s.contextWindow.ResolveGoverned(ctx, organizationID, model)
 	if err != nil {
 		s.logger.WarnContext(ctx, "resolve model context window", attr.SlogError(err), attr.SlogGenAIRequestModel(model))
 		return 0
@@ -2235,6 +2251,10 @@ func (s *Service) Summarize(ctx context.Context, payload *gen.SummarizePayload) 
 
 	summaryCtx, cancel := context.WithTimeout(ctx, summarizeCompletionTimeout)
 	defer cancel()
+	summaryCtx, err = classifySessionInference(summaryCtx, hostedinference.CallCategoryChatSummary, hostedinference.CallCategoryAPIKeyChatSummary, hostedinference.CallCategoryNonOrdinarySessionChatSummary)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "classify chat summary inference").LogError(ctx, s.logger)
+	}
 
 	systemPrompt := "You summarize agent session transcripts for an operations dashboard. " +
 		"Write a concise summary in 2-4 short paragraphs covering: the user's goal, " +
@@ -2271,6 +2291,10 @@ func (s *Service) Summarize(ctx context.Context, payload *gen.SummarizePayload) 
 		DisableResponseHealing:    false,
 	})
 	if err != nil {
+		//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+		if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+			return nil, mapped
+		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to generate summary").LogError(ctx, s.logger)
 	}
 	if response == nil || response.Message == nil {
@@ -2423,6 +2447,10 @@ func (s *Service) SummarizeToolCall(ctx context.Context, payload *gen.SummarizeT
 
 	summaryCtx, cancel := context.WithTimeout(ctx, summarizeCompletionTimeout)
 	defer cancel()
+	summaryCtx, err = classifySessionInference(summaryCtx, hostedinference.CallCategoryToolCallSummary, hostedinference.CallCategoryAPIKeyToolCallSummary, hostedinference.CallCategoryNonOrdinarySessionToolSummary)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "classify tool-call summary inference").LogError(ctx, s.logger)
+	}
 	strict := true
 	jsonSchema := or.ChatJSONSchemaConfig{
 		Name: "tool_call_summary",
@@ -2457,6 +2485,10 @@ func (s *Service) SummarizeToolCall(ctx context.Context, payload *gen.SummarizeT
 		WebSearch: nil, DisableResponseHealing: false,
 	})
 	if err != nil {
+		//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+		if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+			return nil, mapped
+		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to summarize tool call").LogError(ctx, s.logger)
 	}
 	if response == nil || response.Message == nil {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -2251,7 +2251,7 @@ func (s *Service) Summarize(ctx context.Context, payload *gen.SummarizePayload) 
 
 	summaryCtx, cancel := context.WithTimeout(ctx, summarizeCompletionTimeout)
 	defer cancel()
-	summaryCtx, err = classifySessionInference(summaryCtx, hostedinference.CallCategoryChatSummary, hostedinference.CallCategoryAPIKeyChatSummary, hostedinference.CallCategoryNonOrdinarySessionChatSummary)
+	summaryCtx, err = classifyChatSummaryInference(summaryCtx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "classify chat summary inference").LogError(ctx, s.logger)
 	}
@@ -2447,7 +2447,7 @@ func (s *Service) SummarizeToolCall(ctx context.Context, payload *gen.SummarizeT
 
 	summaryCtx, cancel := context.WithTimeout(ctx, summarizeCompletionTimeout)
 	defer cancel()
-	summaryCtx, err = classifySessionInference(summaryCtx, hostedinference.CallCategoryToolCallSummary, hostedinference.CallCategoryAPIKeyToolCallSummary, hostedinference.CallCategoryNonOrdinarySessionToolSummary)
+	summaryCtx, err = classifyToolCallSummaryInference(summaryCtx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "classify tool-call summary inference").LogError(ctx, s.logger)
 	}

--- a/server/internal/chat/setup_test.go
+++ b/server/internal/chat/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	authchatsessions "github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
@@ -25,6 +26,7 @@ import (
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 )
 
@@ -52,12 +54,13 @@ func TestMain(m *testing.M) {
 }
 
 type chatTestInstance struct {
-	service   *chat.Service
-	sessions  *sessions.Manager
-	conn      *pgxpool.Pool
-	projectID uuid.UUID
-	orgID     string
-	assets    assets.BlobStore
+	service      *chat.Service
+	sessions     *sessions.Manager
+	chatSessions *authchatsessions.Manager
+	conn         *pgxpool.Pool
+	projectID    uuid.UUID
+	orgID        string
+	assets       assets.BlobStore
 }
 
 // newTestChatService builds a chat service with RBAC enforcement.
@@ -110,14 +113,17 @@ func newTestChatServiceWithOptions(t *testing.T, completionClient openrouter.Com
 
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	assetStorage := assetstest.NewTestBlobStore(t)
-	svc := chat.NewService(logger, tp, conn, mgr, nil, nil, completionClient, nil, nil, nil, assetStorage, authzEngine, nil, billingClient, audit.NewLogger())
+	chatSessions := authchatsessions.NewManager(logger, redisClient, "test-chat-session-secret")
+	posthogClient := posthog.New(ctx, logger, "", "", "")
+	svc := chat.NewService(logger, tp, conn, mgr, chatSessions, nil, completionClient, nil, posthogClient, nil, assetStorage, authzEngine, nil, billingClient, audit.NewLogger()).WithTurnStream(chat.NewTurnStream(redisClient))
 
 	return &chatTestInstance{
-		service:   svc,
-		sessions:  mgr,
-		conn:      conn,
-		projectID: project.ID,
-		orgID:     orgID,
-		assets:    assetStorage,
+		service:      svc,
+		sessions:     mgr,
+		chatSessions: chatSessions,
+		conn:         conn,
+		projectID:    project.ID,
+		orgID:        orgID,
+		assets:       assetStorage,
 	}
 }

--- a/server/internal/chatsessions/hosted_inference_test.go
+++ b/server/internal/chatsessions/hosted_inference_test.go
@@ -1,0 +1,113 @@
+package chatsessions
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/chat_sessions"
+	authchatsessions "github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestCreateSignsOrdinarySessionProvenanceOnly(t *testing.T) {
+	t.Parallel()
+
+	const secret = "chat-session-signing-secret"
+	logger := testenv.NewLogger(t)
+	manager := authchatsessions.NewManager(logger, nil, secret)
+	service := &Service{
+		tracer:              testenv.NewTracerProvider(t).Tracer("test"),
+		logger:              logger,
+		chatSessionsManager: manager,
+	}
+	projectID := uuid.New()
+	projectSlug := "project"
+	sessionID := "session"
+	authCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID,
+		ProjectID: &projectID, ProjectSlug: &projectSlug,
+	}
+	payload := &gen.CreatePayload{EmbedOrigin: "https://example.com", ExpiresAfter: 3600}
+
+	decode := func(tokenString string) *authchatsessions.ChatSessionClaims {
+		t.Helper()
+		token, err := jwt.ParseWithClaims(tokenString, &authchatsessions.ChatSessionClaims{}, func(*jwt.Token) (any, error) {
+			return []byte(secret), nil
+		})
+		require.NoError(t, err)
+		claims, ok := token.Claims.(*authchatsessions.ChatSessionClaims)
+		require.True(t, ok)
+		return claims
+	}
+
+	ordinaryCtx := contextvalues.WithValidatedGramSession(t.Context(), authCtx, false)
+	result, err := service.Create(ordinaryCtx, payload)
+	require.NoError(t, err)
+	claim := decode(result.ClientToken).GramSessionActingUser
+	require.NotNil(t, claim)
+	require.Equal(t, "org", claim.OrgID)
+	require.Equal(t, "user", claim.UserID)
+	require.Equal(t, "session", claim.SessionID)
+
+	apiKeyCtx := *authCtx
+	apiKeyCtx.APIKeyID = "key"
+	result, err = service.Create(contextvalues.SetAuthContext(t.Context(), &apiKeyCtx), payload)
+	require.NoError(t, err)
+	require.Nil(t, decode(result.ClientToken).GramSessionActingUser)
+}
+
+func TestValidatedGramSessionClaimMinting(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "session"
+	authCtx := &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID}
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), authCtx, false)
+
+	claim := validatedGramSessionClaim(ctx, authCtx)
+	require.NotNil(t, claim)
+	require.Equal(t, "org", claim.OrgID)
+	require.Equal(t, "user", claim.UserID)
+	require.Equal(t, "session", claim.SessionID)
+
+	for name, testCtx := range map[string]func() (*contextvalues.AuthContext, bool){
+		"API key creator fields": func() (*contextvalues.AuthContext, bool) {
+			return &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "owner", SessionID: &sessionID, APIKeyID: "key"}, false
+		},
+		"legacy impersonation": func() (*contextvalues.AuthContext, bool) {
+			return authCtx, true
+		},
+		"shared demo": func() (*contextvalues.AuthContext, bool) {
+			demo := *authCtx
+			demo.ActiveOrganizationID = constants.DemoOrganizationID
+			return &demo, false
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			candidate, legacy := testCtx()
+			candidateCtx := contextvalues.SetAuthContext(t.Context(), candidate)
+			if candidate.APIKeyID == "" {
+				candidateCtx = contextvalues.WithValidatedGramSession(t.Context(), candidate, legacy)
+			}
+			require.Nil(t, validatedGramSessionClaim(candidateCtx, candidate))
+		})
+	}
+}
+
+func TestValidatedGramSessionClaimRejectsPostValidationIdentityMutation(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "session"
+	authCtx := &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID}
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), authCtx, false)
+	carried, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	carried.UserID = "substitute-owner"
+
+	require.Nil(t, validatedGramSessionClaim(ctx, carried))
+}

--- a/server/internal/chatsessions/impl.go
+++ b/server/internal/chatsessions/impl.go
@@ -62,6 +62,20 @@ func (s *Service) ProjectSlugAuth(ctx context.Context, slug string, scheme *secu
 	return s.auth.Authorize(ctx, slug, scheme)
 }
 
+func validatedGramSessionClaim(ctx context.Context, authCtx *contextvalues.AuthContext) *chatsessions.GramSessionActingUserClaim {
+	provenance, ok := contextvalues.ValidatedGramSessionActingUser(ctx)
+	if !ok || authCtx == nil || authCtx.SessionID == nil ||
+		authCtx.ActiveOrganizationID != provenance.OrganizationID() ||
+		authCtx.UserID != provenance.UserID() || *authCtx.SessionID != provenance.SessionID() {
+		return nil
+	}
+	return &chatsessions.GramSessionActingUserClaim{
+		OrgID:     provenance.OrganizationID(),
+		UserID:    provenance.UserID(),
+		SessionID: provenance.SessionID(),
+	}
+}
+
 func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.CreateResult, error) {
 	ctx, span := s.tracer.Start(ctx, "chatsessions.create")
 	defer span.End()
@@ -84,16 +98,17 @@ func (s *Service) Create(ctx context.Context, p *gen.CreatePayload) (*gen.Create
 	}
 
 	claims := chatsessions.ChatSessionClaims{
-		OrgID:            authCtx.ActiveOrganizationID,
-		ProjectID:        authCtx.ProjectID.String(),
-		OrganizationSlug: authCtx.OrganizationSlug,
-		ProjectSlug:      *authCtx.ProjectSlug,
-		ExternalUserID:   p.UserIdentifier,
-		APIKeyID:         authCtx.APIKeyID,
-		UserID:           authCtx.UserID,
-		SessionID:        sessionID,
-		AccountType:      authCtx.AccountType,
-		RegisteredClaims: jwt.RegisteredClaims{}, //nolint:exhaustruct // to be populated by chatSessionsManager
+		OrgID:                 authCtx.ActiveOrganizationID,
+		ProjectID:             authCtx.ProjectID.String(),
+		OrganizationSlug:      authCtx.OrganizationSlug,
+		ProjectSlug:           *authCtx.ProjectSlug,
+		ExternalUserID:        p.UserIdentifier,
+		APIKeyID:              authCtx.APIKeyID,
+		UserID:                authCtx.UserID,
+		SessionID:             sessionID,
+		AccountType:           authCtx.AccountType,
+		GramSessionActingUser: validatedGramSessionClaim(ctx, authCtx),
+		RegisteredClaims:      jwt.RegisteredClaims{}, //nolint:exhaustruct // to be populated by chatSessionsManager
 	}
 
 	token, _, err := s.chatSessionsManager.GenerateToken(

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 )
 
@@ -28,10 +29,13 @@ type AuthContext struct {
 	IsAdmin               bool
 	// SupportOrganizationID is set only after session authentication validates
 	// a time-bounded platform-admin support session for this organization.
-	SupportOrganizationID     string
-	gramSessionValidated      bool
-	supportSessionValidated   bool
-	legacySessionImpersonated bool
+	SupportOrganizationID              string
+	gramSessionValidated               bool
+	validatedGramSessionOrganizationID string
+	validatedGramSessionUserID         string
+	validatedGramSessionSessionID      string
+	supportSessionValidated            bool
+	legacySessionImpersonated          bool
 }
 
 // WithValidatedGramSession records provenance established by sessions.Authenticate.
@@ -39,6 +43,11 @@ type AuthContext struct {
 func WithValidatedGramSession(ctx context.Context, authCtx *AuthContext, legacyImpersonated bool) context.Context {
 	validated := *authCtx
 	validated.gramSessionValidated = true
+	validated.validatedGramSessionOrganizationID = authCtx.ActiveOrganizationID
+	validated.validatedGramSessionUserID = authCtx.UserID
+	if authCtx.SessionID != nil {
+		validated.validatedGramSessionSessionID = *authCtx.SessionID
+	}
 	validated.legacySessionImpersonated = legacyImpersonated
 	return SetAuthContext(ctx, &validated)
 }
@@ -79,6 +88,102 @@ func IsOrdinaryGramUserSession(ctx context.Context) bool {
 func IsLegacyImpersonatedSession(ctx context.Context) bool {
 	authCtx, ok := GetAuthContext(ctx)
 	return ok && authCtx != nil && authCtx.gramSessionValidated && authCtx.legacySessionImpersonated
+}
+
+// GramSessionActingUser is opaque, tenant-bound provenance for an acting user
+// established by ordinary Gram session authentication. It cannot be assembled
+// from attribution fields such as API-key owners, assistant owners, chat users,
+// external user IDs, or anonymous organization context.
+type GramSessionActingUser struct {
+	organizationID string
+	userID         string
+	sessionID      string
+}
+
+// ActingUserProvenance is implemented only by opaque acting-user values minted
+// after an ordinary Gram session or a qualifying session-backed chat JWT is
+// validated. Callers can inspect but cannot manufacture implementations.
+type ActingUserProvenance interface {
+	OrganizationID() string
+	UserID() string
+	SessionID() string
+	validatedActingUserProvenance()
+}
+
+// ValidatedGramSessionActingUser derives acting-user provenance only from an
+// authenticated customer Gram session. The frozen identity snapshot is composed
+// with IsOrdinaryGramUserSession so support, impersonation, API-key attribution,
+// and every alternate or elevated acting surface remain excluded.
+func ValidatedGramSessionActingUser(ctx context.Context) (GramSessionActingUser, bool) {
+	authCtx, ok := GetAuthContext(ctx)
+	if !ok || authCtx == nil || !IsOrdinaryGramUserSession(ctx) ||
+		authCtx.supportSessionValidated || authCtx.legacySessionImpersonated ||
+		authCtx.validatedGramSessionOrganizationID == "" ||
+		authCtx.validatedGramSessionOrganizationID == constants.DemoOrganizationID ||
+		authCtx.validatedGramSessionUserID == "" ||
+		authCtx.validatedGramSessionSessionID == "" {
+		return GramSessionActingUser{organizationID: "", userID: "", sessionID: ""}, false
+	}
+	return GramSessionActingUser{
+		organizationID: authCtx.validatedGramSessionOrganizationID,
+		userID:         authCtx.validatedGramSessionUserID,
+		sessionID:      authCtx.validatedGramSessionSessionID,
+	}, true
+}
+
+// OrganizationID returns the authenticated active organization.
+func (p GramSessionActingUser) OrganizationID() string { return p.organizationID }
+
+// UserID returns the authenticated acting user.
+func (p GramSessionActingUser) UserID() string { return p.userID }
+
+// SessionID returns the validated Gram session identifier.
+func (p GramSessionActingUser) SessionID() string { return p.sessionID }
+
+func (GramSessionActingUser) validatedActingUserProvenance() {}
+
+type chatSessionActingUser struct {
+	organizationID string
+	userID         string
+	sessionID      string
+}
+
+func (p chatSessionActingUser) OrganizationID() string       { return p.organizationID }
+func (p chatSessionActingUser) UserID() string               { return p.userID }
+func (p chatSessionActingUser) SessionID() string            { return p.sessionID }
+func (chatSessionActingUser) validatedActingUserProvenance() {}
+
+type chatSessionActingUserContextKey struct{}
+
+// WithValidatedChatSessionActingUser records provenance from a validated chat
+// JWT whose signed ordinary-session claim matches its nonempty tenant, user, and
+// session claims. Only auth/chatsessions may call this after token validation.
+func WithValidatedChatSessionActingUser(ctx context.Context, organizationID, userID, sessionID string) context.Context {
+	if organizationID == "" || organizationID == constants.DemoOrganizationID || userID == "" || sessionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, chatSessionActingUserContextKey{}, chatSessionActingUser{
+		organizationID: organizationID,
+		userID:         userID,
+		sessionID:      sessionID,
+	})
+}
+
+// ValidatedChatSessionActingUser returns only opaque provenance stamped during
+// chat JWT authorization. UserID and SessionID attribution fields alone do not
+// satisfy it.
+func ValidatedChatSessionActingUser(ctx context.Context) (ActingUserProvenance, bool) {
+	provenance, ok := ctx.Value(chatSessionActingUserContextKey{}).(chatSessionActingUser)
+	return provenance, ok
+}
+
+// ValidatedHostedInferenceActingUser returns either supported ordinary-session
+// provenance. Both forms are immutable snapshots of the validated identity.
+func ValidatedHostedInferenceActingUser(ctx context.Context) (ActingUserProvenance, bool) {
+	if provenance, ok := ValidatedGramSessionActingUser(ctx); ok {
+		return provenance, true
+	}
+	return ValidatedChatSessionActingUser(ctx)
 }
 
 // WithValidatedSupportSession records the support decision made during session

--- a/server/internal/contextvalues/context_test.go
+++ b/server/internal/contextvalues/context_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
 )
 
 func TestIsSupportSessionRequiresValidatedContext(t *testing.T) {
@@ -57,6 +59,123 @@ func TestIsOrdinaryGramUserSessionRejectsAlternateProvenance(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			require.False(t, IsOrdinaryGramUserSession(decorate(validated)))
+		})
+	}
+}
+
+func TestValidatedGramSessionActingUser(t *testing.T) {
+	t.Parallel()
+	sessionID := "session"
+	base := &AuthContext{ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID}
+
+	_, ok := ValidatedGramSessionActingUser(SetAuthContext(t.Context(), base))
+	require.False(t, ok)
+
+	provenance, ok := ValidatedGramSessionActingUser(WithValidatedGramSession(t.Context(), base, false))
+	require.True(t, ok)
+	require.Equal(t, "org", provenance.OrganizationID())
+	require.Equal(t, "user", provenance.UserID())
+	require.Equal(t, "session", provenance.SessionID())
+
+	_, ok = ValidatedGramSessionActingUser(WithValidatedGramSession(t.Context(), base, true))
+	require.False(t, ok, "legacy impersonation must not establish an acting user")
+
+	support := *base
+	support.IsAdmin = true
+	support.SupportOrganizationID = "org"
+	supportCtx := WithValidatedGramSession(t.Context(), &support, false)
+	supportCtx = WithValidatedSupportSession(supportCtx, &support)
+	_, ok = ValidatedGramSessionActingUser(supportCtx)
+	require.False(t, ok, "support sessions must not establish an acting user")
+
+	demo := *base
+	demo.ActiveOrganizationID = constants.DemoOrganizationID
+	_, ok = ValidatedGramSessionActingUser(WithValidatedGramSession(t.Context(), &demo, false))
+	require.False(t, ok, "shared demo sessions have no active membership and remain unsupported")
+
+	missingSession := *base
+	missingSession.SessionID = nil
+	_, ok = ValidatedGramSessionActingUser(WithValidatedGramSession(t.Context(), &missingSession, false))
+	require.False(t, ok)
+
+	for name, authCtx := range map[string]*AuthContext{
+		"api key attribution":        {ActiveOrganizationID: "org", UserID: "creator", APIKeyID: "key"},
+		"assistant/chat attribution": {ActiveOrganizationID: "org", UserID: "owner", ExternalUserID: "assistant"},
+		"anonymous organization":     {ActiveOrganizationID: "org"},
+	} {
+		_, ok = ValidatedGramSessionActingUser(SetAuthContext(t.Context(), authCtx))
+		require.False(t, ok, name)
+	}
+}
+
+func TestValidatedGramSessionActingUserUsesImmutableIdentitySnapshot(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "session-original"
+	source := &AuthContext{ActiveOrganizationID: "org-original", UserID: "user-original", SessionID: &sessionID}
+	ctx := WithValidatedGramSession(t.Context(), source, false)
+
+	// Mutate both the source pointer and the AuthContext pointer carried by ctx.
+	// Neither can substitute a different identity after validation.
+	sessionID = "session-source-mutated"
+	source.ActiveOrganizationID = "org-source-mutated"
+	source.UserID = "user-source-mutated"
+	authCtx, ok := GetAuthContext(ctx)
+	require.True(t, ok)
+	mutatedSessionID := "session-context-mutated"
+	authCtx.ActiveOrganizationID = "org-context-mutated"
+	authCtx.UserID = "user-context-mutated"
+	authCtx.SessionID = &mutatedSessionID
+
+	provenance, ok := ValidatedGramSessionActingUser(ctx)
+	require.True(t, ok)
+	require.Equal(t, "org-original", provenance.OrganizationID())
+	require.Equal(t, "user-original", provenance.UserID())
+	require.Equal(t, "session-original", provenance.SessionID())
+}
+
+func TestValidatedGramSessionActingUserRejectsAlternateProvenance(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "session"
+	base := &AuthContext{ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID}
+	validated := WithValidatedGramSession(t.Context(), base, false)
+	cases := map[string]func(context.Context) context.Context{
+		"assistant":      func(ctx context.Context) context.Context { return SetAssistantPrincipal(ctx, AssistantPrincipal{}) },
+		"OAuth":          func(ctx context.Context) context.Context { return SetOAuthClientID(ctx, "client") },
+		"acting surface": func(ctx context.Context) context.Context { return SetActingSurface(ctx, ActingSurfacePlatformMCP) },
+		"RBAC override":  func(ctx context.Context) context.Context { return SetRBACScopeOverride(ctx, "scope") },
+	}
+	for name, decorate := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := ValidatedHostedInferenceActingUser(decorate(validated))
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestValidatedChatSessionActingUserRequiresCompleteNonDemoStamp(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithValidatedChatSessionActingUser(t.Context(), "org", "user", "session")
+	provenance, ok := ValidatedChatSessionActingUser(ctx)
+	require.True(t, ok)
+	require.Equal(t, "org", provenance.OrganizationID())
+	require.Equal(t, "user", provenance.UserID())
+	require.Equal(t, "session", provenance.SessionID())
+
+	for name, values := range map[string][3]string{
+		"missing organization": {"", "user", "session"},
+		"missing user":         {"org", "", "session"},
+		"missing session":      {"org", "user", ""},
+		"shared demo":          {constants.DemoOrganizationID, "user", "session"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			unstamped := WithValidatedChatSessionActingUser(t.Context(), values[0], values[1], values[2])
+			_, ok := ValidatedChatSessionActingUser(unstamped)
+			require.False(t, ok)
 		})
 	}
 }

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -140,6 +141,7 @@ func DefaultRetryConfig() *RetryConfig {
 type httpClientOptions struct {
 	otelHTTPOptions   []otelhttp.Option
 	retryConfig       *RetryConfig
+	attemptCheck      func(*http.Request) error
 	resolver          *net.Resolver
 	allowedCIDRBlocks []*net.IPNet
 	resilience        *resilienceOptions
@@ -166,6 +168,36 @@ func WithDefaultRetryConfig() func(*httpClientOptions) {
 	return func(o *httpClientOptions) {
 		o.retryConfig = DefaultRetryConfig()
 	}
+}
+
+// WithAttemptCheck runs check inside the retry loop immediately before each
+// network attempt. A rejection stops retries and prevents the wrapped transport
+// from performing any network I/O for that attempt.
+func WithAttemptCheck(check func(*http.Request) error) func(*httpClientOptions) {
+	return func(o *httpClientOptions) {
+		o.attemptCheck = check
+	}
+}
+
+type attemptRejectedError struct{ cause error }
+
+func (e *attemptRejectedError) Error() string { return "HTTP attempt rejected" }
+func (e *attemptRejectedError) Unwrap() error { return e.cause }
+
+type attemptCheckRoundTripper struct {
+	next  http.RoundTripper
+	check func(*http.Request) error
+}
+
+func (t *attemptCheckRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.check(req); err != nil {
+		return nil, &attemptRejectedError{cause: err}
+	}
+	resp, err := t.next.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("round trip guarded request: %w", err)
+	}
+	return resp, nil
 }
 
 // WithAllowedCIDRBlocks permits this client to dial IPs inside the given CIDR
@@ -373,6 +405,9 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 			breaker: p.breaker,
 		}
 	}
+	if opts.attemptCheck != nil {
+		roundTripper = &attemptCheckRoundTripper{next: roundTripper, check: opts.attemptCheck}
+	}
 	roundTripper = &closeIdleRoundTripper{
 		RoundTripper:         roundTripper,
 		closeIdleConnections: transport.CloseIdleConnections,
@@ -391,6 +426,18 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 	checkRetry := opts.retryConfig.CheckRetry
 	if opts.resilience != nil {
 		checkRetry = noRetryOnResilienceDenial(checkRetry)
+	}
+	if opts.attemptCheck != nil {
+		next := checkRetry
+		if next == nil {
+			next = retryablehttp.DefaultRetryPolicy
+		}
+		checkRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			if _, ok := errors.AsType[*attemptRejectedError](err); ok {
+				return false, err
+			}
+			return next(ctx, resp, err)
+		}
 	}
 
 	retryClient.RetryWaitMin = opts.retryConfig.WaitMin

--- a/server/internal/killswitches/contracts.go
+++ b/server/internal/killswitches/contracts.go
@@ -18,6 +18,14 @@ type IdentityContractKey string
 // PrincipalKind identifies a canonical principal namespace.
 type PrincipalKind string
 
+// Shared identifiers used by every ai_access enforcement surface. Keeping
+// these values at the dependency-light contract layer prevents registry and
+// checkpoint implementations from defining divergent security identities.
+const (
+	DefinitionKeyAIAccess DefinitionKey = "ai_access"
+	PrincipalKindUser     PrincipalKind = "user"
+)
+
 // PrincipalKey identifies a principal within a principal namespace.
 type PrincipalKey string
 

--- a/server/internal/killswitches/hostedinference/checkpoint.go
+++ b/server/internal/killswitches/hostedinference/checkpoint.go
@@ -1,0 +1,167 @@
+package hostedinference
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+// AttemptCheckpoint is the dependency injected into the production ChatClient.
+// Check is called once before request setup and again immediately before every
+// actual provider attempt.
+const DefaultEvaluationTimeout = time.Second
+
+// ErrCheckpointUnavailable is the shared fail-closed cause for missing
+// hosted-inference enforcement dependencies.
+var ErrCheckpointUnavailable = errors.New("hosted-inference checkpoint is unavailable")
+
+type AttemptCheckpoint interface {
+	Check(ctx context.Context, organizationID string) error
+}
+
+type evaluator interface {
+	Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult
+}
+
+// Checkpoint evaluates ai_access for governed user calls and explicitly
+// bypasses the registered internal, background, and unsupported classes.
+type Checkpoint struct {
+	principal     killswitches.PrincipalAdapter
+	resource      killswitches.ResourceAdapter
+	evaluator     evaluator
+	transport     killswitches.TransportAdapter
+	failurePolicy killswitches.FailurePolicy
+	timeout       time.Duration
+}
+
+var _ AttemptCheckpoint = (*Checkpoint)(nil)
+
+func NewCheckpoint(registry *killswitches.Registry, evaluation evaluator, timeout time.Duration) (*Checkpoint, error) {
+	if registry == nil || evaluation == nil {
+		return nil, errors.New("hosted-inference registry and evaluator are required")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("hosted-inference checkpoint timeout must be positive")
+	}
+	definition, ok := registry.Definition(DefinitionKeyAIAccess)
+	if !ok {
+		return nil, errors.New("ai_access definition is not registered")
+	}
+	coverage, ok := registry.Coverage(DefinitionKeyAIAccess, SurfaceGramHostedInference)
+	if !ok {
+		return nil, errors.New("gram-hosted-inference coverage is not registered")
+	}
+	principal, ok := registry.PrincipalAdapter(PrincipalKindUser)
+	if !ok {
+		return nil, errors.New("authenticated user principal adapter is not registered")
+	}
+	resource, ok := registry.ResourceAdapter(ResourceKindGramHostedInference)
+	if !ok {
+		return nil, errors.New("gram-hosted-inference resource adapter is not registered")
+	}
+	transport, ok := registry.TransportAdapter(coverage.TransportAdapter)
+	if !ok {
+		return nil, errors.New("gram-hosted-inference transport adapter is not registered")
+	}
+	if definition.FailurePolicy != killswitches.FailurePolicyFailClosed || coverage.FailurePolicy != definition.FailurePolicy {
+		return nil, errors.New("gram-hosted-inference ai_access must be fail-closed")
+	}
+	return &Checkpoint{principal: principal, resource: resource, evaluator: evaluation, transport: transport, failurePolicy: coverage.FailurePolicy, timeout: timeout}, nil
+}
+
+func (c *Checkpoint) Check(ctx context.Context, organizationID string) error {
+	if c == nil {
+		return newInfrastructureUnavailable(ErrCheckpointUnavailable)
+	}
+	classification, ok := classificationFromContext(ctx)
+	if !ok {
+		return newInfrastructureUnavailable(errors.New("hosted-inference classification is required"))
+	}
+	if err := validateCategoryClass(classification.category, classification.class); err != nil {
+		return newInfrastructureUnavailable(err)
+	}
+	switch classification.class {
+	case CallClassInternal, CallClassBackground, CallClassUnsupported:
+		return nil
+	case CallClassGovernedUser:
+	default:
+		return newInfrastructureUnavailable(fmt.Errorf("unknown hosted-inference call class %q", classification.class))
+	}
+
+	organization := killswitches.OrganizationID(organizationID)
+	if organization == "" || classification.actingUser.OrganizationID() != organizationID {
+		return newInfrastructureUnavailable(errors.New("acting user organization does not match the inference organization"))
+	}
+
+	checkCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	principals, err := c.principal.DeriveCandidates(checkCtx, organization, classification.actingUser)
+	if err != nil {
+		return newInfrastructureUnavailable(fmt.Errorf("derive acting user: %w", err))
+	}
+	if principals.Kind() != killswitches.PrincipalCandidateResultCandidates {
+		return newInfrastructureUnavailable(errors.New("acting user is not an active organization member"))
+	}
+	resourceResult, err := c.resource.Derive(checkCtx, organization, classification.category)
+	if err != nil {
+		return newInfrastructureUnavailable(fmt.Errorf("derive hosted-inference resource: %w", err))
+	}
+	resourceKey, supported, err := resourceResult.Key()
+	if err != nil || !supported {
+		return newInfrastructureUnavailable(errors.New("hosted-inference resource is unavailable"))
+	}
+
+	result := c.evaluator.Evaluate(checkCtx, killswitches.EvaluationRequest{
+		OrganizationID:      organization,
+		DefinitionKeys:      []killswitches.DefinitionKey{DefinitionKeyAIAccess},
+		PrincipalCandidates: principals.Candidates(),
+		ResourceKind:        ResourceKindGramHostedInference,
+		ResourceKey:         resourceKey,
+	})
+	disposition, err := c.transport(result, c.failurePolicy)
+	if err != nil {
+		return newInfrastructureUnavailable(fmt.Errorf("resolve hosted-inference disposition: %w", err))
+	}
+	switch disposition.Kind() {
+	case killswitches.TransportDispositionContinue:
+		return nil
+	case killswitches.TransportDispositionMatchedDenial:
+		note, ok := disposition.ExternalNote()
+		if !ok {
+			return newInfrastructureUnavailable(errors.New("matched denial has no external note"))
+		}
+		return &MatchedDenialError{externalNote: note}
+	case killswitches.TransportDispositionInfrastructureRejection:
+		cause := result.InfrastructureError()
+		if cause == nil {
+			cause = errors.New("ai_access evaluation is unavailable")
+		}
+		return newInfrastructureUnavailable(cause)
+	default:
+		return newInfrastructureUnavailable(errors.New("invalid hosted-inference disposition"))
+	}
+}
+
+// MatchedDenialError is a typed matched prescription denial. Error stays
+// generic so tenant-authored notes cannot enter logs, traces, or wrapped causes;
+// only HTTP/Goa boundary mapping may read ExternalNote.
+type MatchedDenialError struct{ externalNote string }
+
+func (*MatchedDenialError) Error() string          { return "hosted inference access denied" }
+func (e *MatchedDenialError) ExternalNote() string { return e.externalNote }
+
+// InfrastructureUnavailableError is deliberately free of match language and
+// external notes. Its cause is available to trusted internal handling only.
+type InfrastructureUnavailableError struct{ cause error }
+
+func newInfrastructureUnavailable(cause error) *InfrastructureUnavailableError {
+	return &InfrastructureUnavailableError{cause: cause}
+}
+func (e *InfrastructureUnavailableError) Error() string {
+	return "hosted inference access evaluation is unavailable"
+}
+func (e *InfrastructureUnavailableError) Unwrap() error { return e.cause }

--- a/server/internal/killswitches/hostedinference/checkpoint_test.go
+++ b/server/internal/killswitches/hostedinference/checkpoint_test.go
@@ -1,0 +1,236 @@
+package hostedinference
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+type fakePrincipalAdapter struct {
+	active bool
+	err    error
+}
+
+func (f fakePrincipalAdapter) Kind() killswitches.PrincipalKind { return PrincipalKindUser }
+func (f fakePrincipalAdapter) Canonicalize(killswitches.OrganizationID, string) (killswitches.CanonicalizationResult[killswitches.PrincipalKey], error) {
+	panic("unused")
+}
+func (f fakePrincipalAdapter) ValidateCurrentOrganization(context.Context, killswitches.OrganizationID, killswitches.PrincipalKey) (bool, error) {
+	return f.active, f.err
+}
+func (f fakePrincipalAdapter) DeriveCandidates(_ context.Context, org killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
+	if f.err != nil {
+		return killswitches.PrincipalCandidateResult{}, f.err
+	}
+	provenance, ok := source.(contextvalues.ActingUserProvenance)
+	if !ok || provenance.OrganizationID() != string(org) {
+		return killswitches.PrincipalCandidateResult{}, errors.New("invalid provenance")
+	}
+	if !f.active {
+		return killswitches.UnsupportedPrincipalCandidateResult(), nil
+	}
+	return killswitches.NewPrincipalCandidateResult([]killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(provenance.UserID())}}) //nolint:wrapcheck // Preserve the constructor's exact test result.
+}
+
+type fakeEvaluator struct {
+	result killswitches.EvaluationResult
+	calls  int
+}
+
+func (f *fakeEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+	f.calls++
+	return f.result
+}
+
+func testCheckpoint(t *testing.T, principal fakePrincipalAdapter, result killswitches.EvaluationResult) (*Checkpoint, *fakeEvaluator) {
+	t.Helper()
+	evaluation := &fakeEvaluator{result: result}
+	return &Checkpoint{principal: principal, resource: ResourceAdapter{}, evaluator: evaluation, transport: killswitches.ResolveTransportDisposition, failurePolicy: killswitches.FailurePolicyFailClosed, timeout: time.Second}, evaluation
+}
+
+func governedContext(t *testing.T, org, user string) context.Context {
+	t.Helper()
+	sessionID := "session"
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: org, UserID: user, SessionID: &sessionID}, false)
+	ctx, err := WithGovernedUser(ctx, CallCategoryUserChatCompletion)
+	require.NoError(t, err)
+	return ctx
+}
+
+func governedChatContext(t *testing.T, org, user string) context.Context {
+	t.Helper()
+	ctx := contextvalues.WithValidatedChatSessionActingUser(t.Context(), org, user, "session")
+	ctx, err := WithGovernedUser(ctx, CallCategoryUserChatCompletion)
+	require.NoError(t, err)
+	return ctx
+}
+
+func TestCheckpointDistinguishesMatchedDenialAndInfrastructure(t *testing.T) {
+	t.Parallel()
+	match, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", "  Paused exactly.  ")
+	require.NoError(t, err)
+	checkpoint, _ := testCheckpoint(t, fakePrincipalAdapter{active: true}, match)
+
+	err = checkpoint.Check(governedContext(t, "org", "user"), "org")
+	var denial *MatchedDenialError
+	require.ErrorAs(t, err, &denial)
+	require.Equal(t, "hosted inference access denied", denial.Error())
+	require.Equal(t, "Paused exactly.", denial.ExternalNote())
+
+	failure, err := killswitches.NewInfrastructureFailureResult(errors.New("database secret detail"))
+	require.NoError(t, err)
+	checkpoint, _ = testCheckpoint(t, fakePrincipalAdapter{active: true}, failure)
+	err = checkpoint.Check(governedContext(t, "org", "user"), "org")
+	var unavailable *InfrastructureUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+	require.Equal(t, "hosted inference access evaluation is unavailable", err.Error())
+	require.NotContains(t, err.Error(), "Paused")
+	require.NotContains(t, err.Error(), "match")
+}
+
+func TestGovernedUserSurfaceCategoriesEvaluate(t *testing.T) {
+	t.Parallel()
+	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
+	require.NoError(t, err)
+	sessionID := "session"
+	base := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "user", SessionID: &sessionID}, false)
+	for _, category := range []CallCategory{
+		CallCategoryUserChatCompletion,
+		CallCategoryChatSummary,
+		CallCategoryToolCallSummary,
+		CallCategoryRiskAuthoring,
+		CallCategoryBusinessMemorySearchEmbedding,
+	} {
+		ctx, classifyErr := WithGovernedUser(base, category)
+		require.NoError(t, classifyErr)
+		checkpoint, evaluation := testCheckpoint(t, fakePrincipalAdapter{active: true}, noMatch)
+		require.NoError(t, checkpoint.Check(ctx, "org"))
+		require.Equal(t, 1, evaluation.calls, category)
+	}
+}
+
+func TestCheckpointClassificationAndIdentityPosture(t *testing.T) {
+	t.Parallel()
+	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
+	require.NoError(t, err)
+
+	for name, build := range map[string]func(*testing.T) (context.Context, string, fakePrincipalAdapter){
+		"missing classification": func(t *testing.T) (context.Context, string, fakePrincipalAdapter) {
+			t.Helper()
+			return t.Context(), "org", fakePrincipalAdapter{active: true}
+		},
+		"cross tenant": func(t *testing.T) (context.Context, string, fakePrincipalAdapter) {
+			t.Helper()
+			return governedContext(t, "org-a", "user"), "org-b", fakePrincipalAdapter{active: true}
+		},
+		"inactive user": func(t *testing.T) (context.Context, string, fakePrincipalAdapter) {
+			t.Helper()
+			return governedContext(t, "org", "user"), "org", fakePrincipalAdapter{active: false}
+		},
+		"session-backed JWT cross tenant": func(t *testing.T) (context.Context, string, fakePrincipalAdapter) {
+			t.Helper()
+			return governedChatContext(t, "org-a", "user"), "org-b", fakePrincipalAdapter{active: true}
+		},
+		"session-backed JWT inactive user": func(t *testing.T) (context.Context, string, fakePrincipalAdapter) {
+			t.Helper()
+			return governedChatContext(t, "org", "user"), "org", fakePrincipalAdapter{active: false}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, org, principal := build(t)
+			checkpoint, evaluation := testCheckpoint(t, principal, noMatch)
+			err := checkpoint.Check(ctx, org)
+			var unavailable *InfrastructureUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+			require.Zero(t, evaluation.calls)
+		})
+	}
+
+	for name, classify := range map[string]func(context.Context) (context.Context, error){
+		"internal": func(ctx context.Context) (context.Context, error) {
+			return WithInternal(ctx, CallCategoryPromptScanner)
+		},
+		"background": func(ctx context.Context) (context.Context, error) {
+			return WithBackground(ctx, CallCategoryAutomaticChatTitle)
+		},
+		"unsupported": func(ctx context.Context) (context.Context, error) {
+			return WithUnsupported(ctx, CallCategoryAssistantChat)
+		},
+	} {
+		t.Run(name+" bypass", func(t *testing.T) {
+			t.Parallel()
+			ctx, err := classify(t.Context())
+			require.NoError(t, err)
+			checkpoint, evaluation := testCheckpoint(t, fakePrincipalAdapter{}, noMatch)
+			require.NoError(t, checkpoint.Check(ctx, "org"))
+			require.Zero(t, evaluation.calls)
+		})
+	}
+}
+
+func TestSessionBackedChatJWTClassificationIsGoverned(t *testing.T) {
+	t.Parallel()
+
+	ctx := contextvalues.WithValidatedChatSessionActingUser(t.Context(), "org", "user", "session")
+	classified, err := WithGovernedUser(ctx, CallCategoryUserChatCompletion)
+	require.NoError(t, err)
+	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
+	require.NoError(t, err)
+	checkpoint, evaluation := testCheckpoint(t, fakePrincipalAdapter{active: true}, noMatch)
+	require.NoError(t, checkpoint.Check(classified, "org"))
+	require.Equal(t, 1, evaluation.calls)
+}
+
+func TestClassificationRejectsUnknownAndSubstituteIdentity(t *testing.T) {
+	t.Parallel()
+	_, err := WithInternal(t.Context(), CallCategory("new-unregistered-path"))
+	require.Error(t, err)
+	_, err = WithInternal(t.Context(), CallCategoryUserChatCompletion)
+	require.Error(t, err)
+
+	chatSessionID := "chat-session"
+	for name, buildContext := range map[string]func(*testing.T) context.Context{
+		"api key creator": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "api-key-owner", APIKeyID: "key"})
+		},
+		"assistant owner": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "assistant-owner"})
+		},
+		"chat session": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org", UserID: "chat-user", SessionID: &chatSessionID})
+		},
+		"external identity": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org", ExternalUserID: "external"})
+		},
+		"anonymous organization": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org"})
+		},
+		"shared demo session": func(t *testing.T) context.Context {
+			t.Helper()
+			return contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: constants.DemoOrganizationID, UserID: "user", SessionID: &chatSessionID}, false)
+		},
+		"absent identity": func(t *testing.T) context.Context {
+			t.Helper()
+			return t.Context()
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := WithGovernedUser(buildContext(t), CallCategoryUserChatCompletion)
+			require.Error(t, err)
+		})
+	}
+}

--- a/server/internal/killswitches/hostedinference/contracts.go
+++ b/server/internal/killswitches/hostedinference/contracts.go
@@ -1,0 +1,177 @@
+package hostedinference
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+const (
+	DefinitionKeyAIAccess                                                = killswitches.DefinitionKeyAIAccess
+	PrincipalKindUser                                                    = killswitches.PrincipalKindUser
+	ResourceKindGramHostedInference     killswitches.ResourceKind        = "gram_hosted_inference"
+	SurfaceGramHostedInference          killswitches.Surface             = "gram_hosted_inference"
+	TransportAdapterGramHostedInference killswitches.TransportAdapterKey = "gram_hosted_inference"
+)
+
+// CallClass states why one provider call is governed or deliberately outside
+// DNO-991. The zero value is intentionally invalid.
+type CallClass string
+
+const (
+	CallClassGovernedUser CallClass = "governed_user"
+	CallClassInternal     CallClass = "internal"
+	CallClassBackground   CallClass = "background"
+	CallClassUnsupported  CallClass = "unsupported"
+)
+
+// CallCategory is a static identity for a current production inference path.
+// New paths must be added to the inventory below before they can egress through
+// a production-injected ChatClient.
+type CallCategory string
+
+const (
+	// Governed user paths. These are also canonical ai_access resources.
+	CallCategoryUserChatCompletion            CallCategory = "user_chat_completion"
+	CallCategoryChatSummary                   CallCategory = "chat_summary"
+	CallCategoryToolCallSummary               CallCategory = "tool_call_summary"
+	CallCategoryRiskAuthoring                 CallCategory = "risk_authoring"
+	CallCategoryBusinessMemorySearchEmbedding CallCategory = "business_memory_search_embedding"
+
+	// Unsupported request identities. Attribution fields on these requests
+	// never become acting users.
+	CallCategoryAPIKeyChat                      CallCategory = "api_key_chat" //nolint:gosec // This names an authentication category, not a credential.
+	CallCategoryChatSessionChat                 CallCategory = "chat_session_chat"
+	CallCategoryNonOrdinaryGramSessionChat      CallCategory = "non_ordinary_gram_session_chat"
+	CallCategoryAPIKeyChatSummary               CallCategory = "api_key_chat_summary"      //nolint:gosec // This names an authentication category, not a credential.
+	CallCategoryAPIKeyToolCallSummary           CallCategory = "api_key_tool_call_summary" //nolint:gosec // This names an authentication category, not a credential.
+	CallCategoryAPIKeyRiskAuthoring             CallCategory = "api_key_risk_authoring"    //nolint:gosec // This names an authentication category, not a credential.
+	CallCategoryAPIKeyBusinessMemorySearch      CallCategory = "api_key_business_memory_search"
+	CallCategoryNonOrdinarySessionChatSummary   CallCategory = "non_ordinary_session_chat_summary"
+	CallCategoryNonOrdinarySessionToolSummary   CallCategory = "non_ordinary_session_tool_call_summary"
+	CallCategoryNonOrdinarySessionRiskAuthoring CallCategory = "non_ordinary_session_risk_authoring"
+	CallCategoryNonOrdinarySessionMemorySearch  CallCategory = "non_ordinary_session_business_memory_search"
+
+	// Explicit internal/background paths that preserve existing behavior.
+	CallCategoryAutomaticChatTitle  CallCategory = "automatic_chat_title"
+	CallCategoryChatResolution      CallCategory = "chat_resolution"
+	CallCategoryChatAnalysis        CallCategory = "chat_analysis"
+	CallCategoryPromptScanner       CallCategory = "prompt_scanner"
+	CallCategorySkillJudge          CallCategory = "skill_judge"
+	CallCategoryBusinessMemoryJudge CallCategory = "business_memory_judge"
+	CallCategoryRAGIndexing         CallCategory = "rag_indexing"
+
+	// Assistant-owned paths are explicitly deferred rather than attributed to
+	// an assistant owner or another substitute identity.
+	CallCategoryAssistantChat     CallCategory = "assistant_chat"
+	CallCategoryAssistantMemory   CallCategory = "assistant_memory"
+	CallCategoryAssistantResearch CallCategory = "assistant_research"
+	CallCategoryAssistantRAG      CallCategory = "assistant_rag"
+)
+
+var categoryClasses = map[CallCategory]CallClass{
+	CallCategoryUserChatCompletion:              CallClassGovernedUser,
+	CallCategoryChatSummary:                     CallClassGovernedUser,
+	CallCategoryToolCallSummary:                 CallClassGovernedUser,
+	CallCategoryRiskAuthoring:                   CallClassGovernedUser,
+	CallCategoryBusinessMemorySearchEmbedding:   CallClassGovernedUser,
+	CallCategoryAPIKeyChat:                      CallClassUnsupported,
+	CallCategoryChatSessionChat:                 CallClassUnsupported,
+	CallCategoryNonOrdinaryGramSessionChat:      CallClassUnsupported,
+	CallCategoryAPIKeyChatSummary:               CallClassUnsupported,
+	CallCategoryAPIKeyToolCallSummary:           CallClassUnsupported,
+	CallCategoryAPIKeyRiskAuthoring:             CallClassUnsupported,
+	CallCategoryAPIKeyBusinessMemorySearch:      CallClassUnsupported,
+	CallCategoryNonOrdinarySessionChatSummary:   CallClassUnsupported,
+	CallCategoryNonOrdinarySessionToolSummary:   CallClassUnsupported,
+	CallCategoryNonOrdinarySessionRiskAuthoring: CallClassUnsupported,
+	CallCategoryNonOrdinarySessionMemorySearch:  CallClassUnsupported,
+	CallCategoryAutomaticChatTitle:              CallClassBackground,
+	CallCategoryChatResolution:                  CallClassBackground,
+	CallCategoryChatAnalysis:                    CallClassInternal,
+	CallCategoryPromptScanner:                   CallClassInternal,
+	CallCategorySkillJudge:                      CallClassBackground,
+	CallCategoryBusinessMemoryJudge:             CallClassBackground,
+	CallCategoryRAGIndexing:                     CallClassBackground,
+	CallCategoryAssistantChat:                   CallClassUnsupported,
+	CallCategoryAssistantMemory:                 CallClassUnsupported,
+	CallCategoryAssistantResearch:               CallClassUnsupported,
+	CallCategoryAssistantRAG:                    CallClassUnsupported,
+}
+
+// Classification is an opaque, server-authored call classification.
+type Classification struct {
+	class      CallClass
+	category   CallCategory
+	actingUser contextvalues.ActingUserProvenance
+}
+
+type classificationContextKey struct{}
+
+// WithGovernedUser classifies a governed call only when ctx carries validated
+// ordinary Gram-session provenance directly or through a qualifying chat JWT.
+func WithGovernedUser(ctx context.Context, category CallCategory) (context.Context, error) {
+	if err := validateCategoryClass(category, CallClassGovernedUser); err != nil {
+		return ctx, err
+	}
+	actingUser, ok := contextvalues.ValidatedHostedInferenceActingUser(ctx)
+	if !ok {
+		return ctx, fmt.Errorf("validated session-backed acting user is required")
+	}
+	return context.WithValue(ctx, classificationContextKey{}, Classification{class: CallClassGovernedUser, category: category, actingUser: actingUser}), nil
+}
+
+// WithGovernedUserOrUnsupported governs an ordinary validated Gram session or
+// a chat JWT carrying matching ordinary-session provenance. API-key and other
+// non-ordinary categories never use owner, creator, external, or absent fields.
+func WithGovernedUserOrUnsupported(ctx context.Context, governed, apiKey, nonOrdinary CallCategory) (context.Context, error) {
+	if _, ok := contextvalues.ValidatedHostedInferenceActingUser(ctx); ok {
+		return WithGovernedUser(ctx, governed)
+	}
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	if authCtx != nil && authCtx.APIKeyID != "" {
+		return WithUnsupported(ctx, apiKey)
+	}
+	return WithUnsupported(ctx, nonOrdinary)
+}
+
+func WithInternal(ctx context.Context, category CallCategory) (context.Context, error) {
+	return withBypass(ctx, category, CallClassInternal)
+}
+
+func WithBackground(ctx context.Context, category CallCategory) (context.Context, error) {
+	return withBypass(ctx, category, CallClassBackground)
+}
+
+func WithUnsupported(ctx context.Context, category CallCategory) (context.Context, error) {
+	return withBypass(ctx, category, CallClassUnsupported)
+}
+
+func withBypass(ctx context.Context, category CallCategory, class CallClass) (context.Context, error) {
+	if err := validateCategoryClass(category, class); err != nil {
+		return ctx, err
+	}
+	return context.WithValue(ctx, classificationContextKey{}, Classification{class: class, category: category, actingUser: nil}), nil
+}
+
+func validateCategoryClass(category CallCategory, class CallClass) error {
+	expected, ok := categoryClasses[category]
+	if !ok {
+		return fmt.Errorf("unknown hosted-inference category %q", category)
+	}
+	if expected != class {
+		return fmt.Errorf("hosted-inference category %q requires class %q", category, expected)
+	}
+	return nil
+}
+
+func classificationFromContext(ctx context.Context) (Classification, bool) {
+	classification, ok := ctx.Value(classificationContextKey{}).(Classification)
+	return classification, ok
+}
+
+func isGovernedCategory(category CallCategory) bool {
+	return categoryClasses[category] == CallClassGovernedUser
+}

--- a/server/internal/killswitches/hostedinference/inventory_analysis_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_analysis_test.go
@@ -1,0 +1,1256 @@
+package hostedinference
+
+import (
+	"fmt"
+	"go/constant"
+	"go/token"
+	"go/types"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+const (
+	gramModulePath       = "github.com/speakeasy-api/gram"
+	openRouterPackage    = gramModulePath + "/server/internal/thirdparty/openrouter"
+	hostedPackage        = gramModulePath + "/server/internal/killswitches/hostedinference"
+	chatPackage          = gramModulePath + "/server/internal/chat"
+	contextValuesPackage = gramModulePath + "/server/internal/contextvalues"
+	openRouterSDKPrefix  = "github.com/OpenRouterTeam/go-sdk"
+)
+
+type inventoryIssue struct {
+	Kind     string
+	Path     string
+	Function string
+	Detail   string
+}
+
+func (i inventoryIssue) String() string {
+	return fmt.Sprintf("%s: %s:%s: %s", i.Kind, i.Path, i.Function, i.Detail)
+}
+
+type packageImport struct {
+	packagePath string
+	importPath  string
+}
+
+type typedCall struct {
+	path        string
+	packagePath string
+	function    string
+	callee      *types.Func
+	call        ssa.CallInstruction
+}
+
+type inventoryAnalysis struct {
+	serverRoot        string
+	program           *ssa.Program
+	functions         []*ssa.Function
+	calls             []typedCall
+	imports           []packageImport
+	completionMethods map[string][]*types.Signature
+	flowCategories    map[ssa.Value]map[CallCategory]struct{}
+	flowUnclassified  map[ssa.Value]bool
+	constructors      map[*ssa.Function]ConstructorKind
+	callers           map[*ssa.Function][]ssa.CallInstruction
+	escapedFunctions  map[*ssa.Function]bool
+}
+
+var (
+	repositoryAnalysisOnce sync.Once
+	repositoryAnalysis     *inventoryAnalysis
+	repositoryAnalysisErr  error
+)
+
+func loadRepositoryAnalysis(t *testing.T) *inventoryAnalysis {
+	t.Helper()
+	repositoryAnalysisOnce.Do(func() {
+		root := repositoryRoot(t)
+		patterns, err := repositoryInventoryPatterns(root)
+		if err != nil {
+			repositoryAnalysisErr = err
+			return
+		}
+		repositoryAnalysis, repositoryAnalysisErr = loadInventoryAnalysis(root, patterns...)
+	})
+	require.NoError(t, repositoryAnalysisErr)
+	return repositoryAnalysis
+}
+
+func repositoryInventoryPatterns(root string) ([]string, error) {
+	serverRoot := filepath.Join(root, "server")
+	patterns := map[string]bool{
+		"./server/internal/killswitches/hostedinference": true,
+		"./server/internal/thirdparty/openrouter":        true,
+	}
+	err := filepath.WalkDir(serverRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == "testdata" || path == filepath.Join(serverRoot, "gen") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(source)
+		relevant := strings.Contains(text, "NewUnifiedClient") ||
+			strings.Contains(text, "NewUncheckedUnifiedClient") ||
+			strings.Contains(text, "ChatClient") ||
+			strings.Contains(text, ".GetCompletion(") ||
+			strings.Contains(text, ".GetCompletionStream(") ||
+			strings.Contains(text, ".GetObjectCompletion(") ||
+			strings.Contains(text, ".CreateEmbeddings(") ||
+			strings.Contains(text, "WithValidatedGramSession(") ||
+			strings.Contains(text, "WithValidatedChatSessionActingUser(") ||
+			strings.Contains(text, hostedPackage) ||
+			strings.Contains(text, openRouterSDKPrefix) ||
+			strings.Contains(text, "OpenRouterBaseURL") ||
+			strings.Contains(text, "openrouter.ai/")
+		if !relevant && strings.Contains(text, "\"net/http\"") {
+			for _, operation := range []string{".Do(", ".RoundTrip(", ".Get(", ".Head(", ".Post(", ".PostForm("} {
+				if strings.Contains(text, operation) {
+					relevant = true
+					break
+				}
+			}
+		}
+		if relevant {
+			relative, err := filepath.Rel(root, filepath.Dir(path))
+			if err != nil {
+				return err
+			}
+			patterns["./"+filepath.ToSlash(relative)] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover inventory packages: %w", err)
+	}
+	result := make([]string, 0, len(patterns))
+	for pattern := range patterns {
+		result = append(result, pattern)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", "..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+func loadInventoryAnalysis(root string, patterns ...string) (*inventoryAnalysis, error) {
+	config := &packages.Config{
+		Dir: root,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo |
+			packages.NeedImports | packages.NeedTypesSizes,
+		Tests: false,
+	}
+	loaded, err := packages.Load(config, patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("load inventory packages: %w", err)
+	}
+	var packageErrors []string
+	for _, pkg := range loaded {
+		for _, packageErr := range pkg.Errors {
+			packageErrors = append(packageErrors, packageErr.Error())
+		}
+	}
+	if len(packageErrors) > 0 {
+		sort.Strings(packageErrors)
+		if len(packageErrors) > 8 {
+			packageErrors = packageErrors[:8]
+		}
+		return nil, fmt.Errorf("load inventory packages: %s", strings.Join(packageErrors, "; "))
+	}
+
+	program, ssaPackages := ssautil.Packages(loaded, ssa.InstantiateGenerics)
+	program.Build()
+
+	serverRoot := filepath.Join(root, "server")
+	analysis := &inventoryAnalysis{
+		serverRoot:        serverRoot,
+		program:           program,
+		completionMethods: map[string][]*types.Signature{},
+		flowCategories:    map[ssa.Value]map[CallCategory]struct{}{},
+		flowUnclassified:  map[ssa.Value]bool{},
+		constructors:      map[*ssa.Function]ConstructorKind{},
+		callers:           map[*ssa.Function][]ssa.CallInstruction{},
+		escapedFunctions:  map[*ssa.Function]bool{},
+	}
+	for _, pkg := range loaded {
+		analysis.registerOpenRouterSymbols(pkg)
+		if !strings.HasPrefix(pkg.PkgPath, gramModulePath+"/server/") {
+			continue
+		}
+		for importPath := range pkg.Imports {
+			analysis.imports = append(analysis.imports, packageImport{packagePath: pkg.PkgPath, importPath: importPath})
+		}
+	}
+	seenFunctions := map[*ssa.Function]bool{}
+	var addFunction func(*ssa.Function)
+	addFunction = func(fn *ssa.Function) {
+		if fn == nil || seenFunctions[fn] || len(fn.Blocks) == 0 {
+			return
+		}
+		seenFunctions[fn] = true
+		analysis.functions = append(analysis.functions, fn)
+		for _, anonymous := range fn.AnonFuncs {
+			addFunction(anonymous)
+		}
+	}
+	packages.Visit(loaded, func(pkg *packages.Package) bool {
+		analysis.registerOpenRouterSymbols(pkg)
+		return len(analysis.completionMethods) == 0 || len(analysis.constructors) == 0
+	}, nil)
+	for index, pkg := range loaded {
+		if index < len(ssaPackages) && ssaPackages[index] != nil {
+			for _, member := range ssaPackages[index].Members {
+				if fn, ok := member.(*ssa.Function); ok {
+					addFunction(fn)
+				}
+			}
+		}
+		for _, object := range pkg.TypesInfo.Defs {
+			if fnObject, ok := object.(*types.Func); ok {
+				addFunction(program.FuncValue(fnObject))
+			}
+		}
+	}
+	for _, fn := range analysis.functions {
+		path := analysis.functionPath(fn)
+		for _, block := range fn.Blocks {
+			for _, instruction := range block.Instrs {
+				call, _ := instruction.(ssa.CallInstruction)
+				var direct *ssa.Function
+				if call != nil {
+					direct = call.Common().StaticCallee()
+					if direct != nil {
+						analysis.callers[direct] = append(analysis.callers[direct], call)
+					}
+				}
+				for _, operand := range instruction.Operands(nil) {
+					referenced, ok := (*operand).(*ssa.Function)
+					if ok && referenced != direct {
+						analysis.escapedFunctions[referenced] = true
+					}
+				}
+				if call != nil {
+					if callee := calledObject(call.Common()); callee != nil {
+						ownerPackage := ""
+						if fn.Package() != nil && fn.Package().Pkg != nil {
+							ownerPackage = fn.Package().Pkg.Path()
+						}
+						analysis.calls = append(analysis.calls, typedCall{path: path, packagePath: ownerPackage, function: sourceFunctionName(fn), callee: callee, call: call})
+					}
+				}
+			}
+		}
+	}
+	analysis.computeCategoryFlow()
+	return analysis, nil
+}
+
+func (a *inventoryAnalysis) registerOpenRouterSymbols(pkg *packages.Package) {
+	if pkg == nil || pkg.PkgPath != openRouterPackage || pkg.Types == nil {
+		return
+	}
+	for _, kind := range []ConstructorKind{ConstructorProduction, ConstructorUnchecked} {
+		if object, ok := pkg.Types.Scope().Lookup(string(kind)).(*types.Func); ok {
+			a.constructors[a.program.FuncValue(object)] = kind
+		}
+	}
+	if len(a.completionMethods) > 0 {
+		return
+	}
+	object := pkg.Types.Scope().Lookup("CompletionClient")
+	if object == nil {
+		return
+	}
+	named, ok := types.Unalias(object.Type()).(*types.Named)
+	if !ok {
+		return
+	}
+	contract, ok := named.Underlying().(*types.Interface)
+	if !ok {
+		return
+	}
+	contract.Complete()
+	for method := range contract.Methods() {
+		switch method.Name() {
+		case "GetCompletion", "GetCompletionStream", "GetObjectCompletion", "CreateEmbeddings":
+			signature, _ := method.Type().(*types.Signature)
+			a.completionMethods[method.Name()] = append(a.completionMethods[method.Name()], signature)
+		}
+	}
+}
+
+func (a *inventoryAnalysis) functionPath(fn *ssa.Function) string {
+	filename := a.program.Fset.Position(fn.Pos()).Filename
+	rel, err := filepath.Rel(a.serverRoot, filename)
+	if err != nil {
+		return filepath.ToSlash(filename)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func sourceFunctionName(fn *ssa.Function) string {
+	for fn.Parent() != nil {
+		fn = fn.Parent()
+	}
+	return fn.Name()
+}
+
+func calledObject(common *ssa.CallCommon) *types.Func {
+	if common == nil {
+		return nil
+	}
+	if common.Method != nil {
+		return common.Method
+	}
+	if callee := common.StaticCallee(); callee != nil {
+		if object, ok := callee.Object().(*types.Func); ok {
+			return object
+		}
+	}
+	return nil
+}
+
+func packagePath(object *types.Func) string {
+	if object == nil || object.Pkg() == nil {
+		return ""
+	}
+	return object.Pkg().Path()
+}
+
+func isKnownContextPreserver(object *types.Func) bool {
+	if object == nil {
+		return false
+	}
+	switch packagePath(object) {
+	case "context":
+		switch object.Name() {
+		case "WithCancel", "WithCancelCause", "WithDeadline", "WithDeadlineCause", "WithTimeout", "WithTimeoutCause", "WithoutCancel":
+			return true
+		}
+	case "go.opentelemetry.io/otel/trace":
+		return object.Name() == "Start"
+	case chatPackage:
+		return object.Name() == "wrapHostedInferenceClassification"
+	}
+	return false
+}
+
+func isContextType(value types.Type) bool {
+	return isNamedType(value, "context", "Context")
+}
+
+func isNamedType(value types.Type, packagePath, name string) bool {
+	named, ok := types.Unalias(value).(*types.Named)
+	return ok && named.Obj().Pkg() != nil && named.Obj().Pkg().Path() == packagePath && named.Obj().Name() == name
+}
+
+func isPointerToNamedType(value types.Type, packagePath, name string) bool {
+	pointer, ok := types.Unalias(value).(*types.Pointer)
+	return ok && isNamedType(pointer.Elem(), packagePath, name)
+}
+
+func (a *inventoryAnalysis) completionIssues() []inventoryIssue {
+	type actualCall struct {
+		typedCall
+		categories   map[CallCategory]struct{}
+		unclassified bool
+	}
+	actual := map[string][]actualCall{}
+	for _, call := range a.calls {
+		if !a.isCompletionOperation(call.callee) || call.packagePath == openRouterPackage || isUncheckedConstructorAllowedPath(call.path) {
+			continue
+		}
+		shortPath := strings.TrimPrefix(call.path, "internal/")
+		owner := shortPath + ":" + call.function
+		if _, transparent := transparentForwarders[owner]; transparent {
+			continue
+		}
+		key := owner + ":" + call.callee.Name()
+		categories, unclassified := a.callClassification(call.call.Common())
+		actual[key] = append(actual[key], actualCall{typedCall: call, categories: categories, unclassified: unclassified})
+	}
+
+	expected := map[string][]CallSiteClaim{}
+	var issues []inventoryIssue
+	governedClaimed := map[CallCategory]bool{}
+	for _, claim := range productionCallSiteInventory {
+		key := claim.Path + ":" + claim.Function + ":" + claim.Method
+		expected[key] = append(expected[key], claim)
+		if err := validateCategoryClass(claim.Category, categoryClasses[claim.Category]); err != nil {
+			issues = append(issues, inventoryIssue{Kind: "invalid-class-claim", Path: claim.Path, Function: claim.Function, Detail: err.Error()})
+		}
+		if isGovernedCategory(claim.Category) {
+			governedClaimed[claim.Category] = true
+		}
+	}
+	for key, calls := range actual {
+		claims := expected[key]
+		if len(claims) != len(calls) {
+			issues = append(issues, inventoryIssue{Kind: "completion-inventory", Path: calls[0].path, Function: calls[0].function, Detail: fmt.Sprintf("%s actual=%d claimed=%d", calls[0].callee.Name(), len(calls), len(claims))})
+		}
+		for index, call := range calls {
+			if len(call.categories) == 0 || call.unclassified {
+				issues = append(issues, inventoryIssue{Kind: "completion-context", Path: call.path, Function: call.function, Detail: call.callee.Name() + " may receive an unclassified context"})
+			}
+			if index >= len(claims) {
+				continue
+			}
+			if !categoriesMatchClaim(call.categories, call.unclassified, claims[index]) {
+				issues = append(issues, inventoryIssue{Kind: "completion-context", Path: call.path, Function: call.function, Detail: fmt.Sprintf("%s receives categories %v (may be unclassified: %t), want %v", call.callee.Name(), sortedCategories(call.categories), call.unclassified, sortedCategories(allowedCategories(claims[index].Category)))})
+			}
+		}
+		delete(expected, key)
+	}
+	for key, claims := range expected {
+		if len(claims) > 0 {
+			issues = append(issues, inventoryIssue{Kind: "completion-inventory", Path: claims[0].Path, Function: claims[0].Function, Detail: key + " is claimed but absent"})
+		}
+	}
+	for category, class := range categoryClasses {
+		if class == CallClassGovernedUser && !governedClaimed[category] {
+			issues = append(issues, inventoryIssue{Kind: "missing-governed-claim", Detail: string(category)})
+		}
+	}
+	return sortedIssues(issues)
+}
+
+func categoriesMatchClaim(actual map[CallCategory]struct{}, unclassified bool, claim CallSiteClaim) bool {
+	return !unclassified && maps.Equal(actual, allowedCategories(claim.Category))
+}
+
+func allowedCategories(primary CallCategory) map[CallCategory]struct{} {
+	categories := []CallCategory{primary}
+	switch primary {
+	case CallCategoryUserChatCompletion:
+		categories = []CallCategory{CallCategoryUserChatCompletion, CallCategoryAPIKeyChat, CallCategoryNonOrdinaryGramSessionChat, CallCategoryAssistantChat, CallCategoryChatSessionChat}
+	case CallCategoryChatSummary:
+		categories = []CallCategory{CallCategoryChatSummary, CallCategoryAPIKeyChatSummary, CallCategoryNonOrdinarySessionChatSummary}
+	case CallCategoryToolCallSummary:
+		categories = []CallCategory{CallCategoryToolCallSummary, CallCategoryAPIKeyToolCallSummary, CallCategoryNonOrdinarySessionToolSummary}
+	case CallCategoryRiskAuthoring:
+		categories = []CallCategory{CallCategoryRiskAuthoring, CallCategoryAPIKeyRiskAuthoring, CallCategoryNonOrdinarySessionRiskAuthoring}
+	case CallCategoryBusinessMemorySearchEmbedding:
+		categories = []CallCategory{CallCategoryBusinessMemorySearchEmbedding, CallCategoryAPIKeyBusinessMemorySearch, CallCategoryNonOrdinarySessionMemorySearch}
+	}
+	result := make(map[CallCategory]struct{}, len(categories))
+	for _, category := range categories {
+		result[category] = struct{}{}
+	}
+	return result
+}
+
+func sortedCategories(categories map[CallCategory]struct{}) []string {
+	result := make([]string, 0, len(categories))
+	for category := range categories {
+		result = append(result, string(category))
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (a *inventoryAnalysis) isCompletionOperation(object *types.Func) bool {
+	if object == nil {
+		return false
+	}
+	signature, ok := object.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	for _, expected := range a.completionMethods[object.Name()] {
+		if sameCallableSignature(signature, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameCallableSignature(actual, expected *types.Signature) bool {
+	return types.Identical(actual, expected)
+}
+
+func (a *inventoryAnalysis) callClassification(common *ssa.CallCommon) (map[CallCategory]struct{}, bool) {
+	for _, argument := range common.Args {
+		if isContextType(argument.Type()) {
+			return a.flowCategories[argument], a.flowUnclassified[argument]
+		}
+	}
+	return nil, true
+}
+
+func (a *inventoryAnalysis) computeCategoryFlow() {
+	relevant := map[*ssa.Function]bool{}
+	for _, call := range a.calls {
+		if a.isCompletionOperation(call.callee) {
+			for fn := call.call.Parent(); fn != nil; fn = fn.Parent() {
+				relevant[fn] = true
+			}
+		}
+	}
+	changed := true
+	for changed {
+		changed = false
+		for fn := range relevant {
+			for _, caller := range a.callers[fn] {
+				if parent := caller.Parent(); parent != nil && !relevant[parent] {
+					relevant[parent] = true
+					changed = true
+				}
+			}
+			for _, block := range fn.Blocks {
+				for _, instruction := range block.Instrs {
+					call, ok := instruction.(ssa.CallInstruction)
+					if !ok {
+						continue
+					}
+					callee := call.Common().StaticCallee()
+					if callee != nil && functionReturnsContext(callee) && len(directClassificationCategories(call.Common())) == 0 && !isKnownContextPreserver(calledObject(call.Common())) && !relevant[callee] {
+						relevant[callee] = true
+						changed = true
+					}
+				}
+			}
+		}
+	}
+
+	edges := map[ssa.Value][]ssa.Value{}
+	var phis []*ssa.Phi
+	addEdge := func(from, to ssa.Value) {
+		if from != nil && to != nil {
+			edges[from] = append(edges[from], to)
+		}
+	}
+	seed := func(value ssa.Value, categories map[CallCategory]struct{}) {
+		if value == nil || len(categories) == 0 {
+			return
+		}
+		target := a.flowCategories[value]
+		if target == nil {
+			target = map[CallCategory]struct{}{}
+			a.flowCategories[value] = target
+		}
+		maps.Copy(target, categories)
+	}
+
+	for fn := range relevant {
+		for _, block := range fn.Blocks {
+			for _, instruction := range block.Instrs {
+				switch value := instruction.(type) {
+				case *ssa.Phi:
+					phis = append(phis, value)
+					for _, incoming := range value.Edges {
+						addEdge(incoming, value)
+					}
+				case *ssa.ChangeInterface:
+					addEdge(value.X, value)
+				case *ssa.ChangeType:
+					addEdge(value.X, value)
+				case *ssa.Convert:
+					addEdge(value.X, value)
+				case *ssa.MakeInterface:
+					addEdge(value.X, value)
+				case *ssa.Store:
+					addEdge(value.Val, value.Addr)
+				case *ssa.UnOp:
+					if value.Op == token.MUL {
+						addEdge(value.X, value)
+					}
+				case *ssa.MakeClosure:
+					closure, ok := value.Fn.(*ssa.Function)
+					if ok {
+						for index, binding := range value.Bindings {
+							if index < len(closure.FreeVars) {
+								addEdge(binding, closure.FreeVars[index])
+							}
+						}
+					}
+				}
+
+				call, ok := instruction.(ssa.CallInstruction)
+				if !ok {
+					continue
+				}
+				common := call.Common()
+				outputs := contextCallOutputs(call)
+				if categories := directClassificationCategories(common); len(categories) > 0 {
+					for _, output := range outputs {
+						seed(output.value, categories)
+					}
+				}
+				if isKnownContextPreserver(calledObject(common)) {
+					for _, argument := range common.Args {
+						if isContextType(argument.Type()) {
+							for _, output := range outputs {
+								addEdge(argument, output.value)
+							}
+						}
+					}
+				}
+				callee := common.StaticCallee()
+				if callee == nil || !relevant[callee] || len(directClassificationCategories(common)) > 0 || isKnownContextPreserver(calledObject(common)) {
+					continue
+				}
+				for index, argument := range common.Args {
+					if index < len(callee.Params) {
+						addEdge(argument, callee.Params[index])
+					}
+				}
+				for _, calleeBlock := range callee.Blocks {
+					for _, calleeInstruction := range calleeBlock.Instrs {
+						returned, ok := calleeInstruction.(*ssa.Return)
+						if !ok {
+							continue
+						}
+						for _, output := range outputs {
+							if output.index < len(returned.Results) {
+								addEdge(returned.Results[output.index], output.value)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	queue := make([]ssa.Value, 0, len(a.flowCategories))
+	for value := range a.flowCategories {
+		queue = append(queue, value)
+	}
+	for len(queue) > 0 {
+		value := queue[0]
+		queue = queue[1:]
+		for _, target := range edges[value] {
+			targetCategories := a.flowCategories[target]
+			if targetCategories == nil {
+				targetCategories = map[CallCategory]struct{}{}
+				a.flowCategories[target] = targetCategories
+			}
+			before := len(targetCategories)
+			maps.Copy(targetCategories, a.flowCategories[value])
+			if len(targetCategories) != before {
+				queue = append(queue, target)
+			}
+		}
+	}
+
+	for _, phi := range phis {
+		for _, incoming := range phi.Edges {
+			if isContextType(phi.Type()) && len(a.flowCategories[incoming]) == 0 {
+				a.flowUnclassified[phi] = true
+				break
+			}
+		}
+	}
+	for fn := range relevant {
+		for index, parameter := range fn.Params {
+			if !isContextType(parameter.Type()) {
+				continue
+			}
+			if a.escapedFunctions[fn] {
+				a.flowUnclassified[parameter] = true
+			}
+			for _, caller := range a.callers[fn] {
+				if index >= len(caller.Common().Args) {
+					continue
+				}
+				argument := caller.Common().Args[index]
+				if len(a.flowCategories[argument]) == 0 || a.flowUnclassified[argument] {
+					a.flowUnclassified[parameter] = true
+					break
+				}
+			}
+		}
+	}
+	queue = queue[:0]
+	for value := range a.flowUnclassified {
+		queue = append(queue, value)
+	}
+	for len(queue) > 0 {
+		value := queue[0]
+		queue = queue[1:]
+		for _, target := range edges[value] {
+			if !isContextType(value.Type()) || !isContextType(target.Type()) {
+				continue
+			}
+			if !a.flowUnclassified[target] {
+				a.flowUnclassified[target] = true
+				queue = append(queue, target)
+			}
+		}
+	}
+}
+
+type indexedContextValue struct {
+	index int
+	value ssa.Value
+}
+
+func contextCallOutputs(call ssa.CallInstruction) []indexedContextValue {
+	var result []indexedContextValue
+	if value, ok := call.(ssa.Value); ok && isContextType(value.Type()) {
+		result = append(result, indexedContextValue{index: 0, value: value})
+	}
+	value, hasValue := call.(ssa.Value)
+	if hasValue && value.Referrers() != nil {
+		for _, reference := range *value.Referrers() {
+			if extracted, ok := reference.(*ssa.Extract); ok && isContextType(extracted.Type()) {
+				result = append(result, indexedContextValue{index: extracted.Index, value: extracted})
+			}
+		}
+	}
+	return result
+}
+
+func functionReturnsContext(fn *ssa.Function) bool {
+	if fn == nil {
+		return false
+	}
+	signature := fn.Signature
+	for v := range signature.Results().Variables() {
+		if isContextType(v.Type()) {
+			return true
+		}
+	}
+	return false
+}
+
+func directClassificationCategories(common *ssa.CallCommon) map[CallCategory]struct{} {
+	object := calledObject(common)
+	if packagePath(object) != hostedPackage {
+		return nil
+	}
+	switch object.Name() {
+	case "WithGovernedUser", "WithGovernedUserOrUnsupported", "WithInternal", "WithBackground", "WithUnsupported":
+	default:
+		return nil
+	}
+	result := map[CallCategory]struct{}{}
+	for _, argument := range common.Args {
+		constantValue, ok := argument.(*ssa.Const)
+		if !ok || constantValue.Value == nil || constantValue.Value.Kind() != constant.String {
+			continue
+		}
+		category := CallCategory(constant.StringVal(constantValue.Value))
+		if _, registered := categoryClasses[category]; registered {
+			result[category] = struct{}{}
+		}
+	}
+	return result
+}
+
+func (a *inventoryAnalysis) constructorIssues() []inventoryIssue {
+	actual := map[string]int{}
+	factories := map[string]int{}
+	allocations := map[string]int{}
+	checkpointWrites := map[string]int{}
+	var issues []inventoryIssue
+	for _, fn := range a.functions {
+		constructionKey := a.functionPath(fn) + ":" + sourceFunctionName(fn)
+		if functionReturnsChatClient(fn) {
+			factories[constructionKey]++
+		}
+		for _, block := range fn.Blocks {
+			for _, instruction := range block.Instrs {
+				allocation, ok := instruction.(*ssa.Alloc)
+				if ok && isPointerToNamedType(allocation.Type(), openRouterPackage, "ChatClient") {
+					allocations[constructionKey]++
+				}
+				store, ok := instruction.(*ssa.Store)
+				field, fieldOK := storeAddrField(store, ok)
+				if fieldOK && field == "inferenceCheckpoint" {
+					checkpointWrites[constructionKey]++
+				}
+			}
+		}
+		for _, block := range fn.Blocks {
+			for _, instruction := range block.Instrs {
+				direct, _ := instruction.(ssa.CallInstruction)
+				for _, operand := range instruction.Operands(nil) {
+					constructor, ok := (*operand).(*ssa.Function)
+					if !ok {
+						continue
+					}
+					kind, tracked := a.constructors[constructor]
+					if !tracked || (direct != nil && direct.Common().StaticCallee() == constructor) {
+						continue
+					}
+					issues = append(issues, inventoryIssue{Kind: "constructor-reference", Path: a.functionPath(fn), Function: sourceFunctionName(fn), Detail: string(kind) + " must be called directly"})
+				}
+			}
+		}
+	}
+	constructionExpected := map[string]ClientConstructionClaim{}
+	for _, claim := range clientConstructionInventory {
+		constructionExpected[claim.Path+":"+claim.Function] = claim
+	}
+	constructionKeys := map[string]bool{}
+	for key := range factories {
+		constructionKeys[key] = true
+	}
+	for key := range allocations {
+		constructionKeys[key] = true
+	}
+	for key := range checkpointWrites {
+		constructionKeys[key] = true
+	}
+	for key := range constructionKeys {
+		claim, found := constructionExpected[key]
+		if !found || factories[key] != 1 || allocations[key] != claim.Allocations || checkpointWrites[key] != claim.CheckpointWrites {
+			issues = append(issues, inventoryIssue{Kind: "client-construction-inventory", Detail: fmt.Sprintf("%s factories=%d allocations=%d checkpoint-writes=%d", key, factories[key], allocations[key], checkpointWrites[key])})
+		}
+		delete(constructionExpected, key)
+	}
+	for key, claim := range constructionExpected {
+		issues = append(issues, inventoryIssue{Kind: "client-construction-inventory", Detail: fmt.Sprintf("%s factories=0 allocations=0 checkpoint-writes=0 want allocations=%d checkpoint-writes=%d", key, claim.Allocations, claim.CheckpointWrites)})
+	}
+
+	for _, call := range a.calls {
+		if packagePath(call.callee) != openRouterPackage {
+			continue
+		}
+		kind := ConstructorKind(call.callee.Name())
+		if kind != ConstructorProduction && kind != ConstructorUnchecked {
+			continue
+		}
+		if kind == ConstructorUnchecked && call.path == "internal/thirdparty/openrouter/unified_client.go" && call.function == "NewUnifiedClient" {
+			continue
+		}
+		key := call.path + ":" + string(kind)
+		actual[key]++
+		if kind == ConstructorProduction && call.packagePath != gramModulePath+"/server/cmd/gram" {
+			issues = append(issues, inventoryIssue{Kind: "production-constructor-boundary", Path: call.path, Function: call.function, Detail: string(kind)})
+		}
+		if kind == ConstructorUnchecked && !isUncheckedConstructorAllowedPath(call.path) {
+			issues = append(issues, inventoryIssue{Kind: "unchecked-constructor", Path: call.path, Function: call.function, Detail: string(kind)})
+		}
+	}
+	expected := map[string]int{}
+	for _, claim := range repositoryConstructorInventory {
+		expected[claim.Path+":"+string(claim.Kind)]++
+	}
+	for key, count := range actual {
+		if expected[key] != count {
+			issues = append(issues, inventoryIssue{Kind: "constructor-inventory", Detail: fmt.Sprintf("%s actual=%d claimed=%d", key, count, expected[key])})
+		}
+		delete(expected, key)
+	}
+	for key, count := range expected {
+		issues = append(issues, inventoryIssue{Kind: "constructor-inventory", Detail: fmt.Sprintf("%s actual=0 claimed=%d", key, count)})
+	}
+	return sortedIssues(issues)
+}
+
+func storeAddrField(store *ssa.Store, ok bool) (string, bool) {
+	if !ok {
+		return "", false
+	}
+	fieldAddr, ok := store.Addr.(*ssa.FieldAddr)
+	if !ok {
+		return "", false
+	}
+	pointer, ok := types.Unalias(fieldAddr.X.Type()).(*types.Pointer)
+	if !ok {
+		return "", false
+	}
+	named, ok := types.Unalias(pointer.Elem()).(*types.Named)
+	if !ok || named.Obj().Pkg() == nil || named.Obj().Pkg().Path() != openRouterPackage || named.Obj().Name() != "ChatClient" {
+		return "", false
+	}
+	structure, ok := named.Underlying().(*types.Struct)
+	if !ok || fieldAddr.Field >= structure.NumFields() {
+		return "", false
+	}
+	return structure.Field(fieldAddr.Field).Name(), true
+}
+
+func functionReturnsChatClient(fn *ssa.Function) bool {
+	if fn == nil || fn.Signature == nil {
+		return false
+	}
+	results := fn.Signature.Results()
+	for v := range results.Variables() {
+		if isPointerToNamedType(v.Type(), openRouterPackage, "ChatClient") {
+			return true
+		}
+	}
+	return false
+}
+
+func isUncheckedConstructorAllowedPath(filePath string) bool {
+	for _, claim := range repositoryConstructorInventory {
+		if claim.Kind == ConstructorUnchecked && filepath.Dir(claim.Path) == filepath.Dir(filePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) providerIssues() []inventoryIssue {
+	actual := map[string]int{}
+	var issues []inventoryIssue
+	for _, imported := range a.imports {
+		if imported.packagePath == openRouterPackage || !strings.HasPrefix(imported.importPath, openRouterSDKPrefix) || isOpenRouterSDKDataPackage(imported.importPath) {
+			continue
+		}
+		issues = append(issues, inventoryIssue{Kind: "provider-import-boundary", Path: strings.TrimPrefix(imported.packagePath, gramModulePath+"/server/"), Detail: imported.importPath})
+	}
+	for _, call := range a.calls {
+		operation := providerOperation(call.callee)
+		if operation == "" {
+			continue
+		}
+		inside := call.packagePath == openRouterPackage
+		if inside {
+			actual[call.path+":"+call.function+":"+operation]++
+			continue
+		}
+		if operation == ProviderOperationOpenRouterSDK || a.callTargetsOpenRouter(call.call.Common()) {
+			issues = append(issues, inventoryIssue{Kind: "provider-boundary", Path: call.path, Function: call.function, Detail: operation})
+		}
+	}
+
+	expected := map[string]int{}
+	claimedClass := map[string]string{}
+	for class, claims := range map[string][]ProviderOperationClaim{
+		"governed": governedProviderOperationInventory,
+		"excluded": excludedProviderOperationInventory,
+	} {
+		for _, claim := range claims {
+			key := claim.Path + ":" + claim.Function + ":" + claim.Operation
+			if previous, duplicate := claimedClass[key]; duplicate {
+				issues = append(issues, inventoryIssue{Kind: "duplicate-provider-classification", Path: claim.Path, Function: claim.Function, Detail: previous + " and " + class})
+			}
+			claimedClass[key] = class
+			expected[key]++
+		}
+	}
+	for key, count := range actual {
+		if expected[key] != count {
+			issues = append(issues, inventoryIssue{Kind: "provider-inventory", Detail: fmt.Sprintf("%s actual=%d claimed=%d", key, count, expected[key])})
+		}
+		delete(expected, key)
+	}
+	for key, count := range expected {
+		issues = append(issues, inventoryIssue{Kind: "provider-inventory", Detail: fmt.Sprintf("%s actual=0 claimed=%d", key, count)})
+	}
+	return sortedIssues(issues)
+}
+
+func isOpenRouterSDKDataPackage(path string) bool {
+	return path == openRouterSDKPrefix+"/models/components" || path == openRouterSDKPrefix+"/optionalnullable"
+}
+
+func providerOperation(object *types.Func) string {
+	if isHTTPClientDo(object) {
+		return ProviderOperationHTTPDo
+	}
+	if isHTTPRoundTrip(object) {
+		return ProviderOperationHTTPRoundTrip
+	}
+	if isHTTPConvenienceEgress(object) {
+		return ProviderOperationHTTPPackage
+	}
+	if isOpenRouterSDKOperation(object) {
+		return ProviderOperationOpenRouterSDK
+	}
+	return ""
+}
+
+func isHTTPClientDo(object *types.Func) bool {
+	return isHTTPRequestMethod(object, "Do")
+}
+
+func isHTTPRoundTrip(object *types.Func) bool {
+	return isHTTPRequestMethod(object, "RoundTrip")
+}
+
+func isHTTPRequestMethod(object *types.Func, name string) bool {
+	if object == nil || object.Name() != name {
+		return false
+	}
+	signature, ok := object.Type().(*types.Signature)
+	return ok && signature.Params().Len() == 1 && signature.Results().Len() >= 1 &&
+		isPointerToNamedType(signature.Params().At(0).Type(), "net/http", "Request") &&
+		isPointerToNamedType(signature.Results().At(0).Type(), "net/http", "Response")
+}
+
+func isHTTPConvenienceEgress(object *types.Func) bool {
+	if object == nil || packagePath(object) != "net/http" {
+		return false
+	}
+	signature, ok := object.Type().(*types.Signature)
+	if !ok || signature.Results().Len() == 0 || !isPointerToNamedType(signature.Results().At(0).Type(), "net/http", "Response") {
+		return false
+	}
+	if receiver := signature.Recv(); receiver != nil && !isPointerToNamedType(receiver.Type(), "net/http", "Client") {
+		return false
+	}
+	switch object.Name() {
+	case "Get", "Head", "Post", "PostForm":
+		return true
+	default:
+		return false
+	}
+}
+
+func isOpenRouterSDKOperation(object *types.Func) bool {
+	if object == nil || !strings.HasPrefix(packagePath(object), openRouterSDKPrefix) {
+		return false
+	}
+	signature, ok := object.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	for v := range signature.Params().Variables() {
+		if isContextType(v.Type()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) callTargetsOpenRouter(common *ssa.CallCommon) bool {
+	for _, argument := range common.Args {
+		if isPointerToNamedType(argument.Type(), "net/http", "Request") && a.requestUsesOpenRouterURL(argument, map[ssa.Value]bool{}) {
+			return true
+		}
+		if isStringType(argument.Type()) && a.valueUsesOpenRouterURL(argument, map[ssa.Value]bool{}) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStringType(value types.Type) bool {
+	basic, ok := types.Unalias(value).Underlying().(*types.Basic)
+	return ok && basic.Kind() == types.String
+}
+
+func (a *inventoryAnalysis) requestUsesOpenRouterURL(value ssa.Value, seen map[ssa.Value]bool) bool {
+	if value == nil || seen[value] {
+		return false
+	}
+	seen[value] = true
+	switch typed := value.(type) {
+	case *ssa.Extract:
+		call, ok := typed.Tuple.(ssa.CallInstruction)
+		return ok && (a.requestCallUsesOpenRouterURL(call.Common(), typed.Index, seen) || a.requestResultUsesOpenRouterURL(call.Common(), typed.Index, seen))
+	case *ssa.Call:
+		return a.requestCallUsesOpenRouterURL(typed.Common(), 0, seen) || a.requestResultUsesOpenRouterURL(typed.Common(), 0, seen)
+	case *ssa.Phi:
+		for _, edge := range typed.Edges {
+			if a.requestUsesOpenRouterURL(edge, seen) {
+				return true
+			}
+		}
+	case *ssa.ChangeType:
+		return a.requestUsesOpenRouterURL(typed.X, seen)
+	case *ssa.Convert:
+		return a.requestUsesOpenRouterURL(typed.X, seen)
+	case *ssa.Parameter:
+		callee := typed.Parent()
+		for _, call := range a.callers[callee] {
+			for index, parameter := range callee.Params {
+				if parameter == typed && index < len(call.Common().Args) && a.requestUsesOpenRouterURL(call.Common().Args[index], seen) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) requestCallUsesOpenRouterURL(common *ssa.CallCommon, _ int, seen map[ssa.Value]bool) bool {
+	object := calledObject(common)
+	if packagePath(object) != "net/http" || (object.Name() != "NewRequest" && object.Name() != "NewRequestWithContext") {
+		return false
+	}
+	for _, argument := range common.Args {
+		if isStringType(argument.Type()) && a.valueUsesOpenRouterURL(argument, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) requestResultUsesOpenRouterURL(common *ssa.CallCommon, resultIndex int, seen map[ssa.Value]bool) bool {
+	callee := common.StaticCallee()
+	if callee == nil {
+		return false
+	}
+	for _, block := range callee.Blocks {
+		for _, instruction := range block.Instrs {
+			returned, ok := instruction.(*ssa.Return)
+			if ok && resultIndex < len(returned.Results) && a.requestUsesOpenRouterURL(returned.Results[resultIndex], seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) valueUsesOpenRouterURL(value ssa.Value, seen map[ssa.Value]bool) bool {
+	if value == nil || seen[value] {
+		return false
+	}
+	seen[value] = true
+	if constantValue, ok := value.(*ssa.Const); ok && constantValue.Value != nil && constantValue.Value.Kind() == constant.String {
+		return strings.HasPrefix(constant.StringVal(constantValue.Value), "https://openrouter.ai/")
+	}
+	switch typed := value.(type) {
+	case *ssa.Phi:
+		for _, edge := range typed.Edges {
+			if a.valueUsesOpenRouterURL(edge, seen) {
+				return true
+			}
+		}
+	case *ssa.ChangeInterface:
+		return a.valueUsesOpenRouterURL(typed.X, seen)
+	case *ssa.ChangeType:
+		return a.valueUsesOpenRouterURL(typed.X, seen)
+	case *ssa.Convert:
+		return a.valueUsesOpenRouterURL(typed.X, seen)
+	case *ssa.MakeInterface:
+		return a.valueUsesOpenRouterURL(typed.X, seen)
+	case *ssa.Slice:
+		return a.valueUsesOpenRouterURL(typed.X, seen)
+	case *ssa.Alloc, *ssa.IndexAddr:
+		return a.aggregateUsesOpenRouterURL(value, seen)
+	case *ssa.BinOp:
+		return typed.Op == token.ADD && (a.valueUsesOpenRouterURL(typed.X, seen) || a.valueUsesOpenRouterURL(typed.Y, seen))
+	case *ssa.Extract:
+		if call, ok := typed.Tuple.(ssa.CallInstruction); ok {
+			return a.stringCallUsesOpenRouterURL(call.Common(), seen) || a.stringResultUsesOpenRouterURL(call.Common(), typed.Index, seen)
+		}
+	case *ssa.Call:
+		return a.stringCallUsesOpenRouterURL(typed.Common(), seen) || a.stringResultUsesOpenRouterURL(typed.Common(), 0, seen)
+	case *ssa.Parameter:
+		callee := typed.Parent()
+		for _, call := range a.callers[callee] {
+			for index, parameter := range callee.Params {
+				if parameter == typed && index < len(call.Common().Args) && a.valueUsesOpenRouterURL(call.Common().Args[index], seen) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) aggregateUsesOpenRouterURL(value ssa.Value, seen map[ssa.Value]bool) bool {
+	referrers := value.Referrers()
+	if referrers == nil {
+		return false
+	}
+	for _, instruction := range *referrers {
+		switch typed := instruction.(type) {
+		case *ssa.Store:
+			if a.valueUsesOpenRouterURL(typed.Val, seen) {
+				return true
+			}
+		case *ssa.IndexAddr, *ssa.Slice:
+			if a.valueUsesOpenRouterURL(typed.(ssa.Value), seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) stringCallUsesOpenRouterURL(common *ssa.CallCommon, seen map[ssa.Value]bool) bool {
+	object := calledObject(common)
+	if object == nil {
+		return false
+	}
+	preservesInput := false
+	switch packagePath(object) {
+	case "fmt":
+		preservesInput = object.Name() == "Sprint" || object.Name() == "Sprintf" || object.Name() == "Sprintln"
+	case "strings":
+		switch object.Name() {
+		case "Join", "Replace", "ReplaceAll", "ToLower", "ToUpper", "Trim", "TrimFunc", "TrimLeft", "TrimLeftFunc", "TrimPrefix", "TrimRight", "TrimRightFunc", "TrimSpace", "TrimSuffix":
+			preservesInput = true
+		}
+	case "path":
+		preservesInput = object.Name() == "Join"
+	case "net/url":
+		preservesInput = true
+	}
+	if !preservesInput {
+		return false
+	}
+	for _, argument := range common.Args {
+		if a.valueUsesOpenRouterURL(argument, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *inventoryAnalysis) stringResultUsesOpenRouterURL(common *ssa.CallCommon, resultIndex int, seen map[ssa.Value]bool) bool {
+	callee := common.StaticCallee()
+	if callee == nil {
+		return false
+	}
+	for _, block := range callee.Blocks {
+		for _, instruction := range block.Instrs {
+			returned, ok := instruction.(*ssa.Return)
+			if ok && resultIndex < len(returned.Results) && a.valueUsesOpenRouterURL(returned.Results[resultIndex], seen) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func sortedIssues(issues []inventoryIssue) []inventoryIssue {
+	sort.Slice(issues, func(i, j int) bool { return issues[i].String() < issues[j].String() })
+	return issues
+}
+
+func requireNoInventoryIssues(t *testing.T, issues []inventoryIssue) {
+	t.Helper()
+	if len(issues) == 0 {
+		return
+	}
+	formatted := make([]string, len(issues))
+	for index, issue := range issues {
+		formatted[index] = issue.String()
+	}
+	require.Empty(t, issues, strings.Join(formatted, "\n"))
+}
+
+func writeMutationPackage(t *testing.T, source string) string {
+	t.Helper()
+	directory, err := os.MkdirTemp(filepath.Join(repositoryRoot(t), "server", "internal", "thirdparty", "openrouter", "testdata"), "inventorymutation")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(directory)) })
+	require.NoError(t, os.WriteFile(filepath.Join(directory, "mutation.go"), []byte(source), 0o600))
+	return directory
+}

--- a/server/internal/killswitches/hostedinference/inventory_analysis_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_analysis_test.go
@@ -69,7 +69,7 @@ type inventoryAnalysis struct {
 var (
 	repositoryAnalysisOnce sync.Once
 	repositoryAnalysis     *inventoryAnalysis
-	repositoryAnalysisErr  error
+	errRepositoryAnalysis  error
 )
 
 func loadRepositoryAnalysis(t *testing.T) *inventoryAnalysis {
@@ -78,12 +78,12 @@ func loadRepositoryAnalysis(t *testing.T) *inventoryAnalysis {
 		root := repositoryRoot(t)
 		patterns, err := repositoryInventoryPatterns(root)
 		if err != nil {
-			repositoryAnalysisErr = err
+			errRepositoryAnalysis = err
 			return
 		}
-		repositoryAnalysis, repositoryAnalysisErr = loadInventoryAnalysis(root, patterns...)
+		repositoryAnalysis, errRepositoryAnalysis = loadInventoryAnalysis(root, patterns...)
 	})
-	require.NoError(t, repositoryAnalysisErr)
+	require.NoError(t, errRepositoryAnalysis)
 	return repositoryAnalysis
 }
 
@@ -108,7 +108,7 @@ func repositoryInventoryPatterns(root string) ([]string, error) {
 		}
 		source, err := os.ReadFile(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("read inventory candidate %s: %w", path, err)
 		}
 		text := string(source)
 		relevant := strings.Contains(text, "NewUnifiedClient") ||
@@ -135,7 +135,7 @@ func repositoryInventoryPatterns(root string) ([]string, error) {
 		if relevant {
 			relative, err := filepath.Rel(root, filepath.Dir(path))
 			if err != nil {
-				return err
+				return fmt.Errorf("make inventory package path relative: %w", err)
 			}
 			patterns["./"+filepath.ToSlash(relative)] = true
 		}
@@ -458,6 +458,7 @@ func allowedCategories(primary CallCategory) map[CallCategory]struct{} {
 		categories = []CallCategory{CallCategoryRiskAuthoring, CallCategoryAPIKeyRiskAuthoring, CallCategoryNonOrdinarySessionRiskAuthoring}
 	case CallCategoryBusinessMemorySearchEmbedding:
 		categories = []CallCategory{CallCategoryBusinessMemorySearchEmbedding, CallCategoryAPIKeyBusinessMemorySearch, CallCategoryNonOrdinarySessionMemorySearch}
+	default:
 	}
 	result := make(map[CallCategory]struct{}, len(categories))
 	for _, category := range categories {
@@ -1169,15 +1170,17 @@ func (a *inventoryAnalysis) aggregateUsesOpenRouterURL(value ssa.Value, seen map
 		return false
 	}
 	for _, instruction := range *referrers {
+		var candidate ssa.Value
 		switch typed := instruction.(type) {
 		case *ssa.Store:
-			if a.valueUsesOpenRouterURL(typed.Val, seen) {
-				return true
-			}
-		case *ssa.IndexAddr, *ssa.Slice:
-			if a.valueUsesOpenRouterURL(typed.(ssa.Value), seen) {
-				return true
-			}
+			candidate = typed.Val
+		case *ssa.IndexAddr:
+			candidate = typed
+		case *ssa.Slice:
+			candidate = typed
+		}
+		if candidate != nil && a.valueUsesOpenRouterURL(candidate, seen) {
+			return true
 		}
 	}
 	return false
@@ -1248,7 +1251,8 @@ func requireNoInventoryIssues(t *testing.T, issues []inventoryIssue) {
 
 func writeMutationPackage(t *testing.T, source string) string {
 	t.Helper()
-	directory, err := os.MkdirTemp(filepath.Join(repositoryRoot(t), "server", "internal", "thirdparty", "openrouter", "testdata"), "inventorymutation")
+	fixtureRoot := filepath.Join(repositoryRoot(t), "server", "internal", "thirdparty", "openrouter", "testdata")
+	directory, err := os.MkdirTemp(fixtureRoot, "inventorymutation") //nolint:usetesting // packages.Load requires the fixture beneath the repository module.
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(directory)) })
 	require.NoError(t, os.WriteFile(filepath.Join(directory, "mutation.go"), []byte(source), 0o600))

--- a/server/internal/killswitches/hostedinference/inventory_data_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_data_test.go
@@ -42,11 +42,74 @@ var productionCallSiteInventory = []CallSiteClaim{
 	{"skills/suggest/judge.go", "Generate", "GetObjectCompletion", CallCategorySkillJudge},
 }
 
-// standaloneCommandExclusions are report/benchmark binaries that deliberately
-// construct an uninjected client. They are not production Gram compositions.
-var standaloneCommandExclusions = []string{
-	"risk-pi-report",
-	"riskjudgebench",
-	"skillefficacybench",
-	"skillsuggestbench",
+// ConstructorKind identifies one supported ChatClient construction mode.
+type ConstructorKind string
+
+const (
+	ConstructorProduction ConstructorKind = "NewUnifiedClient"
+	ConstructorUnchecked  ConstructorKind = "NewUncheckedUnifiedClient"
+)
+
+// ConstructorClaim is an allowed repository construction site. The unchecked
+// constructor is restricted to the explicit standalone commands above.
+type ConstructorClaim struct {
+	Path string
+	Kind ConstructorKind
+}
+
+var repositoryConstructorInventory = []ConstructorClaim{
+	{"cmd/gram/start.go", ConstructorProduction},
+	{"cmd/gram/streams.go", ConstructorProduction},
+	{"cmd/gram/worker.go", ConstructorProduction},
+	{"cmd/risk-pi-report/main.go", ConstructorUnchecked},
+	{"cmd/riskjudgebench/main.go", ConstructorUnchecked},
+	{"cmd/skillefficacybench/main.go", ConstructorUnchecked},
+	{"cmd/skillsuggestbench/main.go", ConstructorUnchecked},
+}
+
+type ClientConstructionClaim struct {
+	Path             string
+	Function         string
+	Allocations      int
+	CheckpointWrites int
+}
+
+var clientConstructionInventory = []ClientConstructionClaim{
+	{"internal/thirdparty/openrouter/unified_client.go", "NewUnifiedClient", 0, 0},
+	{"internal/thirdparty/openrouter/unified_client.go", "NewUncheckedUnifiedClient", 1, 0},
+	{"internal/thirdparty/openrouter/unified_client.go", "WithHostedInferenceCheckpoint", 1, 1},
+}
+
+const (
+	ProviderOperationHTTPDo        = "HTTPClient.Do"
+	ProviderOperationHTTPRoundTrip = "HTTP.RoundTrip"
+	ProviderOperationHTTPPackage   = "HTTP.PackageFunction"
+	ProviderOperationOpenRouterSDK = "OpenRouterSDK.Operation"
+)
+
+// ProviderOperationClaim identifies one typed network operation implemented
+// by the OpenRouter provider package. Calls in other packages are forbidden.
+type ProviderOperationClaim struct {
+	Path      string
+	Function  string
+	Operation string
+}
+
+// governedProviderOperationInventory contains model inference attempts that are
+// covered by the hosted-inference checkpoint.
+var governedProviderOperationInventory = []ProviderOperationClaim{
+	{"internal/thirdparty/openrouter/unified_client.go", "Do", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/unified_client.go", "createEmbeddings", ProviderOperationOpenRouterSDK},
+	{"internal/thirdparty/openrouter/unified_client.go", "makeHTTPRequest", ProviderOperationHTTPDo},
+}
+
+// excludedProviderOperationInventory contains reviewed metadata, control-plane,
+// and background-accounting operations that do not perform hosted inference.
+var excludedProviderOperationInventory = []ProviderOperationClaim{
+	{"internal/thirdparty/openrouter/context_window.go", "fetchMin", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/openrouter.go", "GetKeyUsage", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/openrouter.go", "createOpenRouterAPIKey", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/openrouter.go", "getGenerationDetails", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/openrouter.go", "patchOpenRouterAPIKey", ProviderOperationHTTPDo},
+	{"internal/thirdparty/openrouter/spend.go", "doSpendRequest", ProviderOperationHTTPDo},
 }

--- a/server/internal/killswitches/hostedinference/inventory_data_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_data_test.go
@@ -1,0 +1,52 @@
+package hostedinference
+
+// CallSiteClaim is one statically classified production call site. Function
+// names make repeated methods in the same file independently reviewable.
+type CallSiteClaim struct {
+	Path     string
+	Function string
+	Method   string
+	Category CallCategory
+}
+
+var productionCallSiteInventory = []CallSiteClaim{
+	{"background/activities/chat_resolutions/analyze_segment.go", "analyzeWithLLM", "GetObjectCompletion", CallCategoryChatResolution},
+	{"background/activities/chat_resolutions/segment_chat.go", "segmentWithLLM", "GetObjectCompletion", CallCategoryChatResolution},
+	{"background/activities/generate_chat_title.go", "generateTitle", "GetCompletion", CallCategoryAutomaticChatTitle},
+	{"businessmemory/impl.go", "SearchBusinessMemories", "CreateEmbeddings", CallCategoryBusinessMemorySearchEmbedding},
+	{"businessmemory/judge.go", "persist", "CreateEmbeddings", CallCategoryBusinessMemoryJudge},
+	{"chat/agent_client.go", "AgentChat", "GetCompletion", CallCategoryAssistantChat},
+	{"chat/analysis/judge.go", "CallStructured", "GetObjectCompletion", CallCategoryChatAnalysis},
+	{"chat/impl.go", "HandleCompletion", "GetCompletionStream", CallCategoryUserChatCompletion},
+	{"chat/impl.go", "HandleCompletion", "GetCompletion", CallCategoryUserChatCompletion},
+	{"chat/impl.go", "Summarize", "GetCompletion", CallCategoryChatSummary},
+	{"chat/impl.go", "SummarizeToolCall", "GetCompletion", CallCategoryToolCallSummary},
+	{"chat/turnstream_tee.go", "teedCompletion", "GetCompletionStream", CallCategoryUserChatCompletion},
+	{"chat/turnstream_tee.go", "teedCompletion", "GetCompletion", CallCategoryUserChatCompletion},
+	{"mcpapproval/researchagent/researchagent.go", "Run", "GetCompletion", CallCategoryAssistantResearch},
+	{"mcpapproval/researchagent/researchagent.go", "extract", "GetObjectCompletion", CallCategoryAssistantResearch},
+	{"memory/contradiction.go", "detectContradiction", "GetObjectCompletion", CallCategoryAssistantMemory},
+	{"memory/service.go", "Remember", "CreateEmbeddings", CallCategoryAssistantMemory},
+	{"memory/service.go", "Recall", "CreateEmbeddings", CallCategoryAssistantMemory},
+	{"memory/service.go", "Forget", "CreateEmbeddings", CallCategoryAssistantMemory},
+	{"platformtools/research/research.go", "Search", "GetCompletion", CallCategoryAssistantResearch},
+	{"rag/search_tools.go", "SearchToolsetTools", "CreateEmbeddings", CallCategoryAssistantRAG},
+	{"rag/search_tools.go", "generateEmbeddings", "CreateEmbeddings", CallCategoryRAGIndexing},
+	{"risk/impl.go", "suggestCustomRuleViaLLM", "GetObjectCompletion", CallCategoryRiskAuthoring},
+	{"risk/impl.go", "requestExclusionSuggestion", "GetObjectCompletion", CallCategoryRiskAuthoring},
+	{"risk/impl.go", "generatePolicyName", "GetCompletion", CallCategoryRiskAuthoring},
+	{"risk/impl.go", "generatePromptPolicyName", "GetCompletion", CallCategoryRiskAuthoring},
+	{"scanners/promptinjection/openrouter/judge.go", "call", "GetCompletion", CallCategoryPromptScanner},
+	{"scanners/promptpolicy/openrouter/judge.go", "call", "GetObjectCompletion", CallCategoryPromptScanner},
+	{"skills/efficacy/judge.go", "call", "GetObjectCompletion", CallCategorySkillJudge},
+	{"skills/suggest/judge.go", "Generate", "GetObjectCompletion", CallCategorySkillJudge},
+}
+
+// standaloneCommandExclusions are report/benchmark binaries that deliberately
+// construct an uninjected client. They are not production Gram compositions.
+var standaloneCommandExclusions = []string{
+	"risk-pi-report",
+	"riskjudgebench",
+	"skillefficacybench",
+	"skillsuggestbench",
+}

--- a/server/internal/killswitches/hostedinference/inventory_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_test.go
@@ -1,22 +1,14 @@
 package hostedinference
 
 import (
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-var inventoriedMethods = map[string]struct{}{
-	"GetCompletion": {}, "GetCompletionStream": {},
-	"GetObjectCompletion": {}, "CreateEmbeddings": {},
-}
 
 // Transparent wrappers preserve the owning caller's classification and are not
 // independent inventory claims. Their forwarding behavior has focused tests in chat.
@@ -27,170 +19,14 @@ var transparentForwarders = map[string]struct{}{
 	"chat/agent_client.go:CreateEmbeddings":    {},
 }
 
-// classificationOwners explicitly links forwarding/fallback call sites to the
-// function that owns their classification. Every unlisted call site must
-// classify in its own function.
-var classificationOwners = map[string]string{
-	"chat/impl.go:HandleCompletion":                     "chat/hosted_inference.go:classifyChatInference",
-	"chat/turnstream_tee.go:teedCompletion":             "chat/hosted_inference.go:classifyChatInference",
-	"scanners/promptinjection/openrouter/judge.go:call": "scanners/promptinjection/openrouter/judge.go:Classify",
-	"scanners/promptpolicy/openrouter/judge.go:call":    "scanners/promptpolicy/openrouter/judge.go:Evaluate",
-	"skills/efficacy/judge.go:call":                     "skills/efficacy/judge.go:Judge",
-}
-
 func TestProductionCallSiteInventoryIsSynchronized(t *testing.T) {
 	t.Parallel()
-	internalRoot := filepath.Clean(filepath.Join("..", ".."))
-	actual := map[string]int{}
-	err := filepath.WalkDir(internalRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		require.NoError(t, walkErr)
-		if entry.IsDir() {
-			rel, _ := filepath.Rel(internalRoot, path)
-			if rel == filepath.Join("thirdparty", "openrouter") || rel == "gen" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-		require.NoError(t, parseErr)
-		rel, relErr := filepath.Rel(internalRoot, path)
-		require.NoError(t, relErr)
-		for _, declaration := range parsed.Decls {
-			fn, ok := declaration.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			if _, transparent := transparentForwarders[filepath.ToSlash(rel)+":"+fn.Name.Name]; transparent {
-				continue
-			}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				call, ok := node.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				selector, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok {
-					return true
-				}
-				method := selector.Sel.Name
-				if _, tracked := inventoriedMethods[method]; tracked {
-					actual[filepath.ToSlash(rel)+":"+fn.Name.Name+":"+method]++
-				}
-				return true
-			})
-		}
-		return nil
-	})
-	require.NoError(t, err)
-
-	expected := map[string]int{}
-	governedClaimed := map[CallCategory]bool{}
-	for _, claim := range productionCallSiteInventory {
-		require.NoError(t, validateCategoryClass(claim.Category, categoryClasses[claim.Category]), claim)
-		callSiteOwner := claim.Path + ":" + claim.Function
-		classificationOwner := callSiteOwner
-		if linked, ok := classificationOwners[callSiteOwner]; ok {
-			classificationOwner = linked
-		}
-		ownerPath, ownerFunction, ok := strings.Cut(classificationOwner, ":")
-		require.True(t, ok, "invalid classification owner: %s", classificationOwner)
-		require.True(t, functionReferencesIdentifier(t, filepath.Join(internalRoot, filepath.FromSlash(ownerPath)), ownerFunction, categoryIdentifier(claim.Category)),
-			"inventory claim is not classified by its linked function: %v owner=%s", claim, classificationOwner)
-
-		key := claim.Path + ":" + claim.Function + ":" + claim.Method
-		expected[key]++
-		if isGovernedCategory(claim.Category) {
-			governedClaimed[claim.Category] = true
-		}
-	}
-	require.Equal(t, expected, actual)
-	for category, class := range categoryClasses {
-		if class == CallClassGovernedUser {
-			require.True(t, governedClaimed[category], "registered governed category has no production coverage claim: %s", category)
-		}
-	}
+	requireNoInventoryIssues(t, loadRepositoryAnalysis(t).completionIssues())
 }
 
-func functionReferencesIdentifier(t *testing.T, path, function, identifier string) bool {
-	t.Helper()
-	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-	require.NoError(t, err)
-	for _, declaration := range parsed.Decls {
-		fn, ok := declaration.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != function || fn.Body == nil {
-			continue
-		}
-		found := false
-		ast.Inspect(fn.Body, func(node ast.Node) bool {
-			selector, ok := node.(*ast.SelectorExpr)
-			if ok && selector.Sel.Name == identifier {
-				found = true
-			}
-			return !found
-		})
-		return found
-	}
-	return false
-}
-
-func categoryIdentifier(category CallCategory) string {
-	return map[CallCategory]string{
-		CallCategoryUserChatCompletion:              "CallCategoryUserChatCompletion",
-		CallCategoryChatSummary:                     "CallCategoryChatSummary",
-		CallCategoryToolCallSummary:                 "CallCategoryToolCallSummary",
-		CallCategoryRiskAuthoring:                   "CallCategoryRiskAuthoring",
-		CallCategoryBusinessMemorySearchEmbedding:   "CallCategoryBusinessMemorySearchEmbedding",
-		CallCategoryAPIKeyChat:                      "CallCategoryAPIKeyChat",
-		CallCategoryChatSessionChat:                 "CallCategoryChatSessionChat",
-		CallCategoryNonOrdinaryGramSessionChat:      "CallCategoryNonOrdinaryGramSessionChat",
-		CallCategoryAPIKeyChatSummary:               "CallCategoryAPIKeyChatSummary",
-		CallCategoryAPIKeyToolCallSummary:           "CallCategoryAPIKeyToolCallSummary",
-		CallCategoryAPIKeyRiskAuthoring:             "CallCategoryAPIKeyRiskAuthoring",
-		CallCategoryAPIKeyBusinessMemorySearch:      "CallCategoryAPIKeyBusinessMemorySearch",
-		CallCategoryNonOrdinarySessionChatSummary:   "CallCategoryNonOrdinarySessionChatSummary",
-		CallCategoryNonOrdinarySessionToolSummary:   "CallCategoryNonOrdinarySessionToolSummary",
-		CallCategoryNonOrdinarySessionRiskAuthoring: "CallCategoryNonOrdinarySessionRiskAuthoring",
-		CallCategoryNonOrdinarySessionMemorySearch:  "CallCategoryNonOrdinarySessionMemorySearch",
-		CallCategoryAutomaticChatTitle:              "CallCategoryAutomaticChatTitle",
-		CallCategoryChatResolution:                  "CallCategoryChatResolution",
-		CallCategoryChatAnalysis:                    "CallCategoryChatAnalysis",
-		CallCategoryPromptScanner:                   "CallCategoryPromptScanner",
-		CallCategorySkillJudge:                      "CallCategorySkillJudge",
-		CallCategoryBusinessMemoryJudge:             "CallCategoryBusinessMemoryJudge",
-		CallCategoryRAGIndexing:                     "CallCategoryRAGIndexing",
-		CallCategoryAssistantChat:                   "CallCategoryAssistantChat",
-		CallCategoryAssistantMemory:                 "CallCategoryAssistantMemory",
-		CallCategoryAssistantResearch:               "CallCategoryAssistantResearch",
-		CallCategoryAssistantRAG:                    "CallCategoryAssistantRAG",
-	}[category]
-}
-
-func TestProductionCompositionsInjectCheckpoint(t *testing.T) {
+func TestRepositoryConstructorInventoryIsSynchronized(t *testing.T) {
 	t.Parallel()
-	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
-	production := []string{"cmd/gram/start.go", "cmd/gram/worker.go", "cmd/gram/streams.go"}
-	for _, rel := range production {
-		body, err := os.ReadFile(filepath.Join(serverRoot, rel))
-		require.NoError(t, err)
-		text := string(body)
-		require.Equal(t, 1, strings.Count(text, "NewUnifiedClient("), rel)
-		require.Contains(t, text, "WithHostedInferenceCheckpoint(", rel)
-	}
-	for _, command := range standaloneCommandExclusions {
-		matches, err := filepath.Glob(filepath.Join(serverRoot, "cmd", command, "*.go"))
-		require.NoError(t, err)
-		joined := strings.Builder{}
-		for _, match := range matches {
-			body, readErr := os.ReadFile(match)
-			require.NoError(t, readErr)
-			joined.Write(body)
-		}
-		require.Equal(t, 1, strings.Count(joined.String(), "NewUnifiedClient("), command)
-		require.NotContains(t, joined.String(), "WithHostedInferenceCheckpoint(", command)
-	}
+	requireNoInventoryIssues(t, loadRepositoryAnalysis(t).constructorIssues())
 }
 
 func TestProductionAIAccessCompositionSharesRegistryAndEvaluator(t *testing.T) {
@@ -208,7 +44,8 @@ func TestProductionAIAccessCompositionSharesRegistryAndEvaluator(t *testing.T) {
 	require.NotContains(t, text, "killswitches.NewEvaluator(")
 	require.Contains(t, text, "NewHookAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator")
 	require.Contains(t, text, "NewLiteLLMAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator")
-	require.Contains(t, text, "WithHostedInferenceCheckpoint(aiAccess.hostedInference)")
+	require.Contains(t, text, "openrouter.NewUnifiedClient(")
+	require.NotContains(t, text, "WithHostedInferenceCheckpoint(aiAccess.hostedInference)")
 
 	checkpoint, err := os.ReadFile(filepath.Join(serverRoot, "internal/killswitches/hostedinference/checkpoint.go"))
 	require.NoError(t, err)
@@ -217,23 +54,21 @@ func TestProductionAIAccessCompositionSharesRegistryAndEvaluator(t *testing.T) {
 
 func TestManagementAuditAndPlatformControlPathsDoNotDependOnHostedInferenceCheckpoint(t *testing.T) {
 	t.Parallel()
-
-	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
-	for _, rel := range []string{"internal/killswitchapi", "internal/audit", "internal/auditapi", "internal/platformmcp"} {
-		err := filepath.WalkDir(filepath.Join(serverRoot, rel), func(path string, entry fs.DirEntry, walkErr error) error {
-			require.NoError(t, walkErr)
-			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-				return nil
+	analysis := loadRepositoryAnalysis(t)
+	restricted := []string{"/internal/killswitchapi", "/internal/audit", "/internal/auditapi", "/internal/platformmcp"}
+	for _, imported := range analysis.imports {
+		for _, suffix := range restricted {
+			if strings.HasPrefix(imported.packagePath, gramModulePath+"/server"+suffix) {
+				require.NotEqual(t, hostedPackage, imported.importPath, imported.packagePath)
 			}
-			body, readErr := os.ReadFile(path)
-			require.NoError(t, readErr)
-			text := string(body)
-			require.NotContains(t, text, "killswitches/hostedinference", path)
-			require.NotContains(t, text, "PreflightHostedInference", path)
-			require.NotContains(t, text, "WithHostedInferenceCheckpoint", path)
-			return nil
-		})
-		require.NoError(t, err)
+		}
+	}
+	for _, call := range analysis.calls {
+		for _, suffix := range restricted {
+			if strings.HasPrefix(call.packagePath, gramModulePath+"/server"+suffix) {
+				require.NotEqual(t, hostedPackage, packagePath(call.callee), call.path)
+			}
+		}
 	}
 }
 
@@ -244,38 +79,22 @@ func TestManagementAuditAndPlatformControlPathsDoNotDependOnHostedInferenceCheck
 func TestValidatedSessionProvenanceMintingIsAuthBoundaryOwned(t *testing.T) {
 	t.Parallel()
 
-	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
 	actual := map[string][]string{}
 	tracked := map[string]struct{}{
 		"WithValidatedGramSession":           {},
 		"WithValidatedChatSessionActingUser": {},
 	}
-	err := filepath.WalkDir(serverRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		require.NoError(t, walkErr)
-		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
+	for _, call := range loadRepositoryAnalysis(t).calls {
+		if packagePath(call.callee) != contextValuesPackage {
+			continue
 		}
-		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-		require.NoError(t, parseErr)
-		rel, relErr := filepath.Rel(serverRoot, path)
-		require.NoError(t, relErr)
-		ast.Inspect(parsed, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			selector, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			if _, ok := tracked[selector.Sel.Name]; ok {
-				actual[selector.Sel.Name] = append(actual[selector.Sel.Name], filepath.ToSlash(rel))
-			}
-			return true
-		})
-		return nil
-	})
-	require.NoError(t, err)
+		if _, ok := tracked[call.callee.Name()]; ok {
+			actual[call.callee.Name()] = append(actual[call.callee.Name()], call.path)
+		}
+	}
+	for _, paths := range actual {
+		sort.Strings(paths)
+	}
 	require.Equal(t, map[string][]string{
 		"WithValidatedGramSession": {
 			"internal/auth/sessions/sessions.go",
@@ -287,64 +106,187 @@ func TestValidatedSessionProvenanceMintingIsAuthBoundaryOwned(t *testing.T) {
 	}, actual)
 }
 
-func TestHostedProviderTransportsAreRepoWideAllowlisted(t *testing.T) {
+func TestProviderOperationInventoryIsSynchronized(t *testing.T) {
 	t.Parallel()
-	repoRoot := filepath.Clean(filepath.Join("..", "..", "..", ".."))
-	matches := map[string]int{}
-	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
-		require.NoError(t, walkErr)
-		if entry.IsDir() {
-			name := entry.Name()
-			if name == ".git" || name == "node_modules" || name == "vendor" || name == "gen" {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
-		require.NoError(t, parseErr)
-		rel, relErr := filepath.Rel(repoRoot, path)
-		require.NoError(t, relErr)
-		for _, declaration := range parsed.Decls {
-			fn, ok := declaration.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			ast.Inspect(fn.Body, func(node ast.Node) bool {
-				switch value := node.(type) {
-				case *ast.BasicLit:
-					if strings.Contains(value.Value, "/v1/chat/completions") {
-						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":raw_chat_completions"]++
-					}
-					if strings.Contains(value.Value, "/endpoints") {
-						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":raw_model_endpoints"]++
-					}
-				case *ast.CallExpr:
-					selector, ok := value.Fun.(*ast.SelectorExpr)
-					if !ok {
-						break
-					}
-					if selector.Sel.Name == "Generate" {
-						if owner, ok := selector.X.(*ast.SelectorExpr); ok && owner.Sel.Name == "Embeddings" {
-							matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":sdk_embeddings"]++
-						}
-					}
-					if ident, ok := selector.X.(*ast.Ident); ok && ident.Name == "or_base" && selector.Sel.Name == "New" {
-						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":sdk_client"]++
-					}
-				}
-				return true
-			})
-		}
-		return nil
-	})
+	requireNoInventoryIssues(t, loadRepositoryAnalysis(t).providerIssues())
+}
+
+func TestTypeAwareInventoryDetectsRegressions(t *testing.T) {
+	directory := writeMutationPackage(t, `package inventorymutation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	_ "github.com/OpenRouterTeam/go-sdk/retry"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+func droppedClassification(ctx context.Context, client openrouter.CompletionClient) {
+	classified, _ := hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	_ = classified
+	_, _ = client.GetCompletion(ctx, openrouter.CompletionRequest{})
+}
+
+func mergedClassification(ctx context.Context, client openrouter.CompletionClient, background bool) {
+	classified, _ := hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	if background {
+		classified, _ = hostedinference.WithBackground(ctx, hostedinference.CallCategoryAutomaticChatTitle)
+	}
+	_, _ = client.GetCompletion(classified, openrouter.CompletionRequest{})
+}
+
+func conditionallyDroppedClassification(ctx context.Context, client openrouter.CompletionClient, drop bool) {
+	classified, _ := hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	if drop {
+		classified = ctx
+	}
+	_, _ = client.GetCompletion(classified, openrouter.CompletionRequest{})
+}
+
+func forwardCompletion(ctx context.Context, client openrouter.CompletionClient) {
+	_, _ = client.GetCompletion(ctx, openrouter.CompletionRequest{})
+}
+
+func classifiedForwardingCaller(ctx context.Context, client openrouter.CompletionClient) {
+	classified, _ := hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	forwardCompletion(classified, client)
+}
+
+var forwardAlias = forwardCompletion
+
+func rawForwardingCaller(ctx context.Context, client openrouter.CompletionClient) {
+	forwardAlias(ctx, client)
+}
+
+var uncheckedFactory = openrouter.NewUncheckedUnifiedClient
+
+func uncheckedProductionConstruction() {
+	_ = openrouter.NewUncheckedUnifiedClient(nil, nil, nil, nil, nil, nil, nil, nil)
+	_ = uncheckedFactory(nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
+func misplacedProductionConstruction() {
+	_, _ = openrouter.NewUnifiedClient(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
+func rogueClientFactory() openrouter.CompletionClient {
+	return &openrouter.ChatClient{}
+}
+
+func directProviderEgress(ctx context.Context) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, openrouter.OpenRouterBaseURL+"/v1/chat/completions", nil)
+	_, _ = http.DefaultClient.Do(req)
+}
+
+func providerRequest(ctx context.Context) *http.Request {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, openrouter.OpenRouterBaseURL+"/v1/chat/completions", nil)
+	return req
+}
+
+func helperProviderEgress(ctx context.Context) {
+	_, _ = http.DefaultTransport.RoundTrip(providerRequest(ctx))
+}
+
+func sendProviderRequest(req *http.Request) {
+	_, _ = http.DefaultClient.Do(req)
+}
+
+func parameterProviderEgress(ctx context.Context) {
+	sendProviderRequest(providerRequest(ctx))
+}
+
+func formattedProviderEgress(ctx context.Context) {
+	providerURL := fmt.Sprintf("%s/v1/chat/completions", openrouter.OpenRouterBaseURL)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, providerURL, nil)
+	_, _ = http.DefaultClient.Do(req)
+}
+
+func parsedProviderEgress(ctx context.Context) {
+	providerURL, _ := url.Parse(openrouter.OpenRouterBaseURL)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, providerURL.JoinPath("v1", "chat", "completions").String(), nil)
+	_, _ = http.DefaultClient.Do(req)
+}
+
+func clientGetProviderEgress() {
+	_, _ = http.DefaultClient.Get(openrouter.OpenRouterBaseURL + "/v1/models")
+}
+
+func clientHeadProviderEgress() {
+	_, _ = http.DefaultClient.Head(openrouter.OpenRouterBaseURL + "/v1/models")
+}
+
+func clientPostProviderEgress() {
+	_, _ = http.DefaultClient.Post(openrouter.OpenRouterBaseURL+"/v1/chat/completions", "application/json", nil)
+}
+
+func clientPostFormProviderEgress() {
+	_, _ = http.DefaultClient.PostForm(openrouter.OpenRouterBaseURL+"/v1/chat/completions", nil)
+}
+
+func packageProviderEgress() {
+	_, _ = http.Post(openrouter.OpenRouterBaseURL+"/v1/chat/completions", "application/json", nil)
+}
+`)
+
+	root := repositoryRoot(t)
+	relative, err := filepath.Rel(root, directory)
 	require.NoError(t, err)
+	analysis, err := loadInventoryAnalysis(root, "./"+filepath.ToSlash(relative))
+	require.NoError(t, err)
+	issues := append(analysis.completionIssues(), analysis.constructorIssues()...)
+	issues = append(issues, analysis.providerIssues()...)
+
+	kinds := map[string]bool{}
+	boundaryFunctions := map[string]bool{}
+	contextIssueFunctions := map[string]bool{}
+	for _, issue := range issues {
+		kinds[issue.Kind] = true
+		if issue.Kind == "provider-boundary" {
+			boundaryFunctions[issue.Function] = true
+		}
+		if issue.Kind == "completion-context" {
+			contextIssueFunctions[issue.Function] = true
+		}
+	}
+	for _, function := range []string{"droppedClassification", "conditionallyDroppedClassification", "forwardCompletion"} {
+		require.True(t, contextIssueFunctions[function], "%s context regression was not detected: %v", function, issues)
+	}
+	require.True(t, kinds["unchecked-constructor"], "unchecked production constructor was not detected: %v", issues)
+	require.True(t, kinds["production-constructor-boundary"], "misplaced production constructor was not detected: %v", issues)
+	require.True(t, kinds["client-construction-inventory"], "rogue client factory was not detected: %v", issues)
+	require.True(t, kinds["constructor-reference"], "aliased constructor was not detected: %v", issues)
+	for _, function := range []string{"directProviderEgress", "helperProviderEgress", "sendProviderRequest", "formattedProviderEgress", "parsedProviderEgress", "clientGetProviderEgress", "clientHeadProviderEgress", "clientPostProviderEgress", "clientPostFormProviderEgress", "packageProviderEgress"} {
+		require.True(t, boundaryFunctions[function], "%s was not detected: %v", function, issues)
+	}
+	require.True(t, kinds["provider-import-boundary"], "operational OpenRouter SDK import was not detected: %v", issues)
+
+	matched := map[string]int{}
+	for _, call := range analysis.calls {
+		if !analysis.isCompletionOperation(call.callee) {
+			continue
+		}
+		switch call.function {
+		case "mergedClassification":
+			matched[call.function]++
+			categories, unclassified := analysis.callClassification(call.call.Common())
+			require.Contains(t, categories, CallCategoryPromptScanner)
+			require.Contains(t, categories, CallCategoryAutomaticChatTitle)
+			require.False(t, categoriesMatchClaim(categories, unclassified, CallSiteClaim{Category: CallCategoryPromptScanner}), "mixed-category flow must not satisfy an exact claim")
+		case "conditionallyDroppedClassification", "forwardCompletion":
+			matched[call.function]++
+			categories, unclassified := analysis.callClassification(call.call.Common())
+			require.Contains(t, categories, CallCategoryPromptScanner)
+			require.True(t, unclassified, "%s must retain an unclassified path", call.function)
+			require.False(t, categoriesMatchClaim(categories, unclassified, CallSiteClaim{Category: CallCategoryPromptScanner}))
+		}
+	}
 	require.Equal(t, map[string]int{
-		"server/internal/thirdparty/openrouter/context_window.go:fetchMin:raw_model_endpoints":         1,
-		"server/internal/thirdparty/openrouter/unified_client.go:createEmbeddings:sdk_client":          1,
-		"server/internal/thirdparty/openrouter/unified_client.go:createEmbeddings:sdk_embeddings":      1,
-		"server/internal/thirdparty/openrouter/unified_client.go:makeHTTPRequest:raw_chat_completions": 1,
-	}, matches)
+		"mergedClassification":               1,
+		"conditionallyDroppedClassification": 1,
+		"forwardCompletion":                  1,
+	}, matched)
 }

--- a/server/internal/killswitches/hostedinference/inventory_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_test.go
@@ -1,0 +1,350 @@
+package hostedinference
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var inventoriedMethods = map[string]struct{}{
+	"GetCompletion": {}, "GetCompletionStream": {},
+	"GetObjectCompletion": {}, "CreateEmbeddings": {},
+}
+
+// Transparent wrappers preserve the owning caller's classification and are not
+// independent inventory claims. Their forwarding behavior has focused tests in chat.
+var transparentForwarders = map[string]struct{}{
+	"chat/agent_client.go:GetCompletion":       {},
+	"chat/agent_client.go:GetCompletionStream": {},
+	"chat/agent_client.go:GetObjectCompletion": {},
+	"chat/agent_client.go:CreateEmbeddings":    {},
+}
+
+// classificationOwners explicitly links forwarding/fallback call sites to the
+// function that owns their classification. Every unlisted call site must
+// classify in its own function.
+var classificationOwners = map[string]string{
+	"chat/impl.go:HandleCompletion":                     "chat/hosted_inference.go:classifyChatInference",
+	"chat/turnstream_tee.go:teedCompletion":             "chat/hosted_inference.go:classifyChatInference",
+	"scanners/promptinjection/openrouter/judge.go:call": "scanners/promptinjection/openrouter/judge.go:Classify",
+	"scanners/promptpolicy/openrouter/judge.go:call":    "scanners/promptpolicy/openrouter/judge.go:Evaluate",
+	"skills/efficacy/judge.go:call":                     "skills/efficacy/judge.go:Judge",
+}
+
+func TestProductionCallSiteInventoryIsSynchronized(t *testing.T) {
+	t.Parallel()
+	internalRoot := filepath.Clean(filepath.Join("..", ".."))
+	actual := map[string]int{}
+	err := filepath.WalkDir(internalRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		require.NoError(t, walkErr)
+		if entry.IsDir() {
+			rel, _ := filepath.Rel(internalRoot, path)
+			if rel == filepath.Join("thirdparty", "openrouter") || rel == "gen" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		require.NoError(t, parseErr)
+		rel, relErr := filepath.Rel(internalRoot, path)
+		require.NoError(t, relErr)
+		for _, declaration := range parsed.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if _, transparent := transparentForwarders[filepath.ToSlash(rel)+":"+fn.Name.Name]; transparent {
+				continue
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				selector, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				method := selector.Sel.Name
+				if _, tracked := inventoriedMethods[method]; tracked {
+					actual[filepath.ToSlash(rel)+":"+fn.Name.Name+":"+method]++
+				}
+				return true
+			})
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	expected := map[string]int{}
+	governedClaimed := map[CallCategory]bool{}
+	for _, claim := range productionCallSiteInventory {
+		require.NoError(t, validateCategoryClass(claim.Category, categoryClasses[claim.Category]), claim)
+		callSiteOwner := claim.Path + ":" + claim.Function
+		classificationOwner := callSiteOwner
+		if linked, ok := classificationOwners[callSiteOwner]; ok {
+			classificationOwner = linked
+		}
+		ownerPath, ownerFunction, ok := strings.Cut(classificationOwner, ":")
+		require.True(t, ok, "invalid classification owner: %s", classificationOwner)
+		require.True(t, functionReferencesIdentifier(t, filepath.Join(internalRoot, filepath.FromSlash(ownerPath)), ownerFunction, categoryIdentifier(claim.Category)),
+			"inventory claim is not classified by its linked function: %v owner=%s", claim, classificationOwner)
+
+		key := claim.Path + ":" + claim.Function + ":" + claim.Method
+		expected[key]++
+		if isGovernedCategory(claim.Category) {
+			governedClaimed[claim.Category] = true
+		}
+	}
+	require.Equal(t, expected, actual)
+	for category, class := range categoryClasses {
+		if class == CallClassGovernedUser {
+			require.True(t, governedClaimed[category], "registered governed category has no production coverage claim: %s", category)
+		}
+	}
+}
+
+func functionReferencesIdentifier(t *testing.T, path, function, identifier string) bool {
+	t.Helper()
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	require.NoError(t, err)
+	for _, declaration := range parsed.Decls {
+		fn, ok := declaration.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != function || fn.Body == nil {
+			continue
+		}
+		found := false
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			selector, ok := node.(*ast.SelectorExpr)
+			if ok && selector.Sel.Name == identifier {
+				found = true
+			}
+			return !found
+		})
+		return found
+	}
+	return false
+}
+
+func categoryIdentifier(category CallCategory) string {
+	return map[CallCategory]string{
+		CallCategoryUserChatCompletion:              "CallCategoryUserChatCompletion",
+		CallCategoryChatSummary:                     "CallCategoryChatSummary",
+		CallCategoryToolCallSummary:                 "CallCategoryToolCallSummary",
+		CallCategoryRiskAuthoring:                   "CallCategoryRiskAuthoring",
+		CallCategoryBusinessMemorySearchEmbedding:   "CallCategoryBusinessMemorySearchEmbedding",
+		CallCategoryAPIKeyChat:                      "CallCategoryAPIKeyChat",
+		CallCategoryChatSessionChat:                 "CallCategoryChatSessionChat",
+		CallCategoryNonOrdinaryGramSessionChat:      "CallCategoryNonOrdinaryGramSessionChat",
+		CallCategoryAPIKeyChatSummary:               "CallCategoryAPIKeyChatSummary",
+		CallCategoryAPIKeyToolCallSummary:           "CallCategoryAPIKeyToolCallSummary",
+		CallCategoryAPIKeyRiskAuthoring:             "CallCategoryAPIKeyRiskAuthoring",
+		CallCategoryAPIKeyBusinessMemorySearch:      "CallCategoryAPIKeyBusinessMemorySearch",
+		CallCategoryNonOrdinarySessionChatSummary:   "CallCategoryNonOrdinarySessionChatSummary",
+		CallCategoryNonOrdinarySessionToolSummary:   "CallCategoryNonOrdinarySessionToolSummary",
+		CallCategoryNonOrdinarySessionRiskAuthoring: "CallCategoryNonOrdinarySessionRiskAuthoring",
+		CallCategoryNonOrdinarySessionMemorySearch:  "CallCategoryNonOrdinarySessionMemorySearch",
+		CallCategoryAutomaticChatTitle:              "CallCategoryAutomaticChatTitle",
+		CallCategoryChatResolution:                  "CallCategoryChatResolution",
+		CallCategoryChatAnalysis:                    "CallCategoryChatAnalysis",
+		CallCategoryPromptScanner:                   "CallCategoryPromptScanner",
+		CallCategorySkillJudge:                      "CallCategorySkillJudge",
+		CallCategoryBusinessMemoryJudge:             "CallCategoryBusinessMemoryJudge",
+		CallCategoryRAGIndexing:                     "CallCategoryRAGIndexing",
+		CallCategoryAssistantChat:                   "CallCategoryAssistantChat",
+		CallCategoryAssistantMemory:                 "CallCategoryAssistantMemory",
+		CallCategoryAssistantResearch:               "CallCategoryAssistantResearch",
+		CallCategoryAssistantRAG:                    "CallCategoryAssistantRAG",
+	}[category]
+}
+
+func TestProductionCompositionsInjectCheckpoint(t *testing.T) {
+	t.Parallel()
+	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	production := []string{"cmd/gram/start.go", "cmd/gram/worker.go", "cmd/gram/streams.go"}
+	for _, rel := range production {
+		body, err := os.ReadFile(filepath.Join(serverRoot, rel))
+		require.NoError(t, err)
+		text := string(body)
+		require.Equal(t, 1, strings.Count(text, "NewUnifiedClient("), rel)
+		require.Contains(t, text, "WithHostedInferenceCheckpoint(", rel)
+	}
+	for _, command := range standaloneCommandExclusions {
+		matches, err := filepath.Glob(filepath.Join(serverRoot, "cmd", command, "*.go"))
+		require.NoError(t, err)
+		joined := strings.Builder{}
+		for _, match := range matches {
+			body, readErr := os.ReadFile(match)
+			require.NoError(t, readErr)
+			joined.Write(body)
+		}
+		require.Equal(t, 1, strings.Count(joined.String(), "NewUnifiedClient("), command)
+		require.NotContains(t, joined.String(), "WithHostedInferenceCheckpoint(", command)
+	}
+}
+
+func TestProductionAIAccessCompositionSharesRegistryAndEvaluator(t *testing.T) {
+	t.Parallel()
+	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	helper, err := os.ReadFile(filepath.Join(serverRoot, "cmd/gram/hosted_inference.go"))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(string(helper), "mcptoolexecution.NewRegistry("))
+	require.Equal(t, 1, strings.Count(string(helper), "killswitches.NewEvaluator("))
+
+	start, err := os.ReadFile(filepath.Join(serverRoot, "cmd/gram/start.go"))
+	require.NoError(t, err)
+	text := string(start)
+	require.NotContains(t, text, "mcptoolexecution.NewRegistry(")
+	require.NotContains(t, text, "killswitches.NewEvaluator(")
+	require.Contains(t, text, "NewHookAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator")
+	require.Contains(t, text, "NewLiteLLMAIAccessCheckpoint(aiAccess.registry, aiAccess.evaluator")
+	require.Contains(t, text, "WithHostedInferenceCheckpoint(aiAccess.hostedInference)")
+
+	checkpoint, err := os.ReadFile(filepath.Join(serverRoot, "internal/killswitches/hostedinference/checkpoint.go"))
+	require.NoError(t, err)
+	require.NotContains(t, string(checkpoint), "NewEvaluator(", "surface checkpoints must not construct a parallel evaluator")
+}
+
+func TestManagementAuditAndPlatformControlPathsDoNotDependOnHostedInferenceCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	for _, rel := range []string{"internal/killswitchapi", "internal/audit", "internal/auditapi", "internal/platformmcp"} {
+		err := filepath.WalkDir(filepath.Join(serverRoot, rel), func(path string, entry fs.DirEntry, walkErr error) error {
+			require.NoError(t, walkErr)
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			body, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			text := string(body)
+			require.NotContains(t, text, "killswitches/hostedinference", path)
+			require.NotContains(t, text, "PreflightHostedInference", path)
+			require.NotContains(t, text, "WithHostedInferenceCheckpoint", path)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+}
+
+// TestValidatedSessionProvenanceMintingIsAuthBoundaryOwned prevents ordinary
+// production packages from manufacturing the opaque provenance consumed by
+// hosted-inference policy. Tests may mint it directly; production calls stay
+// inside the credential validators that established the underlying facts.
+func TestValidatedSessionProvenanceMintingIsAuthBoundaryOwned(t *testing.T) {
+	t.Parallel()
+
+	serverRoot := filepath.Clean(filepath.Join("..", "..", ".."))
+	actual := map[string][]string{}
+	tracked := map[string]struct{}{
+		"WithValidatedGramSession":           {},
+		"WithValidatedChatSessionActingUser": {},
+	}
+	err := filepath.WalkDir(serverRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		require.NoError(t, walkErr)
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		require.NoError(t, parseErr)
+		rel, relErr := filepath.Rel(serverRoot, path)
+		require.NoError(t, relErr)
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if _, ok := tracked[selector.Sel.Name]; ok {
+				actual[selector.Sel.Name] = append(actual[selector.Sel.Name], filepath.ToSlash(rel))
+			}
+			return true
+		})
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{
+		"WithValidatedGramSession": {
+			"internal/auth/sessions/sessions.go",
+			"internal/auth/sessions/sessions.go",
+		},
+		"WithValidatedChatSessionActingUser": {
+			"internal/auth/chatsessions/manager.go",
+		},
+	}, actual)
+}
+
+func TestHostedProviderTransportsAreRepoWideAllowlisted(t *testing.T) {
+	t.Parallel()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	matches := map[string]int{}
+	err := filepath.WalkDir(repoRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		require.NoError(t, walkErr)
+		if entry.IsDir() {
+			name := entry.Name()
+			if name == ".git" || name == "node_modules" || name == "vendor" || name == "gen" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		require.NoError(t, parseErr)
+		rel, relErr := filepath.Rel(repoRoot, path)
+		require.NoError(t, relErr)
+		for _, declaration := range parsed.Decls {
+			fn, ok := declaration.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				switch value := node.(type) {
+				case *ast.BasicLit:
+					if strings.Contains(value.Value, "/v1/chat/completions") {
+						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":raw_chat_completions"]++
+					}
+					if strings.Contains(value.Value, "/endpoints") {
+						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":raw_model_endpoints"]++
+					}
+				case *ast.CallExpr:
+					selector, ok := value.Fun.(*ast.SelectorExpr)
+					if !ok {
+						break
+					}
+					if selector.Sel.Name == "Generate" {
+						if owner, ok := selector.X.(*ast.SelectorExpr); ok && owner.Sel.Name == "Embeddings" {
+							matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":sdk_embeddings"]++
+						}
+					}
+					if ident, ok := selector.X.(*ast.Ident); ok && ident.Name == "or_base" && selector.Sel.Name == "New" {
+						matches[filepath.ToSlash(rel)+":"+fn.Name.Name+":sdk_client"]++
+					}
+				}
+				return true
+			})
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]int{
+		"server/internal/thirdparty/openrouter/context_window.go:fetchMin:raw_model_endpoints":         1,
+		"server/internal/thirdparty/openrouter/unified_client.go:createEmbeddings:sdk_client":          1,
+		"server/internal/thirdparty/openrouter/unified_client.go:createEmbeddings:sdk_embeddings":      1,
+		"server/internal/thirdparty/openrouter/unified_client.go:makeHTTPRequest:raw_chat_completions": 1,
+	}, matches)
+}

--- a/server/internal/killswitches/hostedinference/inventory_test.go
+++ b/server/internal/killswitches/hostedinference/inventory_test.go
@@ -112,6 +112,7 @@ func TestProviderOperationInventoryIsSynchronized(t *testing.T) {
 }
 
 func TestTypeAwareInventoryDetectsRegressions(t *testing.T) {
+	t.Parallel()
 	directory := writeMutationPackage(t, `package inventorymutation
 
 import (

--- a/server/internal/killswitches/hostedinference/resource.go
+++ b/server/internal/killswitches/hostedinference/resource.go
@@ -1,0 +1,65 @@
+package hostedinference
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+)
+
+// ResourceAdapter owns the static canonical identities for the enumerated
+// governed Gram-hosted inference categories.
+type ResourceAdapter struct{}
+
+var _ killswitches.ResourceAdapter = ResourceAdapter{}
+
+func (ResourceAdapter) Kind() killswitches.ResourceKind { return ResourceKindGramHostedInference }
+
+func (ResourceAdapter) Canonicalize(_ killswitches.OrganizationID, input string) (killswitches.CanonicalizationResult[killswitches.ResourceKey], error) {
+	category := CallCategory(strings.TrimSpace(input))
+	if !isGovernedCategory(category) {
+		return killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey](), nil
+	}
+	result, err := killswitches.NewCanonicalizationResult(killswitches.ResourceKey(category))
+	if err != nil {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("canonicalize hosted-inference resource: %w", err)
+	}
+	return result, nil
+}
+
+func (a ResourceAdapter) ValidateCurrentOrganization(_ context.Context, organizationID killswitches.OrganizationID, key killswitches.ResourceKey) (bool, error) {
+	if organizationID == "" {
+		return false, nil
+	}
+	result, err := a.Canonicalize(organizationID, string(key))
+	if err != nil {
+		return false, err
+	}
+	canonical, supported, err := result.Key()
+	if err != nil {
+		return false, fmt.Errorf("read canonical hosted-inference resource key: %w", err)
+	}
+	return supported && canonical == key, nil
+}
+
+func (a ResourceAdapter) Derive(_ context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.CanonicalizationResult[killswitches.ResourceKey], error) {
+	category, ok := source.(CallCategory)
+	if !ok {
+		return killswitches.CanonicalizationResult[killswitches.ResourceKey]{}, fmt.Errorf("unsupported hosted-inference resource source type %T", source)
+	}
+	return a.Canonicalize(organizationID, string(category))
+}
+
+func ResourceFixtures() []killswitches.ResourceCanonicalizationFixture {
+	result := make([]killswitches.ResourceCanonicalizationFixture, 0, 6)
+	for category, class := range categoryClasses {
+		if class != CallClassGovernedUser {
+			continue
+		}
+		expected, _ := killswitches.NewCanonicalizationResult(killswitches.ResourceKey(category))
+		result = append(result, killswitches.ResourceCanonicalizationFixture{OrganizationID: "org_fixture", Input: string(category), Expected: expected})
+	}
+	result = append(result, killswitches.ResourceCanonicalizationFixture{OrganizationID: "org_fixture", Input: "unknown", Expected: killswitches.UnsupportedCanonicalizationResult[killswitches.ResourceKey]()})
+	return result
+}

--- a/server/internal/killswitches/hostedinference/resource_test.go
+++ b/server/internal/killswitches/hostedinference/resource_test.go
@@ -1,0 +1,30 @@
+package hostedinference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceAdapterCoversOnlyGovernedInventory(t *testing.T) {
+	t.Parallel()
+	adapter := ResourceAdapter{}
+	for category, class := range categoryClasses {
+		result, err := adapter.Canonicalize("org", string(category))
+		require.NoError(t, err)
+		key, supported, err := result.Key()
+		require.NoError(t, err)
+		if class == CallClassGovernedUser {
+			require.True(t, supported, category)
+			require.Equal(t, string(category), string(key))
+		} else {
+			require.False(t, supported, category)
+		}
+	}
+
+	result, err := adapter.Canonicalize("org", "future_unregistered_category")
+	require.NoError(t, err)
+	_, supported, err := result.Key()
+	require.NoError(t, err)
+	require.False(t, supported)
+}

--- a/server/internal/killswitches/hostedinference/transport.go
+++ b/server/internal/killswitches/hostedinference/transport.go
@@ -1,0 +1,49 @@
+package hostedinference
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// IsBoundaryError reports whether err is a hosted-inference outcome that an
+// HTTP/Goa boundary must map to a safe public error.
+func IsBoundaryError(err error) bool {
+	if _, ok := errors.AsType[*MatchedDenialError](err); ok {
+		return true
+	}
+	_, ok := errors.AsType[*InfrastructureUnavailableError](err)
+	return ok
+}
+
+// AsShareableError maps checkpoint outcomes at HTTP/Goa boundaries. Matched
+// denials intentionally have no wrapped cause so tenant-authored notes cannot
+// leak through internal cause logging. Infrastructure rejection has only the
+// generic unavailable public message and retains its cause for diagnostics.
+func AsShareableError(err error) (*oops.ShareableError, bool) {
+	if matched, ok := errors.AsType[*MatchedDenialError](err); ok {
+		return oops.E(oops.CodeAIAccessDenied, nil, "%s", matched.ExternalNote()).SuppressInternalReporting(), true
+	}
+
+	if _, ok := errors.AsType[*InfrastructureUnavailableError](err); ok {
+		return oops.E(oops.CodeUnavailable, err, "%s", oops.CodeUnavailable.UserMessage()), true
+	}
+
+	return nil, false
+}
+
+// MapBoundaryError converts hosted-inference errors and applies the one safe
+// reporting policy: matched notes bypass internal reporting, while generic
+// infrastructure failures retain and log their diagnostic cause.
+func MapBoundaryError(ctx context.Context, logger *slog.Logger, err error) (error, bool) {
+	shareable, ok := AsShareableError(err)
+	if !ok {
+		return nil, false
+	}
+	if shareable.SpanHandled() {
+		return shareable, true
+	}
+	return shareable.LogError(ctx, logger), true
+}

--- a/server/internal/killswitches/hostedinference/transport_test.go
+++ b/server/internal/killswitches/hostedinference/transport_test.go
@@ -1,0 +1,36 @@
+package hostedinference
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestAsShareableErrorPreservesOnlyMatchedExternalNote(t *testing.T) {
+	t.Parallel()
+	note := "Paused by the organization."
+	shareable, ok := AsShareableError(&MatchedDenialError{externalNote: note})
+	require.True(t, ok)
+	require.Equal(t, oops.CodeAIAccessDenied, shareable.Code)
+	require.Equal(t, note, shareable.Error())
+	require.True(t, shareable.SpanHandled(), "tenant-authored note must not be recorded by outer tracing")
+	require.Equal(t, 403, shareable.HTTPStatus(t.Context()))
+	require.Equal(t, string(oops.CodeAIAccessDenied), shareable.AsGoa(t.Context()).GoaErrorName())
+	require.Equal(t, note, shareable.AsGoa(t.Context()).Error())
+	require.NoError(t, shareable.Unwrap(), "matched notes must not be retained as a loggable cause")
+}
+
+func TestAsShareableErrorMakesInfrastructureGeneric(t *testing.T) {
+	t.Parallel()
+	cause := errors.New("database detail")
+	shareable, ok := AsShareableError(newInfrastructureUnavailable(cause))
+	require.True(t, ok)
+	require.Equal(t, oops.CodeUnavailable, shareable.Code)
+	require.Equal(t, oops.CodeUnavailable.UserMessage(), shareable.Error())
+	require.NotContains(t, shareable.Error(), "match")
+	require.NotContains(t, shareable.Error(), cause.Error())
+	require.ErrorIs(t, shareable, cause)
+}

--- a/server/internal/killswitches/mcptoolexecution/adapters_test.go
+++ b/server/internal/killswitches/mcptoolexecution/adapters_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -98,6 +99,34 @@ func TestAuthenticatedUserAdapterDeriveCandidates(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, killswitches.PrincipalCandidateResultCandidates, result.Kind())
 	require.Equal(t, []killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(activeUser)}}, result.Candidates())
+
+	sessionID := "session"
+	validatedContext := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: orgID, UserID: activeUser, SessionID: &sessionID}, false)
+	provenance, ok := contextvalues.ValidatedGramSessionActingUser(validatedContext)
+	require.True(t, ok)
+	result, err = adapter.DeriveCandidates(t.Context(), organization, provenance)
+	require.NoError(t, err)
+	require.Equal(t, []killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(activeUser)}}, result.Candidates())
+
+	chatContext := contextvalues.WithValidatedChatSessionActingUser(t.Context(), orgID, activeUser, sessionID)
+	chatProvenance, ok := contextvalues.ValidatedChatSessionActingUser(chatContext)
+	require.True(t, ok)
+	result, err = adapter.DeriveCandidates(t.Context(), organization, chatProvenance)
+	require.NoError(t, err)
+	require.Equal(t, []killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: killswitches.PrincipalKey(activeUser)}}, result.Candidates())
+
+	inactiveContext := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: orgID, UserID: inactiveUser, SessionID: &sessionID}, false)
+	inactiveProvenance, ok := contextvalues.ValidatedGramSessionActingUser(inactiveContext)
+	require.True(t, ok)
+	result, err = adapter.DeriveCandidates(t.Context(), organization, inactiveProvenance)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.PrincipalCandidateResultUnsupported, result.Kind())
+
+	foreignContext := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: otherOrg, UserID: crossOrgUser, SessionID: &sessionID}, false)
+	foreignProvenance, ok := contextvalues.ValidatedGramSessionActingUser(foreignContext)
+	require.True(t, ok)
+	_, err = adapter.DeriveCandidates(t.Context(), organization, foreignProvenance)
+	require.Error(t, err, "tenant-bound provenance must not cross organizations")
 
 	for name, userID := range map[string]string{
 		"inactive member":     inactiveUser,

--- a/server/internal/killswitches/mcptoolexecution/hosted_inference_test.go
+++ b/server/internal/killswitches/mcptoolexecution/hosted_inference_test.go
@@ -1,0 +1,55 @@
+package mcptoolexecution
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestHostedInferenceCheckpointUsesRealAIAccessEvaluator(t *testing.T) {
+	t.Parallel()
+	conn, orgID := newTestDatabase(t, "ks_hosted_inference")
+	registry, err := NewRegistry(conn)
+	require.NoError(t, err)
+	evaluation, err := killswitches.NewEvaluator(conn, registry, time.Second, nil, testenv.NewLogger(t))
+	require.NoError(t, err)
+	checkpoint, err := hostedinference.NewCheckpoint(registry, evaluation, time.Second)
+	require.NoError(t, err)
+
+	userID := "user_" + uuid.NewString()
+	insertUser(t, conn, userID, nil)
+	insertMembership(t, conn, orgID, userID, nil)
+	sessionID := "session"
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: orgID, UserID: userID, SessionID: &sessionID}, false)
+	ctx, err = hostedinference.WithGovernedUser(ctx, hostedinference.CallCategoryUserChatCompletion)
+	require.NoError(t, err)
+
+	require.NoError(t, checkpoint.Check(ctx, orgID))
+	insertPrescription(t, conn, orgID, prescriptionFixture{
+		ID: uuid.New(), DefinitionKey: DefinitionKeyAIAccess, PrincipalKey: userID,
+		ResourceKind: hostedinference.ResourceKindGramHostedInference, Scope: "selected",
+		Resources:    []string{string(hostedinference.CallCategoryUserChatCompletion)},
+		ExternalNote: "  Hosted inference paused exactly.  ",
+	})
+
+	err = checkpoint.Check(ctx, orgID)
+	var denial *hostedinference.MatchedDenialError
+	require.ErrorAs(t, err, &denial)
+	require.Equal(t, "hosted inference access denied", denial.Error())
+	require.Equal(t, "Hosted inference paused exactly.", denial.ExternalNote())
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	err = checkpoint.Check(canceled, orgID)
+	var unavailable *hostedinference.InfrastructureUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+	require.NotContains(t, err.Error(), "Hosted inference paused")
+}

--- a/server/internal/killswitches/mcptoolexecution/principal.go
+++ b/server/internal/killswitches/mcptoolexecution/principal.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
@@ -71,53 +72,57 @@ func (a *AuthenticatedUserPrincipalAdapter) ValidateCurrentOrganization(ctx cont
 	return member, nil
 }
 
-// DeriveCandidates accepts only mcpidentity.Identity provenance stamped by a
-// serving surface after credential validation. Checkpoints call it only when
-// mcpidentity.FromContext returns ok: unstamped traffic is classified
-// unattributed at the checkpoint and never reaches derivation — that skip is
-// the authoritative unsupported/no-candidate outcome for such traffic, not a
-// failure. Any non-Identity source here is therefore a checkpoint wiring bug
-// and errors.
-//
-// Only KindUserSession claims an authoritative acting user; that claim is
-// then revalidated as an active organization membership before producing the
-// single concrete candidate. Anonymous, API-key, assistant, and chat-session
-// provenance are deliberately unsupported. A stamped identity with a zero or
-// unknown kind, a malformed authoritative claim, or a membership lookup
-// failure is an error and follows the definition's fail-closed policy.
+// DeriveCandidates accepts either MCP identity provenance stamped after MCP
+// credential validation or opaque contextvalues session-backed acting-user
+// provenance. Both supported forms are revalidated as an active membership in
+// the same organization for every derivation. Anonymous, API-key, assistant,
+// unstamped chat-session, support, legacy impersonation, attribution, and owner
+// substitutes never produce candidates. Malformed authoritative claims,
+// cross-tenant provenance, and lookup failures are errors and follow the
+// definition's fail-closed policy.
 func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
-	identity, ok := source.(mcpidentity.Identity)
-	if !ok {
-		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unsupported principal source type %T", source)
-	}
 	if organizationID == "" {
 		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("organization ID is required")
 	}
 
+	if provenance, ok := source.(contextvalues.ActingUserProvenance); ok {
+		if provenance.OrganizationID() != string(organizationID) {
+			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("acting-user provenance belongs to another organization")
+		}
+		return a.deriveActiveUser(ctx, organizationID, provenance.UserID())
+	}
+
+	identity, ok := source.(mcpidentity.Identity)
+	if !ok {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unsupported principal source type %T", source)
+	}
 	switch identity.Kind() {
 	case mcpidentity.KindUserSession:
-		userID := identity.UserID()
-		key, canonical := canonicalUserKey(userID)
-		if !canonical || string(key) != userID {
-			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("authoritative user provenance carries a non-canonical user ID")
-		}
-		member, err := a.ValidateCurrentOrganization(ctx, organizationID, key)
-		if err != nil {
-			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("revalidate active organization membership: %w", err)
-		}
-		if !member {
-			return killswitches.UnsupportedPrincipalCandidateResult(), nil
-		}
-		result, err := killswitches.NewPrincipalCandidateResult([]killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: key}})
-		if err != nil {
-			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
-		}
-		return result, nil
+		return a.deriveActiveUser(ctx, organizationID, identity.UserID())
 	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindChatSession:
 		return killswitches.UnsupportedPrincipalCandidateResult(), nil
 	default:
 		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unknown identity provenance kind %q", identity.Kind())
 	}
+}
+
+func (a *AuthenticatedUserPrincipalAdapter) deriveActiveUser(ctx context.Context, organizationID killswitches.OrganizationID, userID string) (killswitches.PrincipalCandidateResult, error) {
+	key, canonical := canonicalUserKey(userID)
+	if !canonical || string(key) != userID {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("authoritative user provenance carries a non-canonical user ID")
+	}
+	member, err := a.ValidateCurrentOrganization(ctx, organizationID, key)
+	if err != nil {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("revalidate active organization membership: %w", err)
+	}
+	if !member {
+		return killswitches.UnsupportedPrincipalCandidateResult(), nil
+	}
+	result, err := killswitches.NewPrincipalCandidateResult([]killswitches.PrincipalCandidate{{Kind: PrincipalKindUser, Key: key}})
+	if err != nil {
+		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
+	}
+	return result, nil
 }
 
 func canonicalUserKey(input string) (killswitches.PrincipalKey, bool) {

--- a/server/internal/killswitches/mcptoolexecution/registration.go
+++ b/server/internal/killswitches/mcptoolexecution/registration.go
@@ -3,7 +3,7 @@
 // authoritative concrete-user principal adapter, the canonical
 // organization-owned resource adapters, and the coverage inventory for hosted
 // and private-proxy MCP tools/call, approved live Claude/Codex hook activity,
-// and managed LiteLLM pre-inference requests.
+// managed LiteLLM pre-inference requests, and Gram-hosted inference.
 //
 // Registration declares the contracts consumed by the MCP and hook checkpoints.
 // The internal ai_access definition is not exposed through customer management.
@@ -17,6 +17,7 @@ import (
 
 	"github.com/speakeasy-api/gram/hooks/delegation"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 )
 
 const (
@@ -26,13 +27,13 @@ const (
 
 	// DefinitionKeyAIAccess is the internal broad AI-access capability. Its
 	// verified coverage is limited to authenticated MCP tools/call, the
-	// explicitly registered live Claude/Codex hooks, and the managed LiteLLM
-	// pre-inference surface below.
-	DefinitionKeyAIAccess killswitches.DefinitionKey = "ai_access"
+	// explicitly registered live Claude/Codex hooks, managed LiteLLM
+	// pre-inference, and Gram-hosted inference surfaces below.
+	DefinitionKeyAIAccess = killswitches.DefinitionKeyAIAccess
 
 	// PrincipalKindUser is the concrete Gram user principal namespace; keys
 	// are user IDs of authoritative active organization members.
-	PrincipalKindUser killswitches.PrincipalKind = "user"
+	PrincipalKindUser = killswitches.PrincipalKindUser
 
 	// ResourceKindMCPServer is the canonical MCP server resource namespace;
 	// keys are fronting mcp_servers row IDs.
@@ -43,8 +44,8 @@ const (
 	IdentityContractKeyAuthenticatedUserMCPServer killswitches.IdentityContractKey = "authenticated_user_mcp_server"
 
 	// IdentityContractKeyAuthenticatedUserAIResource is the additive ai_access
-	// contract spanning MCP servers, governed native hooks, and managed LiteLLM
-	// pre-inference activity.
+	// contract spanning MCP servers, governed native hooks, managed LiteLLM
+	// pre-inference activity, and Gram-hosted inference.
 	IdentityContractKeyAuthenticatedUserAIResource killswitches.IdentityContractKey = "authenticated_user_ai_resource"
 
 	ResourceKindHookActivity    killswitches.ResourceKind = "hook_activity"
@@ -111,13 +112,13 @@ func NewRegistration(db *pgxpool.Pool) (killswitches.Registration, error) {
 			{
 				Key:                 DefinitionKeyAIAccess,
 				PrincipalKinds:      []killswitches.PrincipalKind{PrincipalKindUser},
-				ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance},
+				ResourceKinds:       []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance, hostedinference.ResourceKindGramHostedInference},
 				FailurePolicy:       killswitches.FailurePolicyFailClosed,
 				DefaultExternalNote: DefaultAIAccessExternalNote,
 				EnforcementOwner:    EnforcementOwner,
 				IdentityContract:    IdentityContractKeyAuthenticatedUserAIResource,
-				Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference},
-				TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative, TransportAdapterLiteLLMGenericGuardrail},
+				Surfaces:            []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference, hostedinference.SurfaceGramHostedInference},
+				TransportAdapters:   []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative, TransportAdapterLiteLLMGenericGuardrail, hostedinference.TransportAdapterGramHostedInference},
 			},
 		},
 		IdentityContracts: []killswitches.IdentityContract{
@@ -129,7 +130,7 @@ func NewRegistration(db *pgxpool.Pool) (killswitches.Registration, error) {
 			{
 				Key:            IdentityContractKeyAuthenticatedUserAIResource,
 				PrincipalKinds: []killswitches.PrincipalKind{PrincipalKindUser},
-				ResourceKinds:  []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance},
+				ResourceKinds:  []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance, hostedinference.ResourceKindGramHostedInference},
 			},
 		},
 		PrincipalAdapters: []killswitches.PrincipalAdapterRegistration{{
@@ -140,13 +141,15 @@ func NewRegistration(db *pgxpool.Pool) (killswitches.Registration, error) {
 			{Adapter: NewMCPServerResourceAdapter(db), Fixtures: resourceFixtures()},
 			{Adapter: HookActivityResourceAdapter{}, Fixtures: hookResourceFixtures()},
 			{Adapter: NewLiteLLMInstanceResourceAdapter(db), Fixtures: litellmResourceFixtures()},
+			{Adapter: hostedinference.ResourceAdapter{}, Fixtures: hostedinference.ResourceFixtures()},
 		},
-		Surfaces: []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference},
+		Surfaces: []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference, hostedinference.SurfaceGramHostedInference},
 		TransportAdapters: []killswitches.TransportAdapterRegistration{
 			{Key: TransportAdapterHostedJSONRPC, Adapter: killswitches.ResolveTransportDisposition},
 			{Key: TransportAdapterPrivateProxyJSONRPC, Adapter: killswitches.ResolveTransportDisposition},
 			{Key: TransportAdapterHookNative, Adapter: killswitches.ResolveTransportDisposition},
 			{Key: TransportAdapterLiteLLMGenericGuardrail, Adapter: killswitches.ResolveTransportDisposition},
+			{Key: hostedinference.TransportAdapterGramHostedInference, Adapter: killswitches.ResolveTransportDisposition},
 		},
 		Coverage: append([]killswitches.CoverageContract{
 			{
@@ -205,6 +208,18 @@ func NewRegistration(db *pgxpool.Pool) (killswitches.Registration, error) {
 				ProtectedWork:   "Pre-inference request callbacks from the tested LiteLLM 1.94.0 fail-closed Generic Guardrail configuration. Response callbacks and unmanaged, unasserted, or fail-open deployments are not claimed as covered.",
 				FailurePolicy:   killswitches.FailurePolicyFailClosed, TransportAdapter: TransportAdapterLiteLLMGenericGuardrail,
 				EnforcementOwner: EnforcementOwner, IdentityContract: IdentityContractKeyAuthenticatedUserAIResource,
+			},
+			{
+				Definition:       DefinitionKeyAIAccess,
+				Surface:          hostedinference.SurfaceGramHostedInference,
+				PrincipalSource:  "Opaque tenant-bound acting-user provenance derived from a validated ordinary Gram session or a qualifying signed chat JWT carrying matching ordinary-session provenance, then revalidated as an active organization member for every provider attempt.",
+				ResourceSource:   "Static canonical Gram-hosted-inference identity for an enumerated current governed user call category.",
+				Checkpoint:       "ChatClient before capture and key resolution, then immediately before every completion, stream, object-completion, or embedding provider attempt.",
+				ProtectedWork:    "Governed user chat completion, chat summaries, tool-call summaries, risk authoring, and organization-admin business-memory search embeddings; internal, background, and assistant-owned classes are explicit bypasses.",
+				FailurePolicy:    killswitches.FailurePolicyFailClosed,
+				TransportAdapter: hostedinference.TransportAdapterGramHostedInference,
+				EnforcementOwner: EnforcementOwner,
+				IdentityContract: IdentityContractKeyAuthenticatedUserAIResource,
 			},
 		}, hookContracts...),
 	}, nil

--- a/server/internal/killswitches/mcptoolexecution/registration_test.go
+++ b/server/internal/killswitches/mcptoolexecution/registration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/hooks/delegation"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 )
 
 // TestMCPToolExecutionRegistration proves the checked-in registration builds
@@ -43,10 +44,10 @@ func TestMCPToolExecutionRegistration(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, killswitches.FailurePolicyFailClosed, aiDefinition.FailurePolicy)
 	require.Equal(t, []killswitches.PrincipalKind{PrincipalKindUser}, aiDefinition.PrincipalKinds)
-	require.ElementsMatch(t, []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance}, aiDefinition.ResourceKinds)
+	require.ElementsMatch(t, []killswitches.ResourceKind{ResourceKindMCPServer, ResourceKindHookActivity, ResourceKindLiteLLMInstance, hostedinference.ResourceKindGramHostedInference}, aiDefinition.ResourceKinds)
 	require.Equal(t, IdentityContractKeyAuthenticatedUserAIResource, aiDefinition.IdentityContract)
-	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference}, aiDefinition.Surfaces)
-	require.ElementsMatch(t, []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative, TransportAdapterLiteLLMGenericGuardrail}, aiDefinition.TransportAdapters)
+	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference, hostedinference.SurfaceGramHostedInference}, aiDefinition.Surfaces)
+	require.ElementsMatch(t, []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative, TransportAdapterLiteLLMGenericGuardrail, hostedinference.TransportAdapterGramHostedInference}, aiDefinition.TransportAdapters)
 	require.Equal(t, DefaultAIAccessExternalNote, aiDefinition.DefaultExternalNote)
 	require.NotEqual(t, definition.DefaultExternalNote, aiDefinition.DefaultExternalNote)
 	require.Equal(t, EnforcementOwner, aiDefinition.EnforcementOwner)
@@ -69,7 +70,7 @@ func TestMCPCoverageInventory(t *testing.T) {
 	require.NoError(t, err)
 
 	inventory := registry.CoverageInventory()
-	require.Len(t, inventory, 9)
+	require.Len(t, inventory, 10)
 	coverageByDefinition := map[killswitches.DefinitionKey][]killswitches.Surface{}
 	for _, contract := range inventory {
 		coverageByDefinition[contract.Definition] = append(coverageByDefinition[contract.Definition], contract.Surface)
@@ -85,7 +86,7 @@ func TestMCPCoverageInventory(t *testing.T) {
 		require.NotEmpty(t, contract.ProtectedWork)
 	}
 	require.Equal(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall}, coverageByDefinition[DefinitionKeyMCPToolExecution])
-	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference}, coverageByDefinition[DefinitionKeyAIAccess])
+	require.ElementsMatch(t, []killswitches.Surface{SurfaceHostedToolsCall, SurfacePrivateProxyToolsCall, SurfaceClaudeUserPromptSubmit, SurfaceClaudePreToolUse, SurfaceCodexUserPromptSubmit, SurfaceCodexPreToolUse, SurfaceLiteLLMPreInference, hostedinference.SurfaceGramHostedInference}, coverageByDefinition[DefinitionKeyAIAccess])
 
 	hosted, ok := registry.Coverage(DefinitionKeyMCPToolExecution, SurfaceHostedToolsCall)
 	require.True(t, ok)
@@ -102,7 +103,10 @@ func TestMCPCoverageInventory(t *testing.T) {
 	aiProxy, ok := registry.Coverage(DefinitionKeyAIAccess, SurfacePrivateProxyToolsCall)
 	require.True(t, ok)
 	require.Equal(t, TransportAdapterPrivateProxyJSONRPC, aiProxy.TransportAdapter)
-	for _, excludedSurface := range []killswitches.Surface{"killswitch_management", "audit_read", "platform_break_glass", "hooks", "litellm", "hosted_inference", "assistant_runtime", "hooks_permission_request", "hooks_backfill"} {
+	hostedInference, ok := registry.Coverage(DefinitionKeyAIAccess, hostedinference.SurfaceGramHostedInference)
+	require.True(t, ok)
+	require.Equal(t, hostedinference.TransportAdapterGramHostedInference, hostedInference.TransportAdapter)
+	for _, excludedSurface := range []killswitches.Surface{"killswitch_management", "audit_read", "platform_break_glass", "hooks", "litellm", "assistant_runtime", "hooks_permission_request", "hooks_backfill"} {
 		_, covered := registry.Coverage(DefinitionKeyAIAccess, excludedSurface)
 		require.False(t, covered, string(excludedSurface))
 	}
@@ -142,7 +146,7 @@ func TestMCPToolExecutionTransportAdaptersFailClosed(t *testing.T) {
 	failure, err := killswitches.NewInfrastructureFailureResult(errors.New("database unavailable"))
 	require.NoError(t, err)
 
-	for _, key := range []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative} {
+	for _, key := range []killswitches.TransportAdapterKey{TransportAdapterHostedJSONRPC, TransportAdapterPrivateProxyJSONRPC, TransportAdapterHookNative, TransportAdapterLiteLLMGenericGuardrail, hostedinference.TransportAdapterGramHostedInference} {
 		adapter, ok := registry.TransportAdapter(key)
 		require.True(t, ok, string(key))
 

--- a/server/internal/killswitches/mcptoolexecution/setup_test.go
+++ b/server/internal/killswitches/mcptoolexecution/setup_test.go
@@ -130,6 +130,7 @@ type prescriptionFixture struct {
 	ID            uuid.UUID
 	DefinitionKey killswitches.DefinitionKey
 	PrincipalKey  string
+	ResourceKind  killswitches.ResourceKind
 	Scope         string
 	Resources     []string
 	ExternalNote  string
@@ -144,13 +145,17 @@ func insertPrescription(t *testing.T, conn *pgxpool.Pool, organizationID string,
 	if definitionKey == "" {
 		definitionKey = DefinitionKeyMCPToolExecution
 	}
+	resourceKind := fixture.ResourceKind
+	if resourceKind == "" {
+		resourceKind = ResourceKindMCPServer
+	}
 	err := testrepo.New(conn).InsertKillswitchPrescriptionFixture(t.Context(), testrepo.InsertKillswitchPrescriptionFixtureParams{
 		PrescriptionID: fixture.ID,
 		OrganizationID: organizationID,
 		DefinitionKey:  string(definitionKey),
 		PrincipalKind:  string(PrincipalKindUser),
 		PrincipalKey:   fixture.PrincipalKey,
-		ResourceKind:   string(ResourceKindMCPServer),
+		ResourceKind:   string(resourceKind),
 		ResourceScope:  fixture.Scope,
 		InternalNote:   "test fixture context",
 		ExternalNote:   fixture.ExternalNote,

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -241,7 +241,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	}
 	billingStub := billing.NewStubClient(logger, tracerProvider)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
+	chatClient := openrouter.NewUncheckedUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessions := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	featClient := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)

--- a/server/internal/mcpapproval/researchagent/researchagent.go
+++ b/server/internal/mcpapproval/researchagent/researchagent.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	platformresearch "github.com/speakeasy-api/gram/server/internal/platformtools/research"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -289,7 +290,11 @@ func (r *Runner) Run(ctx context.Context, input RunInput) (json.RawMessage, RunM
 		}
 
 		compactToolHistory(messages)
-		response, err := r.completions.GetCompletion(ctx, openrouter.CompletionRequest{
+		callCtx, classifyErr := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantResearch)
+		if classifyErr != nil {
+			return nil, meta, toolCalls, fmt.Errorf("classify assistant research inference: %w", classifyErr)
+		}
+		response, err := r.completions.GetCompletion(callCtx, openrouter.CompletionRequest{
 			OrgID:          input.OrgID,
 			ProjectID:      input.ProjectID.String(),
 			Messages:       messages,
@@ -693,7 +698,11 @@ func (r *Runner) extract(ctx context.Context, input RunInput, transcript string,
 
 	strict := true
 	temperature := 0.0
-	response, err := r.completions.GetObjectCompletion(ctx, openrouter.ObjectCompletionRequest{
+	callCtx, err := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantResearch)
+	if err != nil {
+		return nil, fmt.Errorf("classify assistant research extraction: %w", err)
+	}
+	response, err := r.completions.GetObjectCompletion(callCtx, openrouter.ObjectCompletionRequest{
 		OrgID:        input.OrgID,
 		ProjectID:    input.ProjectID.String(),
 		Model:        extractionModel,

--- a/server/internal/memory/contradiction.go
+++ b/server/internal/memory/contradiction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
@@ -110,7 +111,11 @@ func (s *MemoryService) detectContradiction(ctx context.Context, orgID, projectI
 		DisableResponseHealing: false,
 	}
 
-	response, err := s.completions.GetObjectCompletion(ctx, req)
+	callCtx, err := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantMemory)
+	if err != nil {
+		return false, fmt.Errorf("classify assistant memory contradiction inference: %w", err)
+	}
+	response, err := s.completions.GetObjectCompletion(callCtx, req)
 	if err != nil {
 		return false, fmt.Errorf("contradiction completion: %w", err)
 	}

--- a/server/internal/memory/service.go
+++ b/server/internal/memory/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/memory/repo"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -280,8 +281,12 @@ func (s *MemoryService) Remember(
 		return zero, oops.E(oops.CodeUnauthorized, nil, "missing auth context")
 	}
 
+	callCtx, classifyErr := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantMemory)
+	if classifyErr != nil {
+		return zero, fmt.Errorf("classify assistant memory embedding: %w", classifyErr)
+	}
 	embedStart := time.Now()
-	vectors, err := s.completions.CreateEmbeddings(ctx, organizationID, s.embeddingModel, []string{content}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
+	vectors, err := s.completions.CreateEmbeddings(callCtx, organizationID, s.embeddingModel, []string{content}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
 	if duration := time.Since(embedStart).Seconds(); s.metrics.embedDuration != nil {
 		s.metrics.embedDuration.Record(ctx, duration, metric.WithAttributes(
 			attr.GenAIRequestModel(s.embeddingModel),
@@ -465,8 +470,12 @@ func (s *MemoryService) Recall(
 		limit = maxRecallLimit
 	}
 
+	callCtx, classifyErr := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantMemory)
+	if classifyErr != nil {
+		return nil, fmt.Errorf("classify assistant memory recall: %w", classifyErr)
+	}
 	embedStart := time.Now()
-	vectors, embedErr := s.completions.CreateEmbeddings(ctx, organizationID, s.embeddingModel, []string{query}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
+	vectors, embedErr := s.completions.CreateEmbeddings(callCtx, organizationID, s.embeddingModel, []string{query}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
 	if duration := time.Since(embedStart).Seconds(); s.metrics.embedDuration != nil {
 		s.metrics.embedDuration.Record(ctx, duration, metric.WithAttributes(
 			attr.GenAIRequestModel(s.embeddingModel),
@@ -589,8 +598,12 @@ func (s *MemoryService) Forget(
 		return noMatch, nil
 	}
 
+	callCtx, classifyErr := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantMemory)
+	if classifyErr != nil {
+		return ForgetResult{}, fmt.Errorf("classify assistant memory forget: %w", classifyErr)
+	}
 	embedStart := time.Now()
-	vectors, embedErr := s.completions.CreateEmbeddings(ctx, organizationID, s.embeddingModel, []string{query}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
+	vectors, embedErr := s.completions.CreateEmbeddings(callCtx, organizationID, s.embeddingModel, []string{query}, openrouter.WithEmbeddingDimensions(embeddingDimensions))
 	if duration := time.Since(embedStart).Seconds(); s.metrics.embedDuration != nil {
 		s.metrics.embedDuration.Record(ctx, duration, metric.WithAttributes(
 			attr.GenAIRequestModel(s.embeddingModel),

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -29,6 +29,9 @@ const (
 	// an operator locked down. No top-up clears it, which is what separates it
 	// from CodeInsufficientCredits: only a deliberate reinstatement does.
 	CodeInferenceDisabled Code = "inference_disabled"
+	// CodeAIAccessDenied is a matched tenant ai_access prescription. Its public
+	// message is the prescription's selected external note.
+	CodeAIAccessDenied Code = "ai_access_denied"
 	// CodeCanceled represents a request whose client disconnected mid-flight,
 	// surfacing as a context.Canceled cause while the request context is itself
 	// canceled. It is not a server fault. It is never authored directly:
@@ -58,6 +61,7 @@ var StatusCodes = map[Code]int{
 	CodeInsufficientCredits: http.StatusPaymentRequired,
 	CodeRateLimitExceeded:   http.StatusTooManyRequests,
 	CodeInferenceDisabled:   http.StatusForbidden,
+	CodeAIAccessDenied:      http.StatusForbidden,
 	// 499 (client closed request) is non-standard but matches the convention
 	// already used by the request access log middleware.
 	CodeCanceled: 499,
@@ -91,6 +95,8 @@ func (c Code) UserMessage() string {
 		return "token balance exhausted"
 	case CodeInferenceDisabled:
 		return "AI features are disabled for this organization, contact support to restore access"
+	case CodeAIAccessDenied:
+		return "AI access denied"
 	case CodeRateLimitExceeded:
 		return "rate limit exceeded"
 	case CodeUnavailable:
@@ -115,7 +121,7 @@ func (c Code) MCPCode() MCPCode {
 	switch c {
 	case CodeUnauthorized:
 		return MCPCodeUnauthorized
-	case CodeForbidden, CodeInferenceDisabled:
+	case CodeForbidden, CodeInferenceDisabled, CodeAIAccessDenied:
 		return MCPCodeForbidden
 	case CodeBadRequest, CodeConflict, CodeFailedPrecondition, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest

--- a/server/internal/oops/pp.go
+++ b/server/internal/oops/pp.go
@@ -80,6 +80,14 @@ func (e *ShareableError) SpanHandled() bool {
 	return e.spanHandled
 }
 
+// SuppressInternalReporting prevents outer tracing middleware from recording
+// this error's public message. Use it for customer-authored content that must
+// be returned verbatim but must not enter logs or traces.
+func (e *ShareableError) SuppressInternalReporting() *ShareableError {
+	e.spanHandled = true
+	return e
+}
+
 // Error implements the error interface.
 func (e *ShareableError) Error() string {
 	return e.public

--- a/server/internal/platformtools/research/research.go
+++ b/server/internal/platformtools/research/research.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
@@ -105,6 +106,10 @@ func NewSearchClient(completions CompletionProvider) *SearchClient {
 // summarizer. No results with a nil error is a real answer.
 func (c *SearchClient) Search(ctx context.Context, orgID, projectID, query string, maxResults int) ([]SearchResult, SearchUsage, error) {
 	temperature := 0.0
+	ctx, err := hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantResearch)
+	if err != nil {
+		return nil, SearchUsage{}, fmt.Errorf("classify assistant research inference: %w", err)
+	}
 	response, err := c.completions.GetCompletion(ctx, openrouter.CompletionRequest{
 		OrgID:     orgID,
 		ProjectID: projectID,

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/rag/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -215,6 +216,10 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 		limit = defaultFindToolsResultSize
 	}
 
+	ctx, err = hostedinference.WithUnsupported(ctx, hostedinference.CallCategoryAssistantRAG)
+	if err != nil {
+		return nil, fmt.Errorf("classify assistant RAG inference: %w", err)
+	}
 	queryVectors, err := s.chatClient.CreateEmbeddings(ctx, toolset.OrganizationID, s.embeddingModel, []string{query})
 	if err != nil {
 		return nil, fmt.Errorf("create query embedding: %w", err)
@@ -412,6 +417,10 @@ func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID strin
 		return nil, nil
 	}
 
+	ctx, err := hostedinference.WithBackground(ctx, hostedinference.CallCategoryRAGIndexing)
+	if err != nil {
+		return nil, fmt.Errorf("classify RAG indexing inference: %w", err)
+	}
 	total := len(candidates)
 	results := make([][]float32, total)
 

--- a/server/internal/risk/hosted_inference_service_test.go
+++ b/server/internal/risk/hosted_inference_service_test.go
@@ -1,0 +1,135 @@
+package risk_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+const riskHostedInferenceDenialNote = "Hosted inference is paused for this account."
+
+type riskHostedInferenceEvaluator struct {
+	result killswitches.EvaluationResult
+	calls  int
+}
+
+func (e *riskHostedInferenceEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+	e.calls++
+	return e.result
+}
+
+type riskCheckpointCompletionClient struct {
+	checkpoint hostedinference.AttemptCheckpoint
+}
+
+func (c *riskCheckpointCompletionClient) check(ctx context.Context, organizationID string) error {
+	if err := c.checkpoint.Check(ctx, organizationID); err != nil {
+		return fmt.Errorf("check hosted inference: %w", err)
+	}
+	return nil
+}
+
+func wrapRiskTestError(operation string, err error) error {
+	if err != nil {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	return nil
+}
+
+func (c *riskCheckpointCompletionClient) GetCompletion(ctx context.Context, request openrouter.CompletionRequest) (*openrouter.CompletionResponse, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *riskCheckpointCompletionClient) GetCompletionStream(ctx context.Context, request openrouter.CompletionRequest) (openrouter.StreamReader, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *riskCheckpointCompletionClient) GetObjectCompletion(ctx context.Context, request openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
+	return nil, c.check(ctx, request.OrgID)
+}
+
+func (c *riskCheckpointCompletionClient) CreateEmbeddings(ctx context.Context, orgID string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
+	return nil, c.check(ctx, orgID)
+}
+
+func (c *riskCheckpointCompletionClient) ResolveKey(context.Context, string, string, billing.ModelUsageSource, openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	return openrouter.PlatformKey(), nil
+}
+
+func runDeniedRiskAuthoringPath(t *testing.T, invoke func(context.Context, *testInstance) error) {
+	t.Helper()
+
+	result, err := killswitches.NewMatchResult("0198a1b2-c3d4-7000-8000-0123456789ab", riskHostedInferenceDenialNote)
+	require.NoError(t, err)
+	evaluator := &riskHostedInferenceEvaluator{result: result}
+	ctx, ti := newTestRiskService(t, func(ti *testInstance) {
+		registry, registryErr := mcptoolexecution.NewRegistry(ti.conn)
+		require.NoError(t, registryErr)
+		checkpoint, checkpointErr := hostedinference.NewCheckpoint(registry, evaluator, time.Second)
+		require.NoError(t, checkpointErr)
+		gate := &riskCheckpointCompletionClient{checkpoint: checkpoint}
+		ti.completionClient = chat.NewAgenticChatClient(testenv.NewLogger(t), nil, nil, nil, gate, nil)
+	})
+
+	err = invoke(ctx, ti)
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeAIAccessDenied, shareable.Code)
+	require.Equal(t, riskHostedInferenceDenialNote, shareable.Error())
+	require.Equal(t, 1, evaluator.calls)
+}
+
+func TestRiskAuthoringPathsPreserveGovernedClassificationThroughAgenticClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom detection rule", func(t *testing.T) {
+		t.Parallel()
+		runDeniedRiskAuthoringPath(t, func(ctx context.Context, ti *testInstance) error {
+			_, err := ti.service.SuggestCustomDetectionRule(ctx, &gen.SuggestCustomDetectionRulePayload{Prompt: "detect placeholder secrets"})
+			return wrapRiskTestError("suggest custom detection rule", err)
+		})
+	})
+
+	t.Run("exclusion", func(t *testing.T) {
+		t.Parallel()
+		runDeniedRiskAuthoringPath(t, func(ctx context.Context, ti *testInstance) error {
+			_, err := ti.service.SuggestExclusion(ctx, &gen.SuggestExclusionPayload{Prompt: new("ignore placeholder accounts")})
+			return wrapRiskTestError("suggest exclusion", err)
+		})
+	})
+
+	t.Run("standard policy name", func(t *testing.T) {
+		t.Parallel()
+		runDeniedRiskAuthoringPath(t, func(ctx context.Context, ti *testInstance) error {
+			_, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Sources: []string{"gitleaks"}})
+			return wrapRiskTestError("create standard risk policy", err)
+		})
+	})
+
+	t.Run("prompt policy name", func(t *testing.T) {
+		t.Parallel()
+		runDeniedRiskAuthoringPath(t, func(ctx context.Context, ti *testInstance) error {
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			ti.flags.SetFlag(feature.FlagPromptPolicies, authCtx.ActiveOrganizationID, true)
+			prompt := "Block destructive placeholder actions"
+			_, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{PolicyType: "prompt_based", Prompt: &prompt})
+			return wrapRiskTestError("create prompt risk policy", err)
+		})
+	})
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -45,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -429,13 +430,16 @@ func (s *Service) CreateRiskPolicy(ctx context.Context, payload *gen.CreateRiskP
 			existingNames = append(existingNames, p.Name)
 		}
 		if policyType == ra.PolicyTypePromptBased {
-			name = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
+			name, err = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
 		} else if shadowName := shadowMCPPolicyAutoName(sources, action, existingNames); shadowName != "" {
 			name = shadowName
 		} else {
 			customRuleTitles := s.customRuleTitlesForIDs(ctx, *authCtx.ProjectID, payload.CustomRuleIds)
-			name = s.generatePolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), sources, payload.PresidioEntities, customRuleTitles, action, existingNames)
+			name, err = s.generatePolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), sources, payload.PresidioEntities, customRuleTitles, action, existingNames)
 		}
+	}
+	if err != nil {
+		return nil, s.mapHostedInferenceBoundaryError(ctx, err)
 	}
 
 	if err := validatePolicyName(name); err != nil {
@@ -977,13 +981,16 @@ func (s *Service) UpdateRiskPolicy(ctx context.Context, payload *gen.UpdateRiskP
 			}
 		}
 		if current.PolicyType == ra.PolicyTypePromptBased {
-			name = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
+			name, err = s.generatePromptPolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), prompt.String, existingNames)
 		} else if shadowName := shadowMCPPolicyAutoName(sources, action, existingNames); shadowName != "" {
 			name = shadowName
 		} else {
 			customRuleTitles := s.customRuleTitlesForIDs(ctx, *authCtx.ProjectID, customRuleIds)
-			name = s.generatePolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), sources, presidioEntities, customRuleTitles, action, existingNames)
+			name, err = s.generatePolicyName(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), sources, presidioEntities, customRuleTitles, action, existingNames)
 		}
+	}
+	if err != nil {
+		return nil, s.mapHostedInferenceBoundaryError(ctx, err)
 	}
 
 	if err := validatePolicyName(name); err != nil {
@@ -2385,6 +2392,10 @@ func (s *Service) SuggestCustomDetectionRule(ctx context.Context, payload *gen.S
 
 	suggestion, err := s.suggestCustomRuleViaLLM(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), authCtx.UserID, conv.PtrValOr(authCtx.Email, ""), prompt, payload.ExistingRuleIds)
 	if err != nil {
+		//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+		if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+			return nil, mapped
+		}
 		s.logger.WarnContext(ctx, "openrouter suggestion failed; returning heuristic suggestion", attr.SlogError(err))
 		return heuristicCustomRuleSuggestion(prompt, payload.ExistingRuleIds), nil
 	}
@@ -2446,6 +2457,10 @@ func (s *Service) SuggestExclusion(ctx context.Context, payload *gen.SuggestExcl
 
 	suggestion, err := s.suggestExclusionViaLLM(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), authCtx.UserID, conv.PtrValOr(authCtx.Email, ""), prompt, findings, payload.KnownRuleIds)
 	if err != nil {
+		//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+		if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+			return nil, mapped
+		}
 		s.logger.WarnContext(ctx, "openrouter exclusion suggestion failed; returning heuristic suggestion", attr.SlogError(err))
 		return heuristicExclusionSuggestion(prompt, findings), nil
 	}
@@ -2668,6 +2683,10 @@ func validateScopeExpr(eng *celenv.Engine, expr *string) error {
 }
 
 func (s *Service) suggestCustomRuleViaLLM(ctx context.Context, orgID, projectID, userID, userEmail, userPrompt string, existingIDs []string) (*gen.SuggestCustomDetectionRuleResult, error) {
+	ctx, err := hostedinference.WithGovernedUserOrUnsupported(ctx, hostedinference.CallCategoryRiskAuthoring, hostedinference.CallCategoryAPIKeyRiskAuthoring, hostedinference.CallCategoryNonOrdinarySessionRiskAuthoring)
+	if err != nil {
+		return nil, fmt.Errorf("classify custom risk authoring inference: %w", err)
+	}
 	systemPrompt := `You are a security-rules assistant for a runtime risk detection product.
 
 Given a single natural-language description of what an operator wants to detect, return a JSON object the dashboard uses to prefill a "create custom detection rule" form. The rule matches an agent message via a CEL (Common Expression Language) boolean expression in "detection_expr".
@@ -2924,6 +2943,10 @@ Output ONLY the JSON object. No prose, no markdown fences.`
 // validates the response with the same gate the create/update exclusion
 // handlers use. Validation failures wrap errExclusionSuggestionInvalid.
 func (s *Service) requestExclusionSuggestion(ctx context.Context, orgID, projectID, userID, userEmail, systemPrompt, userMessage string, jsonSchema *or.ChatJSONSchemaConfig) (*gen.SuggestExclusionResult, error) {
+	ctx, err := hostedinference.WithGovernedUserOrUnsupported(ctx, hostedinference.CallCategoryRiskAuthoring, hostedinference.CallCategoryAPIKeyRiskAuthoring, hostedinference.CallCategoryNonOrdinarySessionRiskAuthoring)
+	if err != nil {
+		return nil, fmt.Errorf("classify risk exclusion inference: %w", err)
+	}
 	suggestCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -3548,9 +3571,22 @@ func customDetectionRuleToType(row repo.RiskCustomDetectionRule) *types.RiskCust
 	}
 }
 
-func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID string, sources, presidioEntities, customRuleTitles []string, action string, existingNames []string) string {
+func (s *Service) mapHostedInferenceBoundaryError(ctx context.Context, err error) error {
+	//nolint:wrapcheck // The mapper returns a fully wrapped, telemetry-safe boundary error.
+	if mapped, ok := hostedinference.MapBoundaryError(ctx, s.logger, err); ok {
+		return mapped
+	}
+	return oops.E(oops.CodeUnexpected, err, "classify hosted inference").LogError(ctx, s.logger)
+}
+
+func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID string, sources, presidioEntities, customRuleTitles []string, action string, existingNames []string) (string, error) {
+	fallback := s.fallbackPolicyName(sources, customRuleTitles, action)
 	if s.completionClient == nil {
-		return s.fallbackPolicyName(sources, customRuleTitles, action)
+		return fallback, nil
+	}
+	ctx, err := hostedinference.WithGovernedUserOrUnsupported(ctx, hostedinference.CallCategoryRiskAuthoring, hostedinference.CallCategoryAPIKeyRiskAuthoring, hostedinference.CallCategoryNonOrdinarySessionRiskAuthoring)
+	if err != nil {
+		return "", fmt.Errorf("classify risk policy naming inference: %w", err)
 	}
 
 	// Policy authors think in *what* is detected, not *how* (gitleaks,
@@ -3607,13 +3643,16 @@ func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID strin
 		DisableResponseHealing:    false,
 	})
 	if err != nil {
+		if hostedinference.IsBoundaryError(err) {
+			return "", err //nolint:wrapcheck // Preserve the typed error for Goa boundary mapping.
+		}
 		s.logger.WarnContext(ctx, "failed to generate policy name via OpenRouter", attr.SlogError(err))
-		return s.fallbackPolicyName(sources, customRuleTitles, action)
+		return fallback, nil
 	}
 
 	name := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if name == "" {
-		return s.fallbackPolicyName(sources, customRuleTitles, action)
+		return fallback, nil
 	}
 
 	// Truncate to 100 chars
@@ -3622,7 +3661,7 @@ func (s *Service) generatePolicyName(ctx context.Context, orgID, projectID strin
 		name = string(runes[:100])
 	}
 
-	return name
+	return name, nil
 }
 
 // customRuleTitlesForIDs resolves selected custom rule ids to their
@@ -3713,10 +3752,14 @@ func (s *Service) fallbackPolicyName(sources, customRuleTitles []string, action 
 	return strings.Join(parts, " & ") + " " + actionLabel
 }
 
-func (s *Service) generatePromptPolicyName(ctx context.Context, orgID, projectID, prompt string, existingNames []string) string {
+func (s *Service) generatePromptPolicyName(ctx context.Context, orgID, projectID, prompt string, existingNames []string) (string, error) {
 	fallback := fallbackPromptPolicyName(prompt, existingNames)
 	if s.completionClient == nil {
-		return fallback
+		return fallback, nil
+	}
+	ctx, err := hostedinference.WithGovernedUserOrUnsupported(ctx, hostedinference.CallCategoryRiskAuthoring, hostedinference.CallCategoryAPIKeyRiskAuthoring, hostedinference.CallCategoryNonOrdinarySessionRiskAuthoring)
+	if err != nil {
+		return "", fmt.Errorf("classify prompt policy naming inference: %w", err)
 	}
 
 	namePrompt := fmt.Sprintf(
@@ -3761,19 +3804,22 @@ func (s *Service) generatePromptPolicyName(ctx context.Context, orgID, projectID
 		DisableResponseHealing:    false,
 	})
 	if err != nil {
+		if hostedinference.IsBoundaryError(err) {
+			return "", err //nolint:wrapcheck // Preserve the typed error for Goa boundary mapping.
+		}
 		s.logger.WarnContext(ctx, "failed to generate prompt policy name via OpenRouter", attr.SlogError(err))
-		return fallback
+		return fallback, nil
 	}
 	if response == nil || response.Message == nil {
-		return fallback
+		return fallback, nil
 	}
 
 	name := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if name == "" {
-		return fallback
+		return fallback, nil
 	}
 
-	return promptPolicyNameFromBase(name, existingNames)
+	return promptPolicyNameFromBase(name, existingNames), nil
 }
 
 func validateAction(action string) error {

--- a/server/internal/risk/prompt_policy_name_test.go
+++ b/server/internal/risk/prompt_policy_name_test.go
@@ -100,7 +100,10 @@ func TestGeneratePromptPolicyName(t *testing.T) {
 				completionClient: client,
 			}
 
-			got := svc.generatePromptPolicyName(context.Background(), "org_123", "project_123", "Block destructive deletes", tt.existing)
+			got, err := svc.generatePromptPolicyName(context.Background(), "org_123", "project_123", "Block destructive deletes", tt.existing)
+			if err != nil {
+				t.Fatalf("generatePromptPolicyName() error = %v", err)
+			}
 			if got != tt.want {
 				t.Fatalf("generatePromptPolicyName() = %q, want %q", got, tt.want)
 			}
@@ -116,7 +119,10 @@ func TestGeneratePromptPolicyNameWithoutCompletionClient(t *testing.T) {
 	t.Parallel()
 
 	svc := &Service{logger: testenv.NewLogger(t)}
-	got := svc.generatePromptPolicyName(context.Background(), "org_123", "project_123", "Block destructive deletes", nil)
+	got, err := svc.generatePromptPolicyName(context.Background(), "org_123", "project_123", "Block destructive deletes", nil)
+	if err != nil {
+		t.Fatalf("generatePromptPolicyName() error = %v", err)
+	}
 	want := "Prompt Policy: Block destructive deletes"
 	if got != want {
 		t.Fatalf("generatePromptPolicyName() = %q, want %q", got, want)

--- a/server/internal/risk/retro_exclusion_ch_test.go
+++ b/server/internal/risk/retro_exclusion_ch_test.go
@@ -393,6 +393,7 @@ func TestRetroExclusion_RegexReconstruction(t *testing.T) {
 	now := time.Now().UTC()
 	require.NoError(t, chQueries.AppendRetroExclusionApplyByIDs(ctx, scope, exclusionID,
 		chrepo.FormatCHTime(now), chrepo.FormatCHTime(now.Add(time.Microsecond)), []uuid.UUID{c.ID}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	excluded, exID, _ := latestExclusionState(t, ti, c.ID)
 	require.True(t, excluded)

--- a/server/internal/scanners/promptinjection/openrouter/judge.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
@@ -148,6 +149,11 @@ func (c *Engine) Classify(ctx context.Context, req promptinjection.Request) (_ [
 	n := len(req.Messages)
 	if n == 0 {
 		return nil, nil
+	}
+
+	ctx, err = hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	if err != nil {
+		return nil, fmt.Errorf("classify prompt-injection inference: %w", err)
 	}
 
 	ctx, span := c.tracer.Start(ctx, "risk.prompt_injection.classify", trace.WithAttributes(

--- a/server/internal/scanners/promptpolicy/openrouter/judge.go
+++ b/server/internal/scanners/promptpolicy/openrouter/judge.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
@@ -111,6 +112,11 @@ func (j *Judge) Evaluate(ctx context.Context, in promptpolicy.Input) (*promptpol
 	// HasContent keeps those events in scope.
 	if strings.TrimSpace(in.Prompt) == "" || !in.Message.HasContent() {
 		return nil, nil
+	}
+
+	ctx, classifyErr := hostedinference.WithInternal(ctx, hostedinference.CallCategoryPromptScanner)
+	if classifyErr != nil {
+		return nil, fmt.Errorf("classify prompt-policy inference: %w", classifyErr)
 	}
 
 	ctx, span := j.tracer.Start(ctx, "risk.judge.evaluate", trace.WithAttributes(
@@ -207,7 +213,6 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
 	defer cancel()
-
 	response, err := j.client.GetObjectCompletion(callCtx, openrouter.ObjectCompletionRequest{
 		OrgID:                  in.OrgID,
 		ProjectID:              in.ProjectID,

--- a/server/internal/skills/efficacy/judge.go
+++ b/server/internal/skills/efficacy/judge.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -129,6 +130,10 @@ type JudgeResult struct {
 // so the caller can tell an answer it should charge the model for from one it
 // should simply retry.
 func (j *Judge) Judge(ctx context.Context, in JudgeInput) (JudgeResult, error) {
+	ctx, classifyErr := hostedinference.WithBackground(ctx, hostedinference.CallCategorySkillJudge)
+	if classifyErr != nil {
+		return JudgeResult{}, fmt.Errorf("classify skill-efficacy inference: %w", classifyErr)
+	}
 	ctx, span := j.tracer.Start(ctx, "skill.efficacy.judge", trace.WithAttributes(
 		attr.OrganizationID(in.OrgID),
 		attr.ProjectID(in.ProjectID),
@@ -188,7 +193,6 @@ func (j *Judge) call(ctx context.Context, in JudgeInput) (JudgeResult, error) {
 
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
 	defer cancel()
-
 	response, err := j.client.GetObjectCompletion(callCtx, openrouter.ObjectCompletionRequest{
 		OrgID:        in.OrgID,
 		ProjectID:    in.ProjectID,

--- a/server/internal/skills/suggest/judge.go
+++ b/server/internal/skills/suggest/judge.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/skills"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
@@ -176,6 +177,10 @@ func (g *modelGenerator) Generate(ctx context.Context, in GenerateInput) (Genera
 	prompt, err := BuildPrompt(g.config, in)
 	if err != nil {
 		return Generation{}, err
+	}
+	ctx, err = hostedinference.WithBackground(ctx, hostedinference.CallCategorySkillJudge)
+	if err != nil {
+		return Generation{}, fmt.Errorf("classify skill-suggestion inference: %w", err)
 	}
 	bucket := openrouter.ResolveJudgeRateLimitKey(ctx, g.logger, g.completion, in.OrganizationID, in.ProjectID.String(), billing.ModelUsageSourceSkillSuggestions, g.config.Model)
 	switch result, err := g.limiter.Allow(ctx, bucket); {

--- a/server/internal/thirdparty/openrouter/context_window.go
+++ b/server/internal/thirdparty/openrouter/context_window.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
@@ -28,16 +29,36 @@ type ContextWindowResolver struct {
 	baseURL    string
 }
 
-func NewContextWindowResolver(logger *slog.Logger, guardianPolicy *guardian.Policy, cacheImpl cache.Cache) *ContextWindowResolver {
+func NewContextWindowResolver(logger *slog.Logger, guardianPolicy *guardian.Policy, cacheImpl cache.Cache, checkpoint hostedinference.AttemptCheckpoint) *ContextWindowResolver {
 	component := logger.With(attr.SlogComponent("openrouter_context_window"))
+	attemptCheck := func(req *http.Request) error {
+		organizationID, governed := req.Context().Value(contextWindowOrganizationKey{}).(string)
+		if !governed {
+			return nil // assistant context-window lookup remains explicitly unchanged
+		}
+		if checkpoint == nil {
+			return hostedinference.ErrCheckpointUnavailable
+		}
+		return checkpoint.Check(req.Context(), organizationID)
+	}
 	return &ContextWindowResolver{
 		logger:     component,
-		httpClient: guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig()),
+		httpClient: guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig(), guardian.WithAttemptCheck(attemptCheck)),
 		cache:      cache.NewTypedObjectCache[mv.ModelContextWindow](component.With(attr.SlogCacheNamespace("openrouter_context_window")), cacheImpl, cache.SuffixNone),
 		baseURL:    OpenRouterBaseURL,
 	}
 }
 
+type contextWindowOrganizationKey struct{}
+
+// ResolveGoverned resolves metadata for a governed user call. The organization
+// marker is consumed by the HTTP transport immediately before every attempt.
+func (r *ContextWindowResolver) ResolveGoverned(ctx context.Context, organizationID, modelID string) (int, error) {
+	return r.Resolve(context.WithValue(ctx, contextWindowOrganizationKey{}, organizationID), modelID)
+}
+
+// Resolve preserves the explicit assistant/internal metadata path without
+// introducing user-session enforcement.
 func (r *ContextWindowResolver) Resolve(ctx context.Context, modelID string) (int, error) {
 	if cached, err := r.cache.Get(ctx, mv.ModelContextWindowCacheKey(modelID)); err == nil {
 		return cached.Tokens, nil

--- a/server/internal/thirdparty/openrouter/context_window_test.go
+++ b/server/internal/thirdparty/openrouter/context_window_test.go
@@ -3,11 +3,13 @@ package openrouter
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -109,6 +111,32 @@ func TestContextWindowResolver_FetchMinErrorsOnInvalidModelID(t *testing.T) {
 		_, err := r.fetchMin(t.Context(), bad)
 		require.Error(t, err, "id=%q", bad)
 	}
+}
+
+func TestContextWindowResolver_GovernedRetryRechecksBeforeEveryAttempt(t *testing.T) {
+	t.Parallel()
+
+	var providerRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		providerRequests.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	denial := &typedCheckpointDenialError{}
+	checkpoint := &scriptedInferenceCheckpoint{errors: []error{nil, denial}}
+	resolver := NewContextWindowResolver(testenv.NewLogger(t), policy, cache.NoopCache, checkpoint)
+	resolver.baseURL = server.URL
+
+	_, err = resolver.ResolveGoverned(t.Context(), "org", "openai/gpt-5.4")
+	var typedDenial *typedCheckpointDenialError
+	require.ErrorAs(t, err, &typedDenial)
+	require.Equal(t, int32(1), providerRequests.Load(), "the denied retry must not egress")
+	checkpoint.mu.Lock()
+	require.Equal(t, 2, checkpoint.calls, "initial attempt allowed, retry denied")
+	checkpoint.mu.Unlock()
 }
 
 func TestContextWindowResolver_ResolveStoresInCacheOnFetch(t *testing.T) {

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -316,7 +316,7 @@ func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},

--- a/server/internal/thirdparty/openrouter/hosted_inference_checkpoint_test.go
+++ b/server/internal/thirdparty/openrouter/hosted_inference_checkpoint_test.go
@@ -55,6 +55,21 @@ func (r *countingKeyResolver) ResolveKey(context.Context, string, string, billin
 	return ResolvedKey{Key: "key"}, nil
 }
 
+func TestProductionUnifiedClientRequiresCheckpoint(t *testing.T) {
+	t.Parallel()
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	client, err := NewUnifiedClient(testenv.NewLogger(t), policy, nil, &countingKeyResolver{}, nil, nil, nil, nil, nil)
+	require.ErrorIs(t, err, hostedinference.ErrCheckpointUnavailable)
+	require.Nil(t, client)
+
+	checkpoint := &scriptedInferenceCheckpoint{}
+	client, err = NewUnifiedClient(testenv.NewLogger(t), policy, nil, &countingKeyResolver{}, nil, nil, nil, nil, checkpoint)
+	require.NoError(t, err)
+	require.Same(t, checkpoint, client.inferenceCheckpoint)
+}
+
 func TestUnifiedClientDoesNotFollowProviderRedirects(t *testing.T) {
 	t.Parallel()
 
@@ -75,7 +90,7 @@ func TestUnifiedClientDoesNotFollowProviderRedirects(t *testing.T) {
 
 			policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
 			require.NoError(t, err)
-			client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, &countingKeyResolver{}, nil, nil, nil, nil)
+			client := NewUncheckedUnifiedClient(testenv.NewLogger(t), policy, nil, &countingKeyResolver{}, nil, nil, nil, nil)
 			resp, err := client.httpClient.Get(redirect.URL)
 			require.NoError(t, err)
 			require.Equal(t, status, resp.StatusCode)
@@ -180,7 +195,8 @@ func TestEmbeddingSDKRetryRechecksHostedInferenceBeforeHTTPAttempt(t *testing.T)
 	resolver := &countingKeyResolver{}
 	denial := &typedCheckpointDenialError{}
 	checkpoint := &scriptedInferenceCheckpoint{errors: []error{nil, nil, denial}}
-	client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, nil, nil, nil, nil).WithHostedInferenceCheckpoint(checkpoint)
+	client, err := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, nil, nil, nil, nil, checkpoint)
+	require.NoError(t, err)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
 	_, err = client.CreateEmbeddings(t.Context(), "org", "openai/text-embedding-3-small", []string{"hello"})
@@ -207,7 +223,8 @@ func TestHostedInferenceReevaluatesBeforeRetryAttempt(t *testing.T) {
 	capture := &mockMessageCaptureStrategy{}
 	retryDenied := errors.New("activated before retry")
 	checkpoint := &scriptedInferenceCheckpoint{errors: []error{nil, nil, retryDenied}}
-	client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, capture, nil, nil, nil).WithHostedInferenceCheckpoint(checkpoint)
+	client, err := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, capture, nil, nil, nil, checkpoint)
+	require.NoError(t, err)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
 	_, err = client.GetCompletion(t.Context(), CompletionRequest{

--- a/server/internal/thirdparty/openrouter/hosted_inference_checkpoint_test.go
+++ b/server/internal/thirdparty/openrouter/hosted_inference_checkpoint_test.go
@@ -1,0 +1,221 @@
+package openrouter
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/killswitches"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type scriptedInferenceCheckpoint struct {
+	mu     sync.Mutex
+	errors []error
+	calls  int
+}
+
+func (s *scriptedInferenceCheckpoint) Check(context.Context, string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	index := s.calls
+	s.calls++
+	if index < len(s.errors) {
+		return s.errors[index]
+	}
+	return nil
+}
+
+type fixedInferenceEvaluator struct{ result killswitches.EvaluationResult }
+
+func (f fixedInferenceEvaluator) Evaluate(context.Context, killswitches.EvaluationRequest) killswitches.EvaluationResult {
+	return f.result
+}
+
+type countingKeyResolver struct{ calls int }
+
+type typedCheckpointDenialError struct{}
+
+func (*typedCheckpointDenialError) Error() string { return "hosted inference denied during retry" }
+
+func (r *countingKeyResolver) ResolveKey(context.Context, string, string, billing.ModelUsageSource, KeyType) (ResolvedKey, error) {
+	r.calls++
+	return ResolvedKey{Key: "key"}, nil
+}
+
+func TestUnifiedClientDoesNotFollowProviderRedirects(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			var redirectedRequests atomic.Int32
+			target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				redirectedRequests.Add(1)
+			}))
+			t.Cleanup(target.Close)
+
+			redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Location", target.URL)
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(redirect.Close)
+
+			policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+			require.NoError(t, err)
+			client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, &countingKeyResolver{}, nil, nil, nil, nil)
+			resp, err := client.httpClient.Get(redirect.URL)
+			require.NoError(t, err)
+			require.Equal(t, status, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+			require.Zero(t, redirectedRequests.Load(), "redirected provider attempts must never egress")
+		})
+	}
+}
+
+func TestInjectedClientFailsClosedWithoutCheckpointDependency(t *testing.T) {
+	t.Parallel()
+	resolver := &countingKeyResolver{}
+	client := (&ChatClient{logger: testenv.NewLogger(t), keyResolver: resolver}).WithHostedInferenceCheckpoint(nil)
+
+	_, err := client.GetCompletion(t.Context(), CompletionRequest{OrgID: "org", ProjectID: uuid.NewString()})
+	require.ErrorContains(t, err, "checkpoint is unavailable")
+	require.Zero(t, resolver.calls)
+}
+
+func TestInjectedClientFailsClosedWithoutClassification(t *testing.T) {
+	t.Parallel()
+	registry, err := mcptoolexecution.NewRegistry(nil)
+	require.NoError(t, err)
+	noMatch, err := killswitches.NewNoMatchResult(killswitches.NoMatchReasonNoPrescription)
+	require.NoError(t, err)
+	checkpoint, err := hostedinference.NewCheckpoint(registry, fixedInferenceEvaluator{result: noMatch}, hostedinference.DefaultEvaluationTimeout)
+	require.NoError(t, err)
+	resolver := &countingKeyResolver{}
+	capture := &mockMessageCaptureStrategy{}
+	client := (&ChatClient{logger: testenv.NewLogger(t), keyResolver: resolver, messageCaptureStrategy: capture}).WithHostedInferenceCheckpoint(checkpoint)
+
+	_, err = client.GetCompletion(t.Context(), CompletionRequest{OrgID: "org", ProjectID: uuid.NewString()})
+	var unavailable *hostedinference.InfrastructureUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+	require.Zero(t, resolver.calls)
+	require.False(t, capture.startOrResumeCalled)
+}
+
+func TestHostedInferenceDenialPrecedesAllRequestSideEffects(t *testing.T) {
+	t.Parallel()
+	denied := errors.New("denied before side effects")
+	projectID := uuid.NewString()
+	completion := CompletionRequest{OrgID: "org", ProjectID: projectID, Messages: []or.ChatMessages{CreateMessageUser("hello")}}
+
+	tests := []struct {
+		name string
+		call func(*testing.T, *ChatClient) error
+	}{
+		{name: "completion", call: func(t *testing.T, client *ChatClient) error {
+			t.Helper()
+			_, err := client.GetCompletion(t.Context(), completion)
+			return err
+		}},
+		{name: "stream", call: func(t *testing.T, client *ChatClient) error {
+			t.Helper()
+			_, err := client.GetCompletionStream(t.Context(), completion)
+			return err
+		}},
+		{name: "object completion", call: func(t *testing.T, client *ChatClient) error {
+			t.Helper()
+			_, err := client.GetObjectCompletion(t.Context(), ObjectCompletionRequest{OrgID: "org", ProjectID: projectID, Prompt: "hello"})
+			return err
+		}},
+		{name: "embeddings", call: func(t *testing.T, client *ChatClient) error {
+			t.Helper()
+			_, err := client.CreateEmbeddings(t.Context(), "org", "openai/text-embedding-3-small", []string{"hello"})
+			return err
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			checkpoint := &scriptedInferenceCheckpoint{errors: []error{denied}}
+			resolver := &countingKeyResolver{}
+			capture := &mockMessageCaptureStrategy{}
+			client := (&ChatClient{logger: testenv.NewLogger(t), keyResolver: resolver, messageCaptureStrategy: capture}).WithHostedInferenceCheckpoint(checkpoint)
+
+			err := test.call(t, client)
+			require.ErrorIs(t, err, denied)
+			require.Equal(t, 1, checkpoint.calls)
+			require.Zero(t, resolver.calls, "key resolution/provisioning must not run")
+			require.False(t, capture.startOrResumeCalled, "capture must not start")
+		})
+	}
+}
+
+func TestEmbeddingSDKRetryRechecksHostedInferenceBeforeHTTPAttempt(t *testing.T) {
+	t.Parallel()
+
+	var providerRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		providerRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":{"message":"retryable provider failure"}}`))
+	}))
+	defer server.Close()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	resolver := &countingKeyResolver{}
+	denial := &typedCheckpointDenialError{}
+	checkpoint := &scriptedInferenceCheckpoint{errors: []error{nil, nil, denial}}
+	client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, nil, nil, nil, nil).WithHostedInferenceCheckpoint(checkpoint)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+
+	_, err = client.CreateEmbeddings(t.Context(), "org", "openai/text-embedding-3-small", []string{"hello"})
+	var typedDenial *typedCheckpointDenialError
+	require.ErrorAs(t, err, &typedDenial)
+	require.Equal(t, 3, checkpoint.calls, "pre-key guard plus one check for each SDK HTTP attempt")
+	require.EqualValues(t, 1, providerRequests.Load(), "the denied SDK retry must not reach the provider")
+	require.Equal(t, 1, resolver.calls, "key resolution remains behind the initial guard and before SDK attempts")
+}
+
+func TestHostedInferenceReevaluatesBeforeRetryAttempt(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"empty","model":"openai/gpt-5.4","choices":[]}`))
+	}))
+	defer server.Close()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	resolver := &countingKeyResolver{}
+	capture := &mockMessageCaptureStrategy{}
+	retryDenied := errors.New("activated before retry")
+	checkpoint := &scriptedInferenceCheckpoint{errors: []error{nil, nil, retryDenied}}
+	client := NewUnifiedClient(testenv.NewLogger(t), policy, nil, resolver, capture, nil, nil, nil).WithHostedInferenceCheckpoint(checkpoint)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+
+	_, err = client.GetCompletion(t.Context(), CompletionRequest{
+		OrgID: "org", ProjectID: uuid.NewString(), Messages: []or.ChatMessages{CreateMessageUser("hello")}, Model: "openai/gpt-5.4",
+	})
+	require.ErrorIs(t, err, retryDenied)
+	require.Equal(t, 3, checkpoint.calls, "preflight plus one check per attempted provider call")
+	require.Equal(t, 1, requests, "the denied retry must not reach the provider")
+	require.Equal(t, 1, resolver.calls)
+	require.True(t, capture.startOrResumeCalled)
+}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -18,9 +18,11 @@ import (
 	or_base "github.com/OpenRouterTeam/go-sdk"
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	or_operations "github.com/OpenRouterTeam/go-sdk/models/operations"
+	or_retry "github.com/OpenRouterTeam/go-sdk/retry"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/killswitches/hostedinference"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
@@ -50,6 +52,7 @@ type ChatClient struct {
 	usageTrackingStrategy  UsageTrackingStrategy
 	chatTitleGenerator     ChatTitleGenerator
 	telemetryLogger        TelemetryLogger
+	inferenceCheckpoint    hostedinference.AttemptCheckpoint
 }
 
 // NewUnifiedClient creates a new UnifiedClient with the given strategies.
@@ -63,16 +66,80 @@ func NewUnifiedClient(
 	chatTitleGenerator ChatTitleGenerator,
 	telemetryLogger TelemetryLogger,
 ) *ChatClient {
+	httpClient := guardianPolicy.PooledClient()
+	// Provider redirects are never followed implicitly. Following a 307/308
+	// would create another provider attempt inside http.Client.Do, outside the
+	// call site's per-attempt checkpoint. Treat the redirect as the response.
+	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	return &ChatClient{
 		logger:                 logger.With(attr.SlogComponent("openrouter_completions")),
-		httpClient:             guardianPolicy.PooledClient(),
+		httpClient:             httpClient,
 		provisioner:            provisioner,
 		keyResolver:            keyResolver,
 		messageCaptureStrategy: captureStrategy,
 		usageTrackingStrategy:  trackingStrategy,
 		chatTitleGenerator:     chatTitleGenerator,
 		telemetryLogger:        telemetryLogger,
+		inferenceCheckpoint:    nil,
 	}
+}
+
+// WithHostedInferenceCheckpoint returns a client copy with the production
+// pre-provider checkpoint installed. NewUnifiedClient deliberately leaves it
+// unset so tests, local tooling, and non-production composition retain their
+// existing behavior unless they opt in explicitly.
+func (c *ChatClient) WithHostedInferenceCheckpoint(checkpoint hostedinference.AttemptCheckpoint) *ChatClient {
+	if c == nil {
+		return nil
+	}
+	result := *c
+	if checkpoint == nil {
+		checkpoint = unavailableInferenceCheckpoint{}
+	}
+	result.inferenceCheckpoint = checkpoint
+	return &result
+}
+
+type unavailableInferenceCheckpoint struct{}
+
+func (unavailableInferenceCheckpoint) Check(context.Context, string) error {
+	return hostedinference.ErrCheckpointUnavailable
+}
+
+func (c *ChatClient) checkHostedInference(ctx context.Context, organizationID string) error {
+	if c.inferenceCheckpoint == nil {
+		return nil // explicitly unchecked standalone/test construction
+	}
+	if err := c.inferenceCheckpoint.Check(ctx, organizationID); err != nil {
+		return fmt.Errorf("check hosted-inference access: %w", err)
+	}
+	return nil
+}
+
+// hostedInferenceHTTPClient puts the checkpoint inside the OpenRouter SDK's
+// retry loop. Every SDK attempt therefore re-evaluates ai_access immediately
+// before the existing Guardian client performs network I/O. Checkpoint errors
+// are permanent so the SDK returns denials and evaluator outages directly
+// instead of retrying them.
+type hostedInferenceHTTPClient struct {
+	delegate       or_base.HTTPClient
+	checkpoint     hostedinference.AttemptCheckpoint
+	organizationID string
+}
+
+func (c *hostedInferenceHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c.checkpoint != nil {
+		if err := c.checkpoint.Check(req.Context(), c.organizationID); err != nil {
+			return nil, or_retry.Permanent(err) //nolint:wrapcheck // The SDK requires its permanent-error wrapper to remain outermost.
+		}
+	}
+	resp, err := c.delegate.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send hosted-inference request: %w", err)
+	}
+	return resp, nil
 }
 
 // ResolveKey exposes key resolution so callers can scope rate-limit buckets to
@@ -364,6 +431,9 @@ func (c *ChatClient) requestCompletion(ctx context.Context, apiKey string, reqBo
 
 // GetCompletion makes a non-streaming completion request to OpenRouter and applies capture/tracking strategies.
 func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (*CompletionResponse, error) {
+	if err := c.checkHostedInference(ctx, req.OrgID); err != nil {
+		return nil, err
+	}
 	start := time.Now()
 
 	// Build request body (non-streaming)
@@ -384,6 +454,9 @@ func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (
 		body     []byte
 	)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err := c.checkHostedInference(ctx, req.OrgID); err != nil {
+			return nil, err
+		}
 		var err error
 		chatResp, body, err = c.requestCompletion(ctx, initResult.apiKey, reqBody)
 		if err != nil {
@@ -484,6 +557,10 @@ func (c *ChatClient) GetCompletionStream(ctx context.Context, req CompletionRequ
 		return nil, fmt.Errorf("web search is not available on the streaming path: its citations would be dropped")
 	}
 
+	if err := c.checkHostedInference(ctx, req.OrgID); err != nil {
+		return nil, err
+	}
+
 	// Build request body (streaming)
 	initResult, err := c.initializeRequest(ctx, req)
 	if err != nil {
@@ -491,6 +568,11 @@ func (c *ChatClient) GetCompletionStream(ctx context.Context, req CompletionRequ
 	}
 	reqBody := initResult.requestBody
 	reqBody.Stream = true
+
+	// Re-evaluate immediately before the actual provider attempt.
+	if err := c.checkHostedInference(ctx, req.OrgID); err != nil {
+		return nil, err
+	}
 
 	// Make HTTP request
 	httpResp, err := c.makeHTTPRequest(ctx, initResult.apiKey, reqBody)
@@ -872,6 +954,9 @@ func (c *ChatClient) CreateEmbeddings(ctx context.Context, orgID string, model s
 }
 
 func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model string, inputs []string, dimensions *int64, keyType KeyType) ([][]float32, error) {
+	if err := c.checkHostedInference(ctx, orgID); err != nil {
+		return nil, err
+	}
 	resolvedKey, err := c.keyResolver.ResolveKey(ctx, orgID, "", "", keyType)
 	if err != nil {
 		return nil, fmt.Errorf("resolving OpenRouter key: %w", err)
@@ -900,7 +985,14 @@ func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model s
 	}
 	inputs = truncatedInputs
 
-	orClient := or_base.New(or_base.WithSecurity(openrouterKey))
+	orClient := or_base.New(
+		or_base.WithSecurity(openrouterKey),
+		or_base.WithClient(&hostedInferenceHTTPClient{
+			delegate:       c.httpClient,
+			checkpoint:     c.inferenceCheckpoint,
+			organizationID: orgID,
+		}),
+	)
 	result, err := orClient.Embeddings.Generate(ctx, or_operations.CreateEmbeddingsRequest{
 		Model:          model,
 		Input:          or_operations.CreateInputUnionArrayOfStr(inputs),

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -97,7 +97,7 @@ func NewUncheckedUnifiedClient(
 	httpClient.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	return &ChatClient{
+	return &ChatClient{ //nolint:exhaustruct // The explicit unchecked constructor intentionally leaves the checkpoint at its zero value.
 		logger:                 logger.With(attr.SlogComponent("openrouter_completions")),
 		httpClient:             httpClient,
 		provisioner:            provisioner,

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -55,8 +55,32 @@ type ChatClient struct {
 	inferenceCheckpoint    hostedinference.AttemptCheckpoint
 }
 
-// NewUnifiedClient creates a new UnifiedClient with the given strategies.
+// NewUnifiedClient creates a client that cannot egress without the
+// production hosted-inference checkpoint.
 func NewUnifiedClient(
+	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
+	provisioner Provisioner,
+	keyResolver KeyResolver,
+	captureStrategy MessageCaptureStrategy,
+	trackingStrategy UsageTrackingStrategy,
+	chatTitleGenerator ChatTitleGenerator,
+	telemetryLogger TelemetryLogger,
+	checkpoint hostedinference.AttemptCheckpoint,
+) (*ChatClient, error) {
+	if checkpoint == nil {
+		return nil, hostedinference.ErrCheckpointUnavailable
+	}
+	return NewUncheckedUnifiedClient(
+		logger, guardianPolicy, provisioner, keyResolver, captureStrategy,
+		trackingStrategy, chatTitleGenerator, telemetryLogger,
+	).WithHostedInferenceCheckpoint(checkpoint), nil
+}
+
+// NewUncheckedUnifiedClient creates a client without hosted-inference
+// enforcement. It is restricted to tests and explicitly inventoried standalone
+// commands that do not serve production traffic.
+func NewUncheckedUnifiedClient(
 	logger *slog.Logger,
 	guardianPolicy *guardian.Policy,
 	provisioner Provisioner,
@@ -82,14 +106,11 @@ func NewUnifiedClient(
 		usageTrackingStrategy:  trackingStrategy,
 		chatTitleGenerator:     chatTitleGenerator,
 		telemetryLogger:        telemetryLogger,
-		inferenceCheckpoint:    nil,
 	}
 }
 
 // WithHostedInferenceCheckpoint returns a client copy with the production
-// pre-provider checkpoint installed. NewUnifiedClient deliberately leaves it
-// unset so tests, local tooling, and non-production composition retain their
-// existing behavior unless they opt in explicitly.
+// pre-provider checkpoint installed.
 func (c *ChatClient) WithHostedInferenceCheckpoint(checkpoint hostedinference.AttemptCheckpoint) *ChatClient {
 	if c == nil {
 		return nil

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -234,7 +234,7 @@ func TestChatClient_GetCompletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -381,7 +381,7 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -507,7 +507,7 @@ func TestChatClient_GetCompletionStream_FetchesFallbackUsageWhenFinalUsageChunkM
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -602,7 +602,7 @@ func TestChatClient_GetCompletion_FetchesFallbackUsageWhenInlineCostMissing(t *t
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -711,7 +711,7 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -810,7 +810,7 @@ func TestChatClient_NormalizesMixedAssistantOnlyForOpenRouterRequest(t *testing.
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -891,7 +891,7 @@ func TestChatClient_PassesMixedAssistantThroughWhenNormalizeFlagUnset(t *testing
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -972,7 +972,7 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create client
-			client := NewUnifiedClient(
+			client := NewUncheckedUnifiedClient(
 				testenv.NewLogger(t),
 				guardianPolicy,
 				provisioner,
@@ -1043,7 +1043,7 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -1208,7 +1208,7 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	titleGenerator := &trackingTitleGenerator{}
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -1255,7 +1255,7 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 
 	titleGenerator := &trackingTitleGenerator{}
 	tracker := newTrackingCaptureStrategy()
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -1320,7 +1320,7 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	tracker := newTrackingCaptureStrategy()
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -1449,7 +1449,7 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -1565,7 +1565,7 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create client
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		provisioner,
@@ -1687,7 +1687,7 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},
@@ -1745,7 +1745,7 @@ func TestChatClient_GetCompletion_AttributionFields(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
+	client := NewUncheckedUnifiedClient(
 		testenv.NewLogger(t),
 		guardianPolicy,
 		&mockProvisioner{apiKey: "test-api-key"},

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -140,7 +140,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
+	chatClient := openrouter.NewUncheckedUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }


### PR DESCRIPTION
## Summary

Enforce active `ai_access` prescriptions before governed Gram-hosted provider egress. Preserve authoritative acting-user and tenant attribution, deny fail-closed before every provider attempt, and transport administrator-selected notes safely to supported chat surfaces.

## Motivation

[DNO-991](https://linear.app/speakeasy/issue/DNO-991/feat-enforce-ai-access-before-gram-hosted-inference) requires hosted inference to honor the same access controls as governed hooks and managed LiteLLM traffic.

## Impact

Validated current-user model requests can now be denied before provider egress when an active prescription matches. Assistant, internal, background, API-key, chat-session, and other explicitly unsupported attribution classes retain their existing behavior and are excluded from coverage claims.

## Technical details

### Fail-closed provider boundary

A shared checkpoint evaluates the canonical `authenticated_user_ai_resource` contract immediately before every approved OpenRouter completion, embedding, metadata, retry, and governed redirect attempt. Production client construction requires checkpoint injection.

### Identity and transport safety

Only frozen, validated ordinary Gram user-session provenance is eligible. Missing, spoofed, cross-tenant, or unsupported identity cannot become a candidate; evaluator failures deny before egress; selected notes are encoded for supported user-facing errors without entering telemetry.

### Auditable coverage

Typed inventory analysis classifies hosted-provider call sites, validates context propagation, and rejects unchecked production client composition or unclassified provider transports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements DNO-991 by enforcing `ai_access` prescriptions before Gram-hosted provider egress. Hosted inference previously bypassed the killswitch checks applied to governed hooks and managed LiteLLM traffic; now a matching prescription denies validated current-user model calls before any provider attempt. Assistant, internal, background, API-key, and chat-session traffic is unchanged and outside coverage.

**New Features**
- Evaluates the checkpoint before every approved OpenRouter completion, embedding, retry, and governed redirect attempt, and denies fail-closed when the evaluator fails.
- Uses only validated ordinary Gram session provenance as the acting user, so missing, spoofed, or cross-tenant identity cannot match a prescription.
- Returns matched denials as `403 ai_access_denied` with the administrator-selected note, renders the note verbatim in the chat thread, and keeps it out of logs and traces; infrastructure failures return a generic `503`.
- Classifies every production hosted-inference call site as governed user, internal, background, or unsupported, and rejects unchecked production client composition.

**Migration**
- Production OpenRouter clients must now be built with `NewUnifiedClient` plus a hosted-inference checkpoint; benchmarks and tests use `NewUncheckedUnifiedClient`.

<sup>Written for commit b0f69d69f4ec5bab12a3a5436f4445ea3b102cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

