### PR TITLE
fix: prevent oversized tool embedding failures

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -407,6 +407,8 @@ const (
 	OpenRouterBackfillModeKey         = attribute.Key("gram.openrouter.backfill.mode")
 	OpenRouterBackfillScannedKey      = attribute.Key("gram.openrouter.backfill.scanned")
 	OpenRouterBackfillUpdatedKey      = attribute.Key("gram.openrouter.backfill.updated")
+	EmbeddingInputCountKey            = attribute.Key("gram.openrouter.embedding.input_count")
+	EmbeddingTruncatedInputCountKey   = attribute.Key("gram.openrouter.embedding.truncated_input_count")
 	OpenRouterKeyLimitKey             = attribute.Key("gram.openrouter.key.limit")
 	OpenRouterKeyPreviousLimitKey     = attribute.Key("gram.openrouter.key.previous_limit")
 	OpenRouterKeyTypeKey              = attribute.Key("gram.openrouter.key.type")
@@ -1619,6 +1621,20 @@ func SlogOpenRouterBackfillScanned(v int64) slog.Attr {
 
 func SlogOpenRouterBackfillUpdated(v int64) slog.Attr {
 	return slog.Int64(string(OpenRouterBackfillUpdatedKey), v)
+}
+
+func EmbeddingInputCount(v int) attribute.KeyValue {
+	return EmbeddingInputCountKey.Int(v)
+}
+func SlogEmbeddingInputCount(v int) slog.Attr {
+	return slog.Int(string(EmbeddingInputCountKey), v)
+}
+
+func EmbeddingTruncatedInputCount(v int) attribute.KeyValue {
+	return EmbeddingTruncatedInputCountKey.Int(v)
+}
+func SlogEmbeddingTruncatedInputCount(v int) slog.Attr {
+	return slog.Int(string(EmbeddingTruncatedInputCountKey), v)
 }
 
 func OpenRouterKeyLimit(v int) attribute.KeyValue { return OpenRouterKeyLimitKey.Int(v) }

--- a/server/internal/background/activities/generate_toolset_embeddings.go
+++ b/server/internal/background/activities/generate_toolset_embeddings.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"go.opentelemetry.io/otel/trace"
+	"go.temporal.io/sdk/temporal"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -15,7 +16,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/rag"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
+
+const generateToolsetEmbeddingsPermanentErrorType = "GenerateToolsetEmbeddingsPermanent"
 
 type GenerateToolsetEmbeddings struct {
 	logger     *slog.Logger
@@ -34,9 +38,7 @@ func NewGenerateToolsetEmbeddingsActivity(
 	db *pgxpool.Pool,
 	ragService *rag.ToolsetVectorStore,
 	logger *slog.Logger,
-
 ) *GenerateToolsetEmbeddings {
-
 	return &GenerateToolsetEmbeddings{
 		logger:     logger,
 		tracer:     tracerProvider,
@@ -70,13 +72,21 @@ func (a *GenerateToolsetEmbeddings) Do(
 		return getToolsetErr
 	}
 
-	err := a.ragService.IndexToolset(
-		ctx,
-		*toolset,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to index toolset: %w", err)
+	if err := a.ragService.IndexToolset(ctx, *toolset); err != nil {
+		return newGenerateToolsetEmbeddingsError(err)
 	}
 
 	return nil
+}
+
+func newGenerateToolsetEmbeddingsError(err error) error {
+	wrapped := fmt.Errorf("failed to index toolset: %w", err)
+	if openrouter.IsPermanentError(err) {
+		return temporal.NewNonRetryableApplicationError(
+			wrapped.Error(),
+			generateToolsetEmbeddingsPermanentErrorType,
+			wrapped,
+		)
+	}
+	return wrapped
 }

--- a/server/internal/background/activities/generate_toolset_embeddings_test.go
+++ b/server/internal/background/activities/generate_toolset_embeddings_test.go
@@ -1,0 +1,39 @@
+package activities
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGenerateToolsetEmbeddingsError_PermanentProviderErrorIsNonRetryable(t *testing.T) {
+	t.Parallel()
+
+	cause := &openrouter.HTTPError{
+		StatusCode: http.StatusBadRequest,
+		Err:        openrouter.ErrBadRequest,
+	}
+	err := newGenerateToolsetEmbeddingsError(cause)
+
+	var applicationErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &applicationErr)
+	require.True(t, applicationErr.NonRetryable())
+	require.Equal(t, generateToolsetEmbeddingsPermanentErrorType, applicationErr.Type())
+	require.ErrorIs(t, err, openrouter.ErrBadRequest)
+}
+
+func TestNewGenerateToolsetEmbeddingsError_TransientErrorRemainsRetryable(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("connection reset")
+	err := newGenerateToolsetEmbeddingsError(cause)
+
+	var applicationErr *temporal.ApplicationError
+	require.NotErrorAs(t, err, &applicationErr)
+	require.ErrorIs(t, err, cause)
+}

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -416,9 +416,31 @@ type embeddingBatch struct {
 	endIdx   int
 }
 
+func selectEmbeddingCandidateContents(model string, candidates []embeddingCandidate) error {
+	inputs := make([]string, len(candidates))
+	inputFallbacks := make([][]string, len(candidates))
+	for i, candidate := range candidates {
+		inputs[i] = candidate.content
+		inputFallbacks[i] = candidate.fallbacks
+	}
+
+	selected, err := openrouter.SelectEmbeddingInputFallbacks(model, inputs, inputFallbacks)
+	if err != nil {
+		return fmt.Errorf("select embedding input fallbacks: %w", err)
+	}
+	for i, content := range selected {
+		candidates[i].content = content
+	}
+	return nil
+}
+
 func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID string, candidates []embeddingCandidate) ([][]float32, error) {
 	if len(candidates) == 0 {
 		return nil, nil
+	}
+
+	if err := selectEmbeddingCandidateContents(s.embeddingModel, candidates); err != nil {
+		return nil, err
 	}
 
 	total := len(candidates)
@@ -461,19 +483,11 @@ func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID strin
 				}
 
 				inputs := make([]string, 0, batch.endIdx-batch.startIdx)
-				inputFallbacks := make([][]string, 0, batch.endIdx-batch.startIdx)
 				for i := batch.startIdx; i < batch.endIdx; i++ {
 					inputs = append(inputs, candidates[i].content)
-					inputFallbacks = append(inputFallbacks, candidates[i].fallbacks)
 				}
 
-				vectors, err := s.chatClient.CreateEmbeddings(
-					ctx,
-					orgID,
-					s.embeddingModel,
-					inputs,
-					openrouter.WithEmbeddingInputFallbacks(inputFallbacks),
-				)
+				vectors, err := s.chatClient.CreateEmbeddings(ctx, orgID, s.embeddingModel, inputs)
 				if err != nil {
 					setErr(fmt.Errorf("create embeddings batch: %w", err))
 					return
@@ -509,6 +523,10 @@ func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID strin
 }
 
 func (s *ToolsetVectorStore) createBatchesBySize(candidates []embeddingCandidate) []embeddingBatch {
+	return createBatchesWithinSize(candidates, embeddingMaxBatchBytes)
+}
+
+func createBatchesWithinSize(candidates []embeddingCandidate, maxBatchBytes int) []embeddingBatch {
 	var batches []embeddingBatch
 	currentBatchStart := 0
 	currentBatchBytes := 0
@@ -517,7 +535,7 @@ func (s *ToolsetVectorStore) createBatchesBySize(candidates []embeddingCandidate
 		contentBytes := len(candidate.content)
 
 		// If adding this candidate would exceed the limit, finalize current batch
-		if currentBatchBytes > 0 && currentBatchBytes+contentBytes > embeddingMaxBatchBytes {
+		if currentBatchBytes > 0 && currentBatchBytes+contentBytes > maxBatchBytes {
 			batches = append(batches, embeddingBatch{
 				startIdx: currentBatchStart,
 				endIdx:   i,

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -288,10 +288,11 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 }
 
 type embeddingCandidate struct {
-	entryKey string
-	payload  []byte
-	content  string
-	tags     []string
+	entryKey  string
+	payload   []byte
+	content   string
+	fallbacks []string
+	tags      []string
 }
 
 func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, tools []*types.Tool) ([]embeddingCandidate, error) {
@@ -328,7 +329,8 @@ func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, too
 		}
 
 		tags := extractTags(tool)
-		content := buildEmbeddableContent(&entry, tags)
+		schemaSummary, topLevelSchemaSummary := summarizeInputSchemaLevels(entry.InputSchema)
+		content := buildEmbeddableContent(&entry, tags, schemaSummary)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
@@ -337,7 +339,11 @@ func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, too
 			entryKey: baseTool.ToolUrn,
 			payload:  payload,
 			content:  content,
-			tags:     tags,
+			fallbacks: []string{
+				buildTopLevelEmbeddableContent(&entry, topLevelSchemaSummary),
+				buildNameDescriptionEmbeddableContent(&entry),
+			},
+			tags: tags,
 		})
 	}
 
@@ -455,11 +461,19 @@ func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID strin
 				}
 
 				inputs := make([]string, 0, batch.endIdx-batch.startIdx)
+				inputFallbacks := make([][]string, 0, batch.endIdx-batch.startIdx)
 				for i := batch.startIdx; i < batch.endIdx; i++ {
 					inputs = append(inputs, candidates[i].content)
+					inputFallbacks = append(inputFallbacks, candidates[i].fallbacks)
 				}
 
-				vectors, err := s.chatClient.CreateEmbeddings(ctx, orgID, s.embeddingModel, inputs)
+				vectors, err := s.chatClient.CreateEmbeddings(
+					ctx,
+					orgID,
+					s.embeddingModel,
+					inputs,
+					openrouter.WithEmbeddingInputFallbacks(inputFallbacks),
+				)
 				if err != nil {
 					setErr(fmt.Errorf("create embeddings batch: %w", err))
 					return
@@ -533,7 +547,7 @@ type toolListEntry struct {
 	Meta        map[string]any  `json:"_meta,omitempty"`
 }
 
-func buildEmbeddableContent(entry *toolListEntry, tags []string) string {
+func buildEmbeddableContent(entry *toolListEntry, tags []string, schemaSummary string) string {
 	parts := []string{
 		entry.Name,
 		entry.Description,
@@ -541,26 +555,75 @@ func buildEmbeddableContent(entry *toolListEntry, tags []string) string {
 	if len(tags) > 0 {
 		parts = append(parts, "tags: "+strings.Join(tags, ", "))
 	}
-	if schema := summarizeInputSchema(entry.InputSchema); schema != "" {
-		parts = append(parts, "parameters:\n"+schema)
+	if schemaSummary != "" {
+		parts = append(parts, "parameters:\n"+schemaSummary)
 	}
 
 	return strings.TrimSpace(strings.Join(filterNonEmpty(parts), "\n"))
 }
 
 func summarizeInputSchema(raw json.RawMessage) string {
+	summary, _ := summarizeInputSchemaLevels(raw)
+	return summary
+}
+
+func summarizeInputSchemaLevels(raw json.RawMessage) (full string, topLevel string) {
 	if len(raw) == 0 {
-		return ""
+		return "", ""
 	}
 
 	var schema map[string]any
 	if err := json.Unmarshal(raw, &schema); err != nil {
-		return string(raw)
+		return string(raw), ""
 	}
 
 	lines := make([]string, 0)
 	appendSchemaSummary(&lines, "input", schema, false, 0)
+	return strings.Join(lines, "\n"), summarizeTopLevelInputSchema(schema)
+}
+
+func summarizeTopLevelInputSchema(schema map[string]any) string {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	lines := make([]string, 0, len(names))
+	for _, name := range names {
+		line := "- " + name
+		if property, ok := properties[name].(map[string]any); ok {
+			description, _ := property["description"].(string)
+			if description == "" {
+				description, _ = property["title"].(string)
+			}
+			if description = summarizeSchemaText(description, 320); description != "" {
+				line += ": " + description
+			}
+		}
+		lines = append(lines, line)
+	}
 	return strings.Join(lines, "\n")
+}
+
+func buildTopLevelEmbeddableContent(entry *toolListEntry, schemaSummary string) string {
+	parts := []string{entry.Name, entry.Description}
+	if schemaSummary != "" {
+		parts = append(parts, "parameters:\n"+schemaSummary)
+	}
+	return strings.TrimSpace(strings.Join(filterNonEmpty(parts), "\n"))
+}
+
+func buildNameDescriptionEmbeddableContent(entry *toolListEntry) string {
+	return strings.TrimSpace(strings.Join(filterNonEmpty([]string{
+		entry.Name,
+		entry.Description,
+	}), "\n"))
 }
 
 func appendSchemaSummary(lines *[]string, path string, schema map[string]any, required bool, depth int) {

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -29,10 +30,11 @@ const (
 	// If you would like to add another embedding model you must modify the table to handle and index embeddings of that dimension
 	defaultEmbeddingModel      = "openai/text-embedding-3-small"
 	defaultFindToolsResultSize = 3
-	// OpenAI embedding limit: 300,000 tokens max per request, 8192 tokens per input
-	// Using ~4 bytes per token approximation: 300k tokens * 4 bytes = 1.2MB
-	// Use conservative 800KB to account for JSON overhead
-	embeddingMaxBatchBytes        = 800 * 1024 // 800KB
+	// OpenAI allows at most 300,000 tokens across an embedding request.
+	// A tokenizer cannot emit more tokens than the input has UTF-8 bytes, so
+	// this byte ceiling guarantees the aggregate token limit without another
+	// tokenization pass. Oversized individual inputs are limited by the client.
+	embeddingMaxBatchBytes        = 300_000
 	embeddingMaxConcurrentBatches = 5
 )
 
@@ -325,7 +327,8 @@ func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, too
 			return nil, fmt.Errorf("marshal tool entry %s: %w", name, err)
 		}
 
-		content := buildEmbeddableContent(&entry)
+		tags := extractTags(tool)
+		content := buildEmbeddableContent(&entry, tags)
 		if strings.TrimSpace(content) == "" {
 			continue
 		}
@@ -334,7 +337,7 @@ func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, too
 			entryKey: baseTool.ToolUrn,
 			payload:  payload,
 			content:  content,
-			tags:     extractTags(tool),
+			tags:     tags,
 		})
 	}
 
@@ -530,27 +533,205 @@ type toolListEntry struct {
 	Meta        map[string]any  `json:"_meta,omitempty"`
 }
 
-func buildEmbeddableContent(entry *toolListEntry) string {
-	var schema string
-	if len(entry.InputSchema) > 0 {
-		schema = string(entry.InputSchema)
-	}
-
-	var meta string
-	if entry.Meta != nil {
-		if payload, err := json.Marshal(entry.Meta); err == nil {
-			meta = string(payload)
-		}
-	}
-
+func buildEmbeddableContent(entry *toolListEntry, tags []string) string {
 	parts := []string{
 		entry.Name,
 		entry.Description,
-		schema,
-		meta,
+	}
+	if len(tags) > 0 {
+		parts = append(parts, "tags: "+strings.Join(tags, ", "))
+	}
+	if schema := summarizeInputSchema(entry.InputSchema); schema != "" {
+		parts = append(parts, "parameters:\n"+schema)
 	}
 
 	return strings.TrimSpace(strings.Join(filterNonEmpty(parts), "\n"))
+}
+
+func summarizeInputSchema(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return string(raw)
+	}
+
+	lines := make([]string, 0)
+	appendSchemaSummary(&lines, "input", schema, false, 0)
+	return strings.Join(lines, "\n")
+}
+
+func appendSchemaSummary(lines *[]string, path string, schema map[string]any, required bool, depth int) {
+	if depth > 16 {
+		*lines = append(*lines, "- "+path+" (nested schema omitted)")
+		return
+	}
+
+	details := make([]string, 0, 5)
+	if required {
+		details = append(details, "required")
+	}
+	details = append(details, schemaTypes(schema)...)
+	if format, ok := schema["format"].(string); ok && format != "" {
+		details = append(details, "format="+format)
+	}
+	if ref, ok := schema["$ref"].(string); ok && ref != "" {
+		details = append(details, "ref="+ref)
+	}
+	if enum, ok := schema["enum"].([]any); ok && len(enum) > 0 {
+		details = append(details, "enum="+summarizeSchemaValues(enum, 12))
+	}
+	if value, ok := schema["const"]; ok {
+		details = append(details, "const="+summarizeSchemaValue(value))
+	}
+
+	line := "- " + path
+	if len(details) > 0 {
+		line += " (" + strings.Join(details, ", ") + ")"
+	}
+	description, _ := schema["description"].(string)
+	if description == "" {
+		description, _ = schema["title"].(string)
+	}
+	if description = summarizeSchemaText(description, 320); description != "" {
+		line += ": " + description
+	}
+	*lines = append(*lines, line)
+
+	requiredProperties := make(map[string]struct{})
+	if requiredValues, ok := schema["required"].([]any); ok {
+		for _, value := range requiredValues {
+			if name, ok := value.(string); ok {
+				requiredProperties[name] = struct{}{}
+			}
+		}
+	}
+
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		names := make([]string, 0, len(properties))
+		for name := range properties {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			childPath := name
+			if path != "input" {
+				childPath = path + "." + name
+			}
+			_, childRequired := requiredProperties[name]
+			appendSchemaSummaryValue(lines, childPath, properties[name], childRequired, depth+1)
+		}
+	}
+
+	if items, ok := schema["items"]; ok {
+		appendSchemaSummaryValue(lines, path+"[]", items, false, depth+1)
+	}
+	if additional, ok := schema["additionalProperties"].(map[string]any); ok {
+		appendSchemaSummary(lines, path+".*", additional, false, depth+1)
+	}
+
+	for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
+		alternatives, ok := schema[keyword].([]any)
+		if !ok {
+			continue
+		}
+		for i, alternative := range alternatives {
+			appendSchemaSummaryValue(
+				lines,
+				fmt.Sprintf("%s %s[%d]", path, keyword, i+1),
+				alternative,
+				false,
+				depth+1,
+			)
+		}
+	}
+
+	for _, keyword := range []string{"$defs", "definitions"} {
+		definitions, ok := schema[keyword].(map[string]any)
+		if !ok {
+			continue
+		}
+		names := make([]string, 0, len(definitions))
+		for name := range definitions {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			appendSchemaSummaryValue(lines, "definition "+name, definitions[name], false, depth+1)
+		}
+	}
+}
+
+func appendSchemaSummaryValue(lines *[]string, path string, value any, required bool, depth int) {
+	switch schema := value.(type) {
+	case map[string]any:
+		appendSchemaSummary(lines, path, schema, required, depth)
+	case bool:
+		*lines = append(*lines, fmt.Sprintf("- %s (allowed=%t)", path, schema))
+	}
+}
+
+func schemaTypes(schema map[string]any) []string {
+	switch value := schema["type"].(type) {
+	case string:
+		if value != "" {
+			return []string{value}
+		}
+	case []any:
+		types := make([]string, 0, len(value))
+		for _, item := range value {
+			if schemaType, ok := item.(string); ok && schemaType != "" {
+				types = append(types, schemaType)
+			}
+		}
+		if len(types) > 0 {
+			return []string{strings.Join(types, "|")}
+		}
+	}
+
+	if _, ok := schema["properties"]; ok {
+		return []string{"object"}
+	}
+	if _, ok := schema["items"]; ok {
+		return []string{"array"}
+	}
+	return nil
+}
+
+func summarizeSchemaValues(values []any, limit int) string {
+	summaries := make([]string, 0, min(len(values), limit))
+	for _, value := range values[:min(len(values), limit)] {
+		summaries = append(summaries, summarizeSchemaValue(value))
+	}
+	result := "[" + strings.Join(summaries, ", ") + "]"
+	if remaining := len(values) - len(summaries); remaining > 0 {
+		result += fmt.Sprintf(" +%d more", remaining)
+	}
+	return result
+}
+
+func summarizeSchemaValue(value any) string {
+	switch value := value.(type) {
+	case string:
+		return summarizeSchemaText(value, 80)
+	default:
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return ""
+		}
+		return summarizeSchemaText(string(encoded), 80)
+	}
+}
+
+func summarizeSchemaText(value string, maxRunes int) string {
+	value = strings.Join(strings.Fields(value), " ")
+	runes := []rune(value)
+	if len(runes) <= maxRunes {
+		return value
+	}
+	return string(runes[:maxRunes]) + "…"
 }
 
 func filterNonEmpty(values []string) []string {

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -38,7 +38,8 @@ func TestBuildEmbeddableContent_SummarizesSchemaDeterministically(t *testing.T) 
 		},
 	}
 
-	content := buildEmbeddableContent(entry, []string{"source:http", "records"})
+	schemaSummary, topLevelSchemaSummary := summarizeInputSchemaLevels(entry.InputSchema)
+	content := buildEmbeddableContent(entry, []string{"source:http", "records"}, schemaSummary)
 	require.Equal(t, `create_record
 Create a record.
 tags: source:http, records
@@ -50,6 +51,13 @@ parameters:
 - alpha[].mode (string, enum=[fast, safe])
 - zeta (required, string): Last field.`, content)
 	require.NotContains(t, content, "metadata is retained")
+	require.Equal(t, `create_record
+Create a record.
+parameters:
+- alpha
+- zeta: Last field.`, buildTopLevelEmbeddableContent(entry, topLevelSchemaSummary))
+	require.Equal(t, `create_record
+Create a record.`, buildNameDescriptionEmbeddableContent(entry))
 }
 
 func TestSummarizeInputSchema_MalformedSchemaFallsBackToOriginal(t *testing.T) {

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -107,3 +107,22 @@ func TestCreateBatchesBySize_RespectsAggregateInputLimit(t *testing.T) {
 		require.LessOrEqual(t, totalBytes, embeddingMaxBatchBytes)
 	}
 }
+
+func TestSelectEmbeddingCandidateContents_UsesSelectedSizeForBatching(t *testing.T) {
+	t.Parallel()
+
+	denseContent := strings.Repeat("{}", 9_000)
+	candidates := []embeddingCandidate{
+		{content: denseContent, fallbacks: []string{"compact-one"}},
+		{content: denseContent, fallbacks: []string{"compact-two"}},
+		{content: denseContent, fallbacks: []string{"compact-three"}},
+	}
+	batchLimit := len(denseContent) * 2
+	require.Len(t, createBatchesWithinSize(candidates, batchLimit), 2)
+
+	require.NoError(t, selectEmbeddingCandidateContents(defaultEmbeddingModel, candidates))
+	require.Equal(t, "compact-one", candidates[0].content)
+	require.Equal(t, "compact-two", candidates[1].content)
+	require.Equal(t, "compact-three", candidates[2].content)
+	require.Len(t, createBatchesWithinSize(candidates, batchLimit), 1)
+}

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -1,0 +1,101 @@
+package rag
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEmbeddableContent_SummarizesSchemaDeterministically(t *testing.T) {
+	t.Parallel()
+
+	entry := &toolListEntry{
+		Name:        "create_record",
+		Description: "Create a record.",
+		InputSchema: json.RawMessage(`{
+			"type":"object",
+			"description":"Input values.",
+			"required":["zeta"],
+			"properties":{
+				"zeta":{"type":"string","description":" Last field. "},
+				"alpha":{
+					"type":"array",
+					"items":{
+						"type":"object",
+						"required":["id"],
+						"properties":{
+							"mode":{"type":"string","enum":["fast","safe"]},
+							"id":{"type":"string","format":"uuid"}
+						}
+					}
+				}
+			}
+		}`),
+		Meta: map[string]any{
+			"ui": "metadata is retained in the payload, not embedded",
+		},
+	}
+
+	content := buildEmbeddableContent(entry, []string{"source:http", "records"})
+	require.Equal(t, `create_record
+Create a record.
+tags: source:http, records
+parameters:
+- input (object): Input values.
+- alpha (array)
+- alpha[] (object)
+- alpha[].id (required, string, format=uuid)
+- alpha[].mode (string, enum=[fast, safe])
+- zeta (required, string): Last field.`, content)
+	require.NotContains(t, content, "metadata is retained")
+}
+
+func TestSummarizeInputSchema_MalformedSchemaFallsBackToOriginal(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "{malformed", summarizeInputSchema(json.RawMessage("{malformed")))
+}
+
+func TestSummarizeInputSchema_BoundsDescriptionsAndEnums(t *testing.T) {
+	t.Parallel()
+
+	longDescription := strings.Repeat("x", 321)
+	schema, err := json.Marshal(map[string]any{
+		"type":        "string",
+		"description": longDescription,
+		"enum":        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m"},
+	})
+	require.NoError(t, err)
+
+	summary := summarizeInputSchema(schema)
+	require.Contains(t, summary, "enum=[a, b, c, d, e, f, g, h, i, j, k, l] +1 more")
+	require.Contains(t, summary, strings.Repeat("x", 320)+"…")
+	require.NotContains(t, summary, longDescription)
+}
+
+func TestCreateBatchesBySize_RespectsAggregateInputLimit(t *testing.T) {
+	t.Parallel()
+
+	denseContent := strings.Repeat("{}", embeddingMaxBatchBytes/4)
+	candidates := []embeddingCandidate{
+		{content: denseContent},
+		{content: denseContent},
+		{content: denseContent},
+	}
+
+	batches := (&ToolsetVectorStore{}).createBatchesBySize(candidates)
+	require.Equal(t, []embeddingBatch{
+		{startIdx: 0, endIdx: 2},
+		{startIdx: 2, endIdx: 3},
+	}, batches)
+
+	for _, batch := range batches {
+		totalBytes := 0
+		for _, candidate := range candidates[batch.startIdx:batch.endIdx] {
+			totalBytes += len(candidate.content)
+		}
+		require.LessOrEqual(t, totalBytes, embeddingMaxBatchBytes)
+	}
+}

--- a/server/internal/thirdparty/openrouter/completion_client.go
+++ b/server/internal/thirdparty/openrouter/completion_client.go
@@ -35,6 +35,9 @@ type EmbeddingOptions struct {
 	Dimensions *int64
 	// KeyType selects the organization key pool used for the request.
 	KeyType KeyType
+	// InputFallbacks supplies progressively smaller alternatives for each input.
+	// The outer index corresponds to inputs; inner values are tried in order.
+	InputFallbacks [][]string
 }
 
 // WithEmbeddingDimensions requests a specific output dimensionality from the
@@ -52,6 +55,15 @@ func WithEmbeddingDimensions(dimensions int) EmbeddingOption {
 func WithEmbeddingKeyType(keyType KeyType) EmbeddingOption {
 	return func(o *EmbeddingOptions) {
 		o.KeyType = keyType
+	}
+}
+
+// WithEmbeddingInputFallbacks supplies progressively smaller alternatives for
+// oversized inputs. The client tries each alternative before truncating the
+// final one to the model's token limit.
+func WithEmbeddingInputFallbacks(fallbacks [][]string) EmbeddingOption {
+	return func(o *EmbeddingOptions) {
+		o.InputFallbacks = fallbacks
 	}
 }
 

--- a/server/internal/thirdparty/openrouter/completion_client.go
+++ b/server/internal/thirdparty/openrouter/completion_client.go
@@ -35,9 +35,6 @@ type EmbeddingOptions struct {
 	Dimensions *int64
 	// KeyType selects the organization key pool used for the request.
 	KeyType KeyType
-	// InputFallbacks supplies progressively smaller alternatives for each input.
-	// The outer index corresponds to inputs; inner values are tried in order.
-	InputFallbacks [][]string
 }
 
 // WithEmbeddingDimensions requests a specific output dimensionality from the
@@ -55,15 +52,6 @@ func WithEmbeddingDimensions(dimensions int) EmbeddingOption {
 func WithEmbeddingKeyType(keyType KeyType) EmbeddingOption {
 	return func(o *EmbeddingOptions) {
 		o.KeyType = keyType
-	}
-}
-
-// WithEmbeddingInputFallbacks supplies progressively smaller alternatives for
-// oversized inputs. The client tries each alternative before truncating the
-// final one to the model's token limit.
-func WithEmbeddingInputFallbacks(fallbacks [][]string) EmbeddingOption {
-	return func(o *EmbeddingOptions) {
-		o.InputFallbacks = fallbacks
 	}
 }
 

--- a/server/internal/thirdparty/openrouter/embedding_errors_test.go
+++ b/server/internal/thirdparty/openrouter/embedding_errors_test.go
@@ -1,0 +1,58 @@
+package openrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/OpenRouterTeam/go-sdk/models/sdkerrors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifySDKError_BadRequestIsSanitizedAndPermanent(t *testing.T) {
+	t.Parallel()
+
+	const canary = "embedding-input-must-not-reach-error"
+	sdkErr := &sdkerrors.BadRequestResponseError{
+		Error_: or.BadRequestResponseErrorData{
+			Code:     http.StatusBadRequest,
+			Message:  canary,
+			Metadata: nil,
+		},
+		UserID: nil,
+	}
+
+	err := classifySDKError(context.Background(), fmt.Errorf("generate embedding: %w", sdkErr))
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	require.ErrorIs(t, err, ErrBadRequest)
+	require.True(t, IsPermanentError(err))
+	require.NotContains(t, err.Error(), canary)
+}
+
+func TestClassifySDKError_GenericRateLimitRemainsRetryable(t *testing.T) {
+	t.Parallel()
+
+	sdkErr := &sdkerrors.APIError{
+		Message:     "API error occurred",
+		StatusCode:  http.StatusTooManyRequests,
+		Body:        "rate-limit-details",
+		RawResponse: nil,
+	}
+
+	err := classifySDKError(context.Background(), sdkErr)
+	require.ErrorIs(t, err, ErrRateLimited)
+	require.False(t, IsPermanentError(err))
+	require.NotContains(t, err.Error(), sdkErr.Body)
+}
+
+func TestClassifySDKError_LeavesTransportErrorsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	transportErr := errors.New("connection reset")
+	require.ErrorIs(t, classifySDKError(context.Background(), transportErr), transportErr)
+}

--- a/server/internal/thirdparty/openrouter/embedding_errors_test.go
+++ b/server/internal/thirdparty/openrouter/embedding_errors_test.go
@@ -9,6 +9,11 @@ import (
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/OpenRouterTeam/go-sdk/models/sdkerrors"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,20 +39,42 @@ func TestClassifySDKError_BadRequestIsSanitizedAndPermanent(t *testing.T) {
 	require.NotContains(t, err.Error(), canary)
 }
 
-func TestClassifySDKError_GenericRateLimitRemainsRetryable(t *testing.T) {
+func TestClassifySDKError_GenericRateLimitPreservesHeaders(t *testing.T) {
 	t.Parallel()
 
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(t.Context(), "embedding")
+
+	header := http.Header{}
+	header.Set("X-RateLimit-Limit", "60")
+	header.Set("X-RateLimit-Remaining", "0")
+	header.Set("X-RateLimit-Reset", "1785748157000")
+	header.Set("Retry-After", "12")
 	sdkErr := &sdkerrors.APIError{
 		Message:     "API error occurred",
 		StatusCode:  http.StatusTooManyRequests,
 		Body:        "rate-limit-details",
-		RawResponse: nil,
+		RawResponse: &http.Response{Header: header},
 	}
 
-	err := classifySDKError(context.Background(), sdkErr)
+	err := classifySDKError(ctx, sdkErr)
+	span.End()
+
 	require.ErrorIs(t, err, ErrRateLimited)
 	require.False(t, IsPermanentError(err))
 	require.NotContains(t, err.Error(), sdkErr.Body)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	recorded := map[attribute.Key]string{}
+	for _, kv := range spans[0].Attributes() {
+		recorded[kv.Key] = kv.Value.Emit()
+	}
+	require.Equal(t, "60", recorded[attr.OpenRouterRateLimitLimitKey])
+	require.Equal(t, "0", recorded[attr.OpenRouterRateLimitRemainingKey])
+	require.Equal(t, "1785748157000", recorded[attr.OpenRouterRateLimitResetKey])
+	require.Equal(t, "12", recorded[attr.OpenRouterRetryAfterKey])
 }
 
 func TestClassifySDKError_LeavesTransportErrorsUnchanged(t *testing.T) {
@@ -55,4 +82,20 @@ func TestClassifySDKError_LeavesTransportErrorsUnchanged(t *testing.T) {
 
 	transportErr := errors.New("connection reset")
 	require.ErrorIs(t, classifySDKError(context.Background(), transportErr), transportErr)
+}
+
+func TestClassifySDKError_LeavesSuccessfulStatusProtocolErrorsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	sdkErr := &sdkerrors.APIError{
+		Message:     "unsupported response content type",
+		StatusCode:  http.StatusOK,
+		Body:        "text/html",
+		RawResponse: &http.Response{StatusCode: http.StatusOK},
+	}
+
+	err := classifySDKError(t.Context(), sdkErr)
+	require.Same(t, sdkErr, err)
+	var httpErr *HTTPError
+	require.NotErrorAs(t, err, &httpErr)
 }

--- a/server/internal/thirdparty/openrouter/embeddings_test.go
+++ b/server/internal/thirdparty/openrouter/embeddings_test.go
@@ -27,7 +27,7 @@ func TestLimitEmbeddingInputs_OpenAIUsesTokenBoundary(t *testing.T) {
 	require.LessOrEqual(t, underLimitTokens, maxOpenAIEmbeddingInputTokens)
 	require.Greater(t, len(underLimit), maxOpenAIEmbeddingInputTokens, "fixture must exercise tokenization")
 
-	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{"short", dense, underLimit}, nil)
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{"short", dense, underLimit})
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.Equal(t, "short", limited[0])
@@ -43,7 +43,7 @@ func TestLimitEmbeddingInputs_OpenAIPreservesUTF8(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("😀", maxOpenAIEmbeddingInputTokens)
-	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input}, nil)
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input})
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.True(t, utf8.ValidString(limited[0]))
@@ -59,13 +59,13 @@ func TestLimitEmbeddingInputs_OtherModelsPreserveLegacyByteLimit(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("x", legacyMaxEmbeddingInputBytes+1)
-	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input}, nil)
+	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input})
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.Len(t, limited[0], legacyMaxEmbeddingInputBytes)
 }
 
-func TestLimitEmbeddingInputs_OpenAIUsesOrderedFallbacks(t *testing.T) {
+func TestSelectEmbeddingInputFallbacks_OpenAIUsesOrderedFallbacks(t *testing.T) {
 	t.Parallel()
 
 	dense := strings.Repeat("{}", maxOpenAIEmbeddingInputTokens+500)
@@ -75,11 +75,15 @@ func TestLimitEmbeddingInputs_OpenAIUsesOrderedFallbacks(t *testing.T) {
 	t.Run("uses first fallback that fits", func(t *testing.T) {
 		t.Parallel()
 
-		limited, truncatedCount, err := limitEmbeddingInputs(
+		selected, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{dense},
 			[][]string{{compact, minimal}},
 		)
+		require.NoError(t, err)
+		require.Equal(t, compact, selected[0])
+
+		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)
 		require.Zero(t, truncatedCount)
 		require.Equal(t, compact, limited[0])
@@ -88,11 +92,15 @@ func TestLimitEmbeddingInputs_OpenAIUsesOrderedFallbacks(t *testing.T) {
 	t.Run("continues to name and description", func(t *testing.T) {
 		t.Parallel()
 
-		limited, truncatedCount, err := limitEmbeddingInputs(
+		selected, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{dense},
 			[][]string{{"top-level\n" + dense, minimal}},
 		)
+		require.NoError(t, err)
+		require.Equal(t, minimal, selected[0])
+
+		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)
 		require.Zero(t, truncatedCount)
 		require.Equal(t, minimal, limited[0])
@@ -102,11 +110,15 @@ func TestLimitEmbeddingInputs_OpenAIUsesOrderedFallbacks(t *testing.T) {
 		t.Parallel()
 
 		finalFallback := "MINIMAL\n" + dense
-		limited, truncatedCount, err := limitEmbeddingInputs(
+		selected, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{"PRIMARY\n" + dense},
 			[][]string{{"TOP-LEVEL\n" + dense, finalFallback}},
 		)
+		require.NoError(t, err)
+		require.Equal(t, finalFallback, selected[0])
+
+		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)
 		require.Equal(t, 1, truncatedCount)
 		require.True(t, strings.HasPrefix(limited[0], "MINIMAL\n"))

--- a/server/internal/thirdparty/openrouter/embeddings_test.go
+++ b/server/internal/thirdparty/openrouter/embeddings_test.go
@@ -27,7 +27,7 @@ func TestLimitEmbeddingInputs_OpenAIUsesTokenBoundary(t *testing.T) {
 	require.LessOrEqual(t, underLimitTokens, maxOpenAIEmbeddingInputTokens)
 	require.Greater(t, len(underLimit), maxOpenAIEmbeddingInputTokens, "fixture must exercise tokenization")
 
-	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{"short", dense, underLimit})
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{"short", dense, underLimit}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.Equal(t, "short", limited[0])
@@ -43,7 +43,7 @@ func TestLimitEmbeddingInputs_OpenAIPreservesUTF8(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("😀", maxOpenAIEmbeddingInputTokens)
-	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input})
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.True(t, utf8.ValidString(limited[0]))
@@ -59,8 +59,62 @@ func TestLimitEmbeddingInputs_OtherModelsPreserveLegacyByteLimit(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("x", legacyMaxEmbeddingInputBytes+1)
-	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input})
+	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.Len(t, limited[0], legacyMaxEmbeddingInputBytes)
+}
+
+func TestLimitEmbeddingInputs_OpenAIUsesOrderedFallbacks(t *testing.T) {
+	t.Parallel()
+
+	dense := strings.Repeat("{}", maxOpenAIEmbeddingInputTokens+500)
+	compact := "create_record\nCreate a record.\nparameters:\n- id: Record identifier."
+	minimal := "create_record\nCreate a record."
+
+	t.Run("uses first fallback that fits", func(t *testing.T) {
+		t.Parallel()
+
+		limited, truncatedCount, err := limitEmbeddingInputs(
+			openAITextEmbedding3Small,
+			[]string{dense},
+			[][]string{{compact, minimal}},
+		)
+		require.NoError(t, err)
+		require.Zero(t, truncatedCount)
+		require.Equal(t, compact, limited[0])
+	})
+
+	t.Run("continues to name and description", func(t *testing.T) {
+		t.Parallel()
+
+		limited, truncatedCount, err := limitEmbeddingInputs(
+			openAITextEmbedding3Small,
+			[]string{dense},
+			[][]string{{"top-level\n" + dense, minimal}},
+		)
+		require.NoError(t, err)
+		require.Zero(t, truncatedCount)
+		require.Equal(t, minimal, limited[0])
+	})
+
+	t.Run("truncates final fallback as last defense", func(t *testing.T) {
+		t.Parallel()
+
+		finalFallback := "MINIMAL\n" + dense
+		limited, truncatedCount, err := limitEmbeddingInputs(
+			openAITextEmbedding3Small,
+			[]string{"PRIMARY\n" + dense},
+			[][]string{{"TOP-LEVEL\n" + dense, finalFallback}},
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, truncatedCount)
+		require.True(t, strings.HasPrefix(limited[0], "MINIMAL\n"))
+
+		codec, err := tokenizer.Get(tokenizer.Cl100kBase)
+		require.NoError(t, err)
+		limitedTokens, err := codec.Count(limited[0])
+		require.NoError(t, err)
+		require.LessOrEqual(t, limitedTokens, maxOpenAIEmbeddingInputTokens)
+	})
 }

--- a/server/internal/thirdparty/openrouter/embeddings_test.go
+++ b/server/internal/thirdparty/openrouter/embeddings_test.go
@@ -1,0 +1,66 @@
+package openrouter
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tiktoken-go/tokenizer"
+)
+
+func TestLimitEmbeddingInputs_OpenAIUsesTokenBoundary(t *testing.T) {
+	t.Parallel()
+
+	codec, err := tokenizer.Get(tokenizer.Cl100kBase)
+	require.NoError(t, err)
+
+	dense := strings.Repeat("{}", maxOpenAIEmbeddingInputTokens+500)
+	denseTokens, err := codec.Count(dense)
+	require.NoError(t, err)
+	require.Greater(t, denseTokens, maxOpenAIEmbeddingInputTokens)
+	require.Less(t, len(dense), legacyMaxEmbeddingInputBytes, "fixture must bypass the old byte limit")
+
+	underLimit := strings.Repeat("hello ", 1_500)
+	underLimitTokens, err := codec.Count(underLimit)
+	require.NoError(t, err)
+	require.LessOrEqual(t, underLimitTokens, maxOpenAIEmbeddingInputTokens)
+	require.Greater(t, len(underLimit), maxOpenAIEmbeddingInputTokens, "fixture must exercise tokenization")
+
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{"short", dense, underLimit})
+	require.NoError(t, err)
+	require.Equal(t, 1, truncatedCount)
+	require.Equal(t, "short", limited[0])
+	require.Equal(t, underLimit, limited[2])
+	require.NotEqual(t, dense, limited[1])
+
+	limitedTokens, err := codec.Count(limited[1])
+	require.NoError(t, err)
+	require.LessOrEqual(t, limitedTokens, maxOpenAIEmbeddingInputTokens)
+}
+
+func TestLimitEmbeddingInputs_OpenAIPreservesUTF8(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Repeat("😀", maxOpenAIEmbeddingInputTokens)
+	limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input})
+	require.NoError(t, err)
+	require.Equal(t, 1, truncatedCount)
+	require.True(t, utf8.ValidString(limited[0]))
+
+	codec, err := tokenizer.Get(tokenizer.Cl100kBase)
+	require.NoError(t, err)
+	limitedTokens, err := codec.Count(limited[0])
+	require.NoError(t, err)
+	require.LessOrEqual(t, limitedTokens, maxOpenAIEmbeddingInputTokens)
+}
+
+func TestLimitEmbeddingInputs_OtherModelsPreserveLegacyByteLimit(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Repeat("x", legacyMaxEmbeddingInputBytes+1)
+	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input})
+	require.NoError(t, err)
+	require.Equal(t, 1, truncatedCount)
+	require.Len(t, limited[0], legacyMaxEmbeddingInputBytes)
+}

--- a/server/internal/thirdparty/openrouter/embeddings_test.go
+++ b/server/internal/thirdparty/openrouter/embeddings_test.go
@@ -2,6 +2,7 @@ package openrouter
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"unicode/utf8"
 
@@ -59,10 +60,51 @@ func TestLimitEmbeddingInputs_OtherModelsPreserveLegacyByteLimit(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("x", legacyMaxEmbeddingInputBytes+1)
-	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", []string{input})
+	selected, err := SelectEmbeddingInputFallbacks(
+		"qwen/qwen3-embedding-8b",
+		[]string{input},
+		[][]string{{"fallback"}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, input, selected[0])
+
+	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", selected)
 	require.NoError(t, err)
 	require.Equal(t, 1, truncatedCount)
 	require.Len(t, limited[0], legacyMaxEmbeddingInputBytes)
+}
+
+func TestLimitEmbeddingInputs_OpenAIDecodesConcurrently(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Repeat("😀", maxOpenAIEmbeddingInputTokens)
+	type result struct {
+		output         string
+		truncatedCount int
+		err            error
+	}
+
+	const workers = 16
+	results := make(chan result, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, []string{input})
+			var output string
+			if len(limited) > 0 {
+				output = limited[0]
+			}
+			results <- result{output: output, truncatedCount: truncatedCount, err: err}
+		})
+	}
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		require.NoError(t, result.err)
+		require.Equal(t, 1, result.truncatedCount)
+		require.True(t, utf8.ValidString(result.output))
+	}
 }
 
 func TestSelectEmbeddingInputFallbacks_OpenAIUsesOrderedFallbacks(t *testing.T) {

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/OpenRouterTeam/go-sdk/models/sdkerrors"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -182,6 +183,66 @@ func classifyHTTPError(ctx context.Context, status int, header http.Header, body
 	default:
 		return &HTTPError{StatusCode: status, Err: nil}
 	}
+}
+
+func classifySDKError(ctx context.Context, err error) error {
+	status, ok := sdkErrorStatus(err)
+	if !ok {
+		return err
+	}
+	return classifyHTTPError(ctx, status, http.Header{}, []byte(err.Error()))
+}
+
+func sdkErrorStatus(err error) (int, bool) {
+	if _, ok := errors.AsType[*sdkerrors.BadRequestResponseError](err); ok {
+		return http.StatusBadRequest, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.UnauthorizedResponseError](err); ok {
+		return http.StatusUnauthorized, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.PaymentRequiredResponseError](err); ok {
+		return http.StatusPaymentRequired, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.ForbiddenResponseError](err); ok {
+		return http.StatusForbidden, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.NotFoundResponseError](err); ok {
+		return http.StatusNotFound, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.RequestTimeoutResponseError](err); ok {
+		return http.StatusRequestTimeout, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.ConflictResponseError](err); ok {
+		return http.StatusConflict, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.PayloadTooLargeResponseError](err); ok {
+		return http.StatusRequestEntityTooLarge, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.UnprocessableEntityResponseError](err); ok {
+		return http.StatusUnprocessableEntity, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.TooManyRequestsResponseError](err); ok {
+		return http.StatusTooManyRequests, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.InternalServerResponseError](err); ok {
+		return http.StatusInternalServerError, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.BadGatewayResponseError](err); ok {
+		return http.StatusBadGateway, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.ServiceUnavailableResponseError](err); ok {
+		return http.StatusServiceUnavailable, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.EdgeNetworkTimeoutResponseError](err); ok {
+		return 524, true
+	}
+	if _, ok := errors.AsType[*sdkerrors.ProviderOverloadedResponseError](err); ok {
+		return 529, true
+	}
+	if apiErr, ok := errors.AsType[*sdkerrors.APIError](err); ok {
+		return apiErr.StatusCode, true
+	}
+	return 0, false
 }
 
 // historyCorruptionBodyMarkers are fragments inference providers emit when

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -190,7 +190,11 @@ func classifySDKError(ctx context.Context, err error) error {
 	if !ok {
 		return err
 	}
-	return classifyHTTPError(ctx, status, http.Header{}, []byte(err.Error()))
+	header := http.Header{}
+	if apiErr, found := errors.AsType[*sdkerrors.APIError](err); found && apiErr.RawResponse != nil {
+		header = apiErr.RawResponse.Header
+	}
+	return classifyHTTPError(ctx, status, header, []byte(err.Error()))
 }
 
 func sdkErrorStatus(err error) (int, bool) {
@@ -239,7 +243,7 @@ func sdkErrorStatus(err error) (int, bool) {
 	if _, ok := errors.AsType[*sdkerrors.ProviderOverloadedResponseError](err); ok {
 		return 529, true
 	}
-	if apiErr, ok := errors.AsType[*sdkerrors.APIError](err); ok {
+	if apiErr, ok := errors.AsType[*sdkerrors.APIError](err); ok && apiErr.StatusCode >= http.StatusBadRequest {
 		return apiErr.StatusCode, true
 	}
 	return 0, false

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -10,9 +10,11 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/tiktoken-go/tokenizer"
 	"go.opentelemetry.io/otel/trace"
 
 	or_base "github.com/OpenRouterTeam/go-sdk"
@@ -37,7 +39,15 @@ type TelemetryLogger interface {
 
 const (
 	DefaultChatModel = "anthropic/claude-opus-5"
+
+	openAITextEmbedding3Small     = "openai/text-embedding-3-small"
+	maxOpenAIEmbeddingInputTokens = 8_000
+	legacyMaxEmbeddingInputBytes  = 24_000
 )
+
+var loadOpenAIEmbeddingCodec = sync.OnceValues(func() (tokenizer.Codec, error) {
+	return tokenizer.Get(tokenizer.Cl100kBase)
+})
 
 // ChatClient is the single HTTP client for all OpenRouter communication.
 // It applies pluggable strategies for message capture and usage tracking.
@@ -863,6 +873,75 @@ func completionTelemetryIdentity(source string) (resourceURN, normalizedSource s
 	}
 }
 
+func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) {
+	if model == openAITextEmbedding3Small {
+		return limitOpenAIEmbeddingInputs(inputs)
+	}
+
+	var limited []string
+	truncatedCount := 0
+	for i, input := range inputs {
+		if len(input) <= legacyMaxEmbeddingInputBytes {
+			continue
+		}
+		if limited == nil {
+			limited = slices.Clone(inputs)
+		}
+		limited[i] = input[:legacyMaxEmbeddingInputBytes]
+		truncatedCount++
+	}
+	if limited == nil {
+		return inputs, 0, nil
+	}
+	return limited, truncatedCount, nil
+}
+
+func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {
+	var (
+		codec          tokenizer.Codec
+		limited        []string
+		truncatedCount int
+	)
+
+	for i, input := range inputs {
+		// A tokenizer cannot emit more tokens than there are input bytes.
+		if len(input) <= maxOpenAIEmbeddingInputTokens {
+			continue
+		}
+
+		if codec == nil {
+			var err error
+			codec, err = loadOpenAIEmbeddingCodec()
+			if err != nil {
+				return nil, 0, fmt.Errorf("load OpenAI embedding tokenizer: %w", err)
+			}
+		}
+
+		tokenIDs, _, err := codec.Encode(input)
+		if err != nil {
+			return nil, 0, fmt.Errorf("tokenize embedding input %d: %w", i, err)
+		}
+		if len(tokenIDs) <= maxOpenAIEmbeddingInputTokens {
+			continue
+		}
+
+		truncated, err := codec.Decode(tokenIDs[:maxOpenAIEmbeddingInputTokens])
+		if err != nil {
+			return nil, 0, fmt.Errorf("decode truncated embedding input %d: %w", i, err)
+		}
+		if limited == nil {
+			limited = slices.Clone(inputs)
+		}
+		limited[i] = truncated
+		truncatedCount++
+	}
+
+	if limited == nil {
+		return inputs, 0, nil
+	}
+	return limited, truncatedCount, nil
+}
+
 func (c *ChatClient) CreateEmbeddings(ctx context.Context, orgID string, model string, inputs []string, opts ...EmbeddingOption) ([][]float32, error) {
 	var resolved EmbeddingOptions
 	for _, opt := range opts {
@@ -886,19 +965,19 @@ func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model s
 		return nil, fmt.Errorf("at least one input is required")
 	}
 
-	// Truncate inputs that exceed token limits
-	// Embedding models have 8192 token limit, using ~3 chars/token as conservative estimate
-	const maxChars = 24_000
-	truncatedInputs := make([]string, len(inputs))
-	for i, input := range inputs {
-		if len(input) > maxChars {
-			c.logger.WarnContext(ctx, fmt.Sprintf("truncating input for embedding, orgID: %s, model: %s, input length: %d", orgID, model, len(input)))
-			truncatedInputs[i] = input[:maxChars]
-		} else {
-			truncatedInputs[i] = input
-		}
+	inputs, truncatedCount, err := limitEmbeddingInputs(model, inputs)
+	if err != nil {
+		return nil, err
 	}
-	inputs = truncatedInputs
+	if truncatedCount > 0 {
+		c.logger.WarnContext(
+			ctx,
+			"truncated oversized embedding inputs",
+			attr.SlogGenAIRequestModel(model),
+			attr.SlogEmbeddingInputCount(len(inputs)),
+			attr.SlogEmbeddingTruncatedInputCount(truncatedCount),
+		)
+	}
 
 	orClient := or_base.New(or_base.WithSecurity(openrouterKey))
 	result, err := orClient.Embeddings.Generate(ctx, or_operations.CreateEmbeddingsRequest{
@@ -911,7 +990,7 @@ func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model s
 		InputType:      nil,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create embeddings error: %w", err)
+		return nil, fmt.Errorf("create embeddings error: %w", classifySDKError(ctx, err))
 	}
 
 	// The new SDK returns errors via err, not via HTTPMeta

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -44,10 +43,6 @@ const (
 	maxOpenAIEmbeddingInputTokens = 8_000
 	legacyMaxEmbeddingInputBytes  = 24_000
 )
-
-var loadOpenAIEmbeddingCodec = sync.OnceValues(func() (tokenizer.Codec, error) {
-	return tokenizer.Get(tokenizer.Cl100kBase)
-})
 
 // ChatClient is the single HTTP client for all OpenRouter communication.
 // It applies pluggable strategies for message capture and usage tracking.
@@ -897,8 +892,11 @@ func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) 
 }
 
 // SelectEmbeddingInputFallbacks selects the first representation for each
-// input that fits the model's per-input token limit. If every representation
-// is oversized, it returns the final fallback for the client to truncate.
+// input that fits the model's per-input token limit. Selection is currently
+// supported only for openai/text-embedding-3-small; other models are returned
+// unchanged because their tokenizer and token limit are not declared here. If
+// every representation is oversized, the final fallback is returned for the
+// client to truncate.
 func SelectEmbeddingInputFallbacks(model string, inputs []string, inputFallbacks [][]string) ([]string, error) {
 	if model != openAITextEmbedding3Small || len(inputFallbacks) == 0 {
 		return inputs, nil
@@ -989,7 +987,7 @@ func embeddingInputTokensOverLimit(codec *tokenizer.Codec, input string, index i
 	}
 
 	if *codec == nil {
-		loaded, err := loadOpenAIEmbeddingCodec()
+		loaded, err := tokenizer.Get(tokenizer.Cl100kBase)
 		if err != nil {
 			return nil, false, fmt.Errorf("load OpenAI embedding tokenizer: %w", err)
 		}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -873,9 +873,9 @@ func completionTelemetryIdentity(source string) (resourceURN, normalizedSource s
 	}
 }
 
-func limitEmbeddingInputs(model string, inputs []string, inputFallbacks [][]string) ([]string, int, error) {
+func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) {
 	if model == openAITextEmbedding3Small {
-		return limitOpenAIEmbeddingInputs(inputs, inputFallbacks)
+		return limitOpenAIEmbeddingInputs(inputs)
 	}
 
 	var limited []string
@@ -896,18 +896,23 @@ func limitEmbeddingInputs(model string, inputs []string, inputFallbacks [][]stri
 	return limited, truncatedCount, nil
 }
 
-func limitOpenAIEmbeddingInputs(inputs []string, inputFallbacks [][]string) ([]string, int, error) {
-	var (
-		codec          tokenizer.Codec
-		limited        []string
-		truncatedCount int
-	)
+// SelectEmbeddingInputFallbacks selects the first representation for each
+// input that fits the model's per-input token limit. If every representation
+// is oversized, it returns the final fallback for the client to truncate.
+func SelectEmbeddingInputFallbacks(model string, inputs []string, inputFallbacks [][]string) ([]string, error) {
+	if model != openAITextEmbedding3Small || len(inputFallbacks) == 0 {
+		return inputs, nil
+	}
 
+	var (
+		codec    tokenizer.Codec
+		selected []string
+	)
 	for i, input := range inputs {
-		selected := input
-		tokenIDs, exceedsLimit, err := embeddingInputTokensOverLimit(&codec, selected, i)
+		candidate := input
+		_, exceedsLimit, err := embeddingInputTokensOverLimit(&codec, candidate, i)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		if !exceedsLimit {
 			continue
@@ -915,13 +920,13 @@ func limitOpenAIEmbeddingInputs(inputs []string, inputFallbacks [][]string) ([]s
 
 		if i < len(inputFallbacks) {
 			for _, fallback := range inputFallbacks[i] {
-				if fallback == "" || fallback == selected {
+				if fallback == "" || fallback == candidate {
 					continue
 				}
-				selected = fallback
-				tokenIDs, exceedsLimit, err = embeddingInputTokensOverLimit(&codec, selected, i)
+				candidate = fallback
+				_, exceedsLimit, err = embeddingInputTokensOverLimit(&codec, candidate, i)
 				if err != nil {
-					return nil, 0, err
+					return nil, err
 				}
 				if !exceedsLimit {
 					break
@@ -929,18 +934,46 @@ func limitOpenAIEmbeddingInputs(inputs []string, inputFallbacks [][]string) ([]s
 			}
 		}
 
-		if exceedsLimit {
-			selected, err = codec.Decode(tokenIDs[:maxOpenAIEmbeddingInputTokens])
-			if err != nil {
-				return nil, 0, fmt.Errorf("decode truncated embedding input %d: %w", i, err)
-			}
-			truncatedCount++
+		if candidate == input {
+			continue
+		}
+		if selected == nil {
+			selected = slices.Clone(inputs)
+		}
+		selected[i] = candidate
+	}
+
+	if selected == nil {
+		return inputs, nil
+	}
+	return selected, nil
+}
+
+func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {
+	var (
+		codec          tokenizer.Codec
+		limited        []string
+		truncatedCount int
+	)
+
+	for i, input := range inputs {
+		tokenIDs, exceedsLimit, err := embeddingInputTokensOverLimit(&codec, input, i)
+		if err != nil {
+			return nil, 0, err
+		}
+		if !exceedsLimit {
+			continue
 		}
 
+		truncated, err := codec.Decode(tokenIDs[:maxOpenAIEmbeddingInputTokens])
+		if err != nil {
+			return nil, 0, fmt.Errorf("decode truncated embedding input %d: %w", i, err)
+		}
 		if limited == nil {
 			limited = slices.Clone(inputs)
 		}
-		limited[i] = selected
+		limited[i] = truncated
+		truncatedCount++
 	}
 
 	if limited == nil {
@@ -975,10 +1008,10 @@ func (c *ChatClient) CreateEmbeddings(ctx context.Context, orgID string, model s
 	for _, opt := range opts {
 		opt(&resolved)
 	}
-	return c.createEmbeddings(ctx, orgID, model, inputs, resolved.InputFallbacks, resolved.Dimensions, resolved.KeyType.OrDefault())
+	return c.createEmbeddings(ctx, orgID, model, inputs, resolved.Dimensions, resolved.KeyType.OrDefault())
 }
 
-func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model string, inputs []string, inputFallbacks [][]string, dimensions *int64, keyType KeyType) ([][]float32, error) {
+func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model string, inputs []string, dimensions *int64, keyType KeyType) ([][]float32, error) {
 	resolvedKey, err := c.keyResolver.ResolveKey(ctx, orgID, "", "", keyType)
 	if err != nil {
 		return nil, fmt.Errorf("resolving OpenRouter key: %w", err)
@@ -993,7 +1026,7 @@ func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model s
 		return nil, fmt.Errorf("at least one input is required")
 	}
 
-	inputs, truncatedCount, err := limitEmbeddingInputs(model, inputs, inputFallbacks)
+	inputs, truncatedCount, err := limitEmbeddingInputs(model, inputs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -873,9 +873,9 @@ func completionTelemetryIdentity(source string) (resourceURN, normalizedSource s
 	}
 }
 
-func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) {
+func limitEmbeddingInputs(model string, inputs []string, inputFallbacks [][]string) ([]string, int, error) {
 	if model == openAITextEmbedding3Small {
-		return limitOpenAIEmbeddingInputs(inputs)
+		return limitOpenAIEmbeddingInputs(inputs, inputFallbacks)
 	}
 
 	var limited []string
@@ -896,7 +896,7 @@ func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) 
 	return limited, truncatedCount, nil
 }
 
-func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {
+func limitOpenAIEmbeddingInputs(inputs []string, inputFallbacks [][]string) ([]string, int, error) {
 	var (
 		codec          tokenizer.Codec
 		limited        []string
@@ -904,36 +904,43 @@ func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {
 	)
 
 	for i, input := range inputs {
-		// A tokenizer cannot emit more tokens than there are input bytes.
-		if len(input) <= maxOpenAIEmbeddingInputTokens {
+		selected := input
+		tokenIDs, exceedsLimit, err := embeddingInputTokensOverLimit(&codec, selected, i)
+		if err != nil {
+			return nil, 0, err
+		}
+		if !exceedsLimit {
 			continue
 		}
 
-		if codec == nil {
-			var err error
-			codec, err = loadOpenAIEmbeddingCodec()
-			if err != nil {
-				return nil, 0, fmt.Errorf("load OpenAI embedding tokenizer: %w", err)
+		if i < len(inputFallbacks) {
+			for _, fallback := range inputFallbacks[i] {
+				if fallback == "" || fallback == selected {
+					continue
+				}
+				selected = fallback
+				tokenIDs, exceedsLimit, err = embeddingInputTokensOverLimit(&codec, selected, i)
+				if err != nil {
+					return nil, 0, err
+				}
+				if !exceedsLimit {
+					break
+				}
 			}
 		}
 
-		tokenIDs, _, err := codec.Encode(input)
-		if err != nil {
-			return nil, 0, fmt.Errorf("tokenize embedding input %d: %w", i, err)
-		}
-		if len(tokenIDs) <= maxOpenAIEmbeddingInputTokens {
-			continue
+		if exceedsLimit {
+			selected, err = codec.Decode(tokenIDs[:maxOpenAIEmbeddingInputTokens])
+			if err != nil {
+				return nil, 0, fmt.Errorf("decode truncated embedding input %d: %w", i, err)
+			}
+			truncatedCount++
 		}
 
-		truncated, err := codec.Decode(tokenIDs[:maxOpenAIEmbeddingInputTokens])
-		if err != nil {
-			return nil, 0, fmt.Errorf("decode truncated embedding input %d: %w", i, err)
-		}
 		if limited == nil {
 			limited = slices.Clone(inputs)
 		}
-		limited[i] = truncated
-		truncatedCount++
+		limited[i] = selected
 	}
 
 	if limited == nil {
@@ -942,15 +949,36 @@ func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {
 	return limited, truncatedCount, nil
 }
 
+func embeddingInputTokensOverLimit(codec *tokenizer.Codec, input string, index int) ([]uint, bool, error) {
+	// A tokenizer cannot emit more tokens than there are input bytes.
+	if len(input) <= maxOpenAIEmbeddingInputTokens {
+		return nil, false, nil
+	}
+
+	if *codec == nil {
+		loaded, err := loadOpenAIEmbeddingCodec()
+		if err != nil {
+			return nil, false, fmt.Errorf("load OpenAI embedding tokenizer: %w", err)
+		}
+		*codec = loaded
+	}
+
+	tokenIDs, _, err := (*codec).Encode(input)
+	if err != nil {
+		return nil, false, fmt.Errorf("tokenize embedding input %d: %w", index, err)
+	}
+	return tokenIDs, len(tokenIDs) > maxOpenAIEmbeddingInputTokens, nil
+}
+
 func (c *ChatClient) CreateEmbeddings(ctx context.Context, orgID string, model string, inputs []string, opts ...EmbeddingOption) ([][]float32, error) {
 	var resolved EmbeddingOptions
 	for _, opt := range opts {
 		opt(&resolved)
 	}
-	return c.createEmbeddings(ctx, orgID, model, inputs, resolved.Dimensions, resolved.KeyType.OrDefault())
+	return c.createEmbeddings(ctx, orgID, model, inputs, resolved.InputFallbacks, resolved.Dimensions, resolved.KeyType.OrDefault())
 }
 
-func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model string, inputs []string, dimensions *int64, keyType KeyType) ([][]float32, error) {
+func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model string, inputs []string, inputFallbacks [][]string, dimensions *int64, keyType KeyType) ([][]float32, error) {
 	resolvedKey, err := c.keyResolver.ResolveKey(ctx, orgID, "", "", keyType)
 	if err != nil {
 		return nil, fmt.Errorf("resolving OpenRouter key: %w", err)
@@ -965,7 +993,7 @@ func (c *ChatClient) createEmbeddings(ctx context.Context, orgID string, model s
 		return nil, fmt.Errorf("at least one input is required")
 	}
 
-	inputs, truncatedCount, err := limitEmbeddingInputs(model, inputs)
+	inputs, truncatedCount, err := limitEmbeddingInputs(model, inputs, inputFallbacks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
AIM-168

## Summary

Change how tools from dynamic MCP servers are represented and bounded for embedding requests. Tool inputs are now denser, measured with the embedding model's tokenizer, degraded through semantic fallbacks when oversized, and batched using the representation that will actually be sent to OpenRouter.

The same change also classifies deterministic embedding API failures as non-retryable so Temporal does not repeatedly submit an invalid request.

## Motivation

Tool indexing previously serialized each tool entry, including its JSON Schema and metadata, directly into the embedding input. JSON punctuation, repeated structural keys, and deeply nested schemas made that representation token-inefficient.

The OpenRouter client then limited inputs using a 24,000-byte approximation. Byte length is not a reliable proxy for tokens: dense schemas could remain below the byte ceiling while exceeding the embedding model's 8,192-token per-input limit. OpenRouter rejected those requests with HTTP 400, and the generated SDK error was not normalized into Gram's permanent-error classification, so the Temporal activity retried a request that could never succeed.

## Implementation

### 1. Denser tool representation

Generate a deterministic semantic summary instead of embedding the serialized tool payload. The summary retains the fields useful for retrieval: tool name and description, tags, parameter paths, required state, types, formats, enums, constants, and bounded parameter descriptions. Nested property names are sorted so equivalent schemas produce stable input.

For example:

```text
create_customer
Create a customer record
tags: crm, customers
parameters:
- input (object)
- address (object)
- address.country (string): ISO country code
- email (required, string, format=email): Primary email
- name (required, string): Customer display name
- plan (string, enum=[free, pro, enterprise]): Subscription plan
```

Opaque tool metadata remains in the stored payload but is not embedded.

### 2. Model-aware input token counting

For `openai/text-embedding-3-small`, tokenize candidate input locally with `cl100k_base`, the tokenizer used by the selected embedding model. The provider accepts up to 8,192 tokens per input; Gram uses 8,000 as a safety threshold.

Each limiting operation owns its tokenizer codec because the codec lazily initializes decoder state and is not safe to share across concurrent embedding batches.

### 3. Graceful degradation before batching

When the full semantic summary exceeds 8,000 tokens, try progressively smaller representations:

1. Tool name, tool description, and top-level parameter names and descriptions.
2. Tool name and tool description.
3. Token-safe prefix truncation of the final name-and-description representation.

Fallback selection happens before request batches are calculated. Batch sizing therefore reflects the content actually sent to OpenRouter rather than the larger discarded representation. A conservative 300,000-byte aggregate ceiling guarantees the provider's 300,000-token request limit without another tokenization pass.

### 4. Permanent embedding error classification

Normalize generated OpenRouter SDK errors into Gram's HTTP error type. Deterministic 4xx responses are marked non-retryable for the toolset embedding Temporal activity, while request timeouts, rate limits, and server errors remain retryable.

Generic SDK errors are classified only when they carry an HTTP error status, and raw response headers are retained for rate-limit diagnostics. Error bodies remain excluded from returned errors because they may echo embedding input.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents oversized tool schemas from failing toolset embedding generation. Previously, raw schema JSON and metadata were embedded with byte-based truncation that could still exceed provider token limits; now deterministic schema summaries are embedded, and oversized inputs fall back to smaller representations before truncation.

- Summaries sort properties and bound description and enum lengths.
- Fallback order per input: full summary, top-level parameters, name and description, then token-safe truncation.
- Fallbacks are selected before batch sizing so batch limits reflect the payload actually sent; batch byte ceiling lowered from 800KB to 300,000 bytes to match the aggregate token limit.
- OpenAI's `text-embedding-3-small` enforces an 8,000 token per-input limit via tokenizer; other models keep the 24,000 byte limit.
- Embedding API errors are classified by HTTP status; permanent 4xx errors become non-retryable Temporal application errors, and rate-limit headers are preserved for telemetry.
- Adds telemetry attributes for embedding input and truncated counts.

<sup>Written for commit 017f4a29e160acd5b9463a39530913b9b5efdf71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
