### PR TITLE
chore: hand new worktrees a paused stack, and wake it on demand

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -19,7 +19,10 @@ workinit = "mise run git:workinit"
 
 # Background: brings the worktree's stack up on the ports workinit just
 # assigned — compose infra, migrations, dev-idp, the pitchfork daemons, then
-# seed. Non-blocking, so worktree creation returns without waiting on it;
+# seed — and then PAUSES it (`mise run pause`): daemons stopped, containers
+# stopped but not removed. A worktree is therefore handed over complete but
+# idle; `mise run wake` restarts it in seconds when you (or your agent) want
+# it. Non-blocking, so worktree creation returns without waiting on it;
 # `wt config state logs` has the output. The task also publishes a pid marker
 # while it runs, which is what lets `wt status` say "booting" rather than
 # "down". Keep the hook key `stack` — the log file is named after it.

--- a/.mise-tasks/ensure-stack.sh
+++ b/.mise-tasks/ensure-stack.sh
@@ -37,5 +37,14 @@ if [ -n "$gitdir" ] && [ -f "$gitdir/gram-stack-boot.pid" ]; then
     fi
 fi
 
+# A boot that failed leaves containers behind that a wake would happily start,
+# which is worse than not starting them: the databases behind them may have no
+# migrations and no seed, and every daemon then reports confusing errors.
+# Finishing the boot is the fix, and only the developer can decide to.
+if [ -n "$gitdir" ] && [ -f "$gitdir/gram-stack-boot.failed" ]; then
+    echo "This worktree's last boot failed — finish it with \`mise run git:workboot\` before running this." >&2
+    exit 1
+fi
+
 echo "Stack is not running — waking it first."
 exec mise run wake

--- a/.mise-tasks/ensure-stack.sh
+++ b/.mise-tasks/ensure-stack.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+#MISE description="Wake this worktree's stack if it is paused, then return"
+#MISE dir="{{ config_root }}"
+#MISE hide=true
+
+set -e
+
+# A dependency of the tasks that cannot work without a running stack (seed,
+# playwright, open:dashboard). A worktree is handed over paused, so without
+# this those tasks fail with a connection error that says nothing about the
+# fix. Cheap enough to depend on unconditionally: one TCP probe when the stack
+# is already up.
+#
+# Deliberately NOT a dependency of build/lint/test/type-check tasks — the point
+# of pausing is that most work needs no stack at all.
+
+# Postgres is the load-bearing dependency for everything that depends on this,
+# and the one thing `pause` stops that no parker replaces -- so it is the
+# probe. bash's /dev/tcp keeps this to zero subprocesses on the hot path, and a
+# refused connection to a local port fails immediately.
+if exec 3<> "/dev/tcp/${DB_HOST:-127.0.0.1}/${DB_PORT:-5439}" 2> /dev/null; then
+    exec 3>&-
+    exit 0
+fi
+
+# Probe first, guard second: `zero` runs `mise run seed` while the boot marker
+# is still held, and that seed must not be turned away. Past this point the
+# stack is genuinely down, so a boot in flight means waiting is the only sane
+# move -- racing it with a wake fights over the same containers and ports.
+gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+if [ -n "$gitdir" ] && [ -f "$gitdir/gram-stack-boot.pid" ]; then
+    pid=$(cat "$gitdir/gram-stack-boot.pid")
+    if ps -o command= -p "$pid" 2> /dev/null | grep -q workboot; then
+        echo "Stack is still booting — watch it with \`mise run git:workstatus\`." >&2
+        exit 1
+    fi
+fi
+
+echo "Stack is not running — waking it first."
+exec mise run wake

--- a/.mise-tasks/git/workboot.sh
+++ b/.mise-tasks/git/workboot.sh
@@ -27,6 +27,16 @@ echo $$ > "$marker"
 rm -f "$failed"
 trap 'code=$?; rm -f "$marker"; [ "$code" -eq 0 ] || echo "$code" > "$failed"' EXIT
 
+# A fresh worktree is booted so that its containers, migrations and seed data
+# exist -- but it is not left running: a developer usually has several
+# worktrees and only works in one, and idle stacks cost RAM and CPU for nothing.
+# So hand the worktree over paused; `mise run wake` brings it back in seconds
+# (containers are stopped, not removed, so nothing is re-created or re-seeded).
+pause_stack() {
+    echo "Boot complete — pausing the stack. Run \`mise run wake\` to use it."
+    mise run pause
+}
+
 # Re-booting a worktree whose stack is already running fails for a reason that
 # has nothing to do with the worktree: `mise run start` kills the previous
 # daemons, pitchfork records the kill as a daemon failure, `start` reports
@@ -47,6 +57,7 @@ mise run stop || true
 # retry), and infra:start treats the wait as advisory anyway. An interactive
 # `./zero` keeps the wait so its success message stays honest.
 if INFRA_READINESS_TIMEOUT=300 PRESIDIO_READINESS_TIMEOUT=0 ./zero --agent; then
+    pause_stack
     exit 0
 fi
 
@@ -61,6 +72,7 @@ for delay in 15 30 60; do
     sleep "$delay"
     echo "Retrying seed after a ${delay}s wait..."
     if mise run seed; then
+        pause_stack
         exit 0
     fi
 done

--- a/.mise-tasks/git/workstatus.sh
+++ b/.mise-tasks/git/workstatus.sh
@@ -32,8 +32,9 @@ fi
 # exactly like one that was never booted -- the port isn't listening in any of
 # the three cases, and worktrunk tracks no hook liveness. `git:workboot` (the
 # post-start hook) closes that gap with two markers in the worktree's git dir:
-# its pid while the boot runs, and the exit code if the boot failed. Echoes
-# `booting`, `failed`, or nothing.
+# its pid while the boot runs, and the exit code if the boot failed. A booted
+# worktree is then handed over paused, which `mise run pause` records with a
+# third marker. Echoes `booting`, `failed`, `paused`, or nothing.
 boot_state() {
     local gitdir pid
     gitdir="$(git -C "$1" rev-parse --absolute-git-dir 2>/dev/null)"
@@ -52,6 +53,8 @@ boot_state() {
     # would fail the whole script through the caller's assignment.
     if [ -f "$gitdir/gram-stack-boot.failed" ]; then
         echo failed
+    elif [ -f "$gitdir/gram-stack-paused" ]; then
+        echo paused
     fi
 }
 
@@ -75,6 +78,10 @@ while IFS=$'\t' read -r marker branch active url path; do
         booting,true) state=$'\033[33m◐ seeding\033[0m' ;;
         booting,*) state=$'\033[33m◐ booting\033[0m' ;;
         failed,*) state=$'\033[31m✗ failed\033[0m ' ; failures=$((failures + 1)) ;;
+        # Regardless of port liveness: `mise run pause` parks a placeholder
+        # server on the site port (it answers with a page that wakes the
+        # stack), so `url_active` is true for a paused worktree too.
+        paused,*) state=$'\033[90m◼ paused\033[0m ' ;;
         *,true) state=$'\033[32m● up\033[0m     ' ;;
         *) state=$'\033[31m○ down\033[0m   ' ;;
     esac

--- a/.mise-tasks/git/worktui.mts
+++ b/.mise-tasks/git/worktui.mts
@@ -751,7 +751,11 @@ async function run() {
           // Boot log is the interesting one while a boot is live or failed;
           // for a stack that's simply up (or has no boot log), the live
           // service logs are what you want to see.
-          logMode = ["booting", "seeding", "failed"].includes(logTarget.state)
+          // `paused` belongs with the boot states, not with the running ones: a paused
+          // worktree has no pitchfork daemons, so service logs would come back empty.
+          logMode = ["booting", "seeding", "failed", "paused"].includes(
+            logTarget.state,
+          )
             ? "boot"
             : "services";
           logScroll = 0;

--- a/.mise-tasks/git/worktui.mts
+++ b/.mise-tasks/git/worktui.mts
@@ -28,7 +28,7 @@ type Row = {
   isCurrent: boolean;
   url: string;
   urlActive: boolean;
-  // Derived: booting | seeding | failed | up | down
+  // Derived: booting | seeding | failed | paused | up | down
   state: string;
   // Uncommitted changes (staged/modified/untracked) — removal needs --force
   dirty: boolean;
@@ -193,7 +193,9 @@ async function lockOwner(wtPath: string): Promise<string> {
   }
 }
 
-async function bootState(wtPath: string): Promise<"booting" | "failed" | ""> {
+async function bootState(
+  wtPath: string,
+): Promise<"booting" | "failed" | "paused" | ""> {
   const dir = await gitDir(wtPath);
   if (!dir) return "";
   const pidFile = path.join(dir, "gram-stack-boot.pid");
@@ -209,6 +211,9 @@ async function bootState(wtPath: string): Promise<"booting" | "failed" | ""> {
     }
   }
   if (fs.existsSync(path.join(dir, "gram-stack-boot.failed"))) return "failed";
+  // Written by `mise run pause`, which is how every booted worktree is handed
+  // over: its stack is complete but stopped, not missing.
+  if (fs.existsSync(path.join(dir, "gram-stack-paused"))) return "paused";
   return "";
 }
 
@@ -228,6 +233,10 @@ async function collect(): Promise<Row[]> {
     let state: string;
     if (boot === "booting") state = item.url_active ? "seeding" : "booting";
     else if (boot === "failed") state = "failed";
+    // Outranks url_active: a paused worktree's site port is held by the
+    // parker (`mise run park`), which answers with a wake page, not the
+    // dashboard.
+    else if (boot === "paused") state = "paused";
     else state = item.url_active ? "up" : "down";
     rows.push({
       branch: item.branch,
@@ -258,6 +267,7 @@ const STATE_FMT: Record<string, string> = {
   booting: c.yellow("◐ booting"),
   seeding: c.yellow("◐ seeding"),
   failed: c.red("✗ failed "),
+  paused: c.dim("◼ paused "),
 };
 
 function listFrame(

--- a/.mise-tasks/idle-pause.sh
+++ b/.mise-tasks/idle-pause.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+#MISE description="Pause this worktree's stack if nothing has used it for a while"
+#MISE dir="{{ config_root }}"
+
+#USAGE flag "--minutes <minutes>" default="60" help="Idle time before pausing"
+#USAGE flag "--all" help="Check every worktree instead of this one"
+#USAGE flag "--dry-run" help="Report what would be paused without pausing"
+
+set -e
+
+# The complement to `mise run wake`: waking is cheap and now happens on its own
+# (opening the dashboard, or any task that depends on `ensure-stack`), so
+# stacks accumulate as you move between worktrees. This pauses the ones nobody
+# is using.
+#
+# Activity signal: established TCP connections to the site and server ports. An
+# open dashboard tab holds a vite HMR websocket, an agent driving the API holds
+# a connection for the duration of its request, and `pitchfork` itself connects
+# to neither -- so "no connections" really is "nobody is using this". A single
+# quiet sample is not enough (nothing is connected between two requests), so
+# the last-seen time is kept in the worktree's git dir and only a stretch of
+# quiet longer than --minutes pauses the stack.
+#
+# Run it from cron or a launchd agent every few minutes:
+#   */5 * * * * cd /path/to/gram && mise run idle-pause --all --minutes 60
+
+minutes="${usage_minutes:-60}"
+check_all="${usage_all:-false}"
+dry_run="${usage_dry_run:-false}"
+
+if [ "$check_all" = "true" ]; then
+    # Each worktree has its own ports and its own git dir, and mise resolves
+    # both from the directory -- so recurse per worktree rather than trying to
+    # read another worktree's environment from here.
+    forward=(--minutes "$minutes")
+    [ "$dry_run" = "true" ] && forward+=(--dry-run)
+
+    while read -r wt; do
+        [ -d "$wt" ] || continue
+        # Worktrees on a branch that predates this task would just print
+        # "no task idle-pause found" on every cron run -- skip them quietly.
+        (cd "$wt" && mise tasks info idle-pause &> /dev/null \
+            && mise run idle-pause "${forward[@]}") || true
+    done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+    exit 0
+fi
+
+gitdir="$(git rev-parse --absolute-git-dir)"
+branch="$(git branch --show-current 2> /dev/null || echo detached)"
+
+# Already paused, or a boot is in flight: nothing to do either way.
+[ -f "$gitdir/gram-stack-paused" ] && exit 0
+if [ -f "$gitdir/gram-stack-boot.pid" ]; then
+    pid=$(cat "$gitdir/gram-stack-boot.pid")
+    ps -o command= -p "$pid" 2> /dev/null | grep -q workboot && exit 0
+fi
+
+# Nothing listening on the site port means the stack is down (not paused --
+# a nuked or never-booted worktree); leave it alone.
+if ! lsof -nP -iTCP:"${GRAM_SITE_PORT}" -sTCP:LISTEN -t > /dev/null 2>&1; then
+    exit 0
+fi
+
+conns=$(lsof -nP \
+    -iTCP:"${GRAM_SITE_PORT}" -iTCP:"${GRAM_SERVER_PORT}" \
+    -sTCP:ESTABLISHED -t 2> /dev/null | wc -l | tr -d ' ')
+
+stamp="$gitdir/gram-stack-lastseen"
+now=$(date +%s)
+
+if [ "$conns" -gt 0 ]; then
+    echo "$now" > "$stamp"
+    exit 0
+fi
+
+# First quiet sample after a wake has no stamp to compare against. Start the
+# clock now rather than pausing a stack that came up seconds ago.
+if [ ! -f "$stamp" ]; then
+    echo "$now" > "$stamp"
+    exit 0
+fi
+
+idle=$(( (now - $(cat "$stamp")) / 60 ))
+if [ "$idle" -lt "$minutes" ]; then
+    exit 0
+fi
+
+if [ "$dry_run" = "true" ]; then
+    echo "${branch}: idle ${idle}m — would pause"
+    exit 0
+fi
+
+echo "${branch}: idle ${idle}m — pausing"
+rm -f "$stamp"
+mise run pause

--- a/.mise-tasks/idle-pause.sh
+++ b/.mise-tasks/idle-pause.sh
@@ -40,16 +40,21 @@ if [ "$check_all" = "true" ]; then
 
     while read -r wt; do
         [ -d "$wt" ] || continue
-        # Worktrees on a branch that predates this task would just print
-        # "no task idle-pause found" on every cron run -- skip them quietly.
-        (cd "$wt" && mise tasks info idle-pause &> /dev/null \
-            && mise run idle-pause "${forward[@]}") || true
+        # Worktrees on a branch that predates this task would just print "no
+        # task idle-pause found" on every run -- skip those quietly, but keep
+        # reporting a sweep that actually failed.
+        (cd "$wt" && mise tasks info idle-pause &> /dev/null) || continue
+        (cd "$wt" && mise run idle-pause "${forward[@]}") \
+            || echo "⚠️  idle-pause failed in $wt" >&2
     done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
     exit 0
 fi
 
 gitdir="$(git rev-parse --absolute-git-dir)"
-branch="$(git branch --show-current 2> /dev/null || echo detached)"
+# `git branch --show-current` succeeds with empty output on a detached HEAD,
+# so `||` never fires.
+branch="$(git branch --show-current 2> /dev/null)"
+[ -n "$branch" ] || branch="detached"
 
 # Already paused, or a boot is in flight: nothing to do either way.
 [ -f "$gitdir/gram-stack-paused" ] && exit 0
@@ -58,15 +63,37 @@ if [ -f "$gitdir/gram-stack-boot.pid" ]; then
     ps -o command= -p "$pid" 2> /dev/null | grep -q workboot && exit 0
 fi
 
-# Nothing listening on the site port means the stack is down (not paused --
-# a nuked or never-booted worktree); leave it alone.
-if ! lsof -nP -iTCP:"${GRAM_SITE_PORT}" -sTCP:LISTEN -t > /dev/null 2>&1; then
+# `lsof` on macOS and every dev container that has it; `ss` on the Linux hosts
+# that do not (a missing tool would otherwise read as "no connections" and
+# pause a stack somebody is using).
+if command -v lsof > /dev/null 2>&1; then
+    listening() {
+        lsof -nP -iTCP:"$1" -sTCP:LISTEN -t > /dev/null 2>&1
+    }
+    established() {
+        lsof -nP -iTCP:"$1" -iTCP:"$2" -sTCP:ESTABLISHED -t 2> /dev/null \
+            | grep -c . | tr -d ' '
+    }
+elif command -v ss > /dev/null 2>&1; then
+    listening() {
+        ss -Hltn "sport = :$1" 2> /dev/null | grep -q .
+    }
+    established() {
+        ss -Htn "state established ( sport = :$1 or sport = :$2 )" 2> /dev/null \
+            | grep -c . | tr -d ' '
+    }
+else
+    echo "Neither lsof nor ss is available; cannot tell whether this stack is in use." >&2
     exit 0
 fi
 
-conns=$(lsof -nP \
-    -iTCP:"${GRAM_SITE_PORT}" -iTCP:"${GRAM_SERVER_PORT}" \
-    -sTCP:ESTABLISHED -t 2> /dev/null | wc -l | tr -d ' ')
+# Nothing listening on the site port means the stack is down (not paused --
+# a nuked or never-booted worktree); leave it alone.
+if ! listening "${GRAM_SITE_PORT}"; then
+    exit 0
+fi
+
+conns=$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}")
 
 stamp="$gitdir/gram-stack-lastseen"
 now=$(date +%s)
@@ -90,6 +117,13 @@ fi
 
 if [ "$dry_run" = "true" ]; then
     echo "${branch}: idle ${idle}m — would pause"
+    exit 0
+fi
+
+# The sample that decided this is up to five minutes old. Cheap insurance
+# against pausing a stack somebody started using in between.
+if [ "$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}")" -gt 0 ]; then
+    echo "$now" > "$stamp"
     exit 0
 fi
 

--- a/.mise-tasks/idle-pause.sh
+++ b/.mise-tasks/idle-pause.sh
@@ -6,6 +6,8 @@
 #USAGE flag "--minutes <minutes>" default="60" help="Idle time before pausing"
 #USAGE flag "--all" help="Check every worktree instead of this one"
 #USAGE flag "--dry-run" help="Report what would be paused without pausing"
+#USAGE flag "--install" help="Schedule this task to run every 5 minutes (launchd/systemd)"
+#USAGE flag "--uninstall" help="Remove the schedule installed by --install"
 
 set -e
 
@@ -22,12 +24,102 @@ set -e
 # the last-seen time is kept in the worktree's git dir and only a stretch of
 # quiet longer than --minutes pauses the stack.
 #
-# Run it from cron or a launchd agent every few minutes:
-#   */5 * * * * cd /path/to/gram && mise run idle-pause --all --minutes 60
+# `--install` schedules it every 5 minutes (a launchd agent on macOS, a systemd
+# user timer on Linux). `./zero` offers this once, and only to developers who
+# actually use worktrees.
 
 minutes="${usage_minutes:-60}"
 check_all="${usage_all:-false}"
 dry_run="${usage_dry_run:-false}"
+
+# The schedule runs `--all`, which walks `git worktree list` -- so it must live
+# in the main worktree, the one checkout that outlives every branch.
+main_worktree="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
+label="ai.getgram.gram-idle-pause"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+unit_dir="$HOME/.config/systemd/user"
+
+install_schedule() {
+    if [ "$(uname)" = "Darwin" ]; then
+        mkdir -p "$(dirname "$plist")"
+        cat > "$plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <!-- The command runs inside XML, so its and-operator is escaped. -->
+    <string>cd ${main_worktree} &amp;&amp; mise run idle-pause --all --minutes ${minutes}</string>
+  </array>
+  <key>StartInterval</key><integer>300</integer>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>${HOME}/Library/Logs/gram-idle-pause.log</string>
+  <key>StandardErrorPath</key><string>${HOME}/Library/Logs/gram-idle-pause.log</string>
+</dict>
+</plist>
+PLIST
+        # bootout first so a re-install picks up an edited plist; a label that
+        # was never loaded makes bootout fail, which is not an error here.
+        launchctl bootout "gui/$(id -u)/${label}" 2> /dev/null || true
+        launchctl bootstrap "gui/$(id -u)" "$plist"
+        echo "Installed: launchd runs \`idle-pause --all --minutes ${minutes}\` every 5 minutes."
+        echo "Log: ~/Library/Logs/gram-idle-pause.log — remove with \`mise run idle-pause --uninstall\`."
+        return
+    fi
+
+    mkdir -p "$unit_dir"
+    cat > "${unit_dir}/gram-idle-pause.service" << UNIT
+[Unit]
+Description=Pause idle Gram worktree stacks
+
+[Service]
+Type=oneshot
+WorkingDirectory=${main_worktree}
+ExecStart=/bin/bash -lc 'mise run idle-pause --all --minutes ${minutes}'
+UNIT
+    cat > "${unit_dir}/gram-idle-pause.timer" << UNIT
+[Unit]
+Description=Pause idle Gram worktree stacks every 5 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+UNIT
+    systemctl --user daemon-reload
+    systemctl --user enable --now gram-idle-pause.timer
+    echo "Installed: systemd timer runs \`idle-pause --all --minutes ${minutes}\` every 5 minutes."
+    echo "Logs: \`journalctl --user -u gram-idle-pause\` — remove with \`mise run idle-pause --uninstall\`."
+}
+
+uninstall_schedule() {
+    if [ "$(uname)" = "Darwin" ]; then
+        launchctl bootout "gui/$(id -u)/${label}" 2> /dev/null || true
+        rm -f "$plist"
+        echo "Removed the launchd agent."
+        return
+    fi
+    systemctl --user disable --now gram-idle-pause.timer 2> /dev/null || true
+    rm -f "${unit_dir}/gram-idle-pause.service" "${unit_dir}/gram-idle-pause.timer"
+    systemctl --user daemon-reload 2> /dev/null || true
+    echo "Removed the systemd timer."
+}
+
+if [ "${usage_install:-false}" = "true" ]; then
+    install_schedule
+    exit 0
+fi
+
+if [ "${usage_uninstall:-false}" = "true" ]; then
+    uninstall_schedule
+    exit 0
+fi
 
 if [ "$check_all" = "true" ]; then
     # Each worktree has its own ports and its own git dir, and mise resolves

--- a/.mise-tasks/idle-pause.sh
+++ b/.mise-tasks/idle-pause.sh
@@ -6,8 +6,6 @@
 #USAGE flag "--minutes <minutes>" default="60" help="Idle time before pausing"
 #USAGE flag "--all" help="Check every worktree instead of this one"
 #USAGE flag "--dry-run" help="Report what would be paused without pausing"
-#USAGE flag "--install" help="Schedule this task to run every 5 minutes (launchd/systemd)"
-#USAGE flag "--uninstall" help="Remove the schedule installed by --install"
 
 set -e
 
@@ -24,102 +22,14 @@ set -e
 # the last-seen time is kept in the worktree's git dir and only a stretch of
 # quiet longer than --minutes pauses the stack.
 #
-# `--install` schedules it every 5 minutes (a launchd agent on macOS, a systemd
-# user timer on Linux). `./zero` offers this once, and only to developers who
-# actually use worktrees.
+# Scheduled by pitchfork, which is already running the stack it watches -- see
+# the `idle-pause` cron daemon in pitchfork.toml. Deliberately not a launchd
+# agent or a systemd timer: those install a job on the developer's machine that
+# outlives the repo, and we have a hard requirement not to touch their system.
 
 minutes="${usage_minutes:-60}"
 check_all="${usage_all:-false}"
 dry_run="${usage_dry_run:-false}"
-
-# The schedule runs `--all`, which walks `git worktree list` -- so it must live
-# in the main worktree, the one checkout that outlives every branch.
-main_worktree="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
-label="ai.getgram.gram-idle-pause"
-plist="$HOME/Library/LaunchAgents/${label}.plist"
-unit_dir="$HOME/.config/systemd/user"
-
-install_schedule() {
-    if [ "$(uname)" = "Darwin" ]; then
-        mkdir -p "$(dirname "$plist")"
-        cat > "$plist" << PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>${label}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/zsh</string>
-    <string>-lc</string>
-    <!-- The command runs inside XML, so its and-operator is escaped. -->
-    <string>cd ${main_worktree} &amp;&amp; mise run idle-pause --all --minutes ${minutes}</string>
-  </array>
-  <key>StartInterval</key><integer>300</integer>
-  <key>RunAtLoad</key><false/>
-  <key>StandardOutPath</key><string>${HOME}/Library/Logs/gram-idle-pause.log</string>
-  <key>StandardErrorPath</key><string>${HOME}/Library/Logs/gram-idle-pause.log</string>
-</dict>
-</plist>
-PLIST
-        # bootout first so a re-install picks up an edited plist; a label that
-        # was never loaded makes bootout fail, which is not an error here.
-        launchctl bootout "gui/$(id -u)/${label}" 2> /dev/null || true
-        launchctl bootstrap "gui/$(id -u)" "$plist"
-        echo "Installed: launchd runs \`idle-pause --all --minutes ${minutes}\` every 5 minutes."
-        echo "Log: ~/Library/Logs/gram-idle-pause.log — remove with \`mise run idle-pause --uninstall\`."
-        return
-    fi
-
-    mkdir -p "$unit_dir"
-    cat > "${unit_dir}/gram-idle-pause.service" << UNIT
-[Unit]
-Description=Pause idle Gram worktree stacks
-
-[Service]
-Type=oneshot
-WorkingDirectory=${main_worktree}
-ExecStart=/bin/bash -lc 'mise run idle-pause --all --minutes ${minutes}'
-UNIT
-    cat > "${unit_dir}/gram-idle-pause.timer" << UNIT
-[Unit]
-Description=Pause idle Gram worktree stacks every 5 minutes
-
-[Timer]
-OnBootSec=5min
-OnUnitActiveSec=5min
-
-[Install]
-WantedBy=timers.target
-UNIT
-    systemctl --user daemon-reload
-    systemctl --user enable --now gram-idle-pause.timer
-    echo "Installed: systemd timer runs \`idle-pause --all --minutes ${minutes}\` every 5 minutes."
-    echo "Logs: \`journalctl --user -u gram-idle-pause\` — remove with \`mise run idle-pause --uninstall\`."
-}
-
-uninstall_schedule() {
-    if [ "$(uname)" = "Darwin" ]; then
-        launchctl bootout "gui/$(id -u)/${label}" 2> /dev/null || true
-        rm -f "$plist"
-        echo "Removed the launchd agent."
-        return
-    fi
-    systemctl --user disable --now gram-idle-pause.timer 2> /dev/null || true
-    rm -f "${unit_dir}/gram-idle-pause.service" "${unit_dir}/gram-idle-pause.timer"
-    systemctl --user daemon-reload 2> /dev/null || true
-    echo "Removed the systemd timer."
-}
-
-if [ "${usage_install:-false}" = "true" ]; then
-    install_schedule
-    exit 0
-fi
-
-if [ "${usage_uninstall:-false}" = "true" ]; then
-    uninstall_schedule
-    exit 0
-fi
 
 if [ "$check_all" = "true" ]; then
     # Each worktree has its own ports and its own git dir, and mise resolves
@@ -185,4 +95,15 @@ fi
 
 echo "${branch}: idle ${idle}m — pausing"
 rm -f "$stamp"
-mise run pause
+
+# `mise run pause` stops every local daemon -- including the pitchfork cron
+# daemon this task is running under when the schedule fired it. Run it in its
+# own session so pausing cannot kill the pause halfway through, before the
+# containers are stopped. Output goes to the worktree's git dir, since the
+# daemon's own log dies with it.
+if command -v setsid > /dev/null 2>&1; then
+    setsid mise run pause > "$gitdir/gram-stack-idle-pause.log" 2>&1 &
+else
+    nohup mise run pause > "$gitdir/gram-stack-idle-pause.log" 2>&1 &
+fi
+disown 2> /dev/null || true

--- a/.mise-tasks/idle-pause.sh
+++ b/.mise-tasks/idle-pause.sh
@@ -41,9 +41,15 @@ if [ "$check_all" = "true" ]; then
     while read -r wt; do
         [ -d "$wt" ] || continue
         # Worktrees on a branch that predates this task would just print "no
-        # task idle-pause found" on every run -- skip those quietly, but keep
-        # reporting a sweep that actually failed.
-        (cd "$wt" && mise tasks info idle-pause &> /dev/null) || continue
+        # task idle-pause found" on every run -- skip those quietly. Any other
+        # discovery failure (a broken mise config, a missing toolchain) is worth
+        # hearing about.
+        if ! probe="$(cd "$wt" && mise tasks info idle-pause 2>&1)"; then
+            case "$probe" in
+                *"Task not found"* | *"no task"*) continue ;;
+                *) echo "⚠️  cannot run idle-pause in $wt: $probe" >&2; continue ;;
+            esac
+        fi
         (cd "$wt" && mise run idle-pause "${forward[@]}") \
             || echo "⚠️  idle-pause failed in $wt" >&2
     done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
@@ -71,16 +77,22 @@ if command -v lsof > /dev/null 2>&1; then
         lsof -nP -iTCP:"$1" -sTCP:LISTEN -t > /dev/null 2>&1
     }
     established() {
-        lsof -nP -iTCP:"$1" -iTCP:"$2" -sTCP:ESTABLISHED -t 2> /dev/null \
-            | grep -c . | tr -d ' '
+        # `grep -c` last in a pipeline would mask a failing probe as zero
+        # connections, which is exactly the answer that pauses a stack.
+        local out
+        out="$(lsof -nP -iTCP:"$1" -iTCP:"$2" -sTCP:ESTABLISHED -t 2> /dev/null)" \
+            || [ -z "$out" ] || return 1
+        printf '%s' "$out" | grep -c . | tr -d ' '
     }
 elif command -v ss > /dev/null 2>&1; then
     listening() {
         ss -Hltn "sport = :$1" 2> /dev/null | grep -q .
     }
     established() {
-        ss -Htn "state established ( sport = :$1 or sport = :$2 )" 2> /dev/null \
-            | grep -c . | tr -d ' '
+        local out
+        out="$(ss -Htn "state established ( sport = :$1 or sport = :$2 )" 2> /dev/null)" \
+            || return 1
+        printf '%s' "$out" | grep -c . | tr -d ' '
     }
 else
     echo "Neither lsof nor ss is available; cannot tell whether this stack is in use." >&2
@@ -93,7 +105,10 @@ if ! listening "${GRAM_SITE_PORT}"; then
     exit 0
 fi
 
-conns=$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}")
+if ! conns=$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}"); then
+    echo "Could not inspect connections for ${GRAM_SITE_PORT}/${GRAM_SERVER_PORT}; leaving the stack alone." >&2
+    exit 0
+fi
 
 stamp="$gitdir/gram-stack-lastseen"
 now=$(date +%s)
@@ -121,8 +136,12 @@ if [ "$dry_run" = "true" ]; then
 fi
 
 # The sample that decided this is up to five minutes old. Cheap insurance
-# against pausing a stack somebody started using in between.
-if [ "$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}")" -gt 0 ]; then
+# against pausing a stack somebody started using in between -- and a probe that
+# fails here counts as "in use" for the same reason as above.
+if ! recheck=$(established "${GRAM_SITE_PORT}" "${GRAM_SERVER_PORT}"); then
+    exit 0
+fi
+if [ "$recheck" -gt 0 ]; then
     echo "$now" > "$stamp"
     exit 0
 fi

--- a/.mise-tasks/park.mts
+++ b/.mise-tasks/park.mts
@@ -1,0 +1,169 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning --experimental-strip-types
+
+//MISE description="Hold this worktree's site port while the stack is paused and wake it on the first browser hit"
+//MISE dir="{{ config_root }}"
+//MISE hide=true
+
+// `mise run pause` leaves the stack complete but stopped, which also leaves the
+// dashboard URL dead — so a bookmark, a `wt list` link or an agent's browser
+// step lands on a connection error and the developer has to know that `mise run
+// wake` exists. This task parks on the site port in the stack's place: the
+// first request gets an interstitial that starts the wake and reloads itself
+// when the real dashboard answers.
+//
+// The parker cannot proxy the dashboard once it is up (vite wants the port
+// itself), so it hands the port over instead: serve the page, close the
+// listener, spawn `mise run wake`. That leaves a window where nothing is
+// listening, which is why the interstitial polls from the browser — the page is
+// already loaded, so a refused fetch is just another retry.
+//
+// Started detached by `mise run pause`; killed by `mise run wake` (and it exits
+// on its own once it has triggered a wake).
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import path from "node:path";
+
+const port = Number(process.env["GRAM_SITE_PORT"]);
+if (!Number.isInteger(port) || port <= 0) {
+  console.error("GRAM_SITE_PORT is not set to a port number");
+  process.exit(1);
+}
+
+const gitDir = process.env["GRAM_PARK_GIT_DIR"];
+const pidFile = gitDir ? path.join(gitDir, "gram-stack-parked.pid") : null;
+const wakeLog = gitDir ? path.join(gitDir, "gram-stack-wake.log") : null;
+
+// Same key/cert vite serves with, so the browser sees one origin across the
+// handover instead of an https:// URL that suddenly speaks plain HTTP.
+function tls(): { key: Buffer; cert: Buffer } | null {
+  const keyFile = process.env["GRAM_SSL_KEY_FILE"];
+  const certFile = process.env["GRAM_SSL_CERT_FILE"];
+  if (!keyFile || !certFile) return null;
+  try {
+    return { key: fs.readFileSync(keyFile), cert: fs.readFileSync(certFile) };
+  } catch {
+    return null;
+  }
+}
+
+const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Resuming stack…</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+    background: Canvas; color: CanvasText;
+  }
+  main { text-align: center; max-width: 30rem; padding: 2rem; }
+  h1 { font-size: 1.25rem; font-weight: 600; margin: 0 0 .5rem; }
+  p { margin: 0; opacity: .7; }
+  code { font-family: ui-monospace, SFMono-Regular, monospace; }
+  .dot {
+    display: inline-block; width: .5rem; height: .5rem; margin-right: .5rem;
+    border-radius: 50%; background: currentColor; animation: pulse 1.2s infinite;
+  }
+  @keyframes pulse { 0%, 100% { opacity: .25 } 50% { opacity: 1 } }
+</style>
+</head>
+<body>
+<main>
+  <h1><span class="dot"></span>Resuming stack</h1>
+  <p>This worktree's containers and services are starting. The page reloads
+     when the dashboard answers — usually well under a minute.</p>
+  <p id="elapsed"></p>
+  <p><small>Logs: <code>mise run git:workstatus</code>, or
+     <code>pitchfork logs dashboard</code>.</small></p>
+</main>
+<script>
+  const started = Date.now();
+  const elapsed = document.getElementById("elapsed");
+  setInterval(() => {
+    elapsed.textContent = Math.round((Date.now() - started) / 1000) + "s";
+  }, 1000);
+  // The parker closes its listener as soon as it has answered this request, so
+  // the next few probes are refused connections — expected, not an error.
+  // Cache-busted so a probe can't be answered from the bfcache.
+  async function poll() {
+    try {
+      await fetch("/?__wake=" + Date.now(), { cache: "no-store" });
+      location.replace("/");
+      return;
+    } catch {}
+    setTimeout(poll, 1000);
+  }
+  setTimeout(poll, 2000);
+</script>
+</body>
+</html>
+`;
+
+let waking = false;
+
+function wake(): void {
+  if (waking) return;
+  waking = true;
+
+  const out = wakeLog
+    ? fs.openSync(wakeLog, "a")
+    : ("ignore" as unknown as number);
+  const child = spawn("mise", ["run", "wake"], {
+    detached: true,
+    stdio: ["ignore", out, out],
+    cwd: process.cwd(),
+  });
+  child.unref();
+}
+
+const creds = tls();
+const handler = (
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+): void => {
+  res.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  res.end(PAGE, () => {
+    // Free the port before `wake` starts vite, and only once the page is
+    // actually on the wire — closing earlier would strand this response.
+    server.close();
+    wake();
+    // The browser polls from here; nothing else needs this process. Give the
+    // socket a moment to drain, then leave the port to vite.
+    setTimeout(() => process.exit(0), 500);
+  });
+};
+
+const server = creds
+  ? https.createServer(creds, handler)
+  : http.createServer(handler);
+
+server.on("error", (err: NodeJS.ErrnoException) => {
+  // EADDRINUSE means the stack (or another parker) already holds the port —
+  // nothing to park. Exit quietly so `pause` does not report a failure.
+  if (err.code === "EADDRINUSE") process.exit(0);
+  console.error(err);
+  process.exit(1);
+});
+
+server.listen(port, () => {
+  if (pidFile) fs.writeFileSync(pidFile, String(process.pid));
+  console.log(`Parked on port ${port}; first request wakes the stack.`);
+});
+
+for (const sig of ["SIGINT", "SIGTERM"] as const) {
+  process.on(sig, () => {
+    if (pidFile) fs.rmSync(pidFile, { force: true });
+    process.exit(0);
+  });
+}
+process.on("exit", () => {
+  if (pidFile) fs.rmSync(pidFile, { force: true });
+});

--- a/.mise-tasks/park.mts
+++ b/.mise-tasks/park.mts
@@ -12,13 +12,16 @@
 // when the real dashboard answers.
 //
 // The parker cannot proxy the dashboard once it is up (vite wants the port
-// itself), so it hands the port over instead: serve the page, close the
-// listener, spawn `mise run wake`. That leaves a window where nothing is
-// listening, which is why the interstitial polls from the browser — the page is
-// already loaded, so a refused fetch is just another retry.
+// itself), so it hands the port over instead. It keeps serving the interstitial
+// to every request -- a second tab, a reload, a probe -- while the wake it
+// started brings the containers up, and `mise run wake` kills it at the last
+// moment, immediately before vite binds. That leaves only a couple of seconds
+// where nothing is listening, which the interstitial covers by polling from the
+// browser: the page is already loaded, so a refused fetch is just another retry.
 //
-// Started detached by `mise run pause`; killed by `mise run wake` (and it exits
-// on its own once it has triggered a wake).
+// Started detached by `mise run pause`. Killed by `mise run wake`; the timeout
+// below is the backstop for a wake that dies before it gets there, since a
+// parker that outlived its wake would hold the port against vite forever.
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
@@ -49,52 +52,187 @@ function tls(): { key: Buffer; cert: Buffer } | null {
   }
 }
 
+// The Speakeasy mark from client/dashboard/src/assets/speakeasy-icon.svg,
+// inlined because the parker serves one self-contained response with no dev
+// server behind it to fetch assets from.
+function mark(size: number): string {
+  return `<svg width="${size}" height="${size}" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<rect x="4.5" y="4.5" width="291" height="291" rx="43.5" fill="white"/>
+<rect x="4.5" y="4.5" width="291" height="291" rx="43.5" stroke="url(#speakeasy-mark-${size})" stroke-width="9"/>
+<path d="M181.781 215.464L81.7665 201.253L74.0996 207.903L181.781 223.198L225.901 184.921L218.244 183.837L181.781 215.464Z" fill="#111111"/>
+<path d="M181.781 192.261L225.901 153.984L218.244 152.899L181.781 184.517L146.095 179.45L97.0809 172.494L81.7665 170.315L74.0996 176.965L89.4237 179.134L74.0996 192.424L181.781 207.719L225.901 169.452L218.244 168.367L181.79 199.995L130.771 192.74L138.428 186.1L181.781 192.261Z" fill="#111111"/>
+<path d="M181.781 169.045L81.7665 154.834L74.0996 161.484L181.781 176.779L225.901 138.512L218.244 137.428L181.781 169.045Z" fill="#111111"/>
+<path d="M218.244 106.478L202.92 119.767L181.781 138.105L140.443 132.232L81.7665 123.894L74.0996 130.543L132.776 138.872L125.119 145.522L81.7569 139.362L74.0996 146.011L181.781 161.307L225.901 123.04L210.577 120.861L225.901 107.562L218.244 106.478Z" fill="#111111"/>
+<path d="M225.901 92.0971L118.22 76.8018L74.0996 115.069L181.781 130.374L225.901 92.0971Z" fill="#111111"/>
+<defs><linearGradient id="speakeasy-mark-${size}" x1="150" y1="0" x2="150" y2="300" gradientUnits="userSpaceOnUse">
+<stop stop-color="#320F1E"/><stop offset="0.125625" stop-color="#C83228"/><stop offset="0.250625" stop-color="#FB873F"/>
+<stop offset="0.375625" stop-color="#D2DC91"/><stop offset="0.500625" stop-color="#5A8250"/><stop offset="0.620625" stop-color="#002314"/>
+<stop offset="0.740625" stop-color="#00143C"/><stop offset="0.860625" stop-color="#2873D7"/><stop offset="0.970625" stop-color="#9BC3FF"/>
+</linearGradient></defs>
+</svg>`;
+}
+
 const PAGE = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Resuming stack…</title>
 <style>
-  :root { color-scheme: light dark; }
+  /* A still of the login screen (client/dashboard/src/pages/login) under a
+     scrim, so the wake reads as "your dashboard, one moment" rather than as an
+     error page on an unfamiliar host. Static and inert on purpose: nothing here
+     can be fetched while the stack is down, so the panel is a facsimile, not
+     the real thing -- and the whole still is aria-hidden. */
+  :root {
+    --surface: hsl(0, 0%, 98%);
+    --card: #fff;
+    --edge: hsl(0, 0%, 86%);
+    --edge-soft: hsl(0, 0%, 92%);
+    --muted: hsl(0, 0%, 46%);
+    --muted-strong: hsl(0, 0%, 33%);
+    --cta: hsl(0, 0%, 20%);
+    --f-display: "Tobias", "Times New Roman", serif;
+    --f-sans: "Diatype", "Inter", system-ui, -apple-system, sans-serif;
+    --f-mono: "Diatype Mono", ui-monospace, SFMono-Regular, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
   body {
-    margin: 0; min-height: 100vh; display: grid; place-items: center;
-    font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
-    background: Canvas; color: CanvasText;
+    margin: 0; background: var(--surface); color: #000;
+    font-family: var(--f-sans); font-size: 15px; line-height: 1.5;
   }
-  main { text-align: center; max-width: 30rem; padding: 2rem; }
-  h1 { font-size: 1.25rem; font-weight: 600; margin: 0 0 .5rem; }
-  p { margin: 0; opacity: .7; }
-  code { font-family: ui-monospace, SFMono-Regular, monospace; }
-  .dot {
-    display: inline-block; width: .5rem; height: .5rem; margin-right: .5rem;
-    border-radius: 50%; background: currentColor; animation: pulse 1.2s infinite;
+  .mono { font-family: var(--f-mono); letter-spacing: .08em; text-transform: uppercase; }
+
+  /* --- login still ------------------------------------------------------ */
+  .shell { display: flex; flex-direction: column; min-height: 100vh; }
+  .gradient {
+    height: 4px; flex: none;
+    background: linear-gradient(90deg, #320F1E, #C83228 12.5%, #FB873F 25%,
+      #D2DC91 37.5%, #5A8250 50%, #002314 62%, #00143C 74%, #2873D7 86%, #9BC3FF);
   }
-  @keyframes pulse { 0%, 100% { opacity: .25 } 50% { opacity: 1 } }
+  header {
+    height: 64px; flex: none; display: flex; align-items: center;
+    justify-content: space-between; padding: 0 40px;
+    background: var(--card); border-bottom: 1px solid var(--edge);
+  }
+  header .left { display: flex; align-items: center; gap: 12px; font-size: 13px; }
+  header .right { font-size: 13px; color: var(--muted); }
+  .body { flex: 1; display: grid; grid-template-columns: 1fr; }
+  @media (min-width: 1280px) { .body { grid-template-columns: 1fr 1fr; } }
+  /* Stand-in for the agent-session showcase, which animates live data. */
+  .showcase { display: none; padding: 64px 48px; }
+  @media (min-width: 1280px) { .showcase { display: block; } }
+  .skel { border: 1px solid var(--edge-soft); background: var(--card); padding: 20px; }
+  .skel + .skel { margin-top: 16px; }
+  .bar { height: 10px; background: var(--edge-soft); }
+  .bar + .bar { margin-top: 10px; }
+  .panel {
+    display: flex; flex-direction: column; align-items: center;
+    justify-content: center; gap: 24px; padding: 64px 32px;
+    background: var(--card); border-left: 1px solid var(--edge-soft);
+  }
+  .lockup { display: flex; align-items: center; gap: 14px; }
+  .wordmark { font-family: var(--f-display); font-size: 34px; letter-spacing: -.01em; }
+  .pillars { display: flex; gap: 8px; }
+  .pillars span { border: 1px solid var(--edge); padding: 5px 11px; font-size: 11px; }
+  .cta {
+    width: 280px; height: 40px; display: flex; align-items: center;
+    justify-content: center; background: var(--cta); color: #fff;
+    font-family: var(--f-mono); font-size: 15px; text-transform: uppercase;
+  }
+  .fine { font-size: 11px; color: var(--muted); font-family: var(--f-mono); }
+
+  /* --- overlay ---------------------------------------------------------- */
+  .overlay {
+    position: fixed; inset: 0; display: grid; place-items: center;
+    padding: 24px; text-align: center;
+    /* Light enough that the login screen still reads through it -- the point
+       is "your dashboard is coming back", not a page of its own. */
+    background: hsl(0 0% 98% / .55);
+    -webkit-backdrop-filter: blur(3px);
+    backdrop-filter: blur(3px);
+  }
+  /* A panel, not free-floating text: the still behind it has its own copy in
+     the same weight, and centred text over centred text is unreadable. Square
+     corners to match the dashboard's design language. */
+  .overlay main {
+    background: hsl(0 0% 100% / .82);
+    border: 1px solid var(--edge-soft);
+    padding: 44px 56px 40px;
+    max-width: 34rem;
+  }
+  .overlay h1 {
+    font-family: var(--f-display); font-weight: 400; font-size: 34px;
+    margin: 24px 0 10px; letter-spacing: -.01em;
+  }
+  .overlay p { margin: 0 auto; max-width: 30rem; color: var(--muted-strong); }
+  .spinner { animation: spin 1.1s steps(12) infinite; color: #111; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .meta { margin-top: 20px; font-family: var(--f-mono); font-size: 12px; color: var(--muted); }
+  @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
 </style>
 </head>
 <body>
-<main>
-  <h1><span class="dot"></span>Resuming stack</h1>
-  <p>This worktree's containers and services are starting. The page reloads
-     when the dashboard answers — usually well under a minute.</p>
-  <p id="elapsed"></p>
-  <p><small>Logs: <code>mise run git:workstatus</code>, or
-     <code>pitchfork logs dashboard</code>.</small></p>
-</main>
+<div class="shell" aria-hidden="true">
+  <div class="gradient"></div>
+  <header>
+    <span class="left mono">${mark(22)} Speakeasy AI Control Plane</span>
+    <span class="right mono">Login</span>
+  </header>
+  <div class="body">
+    <div class="showcase">
+      <div class="skel"><div class="bar" style="width:40%"></div><div class="bar" style="width:80%"></div><div class="bar" style="width:65%"></div></div>
+      <div class="skel"><div class="bar" style="width:55%"></div><div class="bar" style="width:70%"></div></div>
+      <div class="skel"><div class="bar" style="width:30%"></div><div class="bar" style="width:85%"></div><div class="bar" style="width:50%"></div></div>
+    </div>
+    <div class="panel">
+      <div class="lockup">${mark(40)}<span class="wordmark">Speakeasy</span></div>
+      <div>
+        <p style="font-size:16px;margin:0">Securely scale AI usage across your organization.</p>
+        <p style="font-size:14px;margin:6px 0 0;color:var(--muted-strong)">Control plane to govern Agents, MCP and Skills</p>
+      </div>
+      <div class="pillars mono"><span>Observe</span><span>Secure</span><span>Connect</span><span>Distribute</span></div>
+      <div class="cta">Log in</div>
+      <p class="fine">Single sign-on through your identity provider.</p>
+    </div>
+  </div>
+</div>
+
+<div class="overlay" role="status" aria-live="polite">
+  <main>
+    <!-- lucide "loader" -->
+    <svg class="spinner" xmlns="http://www.w3.org/2000/svg" width="64" height="64"
+         viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M12 2v4"/><path d="m16.2 7.8 2.9-2.9"/><path d="M18 12h4"/>
+      <path d="m16.2 16.2 2.9 2.9"/><path d="M12 18v4"/><path d="m4.9 19.1 2.9-2.9"/>
+      <path d="M2 12h4"/><path d="m4.9 4.9 2.9 2.9"/>
+    </svg>
+    <h1>Resuming stack</h1>
+    <p>This worktree's containers and services are starting. The page reloads
+       as soon as the dashboard answers.</p>
+    <p class="meta"><span id="elapsed">0s</span> &middot; logs: pitchfork logs dashboard</p>
+  </main>
+</div>
+
 <script>
   const started = Date.now();
   const elapsed = document.getElementById("elapsed");
   setInterval(() => {
     elapsed.textContent = Math.round((Date.now() - started) / 1000) + "s";
   }, 1000);
-  // The parker closes its listener as soon as it has answered this request, so
-  // the next few probes are refused connections — expected, not an error.
-  // Cache-busted so a probe can't be answered from the bfcache.
+  // Two things answer this origin in turn: the parker (which marks its
+  // responses) and then vite. Refused connections in between are the couple of
+  // seconds after the parker lets go — expected, not an error. Cache-busted so
+  // a probe can't be answered from the bfcache.
   async function poll() {
     try {
-      await fetch("/?__wake=" + Date.now(), { cache: "no-store" });
-      location.replace("/");
-      return;
+      const res = await fetch("/?__wake=" + Date.now(), { cache: "no-store" });
+      if (!res.headers.get("x-gram-parked")) {
+        location.replace("/");
+        return;
+      }
     } catch {}
     setTimeout(poll, 1000);
   }
@@ -109,6 +247,14 @@ let waking = false;
 function wake(): void {
   if (waking) return;
   waking = true;
+
+  setTimeout(() => {
+    console.error(
+      "wake did not take the port within 10 minutes; releasing it. " +
+        "Check the wake log, then run `mise run wake` by hand.",
+    );
+    process.exit(1);
+  }, WAKE_TIMEOUT_MS).unref();
 
   const out = wakeLog
     ? fs.openSync(wakeLog, "a")
@@ -129,15 +275,13 @@ const handler = (
   res.writeHead(200, {
     "content-type": "text/html; charset=utf-8",
     "cache-control": "no-store",
+    // How the page in the browser tells this parker apart from the dashboard
+    // it is waiting for: the parker keeps answering on the same origin, so a
+    // successful fetch alone would send the page reloading into itself.
+    "x-gram-parked": "1",
   });
   res.end(PAGE, () => {
-    // Free the port before `wake` starts vite, and only once the page is
-    // actually on the wire — closing earlier would strand this response.
-    server.close();
     wake();
-    // The browser polls from here; nothing else needs this process. Give the
-    // socket a moment to drain, then leave the port to vite.
-    setTimeout(() => process.exit(0), 500);
   });
 };
 
@@ -157,6 +301,12 @@ server.listen(port, () => {
   if (pidFile) fs.writeFileSync(pidFile, String(process.pid));
   console.log(`Parked on port ${port}; first request wakes the stack.`);
 });
+
+// Backstop, generous enough to cover a cold `wake` (image pulls, a slow
+// ClickHouse) but bounded, so a wake that died on its way to killing the parker
+// cannot leave the port held. Only armed once a wake is actually running -- an
+// untouched parker on a paused worktree is meant to sit there indefinitely.
+const WAKE_TIMEOUT_MS = 10 * 60 * 1000;
 
 for (const sig of ["SIGINT", "SIGTERM"] as const) {
   process.on(sig, () => {

--- a/.mise-tasks/park.mts
+++ b/.mise-tasks/park.mts
@@ -7,16 +7,18 @@
 // `mise run pause` leaves the stack complete but stopped, which also leaves the
 // dashboard URL dead — so a bookmark, a `wt list` link or an agent's browser
 // step lands on a connection error and the developer has to know that `mise run
-// wake` exists. This task parks on the site port in the stack's place: the
-// first request gets an interstitial that starts the wake and reloads itself
-// when the real dashboard answers.
+// wake` exists. This task parks on the site port in the stack's place and
+// serves a page that says the stack is paused and offers to resume it. The
+// resume is behind a button, not behind the page load: prefetches, link
+// previews and reconnecting tabs all hit this port, and a stack that wakes
+// itself on any of them cannot be kept paused.
 //
 // The parker cannot proxy the dashboard once it is up (vite wants the port
-// itself), so it hands the port over instead. It keeps serving the interstitial
-// to every request -- a second tab, a reload, a probe -- while the wake it
+// itself), so it hands the port over instead. It keeps serving the page to
+// every request -- a second tab, a reload, a probe -- while the wake the button
 // started brings the containers up, and `mise run wake` kills it at the last
 // moment, immediately before vite binds. That leaves only a couple of seconds
-// where nothing is listening, which the interstitial covers by polling from the
+// where nothing is listening, which the page covers by polling from the
 // browser: the page is already loaded, so a refused fetch is just another retry.
 //
 // Started detached by `mise run pause`. Killed by `mise run wake`; the timeout
@@ -167,10 +169,20 @@ const PAGE = `<!doctype html>
     margin: 24px 0 10px; letter-spacing: -.01em;
   }
   .overlay p { margin: 0 auto; max-width: 30rem; color: var(--muted-strong); }
-  .spinner { animation: spin 1.1s steps(12) infinite; color: #111; }
+  #loader { color: #111; opacity: .35; }
+  /* Motion is the signal that something is happening, so it starts with the
+     resume rather than with the page. */
+  #loader.spinning { opacity: 1; animation: spin 1.1s steps(12) infinite; }
   @keyframes spin { to { transform: rotate(360deg); } }
+  .button {
+    margin-top: 24px; width: 280px; height: 40px; border: 0; cursor: pointer;
+    background: var(--cta); color: #fff; font-family: var(--f-mono);
+    font-size: 15px; text-transform: uppercase; letter-spacing: .01em;
+  }
+  .button:hover { background: hsl(0, 0%, 14%); }
+  .button:disabled { opacity: .5; cursor: default; }
   .meta { margin-top: 20px; font-family: var(--f-mono); font-size: 12px; color: var(--muted); }
-  @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+  @media (prefers-reduced-motion: reduce) { #loader.spinning { animation: none; } }
 </style>
 </head>
 <body>
@@ -201,34 +213,67 @@ const PAGE = `<!doctype html>
 
 <div class="overlay" role="status" aria-live="polite">
   <main>
-    <!-- lucide "loader" -->
-    <svg class="spinner" xmlns="http://www.w3.org/2000/svg" width="64" height="64"
+    <!-- lucide "loader", still until the resume starts -->
+    <svg id="loader" xmlns="http://www.w3.org/2000/svg" width="64" height="64"
          viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <path d="M12 2v4"/><path d="m16.2 7.8 2.9-2.9"/><path d="M18 12h4"/>
       <path d="m16.2 16.2 2.9 2.9"/><path d="M12 18v4"/><path d="m4.9 19.1 2.9-2.9"/>
       <path d="M2 12h4"/><path d="m4.9 4.9 2.9 2.9"/>
     </svg>
-    <h1>Resuming stack</h1>
-    <p>This worktree's containers and services are starting. The page reloads
-       as soon as the dashboard answers.</p>
-    <p class="meta"><span id="elapsed">0s</span> &middot; logs: pitchfork logs dashboard</p>
+
+    <div id="idle">
+      <h1>Stack paused</h1>
+      <p>This worktree's containers and services are stopped. Their data is
+         intact — resuming takes about half a minute.</p>
+      <button id="resume" class="button" type="button">Resume stack</button>
+      <p class="meta">Or run <b>mise run wake</b> in the worktree.</p>
+    </div>
+
+    <div id="resuming" hidden>
+      <h1>Resuming stack</h1>
+      <p>Containers and services are starting. The page reloads as soon as the
+         dashboard answers.</p>
+      <p class="meta"><span id="elapsed">0s</span> &middot; logs: pitchfork logs dashboard</p>
+    </div>
   </main>
 </div>
 
 <script>
-  const started = Date.now();
+  const idle = document.getElementById("idle");
+  const resuming = document.getElementById("resuming");
+  const loader = document.getElementById("loader");
+  const button = document.getElementById("resume");
   const elapsed = document.getElementById("elapsed");
-  setInterval(() => {
-    elapsed.textContent = Math.round((Date.now() - started) / 1000) + "s";
-  }, 1000);
+
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+    // Ask the parker to start the wake. Nothing else does: a page load on its
+    // own leaves the stack exactly as it found it.
+    try {
+      await fetch("/__wake", { method: "POST", cache: "no-store" });
+    } catch {
+      // The parker answers before it can be killed, so a failure here means it
+      // is already gone — the poll below sorts out which.
+    }
+    idle.hidden = true;
+    resuming.hidden = false;
+    loader.classList.add("spinning");
+
+    const started = Date.now();
+    setInterval(() => {
+      elapsed.textContent = Math.round((Date.now() - started) / 1000) + "s";
+    }, 1000);
+    setTimeout(poll, 2000);
+  });
+
   // Two things answer this origin in turn: the parker (which marks its
   // responses) and then vite. Refused connections in between are the couple of
   // seconds after the parker lets go — expected, not an error. Cache-busted so
   // a probe can't be answered from the bfcache.
   async function poll() {
     try {
-      const res = await fetch("/?__wake=" + Date.now(), { cache: "no-store" });
+      const res = await fetch("/?__poll=" + Date.now(), { cache: "no-store" });
       if (!res.headers.get("x-gram-parked")) {
         location.replace("/");
         return;
@@ -236,7 +281,6 @@ const PAGE = `<!doctype html>
     } catch {}
     setTimeout(poll, 1000);
   }
-  setTimeout(poll, 2000);
 </script>
 </body>
 </html>
@@ -268,10 +312,23 @@ function wake(): void {
 }
 
 const creds = tls();
-const handler = (
-  _req: http.IncomingMessage,
-  res: http.ServerResponse,
-): void => {
+const handler = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+  // Waking is deliberately behind a click rather than behind the page load:
+  // a bookmark opened by accident, a browser prefetch, a link preview or a
+  // still-open tab reconnecting would otherwise each start a stack the
+  // developer did not ask for -- and pausing a worktree that keeps waking
+  // itself is a losing game.
+  if (req.method === "POST" && (req.url ?? "").startsWith("/__wake")) {
+    wake();
+    res.writeHead(202, {
+      "content-type": "text/plain",
+      "cache-control": "no-store",
+      "x-gram-parked": "1",
+    });
+    res.end("waking");
+    return;
+  }
+
   res.writeHead(200, {
     "content-type": "text/html; charset=utf-8",
     "cache-control": "no-store",
@@ -280,9 +337,7 @@ const handler = (
     // successful fetch alone would send the page reloading into itself.
     "x-gram-parked": "1",
   });
-  res.end(PAGE, () => {
-    wake();
-  });
+  res.end(PAGE);
 };
 
 const server = creds
@@ -299,7 +354,7 @@ server.on("error", (err: NodeJS.ErrnoException) => {
 
 server.listen(port, () => {
   if (pidFile) fs.writeFileSync(pidFile, String(process.pid));
-  console.log(`Parked on port ${port}; first request wakes the stack.`);
+  console.log(`Parked on port ${port}; serving the resume page.`);
 });
 
 // Backstop, generous enough to cover a cold `wake` (image pulls, a slow

--- a/.mise-tasks/park.mts
+++ b/.mise-tasks/park.mts
@@ -79,7 +79,7 @@ const PAGE = `<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Resuming stack…</title>
+<title>Stack paused</title>
 <style>
   /* A still of the login screen (client/dashboard/src/pages/login) under a
      scrim, so the wake reads as "your dashboard, one moment" rather than as an
@@ -259,6 +259,9 @@ const PAGE = `<!doctype html>
     idle.hidden = true;
     resuming.hidden = false;
     loader.classList.add("spinning");
+    // The tab title is the only part of this page visible once it is in the
+    // background, which is exactly where it sits during a wake.
+    document.title = "Resuming stack…";
 
     const started = Date.now();
     setInterval(() => {
@@ -312,7 +315,25 @@ function wake(): void {
 }
 
 const creds = tls();
+// The parker holds a dev port and its only endpoint starts a whole stack, so it
+// answers nobody but this machine. Filtering by peer address rather than
+// binding to 127.0.0.1 keeps `localhost` working in the browser: on macOS that
+// resolves to ::1 first, and one Node listener cannot cover both loopback
+// families.
+function fromLoopback(req: http.IncomingMessage): boolean {
+  const addr = req.socket.remoteAddress ?? "";
+  return (
+    addr === "::1" || addr === "::ffff:127.0.0.1" || addr.startsWith("127.")
+  );
+}
+
 const handler = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+  if (!fromLoopback(req)) {
+    res.writeHead(403, { "content-type": "text/plain" });
+    res.end("This worktree's stack can only be resumed from this machine.\n");
+    return;
+  }
+
   // Waking is deliberately behind a click rather than behind the page load:
   // a bookmark opened by accident, a browser prefetch, a link preview or a
   // still-open tab reconnecting would otherwise each start a stack the

--- a/.mise-tasks/pause.sh
+++ b/.mise-tasks/pause.sh
@@ -16,35 +16,54 @@ gitdir="$(git rev-parse --absolute-git-dir)"
 # Pause and wake move the same containers in opposite directions, and both can
 # start without the developer: the idle sweep pauses, the parker's Resume
 # button wakes. Interleaved, they leave the worktree half-up -- daemons running
-# against stopped databases, or a paused marker over a running stack. mkdir is
-# the portable atomic test-and-set (macOS has no flock binary), and the pid
-# inside it tells a stale lock from a live one.
+# against stopped databases, or a paused marker over a running stack. A symlink
+# is the portable atomic test-and-set here (macOS has no flock binary).
 lock="$gitdir/gram-stack-lock"
+
+# `ln -s` is the atomic test-and-set: creating a symlink fails if the name
+# exists, and its target carries the owner's pid, so the lock and the identity
+# of its owner appear in one step. (A lock file written after a `mkdir` has a
+# window where it exists with no owner recorded, which another process reads as
+# abandoned.) The target is a pid string and never has to resolve.
 release_lock() {
-    rm -f "$lock/pid" 2> /dev/null; rmdir "$lock" 2> /dev/null || true
+    # Only release a lock this process still owns.
+    if [ "$(readlink "$lock" 2> /dev/null)" = "$$" ]; then
+        rm -f "$lock"
+    fi
 }
+
+# Clearing a dead owner's lock cannot be done from the plain retry loop:
+# between reading the owner and removing it, another process can acquire the
+# lock, and the removal then evicts a live holder -- two commands end up
+# running against the same containers. So removal happens under its own lock,
+# which is only ever taken by exclusive create; whoever holds it re-reads the
+# owner before removing anything.
+reap_stale_lock() {
+    local reap="$lock.reap" owner
+    ln -s "$$" "$reap" 2> /dev/null || return 1
+    owner="$(readlink "$lock" 2> /dev/null || true)"
+    if [ -n "$owner" ] && ! kill -0 "$owner" 2> /dev/null; then
+        echo "Clearing a stack lock left behind by a dead process ($owner)." >&2
+        rm -f "$lock"
+    fi
+    rm -f "$reap"
+}
+
 locked=false
 for _ in $(seq 1 60); do
-    if mkdir "$lock" 2> /dev/null; then
-        echo $$ > "$lock/pid"
+    if ln -s "$$" "$lock" 2> /dev/null; then
         trap release_lock EXIT
         locked=true
         break
     fi
-
-    # Only a lock whose owner is gone -- a killed pause or wake, a reboot -- is
-    # safe to clear. An age-based break would eventually steal the lock from a
-    # slow but healthy wake, which is the very thing this guards against.
-    owner="$(cat "$lock/pid" 2> /dev/null || true)"
-    if [ -z "$owner" ] || ! kill -0 "$owner" 2> /dev/null; then
-        echo "Clearing a stack lock left behind by a dead process." >&2
-        release_lock
-    fi
+    reap_stale_lock || true
     sleep 1
 done
 
 if [ "$locked" != true ]; then
-    echo "Another pause or wake has held this worktree's stack lock for a minute; giving up." >&2
+    owner="$(readlink "$lock" 2> /dev/null || true)"
+    echo "Another pause or wake (pid ${owner:-unknown}) has held this worktree's stack lock for a minute; giving up." >&2
+    echo "If nothing is running, remove $lock and retry." >&2
     exit 1
 fi
 

--- a/.mise-tasks/pause.sh
+++ b/.mise-tasks/pause.sh
@@ -29,8 +29,8 @@ gitdir="$(git rev-parse --absolute-git-dir)"
 
 
 # Park on the site port in the dashboard's place, so the worktree's URL answers
-# with a "Resuming stack" page that triggers the wake instead of a connection
-# error. Detached and nohup'd: `pause` is often run from a shell that goes away
+# with a page that says the stack is paused and offers a Resume button, instead
+# of a connection error. Detached and nohup'd: `pause` is often run from a shell that goes away
 # (and from `git:workboot`, whose whole process group is killed when the boot
 # hook finishes). The parker exits on its own once it has woken the stack, and
 # `mise run wake` kills it first when the wake comes from the CLI instead.
@@ -49,4 +49,4 @@ if [ -z "${GRAM_NO_PARK:-}" ]; then
     disown 2> /dev/null || true
 fi
 
-echo "Stack paused. Resume with \`mise run wake\`, or by opening ${GRAM_SITE_URL:-the dashboard URL}."
+echo "Stack paused. Resume with \`mise run wake\`, or from ${GRAM_SITE_URL:-the dashboard URL}."

--- a/.mise-tasks/pause.sh
+++ b/.mise-tasks/pause.sh
@@ -11,6 +11,29 @@ set -e
 # `docker compose start` rather than a re-create plus migrations plus seed.
 # The shared stack (compose.shared.yml) is left alone -- other worktrees use it.
 
+gitdir="$(git rev-parse --absolute-git-dir)"
+
+# Pause and wake move the same containers in opposite directions, and both can
+# start without the developer: the idle sweep pauses, the parker's Resume
+# button wakes. Interleaved, they leave the worktree half-up -- daemons running
+# against stopped databases, or a paused marker over a running stack. mkdir is
+# the portable atomic test-and-set (macOS has no flock binary).
+lock="$gitdir/gram-stack-lock"
+for _ in $(seq 1 60); do
+    if mkdir "$lock" 2> /dev/null; then
+        trap 'rmdir "$lock" 2> /dev/null || true' EXIT
+        break
+    fi
+    # A lock left behind by a killed pause or wake would otherwise block this
+    # worktree forever, and the operation it guards is bounded by the wake's
+    # own runtime.
+    if [ -n "$(find "$lock" -maxdepth 0 -mmin +10 2> /dev/null)" ]; then
+        echo "Clearing a stale stack lock." >&2
+        rmdir "$lock" 2> /dev/null || true
+    fi
+    sleep 1
+done
+
 # Best-effort, as in infra:stop: a supervisor that is not running is not an
 # error here, and neither is a daemon that has already exited.
 if pitchfork supervisor status &> /dev/null; then
@@ -24,29 +47,49 @@ docker compose --profile "*" stop
 # booted and needs a full `./zero --agent`. It also outranks port liveness,
 # since the parker below deliberately keeps the site port listening. `wake`
 # removes it.
-gitdir="$(git rev-parse --absolute-git-dir)"
 : > "$gitdir/gram-stack-paused"
 
+# The idle sweep's activity clock. Left behind, it is a timestamp from before
+# this pause, so the next wake would be measured against it and could be
+# paused again on the sweep's first quiet sample.
+rm -f "$gitdir/gram-stack-lastseen"
 
 # Park on the site port in the dashboard's place, so the worktree's URL answers
 # with a page that says the stack is paused and offers a Resume button, instead
-# of a connection error. Detached and nohup'd: `pause` is often run from a shell that goes away
-# (and from `git:workboot`, whose whole process group is killed when the boot
-# hook finishes). The parker exits on its own once it has woken the stack, and
-# `mise run wake` kills it first when the wake comes from the CLI instead.
+# of a connection error. The parker has to outlive this script: `pause` is
+# often run from a shell that goes away, and from `git:workboot`, whose whole
+# process GROUP wt signals when the hook finishes.
 if [ -z "${GRAM_NO_PARK:-}" ]; then
-    # `setsid` where it exists (Linux, and macOS with util-linux installed)
-    # puts the parker in its own session, so a caller whose whole process
-    # GROUP is signalled -- which is how wt reaps the post-start hook -- cannot
-    # take it down with them. nohup+& is the portable fallback.
+    rm -f "$gitdir/gram-stack-parked.pid"
+
+    # A new session is what actually detaches it -- `nohup` only ignores
+    # SIGHUP and leaves the process in this group, so wt's reap would still
+    # take it down. setsid where it exists (Linux), perl's POSIX::setsid
+    # otherwise (macOS ships perl but not setsid), nohup as the last resort.
     if command -v setsid > /dev/null 2>&1; then
         GRAM_PARK_GIT_DIR="$gitdir" setsid mise run park \
             > "$gitdir/gram-stack-park.log" 2>&1 &
+    elif command -v perl > /dev/null 2>&1; then
+        GRAM_PARK_GIT_DIR="$gitdir" perl -MPOSIX -e 'setsid; exec @ARGV' \
+            mise run park > "$gitdir/gram-stack-park.log" 2>&1 &
     else
         GRAM_PARK_GIT_DIR="$gitdir" nohup mise run park \
             > "$gitdir/gram-stack-park.log" 2>&1 &
     fi
     disown 2> /dev/null || true
+
+    # The parker writes its pid file once it is actually listening, so this
+    # also catches the failure that matters: another process already holds the
+    # site port. Reported rather than fatal -- the stack IS paused either way,
+    # and the only thing lost is the resume page.
+    for _ in $(seq 1 20); do
+        [ -f "$gitdir/gram-stack-parked.pid" ] && break
+        sleep 0.5
+    done
+    if [ ! -f "$gitdir/gram-stack-parked.pid" ]; then
+        echo "⚠️  The resume page did not come up; wake with \`mise run wake\`." >&2
+        echo "    Log: $gitdir/gram-stack-park.log" >&2
+    fi
 fi
 
 echo "Stack paused. Resume with \`mise run wake\`, or from ${GRAM_SITE_URL:-the dashboard URL}."

--- a/.mise-tasks/pause.sh
+++ b/.mise-tasks/pause.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+#MISE description="Stop this worktree's daemons and pause its containers, keeping their data"
+#MISE dir="{{ config_root }}"
+#MISE alias="sleep"
+
+set -e
+
+# The counterpart of `mise run wake`. Unlike `infra:stop`, this does NOT `down`
+# the compose project: containers and volumes stay, so waking again is a
+# `docker compose start` rather than a re-create plus migrations plus seed.
+# The shared stack (compose.shared.yml) is left alone -- other worktrees use it.
+
+# Best-effort, as in infra:stop: a supervisor that is not running is not an
+# error here, and neither is a daemon that has already exited.
+if pitchfork supervisor status &> /dev/null; then
+    pitchfork stop --all-local || true
+fi
+
+docker compose --profile "*" stop
+
+# Marker for `git:workstatus` / `git:worktui`: a paused stack has no boot
+# marker, which otherwise reads as `down` -- i.e. as a worktree that never
+# booted and needs a full `./zero --agent`. It also outranks port liveness,
+# since the parker below deliberately keeps the site port listening. `wake`
+# removes it.
+gitdir="$(git rev-parse --absolute-git-dir)"
+: > "$gitdir/gram-stack-paused"
+
+
+# Park on the site port in the dashboard's place, so the worktree's URL answers
+# with a "Resuming stack" page that triggers the wake instead of a connection
+# error. Detached and nohup'd: `pause` is often run from a shell that goes away
+# (and from `git:workboot`, whose whole process group is killed when the boot
+# hook finishes). The parker exits on its own once it has woken the stack, and
+# `mise run wake` kills it first when the wake comes from the CLI instead.
+if [ -z "${GRAM_NO_PARK:-}" ]; then
+    # `setsid` where it exists (Linux, and macOS with util-linux installed)
+    # puts the parker in its own session, so a caller whose whole process
+    # GROUP is signalled -- which is how wt reaps the post-start hook -- cannot
+    # take it down with them. nohup+& is the portable fallback.
+    if command -v setsid > /dev/null 2>&1; then
+        GRAM_PARK_GIT_DIR="$gitdir" setsid mise run park \
+            > "$gitdir/gram-stack-park.log" 2>&1 &
+    else
+        GRAM_PARK_GIT_DIR="$gitdir" nohup mise run park \
+            > "$gitdir/gram-stack-park.log" 2>&1 &
+    fi
+    disown 2> /dev/null || true
+fi
+
+echo "Stack paused. Resume with \`mise run wake\`, or by opening ${GRAM_SITE_URL:-the dashboard URL}."

--- a/.mise-tasks/pause.sh
+++ b/.mise-tasks/pause.sh
@@ -17,22 +17,36 @@ gitdir="$(git rev-parse --absolute-git-dir)"
 # start without the developer: the idle sweep pauses, the parker's Resume
 # button wakes. Interleaved, they leave the worktree half-up -- daemons running
 # against stopped databases, or a paused marker over a running stack. mkdir is
-# the portable atomic test-and-set (macOS has no flock binary).
+# the portable atomic test-and-set (macOS has no flock binary), and the pid
+# inside it tells a stale lock from a live one.
 lock="$gitdir/gram-stack-lock"
+release_lock() {
+    rm -f "$lock/pid" 2> /dev/null; rmdir "$lock" 2> /dev/null || true
+}
+locked=false
 for _ in $(seq 1 60); do
     if mkdir "$lock" 2> /dev/null; then
-        trap 'rmdir "$lock" 2> /dev/null || true' EXIT
+        echo $$ > "$lock/pid"
+        trap release_lock EXIT
+        locked=true
         break
     fi
-    # A lock left behind by a killed pause or wake would otherwise block this
-    # worktree forever, and the operation it guards is bounded by the wake's
-    # own runtime.
-    if [ -n "$(find "$lock" -maxdepth 0 -mmin +10 2> /dev/null)" ]; then
-        echo "Clearing a stale stack lock." >&2
-        rmdir "$lock" 2> /dev/null || true
+
+    # Only a lock whose owner is gone -- a killed pause or wake, a reboot -- is
+    # safe to clear. An age-based break would eventually steal the lock from a
+    # slow but healthy wake, which is the very thing this guards against.
+    owner="$(cat "$lock/pid" 2> /dev/null || true)"
+    if [ -z "$owner" ] || ! kill -0 "$owner" 2> /dev/null; then
+        echo "Clearing a stack lock left behind by a dead process." >&2
+        release_lock
     fi
     sleep 1
 done
+
+if [ "$locked" != true ]; then
+    echo "Another pause or wake has held this worktree's stack lock for a minute; giving up." >&2
+    exit 1
+fi
 
 # Best-effort, as in infra:stop: a supervisor that is not running is not an
 # error here, and neither is a daemon that has already exited.
@@ -60,7 +74,17 @@ rm -f "$gitdir/gram-stack-lastseen"
 # often run from a shell that goes away, and from `git:workboot`, whose whole
 # process GROUP wt signals when the hook finishes.
 if [ -z "${GRAM_NO_PARK:-}" ]; then
-    rm -f "$gitdir/gram-stack-parked.pid"
+    # Pausing an already-paused worktree finds a parker still holding the port.
+    # Dropping its pid file would orphan it: the replacement dies on
+    # EADDRINUSE, and the next wake has no pid left to kill, so vite cannot
+    # bind either. The parker that is up is as good as a new one.
+    parked="$gitdir/gram-stack-parked.pid"
+    park_pid="$(cat "$parked" 2> /dev/null || true)"
+    if [ -n "$park_pid" ] && ps -o command= -p "$park_pid" 2> /dev/null | grep -q "park"; then
+        echo "Stack paused. Resume with \`mise run wake\`, or from ${GRAM_SITE_URL:-the dashboard URL}."
+        exit 0
+    fi
+    rm -f "$parked"
 
     # A new session is what actually detaches it -- `nohup` only ignores
     # SIGHUP and leaves the process in this group, so wt's reap would still

--- a/.mise-tasks/playwright/_default
+++ b/.mise-tasks/playwright/_default
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 #MISE description="Run Playwright CLI, installing its browser on first use"
+# Browser automation always targets the local dashboard, so wake a paused stack
+# first -- otherwise the run screenshots the parker's "Resuming stack" page.
+#MISE depends=["ensure-stack"]
 
 set -e
 

--- a/.mise-tasks/seed.sh
+++ b/.mise-tasks/seed.sh
@@ -2,6 +2,7 @@
 
 #MISE description="Seed the local development organization (data + your user, API key)"
 #MISE dir="{{ config_root }}"
+#MISE depends=["ensure-stack"]
 
 set -euo pipefail
 

--- a/.mise-tasks/wake.sh
+++ b/.mise-tasks/wake.sh
@@ -18,31 +18,51 @@ gitdir="$(git rev-parse --absolute-git-dir)"
 # race a pause. Duplicated rather than sourced from a helper because every file
 # under .mise-tasks/ is itself a task.
 lock="$gitdir/gram-stack-lock"
+
+# `ln -s` is the atomic test-and-set: creating a symlink fails if the name
+# exists, and its target carries the owner's pid, so the lock and the identity
+# of its owner appear in one step. (A lock file written after a `mkdir` has a
+# window where it exists with no owner recorded, which another process reads as
+# abandoned.) The target is a pid string and never has to resolve.
 release_lock() {
-    rm -f "$lock/pid" 2> /dev/null; rmdir "$lock" 2> /dev/null || true
+    # Only release a lock this process still owns.
+    if [ "$(readlink "$lock" 2> /dev/null)" = "$$" ]; then
+        rm -f "$lock"
+    fi
 }
+
+# Clearing a dead owner's lock cannot be done from the plain retry loop:
+# between reading the owner and removing it, another process can acquire the
+# lock, and the removal then evicts a live holder -- two commands end up
+# running against the same containers. So removal happens under its own lock,
+# which is only ever taken by exclusive create; whoever holds it re-reads the
+# owner before removing anything.
+reap_stale_lock() {
+    local reap="$lock.reap" owner
+    ln -s "$$" "$reap" 2> /dev/null || return 1
+    owner="$(readlink "$lock" 2> /dev/null || true)"
+    if [ -n "$owner" ] && ! kill -0 "$owner" 2> /dev/null; then
+        echo "Clearing a stack lock left behind by a dead process ($owner)." >&2
+        rm -f "$lock"
+    fi
+    rm -f "$reap"
+}
+
 locked=false
 for _ in $(seq 1 60); do
-    if mkdir "$lock" 2> /dev/null; then
-        echo $$ > "$lock/pid"
+    if ln -s "$$" "$lock" 2> /dev/null; then
         trap release_lock EXIT
         locked=true
         break
     fi
-
-    # Only a lock whose owner is gone -- a killed pause or wake, a reboot -- is
-    # safe to clear. An age-based break would eventually steal the lock from a
-    # slow but healthy wake, which is the very thing this guards against.
-    owner="$(cat "$lock/pid" 2> /dev/null || true)"
-    if [ -z "$owner" ] || ! kill -0 "$owner" 2> /dev/null; then
-        echo "Clearing a stack lock left behind by a dead process." >&2
-        release_lock
-    fi
+    reap_stale_lock || true
     sleep 1
 done
 
 if [ "$locked" != true ]; then
-    echo "Another pause or wake has held this worktree's stack lock for a minute; giving up." >&2
+    owner="$(readlink "$lock" 2> /dev/null || true)"
+    echo "Another pause or wake (pid ${owner:-unknown}) has held this worktree's stack lock for a minute; giving up." >&2
+    echo "If nothing is running, remove $lock and retry." >&2
     exit 1
 fi
 

--- a/.mise-tasks/wake.sh
+++ b/.mise-tasks/wake.sh
@@ -13,32 +13,84 @@ set -e
 
 gitdir="$(git rev-parse --absolute-git-dir)"
 
+# See the same block in `mise run pause`: two wakes can be asked for at once
+# (the parker's Resume button and an `ensure-stack` dependency), and a wake can
+# race a pause. Duplicated rather than sourced from a helper because every file
+# under .mise-tasks/ is itself a task.
+lock="$gitdir/gram-stack-lock"
+for _ in $(seq 1 60); do
+    if mkdir "$lock" 2> /dev/null; then
+        trap 'rmdir "$lock" 2> /dev/null || true' EXIT
+        break
+    fi
+    if [ -n "$(find "$lock" -maxdepth 0 -mmin +10 2> /dev/null)" ]; then
+        echo "Clearing a stale stack lock." >&2
+        rmdir "$lock" 2> /dev/null || true
+    fi
+    sleep 1
+done
+
+# A boot builds the stack from nothing and ends by pausing it. Waking underneath
+# one races its migrations and its seed.
+if [ -f "$gitdir/gram-stack-boot.pid" ]; then
+    boot_pid=$(cat "$gitdir/gram-stack-boot.pid")
+    if ps -o command= -p "$boot_pid" 2> /dev/null | grep -q workboot; then
+        echo "This worktree is still booting — watch it with \`mise run git:workstatus\`." >&2
+        exit 1
+    fi
+fi
+
 # `mise run pause` parks a placeholder server on the site port (see
-# `mise run park`), which serves the "Resuming stack" page for as long as it
-# holds it. Killing it is deferred until the containers are up, just before
-# vite binds: a wake takes tens of seconds, and every reload or extra tab in
-# that window should get the page rather than a connection error.
+# `mise run park`), which serves the resume page for as long as it holds it.
+# Killing it is deferred until the containers are up, just before vite binds: a
+# wake takes tens of seconds, and every reload or extra tab in that window
+# should get the page rather than a connection error.
 parked="$gitdir/gram-stack-parked.pid"
 release_port() {
     if [ -f "$parked" ]; then
-        kill "$(cat "$parked")" 2> /dev/null || true
+        # A pid file can outlive its process (SIGKILL, a reboot) and pids are
+        # reused, so check what the pid actually is before signalling it.
+        park_pid=$(cat "$parked")
+        if ps -o command= -p "$park_pid" 2> /dev/null | grep -q "park"; then
+            kill "$park_pid" 2> /dev/null || true
+            # The listener closes on signal delivery, not on return from kill.
+            sleep 1
+        fi
         rm -f "$parked"
-        # The listener closes on signal delivery, not on return from kill.
-        sleep 1
     fi
 }
 
 # No containers at all means this worktree was never booted (or was nuked), so
 # there is nothing to wake: migrations have never run and the databases are
-# empty. Do the full boot instead of starting daemons against an empty DB.
-if [ -z "$(docker compose ps -aq 2>/dev/null)" ]; then
+# empty. Distinguish that from a compose that failed to answer -- treating an
+# error as "no containers" would run `zero`, whose seed rewrites local data.
+if ! containers="$(docker compose ps -aq 2> /dev/null)"; then
+    echo "\`docker compose ps\` failed — is the Docker daemon running?" >&2
+    exit 1
+fi
+
+if [ -z "$containers" ]; then
     echo "No containers for this worktree yet — running a full boot instead."
     release_port
-    exec ./zero --agent
+    # Same markers and the same cold-volume timeout `git:workboot` uses: `exec`
+    # replaces this shell, so nothing here runs afterwards to clean up.
+    rm -f "$gitdir/gram-stack-paused" "$gitdir/gram-stack-lastseen"
+    rmdir "$lock" 2> /dev/null || true
+    trap - EXIT
+    exec env INFRA_READINESS_TIMEOUT=300 ./zero --agent
 fi
+
+# `pause` stops every profile, so start every container that exists before
+# `infra:start` asserts the default ones. Without this a worktree that had an
+# optional profile up (litellm, local-registry) comes back missing it.
+docker compose --profile "*" start > /dev/null 2>&1 || true
 
 mise run infra:start
 release_port
 mise run start
 
-rm -f "$gitdir/gram-stack-paused"
+# A stack that is up is no longer paused, is no longer failed (a `failed`
+# marker outranks `paused` in git:workstatus, so a recovered worktree would
+# keep reading as broken), and starts its idle clock from now.
+rm -f "$gitdir/gram-stack-paused" "$gitdir/gram-stack-boot.failed" \
+    "$gitdir/gram-stack-lastseen"

--- a/.mise-tasks/wake.sh
+++ b/.mise-tasks/wake.sh
@@ -18,17 +18,33 @@ gitdir="$(git rev-parse --absolute-git-dir)"
 # race a pause. Duplicated rather than sourced from a helper because every file
 # under .mise-tasks/ is itself a task.
 lock="$gitdir/gram-stack-lock"
+release_lock() {
+    rm -f "$lock/pid" 2> /dev/null; rmdir "$lock" 2> /dev/null || true
+}
+locked=false
 for _ in $(seq 1 60); do
     if mkdir "$lock" 2> /dev/null; then
-        trap 'rmdir "$lock" 2> /dev/null || true' EXIT
+        echo $$ > "$lock/pid"
+        trap release_lock EXIT
+        locked=true
         break
     fi
-    if [ -n "$(find "$lock" -maxdepth 0 -mmin +10 2> /dev/null)" ]; then
-        echo "Clearing a stale stack lock." >&2
-        rmdir "$lock" 2> /dev/null || true
+
+    # Only a lock whose owner is gone -- a killed pause or wake, a reboot -- is
+    # safe to clear. An age-based break would eventually steal the lock from a
+    # slow but healthy wake, which is the very thing this guards against.
+    owner="$(cat "$lock/pid" 2> /dev/null || true)"
+    if [ -z "$owner" ] || ! kill -0 "$owner" 2> /dev/null; then
+        echo "Clearing a stack lock left behind by a dead process." >&2
+        release_lock
     fi
     sleep 1
 done
+
+if [ "$locked" != true ]; then
+    echo "Another pause or wake has held this worktree's stack lock for a minute; giving up." >&2
+    exit 1
+fi
 
 # A boot builds the stack from nothing and ends by pausing it. Waking underneath
 # one races its migrations and its seed.
@@ -72,12 +88,13 @@ fi
 if [ -z "$containers" ]; then
     echo "No containers for this worktree yet — running a full boot instead."
     release_port
-    # Same markers and the same cold-volume timeout `git:workboot` uses: `exec`
-    # replaces this shell, so nothing here runs afterwards to clean up.
     rm -f "$gitdir/gram-stack-paused" "$gitdir/gram-stack-lastseen"
-    rmdir "$lock" 2> /dev/null || true
-    trap - EXIT
-    exec env INFRA_READINESS_TIMEOUT=300 ./zero --agent
+    # Not `exec`: a bare `zero --agent` publishes no boot marker of its own, so
+    # this lock is the only thing keeping a pause or another wake off the
+    # containers while it migrates and seeds. Running it as a child keeps the
+    # EXIT trap, and with it the lock, until the boot is done.
+    INFRA_READINESS_TIMEOUT=300 ./zero --agent
+    exit $?
 fi
 
 # `pause` stops every profile, so start every container that exists before

--- a/.mise-tasks/wake.sh
+++ b/.mise-tasks/wake.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#MISE description="Start this worktree's paused stack: containers, then daemons"
+#MISE dir="{{ config_root }}"
+
+set -e
+
+# A new worktree boots its stack and then pauses it (see .config/wt.toml and
+# `git:workboot`), so the containers, migrations and seed data are already
+# there and waking is just starting them again. `infra:start` is idempotent and
+# does the starting -- `docker compose up -d` starts stopped containers -- plus
+# the readiness waits and the Temporal namespace check.
+
+gitdir="$(git rev-parse --absolute-git-dir)"
+
+# `mise run pause` parks a placeholder server on the site port (see
+# `mise run park`). It has to let go before vite can bind, and a wake started
+# from the CLI never goes through the parker's own hand-over path — so kill it
+# here. A parker that already exited (it woke us) leaves a stale pid file.
+parked="$gitdir/gram-stack-parked.pid"
+if [ -f "$parked" ]; then
+    kill "$(cat "$parked")" 2> /dev/null || true
+    rm -f "$parked"
+fi
+
+# No containers at all means this worktree was never booted (or was nuked), so
+# there is nothing to wake: migrations have never run and the databases are
+# empty. Do the full boot instead of starting daemons against an empty DB.
+if [ -z "$(docker compose ps -aq 2>/dev/null)" ]; then
+    echo "No containers for this worktree yet — running a full boot instead."
+    exec ./zero --agent
+fi
+
+mise run infra:start
+mise run start
+
+rm -f "$gitdir/gram-stack-paused"

--- a/.mise-tasks/wake.sh
+++ b/.mise-tasks/wake.sh
@@ -14,24 +14,31 @@ set -e
 gitdir="$(git rev-parse --absolute-git-dir)"
 
 # `mise run pause` parks a placeholder server on the site port (see
-# `mise run park`). It has to let go before vite can bind, and a wake started
-# from the CLI never goes through the parker's own hand-over path — so kill it
-# here. A parker that already exited (it woke us) leaves a stale pid file.
+# `mise run park`), which serves the "Resuming stack" page for as long as it
+# holds it. Killing it is deferred until the containers are up, just before
+# vite binds: a wake takes tens of seconds, and every reload or extra tab in
+# that window should get the page rather than a connection error.
 parked="$gitdir/gram-stack-parked.pid"
-if [ -f "$parked" ]; then
-    kill "$(cat "$parked")" 2> /dev/null || true
-    rm -f "$parked"
-fi
+release_port() {
+    if [ -f "$parked" ]; then
+        kill "$(cat "$parked")" 2> /dev/null || true
+        rm -f "$parked"
+        # The listener closes on signal delivery, not on return from kill.
+        sleep 1
+    fi
+}
 
 # No containers at all means this worktree was never booted (or was nuked), so
 # there is nothing to wake: migrations have never run and the databases are
 # empty. Do the full boot instead of starting daemons against an empty DB.
 if [ -z "$(docker compose ps -aq 2>/dev/null)" ]; then
     echo "No containers for this worktree yet — running a full boot instead."
+    release_port
     exec ./zero --agent
 fi
 
 mise run infra:start
+release_port
 mise run start
 
 rm -f "$gitdir/gram-stack-paused"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This document provides an overview of the key directories in the Gram project to
 
 <tip>
 If you've just cloned this repository, then consider running `./zero --agent` to get your development environment set up.
+
+In a fresh git worktree the stack is booted for you and then paused — containers exist with migrations and seed data applied, but nothing is running. You rarely need to wake it by hand: opening the worktree's dashboard URL serves a "Resuming stack" page that wakes it and reloads, and `mise run seed` / `mise run playwright` wake it first. `mise run wake` and `mise run pause` (alias `sleep`) are there when you want to be explicit, and `mise run idle-pause --all` pauses stacks nobody is using.
 </tip>
 
 ## Customer Data Is Confidential
@@ -69,6 +71,9 @@ Contains the main application code for the Gram server:
 - `mise lint:server`: Run linters on the server code
 - `mise run test:server`: Run server tests; accepts the same extra arguments as `go test` and runs from `server/`, so package paths are relative to `server/` (for example, `mise run test:server ./internal/thirdparty/openrouter/`)
 - `mise run start`: Run the process manager that spins up local servers (server, worker, idp, ...)
+- `mise run wake`: Start this worktree's stack (containers, then daemons). A new worktree is booted and then left paused, so run this before you need the dashboard or API.
+- `mise run pause` (alias `mise run sleep`): Stop the daemons and containers again, keeping their data. It also parks a placeholder server on the site port, so opening the dashboard URL wakes the stack.
+- `mise run idle-pause [--all] [--minutes 60]`: Pause stacks with no established connections for that long. Meant for cron/launchd.
 - `hk fix`: Runs formatters across changed files in the current branch.
 
 </commands>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This document provides an overview of the key directories in the Gram project to
 <tip>
 If you've just cloned this repository, then consider running `./zero --agent` to get your development environment set up.
 
-In a fresh git worktree the stack is booted for you and then paused — containers exist with migrations and seed data applied, but nothing is running. You rarely need to wake it by hand: opening the worktree's dashboard URL serves a "Resuming stack" page that wakes it and reloads, and `mise run seed` / `mise run playwright` wake it first. `mise run wake` and `mise run pause` (alias `sleep`) are there when you want to be explicit, and `mise run idle-pause --all` pauses stacks nobody is using.
+In a fresh git worktree the stack is booted for you and then paused — containers exist with migrations and seed data applied, but no application daemons are running (a placeholder holds the dashboard port and serves a resume page). You rarely need to wake it by hand: opening the worktree's dashboard URL serves a "Resuming stack" page that wakes it and reloads, and `mise run seed` / `mise run playwright` wake it first. `mise run wake` and `mise run pause` (alias `sleep`) are there when you want to be explicit, and `mise run idle-pause --all` pauses stacks nobody is using.
 </tip>
 
 ## Customer Data Is Confidential

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Contains the main application code for the Gram server:
 - `mise run start`: Run the process manager that spins up local servers (server, worker, idp, ...)
 - `mise run wake`: Start this worktree's stack (containers, then daemons). A new worktree is booted and then left paused, so run this before you need the dashboard or API.
 - `mise run pause` (alias `mise run sleep`): Stop the daemons and containers again, keeping their data. It also parks a placeholder server on the site port, so opening the dashboard URL wakes the stack.
-- `mise run idle-pause [--all] [--minutes 60]`: Pause stacks with no established connections for that long. Meant for cron/launchd.
+- `mise run idle-pause [--all] [--minutes 60]`: Pause stacks with no established connections for that long. `--install` schedules it every 5 minutes (launchd agent on macOS, systemd user timer on Linux); `--uninstall` removes it. An interactive `./zero` offers this once, and only when the repo has more than one worktree.
 - `hk fix`: Runs formatters across changed files in the current branch.
 
 </commands>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Contains the main application code for the Gram server:
 - `mise run start`: Run the process manager that spins up local servers (server, worker, idp, ...)
 - `mise run wake`: Start this worktree's stack (containers, then daemons). A new worktree is booted and then left paused, so run this before you need the dashboard or API.
 - `mise run pause` (alias `mise run sleep`): Stop the daemons and containers again, keeping their data. It also parks a placeholder server on the site port, so opening the dashboard URL wakes the stack.
-- `mise run idle-pause [--all] [--minutes 60]`: Pause stacks with no established connections for that long. `--install` schedules it every 5 minutes (launchd agent on macOS, systemd user timer on Linux); `--uninstall` removes it. An interactive `./zero` offers this once, and only when the repo has more than one worktree.
+- `mise run idle-pause [--all] [--minutes 60]`: Pause stacks with no established connections for that long. pitchfork runs it every 5 minutes for the current worktree (the `idle-pause` cron daemon in `pitchfork.toml`), so a stack you stop looking at pauses itself.
 - `hk fix`: Runs formatters across changed files in the current branch.
 
 </commands>

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -59,3 +59,15 @@ ready_cmd = "mise run check:daemon --name {{name}}"
 [daemons.tunnel-gateway]
 run = "mise run start:tunnel-gateway"
 ready_cmd = "mise run check:daemon --name {{name}}"
+
+# Not a service: a cron that checks, every five minutes, whether this
+# worktree's stack has gone unused, and pauses it if so (see
+# `mise run idle-pause`). A developer with several worktrees otherwise pays for
+# every stack they are no longer looking at, and the alternative -- a launchd
+# agent or a systemd timer -- installs a job on the developer's machine that
+# outlives the repo. pitchfork is already running the stack it is watching, so
+# the scheduler comes and goes with it: a paused worktree needs no scheduler,
+# and `mise run wake` brings this back with everything else.
+[daemons.idle-pause]
+run = "mise run idle-pause"
+cron = "0 */5 * * * *"

--- a/zero
+++ b/zero
@@ -244,4 +244,35 @@ else
     wait "$server_cache_pid" 2>/dev/null || true
 fi
 
+# Offer the idle-pause schedule, once, and only where it earns its keep: a
+# developer with several worktrees accumulates paused-able stacks, a developer
+# with one checkout has nothing to reclaim. Interactive runs only -- installing
+# a launchd agent or systemd timer behind `--agent` or `-y` would be a machine
+# level change nobody asked for. The answer is remembered in the shared git dir
+# so every worktree sees it and the question is asked at most once.
+if ! $agent_mode && ! $auto_yes && [ -t 0 ]; then
+    idle_pause_marker="$(git rev-parse --git-common-dir 2>/dev/null)/gram-idle-pause-asked"
+    worktree_count=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
+    if [ ! -f "$idle_pause_marker" ] && [ "${worktree_count:-1}" -gt 1 ]; then
+        # Name the mechanism being installed: this writes a file into the
+        # developer's login session, not just into the repo.
+        if [ "$(uname)" = "Darwin" ]; then
+            sched_kind="launchd agent"
+        else
+            sched_kind="systemd user timer"
+        fi
+        echo
+        echo "You can choose to automatically pause idle worktrees. Visiting the"
+        echo "worktree in your browser will automatically wake the worktree stack."
+        echo "Install ${sched_kind}?"
+        echo -n "[y/N] "
+        read -r idle_pause_answer
+        touch "$idle_pause_marker"
+        case "$(echo "$idle_pause_answer" | tr '[:upper:]' '[:lower:]')" in
+            y) mise run idle-pause --install ;;
+            *) echo "Skipped — run \`mise run idle-pause --install\` any time." ;;
+        esac
+    fi
+fi
+
 mise run zero:summary

--- a/zero
+++ b/zero
@@ -244,35 +244,4 @@ else
     wait "$server_cache_pid" 2>/dev/null || true
 fi
 
-# Offer the idle-pause schedule, once, and only where it earns its keep: a
-# developer with several worktrees accumulates paused-able stacks, a developer
-# with one checkout has nothing to reclaim. Interactive runs only -- installing
-# a launchd agent or systemd timer behind `--agent` or `-y` would be a machine
-# level change nobody asked for. The answer is remembered in the shared git dir
-# so every worktree sees it and the question is asked at most once.
-if ! $agent_mode && ! $auto_yes && [ -t 0 ]; then
-    idle_pause_marker="$(git rev-parse --git-common-dir 2>/dev/null)/gram-idle-pause-asked"
-    worktree_count=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
-    if [ ! -f "$idle_pause_marker" ] && [ "${worktree_count:-1}" -gt 1 ]; then
-        # Name the mechanism being installed: this writes a file into the
-        # developer's login session, not just into the repo.
-        if [ "$(uname)" = "Darwin" ]; then
-            sched_kind="launchd agent"
-        else
-            sched_kind="systemd user timer"
-        fi
-        echo
-        echo "You can choose to automatically pause idle worktrees. Visiting the"
-        echo "worktree in your browser will automatically wake the worktree stack."
-        echo "Install ${sched_kind}?"
-        echo -n "[y/N] "
-        read -r idle_pause_answer
-        touch "$idle_pause_marker"
-        case "$(echo "$idle_pause_answer" | tr '[:upper:]' '[:lower:]')" in
-            y) mise run idle-pause --install ;;
-            *) echo "Skipped — run \`mise run idle-pause --install\` any time." ;;
-        esac
-    fi
-fi
-
 mise run zero:summary


### PR DESCRIPTION
## Summary

A new worktree still boots its stack in full — containers, migrations, seed — and then pauses it. `mise run pause` stops the pitchfork daemons and runs `docker compose stop` (not `down`), so containers and volumes survive and coming back is a start, not a rebuild.

Waking is mostly automatic, so the pause is invisible in normal use:

- **Opening the dashboard wakes it.** `pause` parks a placeholder HTTPS server on the site port. The first request gets a "Resuming stack" page — a still of the login screen under a scrim with a spinning loader — which starts the wake and reloads itself once vite answers. The parker keeps serving that page to every reload and every extra tab until `wake` kills it, immediately before vite binds; its responses carry `x-gram-parked` so the page can tell it apart from the real dashboard.
- **Tasks that need a stack wake it.** `ensure-stack` is a dependency of `seed` and `playwright`: one TCP probe when the stack is already up, a wake when it isn't. Build, lint, test and type-check tasks are deliberately left alone.
- **Idle stacks pause themselves.** `idle-pause` pauses a worktree whose site and server ports have had no established connections for an hour. `--install` schedules it every five minutes as a launchd agent or a systemd user timer; an interactive `./zero` offers that once, and only when the repo has more than one worktree.

`mise run wake` and `mise run pause` (alias `sleep`) remain for explicit control, and `git:workstatus` / `git:worktui` gained a `paused` state — which outranks port liveness, since the parker holds the site port.

## Motivation

Worktree creation left every service running, so a developer with several worktrees paid RAM and CPU for stacks nobody was using — and the only way to reclaim it was to know that `mise run stop` and `infra:stop` existed and to remember to run them in the right checkout. Stopping the stack at the end of boot is the easy half; the reason this is more than a two-line change is that a stopped stack must not feel broken.

Pausing rather than tearing down keeps the expensive part (migrations, seed data, cold Postgres volumes) so a wake is seconds, and the parker means the URL in `wt list` still answers — the developer clicks the same link they always did and the stack comes back under them. `--install` exists because a schedule the developer has to hand-write into launchd is a schedule nobody installs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New worktrees now finish booting and then pause their stack, so idle worktrees no longer consume RAM and CPU. Pausing stops containers instead of removing them, so waking restarts the existing stack rather than rebuilding it; pause and wake now serialize behind a race-free per-worktree lock and fail closed when they cannot acquire it.

- Opening the dashboard shows a “Stack paused” page; clicking “Resume stack” wakes it and reloads once the dashboard answers, while prefetches and reconnecting tabs leave it paused.
- Tasks that need a running stack (`seed`, `playwright`) depend on `ensure-stack`, which refuses to race an active or failed boot.
- `idle-pause` pauses worktrees with no established connections for an hour; pitchfork runs it every five minutes and leaves stacks alone when connection checks fail.
- `git:workstatus` and `git:worktui` show a `paused` state that outranks port liveness.
- Wake restores all stopped Compose profiles, keeps its lock through a full-boot fallback, and only falls back when no containers exist.
- The detached parker is loopback-only, stays available until wake releases the port, preserves a live parker on repeated pauses, and reports bind failures.
- `--all` reports real per-worktree sweep failures while silently skipping worktrees without this task.

<sup>Written for commit 2456db4ff71b70cd8895a54b6fc2a584c894f82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

