### PR TITLE
fix: add context to embedding fallback logs

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -408,6 +408,7 @@ const (
 	OpenRouterBackfillScannedKey      = attribute.Key("gram.openrouter.backfill.scanned")
 	OpenRouterBackfillUpdatedKey      = attribute.Key("gram.openrouter.backfill.updated")
 	EmbeddingInputCountKey            = attribute.Key("gram.openrouter.embedding.input_count")
+	EmbeddingFallbackStrategyKey      = attribute.Key("gram.openrouter.embedding.fallback_strategy")
 	EmbeddingTruncatedInputCountKey   = attribute.Key("gram.openrouter.embedding.truncated_input_count")
 	OpenRouterKeyLimitKey             = attribute.Key("gram.openrouter.key.limit")
 	OpenRouterKeyPreviousLimitKey     = attribute.Key("gram.openrouter.key.previous_limit")
@@ -1630,6 +1631,12 @@ func EmbeddingInputCount(v int) attribute.KeyValue {
 }
 func SlogEmbeddingInputCount(v int) slog.Attr {
 	return slog.Int(string(EmbeddingInputCountKey), v)
+}
+func EmbeddingFallbackStrategy(v string) attribute.KeyValue {
+	return EmbeddingFallbackStrategyKey.String(v)
+}
+func SlogEmbeddingFallbackStrategy(v string) slog.Attr {
+	return slog.String(string(EmbeddingFallbackStrategyKey), v)
 }
 
 func EmbeddingTruncatedInputCount(v int) attribute.KeyValue {

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/rag/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -117,6 +118,10 @@ func (s *ToolsetVectorStore) IndexToolset(ctx context.Context, toolset types.Too
 	if err != nil {
 		return fmt.Errorf("parse toolset id: %w", err)
 	}
+	projectUUID, err := uuid.Parse(toolset.ProjectID)
+	if err != nil {
+		return fmt.Errorf("parse project id: %w", err)
+	}
 
 	candidates, err := s.prepareEmbeddingCandidates(ctx, toolset.Tools)
 	if err != nil {
@@ -127,7 +132,7 @@ func (s *ToolsetVectorStore) IndexToolset(ctx context.Context, toolset types.Too
 		return nil
 	}
 
-	vectors, err := s.generateEmbeddings(ctx, toolset.OrganizationID, candidates)
+	vectors, err := s.generateEmbeddings(ctx, toolset, projectUUID, candidates)
 	if err != nil {
 		return err
 	}
@@ -142,7 +147,7 @@ func (s *ToolsetVectorStore) IndexToolset(ctx context.Context, toolset types.Too
 		vector := pgvector_go.NewVector(vectors[i])
 		if err := s.insertToolEmbedding(
 			ctx,
-			uuid.MustParse(toolset.ProjectID),
+			projectUUID,
 			toolsetUUID,
 			toolset.ToolsetVersion,
 			candidate.entryKey,
@@ -288,6 +293,7 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 }
 
 type embeddingCandidate struct {
+	toolID    string
 	entryKey  string
 	payload   []byte
 	content   string
@@ -336,6 +342,7 @@ func (s *ToolsetVectorStore) prepareEmbeddingCandidates(ctx context.Context, too
 		}
 
 		candidates = append(candidates, embeddingCandidate{
+			toolID:   baseTool.ID,
 			entryKey: baseTool.ToolUrn,
 			payload:  payload,
 			content:  content,
@@ -416,7 +423,28 @@ type embeddingBatch struct {
 	endIdx   int
 }
 
-func selectEmbeddingCandidateContents(model string, candidates []embeddingCandidate) error {
+const (
+	embeddingFallbackStrategyTopLevelSchema  = "top_level_schema"
+	embeddingFallbackStrategyNameDescription = "name_description"
+	embeddingFallbackStrategyTokenTruncation = "token_truncation"
+)
+
+type embeddingFallbackSelection struct {
+	candidateIndex int
+	strategy       string
+}
+
+type embeddingFallbackLogContext struct {
+	organizationID   string
+	organizationSlug string
+	projectID        string
+	projectSlug      string
+	toolsetID        string
+	toolsetSlug      string
+	model            string
+}
+
+func selectEmbeddingCandidateContents(model string, candidates []embeddingCandidate) ([]embeddingFallbackSelection, error) {
 	inputs := make([]string, len(candidates))
 	inputFallbacks := make([][]string, len(candidates))
 	for i, candidate := range candidates {
@@ -424,23 +452,113 @@ func selectEmbeddingCandidateContents(model string, candidates []embeddingCandid
 		inputFallbacks[i] = candidate.fallbacks
 	}
 
-	selected, err := openrouter.SelectEmbeddingInputFallbacks(model, inputs, inputFallbacks)
+	selected, selectedFallbacks, err := openrouter.SelectEmbeddingInputFallbacks(model, inputs, inputFallbacks)
 	if err != nil {
-		return fmt.Errorf("select embedding input fallbacks: %w", err)
+		return nil, fmt.Errorf("select embedding input fallbacks: %w", err)
 	}
 	for i, content := range selected {
 		candidates[i].content = content
 	}
-	return nil
+
+	var fallbackSelections []embeddingFallbackSelection
+	for _, selection := range selectedFallbacks {
+		strategy := ""
+		switch {
+		case selection.RequiresTruncation:
+			strategy = embeddingFallbackStrategyTokenTruncation
+		case selection.FallbackIndex == 0:
+			strategy = embeddingFallbackStrategyTopLevelSchema
+		case selection.FallbackIndex > 0:
+			strategy = embeddingFallbackStrategyNameDescription
+		}
+		if strategy != "" {
+			fallbackSelections = append(fallbackSelections, embeddingFallbackSelection{
+				candidateIndex: selection.InputIndex,
+				strategy:       strategy,
+			})
+		}
+	}
+
+	return fallbackSelections, nil
 }
 
-func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID string, candidates []embeddingCandidate) ([][]float32, error) {
+func emitEmbeddingFallbackLogs(
+	ctx context.Context,
+	logger *slog.Logger,
+	logContext embeddingFallbackLogContext,
+	candidates []embeddingCandidate,
+	selections []embeddingFallbackSelection,
+) {
+	for _, selection := range selections {
+		candidate := candidates[selection.candidateIndex]
+		attrs := []any{
+			attr.SlogOrganizationID(logContext.organizationID),
+			attr.SlogProjectID(logContext.projectID),
+			attr.SlogToolsetID(logContext.toolsetID),
+			attr.SlogToolsetSlug(logContext.toolsetSlug),
+			attr.SlogToolID(candidate.toolID),
+			attr.SlogToolURN(candidate.entryKey),
+			attr.SlogGenAIRequestModel(logContext.model),
+			attr.SlogEmbeddingFallbackStrategy(selection.strategy),
+		}
+		if logContext.organizationSlug != "" {
+			attrs = append(attrs, attr.SlogOrganizationSlug(logContext.organizationSlug))
+		}
+		if logContext.projectSlug != "" {
+			attrs = append(attrs, attr.SlogProjectSlug(logContext.projectSlug))
+		}
+
+		logger.WarnContext(ctx, "tool embedding input exceeded token limit; using fallback", attrs...)
+	}
+}
+
+func (s *ToolsetVectorStore) logEmbeddingFallbacks(
+	ctx context.Context,
+	toolset types.Toolset,
+	projectID uuid.UUID,
+	candidates []embeddingCandidate,
+	selections []embeddingFallbackSelection,
+) {
+	logContext := embeddingFallbackLogContext{
+		organizationID:   toolset.OrganizationID,
+		organizationSlug: "",
+		projectID:        toolset.ProjectID,
+		projectSlug:      "",
+		toolsetID:        toolset.ID,
+		toolsetSlug:      string(toolset.Slug),
+		model:            s.embeddingModel,
+	}
+
+	metadata, err := projectsrepo.New(s.db).GetProjectWithOrganizationMetadata(ctx, projectID)
+	if err != nil {
+		s.logger.WarnContext(
+			ctx,
+			"failed to load project metadata for embedding fallback log",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(toolset.OrganizationID),
+			attr.SlogProjectID(toolset.ProjectID),
+			attr.SlogToolsetID(toolset.ID),
+			attr.SlogToolsetSlug(string(toolset.Slug)),
+		)
+	} else {
+		logContext.organizationSlug = metadata.Slug
+		logContext.projectSlug = metadata.ProjectSlug
+	}
+
+	emitEmbeddingFallbackLogs(ctx, s.logger, logContext, candidates, selections)
+}
+
+func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, toolset types.Toolset, projectID uuid.UUID, candidates []embeddingCandidate) ([][]float32, error) {
 	if len(candidates) == 0 {
 		return nil, nil
 	}
 
-	if err := selectEmbeddingCandidateContents(s.embeddingModel, candidates); err != nil {
+	fallbackSelections, err := selectEmbeddingCandidateContents(s.embeddingModel, candidates)
+	if err != nil {
 		return nil, err
+	}
+	if len(fallbackSelections) > 0 {
+		s.logEmbeddingFallbacks(ctx, toolset, projectID, candidates, fallbackSelections)
 	}
 
 	total := len(candidates)
@@ -487,7 +605,7 @@ func (s *ToolsetVectorStore) generateEmbeddings(ctx context.Context, orgID strin
 					inputs = append(inputs, candidates[i].content)
 				}
 
-				vectors, err := s.chatClient.CreateEmbeddings(ctx, orgID, s.embeddingModel, inputs)
+				vectors, err := s.chatClient.CreateEmbeddings(ctx, toolset.OrganizationID, s.embeddingModel, inputs)
 				if err != nil {
 					setErr(fmt.Errorf("create embeddings batch: %w", err))
 					return

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -1,11 +1,16 @@
 package rag
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
 func TestBuildEmbeddableContent_SummarizesSchemaDeterministically(t *testing.T) {
@@ -120,9 +125,61 @@ func TestSelectEmbeddingCandidateContents_UsesSelectedSizeForBatching(t *testing
 	batchLimit := len(denseContent) * 2
 	require.Len(t, createBatchesWithinSize(candidates, batchLimit), 2)
 
-	require.NoError(t, selectEmbeddingCandidateContents(defaultEmbeddingModel, candidates))
+	selections, err := selectEmbeddingCandidateContents(defaultEmbeddingModel, candidates)
+	require.NoError(t, err)
+	require.Equal(t, []embeddingFallbackSelection{
+		{candidateIndex: 0, strategy: embeddingFallbackStrategyTopLevelSchema},
+		{candidateIndex: 1, strategy: embeddingFallbackStrategyTopLevelSchema},
+		{candidateIndex: 2, strategy: embeddingFallbackStrategyTopLevelSchema},
+	}, selections)
 	require.Equal(t, "compact-one", candidates[0].content)
 	require.Equal(t, "compact-two", candidates[1].content)
 	require.Equal(t, "compact-three", candidates[2].content)
 	require.Len(t, createBatchesWithinSize(candidates, batchLimit), 1)
+}
+
+func TestEmitEmbeddingFallbackLogs_IncludesCustomerAndToolContext(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	candidates := []embeddingCandidate{{
+		toolID:   "tool-id",
+		entryKey: "urn:gram:tool:tool-id",
+	}}
+	logContext := embeddingFallbackLogContext{
+		organizationID:   "org-id",
+		organizationSlug: "org-slug",
+		projectID:        "project-id",
+		projectSlug:      "project-slug",
+		toolsetID:        "toolset-id",
+		toolsetSlug:      "toolset-slug",
+		model:            defaultEmbeddingModel,
+	}
+
+	emitEmbeddingFallbackLogs(
+		context.Background(),
+		logger,
+		logContext,
+		candidates,
+		[]embeddingFallbackSelection{{
+			candidateIndex: 0,
+			strategy:       embeddingFallbackStrategyNameDescription,
+		}},
+	)
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &record))
+	require.Equal(t, "WARN", record["level"])
+	require.Equal(t, "tool embedding input exceeded token limit; using fallback", record["msg"])
+	require.Equal(t, "org-id", record[string(attr.OrganizationIDKey)])
+	require.Equal(t, "org-slug", record[string(attr.OrganizationSlugKey)])
+	require.Equal(t, "project-id", record[string(attr.ProjectIDKey)])
+	require.Equal(t, "project-slug", record[string(attr.ProjectSlugKey)])
+	require.Equal(t, "toolset-id", record[string(attr.ToolsetIDKey)])
+	require.Equal(t, "toolset-slug", record[string(attr.ToolsetSlugKey)])
+	require.Equal(t, "tool-id", record[string(attr.ToolIDKey)])
+	require.Equal(t, "urn:gram:tool:tool-id", record[string(attr.ToolURNKey)])
+	require.Equal(t, defaultEmbeddingModel, record[string(attr.GenAIRequestModelKey)])
+	require.Equal(t, embeddingFallbackStrategyNameDescription, record[string(attr.EmbeddingFallbackStrategyKey)])
 }

--- a/server/internal/thirdparty/openrouter/embeddings_test.go
+++ b/server/internal/thirdparty/openrouter/embeddings_test.go
@@ -60,13 +60,14 @@ func TestLimitEmbeddingInputs_OtherModelsPreserveLegacyByteLimit(t *testing.T) {
 	t.Parallel()
 
 	input := strings.Repeat("x", legacyMaxEmbeddingInputBytes+1)
-	selected, err := SelectEmbeddingInputFallbacks(
+	selected, fallbackSelections, err := SelectEmbeddingInputFallbacks(
 		"qwen/qwen3-embedding-8b",
 		[]string{input},
 		[][]string{{"fallback"}},
 	)
 	require.NoError(t, err)
 	require.Equal(t, input, selected[0])
+	require.Empty(t, fallbackSelections)
 
 	limited, truncatedCount, err := limitEmbeddingInputs("qwen/qwen3-embedding-8b", selected)
 	require.NoError(t, err)
@@ -117,13 +118,18 @@ func TestSelectEmbeddingInputFallbacks_OpenAIUsesOrderedFallbacks(t *testing.T) 
 	t.Run("uses first fallback that fits", func(t *testing.T) {
 		t.Parallel()
 
-		selected, err := SelectEmbeddingInputFallbacks(
+		selected, fallbackSelections, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{dense},
 			[][]string{{compact, minimal}},
 		)
 		require.NoError(t, err)
 		require.Equal(t, compact, selected[0])
+		require.Equal(t, []EmbeddingInputFallbackSelection{{
+			InputIndex:         0,
+			FallbackIndex:      0,
+			RequiresTruncation: false,
+		}}, fallbackSelections)
 
 		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)
@@ -134,13 +140,18 @@ func TestSelectEmbeddingInputFallbacks_OpenAIUsesOrderedFallbacks(t *testing.T) 
 	t.Run("continues to name and description", func(t *testing.T) {
 		t.Parallel()
 
-		selected, err := SelectEmbeddingInputFallbacks(
+		selected, fallbackSelections, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{dense},
 			[][]string{{"top-level\n" + dense, minimal}},
 		)
 		require.NoError(t, err)
 		require.Equal(t, minimal, selected[0])
+		require.Equal(t, []EmbeddingInputFallbackSelection{{
+			InputIndex:         0,
+			FallbackIndex:      1,
+			RequiresTruncation: false,
+		}}, fallbackSelections)
 
 		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)
@@ -152,13 +163,18 @@ func TestSelectEmbeddingInputFallbacks_OpenAIUsesOrderedFallbacks(t *testing.T) 
 		t.Parallel()
 
 		finalFallback := "MINIMAL\n" + dense
-		selected, err := SelectEmbeddingInputFallbacks(
+		selected, fallbackSelections, err := SelectEmbeddingInputFallbacks(
 			openAITextEmbedding3Small,
 			[]string{"PRIMARY\n" + dense},
 			[][]string{{"TOP-LEVEL\n" + dense, finalFallback}},
 		)
 		require.NoError(t, err)
 		require.Equal(t, finalFallback, selected[0])
+		require.Equal(t, []EmbeddingInputFallbackSelection{{
+			InputIndex:         0,
+			FallbackIndex:      1,
+			RequiresTruncation: true,
+		}}, fallbackSelections)
 
 		limited, truncatedCount, err := limitEmbeddingInputs(openAITextEmbedding3Small, selected)
 		require.NoError(t, err)

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -898,40 +898,63 @@ func limitEmbeddingInputs(model string, inputs []string) ([]string, int, error) 
 	return limited, truncatedCount, nil
 }
 
+// EmbeddingInputFallbackSelection describes a fallback chosen for one
+// embedding input.
+type EmbeddingInputFallbackSelection struct {
+	// InputIndex identifies the selected input in the request.
+	InputIndex int
+
+	// FallbackIndex is zero-based within the supplied fallback list, or -1 when
+	// the primary input remains selected.
+	FallbackIndex int
+
+	// RequiresTruncation reports whether the selected representation still
+	// exceeds the model's per-input token limit.
+	RequiresTruncation bool
+}
+
 // SelectEmbeddingInputFallbacks selects the first representation for each
-// input that fits the model's per-input token limit. Selection is currently
-// supported only for openai/text-embedding-3-small; other models are returned
-// unchanged because their tokenizer and token limit are not declared here. If
-// every representation is oversized, the final fallback is returned for the
-// client to truncate.
-func SelectEmbeddingInputFallbacks(model string, inputs []string, inputFallbacks [][]string) ([]string, error) {
+// input that fits the model's per-input token limit and reports inputs that
+// required a fallback. Selection is currently supported only for
+// openai/text-embedding-3-small; other models are returned unchanged because
+// their tokenizer and token limit are not declared here. If every
+// representation is oversized, the final fallback is returned for the client
+// to truncate.
+func SelectEmbeddingInputFallbacks(
+	model string,
+	inputs []string,
+	inputFallbacks [][]string,
+) ([]string, []EmbeddingInputFallbackSelection, error) {
 	if model != openAITextEmbedding3Small || len(inputFallbacks) == 0 {
-		return inputs, nil
+		return inputs, nil, nil
 	}
 
 	var (
-		codec    tokenizer.Codec
-		selected []string
+		codec              tokenizer.Codec
+		selected           []string
+		fallbackSelections []EmbeddingInputFallbackSelection
 	)
 	for i, input := range inputs {
 		candidate := input
+		fallbackIndex := -1
 		_, exceedsLimit, err := embeddingInputTokensOverLimit(&codec, candidate, i)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !exceedsLimit {
 			continue
 		}
 
 		if i < len(inputFallbacks) {
-			for _, fallback := range inputFallbacks[i] {
+			for index, fallback := range inputFallbacks[i] {
 				if fallback == "" || fallback == candidate {
 					continue
 				}
 				candidate = fallback
+				fallbackIndex = index
 				_, exceedsLimit, err = embeddingInputTokensOverLimit(&codec, candidate, i)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				if !exceedsLimit {
 					break
@@ -939,19 +962,23 @@ func SelectEmbeddingInputFallbacks(model string, inputs []string, inputFallbacks
 			}
 		}
 
-		if candidate == input {
-			continue
+		if candidate != input {
+			if selected == nil {
+				selected = slices.Clone(inputs)
+			}
+			selected[i] = candidate
 		}
-		if selected == nil {
-			selected = slices.Clone(inputs)
-		}
-		selected[i] = candidate
+		fallbackSelections = append(fallbackSelections, EmbeddingInputFallbackSelection{
+			InputIndex:         i,
+			FallbackIndex:      fallbackIndex,
+			RequiresTruncation: exceedsLimit,
+		})
 	}
 
 	if selected == nil {
-		return inputs, nil
+		selected = inputs
 	}
-	return selected, nil
+	return selected, fallbackSelections, nil
 }
 
 func limitOpenAIEmbeddingInputs(inputs []string) ([]string, int, error) {


### PR DESCRIPTION
AIM-168

## Summary

- Emit one structured warning per tool when embedding input exceeds the model token limit and selects a reduced representation or token truncation.
- Include organization, project, toolset, and tool identifiers; organization, project, and toolset slugs; tool URN; model; and fallback strategy.
- Resolve slug context only on degraded indexing paths and preserve indexing when metadata enrichment fails.

## Motivation

The existing truncation warning only reported aggregate input counts and the model. Per-tool fallback logs make oversized schemas attributable and actionable without adding database work to normal indexing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tool context to embedding fallback warnings so oversized schemas are attributable to specific tools. Previously the warning only reported aggregate input counts and the model; now each tool that falls back logs a structured warning with organization, project, toolset, and tool identifiers, slugs, tool URN, model, and fallback strategy.

**Changes**
- Reports fallback strategy (top-level schema, name/description, or token truncation) from the embedding selection path.
- Resolves organization and project slugs only on degraded indexing paths; indexing continues if metadata enrichment fails.

<sup>Written for commit 63b0c28b4fbf79ee6e6df4ed8f09297c6f0a55b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

