### PR TITLE
feat: presidio enforcement scanning domain

### DIFF
--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -177,14 +177,16 @@ flowchart LR
   s_gram_risk_v1_gitleaks_enforcer --> c31
   c32[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
   s_gram_risk_v1_presidio_analyzer --> c32
-  c33[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
-  s_gram_risk_v1_prompt_injection_analyzer --> c33
-  c34[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
-  s_gram_risk_v1_prompt_policy_analyzer --> c34
-  c35[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
-  s_gram_telemetry_v1_noop --> c35
-  c36[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
-  s_gram_webhooks_v1_svix_relay --> c36
+  c33[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>enforce_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_enforcer --> c33
+  c34[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
+  s_gram_risk_v1_prompt_injection_analyzer --> c34
+  c35[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
+  s_gram_risk_v1_prompt_policy_analyzer --> c35
+  c36[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
+  s_gram_telemetry_v1_noop --> c36
+  c37[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
+  s_gram_webhooks_v1_svix_relay --> c37
 ```
 
 ## Topics
@@ -248,7 +250,7 @@ flowchart LR
 | [`gram-risk-v1-gitleaks-analyzer`](../infra/proto/gram/risk/v1/gitleaks_analyzer.proto) | `gram-risk-v1-gitleaks-analysis` | 1m | — | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-risk-v1-gitleaks-enforcer`](../infra/proto/gram/risk/v1/gitleaks_enforcer.proto) | `gram-risk-v1-gitleaks-enforcement` | 10s | `gram-risk-v1-gitleaks-enforcer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-risk-v1-presidio-analyzer`](../infra/proto/gram/risk/v1/presidio_analyzer.proto) | `gram-risk-v1-presidio-analysis` | 1m | — | [`pystreams/src/pystreams/cmd/multi.py`](../pystreams/src/pystreams/cmd/multi.py) |
-| [`gram-risk-v1-presidio-enforcer`](../infra/proto/gram/risk/v1/presidio_enforcer.proto) | `gram-risk-v1-presidio-enforcement` | 10s | `gram-risk-v1-presidio-enforcer-dlq` | — |
+| [`gram-risk-v1-presidio-enforcer`](../infra/proto/gram/risk/v1/presidio_enforcer.proto) | `gram-risk-v1-presidio-enforcement` | 10s | `gram-risk-v1-presidio-enforcer-dlq` | [`pystreams/src/pystreams/cmd/multi.py`](../pystreams/src/pystreams/cmd/multi.py) |
 | [`gram-risk-v1-prompt-injection-analyzer`](../infra/proto/gram/risk/v1/prompt_injection_analyzer.proto) | `gram-risk-v1-prompt-injection-analysis` | 1m | — | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-risk-v1-prompt-policy-analyzer`](../infra/proto/gram/risk/v1/prompt_policy_analyzer.proto) | `gram-risk-v1-prompt-policy-analysis` | 1m | — | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-telemetry-v1-noop`](../infra/proto/gram/telemetry/v1/noop.proto) | `gram-telemetry-v1-log-record` | 1m | — | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
@@ -262,5 +264,4 @@ flowchart LR
 - Topic `gram-otel-v1-log-record` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-metric` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-span` has no publisher in `server/` or `pystreams/`.
-- Subscription `gram-risk-v1-presidio-enforcer` has no consumer in `server/` or `pystreams/`.
 

--- a/pystreams/src/pystreams/cmd/flags_enforce.py
+++ b/pystreams/src/pystreams/cmd/flags_enforce.py
@@ -1,0 +1,33 @@
+from collections.abc import Sequence
+
+import click
+
+
+def enforce_options() -> Sequence[click.Option]:
+    """Options for the Presidio enforcement lane (reply inbox + fingerprints).
+
+    The lane activates only when both the Redis address and the pepper keyring
+    are set; otherwise the enforcement receiver is not registered and the
+    process serves only the batch subscriptions. The Redis password is
+    independently optional.
+    """
+    return [
+        click.Option(
+            ["--redis-addr"],
+            type=str,
+            envvar="GRAM_REDIS_CACHE_ADDR",
+            help="Redis address (host:port) for enforcement reply inboxes.",
+        ),
+        click.Option(
+            ["--redis-password"],
+            type=str,
+            envvar="GRAM_REDIS_CACHE_PASSWORD",
+            help="Redis password for enforcement reply inboxes.",
+        ),
+        click.Option(
+            ["--risk-fingerprint-pepper-keyring"],
+            type=str,
+            envvar="GRAM_RISK_FINGERPRINT_PEPPER_KEYRING",
+            help="JSON pepper keyring for tenant-scoped finding fingerprints.",
+        ),
+    ]

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -1,6 +1,7 @@
 import logging as stdlogging
 import os
 import signal
+from contextlib import AsyncExitStack
 from functools import partial
 
 import anyio
@@ -8,12 +9,19 @@ import click
 import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
 from gram.ping.v2 import ping_pb2, processor_pb2
-from gram.risk.v1 import finding_pb2, presidio_analysis_pb2, presidio_analyzer_pb2
+from gram.risk.v1 import (
+    finding_pb2,
+    presidio_analysis_pb2,
+    presidio_analyzer_pb2,
+    presidio_enforcement_pb2,
+    presidio_enforcer_pb2,
+)
 from gram_infra.pubsub import (
     EmulatedPubSubBroker,
     PubSubBroker,
     pubsub_publisher_for_message_async,
 )
+from redis import asyncio as redis_asyncio
 
 from pystreams import attr
 from pystreams.deps import logging, otel
@@ -22,9 +30,12 @@ from pystreams.deps.loop_lag import monitor_event_loop_lag
 from pystreams.deps.scanner import build_presidio_scanner
 from pystreams.health import HealthState, serve_control
 from pystreams.ping.handler import PingHandler
+from pystreams.risk.enforce_handler import PresidioEnforceHandler
+from pystreams.risk.fingerprint import parse_pepper_keyring
 from pystreams.risk.handler import PresidioHandler
+from pystreams.risk.replywriter import ReplyWriter
 
-from . import flags_control, flags_gcp, flags_presidio, flags_service
+from . import flags_control, flags_enforce, flags_gcp, flags_presidio, flags_service
 from .receiver import ReceiverGroup
 
 
@@ -35,6 +46,7 @@ from .receiver import ReceiverGroup
         *flags_control.server_options(),
         *flags_gcp.pubsub_options(),
         *flags_presidio.presidio_options(),
+        *flags_enforce.enforce_options(),
     ],
 )
 def cli(**kwargs):
@@ -64,6 +76,10 @@ async def multi(
     scan_timeout: float,
     scan_slot_timeout: float,
     max_inflight: int | None,
+    # Enforcement lane options
+    redis_addr: str | None,
+    redis_password: str | None,
+    risk_fingerprint_pepper_keyring: str | None,
 ):
     logging.configure_logging(
         pretty_log=pretty_log,
@@ -107,11 +123,48 @@ async def multi(
     async with otel.otel_sdk(otel_options, logger=logger):
         # The broker owns the publisher/subscriber clients: entering it flushes
         # and closes them on exit (including a clean teardown on Ctrl-C).
-        with broker:
+        # The stack owns the Redis client from creation, so any later startup
+        # failure still closes its pool.
+        async with AsyncExitStack() as stack:
+            stack.enter_context(broker)
             health_state = HealthState()
             findings_publisher = await pubsub_publisher_for_message_async(
                 broker, finding_pb2.Finding
             )
+
+            # The enforcement lane registers only when both Redis and the
+            # pepper keyring are configured; validated before the scan pool
+            # exists so a startup failure cannot leak pool workers.
+            enforce_redis = None
+            enforce_fingerprinter = None
+            if redis_addr and risk_fingerprint_pepper_keyring:
+                host, sep, port = redis_addr.rpartition(":")
+                if not sep or "]" in port or (":" in host and "[" not in host):
+                    # Bare hostname, or an IPv6 literal without a port.
+                    host, port = redis_addr, ""
+                # Accept bracketed IPv6 endpoints such as [::1]:6379.
+                host = host.strip("[]")
+                # Bounded timeouts: a Redis stall surfaces as an ACKed write
+                # failure instead of hanging past the ack deadline.
+                enforce_redis = redis_asyncio.Redis(
+                    host=host or redis_addr,
+                    port=int(port) if port else 6379,
+                    password=redis_password or None,
+                    socket_connect_timeout=1.0,
+                    socket_timeout=2.0,
+                )
+                stack.push_async_callback(enforce_redis.aclose)
+                # Fail startup, not per-message: consuming without a reachable
+                # reply store would ACK requests while losing their replies.
+                await enforce_redis.ping()
+                enforce_fingerprinter = parse_pepper_keyring(
+                    risk_fingerprint_pepper_keyring
+                )
+            else:
+                logger.info(
+                    "presidio enforcement lane disabled",
+                    reason="redis address or fingerprint pepper keyring not configured",
+                )
 
             # Build the scan strategy: a pool of worker processes (the default,
             # with --scan-workers > 0) or the in-process thread scanner. The
@@ -140,9 +193,19 @@ async def multi(
                 logger, findings_publisher, presidio_scanner
             )
 
-            # The scanner is an async context manager: leaving the block releases
-            # it, draining in-flight scans and reaping the worker processes for
-            # the pool scanner (a no-op for the in-process one).
+            enforce_handler = None
+            if enforce_redis is not None and enforce_fingerprinter is not None:
+                enforce_handler = PresidioEnforceHandler(
+                    logger,
+                    ReplyWriter(enforce_redis),
+                    presidio_scanner,
+                    enforce_fingerprinter,
+                )
+
+            # The scanner is an async context manager: leaving the block
+            # releases it, draining in-flight scans and reaping the worker
+            # processes for the pool scanner (a no-op for the in-process one).
+            # Exits after the task group drains, before the stack closes Redis.
             async with presidio_scanner, anyio.create_task_group() as tg:
                 tg.start_soon(
                     _shutdown_on_signal, tg.cancel_scope, health_state, logger
@@ -186,6 +249,20 @@ async def multi(
                     presidio_handler.handle,
                     max_concurrency=max_inflight,
                 )
+                if enforce_handler is not None:
+                    # Enforcement shares the scan pool with batch, so it gets
+                    # roughly one handler per slot (floored at two so a reply
+                    # write can overlap a scan); excess waits at the broker.
+                    if scan_workers > 0:
+                        enforce_slots = scan_workers
+                    else:
+                        enforce_slots = max_scan_concurrency or 2
+                    await receivers.receive(
+                        presidio_enforcement_pb2.PresidioEnforcement,
+                        presidio_enforcer_pb2.PresidioEnforcer,
+                        enforce_handler.handle,
+                        max_concurrency=max(2, enforce_slots),
+                    )
 
                 health_state.set_ready()
 

--- a/pystreams/src/pystreams/risk/enforce_handler.py
+++ b/pystreams/src/pystreams/risk/enforce_handler.py
@@ -1,0 +1,288 @@
+"""Inline Presidio enforcement scans with a correlated Redis reply.
+
+Python counterpart of the gitleaks enforcement handler
+(``server/internal/scanners/gitleaks/enforce_handler.go``), consuming the
+dedicated ``gram.risk.v1.PresidioEnforcement`` topic. The handler scans one
+request and writes an ``EnforcementReply`` to the replica inbox named by the
+reply URN. Replies never carry raw matched text: findings hold masked previews
+and tenant-peppered fingerprints only, and logs report entity types and counts.
+
+Ack/nack policy mirrors the Go handler: stale requests, scan failures, and
+reply-write failures are ACKed (redelivery cannot rescue an inline scan, and a
+nack would eventually park raw request content in the DLQ), while undecodable
+or structurally invalid requests raise so the restricted forensic DLQ retains
+what could not be interpreted.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Final
+
+import structlog
+from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
+from gram_infra.pubsub.subscriber import MessageMetadata
+from opentelemetry import metrics
+
+from pystreams.risk import maskdisplay
+from pystreams.risk.fingerprint import Fingerprinter, encode_fingerprint
+from pystreams.risk.replywriter import ReplyWriter, parse_reply_urn
+from pystreams.risk.scanner import (
+    DEFAULT_SCORE_THRESHOLD,
+    Detection,
+    Scanner,
+    ScanSlotTimeout,
+)
+
+# Maximum useful age of an inline scan request; the dispatcher's wait ceiling
+# means anything older can no longer satisfy a caller.
+DEFAULT_MAX_REQUEST_AGE_SECONDS: Final = 30.0
+
+# Per-message content budget, matching replyinbox.MaxContentBytes on the Go
+# dispatcher; a request that bypasses the dispatcher must not buy an unbounded
+# scan.
+MAX_CONTENT_BYTES: Final = 50 * 1024
+
+# Transport-metadata key carrying the request's return address; must match
+# requestreply.ReplyURNAttribute on the Go side.
+REPLY_URN_ATTRIBUTE: Final = "gram-reply-urn"
+
+_MAX_REPLY_REASON_CHARS: Final = 256
+
+# Bounds the analyzer's selector list; the catalog defines far fewer.
+MAX_REQUESTED_ENTITIES: Final = 64
+
+# Presidio pii.* rule ids mapped to their canonical category, mirroring the
+# classification order in server/internal/risk/categories (first match wins;
+# anything else with source "presidio" is pii).
+_GOVERNMENT_ID_RULE_IDS: Final = frozenset(
+    {
+        "pii.us_ssn",
+        "pii.us_passport",
+        "pii.us_itin",
+        "pii.uk_nhs",
+        "pii.uk_nino",
+        "pii.uk_passport",
+        "pii.es_nif",
+        "pii.it_fiscal_code",
+        "pii.au_tfn",
+        "pii.in_pan",
+        "pii.in_aadhaar",
+        "pii.sg_nric_fin",
+    }
+)
+_HEALTHCARE_RULE_IDS: Final = frozenset(
+    {
+        "pii.medical_license",
+        "pii.us_mbi",
+        "pii.us_npi",
+        "pii.medical_disease_disorder",
+        "pii.medical_medication",
+        "pii.medical_therapeutic_procedure",
+        "pii.medical_clinical_event",
+        "pii.medical_biological_attribute",
+        "pii.medical_family_history",
+    }
+)
+_OFF_POLICY_RULE_IDS: Final = frozenset(
+    {
+        "pii.harmful_content_request",
+        "pii.policy_violation",
+        "pii.unauthorized_action",
+        "pii.topic_boundary_violation",
+    }
+)
+
+_meter = metrics.get_meter("pystreams.risk.enforce")
+_stale_dropped = _meter.create_counter(
+    "risk.enforcement.presidio.stale_dropped",
+    unit="{request}",
+    description=(
+        "Presidio enforcement requests acknowledged without scanning because "
+        "their timestamp fell outside the freshness window (stale or "
+        "far-future)"
+    ),
+)
+_reply_write_errors = _meter.create_counter(
+    "risk.enforcement.presidio.reply_write_errors",
+    unit="{error}",
+    description=("Presidio enforcement reply writes acknowledged after Redis failure"),
+)
+
+
+class MalformedEnforcementRequest(ValueError):
+    """A structurally invalid request; raised so it lands in the forensic DLQ."""
+
+
+class PresidioEnforceHandler:
+    """Scans one inline request and writes a safe correlated reply."""
+
+    def __init__(
+        self,
+        logger: structlog.stdlib.BoundLogger,
+        writer: ReplyWriter,
+        scanner: Scanner,
+        fingerprinter: Fingerprinter,
+        max_request_age_seconds: float = DEFAULT_MAX_REQUEST_AGE_SECONDS,
+    ) -> None:
+        self._logger = logger
+        self._writer = writer
+        self._scanner = scanner
+        self._fingerprinter = fingerprinter
+        # abs(age) > NaN/inf is always false, defeating the freshness window.
+        if not math.isfinite(max_request_age_seconds) or max_request_age_seconds <= 0:
+            max_request_age_seconds = DEFAULT_MAX_REQUEST_AGE_SECONDS
+        self._max_request_age = max_request_age_seconds
+        self._consumer_id = str(uuid.uuid4())
+
+    async def handle(
+        self,
+        message: presidio_enforcement_pb2.PresidioEnforcement,
+        meta: MessageMetadata,
+    ) -> None:
+        try:
+            created_at = datetime.fromisoformat(message.created_at)
+        except ValueError:
+            # Constant message: no reflected input; the DLQ keeps the request.
+            raise MalformedEnforcementRequest("parse enforcement created_at") from None
+        if created_at.tzinfo is None:
+            raise MalformedEnforcementRequest(
+                "enforcement created_at must include a timezone"
+            )
+        if not message.organization_id:
+            raise MalformedEnforcementRequest("enforcement organization id is required")
+        if not message.project_id:
+            raise MalformedEnforcementRequest("enforcement project id is required")
+        # The reply address rides transport metadata, mirroring Go's
+        # requestreply.ReplyURNAttribute; payloads carry no routing.
+        reply_urn = meta.attributes.get(REPLY_URN_ATTRIBUTE, "")
+        try:
+            _, scan_id = parse_reply_urn(reply_urn)
+        except ValueError as exc:
+            raise MalformedEnforcementRequest("parse enforcement reply urn") from exc
+        # Structural validation first: a stale AND malformed request belongs in
+        # the forensic DLQ, not in a silent drop.
+        age = (datetime.now(UTC) - created_at).total_seconds()
+        # Symmetric window: a far-future stamp is as suspect as a stale one.
+        if abs(age) > self._max_request_age:
+            _stale_dropped.add(1)
+            return
+
+        started = time.perf_counter()
+        detections: list[Detection] = []
+        status = enforcement_reply_pb2.ENFORCEMENT_STATUS_OK
+        reason = ""
+        if len(message.content.encode()) > MAX_CONTENT_BYTES:
+            status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+            reason = "enforcement content exceeds the maximum byte budget"
+        elif len(message.entities) > MAX_REQUESTED_ENTITIES:
+            status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+            reason = "enforcement entity selection exceeds the maximum count"
+        elif not 0.0 <= message.score_threshold <= 1.0:
+            # A negative threshold admits noise; above 1.0 suppresses every
+            # finding. Neither is a scan worth running.
+            status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+            reason = "enforcement score threshold is outside 0.0-1.0"
+        else:
+            requested = list(message.entities) or None
+            # Explicit presence: honor a caller-set 0.0 over the default.
+            if message.HasField("score_threshold"):
+                score_threshold = message.score_threshold
+            else:
+                score_threshold = DEFAULT_SCORE_THRESHOLD
+            try:
+                detections = await self._scanner.scan(
+                    message.content, requested, score_threshold
+                )
+            except ScanSlotTimeout:
+                # Requeueing cannot rescue an inline scan: reply ERROR now so
+                # the waiter applies its failure mode without burning the deadline.
+                status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+                reason = "presidio scan slot timeout"
+            except Exception as exc:
+                # Only the exception type: an error string can echo the
+                # scanned content, which never leaves this handler.
+                status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+                reason = "presidio scan failed: " + type(exc).__name__
+
+        findings: list[enforcement_reply_pb2.EnforcementFinding] = []
+        if status == enforcement_reply_pb2.ENFORCEMENT_STATUS_OK:
+            try:
+                findings = self._build_findings(message.organization_id, detections)
+            except Exception as exc:
+                status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+                reason = "fingerprint enforcement finding"
+                findings = []
+                self._logger.error(
+                    "fingerprint presidio enforcement finding",
+                    request_id=message.request_id,
+                    error_type=type(exc).__name__,
+                )
+
+        reply = enforcement_reply_pb2.EnforcementReply(
+            correlation_id=scan_id,
+            scanner=enforcement_reply_pb2.ENFORCEMENT_SCANNER_PRESIDIO,
+            status=status,
+            reason=reason[:_MAX_REPLY_REASON_CHARS],
+            findings=findings,
+            diagnostics=enforcement_reply_pb2.EnforcementDiagnostics(
+                scan_duration_ms=int((time.perf_counter() - started) * 1000),
+                consumer_id=self._consumer_id,
+                delivery_attempt=meta.delivery_attempt or 0,
+            ),
+        )
+        try:
+            await self._writer.write(reply_urn, reply)
+        except Exception as exc:
+            _reply_write_errors.add(1)
+            self._logger.error(
+                "write presidio enforcement reply; acknowledging request",
+                request_id=message.request_id,
+                error_type=type(exc).__name__,
+            )
+            return
+
+        await self._logger.adebug(
+            "presidio enforcement scan complete",
+            request_id=message.request_id,
+            detections=len(detections),
+            status=enforcement_reply_pb2.EnforcementStatus.Name(status),
+        )
+
+    def _build_findings(
+        self, organization_id: str, detections: list[Detection]
+    ) -> list[enforcement_reply_pb2.EnforcementFinding]:
+        findings: list[enforcement_reply_pb2.EnforcementFinding] = []
+        for d in detections:
+            rule_id = "pii." + d.entity_type.lower()
+            sum_, _ = self._fingerprinter.tenanted_hs256(
+                organization_id, d.match.encode()
+            )
+            findings.append(
+                enforcement_reply_pb2.EnforcementFinding(
+                    rule_id=rule_id,
+                    category=_classify(rule_id),
+                    score=d.confidence,
+                    start_pos=d.start_pos,
+                    end_pos=d.end_pos,
+                    surface="content",
+                    masked_preview=maskdisplay.display(rule_id, d.match),
+                    fingerprint=encode_fingerprint(sum_),
+                )
+            )
+        return findings
+
+
+def _classify(rule_id: str) -> str:
+    if rule_id in maskdisplay.FINANCIAL_RULE_IDS:
+        return "financial"
+    if rule_id in _GOVERNMENT_ID_RULE_IDS:
+        return "government_ids"
+    if rule_id in _HEALTHCARE_RULE_IDS:
+        return "healthcare"
+    if rule_id in _OFF_POLICY_RULE_IDS:
+        return "off_policy"
+    return "pii"

--- a/pystreams/src/pystreams/risk/fingerprint.py
+++ b/pystreams/src/pystreams/risk/fingerprint.py
@@ -1,0 +1,136 @@
+"""Tenant-peppered finding fingerprints, byte-identical to the Go implementation.
+
+Mirrors ``server/internal/risk/fingerprint.go``: a per-tenant 32-byte key is
+derived from the current pepper via HKDF-SHA256 (tenant id as salt, a fixed
+domain-separation info string), the match is HMAC-SHA256'd under that key, and
+the sum is rendered as unpadded base64url. The keyring JSON format is shared
+(``{"current": "v1", "keys": {"v1": "<base64 key>"}}``), so fingerprints
+produced here match the ones the Go scanners and ClickHouse rows carry.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Final
+
+# Domain-separates tenant fingerprint keys from any other use of the pepper.
+# Must match hkdfInfo in server/internal/risk/fingerprint.go.
+_HKDF_INFO: Final = b"gram/risk/fingerprint/tenant"
+_DERIVED_KEY_LEN: Final = 32
+# A pepper below this length has too little entropy to resist dictionary
+# attacks on fingerprints; reject at parse time rather than fingerprint weakly.
+_MIN_PEPPER_BYTES: Final = 16
+# Bound on cached per-tenant derived keys; the enforcement process is
+# long-lived and must not grow with tenant cardinality.
+_MAX_DERIVED_CACHE: Final = 1024
+
+
+class FingerprintKeyringError(ValueError):
+    """The pepper keyring JSON is missing, malformed, or inconsistent."""
+
+
+class Fingerprinter:
+    """HMAC fingerprinting under per-tenant keys derived from a pepper keyring."""
+
+    def __init__(self, current_version: str, keys: dict[str, bytes]) -> None:
+        # No construction path may sign under a weak current pepper; retired
+        # keys may be any length so a legacy entry cannot block startup.
+        if (
+            not current_version
+            or len(keys.get(current_version, b"")) < _MIN_PEPPER_BYTES
+        ):
+            raise FingerprintKeyringError(
+                f"current pepper {current_version!r} is missing or shorter"
+                f" than {_MIN_PEPPER_BYTES} bytes"
+            )
+        self._current_version = current_version
+        self._keys = keys
+        # Same (version, tenant) pair recurs for every finding in a message;
+        # cache the HKDF output so derivation runs once per tenant.
+        self._derived: dict[tuple[str, str], bytes] = {}
+
+    def tenanted_hs256(self, tenant_id: str, message: bytes) -> tuple[bytes, str]:
+        """Fingerprint message under the tenant's key for the current version."""
+        key = self._derive_key(self._current_version, tenant_id)
+        return hmac.new(key, message, hashlib.sha256).digest(), self._current_version
+
+    def _derive_key(self, version: str, tenant_id: str) -> bytes:
+        cache_key = (version, tenant_id)
+        cached = self._derived.get(cache_key)
+        if cached is not None:
+            # dict preserves insertion order; re-inserting keeps hot tenants
+            # out of the eviction window below.
+            self._derived.pop(cache_key)
+            self._derived[cache_key] = cached
+            return cached
+        pepper = self._keys.get(version)
+        if pepper is None:
+            raise FingerprintKeyringError(
+                f"fingerprint pepper key not found: {version}"
+            )
+        key = _hkdf_sha256(
+            pepper, salt=tenant_id.encode(), info=_HKDF_INFO, length=_DERIVED_KEY_LEN
+        )
+        while len(self._derived) >= _MAX_DERIVED_CACHE:
+            self._derived.pop(next(iter(self._derived)))
+        self._derived[cache_key] = key
+        return key
+
+
+def _hkdf_sha256(ikm: bytes, *, salt: bytes, info: bytes, length: int) -> bytes:
+    """RFC 5869 HKDF over SHA-256, matching Go's ``crypto/hkdf.Key``."""
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()
+    okm = b""
+    block = b""
+    counter = 1
+    while len(okm) < length:
+        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha256).digest()
+        okm += block
+        counter += 1
+    return okm[:length]
+
+
+def encode_fingerprint(sum_: bytes) -> str:
+    """Render a fingerprint sum as unpadded base64url (the stored encoding)."""
+    return base64.urlsafe_b64encode(sum_).rstrip(b"=").decode()
+
+
+def parse_pepper_keyring(raw: str | bytes) -> Fingerprinter:
+    """Parse the shared keyring JSON; raises FingerprintKeyringError when invalid."""
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise FingerprintKeyringError(
+            "invalid fingerprint pepper keyring json"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise FingerprintKeyringError("invalid fingerprint pepper keyring json")
+
+    current = parsed.get("current")
+    raw_keys = parsed.get("keys")
+    if not isinstance(current, str) or not current:
+        raise FingerprintKeyringError("current version not set")
+    if not isinstance(raw_keys, dict) or not raw_keys:
+        raise FingerprintKeyringError("no keys found in keyring")
+
+    keys: dict[str, bytes] = {}
+    for version, encoded in raw_keys.items():
+        if not isinstance(version, str) or not isinstance(encoded, str):
+            raise FingerprintKeyringError("invalid fingerprint pepper keyring")
+        try:
+            # Go's decoder ignores CR/LF; a wrapped shared secret must parse here too.
+            decoded = base64.b64decode(
+                encoded.replace("\r", "").replace("\n", ""), validate=True
+            )
+        except ValueError as exc:
+            raise FingerprintKeyringError(
+                f"failed to decode key for version {version}"
+            ) from exc
+        keys[version] = decoded
+    if current not in keys:
+        raise FingerprintKeyringError(f"current version {current} not found in keys")
+    # The constructor enforces the current-pepper minimum length.
+    return Fingerprinter(current, keys)

--- a/pystreams/src/pystreams/risk/maskdisplay.py
+++ b/pystreams/src/pystreams/risk/maskdisplay.py
@@ -1,0 +1,44 @@
+"""Partial-mask display form of a Presidio match, mirroring the Go package.
+
+Port of the Presidio-relevant subset of
+``server/internal/risk/maskdisplay/maskdisplay.go``. Only the ``presidio``
+source flows through this module, so the judge/derived-source and shadow-mcp
+branches of the Go function are omitted; the email, financial, and general
+tiers are byte-identical for the same input. Keep the two in lockstep.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# The Presidio email rule; its match is an email whose domain is safe to show.
+_EMAIL_RULE_ID: Final = "pii.email_address"
+
+# Presidio rule ids classified as financial (server/internal/risk/categories).
+FINANCIAL_RULE_IDS: Final = frozenset(
+    {"pii.credit_card", "pii.iban_code", "pii.us_bank_number", "pii.crypto"}
+)
+
+
+def display(rule_id: str, match: str) -> str:
+    """Return the partial-mask display form of a raw Presidio match."""
+    if not match:
+        return ""
+
+    if rule_id == _EMAIL_RULE_ID:
+        at = match.rfind("@")
+        if at >= 0:
+            # Fixed three stars so the local-part length does not leak.
+            return "***@" + match[at + 1 :]
+
+    n = len(match)
+    if rule_id in FINANCIAL_RULE_IDS and n >= 5:
+        return "****" + match[n - 4 :]
+
+    if n >= 8:
+        return match[:4] + "*" * (n - 6) + match[n - 2 :]
+    if n >= 5:
+        return match[:2] + "*" * (n - 3) + match[n - 1 :]
+    if n >= 3:
+        return match[:1] + "*" * (n - 2) + match[n - 1 :]
+    return "*" * n

--- a/pystreams/tests/test_multi.py
+++ b/pystreams/tests/test_multi.py
@@ -64,6 +64,9 @@ async def test_blocking_detection_starts_after_scanner_initialization(
             scan_timeout=1,
             scan_slot_timeout=1,
             max_inflight=None,
+            redis_addr=None,
+            redis_password=None,
+            risk_fingerprint_pepper_keyring=None,
         )
 
     assert startup_events == [

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -1,0 +1,388 @@
+"""Tests for the Presidio enforcement scanning domain."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import fakeredis.aioredis
+import pytest
+import structlog
+from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
+from gram_infra.pubsub.subscriber import MessageMetadata
+
+import pystreams.risk.enforce_handler as enforce_handler_mod
+from pystreams.risk import maskdisplay
+from pystreams.risk.enforce_handler import (
+    MAX_CONTENT_BYTES,
+    MalformedEnforcementRequest,
+    PresidioEnforceHandler,
+)
+from pystreams.risk.fingerprint import (
+    Fingerprinter,
+    FingerprintKeyringError,
+    encode_fingerprint,
+    parse_pepper_keyring,
+)
+from pystreams.risk.replywriter import (
+    ReplyWriter,
+    inbox_key,
+)
+from pystreams.risk.scanner import Detection, ScanSlotTimeout
+
+# Keyring shared with the Go golden-vector run (see the fingerprint parity test).
+_KEYRING = json.dumps(
+    {
+        "current": "v1",
+        "keys": {"v1": "c3ludGhldGljLWZpbmdlcnByaW50LWtleS1tYXRlcmlhbA=="},
+    }
+)
+
+_REPLY_URN = "urn:gram:risk:enforce:replica-1:0198f1f4-0000-7000-8000-000000000000"
+_SCAN_ID = "0198f1f4-0000-7000-8000-000000000000"
+
+
+class FakeScanner:
+    def __init__(
+        self,
+        detections: list[Detection] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.detections = detections or []
+        self.error = error
+        self.calls: list[str] = []
+        self.thresholds: list[float] = []
+
+    async def scan(
+        self,
+        content: str,
+        entities: list[str] | None,
+        score_threshold: float,
+    ) -> list[Detection]:
+        self.calls.append(content)
+        self.thresholds.append(score_threshold)
+        if self.error is not None:
+            raise self.error
+        return self.detections
+
+    async def aclose(self) -> None:
+        return None
+
+    async def __aenter__(self) -> FakeScanner:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+
+def _message(
+    *,
+    content: str = "email jane.doe@example.com",
+    created_at: str | None = None,
+    organization_id: str = "org-123",
+) -> presidio_enforcement_pb2.PresidioEnforcement:
+    return presidio_enforcement_pb2.PresidioEnforcement(
+        request_id="req-1",
+        project_id="proj-1",
+        organization_id=organization_id,
+        created_at=(
+            datetime.now(UTC).isoformat() if created_at is None else created_at
+        ),
+        content=content,
+    )
+
+
+def _meta(reply_urn: str = _REPLY_URN) -> MessageMetadata:
+    return MessageMetadata(
+        id="m1",
+        attributes={enforce_handler_mod.REPLY_URN_ATTRIBUTE: reply_urn},
+        delivery_attempt=1,
+    )
+
+
+def _handler(
+    scanner: FakeScanner, client: fakeredis.aioredis.FakeRedis
+) -> PresidioEnforceHandler:
+    return PresidioEnforceHandler(
+        structlog.get_logger(),
+        ReplyWriter(client),
+        scanner,
+        parse_pepper_keyring(_KEYRING),
+    )
+
+
+async def _read_reply(
+    client: fakeredis.aioredis.FakeRedis,
+) -> enforcement_reply_pb2.EnforcementReply:
+    raw = await client.lpop(inbox_key("replica-1"))
+    assert isinstance(raw, bytes)
+    reply = enforcement_reply_pb2.EnforcementReply()
+    reply.ParseFromString(raw)
+    return reply
+
+
+def test_fingerprint_matches_go_golden_vectors():
+    fp = parse_pepper_keyring(_KEYRING)
+    sum1, version = fp.tenanted_hs256("org-123", b"jane.doe@example.com")
+    assert version == "v1"
+    # Golden values from server/internal/risk (TenantedHS256 + EncodeFingerprint).
+    assert encode_fingerprint(sum1) == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
+    sum2, _ = fp.tenanted_hs256("org-456", b"jane.doe@example.com")
+    assert encode_fingerprint(sum2) == "sPaNo7W-wULGODbRJGEiypFFzKfzTAbMsQ77l_KBi54"
+
+
+def test_parse_pepper_keyring_rejects_bad_input():
+    with pytest.raises(FingerprintKeyringError):
+        parse_pepper_keyring("not json")
+    with pytest.raises(FingerprintKeyringError):
+        parse_pepper_keyring(json.dumps({"current": "v2", "keys": {"v1": "AAAA"}}))
+    # Current pepper below the 16-byte minimum ("c2hvcnQ=" decodes to 5 bytes).
+    with pytest.raises(FingerprintKeyringError):
+        parse_pepper_keyring(json.dumps({"current": "v1", "keys": {"v1": "c2hvcnQ="}}))
+    # Direct construction enforces the same invariant.
+    with pytest.raises(FingerprintKeyringError):
+        Fingerprinter("", {"": b"long-enough-pepper-material"})
+
+
+def test_maskdisplay_tiers():
+    assert maskdisplay.display("pii.email_address", "jane.doe@example.com") == (
+        "***@example.com"
+    )
+    assert maskdisplay.display("pii.credit_card", "4111111111111111") == "****1111"
+    assert maskdisplay.display("pii.phone_number", "+14155550123") == ("+141******23")
+    assert maskdisplay.display("pii.person", "Jo") == "**"
+
+
+async def test_handler_writes_ok_reply_with_safe_findings():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner(
+        detections=[
+            Detection(
+                entity_type="EMAIL_ADDRESS",
+                match="jane.doe@example.com",
+                start_pos=6,
+                end_pos=26,
+                confidence=0.9,
+            )
+        ]
+    )
+    await _handler(scanner, client).handle(_message(), _meta())
+
+    # TTL is set alongside the push; -1 (no expiry) must fail. Checked before
+    # reading, since popping the only element deletes the key.
+    assert 0 < await client.ttl(inbox_key("replica-1")) <= 60
+    reply = await _read_reply(client)
+    assert reply.correlation_id == _SCAN_ID
+    assert reply.scanner == enforcement_reply_pb2.ENFORCEMENT_SCANNER_PRESIDIO
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_OK
+    assert len(reply.findings) == 1
+    finding = reply.findings[0]
+    assert finding.rule_id == "pii.email_address"
+    assert finding.category == "pii"
+    assert finding.masked_preview == "***@example.com"
+    assert "jane.doe" not in finding.masked_preview
+    assert finding.fingerprint == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
+
+
+class FailingWriter:
+    def __init__(self) -> None:
+        self.called = False
+
+    async def write(self, reply_urn: str, reply: object) -> None:
+        self.called = True
+        raise ConnectionError("redis unavailable")
+
+
+async def test_handler_acks_request_when_reply_write_fails():
+    # A nack would send raw content to the DLQ; the handler must ack and the
+    # waiter's deadline covers the lost reply.
+    writer = FailingWriter()
+    handler = PresidioEnforceHandler(
+        structlog.get_logger(),
+        cast(ReplyWriter, writer),
+        FakeScanner(),
+        parse_pepper_keyring(_KEYRING),
+    )
+    await handler.handle(_message(), _meta())
+    assert writer.called
+
+
+def test_classify_covers_every_category_set():
+    assert enforce_handler_mod._classify("pii.credit_card") == "financial"
+    assert enforce_handler_mod._classify("pii.us_ssn") == "government_ids"
+    assert enforce_handler_mod._classify("pii.medical_license") == "healthcare"
+    assert enforce_handler_mod._classify("pii.policy_violation") == "off_policy"
+    assert enforce_handler_mod._classify("pii.email_address") == "pii"
+
+
+async def test_handler_replies_error_when_fingerprinting_fails():
+    class FailingFingerprinter:
+        def tenanted_hs256(self, tenant_id: str, message: bytes) -> tuple[bytes, str]:
+            raise RuntimeError("hkdf failure")
+
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner(
+        detections=[
+            Detection(
+                entity_type="EMAIL_ADDRESS",
+                match="jane.doe@example.com",
+                start_pos=6,
+                end_pos=26,
+                confidence=0.9,
+            )
+        ]
+    )
+    handler = PresidioEnforceHandler(
+        structlog.get_logger(),
+        ReplyWriter(client),
+        scanner,
+        cast(Fingerprinter, FailingFingerprinter()),
+    )
+    await handler.handle(_message(), _meta())
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+    assert reply.reason == "fingerprint enforcement finding"
+    assert len(reply.findings) == 0
+
+
+async def test_handler_honors_explicit_zero_score_threshold():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    message = _message()
+    message.score_threshold = 0.0
+    await _handler(scanner, client).handle(message, _meta())
+    assert scanner.thresholds == [0.0]
+
+    unset = FakeScanner()
+    await _handler(unset, client).handle(_message(), _meta())
+    assert unset.thresholds == [enforce_handler_mod.DEFAULT_SCORE_THRESHOLD]
+
+
+def test_handler_rejects_non_finite_max_request_age():
+    for bad in [float("nan"), float("inf"), float("-inf"), 0.0]:
+        handler = PresidioEnforceHandler(
+            structlog.get_logger(),
+            ReplyWriter(fakeredis.aioredis.FakeRedis()),
+            FakeScanner(),
+            parse_pepper_keyring(_KEYRING),
+            max_request_age_seconds=bad,
+        )
+        assert (
+            handler._max_request_age
+            == enforce_handler_mod.DEFAULT_MAX_REQUEST_AGE_SECONDS
+        )
+
+
+def test_parse_pepper_keyring_accepts_line_wrapped_base64():
+    key = "c3ludGhldGljLWZpbmdlcnByaW50\nLWtleS1tYXRlcmlhbA=="
+    wrapped = json.dumps({"current": "v1", "keys": {"v1": key}})
+    fp = parse_pepper_keyring(wrapped)
+    sum1, _ = fp.tenanted_hs256("org-123", b"jane.doe@example.com")
+    assert encode_fingerprint(sum1) == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
+
+
+async def test_handler_drops_stale_request_without_reply():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    stale = (datetime.now(UTC) - timedelta(seconds=45)).isoformat()
+    await _handler(scanner, client).handle(_message(created_at=stale), _meta())
+    assert scanner.calls == []
+    assert await client.lpop(inbox_key("replica-1")) is None
+
+
+async def test_handler_routes_stale_malformed_request_to_dlq():
+    # Structural validation precedes the staleness drop: a stale request with a
+    # missing tenant still raises for the forensic DLQ.
+    stale = (datetime.now(UTC) - timedelta(seconds=45)).isoformat()
+    with pytest.raises(MalformedEnforcementRequest):
+        await _handler(FakeScanner(), fakeredis.aioredis.FakeRedis()).handle(
+            _message(created_at=stale, organization_id=""), _meta()
+        )
+
+
+async def test_handler_rejects_empty_created_at_as_malformed():
+    with pytest.raises(MalformedEnforcementRequest):
+        await _handler(FakeScanner(), fakeredis.aioredis.FakeRedis()).handle(
+            _message(created_at=""), _meta()
+        )
+
+
+async def test_handler_rejects_naive_created_at_as_malformed():
+    naive = datetime.now(UTC).replace(tzinfo=None).isoformat()
+    with pytest.raises(MalformedEnforcementRequest):
+        await _handler(FakeScanner(), fakeredis.aioredis.FakeRedis()).handle(
+            _message(created_at=naive), _meta()
+        )
+
+
+async def test_handler_raises_on_missing_tenant_for_dlq():
+    client = fakeredis.aioredis.FakeRedis()
+    with pytest.raises(MalformedEnforcementRequest):
+        await _handler(FakeScanner(), client).handle(
+            _message(organization_id=""), _meta()
+        )
+
+
+async def test_handler_replies_error_on_scan_failure_without_content():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner(error=RuntimeError("boom jane.doe@example.com"))
+    await _handler(scanner, client).handle(_message(), _meta())
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+    assert "jane.doe" not in reply.reason
+    assert "RuntimeError" in reply.reason
+
+
+async def test_handler_replies_error_on_scan_slot_timeout():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner(error=ScanSlotTimeout("pool saturated"))
+    await _handler(scanner, client).handle(_message(), _meta())
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+
+
+async def test_handler_drops_far_future_request_without_reply():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    future = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    await _handler(scanner, client).handle(_message(created_at=future), _meta())
+    assert scanner.calls == []
+    assert await client.lpop(inbox_key("replica-1")) is None
+
+
+@pytest.mark.parametrize(
+    "threshold", [1.5, -0.5, float("nan"), float("inf"), float("-inf")]
+)
+async def test_handler_rejects_out_of_range_threshold_without_scanning(
+    threshold: float,
+):
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    message = _message()
+    message.score_threshold = threshold
+    await _handler(scanner, client).handle(message, _meta())
+    assert scanner.calls == []
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+
+
+async def test_handler_rejects_oversized_entity_selection_without_scanning():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    message = _message()
+    message.entities.extend(
+        f"ENTITY_{n}" for n in range(enforce_handler_mod.MAX_REQUESTED_ENTITIES + 1)
+    )
+    await _handler(scanner, client).handle(message, _meta())
+    assert scanner.calls == []
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+
+
+async def test_handler_rejects_oversized_content_without_scanning():
+    client = fakeredis.aioredis.FakeRedis()
+    scanner = FakeScanner()
+    big = "a" * (MAX_CONTENT_BYTES + 1)
+    await _handler(scanner, client).handle(_message(content=big), _meta())
+    assert scanner.calls == []
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR

--- a/server/internal/risk/fingerprint.go
+++ b/server/internal/risk/fingerprint.go
@@ -18,6 +18,10 @@ import (
 // other use of the same pepper.
 const hkdfInfo = "gram/risk/fingerprint/tenant"
 
+// minCurrentPepperBytes is the minimum length of the key that signs new
+// fingerprints; an HMAC pepper shorter than this is guessable.
+const minCurrentPepperBytes = 16
+
 var (
 	ErrInvalidFingerprintPepperJSON    = errors.New("invalid fingerprint pepper keyring json")
 	ErrInvalidFingerprintPepperKeyRing = errors.New("invalid fingerprint pepper keyring")
@@ -230,6 +234,12 @@ func ParsePepperKeyRing(jsonSecret []byte) (Fingerprinter, error) {
 
 	if len(keyring.keys) == 0 {
 		return empty, fmt.Errorf("no keys found in keyring: %w", ErrInvalidFingerprintPepperKeyRing)
+	}
+
+	// Only the current key signs new fingerprints; retired keys may be any
+	// length. Mirrors the pystreams keyring validation.
+	if len(keyring.keys[keyring.currentVersion]) < minCurrentPepperBytes {
+		return empty, fmt.Errorf("current pepper %s is %d bytes; minimum is %d: %w", keyring.currentVersion, len(keyring.keys[keyring.currentVersion]), minCurrentPepperBytes, ErrInvalidFingerprintPepperKeyRing)
 	}
 
 	return keyring, nil

--- a/server/internal/risk/fingerprint_test.go
+++ b/server/internal/risk/fingerprint_test.go
@@ -104,6 +104,11 @@ func TestParsePepperKeyRing_Errors(t *testing.T) {
 			payload: []byte(`{"current":"v9","keys":{"v1":"00112233"}}`),
 			wantErr: risk.ErrInvalidFingerprintPepperKeyRing,
 		},
+		{
+			name:    "current pepper shorter than 16 bytes",
+			payload: []byte(`{"current":"v1","keys":{"v1":"c2hvcnQ="}}`),
+			wantErr: risk.ErrInvalidFingerprintPepperKeyRing,
+		},
 	}
 
 	for _, tt := range tests {
@@ -120,7 +125,7 @@ func TestParsePepperKeyRing_Errors(t *testing.T) {
 func TestFingerprinter_HS256WithVersion_UnknownVersion(t *testing.T) {
 	t.Parallel()
 
-	payload := keyRingJSON(t, "v1", map[string][]byte{"v1": []byte("k")})
+	payload := keyRingJSON(t, "v1", map[string][]byte{"v1": []byte("key-material-for-v1")})
 	fp, err := risk.ParsePepperKeyRing(payload)
 	require.NoError(t, err)
 
@@ -226,7 +231,7 @@ func TestFingerprinter_TenantedHS256_WithKeyCache(t *testing.T) {
 func TestFingerprinter_TenantedHS256WithVersion_UnknownVersion(t *testing.T) {
 	t.Parallel()
 
-	payload := keyRingJSON(t, "v1", map[string][]byte{"v1": []byte("k")})
+	payload := keyRingJSON(t, "v1", map[string][]byte{"v1": []byte("key-material-for-v1")})
 	fp, err := risk.ParsePepperKeyRing(payload)
 	require.NoError(t, err)
 

--- a/server/internal/scanners/gitleaks/enforce_handler.go
+++ b/server/internal/scanners/gitleaks/enforce_handler.go
@@ -88,10 +88,6 @@ func (h *EnforceHandler) Handle(ctx context.Context, m *riskv1.GitleaksEnforceme
 	if err != nil {
 		return fmt.Errorf("parse enforcement created_at: %w", err)
 	}
-	if time.Since(createdAt) > h.maxRequestAge {
-		h.metrics.staleDropped.Add(ctx, 1)
-		return nil
-	}
 	if m.GetOrganizationId() == "" {
 		return errors.New("enforcement organization id is required")
 	}
@@ -105,6 +101,13 @@ func (h *EnforceHandler) Handle(ctx context.Context, m *riskv1.GitleaksEnforceme
 	_, correlationID, err := enforcereply.ParseReplyURN(replyURN)
 	if err != nil {
 		return fmt.Errorf("parse enforcement reply urn: %w", err)
+	}
+	// Structural validation first: a stale AND malformed request belongs in the
+	// forensic DLQ, not in a silent drop. Symmetric window: a far-future stamp
+	// is as suspect as a stale one.
+	if age := time.Since(createdAt); age > h.maxRequestAge || age < -h.maxRequestAge {
+		h.metrics.staleDropped.Add(ctx, 1)
+		return nil
 	}
 
 	started := time.Now()

--- a/server/internal/scanners/gitleaks/enforce_handler_test.go
+++ b/server/internal/scanners/gitleaks/enforce_handler_test.go
@@ -82,6 +82,25 @@ func TestEnforceHandlerAcknowledgesStaleRequest(t *testing.T) {
 	require.Equal(t, int64(1), counterValue(t, reader, "risk.enforcement.gitleaks.stale_dropped"))
 }
 
+func TestEnforceHandlerAcknowledgesFarFutureRequest(t *testing.T) {
+	t.Parallel()
+
+	mr, _, writer := newReplyWriter(t)
+	meterProvider, reader := newTestMeterProvider(t)
+	handler, _ := newTestEnforceHandler(t, meterProvider, writer, 30*time.Second)
+	request := riskv1.GitleaksEnforcement_builder{
+		RequestId:      new("scan-future"),
+		ProjectId:      new("project-future"),
+		OrganizationId: new("org-future"),
+		CreatedAt:      new(time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339Nano)),
+		Content:        new(fakeSecret),
+	}.Build()
+
+	require.NoError(t, handler.Handle(t.Context(), request, replyMetadata("replica-future", "scan-future", nil)))
+	require.False(t, mr.Exists(enforcereply.InboxKey("replica-future")))
+	require.Equal(t, int64(1), counterValue(t, reader, "risk.enforcement.gitleaks.stale_dropped"))
+}
+
 func TestEnforceHandlerAcknowledgesReplyWriteFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/scanners/gitleaks/enforce_metrics.go
+++ b/server/internal/scanners/gitleaks/enforce_metrics.go
@@ -15,7 +15,7 @@ func newEnforceHandlerMetrics(meterProvider metric.MeterProvider) (enforceHandle
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/scanners/gitleaks")
 	staleDropped, err := meter.Int64Counter(
 		"risk.enforcement.gitleaks.stale_dropped",
-		metric.WithDescription("Gitleaks enforcement requests acknowledged without scanning because they were stale"),
+		metric.WithDescription("Gitleaks enforcement requests acknowledged without scanning because their timestamp fell outside the freshness window (stale or far-future)"),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {


### PR DESCRIPTION
Presidio scanning domain for the enforcement lane, on top of #5981.

- `PresidioEnforceHandler`: inline scan with strict validation (aware timestamps, symmetric 30s freshness window, content/threshold caps), forensic-DLQ routing for malformed requests, ERROR replies on scan failure carrying only the exception type, and ack-not-nack on reply-write failure so raw content never reaches a DLQ.
- Replies carry masked previews plus tenant-peppered fingerprints only; the Python fingerprint port is golden-vector matched against Go, and both languages enforce a 16-byte minimum on the current pepper.
- Registers the consumer in `multi.py` behind Redis + keyring configuration, validated at startup, with a per-scan-slot admission cap.
- Applies the symmetric freshness window to the gitleaks enforce handler as well.

https://claude.ai/code/session_011zaiS6VU4N6NBoc5jbUL5b
