### PR TITLE
feat(billing): stamp organization identity on Stripe objects

### DIFF
--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -458,14 +458,24 @@ async function main() {
   ]);
 
   // Products created before the metadata contract existed need the tag added.
+  // Only the PAYG product may be tagged: a lookup-key match on a different
+  // product, or a product already classified as something else, is a
+  // misconfiguration to fix by hand rather than overwrite.
   const product = await stripe<StripeProduct>(
     key,
     "GET",
     `/products/${price.product}`,
   );
-  if (
-    product.metadata?.speakeasy_product !== PRODUCT_METADATA_SPEAKEASY_PRODUCT
-  ) {
+  assertConfiguration(`Product ${product.id}`, [
+    ["name", product.name, PRODUCT_NAME],
+  ]);
+  const productTag = product.metadata?.speakeasy_product;
+  if (productTag && productTag !== PRODUCT_METADATA_SPEAKEASY_PRODUCT) {
+    throw new Error(
+      `Product ${product.id} has unexpected metadata.speakeasy_product=${productTag}; fix the product association before re-running.`,
+    );
+  }
+  if (!productTag) {
     await stripe<StripeProduct>(key, "POST", `/products/${product.id}`, {
       "metadata[speakeasy_product]": PRODUCT_METADATA_SPEAKEASY_PRODUCT,
     });

--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -15,6 +15,9 @@ const METER_DISPLAY_NAME = "Tokens under management";
 const PRICE_LOOKUP_KEY = "payg-tum";
 const PRODUCT_NAME = "AI Control Plane PAYG";
 const PORTAL_CONFIGURATION_PURPOSE = "gram-payg";
+// Shared Stripe metadata contract (see server/internal/thirdparty/stripe/client.go):
+// products are tagged so revenue tooling can classify line items without name heuristics.
+const PRODUCT_METADATA_SPEAKEASY_PRODUCT = "aicp";
 // $0.35 per 1M TUMs, linear per-unit, expressed in cents per TUM.
 const UNIT_AMOUNT_DECIMAL_CENTS = "0.000035";
 
@@ -38,8 +41,15 @@ interface StripeMeter {
   customer_mapping?: { type?: string; event_payload_key?: string };
 }
 
+interface StripeProduct {
+  id: string;
+  name: string;
+  metadata?: Record<string, string>;
+}
+
 interface StripePrice {
   id: string;
+  product: string;
   active: boolean;
   livemode: boolean;
   currency: string;
@@ -414,6 +424,8 @@ async function main() {
     );
     const createParams: Record<string, string> = {
       "product_data[name]": PRODUCT_NAME,
+      "product_data[metadata][speakeasy_product]":
+        PRODUCT_METADATA_SPEAKEASY_PRODUCT,
       lookup_key: PRICE_LOOKUP_KEY,
       nickname: "PAYG TUM ($0.35 per 1M)",
       currency: "usd",
@@ -444,6 +456,27 @@ async function main() {
     ["recurring.usage_type", price.recurring?.usage_type, "metered"],
     ["recurring.meter", price.recurring?.meter, meter.id],
   ]);
+
+  // Products created before the metadata contract existed need the tag added.
+  const product = await stripe<StripeProduct>(
+    key,
+    "GET",
+    `/products/${price.product}`,
+  );
+  if (
+    product.metadata?.speakeasy_product !== PRODUCT_METADATA_SPEAKEASY_PRODUCT
+  ) {
+    await stripe<StripeProduct>(key, "POST", `/products/${product.id}`, {
+      "metadata[speakeasy_product]": PRODUCT_METADATA_SPEAKEASY_PRODUCT,
+    });
+    log.success(
+      `Tagged product ${product.id} with metadata.speakeasy_product=${PRODUCT_METADATA_SPEAKEASY_PRODUCT}`,
+    );
+  } else {
+    log.info(
+      `Product ${product.id} already tagged speakeasy_product=${PRODUCT_METADATA_SPEAKEASY_PRODUCT}`,
+    );
+  }
 
   // Billing Portal — use a dedicated, tagged configuration so production
   // behavior cannot drift when someone edits Stripe's mutable default.

--- a/.mise-tasks/stripe/setup.mts
+++ b/.mise-tasks/stripe/setup.mts
@@ -15,8 +15,6 @@ const METER_DISPLAY_NAME = "Tokens under management";
 const PRICE_LOOKUP_KEY = "payg-tum";
 const PRODUCT_NAME = "AI Control Plane PAYG";
 const PORTAL_CONFIGURATION_PURPOSE = "gram-payg";
-// Shared Stripe metadata contract (see server/internal/thirdparty/stripe/client.go):
-// products are tagged so revenue tooling can classify line items without name heuristics.
 const PRODUCT_METADATA_SPEAKEASY_PRODUCT = "aicp";
 // $0.35 per 1M TUMs, linear per-unit, expressed in cents per TUM.
 const UNIT_AMOUNT_DECIMAL_CENTS = "0.000035";
@@ -457,10 +455,7 @@ async function main() {
     ["recurring.meter", price.recurring?.meter, meter.id],
   ]);
 
-  // Products created before the metadata contract existed need the tag added.
-  // Only the PAYG product may be tagged: a lookup-key match on a different
-  // product, or a product already classified as something else, is a
-  // misconfiguration to fix by hand rather than overwrite.
+  // Only the PAYG product may be tagged; a conflicting tag is fixed by hand.
   const product = await stripe<StripeProduct>(
     key,
     "GET",

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -18,15 +18,19 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
-// Metadata keys stamped on Stripe objects. organization_name and account_type go on
-// the Customer only: Checkout requests are replayed under their original idempotency
+// Metadata keys stamped on Stripe objects. Checkout Sessions and Subscriptions belong to
+// this product and carry speakeasy_product. A Customer can be shared with the SDK
+// product (same organization id), so its product-specific key is namespaced and
+// speakeasy_product is never written on a Customer; Stripe merges metadata on update,
+// so each product only touches its own keys. organization_name and the account type go
+// on the Customer only: Checkout requests are replayed under their original idempotency
 // key and Stripe rejects a replay whose parameters differ.
 const (
 	organizationIDMetadataKey   = "organization_id"
 	organizationSlugMetadataKey = "organization_slug"
 	organizationNameMetadataKey = "organization_name"
 	speakeasyProductMetadataKey = "speakeasy_product"
-	accountTypeMetadataKey      = "account_type"
+	accountTypeMetadataKey      = "aicp_account_type"
 	meterCustomerPayloadKey     = "stripe_customer_id"
 	meterValuePayloadKey        = "value"
 	allocationMetadataKey       = "gram_billing_allocation"
@@ -158,9 +162,11 @@ func contractMetadata(org organizationIdentity) map[string]string {
 }
 
 func customerMetadata(org organizationIdentity, name string) map[string]string {
-	metadata := contractMetadata(org)
-	metadata[organizationNameMetadataKey] = name
-	return metadata
+	return map[string]string{
+		organizationIDMetadataKey:   org.id,
+		organizationSlugMetadataKey: org.slug,
+		organizationNameMetadataKey: name,
+	}
 }
 
 // validAccountType returns the account type to stamp, or "" when it is outside

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -17,18 +17,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
-// Stripe metadata contract shared across Speakeasy billing systems so downstream
-// consumers can classify and attribute Stripe objects without heuristics.
-//
-//   - Customer, Checkout Session and Subscription: speakeasy_product,
-//     organization_id, organization_slug.
-//   - Customer only: organization_name and account_type (one of
-//     constants.AccountTypes). Checkout requests are replayed under their original
-//     idempotency key and Stripe rejects a replay whose parameters differ, so
-//     values that can change within a session's lifetime never go on the session.
-//
-// Organization IDs are shared with the other Speakeasy products, so attributes
-// they own are resolved there rather than duplicated here.
+// Metadata keys stamped on Stripe objects. organization_name and account_type go on
+// the Customer only: Checkout requests are replayed under their original idempotency
+// key and Stripe rejects a replay whose parameters differ.
 const (
 	organizationIDMetadataKey   = "organization_id"
 	organizationSlugMetadataKey = "organization_slug"
@@ -164,8 +155,6 @@ func contractMetadata(org organizationIdentity) map[string]string {
 	}
 }
 
-// customerMetadata adds the mutable identity (name, account type) that only belongs
-// on the Customer, which is updated in place rather than replayed.
 func customerMetadata(org organizationIdentity, name, accountType string) map[string]string {
 	metadata := contractMetadata(org)
 	metadata[organizationNameMetadataKey] = name

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -17,13 +17,18 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
-// Stripe metadata contract shared with speakeasy-registry (SDK product). Every
-// Customer, Checkout Session and Subscription carries these keys so downstream
-// consumers (revenue notifications, CRM sync) can classify and attribute Stripe
-// objects without heuristics. Keep key names in sync with
-// speakeasy-registry/internal/stripe/metadata.go. Organization IDs are shared
-// across both products, so registry-owned attributes (e.g. internal) are
-// resolved there rather than duplicated here.
+// Stripe metadata contract shared across Speakeasy billing systems so downstream
+// consumers can classify and attribute Stripe objects without heuristics.
+//
+//   - Customer, Checkout Session and Subscription: speakeasy_product,
+//     organization_id, organization_slug.
+//   - Customer only: organization_name and account_type (one of
+//     constants.AccountTypes). Checkout requests are replayed under their original
+//     idempotency key and Stripe rejects a replay whose parameters differ, so
+//     values that can change within a session's lifetime never go on the session.
+//
+// Organization IDs are shared with the other Speakeasy products, so attributes
+// they own are resolved there rather than duplicated here.
 const (
 	organizationIDMetadataKey   = "organization_id"
 	organizationSlugMetadataKey = "organization_slug"
@@ -118,7 +123,8 @@ type CreateCustomerInput struct {
 	// Email is the billing contact shown on Stripe receipts and Checkout. Empty leaves it unset.
 	Email string
 
-	// AccountType is the organization's gram_account_type at creation time.
+	// AccountType is the organization's gram_account_type at creation time. Empty
+	// leaves the key unset.
 	AccountType string
 
 	IdempotencyKey string
@@ -130,8 +136,13 @@ type UpdateCustomerInput struct {
 	OrganizationID   string
 	OrganizationSlug string
 	OrganizationName string
-	Email            string
-	AccountType      string
+
+	// Email replaces the customer's billing email. Empty leaves the existing value
+	// unchanged: callers resolve it best-effort and must not clear a working address.
+	Email string
+
+	// AccountType is the organization's current gram_account_type. Empty leaves the key unset.
+	AccountType string
 }
 
 // Customer is the Stripe customer data needed by billing callers.
@@ -143,7 +154,6 @@ type Customer struct {
 type organizationIdentity struct {
 	id   string
 	slug string
-	name string
 }
 
 func contractMetadata(org organizationIdentity) map[string]string {
@@ -151,17 +161,17 @@ func contractMetadata(org organizationIdentity) map[string]string {
 		speakeasyProductMetadataKey: speakeasyProductAICP,
 		organizationIDMetadataKey:   org.id,
 		organizationSlugMetadataKey: org.slug,
-		organizationNameMetadataKey: org.name,
 	}
 }
 
-// customerMetadata adds account_type, which only belongs on the customer: Checkout
-// sessions are replayed under their original idempotency key and the account type
-// changes during that window (trial conversion, PAYG activation), so stamping it
-// there would make the replay diverge from the original request.
-func customerMetadata(org organizationIdentity, accountType string) map[string]string {
+// customerMetadata adds the mutable identity (name, account type) that only belongs
+// on the Customer, which is updated in place rather than replayed.
+func customerMetadata(org organizationIdentity, name, accountType string) map[string]string {
 	metadata := contractMetadata(org)
-	metadata[accountTypeMetadataKey] = accountType
+	metadata[organizationNameMetadataKey] = name
+	if accountType != "" {
+		metadata[accountTypeMetadataKey] = accountType
+	}
 	return metadata
 }
 
@@ -175,9 +185,6 @@ type CreateCheckoutSessionInput struct {
 
 	// OrganizationSlug is the organization slug included in Stripe metadata.
 	OrganizationSlug string
-
-	// OrganizationName is the display name included in Stripe metadata.
-	OrganizationName string
 
 	// SuccessURL is the browser destination after successful Checkout.
 	SuccessURL string
@@ -579,8 +586,7 @@ func (c *client) CreateCustomer(ctx context.Context, input CreateCustomerInput) 
 	params.Metadata = customerMetadata(organizationIdentity{
 		id:   input.OrganizationID,
 		slug: input.OrganizationSlug,
-		name: input.OrganizationName,
-	}, input.AccountType)
+	}, input.OrganizationName, input.AccountType)
 	params.SetIdempotencyKey(input.IdempotencyKey)
 
 	customer, err := c.api.createCustomer(ctx, params)
@@ -603,8 +609,7 @@ func (c *client) UpdateCustomer(ctx context.Context, input UpdateCustomerInput) 
 	params.Metadata = customerMetadata(organizationIdentity{
 		id:   input.OrganizationID,
 		slug: input.OrganizationSlug,
-		name: input.OrganizationName,
-	}, input.AccountType)
+	}, input.OrganizationName, input.AccountType)
 
 	if _, err := c.api.updateCustomer(ctx, input.CustomerID, params); err != nil {
 		return fmt.Errorf("update Stripe customer: %w", err)
@@ -638,7 +643,6 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 	identity := organizationIdentity{
 		id:   input.OrganizationID,
 		slug: input.OrganizationSlug,
-		name: input.OrganizationName,
 	}
 	params.Metadata = contractMetadata(identity)
 	params.Mode = stripesdk.String(stripesdk.CheckoutSessionModeSubscription)

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -17,12 +17,25 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
+// Stripe metadata contract shared with speakeasy-registry (SDK product). Every
+// Customer, Checkout Session and Subscription carries these keys so downstream
+// consumers (revenue notifications, CRM sync) can classify and attribute Stripe
+// objects without heuristics. Keep key names in sync with
+// speakeasy-registry/internal/stripe/metadata.go. Organization IDs are shared
+// across both products, so registry-owned attributes (e.g. internal) are
+// resolved there rather than duplicated here.
 const (
 	organizationIDMetadataKey   = "organization_id"
 	organizationSlugMetadataKey = "organization_slug"
+	organizationNameMetadataKey = "organization_name"
+	speakeasyProductMetadataKey = "speakeasy_product"
+	accountTypeMetadataKey      = "account_type"
 	meterCustomerPayloadKey     = "stripe_customer_id"
 	meterValuePayloadKey        = "value"
 	allocationMetadataKey       = "gram_billing_allocation"
+
+	// speakeasyProductAICP identifies objects billed by the AI Control Plane (this service).
+	speakeasyProductAICP = "aicp"
 )
 
 // ErrWebhookNotConfigured indicates that webhook verification cannot run because
@@ -30,6 +43,8 @@ const (
 var ErrWebhookNotConfigured = errors.New("stripe webhook is not configured")
 
 var errMissingIdempotencyKey = errors.New("idempotency key is required")
+
+var errMissingCustomerID = errors.New("customer id is required")
 
 var errMissingMeterEventName = errors.New("meter event name is required")
 
@@ -77,6 +92,7 @@ func IsConfigured(value string) bool {
 // Client is the Stripe surface used by PAYG billing.
 type Client interface {
 	CreateCustomer(context.Context, CreateCustomerInput) (*Customer, error)
+	UpdateCustomer(context.Context, UpdateCustomerInput) error
 	CreateCheckoutSession(context.Context, CreateCheckoutSessionInput) (*CheckoutSession, error)
 	GetCheckoutSession(context.Context, string) (*CheckoutSessionState, error)
 	GetSubscription(context.Context, string) (*SubscriptionState, error)
@@ -97,12 +113,56 @@ type Client interface {
 type CreateCustomerInput struct {
 	OrganizationID   string
 	OrganizationSlug string
-	IdempotencyKey   string
+	OrganizationName string
+
+	// Email is the billing contact shown on Stripe receipts and Checkout. Empty leaves it unset.
+	Email string
+
+	// AccountType is the organization's gram_account_type at creation time.
+	AccountType string
+
+	IdempotencyKey string
+}
+
+// UpdateCustomerInput refreshes the identity and contract metadata of an existing Stripe customer.
+type UpdateCustomerInput struct {
+	CustomerID       string
+	OrganizationID   string
+	OrganizationSlug string
+	OrganizationName string
+	Email            string
+	AccountType      string
 }
 
 // Customer is the Stripe customer data needed by billing callers.
 type Customer struct {
 	ID string
+}
+
+// organizationIdentity is the organization view stamped onto every Stripe object.
+type organizationIdentity struct {
+	id   string
+	slug string
+	name string
+}
+
+func contractMetadata(org organizationIdentity) map[string]string {
+	return map[string]string{
+		speakeasyProductMetadataKey: speakeasyProductAICP,
+		organizationIDMetadataKey:   org.id,
+		organizationSlugMetadataKey: org.slug,
+		organizationNameMetadataKey: org.name,
+	}
+}
+
+// customerMetadata adds account_type, which only belongs on the customer: Checkout
+// sessions are replayed under their original idempotency key and the account type
+// changes during that window (trial conversion, PAYG activation), so stamping it
+// there would make the replay diverge from the original request.
+func customerMetadata(org organizationIdentity, accountType string) map[string]string {
+	metadata := contractMetadata(org)
+	metadata[accountTypeMetadataKey] = accountType
+	return metadata
 }
 
 // CreateCheckoutSessionInput describes the hosted Checkout session for a PAYG subscription.
@@ -115,6 +175,9 @@ type CreateCheckoutSessionInput struct {
 
 	// OrganizationSlug is the organization slug included in Stripe metadata.
 	OrganizationSlug string
+
+	// OrganizationName is the display name included in Stripe metadata.
+	OrganizationName string
 
 	// SuccessURL is the browser destination after successful Checkout.
 	SuccessURL string
@@ -347,6 +410,7 @@ type WebhookEvent struct {
 
 type stripeAPI interface {
 	createCustomer(context.Context, *stripesdk.CustomerCreateParams) (*stripesdk.Customer, error)
+	updateCustomer(context.Context, string, *stripesdk.CustomerUpdateParams) (*stripesdk.Customer, error)
 	createCheckoutSession(context.Context, *stripesdk.CheckoutSessionCreateParams) (*stripesdk.CheckoutSession, error)
 	expireCheckoutSession(context.Context, string, *stripesdk.CheckoutSessionExpireParams) (*stripesdk.CheckoutSession, error)
 	retrieveCheckoutSession(context.Context, string, *stripesdk.CheckoutSessionRetrieveParams) (*stripesdk.CheckoutSession, error)
@@ -370,6 +434,14 @@ func (s *sdkAPI) createCustomer(ctx context.Context, params *stripesdk.CustomerC
 	customer, err := s.client.V1Customers.Create(ctx, params)
 	if err != nil {
 		return nil, fmt.Errorf("stripe SDK create customer: %w", err)
+	}
+	return customer, nil
+}
+
+func (s *sdkAPI) updateCustomer(ctx context.Context, id string, params *stripesdk.CustomerUpdateParams) (*stripesdk.Customer, error) {
+	customer, err := s.client.V1Customers.Update(ctx, id, params)
+	if err != nil {
+		return nil, fmt.Errorf("stripe SDK update customer: %w", err)
 	}
 	return customer, nil
 }
@@ -500,10 +572,15 @@ func (c *client) CreateCustomer(ctx context.Context, input CreateCustomerInput) 
 	}
 
 	params := new(stripesdk.CustomerCreateParams)
-	params.Metadata = map[string]string{
-		organizationIDMetadataKey:   input.OrganizationID,
-		organizationSlugMetadataKey: input.OrganizationSlug,
+	params.Name = stripesdk.String(input.OrganizationName)
+	if input.Email != "" {
+		params.Email = stripesdk.String(input.Email)
 	}
+	params.Metadata = customerMetadata(organizationIdentity{
+		id:   input.OrganizationID,
+		slug: input.OrganizationSlug,
+		name: input.OrganizationName,
+	}, input.AccountType)
 	params.SetIdempotencyKey(input.IdempotencyKey)
 
 	customer, err := c.api.createCustomer(ctx, params)
@@ -511,6 +588,28 @@ func (c *client) CreateCustomer(ctx context.Context, input CreateCustomerInput) 
 		return nil, fmt.Errorf("create Stripe customer: %w", err)
 	}
 	return &Customer{ID: customer.ID}, nil
+}
+
+func (c *client) UpdateCustomer(ctx context.Context, input UpdateCustomerInput) error {
+	if input.CustomerID == "" {
+		return errMissingCustomerID
+	}
+
+	params := new(stripesdk.CustomerUpdateParams)
+	params.Name = stripesdk.String(input.OrganizationName)
+	if input.Email != "" {
+		params.Email = stripesdk.String(input.Email)
+	}
+	params.Metadata = customerMetadata(organizationIdentity{
+		id:   input.OrganizationID,
+		slug: input.OrganizationSlug,
+		name: input.OrganizationName,
+	}, input.AccountType)
+
+	if _, err := c.api.updateCustomer(ctx, input.CustomerID, params); err != nil {
+		return fmt.Errorf("update Stripe customer: %w", err)
+	}
+	return nil
 }
 
 func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {
@@ -536,17 +635,17 @@ func (c *client) CreateCheckoutSession(ctx context.Context, input CreateCheckout
 			Quantity: nil,
 		},
 	}
-	params.Metadata = map[string]string{
-		organizationIDMetadataKey:   input.OrganizationID,
-		organizationSlugMetadataKey: input.OrganizationSlug,
+	identity := organizationIdentity{
+		id:   input.OrganizationID,
+		slug: input.OrganizationSlug,
+		name: input.OrganizationName,
 	}
+	params.Metadata = contractMetadata(identity)
 	params.Mode = stripesdk.String(stripesdk.CheckoutSessionModeSubscription)
 	params.PaymentMethodCollection = stripesdk.String(stripesdk.CheckoutSessionPaymentMethodCollectionAlways)
 	params.SubscriptionData = new(stripesdk.CheckoutSessionCreateSubscriptionDataParams)
-	params.SubscriptionData.Metadata = map[string]string{
-		organizationIDMetadataKey:   input.OrganizationID,
-		organizationSlugMetadataKey: input.OrganizationSlug,
-	}
+	// Subscription metadata is also copied by Stripe onto invoice.parent.subscription_details.metadata.
+	params.SubscriptionData.Metadata = contractMetadata(identity)
 	params.SuccessURL = stripesdk.String(input.SuccessURL)
 	if input.TrialEnd != nil {
 		params.SubscriptionData.TrialEnd = new(input.TrialEnd.Unix())
@@ -1032,6 +1131,11 @@ func NewStubClient(logger *slog.Logger) Client {
 func (s *stubClient) CreateCustomer(ctx context.Context, _ CreateCustomerInput) (*Customer, error) {
 	s.logger.DebugContext(ctx, "stub Stripe customer creation skipped")
 	return &Customer{ID: "cus_local_stub"}, nil
+}
+
+func (s *stubClient) UpdateCustomer(ctx context.Context, _ UpdateCustomerInput) error {
+	s.logger.DebugContext(ctx, "stub Stripe customer update skipped")
+	return nil
 }
 
 func (s *stubClient) CreateCheckoutSession(ctx context.Context, input CreateCheckoutSessionInput) (*CheckoutSession, error) {

--- a/server/internal/thirdparty/stripe/client.go
+++ b/server/internal/thirdparty/stripe/client.go
@@ -14,6 +14,7 @@ import (
 	stripesdk "github.com/stripe/stripe-go/v85"
 	stripewebhook "github.com/stripe/stripe-go/v85/webhook"
 
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
@@ -114,8 +115,8 @@ type CreateCustomerInput struct {
 	// Email is the billing contact shown on Stripe receipts and Checkout. Empty leaves it unset.
 	Email string
 
-	// AccountType is the organization's gram_account_type at creation time. Empty
-	// leaves the key unset.
+	// AccountType is the organization's gram_account_type at creation time. Values
+	// outside constants.AccountTypes leave the key unset.
 	AccountType string
 
 	IdempotencyKey string
@@ -132,7 +133,8 @@ type UpdateCustomerInput struct {
 	// unchanged: callers resolve it best-effort and must not clear a working address.
 	Email string
 
-	// AccountType is the organization's current gram_account_type. Empty leaves the key unset.
+	// AccountType is the organization's current gram_account_type. Values outside
+	// constants.AccountTypes clear the key so a stale tier is never left behind.
 	AccountType string
 }
 
@@ -155,13 +157,19 @@ func contractMetadata(org organizationIdentity) map[string]string {
 	}
 }
 
-func customerMetadata(org organizationIdentity, name, accountType string) map[string]string {
+func customerMetadata(org organizationIdentity, name string) map[string]string {
 	metadata := contractMetadata(org)
 	metadata[organizationNameMetadataKey] = name
-	if accountType != "" {
-		metadata[accountTypeMetadataKey] = accountType
-	}
 	return metadata
+}
+
+// validAccountType returns the account type to stamp, or "" when it is outside
+// constants.AccountTypes.
+func validAccountType(accountType string) string {
+	if constants.IsAccountType(accountType) {
+		return accountType
+	}
+	return ""
 }
 
 // CreateCheckoutSessionInput describes the hosted Checkout session for a PAYG subscription.
@@ -575,7 +583,10 @@ func (c *client) CreateCustomer(ctx context.Context, input CreateCustomerInput) 
 	params.Metadata = customerMetadata(organizationIdentity{
 		id:   input.OrganizationID,
 		slug: input.OrganizationSlug,
-	}, input.OrganizationName, input.AccountType)
+	}, input.OrganizationName)
+	if accountType := validAccountType(input.AccountType); accountType != "" {
+		params.Metadata[accountTypeMetadataKey] = accountType
+	}
 	params.SetIdempotencyKey(input.IdempotencyKey)
 
 	customer, err := c.api.createCustomer(ctx, params)
@@ -598,7 +609,10 @@ func (c *client) UpdateCustomer(ctx context.Context, input UpdateCustomerInput) 
 	params.Metadata = customerMetadata(organizationIdentity{
 		id:   input.OrganizationID,
 		slug: input.OrganizationSlug,
-	}, input.OrganizationName, input.AccountType)
+	}, input.OrganizationName)
+	// Stripe deletes a metadata key whose value is "", so an unknown or missing
+	// account type clears the stale one instead of preserving it.
+	params.Metadata[accountTypeMetadataKey] = validAccountType(input.AccountType)
 
 	if _, err := c.api.updateCustomer(ctx, input.CustomerID, params); err != nil {
 		return fmt.Errorf("update Stripe customer: %w", err)

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1215,12 +1215,13 @@ func TestCreateCustomerSetsIdentityAndContractMetadata(t *testing.T) {
 	params := api.customerParams
 	require.Equal(t, "The Customer, Inc.", stripesdk.StringValue(params.Name))
 	require.Equal(t, "billing@the-customer.test", stripesdk.StringValue(params.Email))
+	// A Stripe Customer can be shared with the SDK product (same organization id), so
+	// product-specific keys are namespaced and speakeasy_product stays off the customer.
 	require.Equal(t, map[string]string{
-		"speakeasy_product": "aicp",
 		"organization_id":   "<ORG_ID>",
 		"organization_slug": "the-customer",
 		"organization_name": "The Customer, Inc.",
-		"account_type":      "free",
+		"aicp_account_type": "free",
 	}, params.Metadata)
 }
 
@@ -1289,8 +1290,8 @@ func TestUpdateCustomerSetsIdentityAndContractMetadata(t *testing.T) {
 	params := api.customerUpdateParams
 	require.Equal(t, "The Customer, Inc.", stripesdk.StringValue(params.Name))
 	require.Equal(t, "billing@the-customer.test", stripesdk.StringValue(params.Email))
-	require.Equal(t, "aicp", params.Metadata["speakeasy_product"])
-	require.Equal(t, "payg", params.Metadata["account_type"])
+	require.NotContains(t, params.Metadata, "speakeasy_product", "the customer may be shared with another product")
+	require.Equal(t, "payg", params.Metadata["aicp_account_type"])
 	require.Equal(t, "the-customer", params.Metadata["organization_slug"])
 }
 
@@ -1320,7 +1321,7 @@ func TestCreateCustomerOmitsUnknownAccountType(t *testing.T) {
 			IdempotencyKey:   "customer:<ORG_ID>",
 		})
 		require.NoError(t, err)
-		require.NotContains(t, api.customerParams.Metadata, "account_type", "account type %q must not be stamped", accountType)
+		require.NotContains(t, api.customerParams.Metadata, "aicp_account_type", "account type %q must not be stamped", accountType)
 	}
 }
 
@@ -1340,7 +1341,7 @@ func TestUpdateCustomerClearsUnknownAccountType(t *testing.T) {
 		})
 		require.NoError(t, err)
 		// Stripe deletes a metadata key when its value is set to "".
-		value, ok := api.customerUpdateParams.Metadata["account_type"]
+		value, ok := api.customerUpdateParams.Metadata["aicp_account_type"]
 		require.True(t, ok, "account type %q must clear the stale key on update", accountType)
 		require.Empty(t, value)
 	}

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1308,18 +1308,42 @@ func TestUpdateCustomerRequiresCustomerID(t *testing.T) {
 func TestCreateCustomerOmitsUnknownAccountType(t *testing.T) {
 	t.Parallel()
 
-	api := &fakeStripeAPI{}
-	c := &client{api: api}
+	for _, accountType := range []string{"", "not-an-account-type"} {
+		api := &fakeStripeAPI{}
+		c := &client{api: api}
 
-	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
-		OrganizationID:   "<ORG_ID>",
-		OrganizationSlug: "the-customer",
-		OrganizationName: "The Customer, Inc.",
-		AccountType:      "",
-		IdempotencyKey:   "customer:<ORG_ID>",
-	})
-	require.NoError(t, err)
-	require.NotContains(t, api.customerParams.Metadata, "account_type", "an empty account type must not be stamped")
+		_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
+			OrganizationID:   "<ORG_ID>",
+			OrganizationSlug: "the-customer",
+			OrganizationName: "The Customer, Inc.",
+			AccountType:      accountType,
+			IdempotencyKey:   "customer:<ORG_ID>",
+		})
+		require.NoError(t, err)
+		require.NotContains(t, api.customerParams.Metadata, "account_type", "account type %q must not be stamped", accountType)
+	}
+}
+
+func TestUpdateCustomerClearsUnknownAccountType(t *testing.T) {
+	t.Parallel()
+
+	for _, accountType := range []string{"", "not-an-account-type"} {
+		api := &fakeStripeAPI{}
+		c := &client{api: api}
+
+		err := c.UpdateCustomer(t.Context(), UpdateCustomerInput{
+			CustomerID:       "cus_test",
+			OrganizationID:   "<ORG_ID>",
+			OrganizationSlug: "the-customer",
+			OrganizationName: "The Customer, Inc.",
+			AccountType:      accountType,
+		})
+		require.NoError(t, err)
+		// Stripe deletes a metadata key when its value is set to "".
+		value, ok := api.customerUpdateParams.Metadata["account_type"]
+		require.True(t, ok, "account type %q must clear the stale key on update", accountType)
+		require.Empty(t, value)
+	}
 }
 
 func TestUpdateCustomerLeavesEmailUnchangedWhenEmpty(t *testing.T) {

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1251,7 +1251,6 @@ func TestCreateCheckoutSessionStampsContractMetadata(t *testing.T) {
 		CustomerID:         "cus_test",
 		OrganizationID:     "<ORG_ID>",
 		OrganizationSlug:   "the-customer",
-		OrganizationName:   "The Customer, Inc.",
 		SuccessURL:         "https://app.example.test/the-customer/billing",
 		CancelURL:          "https://app.example.test/the-customer/billing",
 		BillingCycleAnchor: anchor,
@@ -1260,13 +1259,15 @@ func TestCreateCheckoutSessionStampsContractMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Only values that cannot change within a session's lifetime: Checkout requests are
+	// replayed under their original idempotency key, and Stripe rejects a replay whose
+	// parameters differ. Name and account type live on the Customer instead.
 	want := map[string]string{
 		"speakeasy_product": "aicp",
 		"organization_id":   "<ORG_ID>",
 		"organization_slug": "the-customer",
-		"organization_name": "The Customer, Inc.",
 	}
-	require.Equal(t, want, api.checkoutSessionParams.Metadata, "account_type is customer-only so idempotent Checkout replays stay identical")
+	require.Equal(t, want, api.checkoutSessionParams.Metadata)
 	require.Equal(t, want, api.checkoutSessionParams.SubscriptionData.Metadata)
 }
 
@@ -1304,4 +1305,38 @@ func TestUpdateCustomerRequiresCustomerID(t *testing.T) {
 	err := c.UpdateCustomer(t.Context(), UpdateCustomerInput{})
 	require.ErrorIs(t, err, errMissingCustomerID)
 	require.Zero(t, api.calls)
+}
+
+func TestCreateCustomerOmitsUnknownAccountType(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		OrganizationName: "The Customer, Inc.",
+		AccountType:      "",
+		IdempotencyKey:   "customer:<ORG_ID>",
+	})
+	require.NoError(t, err)
+	require.NotContains(t, api.customerParams.Metadata, "account_type", "an empty account type must not be stamped")
+}
+
+func TestUpdateCustomerLeavesEmailUnchangedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	err := c.UpdateCustomer(t.Context(), UpdateCustomerInput{
+		CustomerID:       "cus_test",
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		OrganizationName: "The Customer, Inc.",
+		AccountType:      "payg",
+	})
+	require.NoError(t, err)
+	require.Nil(t, api.customerUpdateParams.Email, "an empty email must not clear the address Stripe already has")
 }

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -1259,9 +1259,7 @@ func TestCreateCheckoutSessionStampsContractMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Only values that cannot change within a session's lifetime: Checkout requests are
-	// replayed under their original idempotency key, and Stripe rejects a replay whose
-	// parameters differ. Name and account type live on the Customer instead.
+	// Name and account type are customer-only so idempotent replays stay identical.
 	want := map[string]string{
 		"speakeasy_product": "aicp",
 		"organization_id":   "<ORG_ID>",

--- a/server/internal/thirdparty/stripe/client_test.go
+++ b/server/internal/thirdparty/stripe/client_test.go
@@ -97,6 +97,8 @@ func TestIsConfigured(t *testing.T) {
 
 type fakeStripeAPI struct {
 	customerParams             *stripesdk.CustomerCreateParams
+	customerUpdateID           string
+	customerUpdateParams       *stripesdk.CustomerUpdateParams
 	checkoutSessionParams      *stripesdk.CheckoutSessionCreateParams
 	checkoutRetrieveParams     *stripesdk.CheckoutSessionRetrieveParams
 	checkoutExpireID           string
@@ -125,6 +127,13 @@ func (f *fakeStripeAPI) createCustomer(_ context.Context, params *stripesdk.Cust
 	f.calls++
 	f.customerParams = params
 	return &stripesdk.Customer{ID: "cus_test"}, f.err
+}
+
+func (f *fakeStripeAPI) updateCustomer(_ context.Context, id string, params *stripesdk.CustomerUpdateParams) (*stripesdk.Customer, error) {
+	f.calls++
+	f.customerUpdateID = id
+	f.customerUpdateParams = params
+	return &stripesdk.Customer{ID: id}, f.err
 }
 
 func (f *fakeStripeAPI) createCheckoutSession(_ context.Context, params *stripesdk.CheckoutSessionCreateParams) (*stripesdk.CheckoutSession, error) {
@@ -1185,4 +1194,114 @@ func webhookPayloadForType(t *testing.T, apiVersion string, created time.Time, e
 	})
 	require.NoError(t, err)
 	return payload
+}
+
+func TestCreateCustomerSetsIdentityAndContractMetadata(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		OrganizationName: "The Customer, Inc.",
+		Email:            "billing@the-customer.test",
+		AccountType:      "free",
+		IdempotencyKey:   "customer:<ORG_ID>",
+	})
+	require.NoError(t, err)
+
+	params := api.customerParams
+	require.Equal(t, "The Customer, Inc.", stripesdk.StringValue(params.Name))
+	require.Equal(t, "billing@the-customer.test", stripesdk.StringValue(params.Email))
+	require.Equal(t, map[string]string{
+		"speakeasy_product": "aicp",
+		"organization_id":   "<ORG_ID>",
+		"organization_slug": "the-customer",
+		"organization_name": "The Customer, Inc.",
+		"account_type":      "free",
+	}, params.Metadata)
+}
+
+func TestCreateCustomerOmitsEmptyEmail(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	_, err := c.CreateCustomer(t.Context(), CreateCustomerInput{
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		OrganizationName: "The Customer, Inc.",
+		IdempotencyKey:   "customer:<ORG_ID>",
+	})
+	require.NoError(t, err)
+	require.Nil(t, api.customerParams.Email, "empty email must not be sent to Stripe")
+}
+
+func TestCreateCheckoutSessionStampsContractMetadata(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api, catalog: Catalog{PriceIDTUM: "price_tum", MeterIDTUM: "mtr_tum", MeterEventName: "tum", PortalConfigurationID: "bpc_test"}}
+	anchor := time.Date(2026, time.September, 3, 0, 0, 0, 0, time.UTC)
+
+	_, err := c.CreateCheckoutSession(t.Context(), CreateCheckoutSessionInput{
+		CustomerID:         "cus_test",
+		OrganizationID:     "<ORG_ID>",
+		OrganizationSlug:   "the-customer",
+		OrganizationName:   "The Customer, Inc.",
+		SuccessURL:         "https://app.example.test/the-customer/billing",
+		CancelURL:          "https://app.example.test/the-customer/billing",
+		BillingCycleAnchor: anchor,
+		ExpiresAt:          anchor.Add(-time.Minute),
+		IdempotencyKey:     "checkout:<ORG_ID>:request",
+	})
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"speakeasy_product": "aicp",
+		"organization_id":   "<ORG_ID>",
+		"organization_slug": "the-customer",
+		"organization_name": "The Customer, Inc.",
+	}
+	require.Equal(t, want, api.checkoutSessionParams.Metadata, "account_type is customer-only so idempotent Checkout replays stay identical")
+	require.Equal(t, want, api.checkoutSessionParams.SubscriptionData.Metadata)
+}
+
+func TestUpdateCustomerSetsIdentityAndContractMetadata(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	err := c.UpdateCustomer(t.Context(), UpdateCustomerInput{
+		CustomerID:       "cus_test",
+		OrganizationID:   "<ORG_ID>",
+		OrganizationSlug: "the-customer",
+		OrganizationName: "The Customer, Inc.",
+		Email:            "billing@the-customer.test",
+		AccountType:      "payg",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "cus_test", api.customerUpdateID)
+	params := api.customerUpdateParams
+	require.Equal(t, "The Customer, Inc.", stripesdk.StringValue(params.Name))
+	require.Equal(t, "billing@the-customer.test", stripesdk.StringValue(params.Email))
+	require.Equal(t, "aicp", params.Metadata["speakeasy_product"])
+	require.Equal(t, "payg", params.Metadata["account_type"])
+	require.Equal(t, "the-customer", params.Metadata["organization_slug"])
+}
+
+func TestUpdateCustomerRequiresCustomerID(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeStripeAPI{}
+	c := &client{api: api}
+
+	err := c.UpdateCustomer(t.Context(), UpdateCustomerInput{})
+	require.ErrorIs(t, err, errMissingCustomerID)
+	require.Zero(t, api.calls)
 }

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -58,10 +58,8 @@ type preparedStripeCheckoutIntent struct {
 	customerID string
 }
 
-// stripeOrganizationIdentity is the mutable organization view stamped onto the Stripe
-// Customer so downstream consumers can attribute it without a Gram DB lookup. It is
-// never part of a Checkout request, which must replay byte-for-byte under its
-// idempotency key.
+// stripeOrganizationIdentity is stamped onto the Stripe Customer only; Checkout
+// requests replay byte-for-byte under their idempotency key.
 type stripeOrganizationIdentity struct {
 	name        string
 	accountType string

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -54,6 +55,44 @@ type stripeCheckoutTrialFingerprint struct {
 type preparedStripeCheckoutIntent struct {
 	stripeCheckoutIntent
 	customerID string
+}
+
+// stripeOrganizationIdentity is the organization view stamped onto Stripe customers,
+// Checkout sessions and subscriptions so downstream consumers (revenue notifications,
+// CRM sync) can attribute them without a Gram DB lookup.
+type stripeOrganizationIdentity struct {
+	name        string
+	accountType string
+	email       string
+}
+
+// stripeOrganizationIdentity resolves the identity from organization metadata. The
+// customer email prefers the billing alert email and falls back to the first
+// organization admin; it stays empty when neither exists.
+func (s *Service) stripeOrganizationIdentity(ctx context.Context, organizationID string, billingMetadata repo.BillingMetadatum) (stripeOrganizationIdentity, error) {
+	organization, err := s.orgRepo.GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		return stripeOrganizationIdentity{}, oops.E(oops.CodeUnexpected, err, "failed to load organization for billing").LogError(ctx, s.logger)
+	}
+
+	email := ""
+	if billingMetadata.AlertEmail.Valid && billingMetadata.AlertEmail.String != "" {
+		email = billingMetadata.AlertEmail.String
+	} else {
+		admins, adminErr := authz.ResolveOrganizationAdminEmails(ctx, s.db, organizationID)
+		if adminErr != nil {
+			s.logger.WarnContext(ctx, "failed to resolve organization admin emails for Stripe customer", attr.SlogError(adminErr))
+		}
+		if len(admins) > 0 {
+			email = admins[0]
+		}
+	}
+
+	return stripeOrganizationIdentity{
+		name:        organization.Name,
+		accountType: organization.GramAccountType,
+		email:       email,
+	}, nil
 }
 
 type stripeCheckoutSessionExpirer interface {
@@ -125,13 +164,33 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		proposedIntent = storedIntent
 	}
 
+	identity, identityErr := s.stripeOrganizationIdentity(ctx, authCtx.ActiveOrganizationID, billingMetadata)
+	if identityErr != nil {
+		return "", identityErr
+	}
+
 	customerID := ""
 	if err == nil && billingMetadata.StripeCustomerID.Valid {
 		customerID = billingMetadata.StripeCustomerID.String
+		// Best effort: keep identity and contract metadata current on customers created
+		// before the contract existed, or whose name/email/account type changed.
+		if updateErr := s.stripeClient.UpdateCustomer(ctx, stripeclient.UpdateCustomerInput{
+			CustomerID:       customerID,
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			OrganizationSlug: authCtx.OrganizationSlug,
+			OrganizationName: identity.name,
+			Email:            identity.email,
+			AccountType:      identity.accountType,
+		}); updateErr != nil {
+			s.logger.WarnContext(ctx, "failed to refresh Stripe customer identity", attr.SlogError(updateErr))
+		}
 	} else {
 		customer, err := s.stripeClient.CreateCustomer(ctx, stripeclient.CreateCustomerInput{
 			OrganizationID:   authCtx.ActiveOrganizationID,
 			OrganizationSlug: authCtx.OrganizationSlug,
+			OrganizationName: identity.name,
+			Email:            identity.email,
+			AccountType:      identity.accountType,
 			IdempotencyKey:   fmt.Sprintf("customer:%s", authCtx.ActiveOrganizationID),
 		})
 		if err != nil {
@@ -140,7 +199,7 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		customerID = customer.ID
 	}
 	billingURL := s.siteURL.JoinPath(authCtx.OrganizationSlug, "billing").String()
-	replaceLifecycleIntentKey, err := s.expireLifecycleStaleCheckoutSession(ctx, billingMetadata, customerID, authCtx.ActiveOrganizationID, authCtx.OrganizationSlug, billingURL, proposedIntent, now)
+	replaceLifecycleIntentKey, err := s.expireLifecycleStaleCheckoutSession(ctx, billingMetadata, customerID, authCtx.ActiveOrganizationID, authCtx.OrganizationSlug, billingURL, identity, proposedIntent, now)
 	if err != nil {
 		return "", err
 	}
@@ -158,6 +217,7 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		CustomerID:         preparedIntent.customerID,
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		OrganizationSlug:   authCtx.OrganizationSlug,
+		OrganizationName:   identity.name,
 		SuccessURL:         billingURL,
 		CancelURL:          billingURL,
 		TrialEnd:           preparedIntent.trialEnd,
@@ -320,6 +380,7 @@ func (s *Service) expireLifecycleStaleCheckoutSession(
 	ctx context.Context,
 	metadata repo.BillingMetadatum,
 	customerID, organizationID, organizationSlug, billingURL string,
+	identity stripeOrganizationIdentity,
 	proposed stripeCheckoutIntent,
 	now time.Time,
 ) (pgtype.Text, error) {
@@ -337,9 +398,11 @@ func (s *Service) expireLifecycleStaleCheckoutSession(
 	if metadata.StripeCheckoutSessionID.Valid {
 		sessionID = metadata.StripeCheckoutSessionID.String
 	} else {
+		// Same idempotency key as the original request, so the input must match it exactly.
 		stale, createErr := s.stripeClient.CreateCheckoutSession(ctx, stripeclient.CreateCheckoutSessionInput{
 			CustomerID: customerID, OrganizationID: organizationID, OrganizationSlug: organizationSlug,
-			SuccessURL: billingURL, CancelURL: billingURL, TrialEnd: staleIntent.trialEnd,
+			OrganizationName: identity.name,
+			SuccessURL:       billingURL, CancelURL: billingURL, TrialEnd: staleIntent.trialEnd,
 			BillingCycleAnchor: staleIntent.billingCycleAnchor, ExpiresAt: staleIntent.expiresAt, IdempotencyKey: staleIntent.idempotencyKey,
 		})
 		if createErr != nil || stale == nil || stale.ID == "" {

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -57,9 +58,10 @@ type preparedStripeCheckoutIntent struct {
 	customerID string
 }
 
-// stripeOrganizationIdentity is the organization view stamped onto Stripe customers,
-// Checkout sessions and subscriptions so downstream consumers (revenue notifications,
-// CRM sync) can attribute them without a Gram DB lookup.
+// stripeOrganizationIdentity is the mutable organization view stamped onto the Stripe
+// Customer so downstream consumers can attribute it without a Gram DB lookup. It is
+// never part of a Checkout request, which must replay byte-for-byte under its
+// idempotency key.
 type stripeOrganizationIdentity struct {
 	name        string
 	accountType string
@@ -68,7 +70,8 @@ type stripeOrganizationIdentity struct {
 
 // stripeOrganizationIdentity resolves the identity from organization metadata. The
 // customer email prefers the billing alert email and falls back to the first
-// organization admin; it stays empty when neither exists.
+// organization admin; it stays empty when neither exists. Account types outside
+// constants.AccountTypes are dropped rather than leaked into the contract.
 func (s *Service) stripeOrganizationIdentity(ctx context.Context, organizationID string, billingMetadata repo.BillingMetadatum) (stripeOrganizationIdentity, error) {
 	organization, err := s.orgRepo.GetOrganizationMetadata(ctx, organizationID)
 	if err != nil {
@@ -88,9 +91,15 @@ func (s *Service) stripeOrganizationIdentity(ctx context.Context, organizationID
 		}
 	}
 
+	accountType := organization.GramAccountType
+	if !constants.IsAccountType(accountType) {
+		s.logger.WarnContext(ctx, "organization account type is outside the Stripe metadata contract; omitting it", attr.SlogOrganizationID(organizationID))
+		accountType = ""
+	}
+
 	return stripeOrganizationIdentity{
 		name:        organization.Name,
-		accountType: organization.GramAccountType,
+		accountType: accountType,
 		email:       email,
 	}, nil
 }
@@ -199,7 +208,7 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		customerID = customer.ID
 	}
 	billingURL := s.siteURL.JoinPath(authCtx.OrganizationSlug, "billing").String()
-	replaceLifecycleIntentKey, err := s.expireLifecycleStaleCheckoutSession(ctx, billingMetadata, customerID, authCtx.ActiveOrganizationID, authCtx.OrganizationSlug, billingURL, identity, proposedIntent, now)
+	replaceLifecycleIntentKey, err := s.expireLifecycleStaleCheckoutSession(ctx, billingMetadata, customerID, authCtx.ActiveOrganizationID, authCtx.OrganizationSlug, billingURL, proposedIntent, now)
 	if err != nil {
 		return "", err
 	}
@@ -217,7 +226,6 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 		CustomerID:         preparedIntent.customerID,
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		OrganizationSlug:   authCtx.OrganizationSlug,
-		OrganizationName:   identity.name,
 		SuccessURL:         billingURL,
 		CancelURL:          billingURL,
 		TrialEnd:           preparedIntent.trialEnd,
@@ -380,7 +388,6 @@ func (s *Service) expireLifecycleStaleCheckoutSession(
 	ctx context.Context,
 	metadata repo.BillingMetadatum,
 	customerID, organizationID, organizationSlug, billingURL string,
-	identity stripeOrganizationIdentity,
 	proposed stripeCheckoutIntent,
 	now time.Time,
 ) (pgtype.Text, error) {
@@ -401,8 +408,7 @@ func (s *Service) expireLifecycleStaleCheckoutSession(
 		// Same idempotency key as the original request, so the input must match it exactly.
 		stale, createErr := s.stripeClient.CreateCheckoutSession(ctx, stripeclient.CreateCheckoutSessionInput{
 			CustomerID: customerID, OrganizationID: organizationID, OrganizationSlug: organizationSlug,
-			OrganizationName: identity.name,
-			SuccessURL:       billingURL, CancelURL: billingURL, TrialEnd: staleIntent.trialEnd,
+			SuccessURL: billingURL, CancelURL: billingURL, TrialEnd: staleIntent.trialEnd,
 			BillingCycleAnchor: staleIntent.billingCycleAnchor, ExpiresAt: staleIntent.expiresAt, IdempotencyKey: staleIntent.idempotencyKey,
 		})
 		if createErr != nil || stale == nil || stale.ID == "" {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -806,7 +806,7 @@ func TestExpireLifecycleStaleCheckoutSessionAcceptsConcurrentExpiration(t *testi
 
 	replaceKey, err := ti.service.expireLifecycleStaleCheckoutSession(
 		t.Context(), metadata, "cus_test", ti.orgID, ti.orgSlug, "https://example.test/billing",
-		stripeOrganizationIdentity{}, stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
+		stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
 	)
 	require.NoError(t, err)
 	require.Equal(t, pgtype.Text{String: staleIntent.idempotencyKey, Valid: true}, replaceKey)
@@ -850,7 +850,7 @@ func TestExpireLifecycleStaleCheckoutSessionRejectsUnconfirmedConcurrentExpirati
 
 			_, err := ti.service.expireLifecycleStaleCheckoutSession(
 				t.Context(), metadata, "cus_test", ti.orgID, ti.orgSlug, "https://example.test/billing",
-				stripeOrganizationIdentity{}, stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
+				stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
 			)
 			require.Error(t, err)
 			requireOopsCode(t, err, oops.CodeUnavailable)
@@ -1645,7 +1645,7 @@ func TestCreateStripeCheckoutStampsOrganizationIdentity(t *testing.T) {
 	require.Empty(t, customers[0].Email, "no alert email and no org admins: customer email stays unset")
 
 	require.Len(t, checkouts, 1)
-	require.Equal(t, "Billing Test Organization", checkouts[0].OrganizationName)
+	require.Equal(t, ti.orgID, checkouts[0].OrganizationID)
 	require.Empty(t, ti.stripe.updates(), "a freshly created customer must not also be updated")
 }
 
@@ -1732,4 +1732,21 @@ func TestCreateStripeCheckoutRefreshesExistingCustomerIdentity(t *testing.T) {
 	require.Equal(t, ti.orgSlug, updates[0].OrganizationSlug)
 	require.Equal(t, "Billing Test Organization", updates[0].OrganizationName)
 	require.Equal(t, "free", updates[0].AccountType)
+}
+
+func TestCreateStripeCheckoutOmitsUnknownAccountType(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	require.NoError(t, orgrepo.New(ti.db).SetAccountType(t.Context(), orgrepo.SetAccountTypeParams{
+		GramAccountType: "legacy-unknown",
+		ID:              ti.orgID,
+	}))
+
+	_, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	_, customers, _ := ti.stripe.snapshot()
+	require.Len(t, customers, 1)
+	require.Empty(t, customers[0].AccountType, "values outside constants.AccountTypes must not reach Stripe")
 }

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/usage"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
@@ -39,6 +41,7 @@ import (
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usage/repo"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 type checkoutStripeClient struct {
@@ -47,6 +50,8 @@ type checkoutStripeClient struct {
 	customers                map[string]*stripeclient.Customer
 	checkoutResults          map[string]checkoutStripeResult
 	customerInputs           []stripeclient.CreateCustomerInput
+	customerUpdates          []stripeclient.UpdateCustomerInput
+	customerUpdateError      error
 	checkoutInputs           []stripeclient.CreateCheckoutSessionInput
 	customerError            error
 	checkoutError            error
@@ -97,6 +102,14 @@ func (c *checkoutStripeClient) CreateCustomer(_ context.Context, input stripecli
 	customer := &stripeclient.Customer{ID: fmt.Sprintf("cus_%d", len(c.customers)+1)}
 	c.customers[input.IdempotencyKey] = customer
 	return customer, nil
+}
+
+func (c *checkoutStripeClient) UpdateCustomer(_ context.Context, input stripeclient.UpdateCustomerInput) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.customerUpdates = append(c.customerUpdates, input)
+	return c.customerUpdateError
 }
 
 func (c *checkoutStripeClient) CreateCheckoutSession(_ context.Context, input stripeclient.CreateCheckoutSessionInput) (*stripeclient.CheckoutSession, error) {
@@ -236,6 +249,15 @@ func (c *checkoutStripeClient) VerifyWebhook([]byte, string) (*stripeclient.Webh
 
 func (c *checkoutStripeClient) Catalog() stripeclient.Catalog {
 	return stripeclient.Catalog{PriceIDTUM: "price_tum", MeterIDTUM: "mtr_tum", MeterEventName: "tum", PortalConfigurationID: "bpc_test"}
+}
+
+func (c *checkoutStripeClient) updates() []stripeclient.UpdateCustomerInput {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	updates := make([]stripeclient.UpdateCustomerInput, len(c.customerUpdates))
+	copy(updates, c.customerUpdates)
+	return updates
 }
 
 func (c *checkoutStripeClient) snapshot() (int, []stripeclient.CreateCustomerInput, []stripeclient.CreateCheckoutSessionInput) {
@@ -784,7 +806,7 @@ func TestExpireLifecycleStaleCheckoutSessionAcceptsConcurrentExpiration(t *testi
 
 	replaceKey, err := ti.service.expireLifecycleStaleCheckoutSession(
 		t.Context(), metadata, "cus_test", ti.orgID, ti.orgSlug, "https://example.test/billing",
-		stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
+		stripeOrganizationIdentity{}, stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
 	)
 	require.NoError(t, err)
 	require.Equal(t, pgtype.Text{String: staleIntent.idempotencyKey, Valid: true}, replaceKey)
@@ -828,7 +850,7 @@ func TestExpireLifecycleStaleCheckoutSessionRejectsUnconfirmedConcurrentExpirati
 
 			_, err := ti.service.expireLifecycleStaleCheckoutSession(
 				t.Context(), metadata, "cus_test", ti.orgID, ti.orgSlug, "https://example.test/billing",
-				stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
+				stripeOrganizationIdentity{}, stripeCheckoutIntent{idempotencyKey: "checkout-session:org:3:4:new-lifecycle"}, now,
 			)
 			require.Error(t, err)
 			requireOopsCode(t, err, oops.CodeUnavailable)
@@ -1604,4 +1626,110 @@ func TestCreateStripeCheckoutPersistsIntentWhenCheckoutFails(t *testing.T) {
 	count, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionBillingMetadataCreateStripeCheckout)
 	require.NoError(t, err)
 	require.Zero(t, count)
+}
+
+func TestCreateStripeCheckoutStampsOrganizationIdentity(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+
+	_, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	_, customers, checkouts := ti.stripe.snapshot()
+	require.Len(t, customers, 1)
+	require.Equal(t, ti.orgID, customers[0].OrganizationID)
+	require.Equal(t, ti.orgSlug, customers[0].OrganizationSlug)
+	require.Equal(t, "Billing Test Organization", customers[0].OrganizationName)
+	require.Equal(t, "free", customers[0].AccountType)
+	require.Empty(t, customers[0].Email, "no alert email and no org admins: customer email stays unset")
+
+	require.Len(t, checkouts, 1)
+	require.Equal(t, "Billing Test Organization", checkouts[0].OrganizationName)
+	require.Empty(t, ti.stripe.updates(), "a freshly created customer must not also be updated")
+}
+
+func TestCreateStripeCheckoutUsesBillingAlertEmailForCustomer(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	_, err := repo.New(ti.db).UpsertBillingEmail(t.Context(), repo.UpsertBillingEmailParams{
+		OrganizationID: ti.orgID,
+		AlertEmail:     conv.ToPGText("finance@example.test"),
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	_, customers, _ := ti.stripe.snapshot()
+	require.Len(t, customers, 1)
+	require.Equal(t, "finance@example.test", customers[0].Email)
+}
+
+func TestCreateStripeCheckoutFallsBackToOrganizationAdminEmail(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	ctx := t.Context()
+	pool, ok := ti.db.(*pgxpool.Pool)
+	require.True(t, ok, "test database must be a pgxpool.Pool to seed system role grants")
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, pool, ti.orgID))
+	_, err := usersrepo.New(ti.db).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          ti.userID,
+		Email:       ti.email,
+		DisplayName: "Billing Admin",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	_, err = orgrepo.New(ti.db).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: ti.orgID,
+		UserID:         conv.ToPGText(ti.userID),
+	})
+	require.NoError(t, err)
+	_, err = accessrepo.New(ti.db).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     ti.orgID,
+		WorkosUserID:       ti.userID,
+		UserID:             conv.ToPGText(ti.userID),
+		WorkosMembershipID: conv.ToPGText("membership_" + ti.userID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleAdmin,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	_, customers, _ := ti.stripe.snapshot()
+	require.Len(t, customers, 1)
+	require.Equal(t, ti.email, customers[0].Email)
+}
+
+func TestCreateStripeCheckoutRefreshesExistingCustomerIdentity(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	_, err := repo.New(ti.db).StoreStripeCustomer(t.Context(), repo.StoreStripeCustomerParams{
+		OrganizationID:   ti.orgID,
+		StripeCustomerID: conv.ToPGText("cus_existing"),
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	uniqueCustomers, _, checkouts := ti.stripe.snapshot()
+	require.Zero(t, uniqueCustomers, "existing customer must be reused")
+	require.Len(t, checkouts, 1)
+	require.Equal(t, "cus_existing", checkouts[0].CustomerID)
+
+	updates := ti.stripe.updates()
+	require.Len(t, updates, 1)
+	require.Equal(t, "cus_existing", updates[0].CustomerID)
+	require.Equal(t, ti.orgID, updates[0].OrganizationID)
+	require.Equal(t, ti.orgSlug, updates[0].OrganizationSlug)
+	require.Equal(t, "Billing Test Organization", updates[0].OrganizationName)
+	require.Equal(t, "free", updates[0].AccountType)
 }

--- a/server/internal/usage/m3_subscription_lifecycle_integration_test.go
+++ b/server/internal/usage/m3_subscription_lifecycle_integration_test.go
@@ -38,6 +38,10 @@ func (*m3StripeWebhookClient) CreateCustomer(context.Context, stripeclient.Creat
 	return nil, errors.New("not implemented")
 }
 
+func (*m3StripeWebhookClient) UpdateCustomer(context.Context, stripeclient.UpdateCustomerInput) error {
+	return errors.New("not implemented")
+}
+
 func (*m3StripeWebhookClient) CreateCheckoutSession(context.Context, stripeclient.CreateCheckoutSessionInput) (*stripeclient.CheckoutSession, error) {
 	return nil, errors.New("not implemented")
 }

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -58,6 +58,10 @@ func (f *fakeStripeWebhookClient) CreateCustomer(context.Context, stripeclient.C
 	return nil, errors.New("not implemented")
 }
 
+func (f *fakeStripeWebhookClient) UpdateCustomer(context.Context, stripeclient.UpdateCustomerInput) error {
+	return errors.New("not implemented")
+}
+
 func (f *fakeStripeWebhookClient) CreateCheckoutSession(context.Context, stripeclient.CreateCheckoutSessionInput) (*stripeclient.CheckoutSession, error) {
 	return nil, errors.New("not implemented")
 }


### PR DESCRIPTION
## Why

Stripe objects created by Gram carried only `organization_id` and `organization_slug`, and customers had no name or billing email. Anything reading Stripe events downstream (finance, revenue reporting, CRM sync) had to guess which Speakeasy product an object belonged to and look up the organization elsewhere, and Stripe's own dashboard and notifications showed blank customers.

This PR stamps a small, stable metadata contract on every Stripe object Gram creates and gives customers a name and billing email. The same contract is written by Speakeasy's other billing systems, so a single Stripe event can be attributed consistently regardless of product.

## Contract

**Checkout Session and Subscription** (`subscription_data.metadata`, which Stripe also copies onto `invoice.parent.subscription_details.metadata`):

| key | value |
|---|---|
| `speakeasy_product` | `aicp` |
| `organization_id` | existing |
| `organization_slug` | existing |

**Customer:**

| key | value |
|---|---|
| `organization_id` | existing |
| `organization_slug` | existing |
| `organization_name` | organization display name |
| `aicp_account_type` | one of `constants.AccountTypes` (`free`, `pro`, `payg`, `enterprise`); omitted on create and cleared on update for anything else |

Plus the customer's `name` and `email` (billing alert email, else the first organization admin, else unset).

Organization ids are shared with the SDK product, so a Stripe Customer may end up shared between the two. Product-specific customer keys are therefore namespaced (`aicp_account_type` here, `sdk_account_type` on the other side) and `speakeasy_product` is never written on a Customer; Stripe merges metadata on update, so each product only touches its own keys. Which products a customer belongs to is read from which `*_account_type` keys exist. Checkout Sessions and Subscriptions belong to exactly one product and keep the plain keys.

Only values that cannot change within a session's lifetime go on the Checkout request: Checkout sessions are replayed under their original idempotency key (converted-trial receipts, stale-session recovery) and Stripe rejects a replay whose parameters differ. Name and account type change inside that window (renames, trial conversion, PAYG activation), so they live on the Customer, which is updated in place. `TestCreateStripeCheckoutFirstConversionIsAtomicAndReceiptReplayIsIdempotent` covers the replay.

## Changes

- `thirdparty/stripe`: `CreateCustomerInput` carries name, email and account type; new `UpdateCustomer` on the `Client` interface (real client, local stub, test fakes); Checkout/Subscription metadata gains `speakeasy_product`. Account types are validated against `constants.AccountTypes` in the client.
- `usage.CreateStripeCheckout`: resolves the identity from `organization_metadata`; email prefers `billing_metadata.alert_email`, then the first organization admin, else stays unset. Existing customers are refreshed via `UpdateCustomer` (best effort, logged on failure) so customers created before this change pick up name, email and metadata on their next checkout. An empty email on update leaves Stripe's existing address unchanged.
- `.mise-tasks/stripe/setup.mts`: tags the PAYG product with `metadata.speakeasy_product=aicp` on creation and back-fills the tag on an existing product, after asserting it is the PAYG product and refusing to overwrite a conflicting tag. The task refuses live keys, so production products are tagged by a separate operational step.

## Non-breaking

- Metadata is additive; Stripe merges on update. The webhook handler reads only `organization_id`.
- No migrations, no API changes. `Client` gains one method; fakes updated.
- Checkout sessions created before deploy and replayed within their 24h window would see a parameter mismatch because `speakeasy_product` is new; there are no such sessions in flight.
- Customer email becomes set, so Checkout prefills it and receipts go to the alert/admin address.

## Testing

- `thirdparty/stripe`: unit tests for customer/checkout metadata, name/email handling, unknown account type, and `UpdateCustomer` (including empty email leaving the address unchanged).
- `usage`: tests for identity stamping, alert-email precedence, admin-email fallback, existing-customer refresh, unknown account type, and the existing replay/stale-recovery suite; full `usage` package green locally.
- `mise run lint:server` clean on touched packages.
