### PR TITLE
fix: give LogDefer a real message and drop the last inbound body close

### DIFF
--- a/cli/internal/o11y/slog.go
+++ b/cli/internal/o11y/slog.go
@@ -94,13 +94,18 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 	return nil
 }
 
-func LogDefer(ctx context.Context, logger *slog.Logger, cb func() error) error {
+// LogDefer runs cb and, when it returns a non-nil error, logs that error at
+// ERROR level under msg. Reserve it for cleanup whose failure is actionable:
+// msg must name the resource that failed to close so the log is diagnosable on
+// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
+// in NoLogDefer instead.
+func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {
 		return nil
 	}
 
-	logger.ErrorContext(ctx, "error", slog.String("error", err.Error()))
+	logger.ErrorContext(ctx, msg, slog.String("error", err.Error()))
 
 	return err
 }

--- a/cli/internal/o11y/slog.go
+++ b/cli/internal/o11y/slog.go
@@ -96,9 +96,9 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 
 // LogDefer runs cb and, when it returns a non-nil error, logs that error at
 // ERROR level under msg. Reserve it for cleanup whose failure is actionable:
-// msg must name the resource that failed to close so the log is diagnosable on
-// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
-// in NoLogDefer instead.
+// msg must name the cleanup operation and the resource it acted on, so the log
+// is diagnosable on its own. Cleanup that is expected to fail, or whose
+// failure is inert, belongs in NoLogDefer instead.
 func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {

--- a/functions/internal/bootstrap/prepare.go
+++ b/functions/internal/bootstrap/prepare.go
@@ -87,7 +87,7 @@ func unzipCode(ctx context.Context, logger *slog.Logger, zipPath string, dest st
 		}
 		return fmt.Errorf("%s: open zip file: %w", zipPath, err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return zipFile.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close function zip file", func() error { return zipFile.Close() })
 
 	for _, file := range zipFile.File {
 		if err := handleZipFile(ctx, logger, file, dest); err != nil {
@@ -124,13 +124,13 @@ func handleZipFile(ctx context.Context, logger *slog.Logger, file *zip.File, des
 	if err != nil {
 		return fmt.Errorf("%s: open file in zip: %w", file.Name, err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return fileReader.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close file in zip archive", func() error { return fileReader.Close() })
 
 	targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0444)
 	if err != nil {
 		return fmt.Errorf("%s: create target file: %w", path, err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return targetFile.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close extracted target file", func() error { return targetFile.Close() })
 
 	// Limit extraction to 10MiB per file to prevent decompression bombs
 	const maxFileSize = 10 * 1024 * 1024
@@ -265,7 +265,7 @@ func resolveLazyFile(ctx context.Context, logger *slog.Logger, ident auth.Runner
 	if err != nil {
 		return "", fmt.Errorf("download asset %s: %w", assetID, err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close asset download response body", func() error {
 		if err := res.Body.Close(); err != nil {
 			return fmt.Errorf("close asset %s response body: %w", assetID, err)
 		}
@@ -282,7 +282,7 @@ func resolveLazyFile(ctx context.Context, logger *slog.Logger, ident auth.Runner
 	if err != nil {
 		return "", fmt.Errorf("create target file %s: %w", filename, err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close downloaded asset file", func() error {
 		if err := outFile.Close(); err != nil {
 			return fmt.Errorf("close %s: %w", filename, err)
 		}

--- a/functions/internal/o11y/logger.go
+++ b/functions/internal/o11y/logger.go
@@ -83,13 +83,19 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 	return nil
 }
 
-func LogDefer(ctx context.Context, logger *slog.Logger, cb func() error) error {
+// LogDefer runs cb and, when it returns a non-nil error, logs that error at
+// ERROR level under msg. Reserve it for cleanup whose failure is actionable:
+// msg must name the resource that failed to close so the log is diagnosable on
+// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
+// in NoLogDefer instead. Inbound HTTP request bodies are neither: net/http owns
+// closing them, so handlers must not close them at all.
+func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {
 		return nil
 	}
 
-	logger.ErrorContext(ctx, "error", attr.SlogError(err))
+	logger.ErrorContext(ctx, msg, attr.SlogError(err))
 
 	return err
 }

--- a/functions/internal/o11y/logger.go
+++ b/functions/internal/o11y/logger.go
@@ -85,10 +85,11 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 
 // LogDefer runs cb and, when it returns a non-nil error, logs that error at
 // ERROR level under msg. Reserve it for cleanup whose failure is actionable:
-// msg must name the resource that failed to close so the log is diagnosable on
-// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
-// in NoLogDefer instead. Inbound HTTP request bodies are neither: net/http owns
-// closing them, so handlers must not close them at all.
+// msg must name the cleanup operation and the resource it acted on, so the log
+// is diagnosable on its own. Cleanup that is expected to fail, or whose
+// failure is inert, belongs in NoLogDefer instead. Inbound HTTP request bodies
+// are neither: net/http owns closing them, so handlers must not close them at
+// all.
 func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {

--- a/functions/internal/runner/handle_tool_call.go
+++ b/functions/internal/runner/handle_tool_call.go
@@ -87,7 +87,7 @@ func (s *Service) executeRequest(ctx context.Context, logger *slog.Logger, req c
 			http.StatusInternalServerError,
 		)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return cleanup() })
+	defer o11y.LogDefer(ctx, logger, "failed to remove tool call fifo", func() error { return cleanup() })
 
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer timeoutCancel()
@@ -105,7 +105,7 @@ func (s *Service) executeRequest(ctx context.Context, logger *slog.Logger, req c
 			s.logger.ErrorContext(ctx, "failed to capture stderr log lines", attr.SlogError(err))
 		}
 	})
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close tool call log writers", func() error {
 		var err error
 		if e := stdoutWrt.Close(); e != nil {
 			err = errors.Join(err, fmt.Errorf("close stdout writer: %w", e))
@@ -192,7 +192,7 @@ func (s *Service) executeRequest(ctx context.Context, logger *slog.Logger, req c
 		)
 	case f := <-pipech:
 		pipe = f
-		defer o11y.LogDefer(ctx, logger, func() error { return pipe.Close() })
+		defer o11y.LogDefer(ctx, logger, "failed to close tool call pipe", func() error { return pipe.Close() })
 	}
 
 	response, err := http.ReadResponse(bufio.NewReader(pipe), nil)
@@ -202,7 +202,7 @@ func (s *Service) executeRequest(ctx context.Context, logger *slog.Logger, req c
 			http.StatusInternalServerError,
 		)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return response.Body.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close tool call response body", func() error { return response.Body.Close() })
 
 	ct := response.Header.Get("Content-Type")
 	if strings.HasPrefix(ct, "application/vnd.fly.replay") {

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -365,7 +365,7 @@ func newAdminCommand() *cli.Command {
 				if err != nil {
 					logger.WarnContext(ctx, "billing usage telemetry unavailable; continuing without ClickHouse", attr.SlogError(err))
 				} else {
-					defer o11y.LogDefer(ctx, logger, func() error { return chShutdown(ctx) })
+					defer o11y.LogDefer(ctx, logger, "failed to shut down clickhouse client", func() error { return chShutdown(ctx) })
 					billingTelemetry = telemetryrepo.New(chDB)
 				}
 			}

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -467,7 +467,7 @@ func newLocalFeatureFlags(ctx context.Context, logger *slog.Logger, csvPath stri
 		logger.ErrorContext(ctx, "newLocalFeatureFlags: error opening local feature flags csv file", attr.SlogError(err), attr.SlogFilePath(csvPath))
 		return inmem
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return file.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close local feature flags csv file", func() error { return file.Close() })
 
 	rdr := csv.NewReader(file)
 	rdr.FieldsPerRecord = -1

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1935,7 +1935,7 @@ func newStartCommand() *cli.Command {
 		After: func(c *cli.Context) error {
 			ctx := context.WithoutCancel(c.Context)
 			defer dbClose()
-			defer o11y.LogDefer(ctx, PullLogger(c.Context), func() error { return clickhouseShutdown(ctx) })
+			defer o11y.LogDefer(ctx, PullLogger(c.Context), "failed to shut down clickhouse client", func() error { return clickhouseShutdown(ctx) })
 			return runShutdown(PullLogger(c.Context), c.Context, shutdownFuncs)
 		},
 	}

--- a/server/internal/admin/verifier.go
+++ b/server/internal/admin/verifier.go
@@ -141,7 +141,7 @@ func (v *Verifier) refreshSession(ctx context.Context, session Session) (Session
 }
 
 func (v *Verifier) refreshSessionLocked(ctx context.Context, session Session, lockKey, owner string) (Session, string, error) {
-	defer o11y.LogDefer(ctx, v.logger, func() error {
+	defer o11y.LogDefer(ctx, v.logger, "failed to release admin session refresh lock", func() error {
 		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), adminRefreshReleaseTimeout)
 		defer cancel()
 		return v.locks.ReleaseLease(releaseCtx, lockKey, owner)

--- a/server/internal/agent/handoffs.go
+++ b/server/internal/agent/handoffs.go
@@ -257,7 +257,7 @@ func (s *Service) ServeSessionHandoff(w http.ResponseWriter, r *http.Request) er
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "read handoff document").LogError(r.Context(), s.logger)
 	}
-	defer o11y.LogDefer(r.Context(), s.logger, func() error { return rdr.Close() })
+	defer o11y.LogDefer(r.Context(), s.logger, "failed to close handoff document reader", func() error { return rdr.Close() })
 
 	// no-store on a single-use document: any cache replaying it would defeat
 	// burn-after-read; noindex belt-and-braces against crawler ingestion.

--- a/server/internal/assets/adminhandlers.go
+++ b/server/internal/assets/adminhandlers.go
@@ -26,7 +26,7 @@ import (
 // (audit_log.organization_id is NOT NULL).
 
 func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.UploadPlatformImageForm, reader io.ReadCloser) (*admingen.UploadImageResult, error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close platform image upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -43,7 +43,7 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up platform image upload", func() error {
 		return result.cleanup()
 	})
 

--- a/server/internal/assets/functions.go
+++ b/server/internal/assets/functions.go
@@ -23,7 +23,7 @@ func validateFunctionsArchive(ctx context.Context, logger *slog.Logger, filename
 	if err != nil {
 		return fmt.Errorf("open zip archive: %w", err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close functions zip archive", func() error {
 		return rdr.Close()
 	})
 

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -219,7 +219,7 @@ func (s *Service) ServeImage(ctx context.Context, payload *gen.ServeImageForm) (
 }
 
 func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm, reader io.ReadCloser) (res *gen.UploadImageResult, err error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close image upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -236,7 +236,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up image upload", func() error {
 		return result.cleanup()
 	})
 
@@ -337,7 +337,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 }
 
 func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFunctionsForm, reader io.ReadCloser) (*gen.UploadFunctionsResult, error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close functions upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -356,7 +356,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up functions upload", func() error {
 		return result.cleanup()
 	})
 
@@ -459,7 +459,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 }
 
 func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAPIv3Form, reader io.ReadCloser) (*gen.UploadOpenAPIv3Result, error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close openapi v3 upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -478,7 +478,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up openapi v3 upload", func() error {
 		return result.cleanup()
 	})
 
@@ -735,7 +735,7 @@ func (s *Service) uploadAsset(ctx context.Context, params *uploadAssetParams) (*
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, fmt.Errorf("write to blob storage: %w", err), "error writing document")
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close blob storage writer", func() error {
 		if err := dst.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			return fmt.Errorf("close blob storage: %w", err)
 		}
@@ -898,7 +898,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 	if err != nil {
 		return nil, fetchURLRequestError(err)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close openapi document fetch response body", func() error {
 		return resp.Body.Close()
 	})
 
@@ -970,7 +970,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up fetched openapi document", func() error {
 		return result.cleanup()
 	})
 
@@ -1102,7 +1102,7 @@ func (s *Service) FetchImageAssetFromURL(ctx context.Context, imageURL string) (
 	if err != nil {
 		return nil, fetchURLRequestError(err)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close image fetch response body", func() error {
 		return resp.Body.Close()
 	})
 
@@ -1126,7 +1126,7 @@ func (s *Service) FetchImageAssetFromURL(ctx context.Context, imageURL string) (
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up fetched image", func() error {
 		return result.cleanup()
 	})
 
@@ -1345,7 +1345,7 @@ func validateChatAttachmentContentType(contentType string) (mimeType, ext string
 }
 
 func (s *Service) UploadChatAttachment(ctx context.Context, payload *gen.UploadChatAttachmentForm, reader io.ReadCloser) (*gen.UploadChatAttachmentResult, error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close chat attachment upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -1362,7 +1362,7 @@ func (s *Service) UploadChatAttachment(ctx context.Context, payload *gen.UploadC
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up chat attachment upload", func() error {
 		return result.cleanup()
 	})
 

--- a/server/internal/assets/organizationhandlers.go
+++ b/server/internal/assets/organizationhandlers.go
@@ -26,7 +26,7 @@ import (
 // organization.
 
 func (s *Service) UploadOrganizationImage(ctx context.Context, payload *orggen.UploadOrganizationImageForm, reader io.ReadCloser) (*orggen.UploadImageResult, error) {
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close organization image upload reader", func() error {
 		return reader.Close()
 	})
 
@@ -54,7 +54,7 @@ func (s *Service) UploadOrganizationImage(ctx context.Context, payload *orggen.U
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to clean up organization image upload", func() error {
 		return result.cleanup()
 	})
 

--- a/server/internal/assets/store_fs.go
+++ b/server/internal/assets/store_fs.go
@@ -94,7 +94,7 @@ func (fbs *FSBlobStore) ReadAt(ctx context.Context, u *url.URL) (ReaderAtCloser,
 
 	stat, err := f.Stat()
 	if err != nil {
-		defer o11y.LogDefer(ctx, fbs.Logger, func() error {
+		defer o11y.LogDefer(ctx, fbs.Logger, "failed to close asset file", func() error {
 			return f.Close()
 		})
 		return nil, 0, fmt.Errorf("stat file: %w", err)

--- a/server/internal/assets/store_gcs.go
+++ b/server/internal/assets/store_gcs.go
@@ -237,7 +237,7 @@ func (g *gcsChunkReader) ReadAt(p []byte, offset int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("create range reader: %w", err)
 	}
-	defer o11y.LogDefer(ctx, g.logger, func() error {
+	defer o11y.LogDefer(ctx, g.logger, "failed to close gcs range reader", func() error {
 		return rdr.Close()
 	})
 

--- a/server/internal/assets/store_s3.go
+++ b/server/internal/assets/store_s3.go
@@ -271,7 +271,7 @@ func (s *s3ChunkReader) ReadAt(p []byte, offset int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("get object with range: %w", err)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close s3 object body", func() error {
 		return result.Body.Close()
 	})
 

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -401,7 +401,7 @@ func (s *StubClient) writePeriodUsage(ctx context.Context, orgID string, pu *gen
 	if err != nil {
 		return fmt.Errorf("open local billing file: %w", err)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close local billing usage file", func() error {
 		return f.Close()
 	})
 
@@ -476,7 +476,7 @@ func (s *StubClient) writeModelUsage(ctx context.Context, orgID string, usage *m
 	if err != nil {
 		return fmt.Errorf("open local model usage file: %w", err)
 	}
-	defer o11y.LogDefer(ctx, s.logger, func() error {
+	defer o11y.LogDefer(ctx, s.logger, "failed to close local model usage file", func() error {
 		return f.Close()
 	})
 

--- a/server/internal/deployments/helpers_test.go
+++ b/server/internal/deployments/helpers_test.go
@@ -24,7 +24,7 @@ func zipManifest(t *testing.T, path string, runtime string) (rdr io.Reader, err 
 
 	manifest := testenv.ReadFixture(t, path)
 	zipWriter := zip.NewWriter(buf)
-	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), func() error {
+	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), "failed to close zip writer", func() error {
 		return zipWriter.Close()
 	})
 

--- a/server/internal/externalkeys/verify.go
+++ b/server/internal/externalkeys/verify.go
@@ -134,7 +134,7 @@ func (s *Service) VerifyGcpKmsKey(ctx context.Context, payload *gen.VerifyGcpKms
 		return nil, oops.E(oops.CodeUnexpected, err, "cannot verify this key right now, try again shortly").LogError(ctx, logger)
 	}
 	// Each client owns a gRPC connection, so skipping this leaks one per verify.
-	defer o11y.LogDefer(ctx, logger, func() error { return client.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close gcp kms client", func() error { return client.Close() })
 
 	result := gcpkms.VerifySigningKey(ctx, client, row.GcpKmsKey.ResourceName, want)
 	if !result.Verified {

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -355,7 +355,7 @@ func fetchJSON[T any](ctx context.Context, logger *slog.Logger, guardianPolicy *
 	if err != nil {
 		return nil, fmt.Errorf("fetch: %w", err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return resp.Body.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close oauth discovery response body", func() error { return resp.Body.Close() })
 
 	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
 		// The server deliberately answering that this well-known document is

--- a/server/internal/externalmcp/process.go
+++ b/server/internal/externalmcp/process.go
@@ -186,7 +186,7 @@ func (te *ToolExtractor) Do(ctx context.Context, task ToolExtractorTask) error {
 	} else if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "[%s] external mcp server unavailable", task.MCP.Name).LogError(ctx, logger)
 	} else {
-		defer o11y.LogDefer(ctx, logger, mcpClient.Close)
+		defer o11y.LogDefer(ctx, logger, "failed to close external mcp client", mcpClient.Close)
 	}
 
 	// Build OAuth metadata params

--- a/server/internal/externalmcp/proxytoolexecutor.go
+++ b/server/internal/externalmcp/proxytoolexecutor.go
@@ -162,7 +162,7 @@ func (e *ProxyToolExecutor) listToolsForEntry(
 	if err != nil {
 		return nil, err
 	}
-	defer o11y.LogDefer(ctx, e.logger, client.Close)
+	defer o11y.LogDefer(ctx, e.logger, "failed to close external mcp client", client.Close)
 
 	return client.ListTools(ctx)
 }

--- a/server/internal/externalmcp/registryclient.go
+++ b/server/internal/externalmcp/registryclient.go
@@ -524,7 +524,7 @@ func (c *RegistryClient) fetchListServersPage(ctx context.Context, req *http.Req
 	if err != nil {
 		return listResponse{}, fmt.Errorf("fetch from registry: %w", err)
 	}
-	defer o11y.LogDefer(ctx, c.logger, func() error {
+	defer o11y.LogDefer(ctx, c.logger, "failed to close mcp registry response body", func() error {
 		return resp.Body.Close()
 	})
 

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -603,7 +603,7 @@ func (f *FlyRunner) reap(ctx context.Context, logger *slog.Logger, appsRepo *rep
 	if err != nil {
 		return fmt.Errorf("send delete app request: %w", err)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return res.Body.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close fly delete app response body", func() error { return res.Body.Close() })
 
 	if res.StatusCode == http.StatusNotFound {
 		logger.InfoContext(ctx, "app not found during delete, assuming already deleted")
@@ -863,7 +863,7 @@ func (f *FlyRunner) setSecrets(ctx context.Context, logger *slog.Logger, appName
 		if err != nil {
 			return nil, fmt.Errorf("%s: send set secret request: %w", k, err)
 		}
-		defer o11y.LogDefer(ctx, logger, func() error { return res.Body.Close() })
+		defer o11y.LogDefer(ctx, logger, "failed to close fly set secret response body", func() error { return res.Body.Close() })
 
 		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 			return nil, fmt.Errorf("%s: unexpected set secret response code: %d", k, res.StatusCode)
@@ -914,7 +914,7 @@ func (f *FlyRunner) serializeAssets(
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to fetch function asset").LogError(ctx, logger)
 		}
-		defer o11y.LogDefer(ctx, f.logger, func() error {
+		defer o11y.LogDefer(ctx, f.logger, "failed to close function asset reader", func() error {
 			if cerr := rdr.Close(); cerr != nil {
 				return fmt.Errorf("close function asset reader: %w", cerr)
 			}
@@ -927,7 +927,7 @@ func (f *FlyRunner) serializeAssets(
 			if err != nil {
 				return nil, oops.E(oops.CodeUnexpected, err, "failed to create writer for function asset").LogError(ctx, logger)
 			}
-			defer o11y.LogDefer(ctx, f.logger, func() error {
+			defer o11y.LogDefer(ctx, f.logger, "failed to close function asset tigris writer", func() error {
 				if werr := wr.Close(); werr != nil {
 					return fmt.Errorf("close function asset tigris writer: %w", werr)
 				}

--- a/server/internal/functions/deploy_local.go
+++ b/server/internal/functions/deploy_local.go
@@ -330,7 +330,7 @@ func (l *LocalRunner) handleLocalProxyRequest(action string) http.HandlerFunc {
 			http.Error(w, "local function invocation failed", http.StatusBadGateway)
 			return
 		}
-		defer o11y.LogDefer(ctx, l.logger, func() error { return resp.Body.Close() })
+		defer o11y.LogDefer(ctx, l.logger, "failed to close local function runner response body", func() error { return resp.Body.Close() })
 
 		for key, values := range resp.Header {
 			if strings.EqualFold(key, "Content-Length") || strings.EqualFold(key, "Transfer-Encoding") {
@@ -563,7 +563,7 @@ func (l *LocalRunner) copyAsset(ctx context.Context, assetURL *url.URL, dst stri
 	if err != nil {
 		return fmt.Errorf("open asset: %w", err)
 	}
-	defer o11y.LogDefer(ctx, l.logger, func() error { return src.Close() })
+	defer o11y.LogDefer(ctx, l.logger, "failed to close function asset reader", func() error { return src.Close() })
 
 	tmpPath := dst + ".tmp"
 	//nolint:gosec // temporary destination lives under the orchestrator-managed local function directory.
@@ -576,7 +576,7 @@ func (l *LocalRunner) copyAsset(ctx context.Context, assetURL *url.URL, dst stri
 		if closed {
 			return
 		}
-		_ = o11y.LogDefer(ctx, l.logger, func() error { return dstFile.Close() })
+		_ = o11y.LogDefer(ctx, l.logger, "failed to close local function asset file", func() error { return dstFile.Close() })
 	}()
 
 	if _, err := io.Copy(dstFile, src); err != nil {

--- a/server/internal/functions/process.go
+++ b/server/internal/functions/process.go
@@ -174,7 +174,7 @@ func (p *ToolExtractor) Do(
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "%s: error fetching functions zip file", slug).LogError(ctx, logger)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close functions zip file", func() error {
 		return rc.Close()
 	})
 
@@ -207,7 +207,7 @@ func (p *ToolExtractor) Do(
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "%s: error opening manifest file", slug).LogError(ctx, logger, attrError)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error {
+	defer o11y.LogDefer(ctx, logger, "failed to close functions manifest reader", func() error {
 		return manifestRdr.Close()
 	})
 

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -956,7 +956,7 @@ func (tp *ToolProxy) doExternalMCP(
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to connect to external MCP server").LogError(ctx, logger)
 	}
-	defer o11y.LogDefer(ctx, logger, client.Close)
+	defer o11y.LogDefer(ctx, logger, "failed to close external mcp client", client.Close)
 
 	// Call the tool on the external MCP server
 	callResult, err := client.CallTool(ctx, toolName, arguments)
@@ -1109,7 +1109,7 @@ func reverseProxyRequest(ctx context.Context, opts ReverseProxyOptions) error {
 		return oops.E(oops.CodeGatewayError, err, "failed to execute request").LogError(ctx, opts.Logger)
 	}
 
-	defer o11y.LogDefer(ctx, opts.Logger, func() error {
+	defer o11y.LogDefer(ctx, opts.Logger, "failed to close proxied response body", func() error {
 		return resp.Body.Close()
 	})
 

--- a/server/internal/jsonwebkeysets/mint.go
+++ b/server/internal/jsonwebkeysets/mint.go
@@ -152,7 +152,7 @@ func (s *Service) mintFromExternalKey(ctx context.Context, logger *slog.Logger, 
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "cannot publish a key right now, try again shortly").LogError(ctx, logger)
 	}
-	defer o11y.LogDefer(ctx, logger, func() error { return client.Close() })
+	defer o11y.LogDefer(ctx, logger, "failed to close gcp kms client", func() error { return client.Close() })
 
 	public, err := client.GetPublicKey(ctx, row.ResourceName.String)
 	if err != nil {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -882,7 +882,6 @@ func hostedServingFromToolset(toolset *toolsets_repo.Toolset) *hostedServing {
 // downstream tool dispatch doesn't 401 when the in-toolset gate is skipped.
 // The legacy /mcp path passes nil.
 //
-// The caller is responsible for closing r.Body.
 // callerToolSelection is the consent-screen tool policy resolved by a
 // caller-side issuer gate. Nil when the caller ran no gate or the session
 // carries no policy; the in-toolset gate below populates it for legacy-path

--- a/server/internal/mcp/servepublic_credentialspresent_test.go
+++ b/server/internal/mcp/servepublic_credentialspresent_test.go
@@ -8,9 +8,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -23,16 +24,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
-
-type eofCloseBody struct {
-	io.Reader
-	closed bool
-}
-
-func (b *eofCloseBody) Close() error {
-	b.closed = true
-	return io.EOF
-}
 
 // ---------------------------------------------------------------------------
 // Tests from servepublic_auth_test.go (all except helpers and BatchRequest)
@@ -117,7 +108,61 @@ func TestServePublicAuth_WithSecurityDefs_WrongMCPHeader_Returns401(t *testing.T
 	require.Contains(t, err.Error(), "unauthorized")
 }
 
-func TestServePublicAuth_PrivateServer_NoToken_Returns401WithoutClosingRequestBody(t *testing.T) {
+// TestServePublicAuth_PrivateServer_NoToken_LogsNoError pins AIM-160. An
+// unauthenticated POST answered with a 401 challenge is the normal first step
+// of the MCP OAuth handshake, so it is a success path and must not log at
+// ERROR. The regression this guards against is deferred cleanup promoting an
+// expected failure: closing the unread request body through o11y.LogDefer used
+// to return io.EOF, which net/http reports for any body a handler leaves
+// unconsumed, and that single line accounted for the bulk of gram-server's
+// error volume. Asserting on the log level rather than on whether Close was
+// called keeps the test tied to the symptom instead of to one implementation.
+func TestServePublicAuth_PrivateServer_NoToken_LogsNoError(t *testing.T) {
+	t.Parallel()
+
+	logs := &errorLogRecorder{mu: sync.Mutex{}, msgs: nil}
+	ctx, ti := newTestMCPServiceWithLogger(t, slog.New(logs))
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		ProjectID:              *authCtx.ProjectID,
+		Name:                   "Private Auth Log Test MCP",
+		Slug:                   "priv-auth-log-test",
+		Description:            conv.ToPGText("A private MCP for auth logging tests"),
+		DefaultEnvironmentSlug: pgtype.Text{String: "", Valid: false},
+		McpSlug:                conv.ToPGText("priv-auth-log-test"),
+		McpEnabled:             true,
+	})
+	require.NoError(t, err)
+
+	// Fixture setup shares the service logger; only the request matters here.
+	logs.reset()
+
+	// The body reports io.EOF on Close, the way net/http's does for a request
+	// body the handler answered without consuming. Any cleanup that closes it
+	// and logs the result is what produced the noise.
+	reqBody := makeInitializeBody()
+	_, err = servePublicHTTPWithBody(
+		t,
+		context.Background(),
+		ti,
+		toolset.McpSlug.String,
+		eofOnCloseBody{Reader: bytes.NewReader(reqBody)},
+		int64(len(reqBody)),
+		"",
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired or invalid access token")
+
+	require.Empty(t, logs.recorded(), "answering an unauthenticated MCP POST with a 401 challenge must not log at ERROR")
+}
+
+func TestServePublicAuth_PrivateServer_NoToken_Returns401(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -138,22 +183,10 @@ func TestServePublicAuth_PrivateServer_NoToken_Returns401WithoutClosingRequestBo
 	})
 	require.NoError(t, err)
 
-	body := &eofCloseBody{
-		Reader: bytes.NewReader(makeInitializeBody()),
-		closed: false,
-	}
-	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String, body)
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("mcpSlug", toolset.McpSlug.String)
-	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
-
-	err = ti.service.ServePublic(httptest.NewRecorder(), req)
+	unauthCtx := context.Background()
+	_, err = servePublicHTTP(t, unauthCtx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "expired or invalid access token")
-	require.False(t, body.closed, "the HTTP server owns the inbound request body lifecycle")
 }
 
 // ---------------------------------------------------------------------------

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,7 +62,37 @@ func servePublicHTTP(
 ) (*httptest.ResponseRecorder, error) {
 	t.Helper()
 
-	req := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug, bytes.NewReader(body))
+	return servePublicHTTPWithBody(t, ctx, ti, mcpSlug, io.NopCloser(bytes.NewReader(body)), int64(len(body)), authToken, extraHeaders)
+}
+
+// eofOnCloseBody stands in for the request body net/http hands a handler.
+// Closing a server request body that the handler left unconsumed returns
+// io.EOF (see (*body).Close in net/http/transfer.go, which sets sawEOF without
+// clearing err), but httptest.NewRequest wraps a plain reader in io.NopCloser,
+// whose Close returns nil. Tests that care what a handler does with that EOF
+// have to supply it themselves.
+type eofOnCloseBody struct {
+	io.Reader
+}
+
+func (eofOnCloseBody) Close() error { return io.EOF }
+
+// servePublicHTTPWithBody is servePublicHTTP over a caller-supplied body, for
+// tests that need control over what Read and Close return.
+func servePublicHTTPWithBody(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	mcpSlug string,
+	body io.ReadCloser,
+	contentLength int64,
+	authToken string,
+	extraHeaders map[string]string,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug, body)
+	req.ContentLength = contentLength
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	if authToken != "" {

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -116,9 +118,67 @@ func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	return newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{hasAccessOK: true})
 }
 
+// errorLogRecorder is a slog.Handler that keeps the messages of ERROR-level
+// records, so a test can assert a code path logs nothing at that level. It
+// guards its state so a handler that fans out to goroutines stays safe to
+// assert on. Attributes and groups are dropped: the service derives loggers
+// with logger.With, and returning the receiver is what keeps those derived
+// loggers reporting into the same recorder.
+type errorLogRecorder struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (r *errorLogRecorder) Enabled(context.Context, slog.Level) bool { return true }
+
+func (r *errorLogRecorder) Handle(_ context.Context, record slog.Record) error {
+	if record.Level < slog.LevelError {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = append(r.msgs, record.Message)
+
+	return nil
+}
+
+func (r *errorLogRecorder) WithAttrs([]slog.Attr) slog.Handler { return r }
+func (r *errorLogRecorder) WithGroup(string) slog.Handler      { return r }
+
+// reset drops everything recorded so far, so a test can ignore whatever its
+// fixture setup logged and assert only on the code path under test.
+func (r *errorLogRecorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.msgs = nil
+}
+
+func (r *errorLogRecorder) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.msgs)
+}
+
+// newTestMCPServiceWithLogger wires the permissive identity resolver over a
+// caller-supplied logger, for tests that assert on what the service logs.
+// testenv.NewLogger discards records unless the run is verbose, so a test that
+// needs to see them has to supply its own.
+func newTestMCPServiceWithLogger(t *testing.T, logger *slog.Logger) (context.Context, *testInstance) {
+	t.Helper()
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, logger, testenv.NewMeterProvider(t), &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+		SessionTTL:         0,
+		LiveSessionCap:     0,
+		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		MaxRequestLifetime: 0,
+	}, nil)
+}
+
 func newTestMCPServiceWithCacheWrapper(t *testing.T, wrap func(cache.Cache) cache.Cache) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewMeterProvider(t), &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewLogger(t), testenv.NewMeterProvider(t), &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
@@ -132,7 +192,7 @@ func newTestMCPServiceWithCacheWrapper(t *testing.T, wrap func(cache.Cache) cach
 // service records rather than the noop provider the other constructors use.
 func newTestMCPServiceWithMeterProvider(t *testing.T, meterProvider metric.MeterProvider) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewLogger(t), meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
@@ -182,7 +242,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 func newTestMCPServiceWithMeterProviderAndGuardianOptions(t *testing.T, meterProvider metric.MeterProvider, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
 	t.Helper()
 
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewLogger(t), meterProvider, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
@@ -193,11 +253,12 @@ func newTestMCPServiceWithMeterProviderAndGuardianOptions(t *testing.T, meterPro
 
 func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.IdentityResolver, tunnelPublicConfig mcp.TunnelPublicConfig, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewMeterProvider(t), identityResolver, tunnelPublicConfig, nil, guardianOpts...)
+	return newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(t, testenv.NewLogger(t), testenv.NewMeterProvider(t), identityResolver, tunnelPublicConfig, nil, guardianOpts...)
 }
 
 func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	t *testing.T,
+	logger *slog.Logger,
 	meterProvider metric.MeterProvider,
 	identityResolver mcp.IdentityResolver,
 	tunnelPublicConfig mcp.TunnelPublicConfig,
@@ -208,7 +269,6 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 
 	ctx := t.Context()
 
-	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{}, guardianOpts...)
 	require.NoError(t, err)

--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -173,10 +173,11 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 
 // LogDefer runs cb and, when it returns a non-nil error, logs that error at
 // ERROR level under msg. Reserve it for cleanup whose failure is actionable:
-// msg must name the resource that failed to close so the log is diagnosable on
-// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
-// in NoLogDefer instead. Inbound HTTP request bodies are neither: net/http owns
-// closing them, so handlers must not close them at all.
+// msg must name the cleanup operation and the resource it acted on, so the log
+// is diagnosable on its own. Cleanup that is expected to fail, or whose
+// failure is inert, belongs in NoLogDefer instead. Inbound HTTP request bodies
+// are neither: net/http owns closing them, so handlers must not close them at
+// all.
 func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {

--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -171,13 +171,19 @@ func (h *ContextHandler) Handle(ctx context.Context, record slog.Record) error {
 	return nil
 }
 
-func LogDefer(ctx context.Context, logger *slog.Logger, cb func() error) error {
+// LogDefer runs cb and, when it returns a non-nil error, logs that error at
+// ERROR level under msg. Reserve it for cleanup whose failure is actionable:
+// msg must name the resource that failed to close so the log is diagnosable on
+// its own. Cleanup that is expected to fail, or whose failure is inert, belongs
+// in NoLogDefer instead. Inbound HTTP request bodies are neither: net/http owns
+// closing them, so handlers must not close them at all.
+func LogDefer(ctx context.Context, logger *slog.Logger, msg string, cb func() error) error {
 	err := cb()
 	if err == nil {
 		return nil
 	}
 
-	logger.ErrorContext(ctx, "error", attr.SlogError(err))
+	logger.ErrorContext(ctx, msg, attr.SlogError(err))
 
 	return err
 }

--- a/server/internal/o11y/slog_test.go
+++ b/server/internal/o11y/slog_test.go
@@ -1,0 +1,58 @@
+package o11y_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+// captureLogger returns a logger writing JSON records into buf, so a test can
+// assert on the level, message, and attributes a helper emits.
+func captureLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: nil,
+	}))
+}
+
+func TestLogDefer_Success_LogsNothing(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := o11y.LogDefer(t.Context(), captureLogger(&buf), "failed to close widget", func() error {
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "a successful deferred call must not log")
+}
+
+func TestLogDefer_Failure_LogsMessageAndError(t *testing.T) {
+	t.Parallel()
+
+	cbErr := errors.New("boom")
+
+	var buf bytes.Buffer
+	err := o11y.LogDefer(t.Context(), captureLogger(&buf), "failed to close widget", func() error {
+		return cbErr
+	})
+
+	require.ErrorIs(t, err, cbErr, "LogDefer must return the callback error unchanged")
+
+	var record map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &record))
+
+	// The caller-supplied message is what makes the record diagnosable. Before
+	// AIM-160 this was the literal string "error" for every callsite, which
+	// rendered the health digest's top error type meaningless.
+	require.Equal(t, "failed to close widget", record["msg"])
+	require.Equal(t, slog.LevelError.String(), record["level"])
+	require.Equal(t, "boom", record["error.message"])
+}

--- a/server/internal/openapi/process.go
+++ b/server/internal/openapi/process.go
@@ -413,7 +413,7 @@ func readDoc(ctx context.Context, params readDocParams) ([]byte, error) {
 		).LogError(ctx, params.logger)
 	}
 
-	defer o11y.LogDefer(ctx, params.logger, func() error {
+	defer o11y.LogDefer(ctx, params.logger, "failed to close openapi document reader", func() error {
 		return rc.Close()
 	})
 

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -255,7 +255,7 @@ func (s *RefreshService) refresh(
 			attr.SlogCacheKey(lockKey),
 		)
 	default:
-		defer o11y.LogDefer(ctx, s.logger, func() error {
+		defer o11y.LogDefer(ctx, s.logger, "failed to release remote session refresh lock", func() error {
 			// Past TTL the key may be a new holder's lock. Skip delete; TTL reaps.
 			if time.Since(lockAcquiredAt) >= refreshLockTTL {
 				s.logger.WarnContext(ctx, "remote session refresh outlived its lock lease; leaving release to TTL",

--- a/server/internal/tools/setup_test.go
+++ b/server/internal/tools/setup_test.go
@@ -141,7 +141,7 @@ func zipManifest(t *testing.T, path string, runtime string) (rdr io.Reader, err 
 
 	manifest := testenv.ReadFixture(t, path)
 	zipWriter := zip.NewWriter(buf)
-	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), func() error {
+	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), "failed to close zip writer", func() error {
 		return zipWriter.Close()
 	})
 

--- a/server/internal/toolsets/setup_test.go
+++ b/server/internal/toolsets/setup_test.go
@@ -339,7 +339,7 @@ func zipManifest(t *testing.T, path string, runtime string) (rdr io.Reader, err 
 
 	manifest := testenv.ReadFixture(t, path)
 	zipWriter := zip.NewWriter(buf)
-	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), func() error {
+	defer o11y.LogDefer(t.Context(), testenv.NewLogger(t), "failed to close zip writer", func() error {
 		return zipWriter.Close()
 	})
 

--- a/server/internal/usage/stripe_webhook.go
+++ b/server/internal/usage/stripe_webhook.go
@@ -51,7 +51,6 @@ type stripeWebhookHandler func(context.Context, *slog.Logger, pgx.Tx, string, *s
 
 func (s *Service) handleStripeWebhook(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	defer o11y.LogDefer(ctx, s.logger, r.Body.Close)
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxStripeWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-160/stop-logging-request-body-close-eof-as-error-on-mcp-handlers

## Summary

Followup to #5947, which removed the MCP handler request body closes that were logging `io.EOF` at ERROR. Two gaps remained.

- `handleStripeWebhook` still closed its inbound request body through `o11y.LogDefer`. It was written as a method value (`r.Body.Close`) rather than the multi-line closure form the earlier sweep grepped for, so it was missed. This was the last logging close of an inbound request body across `server/`, `cli/`, and `functions/`.
- `o11y.LogDefer` hardcoded the literal string `"error"` as its slog message. It now takes a `msg` parameter naming the resource that failed to close, applied across all 59 callsites and all three copies of the helper (`server/internal/o11y`, `cli/internal/o11y`, `functions/internal/o11y`). The `cli` copy has no callers today but reproduced the same defect, so it was aligned rather than left as a copy-paste source.
- The regression test now asserts that answering an unauthenticated MCP POST with a `401` challenge emits no ERROR record, rather than asserting that the handler does not call `Close`.
- Dropped a stale doc comment on `serveToolsetResolved` saying the caller owns closing `r.Body`, which contradicts the invariant this change documents.

## Motivation

`net/http` owns closing inbound request bodies, and Go's `(*body).Close` returns `io.EOF` for any handler that returns without fully consuming a body of 256KB or less (the `doEarlyClose` branch sets `sawEOF` without clearing `err`). Closing those bodies through `LogDefer` promoted an expected condition to an ERROR log on a success path, which is how a single line came to account for the bulk of `gram-server`'s error volume.

The hardcoded `"error"` message is the other half of the problem. With every callsite logging under the same meaningless string, the health digest's top error type rendered as `error`, which made every report built on it hard to read. Naming the resource makes each record diagnosable on its own.

On the test: the earlier version asserted that `ServePublic` does not call `Close`, which is a change detector rather than a test of the symptom, and it comes apart in both directions. Asserting the log level instead keeps it tied to the behaviour the issue is about. That required supplying a request body reporting `io.EOF` on `Close` the way `net/http`'s does, because `httptest.NewRequest` otherwise wraps a plain reader in `io.NopCloser` and the condition never reproduces in process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes AIM-160 by removing the last deferred close of an inbound HTTP request body and making `LogDefer` messages identify the failed operation. `net/http` now owns the Stripe webhook body, preventing expected `io.EOF` from becoming an ERROR log.

- Updates `LogDefer` across `server`, `cli`, and `functions` to accept messages for close, shutdown, lock release, removal, and other cleanup failures.
- Adds tests for descriptive `LogDefer` records and verifies that an unauthenticated MCP POST emits no ERROR record.
- Removes the stale comment claiming callers must close `r.Body`.

<sup>Written for commit 84e7d3ca539ea8c8ebe602a3f80736109796b5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

