### PR TITLE
fix: stop long identity names overflowing the table row

### DIFF
--- a/client/dashboard/src/components/ui/Table/index.tsx
+++ b/client/dashboard/src/components/ui/Table/index.tsx
@@ -825,7 +825,9 @@ function CellContainer({ children, className }: PropsWithChildrenAndClassName) {
     <td
       className={cn(
         styles.tableCell,
-        `flex max-w-full items-center`,
+        // min-w-0: an unbreakable value (a long agent id) would otherwise set
+        // this cell's min-content width and push the whole row into overflow.
+        `flex max-w-full min-w-0 items-center`,
         className,
       )}
     >

--- a/client/dashboard/src/components/ui/Table/index.tsx
+++ b/client/dashboard/src/components/ui/Table/index.tsx
@@ -825,9 +825,12 @@ function CellContainer({ children, className }: PropsWithChildrenAndClassName) {
     <td
       className={cn(
         styles.tableCell,
-        // min-w-0: an unbreakable value (a long agent id) would otherwise set
-        // this cell's min-content width and push the whole row into overflow.
-        `flex max-w-full min-w-0 items-center`,
+        // min-w-0 lets a cell shrink below its content: an unbreakable value
+        // (a long agent id) would otherwise set the grid track's floor and
+        // push the whole row into overflow. overflow-hidden then keeps what
+        // does not fit inside the column rather than painting over the next
+        // one — a cell that wants an ellipsis still asks for it itself.
+        `flex max-w-full min-w-0 items-center overflow-hidden`,
         className,
       )}
     >

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -611,7 +611,9 @@ function IdentityCell({ identity }: { identity: Employee }): JSX.Element {
               link: no cmd+click, no middle-click, no copy-link, and nothing
               for a screen reader to announce. On a page whose whole job is
               reaching people, the name itself has to be the anchor. */}
-          <Text className="truncate font-medium">
+          {/* An agent's name may be a long unbroken id, so it wraps anywhere
+              and stops at two lines rather than running past the row. */}
+          <Text className="line-clamp-2 min-w-0 font-medium wrap-anywhere">
             <IdentityLink
               identifier={{ urn: identityUrnForEmployee(identity) }}
             >


### PR DESCRIPTION
## Summary

Long identity names no longer push the rest of the identities table into horizontal overflow.

- `Table`: cells get `min-w-0`. The grid tracks are `fr`-sized, so a cell whose content cannot break set its own min-content width as the track floor and grew the column past its share. This is the general fix — any table with an unbreakable value in an `fr` column was affected.
- `IdentitiesIndex`: the name in the leading cell swaps `truncate` for `line-clamp-2 wrap-anywhere`. A person's name still fits on one line; an agent whose name is a bare 64-character id wraps and stops after two lines instead of running the width of the row.

## Motivation

Agents are listed under whatever name they chose for themselves, which is often a long hex id with no spaces or hyphens. `truncate` could not contain it: `text-overflow: ellipsis` only applies once the box is constrained, and the grid track was sizing itself to the string. The Kind column was pushed off to the right and the table scrolled sideways.

Clamping to two lines rather than one keeps the whole id readable at a glance for the cases where it is the only handle a reader has on that agent.

https://claude.ai/code/session_01FHbveto63bxaU6TgPpTUz9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Long identity names no longer push the identities table into horizontal overflow.

- Added `min-w-0` and `overflow-hidden` to table cells so unbreakable content no longer forces an `fr` grid track to grow past its share, and anything that doesn't fit is clipped instead of bleeding into the next column.
- Identity names now use `line-clamp-2 wrap-anywhere` instead of `truncate`, so a long unbroken agent id wraps after two lines instead of widening the column.

<sup>Written for commit c5f848779f44ffc5dfb4dd413ffd494ba65e9fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

