### PR TITLE
feat: explain the org risk score with a tooltip on Watchdog

### DIFF
--- a/.changeset/watchdog-org-risk-score-tooltip.md
+++ b/.changeset/watchdog-org-risk-score-tooltip.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The Watchdog page now explains the org risk score with an info tooltip: each signal's score is inherited from its policy, and the overall score weights the most severe signal, the average of the top signals, and the total number of findings rather than a plain average.

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -483,6 +483,13 @@ function SeverityChip({
   );
 }
 
+/** Explains how the headline number relates to the per-signal scores.
+ * Mirrors orgRiskScore in server/internal/risk/signals.go: the worst
+ * signal dominates, the top-three mean keeps one outlier from saturating
+ * it, and finding volume contributes the rest. */
+const ORG_RISK_SCORE_TOOLTIP =
+  "Each signal's score is inherited from its policy. The overall score is not a plain average: it weights the most severe signal, the average of the top signals, and the total number of findings.";
+
 /** StatTile tone for the org risk score, mirroring the signal table's
  * severity coding: red for high/critical bands, amber for medium, plain
  * ink for low. */
@@ -604,6 +611,7 @@ function KPIRow({
     <StatTileGroup>
       <StatTile
         title="Org risk score"
+        tooltip={ORG_RISK_SCORE_TOOLTIP}
         value={data.orgRiskScore}
         displayValue={data.orgRiskScore.toFixed(1)}
         previousValue={data.previousOrgRiskScore}


### PR DESCRIPTION
## Summary

Adds an info tooltip next to the **Org risk score** stat tile on the Watchdog page. It uses the `tooltip` prop that `StatTile` already supports, so the tile gets the same hover info icon as the work-units tiles on chat logs.

The copy reads:

> Each signal's score is inherited from its policy. The overall score is not a plain average: it weights the most severe signal, the average of the top signals, and the total number of findings.

The string lives in a module-level `ORG_RISK_SCORE_TOOLTIP` constant with a comment pointing at `orgRiskScore` in `server/internal/risk/signals.go`, so the two stay easy to reconcile if the formula changes.

## Motivation

The headline org risk score can look surprising next to the per-signal scores in the table below it, because it is not an average of those rows. Each row's score comes from the policy that produced it, while the org score is a weighted blend: the worst signal dominates, the mean of the top three keeps a single outlier from saturating it, and log-scaled finding volume contributes the rest. The tooltip gives admins that context in place instead of leaving them to guess why the number moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WimMAti7F37pEqKLje6zTY


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an info tooltip to the Org risk score stat tile on the Watchdog page so admins no longer have to guess why the headline number differs from the per-signal scores below it. The tooltip explains that each signal's score comes from its policy, and the overall score weights the most severe signal, the average of the top signals, and the total number of findings rather than taking a plain average. Score calculation is unchanged.

<sup>Written for commit 214bf984ca5d3bc8c255ec2db30cef6094e67a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

