### PR TITLE
mig: per-tunnel public rate limit columns on tunneled_mcp_servers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2191,6 +2191,13 @@ CREATE TABLE IF NOT EXISTS tunneled_mcp_servers (
   -- exact-match credential routing. Names a host inside the customer's
   -- private network — this value must NEVER be dialed by Gram.
   resource_identifier TEXT CHECK (resource_identifier IS NULL OR resource_identifier <> ''),
+  -- Anonymous public MCP request rate limit, requests per second. NULL: deployment default.
+  public_request_rate_per_second integer CHECK (public_request_rate_per_second IS NULL OR (public_request_rate_per_second > 0 AND public_request_rate_per_second <= 100000)),
+  -- Token-bucket capacity for public_request_rate_per_second: the number of
+  -- requests admitted back-to-back from an idle tunnel before admission drops
+  -- to the sustained rate. Each request takes one token; tokens refill at
+  -- public_request_rate_per_second per second up to this cap. NULL: 2 × rate.
+  public_request_burst integer CHECK (public_request_burst IS NULL OR (public_request_burst > 0 AND public_request_burst <= 1000000)),
   -- Most recent persisted heartbeat time, used when Redis liveness data is absent.
   last_seen_at timestamptz,
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2937,7 +2937,9 @@ type TunneledMcpServer struct {
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
 	// RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer's private network — never dialed by Gram.
-	ResourceIdentifier pgtype.Text
+	ResourceIdentifier         pgtype.Text
+	PublicRequestRatePerSecond pgtype.Int4
+	PublicRequestBurst         pgtype.Int4
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
 	LastSeenAt pgtype.Timestamptz
 	// Time when the tunneled MCP source was created.

--- a/server/internal/tunneledmcp/repo/models.go
+++ b/server/internal/tunneledmcp/repo/models.go
@@ -28,7 +28,9 @@ type TunneledMcpServer struct {
 	// Last persisted tunnel agent version reported for this source. Per-connection agent versions are stored in Redis.
 	AgentVersion pgtype.Text
 	// RFC 9728 protected-resource identifier of the tunneled server, recorded as the RFC 8707 resource on grants and used only for exact-match credential routing. Names a host inside the customer's private network — never dialed by Gram.
-	ResourceIdentifier pgtype.Text
+	ResourceIdentifier         pgtype.Text
+	PublicRequestRatePerSecond pgtype.Int4
+	PublicRequestBurst         pgtype.Int4
 	// Most recent persisted heartbeat time for the source, used when Redis liveness data is absent or expired.
 	LastSeenAt pgtype.Timestamptz
 	// Time when the tunneled MCP source was created.

--- a/server/internal/tunneledmcp/repo/queries.sql.go
+++ b/server/internal/tunneledmcp/repo/queries.sql.go
@@ -31,7 +31,7 @@ func (q *Queries) CountActiveServersByOrganizationID(ctx context.Context, organi
 const createServer = `-- name: CreateServer :one
 INSERT INTO tunneled_mcp_servers (id, project_id, name, key_hash, key_prefix, resource_identifier)
 VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateServerParams struct {
@@ -63,6 +63,8 @@ func (q *Queries) CreateServer(ctx context.Context, arg CreateServerParams) (Tun
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -79,7 +81,7 @@ SET
     deleted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteServerParams struct {
@@ -100,6 +102,8 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -110,7 +114,7 @@ func (q *Queries) DeleteServer(ctx context.Context, arg DeleteServerParams) (Tun
 }
 
 const getServerByID = `-- name: GetServerByID :one
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -133,6 +137,8 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (T
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -143,7 +149,7 @@ func (q *Queries) GetServerByID(ctx context.Context, arg GetServerByIDParams) (T
 }
 
 const getServerByIDForUpdate = `-- name: GetServerByIDForUpdate :one
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 FOR UPDATE
@@ -170,6 +176,8 @@ func (q *Queries) GetServerByIDForUpdate(ctx context.Context, arg GetServerByIDF
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -194,7 +202,7 @@ func (q *Queries) GetTunneledMcpServerLimitByOrganizationID(ctx context.Context,
 }
 
 const listServersByProjectID = `-- name: ListServersByProjectID :many
-SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 FROM tunneled_mcp_servers
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -219,6 +227,8 @@ func (q *Queries) ListServersByProjectID(ctx context.Context, projectID uuid.UUI
 			&i.AllowPublic,
 			&i.AgentVersion,
 			&i.ResourceIdentifier,
+			&i.PublicRequestRatePerSecond,
+			&i.PublicRequestBurst,
 			&i.LastSeenAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -257,7 +267,7 @@ SET
     last_seen_at = NULL,
     updated_at = clock_timestamp()
 WHERE id = $3 AND project_id = $4 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type RotateServerKeyParams struct {
@@ -285,6 +295,8 @@ func (q *Queries) RotateServerKey(ctx context.Context, arg RotateServerKeyParams
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -306,7 +318,7 @@ SET
     END,
     updated_at = clock_timestamp()
 WHERE id = $4 AND project_id = $5 AND deleted IS FALSE
-RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, last_seen_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, name, key_hash, key_prefix, status, allow_public, agent_version, resource_identifier, public_request_rate_per_second, public_request_burst, last_seen_at, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateServerParams struct {
@@ -336,6 +348,8 @@ func (q *Queries) UpdateServer(ctx context.Context, arg UpdateServerParams) (Tun
 		&i.AllowPublic,
 		&i.AgentVersion,
 		&i.ResourceIdentifier,
+		&i.PublicRequestRatePerSecond,
+		&i.PublicRequestBurst,
 		&i.LastSeenAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/migrations/20260902212254_public-tunnel-rate-limits.sql
+++ b/server/migrations/20260902212254_public-tunnel-rate-limits.sql
@@ -1,0 +1,2 @@
+-- Modify "tunneled_mcp_servers" table
+ALTER TABLE "tunneled_mcp_servers" ADD CONSTRAINT "tunneled_mcp_servers_public_request_burst_check" CHECK ((public_request_burst IS NULL) OR ((public_request_burst > 0) AND (public_request_burst <= 1000000))), ADD CONSTRAINT "tunneled_mcp_servers_public_request_rate_per_second_check" CHECK ((public_request_rate_per_second IS NULL) OR ((public_request_rate_per_second > 0) AND (public_request_rate_per_second <= 100000))), ADD COLUMN "public_request_rate_per_second" integer NULL, ADD COLUMN "public_request_burst" integer NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:MU+PxXlyWSzXJcLArncH1k8LYWhbjOc/ppbHEOnRm70=
+h1:WSsacfXez3IFqaPvrUWqETMbRAPI3maeBhUedluNTz8=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -380,3 +380,4 @@ h1:MU+PxXlyWSzXJcLArncH1k8LYWhbjOc/ppbHEOnRm70=
 20260831170736_tunneled-mcp-server-resource-identifier.sql h1:knIZQZflX4azED7sFXe+uPiJJexkH2eTDfteUGnaKXg=
 20260831182126_aim-78-remote-session-client-jwks.sql h1:s39s09GZ0Zjh20gDECQj9ZmkSOsXZsHxpADmdM8uRrI=
 20260901222548_remote-session-issuer-tunnel-binding.sql h1:3JREClrlXOmZInBZO8aup9+fz/QjQka7XxTuJmGnzjA=
+20260902212254_public-tunnel-rate-limits.sql h1:nZB403TMLx/lHT2gVqVrlsN1Iw4CBhrGJjcNcaOxMuI=


### PR DESCRIPTION
Split out of https://github.com/speakeasy-api/gram/pull/5987 so the schema change can land first; the application code stacks on this branch.

## Summary

- `tunneled_mcp_servers` gains two nullable integer columns: `public_request_rate_per_second` (sustained anonymous MCP requests per second, every method) and `public_request_burst` (token-bucket capacity: requests admitted back-to-back from idle before admission drops to the sustained rate).
- CHECK constraints (`> 0`, rate `<= 100000`, burst `<= 1000000`) reject out-of-range values at the row.
- Additive and nullable: existing rows read as "no stored limit" and keep the deployment-wide default; a NULL burst means twice the rate.
- Atlas migration and checksum generated from `schema.sql`; sqlc models regenerated.

## Motivation

The anonymous public tunnel path admits requests through a per-tunnel token bucket whose rate was hardcoded. A public server with organic demand above that cap had half its requests rejected with no way to raise the limit short of a deploy. Storing the limit on the row lets the source owner size it while every other tunnel keeps the conservative default.
