### PR TITLE
fix: make account menu "Explore demo org" navigate

### DIFF
--- a/.changeset/explore-demo-account-menu.md
+++ b/.changeset/explore-demo-account-menu.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the "Explore demo org" item in the account menu doing nothing when clicked. Route helpers silently stubbed out `goTo` for absolute-path routes such as `/explore-demo`, so the click closed the menu and stayed on the current page. Absolute routes now navigate the same way every other route does.

--- a/client/dashboard/src/routes.test.tsx
+++ b/client/dashboard/src/routes.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
@@ -19,6 +19,23 @@ function LocationPath(): JSX.Element {
   return <output>{location.pathname + location.search + location.hash}</output>;
 }
 
+function GoToExploreDemo(): JSX.Element {
+  const routes = useRoutes();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          routes.exploreDemo.goTo();
+        }}
+      >
+        go
+      </button>
+      <LocationPath />
+    </>
+  );
+}
+
 describe("project routes", () => {
   it("exposes the standalone guide route", () => {
     render(
@@ -28,6 +45,18 @@ describe("project routes", () => {
     );
 
     expect(screen.getByText("/org/projects/project/guide")).toBeTruthy();
+  });
+
+  it("navigates to absolute routes through goTo", () => {
+    render(
+      <MemoryRouter initialEntries={["/org/projects/project"]}>
+        <GoToExploreDemo />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByText("go"));
+
+    expect(screen.getByText("/explore-demo")).toBeTruthy();
   });
 });
 

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -1064,12 +1064,6 @@ export const useRoutes = (overrides?: {
       ...subPages,
     };
 
-    if (route.url.startsWith("/")) {
-      newRoute.goTo = () => {
-        void route.url;
-      };
-    }
-
     return newRoute;
   };
 


### PR DESCRIPTION
## Summary

- Remove the override in `useRoutes` that replaced `goTo` with a no-op for every route whose `url` starts with `/` (`/login`, `/register`, `/sign-up`, `/explore-demo`). Those routes now navigate through the same `resolveUrl` path that `href()` already uses.
- Add a `routes.test.tsx` case that clicks through `routes.exploreDemo.goTo()` inside a `MemoryRouter` and asserts the location changes to `/explore-demo`.
- Changeset: `dashboard` patch.

The account menu's "Explore demo org" item (#5958) is the only caller of `goTo` on an absolute route, so this is the only behaviour that changes.

## Motivation

Clicking "Explore demo org" in the account menu closed the menu and left the user on their current page. The item calls `routes.exploreDemo.goTo()`, but the route helper has stubbed `goTo` for absolute-path routes since it was introduced (originally `() => route.url`, later rewritten to `() => { void route.url; }` during the oxlint migration), so the call has never navigated. Nothing relied on it until #5958, and that PR's unit test mocks `useRoutes`, so the stub went unnoticed. Visiting `/explore-demo` directly, or through the org-home welcome banner's `<Link>`, already works, which confirms in-app navigation to the route is fine; only the helper was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX9tv2cL6Q353Qyd8vQX7D


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the account menu's "Explore demo org" item so clicking it navigates to `/explore-demo` instead of closing the menu and staying on the current page.

The route helper no longer stubs `goTo` with a no-op for absolute-path routes; those now use the same resolver as `href()`. Adds a test that clicks through `routes.exploreDemo.goTo()` and asserts the location changes.

<sup>Written for commit 3cc133bf713fa08d9e37571fdccf02d557077713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

