### PR TITLE
fix: add whitespace below Platform MCP onboarding cards

### DIFF
--- a/.changeset/mcp-onboarding-card-whitespace.md
+++ b/.changeset/mcp-onboarding-card-whitespace.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Give Platform MCP onboarding sheets a visible bottom gutter so the last card no longer sits flush against the sheet edge.

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -1091,9 +1091,6 @@ const SETUP_LIFECYCLE_STEP_COUNT = 5;
 const SETUP_TOTAL_STEP_COUNT =
   SETUP_PRIMER_STEP_COUNT + SETUP_LIFECYCLE_STEP_COUNT;
 const SECURE_SETUP_RECOVERY_DELAY_MS = 3 * 60_000;
-// Padding lives on an inner wrapper so overflow:auto cannot clip the bottom
-// gutter — otherwise the last card sits flush against the sheet edge.
-const SETUP_SHEET_BODY_CLASS = "px-6 pt-6 pb-10";
 
 function PlatformMCPProgress({ step }: { step: number }): JSX.Element {
   return (
@@ -1143,7 +1140,7 @@ function PlatformMCPAgentPickerSheet({
         </SheetHeader>
         <PlatformMCPProgress step={1} />
         <div className="flex-1 overflow-y-auto">
-          <div className={SETUP_SHEET_BODY_CLASS}>
+          <div className="px-6 pt-6 pb-10">
             <p className="text-eyebrow">Step 1</p>
             <h2 className="text-display-xs mt-1 font-thin">Choose an agent</h2>
             <p className="text-muted-foreground mt-2 text-sm">
@@ -1230,7 +1227,7 @@ function PlatformMCPInstallMethodSheet({
         </SheetHeader>
         <PlatformMCPProgress step={2} />
         <div className="flex-1 overflow-y-auto">
-          <div className={SETUP_SHEET_BODY_CLASS}>
+          <div className="px-6 pt-6 pb-10">
             <p className="text-eyebrow">Step 2</p>
             <h2 className="text-display-xs mt-1 font-thin">
               Choose an install method
@@ -1620,7 +1617,7 @@ function PlatformMCPSetupSheet({
           </span>
         </div>
         <div className="flex-1 overflow-y-auto">
-          <div className={SETUP_SHEET_BODY_CLASS}>
+          <div className="px-6 pt-6 pb-10">
             <p className="text-eyebrow">
               Step {currentStepIndex + SETUP_PRIMER_STEP_COUNT + 1}
             </p>

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -1091,6 +1091,9 @@ const SETUP_LIFECYCLE_STEP_COUNT = 5;
 const SETUP_TOTAL_STEP_COUNT =
   SETUP_PRIMER_STEP_COUNT + SETUP_LIFECYCLE_STEP_COUNT;
 const SECURE_SETUP_RECOVERY_DELAY_MS = 3 * 60_000;
+// Padding lives on an inner wrapper so overflow:auto cannot clip the bottom
+// gutter — otherwise the last card sits flush against the sheet edge.
+const SETUP_SHEET_BODY_CLASS = "px-6 pt-6 pb-10";
 
 function PlatformMCPProgress({ step }: { step: number }): JSX.Element {
   return (
@@ -1139,24 +1142,26 @@ function PlatformMCPAgentPickerSheet({
           </SheetDescription>
         </SheetHeader>
         <PlatformMCPProgress step={1} />
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          <p className="text-eyebrow">Step 1</p>
-          <h2 className="text-display-xs mt-1 font-thin">Choose an agent</h2>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Pick the coding agent you&apos;re setting up. The next step will
-            show the installation methods available for that agent.
-          </p>
-          <div className="mt-5 space-y-2">
-            {clients.map((client) => (
-              <AgentPlatformPickerItem
-                key={client.id}
-                platformId={client.id.replaceAll("_", "-")}
-                name={client.label}
-                description={client.description}
-                disabled={isMutating}
-                onClick={() => onSelect(client)}
-              />
-            ))}
+        <div className="flex-1 overflow-y-auto">
+          <div className={SETUP_SHEET_BODY_CLASS}>
+            <p className="text-eyebrow">Step 1</p>
+            <h2 className="text-display-xs mt-1 font-thin">Choose an agent</h2>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Pick the coding agent you&apos;re setting up. The next step will
+              show the installation methods available for that agent.
+            </p>
+            <div className="mt-5 space-y-2">
+              {clients.map((client) => (
+                <AgentPlatformPickerItem
+                  key={client.id}
+                  platformId={client.id.replaceAll("_", "-")}
+                  name={client.label}
+                  description={client.description}
+                  disabled={isMutating}
+                  onClick={() => onSelect(client)}
+                />
+              ))}
+            </div>
           </div>
         </div>
       </SheetContent>
@@ -1224,35 +1229,37 @@ function PlatformMCPInstallMethodSheet({
           </SheetDescription>
         </SheetHeader>
         <PlatformMCPProgress step={2} />
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          <p className="text-eyebrow">Step 2</p>
-          <h2 className="text-display-xs mt-1 font-thin">
-            Choose an install method
-          </h2>
-          <p className="text-muted-foreground mt-2 text-sm">
-            Install Platform MCP for your {client.label} account. Installation
-            never grants access by itself; you&apos;ll authorize in the
-            following step.
-          </p>
-          <div className="mt-5 space-y-2">
-            {methods.map((method) => (
-              <button
-                key={method.id}
-                type="button"
-                onClick={() => onSelect(method.id)}
-                className="border-border bg-card hover:border-foreground/20 flex w-full items-center gap-4 border p-4 text-left transition-all"
-              >
-                <div className="min-w-0 flex-1 space-y-1">
-                  <p className="text-foreground text-sm font-medium">
-                    {method.title}
-                  </p>
-                  <p className="text-muted-foreground text-xs">
-                    {method.description}
-                  </p>
-                </div>
-                <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
-              </button>
-            ))}
+        <div className="flex-1 overflow-y-auto">
+          <div className={SETUP_SHEET_BODY_CLASS}>
+            <p className="text-eyebrow">Step 2</p>
+            <h2 className="text-display-xs mt-1 font-thin">
+              Choose an install method
+            </h2>
+            <p className="text-muted-foreground mt-2 text-sm">
+              Install Platform MCP for your {client.label} account. Installation
+              never grants access by itself; you&apos;ll authorize in the
+              following step.
+            </p>
+            <div className="mt-5 space-y-2">
+              {methods.map((method) => (
+                <button
+                  key={method.id}
+                  type="button"
+                  onClick={() => onSelect(method.id)}
+                  className="border-border bg-card hover:border-foreground/20 flex w-full items-center gap-4 border p-4 text-left transition-all"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="text-foreground text-sm font-medium">
+                      {method.title}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {method.description}
+                    </p>
+                  </div>
+                  <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                </button>
+              ))}
+            </div>
           </div>
         </div>
         <SheetFooter className="border-border border-t px-6 py-4">
@@ -1612,19 +1619,21 @@ function PlatformMCPSetupSheet({
             {SETUP_TOTAL_STEP_COUNT}
           </span>
         </div>
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          <p className="text-eyebrow">
-            Step {currentStepIndex + SETUP_PRIMER_STEP_COUNT + 1}
-          </p>
-          <div className="mt-1 flex flex-wrap items-center gap-2">
-            <h2 className="text-display-xs font-thin">{currentStep.title}</h2>
-            {currentStep.complete && (
-              <Badge variant="success" size="sm">
-                Complete
-              </Badge>
-            )}
+        <div className="flex-1 overflow-y-auto">
+          <div className={SETUP_SHEET_BODY_CLASS}>
+            <p className="text-eyebrow">
+              Step {currentStepIndex + SETUP_PRIMER_STEP_COUNT + 1}
+            </p>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <h2 className="text-display-xs font-thin">{currentStep.title}</h2>
+              {currentStep.complete && (
+                <Badge variant="success" size="sm">
+                  Complete
+                </Badge>
+              )}
+            </div>
+            <div className="mt-5 space-y-5">{showStep()}</div>
           </div>
-          <div className="mt-5 space-y-5">{showStep()}</div>
         </div>
         <SheetFooter className="border-border flex-row items-center justify-between border-t px-6 py-4">
           <Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes GRW-61.

Platform MCP onboarding’s last card sat flush against the bottom of the sheet. Bottom padding was on the `overflow-y-auto` scroller, which browsers clip, so the gutter disappeared when the step content was taller than the viewport (the secure-setup step with two stacked cards).

This moves padding onto an inner wrapper and increases the bottom gutter from 24px to 40px so the last card has visible breathing room. Measured after scrolling to the end of the setup sheet: 40px inner padding, ~39px from the last card to the scroll edge, ~55px to the footer.

![Platform MCP setup sheet after adding bottom gutter](https://cursor.com/artifacts/c/art-3847395f-6c37-4252-9be9-e63da9840528)

## Testing
- Opened Platform MCP onboarding, chose Cursor + marketplace, scrolled the setup sheet to the last card.
- Confirmed the last card no longer sits flush against the footer.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-61](https://linear.app/speakeasy/issue/GRW-61/feedback-add-whitespace-below-the-mcp-onboarding-card)

<div><a href="https://cursor.com/agents/bc-e775e83c-4338-426a-978c-ddabe9dc5d59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e775e83c-4338-426a-978c-ddabe9dc5d59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GRW-61 by adding bottom whitespace to Platform MCP onboarding sheets. Previously, the scroll container could clip its 24px bottom padding on tall steps; the padding now lives on an inner wrapper, giving the last card a reliable 40px gutter.

- Applies the spacing to agent selection, install method, and setup steps.
- Adds a dashboard patch changeset.

<sup>Written for commit 4d6192967dfa5c0ab60c0b227b8e99375f815bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

