### PR TITLE
feat: filter the identities roster by enrollment, devices, roles and directory profile

### DIFF
--- a/.changeset/identity-roster-filters.md
+++ b/.changeset/identity-roster-filters.md
@@ -1,0 +1,7 @@
+---
+"dashboard": patch
+---
+
+Filter the Identities index by the things an administrator actually asks it: enrollment, how recently someone was last seen working, the agent coverage on their managed devices, the roles they hold, and the department and team their identity provider reports. Personal-account usage gains its own yes/no question, so the people holding an account the organization does not govern — and the people holding none — can each be read on their own.
+
+A filter only appears when the data behind it has something to say: an organization with no device integration connected sees no device filter, and one with no directory synced sees neither department nor team, rather than a control whose every option empties the table.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -62813,9 +62813,17 @@ components:
     AccessMember:
       type: object
       properties:
+        department:
+          type: string
+          description: Department name as reported by the identity provider.
         email:
           type: string
           description: Email address.
+        groups:
+          type: array
+          items:
+            type: string
+          description: Names of the directory groups the member belongs to.
         id:
           type: string
           description: User ID.

--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -36,6 +36,14 @@ export type Employee = {
   mostRecentAccount: EmployeeAccount | null;
   // Convenience flag: any account is personal. Drives the account-type filter.
   hasPersonalAccount: boolean;
+  // Role IDs from the member row, for filtering by role without re-parsing the
+  // display string above. Empty for an identity with no member row.
+  roleIds: string[];
+  // Identity-provider profile, when a directory is connected and knows them:
+  // the department it reports, and the directory groups they belong to (the
+  // "team" a person would name). Empty otherwise.
+  department: string;
+  teams: string[];
 };
 
 // Maps a user summary's linked accounts (from the directory) into the display
@@ -295,6 +303,9 @@ export function buildEmployees(
       accounts,
       mostRecentAccount: mostRecentAccount(accounts),
       hasPersonalAccount: accounts.some((a) => a.accountType === "personal"),
+      roleIds: member.roleIds,
+      department: member.department ?? "",
+      teams: member.groups ?? [],
     };
   });
 
@@ -317,6 +328,11 @@ export function buildEmployees(
       accounts,
       mostRecentAccount: mostRecentAccount(accounts),
       hasPersonalAccount: accounts.some((a) => a.accountType === "personal"),
+      // Usage the directory matched to nobody: no member row, so no roles and
+      // no directory profile to read either.
+      roleIds: [],
+      department: "",
+      teams: [],
     };
   });
 

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -477,9 +477,9 @@ function IdentitiesIndexContent(): JSX.Element {
   }, [identities, deviceCoverage]);
 
   // A dimension with nothing to offer would render an empty control; leave it
-  // out of the schema rather than show a filter that cannot filter. One the URL
-  // still holds a value for stays, whatever its options say: the rows are being
-  // filtered by it, and taking the control away would leave no way to undo that.
+  // out of the schema rather than show a filter that cannot filter. A dimension
+  // whose value is still set in the URL is kept regardless of its options: it is
+  // narrowing the list, and dropping its control would leave no way to clear it.
   const filterSchema = useMemo(
     () =>
       IDENTITY_FILTERS.filter((dimension) => {

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -53,6 +53,12 @@ import {
   IDENTITY_KIND_LABELS,
   type IdentityKind,
 } from "./identityKind";
+import {
+  coverageForIdentity,
+  deviceCoverageQueryKey,
+  fetchDeviceCoverage,
+  NO_DEVICE_BUCKET,
+} from "./identityDeviceCoverage";
 import { fetchIdentityRoster, identityRosterQueryKey } from "./identityRoster";
 
 export function IdentitiesRoot(): JSX.Element {
@@ -100,11 +106,59 @@ const IDENTITY_FILTERS = defineFilters([
     description: "People and agents.",
   },
   {
+    id: "enrollment",
+    label: "Enrollment",
+    kind: "select",
+    allLabel: "All",
+    description: "Whether the platform has seen this identity work at all.",
+  },
+  {
+    id: "activity",
+    label: "Last activity",
+    kind: "select",
+    allLabel: "Any time",
+    description: "How recently the identity was last seen working.",
+  },
+  {
+    id: "device_status",
+    label: "Device agent",
+    kind: "multiselect",
+    description:
+      "Agent coverage on the identity's managed devices, as the MDM inventory reports it. An identity with several machines is described by its best one.",
+  },
+  {
+    id: "role",
+    label: "Roles",
+    kind: "multiselect",
+    description: "Roles assigned in this organization.",
+  },
+  {
+    id: "department",
+    label: "Department",
+    kind: "multiselect",
+    description: "Department as reported by the connected identity provider.",
+  },
+  {
+    id: "team",
+    label: "Team",
+    kind: "multiselect",
+    description:
+      "Directory groups the identity belongs to, from the connected identity provider.",
+  },
+  {
     id: "account_type",
     label: "Account type",
     kind: "select",
     allLabel: "All",
     description: "Usage on personal accounts versus team-managed ones.",
+  },
+  {
+    id: "personal_account",
+    label: "Uses personal account",
+    kind: "select",
+    allLabel: "All",
+    description:
+      "Identities holding at least one personal account, or none at all.",
   },
 ]);
 
@@ -112,6 +166,53 @@ const ACCOUNT_TYPE_OPTIONS = [
   { value: "personal", label: "Personal" },
   { value: "team", label: "Team" },
 ];
+
+const PERSONAL_ACCOUNT_OPTIONS = [
+  { value: "yes", label: "Yes" },
+  { value: "no", label: "No" },
+];
+
+const ENROLLMENT_OPTIONS = [
+  { value: "enrolled", label: "Enrolled" },
+  { value: "not_enrolled", label: "Not enrolled" },
+];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Activity buckets, each the window it names — "Last 30 days" includes the
+ * last week rather than excluding it, because a reader narrowing to a month
+ * means "this month's people", not "the ones who went quiet mid-month".
+ */
+const ACTIVITY_OPTIONS = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "older", label: "Over 30 days ago" },
+  { value: "never", label: "Never" },
+];
+
+function matchesActivity(identity: Employee, bucket: string): boolean {
+  const timestamp = identity.lastActivityTimestamp;
+  if (bucket === "never") return timestamp === null;
+  if (timestamp === null) return false;
+  const age = Date.now() - timestamp;
+  if (bucket === "7d") return age <= 7 * DAY_MS;
+  if (bucket === "30d") return age <= 30 * DAY_MS;
+  if (bucket === "older") return age > 30 * DAY_MS;
+  return true;
+}
+
+/** How each device-coverage bucket reads in the filter. */
+const DEVICE_STATUS_LABELS: Record<string, string> = {
+  agent_active: "Agent active",
+  agent_stale: "Agent stale",
+  agent_other_device: "Agent on another device",
+  no_agent: "No agent",
+  no_email: "No assigned email",
+  unresolved_email: "Email unresolved",
+  missing: "Missing from MDM",
+  [NO_DEVICE_BUCKET]: "No managed device",
+};
 
 const KIND_OPTIONS = (["person", "agent"] as IdentityKind[]).map((kind) => ({
   value: kind,
@@ -122,6 +223,15 @@ const KIND_OPTIONS = (["person", "agent"] as IdentityKind[]).map((kind) => ({
 // person with no account has none yet, and the roster reports an absent role
 // as a bare "-" or "Unknown" depending on which source answered. Three
 // spellings of nothing in one column read as three different states.
+/** The distinct non-empty values in a column, as sorted filter options. */
+function sortedValueOptions(
+  values: string[],
+): { value: string; label: string }[] {
+  return [...new Set(values.filter((value) => value !== ""))]
+    .sort((a, b) => a.localeCompare(b))
+    .map((value) => ({ value, label: value }));
+}
+
 function roleLabel(identity: Employee): string {
   if (identityKindOf(identity) !== "person") return "\u2014";
   const role = identity.role.trim();
@@ -271,6 +381,16 @@ function IdentitiesIndexContent(): JSX.Element {
     queryFn: () => fetchIdentityRoster(client, projectSlug),
     throwOnError: false,
   });
+  // The MDM fleet, read once and folded to a bucket per identity. It is not
+  // part of the roster: an org with no device integration connected simply
+  // has no fleet, and the device filter drops out rather than offering a
+  // dimension where every identity answers the same.
+  const deviceCoverageQuery = useQuery({
+    queryKey: deviceCoverageQueryKey(organization.id),
+    queryFn: () => fetchDeviceCoverage(client),
+    throwOnError: false,
+  });
+  const deviceCoverage = deviceCoverageQuery.data;
 
   // The list is the join of all three reads, so until they land there is no
   // roster to report on — and "0 identities" or "No identities match these
@@ -313,17 +433,115 @@ function IdentitiesIndexContent(): JSX.Element {
     return tally;
   }, [identities]);
 
+  // Option lists the data decides: a role the org never assigned, a department
+  // nobody is in, or a device bucket no machine falls into is a filter that can
+  // only empty the table, so each dimension offers what the roster actually
+  // holds and drops out entirely when it holds nothing.
+  const roleOptions = useMemo(() => {
+    const assigned = new Set(
+      identities.flatMap((identity) => identity.roleIds),
+    );
+    return (rolesQuery.data?.roles ?? [])
+      .filter((role) => assigned.has(role.id))
+      .map((role) => ({ value: role.id, label: role.name }));
+  }, [identities, rolesQuery.data]);
+
+  const departmentOptions = useMemo(
+    () => sortedValueOptions(identities.map((identity) => identity.department)),
+    [identities],
+  );
+  const teamOptions = useMemo(
+    () => sortedValueOptions(identities.flatMap((identity) => identity.teams)),
+    [identities],
+  );
+  const deviceStatusOptions = useMemo(() => {
+    if (!deviceCoverage || deviceCoverage.deviceCount === 0) return [];
+    const present = new Set(
+      identities.map((identity) =>
+        coverageForIdentity(deviceCoverage, identity),
+      ),
+    );
+    return [...present]
+      .map((bucket) => ({
+        value: bucket,
+        label: DEVICE_STATUS_LABELS[bucket] ?? bucket,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [identities, deviceCoverage]);
+
+  // A dimension with nothing to offer would render an empty control; leave it
+  // out of the schema rather than show a filter that cannot filter.
+  const filterSchema = useMemo(
+    () =>
+      IDENTITY_FILTERS.filter((dimension) => {
+        if (dimension.id === "role") return roleOptions.length > 0;
+        if (dimension.id === "department") return departmentOptions.length > 0;
+        if (dimension.id === "team") return teamOptions.length > 0;
+        if (dimension.id === "device_status") {
+          return deviceStatusOptions.length > 0;
+        }
+        return true;
+      }),
+    [
+      roleOptions.length,
+      departmentOptions.length,
+      teamOptions.length,
+      deviceStatusOptions.length,
+    ],
+  );
+
   // Joined rather than held as an array: the filter state hands back a fresh
   // array each render, which would defeat the memo below.
   const kindKey = (values.kind ?? []).join(",");
   const accountType = (values.account_type as string | undefined) ?? "";
+  const personalAccount = (values.personal_account as string | undefined) ?? "";
+  const enrollment = (values.enrollment as string | undefined) ?? "";
+  const activity = (values.activity as string | undefined) ?? "";
+  const deviceStatusKey = (values.device_status ?? []).join(",");
+  const roleKey = (values.role ?? []).join(",");
+  const departmentKey = (values.department ?? []).join(",");
+  const teamKey = (values.team ?? []).join(",");
   const rows = useMemo(() => {
     const selectedKinds = kindKey ? kindKey.split(",") : [];
+    const selectedDeviceStatuses = deviceStatusKey
+      ? deviceStatusKey.split(",")
+      : [];
+    const selectedRoles = roleKey ? roleKey.split(",") : [];
+    const selectedDepartments = departmentKey ? departmentKey.split(",") : [];
+    const selectedTeams = teamKey ? teamKey.split(",") : [];
     const query = search.trim().toLowerCase();
     return identities.filter((identity) => {
       if (
         selectedKinds.length > 0 &&
         !selectedKinds.includes(identityKindOf(identity))
+      ) {
+        return false;
+      }
+      if (enrollment && identity.status !== enrollment) return false;
+      if (activity && !matchesActivity(identity, activity)) return false;
+      if (
+        selectedDeviceStatuses.length > 0 &&
+        !selectedDeviceStatuses.includes(
+          coverageForIdentity(deviceCoverage, identity),
+        )
+      ) {
+        return false;
+      }
+      if (
+        selectedRoles.length > 0 &&
+        !identity.roleIds.some((id) => selectedRoles.includes(id))
+      ) {
+        return false;
+      }
+      if (
+        selectedDepartments.length > 0 &&
+        !selectedDepartments.includes(identity.department)
+      ) {
+        return false;
+      }
+      if (
+        selectedTeams.length > 0 &&
+        !identity.teams.some((team) => selectedTeams.includes(team))
       ) {
         return false;
       }
@@ -336,13 +554,32 @@ function IdentitiesIndexContent(): JSX.Element {
       ) {
         return false;
       }
+      if (
+        personalAccount &&
+        identity.hasPersonalAccount !== (personalAccount === "yes")
+      ) {
+        return false;
+      }
       if (!query) return true;
       return (
         identity.name.toLowerCase().includes(query) ||
         identity.email.toLowerCase().includes(query)
       );
     });
-  }, [identities, search, kindKey, accountType]);
+  }, [
+    identities,
+    search,
+    kindKey,
+    accountType,
+    personalAccount,
+    enrollment,
+    activity,
+    deviceStatusKey,
+    deviceCoverage,
+    roleKey,
+    departmentKey,
+    teamKey,
+  ]);
 
   const sortedRows = useMemo(
     () => sortTableData(rows, IDENTITY_COLUMNS, sort) as Employee[],
@@ -353,7 +590,19 @@ function IdentitiesIndexContent(): JSX.Element {
   // something they have not seen page one of.
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [search, kindKey, accountType, sort]);
+  }, [
+    search,
+    kindKey,
+    accountType,
+    personalAccount,
+    enrollment,
+    activity,
+    deviceStatusKey,
+    roleKey,
+    departmentKey,
+    teamKey,
+    sort,
+  ]);
 
   return (
     <Page.Section>
@@ -423,11 +672,18 @@ function IdentitiesIndexContent(): JSX.Element {
             debounceMs={200}
           />
           <Page.Toolbar.Filters
-            schema={IDENTITY_FILTERS}
+            schema={filterSchema}
             values={values}
             optionsById={{
               kind: KIND_OPTIONS,
+              enrollment: ENROLLMENT_OPTIONS,
+              activity: ACTIVITY_OPTIONS,
+              device_status: deviceStatusOptions,
+              role: roleOptions,
+              department: departmentOptions,
+              team: teamOptions,
               account_type: ACCOUNT_TYPE_OPTIONS,
+              personal_account: PERSONAL_ACCOUNT_OPTIONS,
             }}
             onChange={setValue as (id: string, value: unknown) => void}
             onClear={clearValue as (id: string) => void}

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -458,7 +458,11 @@ function IdentitiesIndexContent(): JSX.Element {
     [identities],
   );
   const deviceStatusOptions = useMemo(() => {
-    if (!deviceCoverage || deviceCoverage.deviceCount === 0) return [];
+    // A capped walk leaves every identity past the cap looking like it owns no
+    // machine, which the filter would report as fact. Offer nothing rather than
+    // a dimension that misfiles the fleet's tail.
+    if (!deviceCoverage || deviceCoverage.truncated) return [];
+    if (deviceCoverage.deviceCount === 0) return [];
     const present = new Set(
       identities.map((identity) =>
         coverageForIdentity(deviceCoverage, identity),
@@ -473,10 +477,15 @@ function IdentitiesIndexContent(): JSX.Element {
   }, [identities, deviceCoverage]);
 
   // A dimension with nothing to offer would render an empty control; leave it
-  // out of the schema rather than show a filter that cannot filter.
+  // out of the schema rather than show a filter that cannot filter. One the URL
+  // still holds a value for stays, whatever its options say: the rows are being
+  // filtered by it, and taking the control away would leave no way to undo that.
   const filterSchema = useMemo(
     () =>
       IDENTITY_FILTERS.filter((dimension) => {
+        const selected = (values[dimension.id as keyof typeof values] ??
+          []) as string[];
+        if (selected.length > 0) return true;
         if (dimension.id === "role") return roleOptions.length > 0;
         if (dimension.id === "department") return departmentOptions.length > 0;
         if (dimension.id === "team") return teamOptions.length > 0;
@@ -486,6 +495,7 @@ function IdentitiesIndexContent(): JSX.Element {
         return true;
       }),
     [
+      values,
       roleOptions.length,
       departmentOptions.length,
       teamOptions.length,
@@ -500,18 +510,19 @@ function IdentitiesIndexContent(): JSX.Element {
   const personalAccount = (values.personal_account as string | undefined) ?? "";
   const enrollment = (values.enrollment as string | undefined) ?? "";
   const activity = (values.activity as string | undefined) ?? "";
-  const deviceStatusKey = (values.device_status ?? []).join(",");
-  const roleKey = (values.role ?? []).join(",");
-  const departmentKey = (values.department ?? []).join(",");
-  const teamKey = (values.team ?? []).join(",");
+  // Department and team hold whatever the directory calls them, so these keys
+  // are JSON rather than a comma join: a department named "Sales, EMEA" would
+  // split back into two values that match nobody.
+  const deviceStatusKey = JSON.stringify(values.device_status ?? []);
+  const roleKey = JSON.stringify(values.role ?? []);
+  const departmentKey = JSON.stringify(values.department ?? []);
+  const teamKey = JSON.stringify(values.team ?? []);
   const rows = useMemo(() => {
     const selectedKinds = kindKey ? kindKey.split(",") : [];
-    const selectedDeviceStatuses = deviceStatusKey
-      ? deviceStatusKey.split(",")
-      : [];
-    const selectedRoles = roleKey ? roleKey.split(",") : [];
-    const selectedDepartments = departmentKey ? departmentKey.split(",") : [];
-    const selectedTeams = teamKey ? teamKey.split(",") : [];
+    const selectedDeviceStatuses = JSON.parse(deviceStatusKey) as string[];
+    const selectedRoles = JSON.parse(roleKey) as string[];
+    const selectedDepartments = JSON.parse(departmentKey) as string[];
+    const selectedTeams = JSON.parse(teamKey) as string[];
     const query = search.trim().toLowerCase();
     return identities.filter((identity) => {
       if (

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -167,9 +167,12 @@ const ACCOUNT_TYPE_OPTIONS = [
   { value: "team", label: "Team" },
 ];
 
+// A chip carries the chosen option's label and nothing else, so each one has
+// to name the filter it came from: a chip reading "Yes" says nothing about
+// what was answered.
 const PERSONAL_ACCOUNT_OPTIONS = [
-  { value: "yes", label: "Yes" },
-  { value: "no", label: "No" },
+  { value: "yes", label: "Personal account" },
+  { value: "no", label: "No personal account" },
 ];
 
 const ENROLLMENT_OPTIONS = [
@@ -188,7 +191,7 @@ const ACTIVITY_OPTIONS = [
   { value: "7d", label: "Last 7 days" },
   { value: "30d", label: "Last 30 days" },
   { value: "older", label: "Over 30 days ago" },
-  { value: "never", label: "Never" },
+  { value: "never", label: "Never active" },
 ];
 
 function matchesActivity(identity: Employee, bucket: string): boolean {

--- a/client/dashboard/src/pages/identities/identityDeviceCoverage.ts
+++ b/client/dashboard/src/pages/identities/identityDeviceCoverage.ts
@@ -1,0 +1,114 @@
+import { deviceIntegrationsListManagedDevices } from "@gram/client/funcs/deviceIntegrationsListManagedDevices";
+import { unwrapAsync } from "@gram/client/types/fp";
+
+/**
+ * The MDM fleet, folded to one coverage bucket per identity.
+ *
+ * The devices endpoint answers per user id or email, which is a question the
+ * detail page asks for one person. The roster asks it of everyone at once, so
+ * this reads the fleet whole and indexes it by both keys — a device carries a
+ * resolved Gram user id only when its MDM-reported email matched a member, so
+ * neither key alone reaches every row.
+ */
+
+/** Page size the endpoint allows, and the number of pages we will walk. */
+const DEVICE_PAGE_SIZE = 200;
+const MAX_DEVICE_PAGES = 10;
+
+/**
+ * Buckets from best to worst. An identity with several machines is described
+ * by their best one: someone whose laptop reports in is covered, whatever a
+ * retired second machine says.
+ */
+const BUCKET_RANK = [
+  "agent_active",
+  "agent_other_device",
+  "agent_stale",
+  "no_agent",
+  "unresolved_email",
+  "no_email",
+  "missing",
+] as const;
+
+/** The bucket for an identity MDM holds no device for at all. */
+export const NO_DEVICE_BUCKET = "no_device";
+
+export type DeviceCoverageIndex = {
+  /** Best bucket per Gram user id. */
+  byUserId: Map<string, string>;
+  /** Best bucket per MDM-reported assigned email, lowercased. */
+  byEmail: Map<string, string>;
+  /** Devices read. Zero means no MDM inventory to filter against. */
+  deviceCount: number;
+  /** True when the fleet is larger than the pages we walked. */
+  truncated: boolean;
+};
+
+export function deviceCoverageQueryKey(organizationId: string): string[] {
+  return ["identities", "device-coverage", organizationId];
+}
+
+function betterBucket(current: string | undefined, next: string): string {
+  if (current === undefined) return next;
+  const currentRank = BUCKET_RANK.indexOf(current as (typeof BUCKET_RANK)[0]);
+  const nextRank = BUCKET_RANK.indexOf(next as (typeof BUCKET_RANK)[0]);
+  // An unranked bucket (one the API grew after this list) loses to a known
+  // one rather than shadowing it.
+  if (nextRank === -1) return current;
+  if (currentRank === -1) return next;
+  return nextRank < currentRank ? next : current;
+}
+
+export async function fetchDeviceCoverage(
+  client: Parameters<typeof deviceIntegrationsListManagedDevices>[0],
+): Promise<DeviceCoverageIndex> {
+  const byUserId = new Map<string, string>();
+  const byEmail = new Map<string, string>();
+  let deviceCount = 0;
+  let cursor: string | undefined;
+  let pages = 0;
+
+  do {
+    const { result } = await unwrapAsync(
+      deviceIntegrationsListManagedDevices(client, {
+        cursor,
+        limit: DEVICE_PAGE_SIZE,
+      }),
+    );
+    for (const device of result.devices) {
+      deviceCount += 1;
+      const bucket = device.coverageBucket;
+      if (device.userId) {
+        byUserId.set(
+          device.userId,
+          betterBucket(byUserId.get(device.userId), bucket),
+        );
+      }
+      const email = (device.userEmail ?? "").toLowerCase();
+      if (email) {
+        byEmail.set(email, betterBucket(byEmail.get(email), bucket));
+      }
+    }
+    cursor = result.nextCursor;
+    pages += 1;
+  } while (cursor && pages < MAX_DEVICE_PAGES);
+
+  return { byUserId, byEmail, deviceCount, truncated: !!cursor };
+}
+
+/**
+ * The bucket describing one identity, or {@link NO_DEVICE_BUCKET} when the
+ * inventory holds no machine for either of their keys.
+ */
+export function coverageForIdentity(
+  index: DeviceCoverageIndex | undefined,
+  identity: { id: string; email: string },
+): string {
+  if (!index) return NO_DEVICE_BUCKET;
+  // Unattributed usage rows carry a synthetic "usage:"-prefixed id that no
+  // device can match; their email is the only key worth trying.
+  const byId = index.byUserId.get(identity.id);
+  const byEmail = index.byEmail.get(identity.email.toLowerCase());
+  if (byId && byEmail) return betterBucket(byId, byEmail);
+  return byId ?? byEmail ?? NO_DEVICE_BUCKET;
+}

--- a/client/dashboard/src/sdk/src/models/components/accessmember.ts
+++ b/client/dashboard/src/sdk/src/models/components/accessmember.ts
@@ -10,9 +10,17 @@ import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 export type AccessMember = {
   /**
+   * Department name as reported by the identity provider.
+   */
+  department?: string | undefined;
+  /**
    * Email address.
    */
   email: string;
+  /**
+   * Names of the directory groups the member belongs to.
+   */
+  groups?: Array<string> | undefined;
   /**
    * User ID.
    */
@@ -43,7 +51,9 @@ export type AccessMember = {
 export const AccessMember$inboundSchema: z.ZodMiniType<AccessMember, unknown> =
   z.pipe(
     z.object({
+      department: z.optional(z.string()),
       email: z.string(),
+      groups: z.optional(z.array(z.string())),
       id: z.string(),
       joined_at: z.pipe(
         z.iso.datetime({ offset: true }),

--- a/server/design/access/design.go
+++ b/server/design/access/design.go
@@ -784,6 +784,11 @@ var MemberModel = Type("AccessMember", func() {
 		Description("When the member joined the organization.")
 		Format(FormatDateTime)
 	})
+	// Directory profile, from the org's synced identity provider. Every field
+	// is absent when no directory is connected, when the member has no profile
+	// in it, or when the provider does not report that attribute.
+	Attribute("department", String, "Department name as reported by the identity provider.")
+	Attribute("groups", ArrayOf(String), "Names of the directory groups the member belongs to.")
 })
 
 var ListMembersResult = Type("ListMembersResult", func() {

--- a/server/gen/access/service.go
+++ b/server/gen/access/service.go
@@ -141,6 +141,10 @@ type AccessMember struct {
 	RoleIds []string
 	// When the member joined the organization.
 	JoinedAt string
+	// Department name as reported by the identity provider.
+	Department *string
+	// Names of the directory groups the member belongs to.
+	Groups []string
 }
 
 type AuthzChallenge struct {

--- a/server/gen/http/access/client/encode_decode.go
+++ b/server/gen/http/access/client/encode_decode.go
@@ -4944,10 +4944,17 @@ func unmarshalAccessMemberResponseBodyToAccessAccessMember(v *AccessMemberRespon
 		Email:        *v.Email,
 		PhotoURL:     v.PhotoURL,
 		JoinedAt:     *v.JoinedAt,
+		Department:   v.Department,
 	}
 	res.RoleIds = make([]string, len(v.RoleIds))
 	for i, val := range v.RoleIds {
 		res.RoleIds[i] = val
+	}
+	if v.Groups != nil {
+		res.Groups = make([]string, len(v.Groups))
+		for i, val := range v.Groups {
+			res.Groups[i] = val
+		}
 	}
 
 	return res

--- a/server/gen/http/access/client/types.go
+++ b/server/gen/http/access/client/types.go
@@ -216,6 +216,10 @@ type UpdateMemberRolesResponseBody struct {
 	RoleIds []string `form:"role_ids,omitempty" json:"role_ids,omitempty" xml:"role_ids,omitempty"`
 	// When the member joined the organization.
 	JoinedAt *string `form:"joined_at,omitempty" json:"joined_at,omitempty" xml:"joined_at,omitempty"`
+	// Department name as reported by the identity provider.
+	Department *string `form:"department,omitempty" json:"department,omitempty" xml:"department,omitempty"`
+	// Names of the directory groups the member belongs to.
+	Groups []string `form:"groups,omitempty" json:"groups,omitempty" xml:"groups,omitempty"`
 }
 
 // ListShadowMCPInventoryResponseBody is the type of the "access" service
@@ -4125,6 +4129,10 @@ type AccessMemberResponseBody struct {
 	RoleIds []string `form:"role_ids,omitempty" json:"role_ids,omitempty" xml:"role_ids,omitempty"`
 	// When the member joined the organization.
 	JoinedAt *string `form:"joined_at,omitempty" json:"joined_at,omitempty" xml:"joined_at,omitempty"`
+	// Department name as reported by the identity provider.
+	Department *string `form:"department,omitempty" json:"department,omitempty" xml:"department,omitempty"`
+	// Names of the directory groups the member belongs to.
+	Groups []string `form:"groups,omitempty" json:"groups,omitempty" xml:"groups,omitempty"`
 }
 
 // ListRoleGrantResponseBody is used to define fields on response body types.
@@ -5892,10 +5900,17 @@ func NewUpdateMemberRolesAccessMemberOK(body *UpdateMemberRolesResponseBody) *ac
 		Email:        *body.Email,
 		PhotoURL:     body.PhotoURL,
 		JoinedAt:     *body.JoinedAt,
+		Department:   body.Department,
 	}
 	v.RoleIds = make([]string, len(body.RoleIds))
 	for i, val := range body.RoleIds {
 		v.RoleIds[i] = val
+	}
+	if body.Groups != nil {
+		v.Groups = make([]string, len(body.Groups))
+		for i, val := range body.Groups {
+			v.Groups[i] = val
+		}
 	}
 
 	return v

--- a/server/gen/http/access/server/encode_decode.go
+++ b/server/gen/http/access/server/encode_decode.go
@@ -4658,6 +4658,7 @@ func marshalAccessAccessMemberToAccessMemberResponseBody(v *access.AccessMember)
 		Email:        v.Email,
 		PhotoURL:     v.PhotoURL,
 		JoinedAt:     v.JoinedAt,
+		Department:   v.Department,
 	}
 	if v.RoleIds != nil {
 		res.RoleIds = make([]string, len(v.RoleIds))
@@ -4666,6 +4667,12 @@ func marshalAccessAccessMemberToAccessMemberResponseBody(v *access.AccessMember)
 		}
 	} else {
 		res.RoleIds = []string{}
+	}
+	if v.Groups != nil {
+		res.Groups = make([]string, len(v.Groups))
+		for i, val := range v.Groups {
+			res.Groups[i] = val
+		}
 	}
 
 	return res

--- a/server/gen/http/access/server/types.go
+++ b/server/gen/http/access/server/types.go
@@ -218,6 +218,10 @@ type UpdateMemberRolesResponseBody struct {
 	RoleIds []string `form:"role_ids" json:"role_ids" xml:"role_ids"`
 	// When the member joined the organization.
 	JoinedAt string `form:"joined_at" json:"joined_at" xml:"joined_at"`
+	// Department name as reported by the identity provider.
+	Department *string `form:"department,omitempty" json:"department,omitempty" xml:"department,omitempty"`
+	// Names of the directory groups the member belongs to.
+	Groups []string `form:"groups,omitempty" json:"groups,omitempty" xml:"groups,omitempty"`
 }
 
 // ListShadowMCPInventoryResponseBody is the type of the "access" service
@@ -4101,6 +4105,10 @@ type AccessMemberResponseBody struct {
 	RoleIds []string `form:"role_ids" json:"role_ids" xml:"role_ids"`
 	// When the member joined the organization.
 	JoinedAt string `form:"joined_at" json:"joined_at" xml:"joined_at"`
+	// Department name as reported by the identity provider.
+	Department *string `form:"department,omitempty" json:"department,omitempty" xml:"department,omitempty"`
+	// Names of the directory groups the member belongs to.
+	Groups []string `form:"groups,omitempty" json:"groups,omitempty" xml:"groups,omitempty"`
 }
 
 // ListRoleGrantResponseBody is used to define fields on response body types.
@@ -4574,6 +4582,7 @@ func NewUpdateMemberRolesResponseBody(res *access.AccessMember) *UpdateMemberRol
 		Email:        res.Email,
 		PhotoURL:     res.PhotoURL,
 		JoinedAt:     res.JoinedAt,
+		Department:   res.Department,
 	}
 	if res.RoleIds != nil {
 		body.RoleIds = make([]string, len(res.RoleIds))
@@ -4582,6 +4591,12 @@ func NewUpdateMemberRolesResponseBody(res *access.AccessMember) *UpdateMemberRol
 		}
 	} else {
 		body.RoleIds = []string{}
+	}
+	if res.Groups != nil {
+		body.Groups = make([]string, len(res.Groups))
+		for i, val := range res.Groups {
+			body.Groups[i] = val
+		}
 	}
 	return body
 }

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -64272,9 +64272,17 @@ components:
         AccessMember:
             type: object
             properties:
+                department:
+                    type: string
+                    description: Department name as reported by the identity provider.
                 email:
                     type: string
                     description: Email address.
+                groups:
+                    type: array
+                    items:
+                        type: string
+                    description: Names of the directory groups the member belongs to.
                 id:
                     type: string
                     description: User ID.

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -520,14 +520,17 @@ JOIN users
   ON users.id = our.user_id
 LEFT JOIN LATERAL (
   -- The member's directory profile, preferring an explicit user link over an
-  -- email match so a stale email row cannot shadow the linked profile.
+  -- email match so a stale email row cannot shadow the linked profile. An
+  -- email-matched row has a NULL user_id, and NULLs sort first under DESC, so
+  -- the link test needs NULLS LAST to actually win; among equals the profile
+  -- the directory updated most recently is the current one.
   SELECT d.id, d.attributes
   FROM directory_users d
   WHERE d.organization_id = our.organization_id
     AND d.deleted IS FALSE
     AND d.workos_deleted IS FALSE
     AND (d.user_id = users.id OR LOWER(d.email) = LOWER(users.email))
-  ORDER BY (d.user_id = users.id) DESC, d.created_at
+  ORDER BY (d.user_id = users.id) DESC NULLS LAST, d.workos_updated_at DESC, d.id
   LIMIT 1
 ) du ON TRUE
 LEFT JOIN LATERAL (

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -509,10 +509,38 @@ SELECT
   users.email,
   users.photo_url,
   COALESCE(organization_roles.id::text, global_roles.id::text, '')::text AS role_id,
-  COALESCE(ora.created_at, our.created_at)::timestamptz AS joined_at
+  COALESCE(ora.created_at, our.created_at)::timestamptz AS joined_at,
+  -- The member's identity-provider profile, when the directory has synced one.
+  -- A member with no directory row, or one whose provider does not report the
+  -- attribute, comes back as an empty string.
+  COALESCE(du.attributes ->> 'department_name', '')::text AS department,
+  COALESCE(dg_names.group_names, '{}'::text[])::text[] AS group_names
 FROM organization_user_relationships AS our
 JOIN users
   ON users.id = our.user_id
+LEFT JOIN LATERAL (
+  -- The member's directory profile, preferring an explicit user link over an
+  -- email match so a stale email row cannot shadow the linked profile.
+  SELECT d.id, d.attributes
+  FROM directory_users d
+  WHERE d.organization_id = our.organization_id
+    AND d.deleted IS FALSE
+    AND d.workos_deleted IS FALSE
+    AND (d.user_id = users.id OR LOWER(d.email) = LOWER(users.email))
+  ORDER BY (d.user_id = users.id) DESC, d.created_at
+  LIMIT 1
+) du ON TRUE
+LEFT JOIN LATERAL (
+  SELECT ARRAY_AGG(DISTINCT dg.name) AS group_names
+  FROM directory_user_group_memberships m
+  INNER JOIN directory_groups dg
+    ON dg.id = m.directory_group_id
+    AND dg.organization_id = our.organization_id
+    AND dg.deleted IS FALSE
+    AND dg.workos_deleted IS FALSE
+  WHERE m.directory_user_id = du.id
+    AND m.deleted IS FALSE
+) dg_names ON TRUE
 LEFT JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
   AND ora.workos_user_id = users.workos_id

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -680,10 +680,38 @@ SELECT
   users.email,
   users.photo_url,
   COALESCE(organization_roles.id::text, global_roles.id::text, '')::text AS role_id,
-  COALESCE(ora.created_at, our.created_at)::timestamptz AS joined_at
+  COALESCE(ora.created_at, our.created_at)::timestamptz AS joined_at,
+  -- The member's identity-provider profile, when the directory has synced one.
+  -- A member with no directory row, or one whose provider does not report the
+  -- attribute, comes back as an empty string.
+  COALESCE(du.attributes ->> 'department_name', '')::text AS department,
+  COALESCE(dg_names.group_names, '{}'::text[])::text[] AS group_names
 FROM organization_user_relationships AS our
 JOIN users
   ON users.id = our.user_id
+LEFT JOIN LATERAL (
+  -- The member's directory profile, preferring an explicit user link over an
+  -- email match so a stale email row cannot shadow the linked profile.
+  SELECT d.id, d.attributes
+  FROM directory_users d
+  WHERE d.organization_id = our.organization_id
+    AND d.deleted IS FALSE
+    AND d.workos_deleted IS FALSE
+    AND (d.user_id = users.id OR LOWER(d.email) = LOWER(users.email))
+  ORDER BY (d.user_id = users.id) DESC, d.created_at
+  LIMIT 1
+) du ON TRUE
+LEFT JOIN LATERAL (
+  SELECT ARRAY_AGG(DISTINCT dg.name) AS group_names
+  FROM directory_user_group_memberships m
+  INNER JOIN directory_groups dg
+    ON dg.id = m.directory_group_id
+    AND dg.organization_id = our.organization_id
+    AND dg.deleted IS FALSE
+    AND dg.workos_deleted IS FALSE
+  WHERE m.directory_user_id = du.id
+    AND m.deleted IS FALSE
+) dg_names ON TRUE
 LEFT JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
   AND ora.workos_user_id = users.workos_id
@@ -710,6 +738,8 @@ type ListAccessMembersRow struct {
 	PhotoUrl    pgtype.Text
 	RoleID      string
 	JoinedAt    pgtype.Timestamptz
+	Department  string
+	GroupNames  []string
 }
 
 func (q *Queries) ListAccessMembers(ctx context.Context, organizationID string) ([]ListAccessMembersRow, error) {
@@ -728,6 +758,8 @@ func (q *Queries) ListAccessMembers(ctx context.Context, organizationID string) 
 			&i.PhotoUrl,
 			&i.RoleID,
 			&i.JoinedAt,
+			&i.Department,
+			&i.GroupNames,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -691,14 +691,17 @@ JOIN users
   ON users.id = our.user_id
 LEFT JOIN LATERAL (
   -- The member's directory profile, preferring an explicit user link over an
-  -- email match so a stale email row cannot shadow the linked profile.
+  -- email match so a stale email row cannot shadow the linked profile. An
+  -- email-matched row has a NULL user_id, and NULLs sort first under DESC, so
+  -- the link test needs NULLS LAST to actually win; among equals the profile
+  -- the directory updated most recently is the current one.
   SELECT d.id, d.attributes
   FROM directory_users d
   WHERE d.organization_id = our.organization_id
     AND d.deleted IS FALSE
     AND d.workos_deleted IS FALSE
     AND (d.user_id = users.id OR LOWER(d.email) = LOWER(users.email))
-  ORDER BY (d.user_id = users.id) DESC, d.created_at
+  ORDER BY (d.user_id = users.id) DESC NULLS LAST, d.workos_updated_at DESC, d.id
   LIMIT 1
 ) du ON TRUE
 LEFT JOIN LATERAL (

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -121,6 +121,11 @@ func (r *RoleManager) ListMembers(ctx context.Context, gramOrgID string) (*gen.L
 				PhotoURL:     conv.FromPGText[string](row.PhotoUrl),
 				RoleIds:      nil,
 				JoinedAt:     conv.FromPGTimestamptz(row.JoinedAt),
+				// An attribute the directory does not report reads as an empty
+				// string from the query; leave it unset rather than send "" so
+				// clients can tell "not reported" from a real blank value.
+				Department: conv.PtrEmpty(row.Department),
+				Groups:     row.GroupNames,
 			}
 			memberMap[row.ID] = m
 			order = append(order, row.ID)
@@ -714,6 +719,9 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 		MembershipID: membershipID,
 		WorkosUserID: connectedUser.WorkosID.String,
 		UserID:       connectedUser.ID,
+		// These two are the audit record of a role change, so they carry the
+		// roles and nothing the directory owns: a profile this update cannot
+		// alter would read as part of the diff.
 		Before: &gen.AccessMember{
 			ID:           connectedUser.ID,
 			PrincipalUrn: memberPrincipalURN,
@@ -722,6 +730,8 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 			PhotoURL:     conv.FromPGText[string](connectedUser.PhotoUrl),
 			RoleIds:      existingRoleIDs,
 			JoinedAt:     conv.FromPGTimestamptz(existing.CreatedAt),
+			Department:   nil,
+			Groups:       nil,
 		},
 		After: &gen.AccessMember{
 			ID:           connectedUser.ID,
@@ -731,6 +741,8 @@ func (r *RoleManager) UpdateMemberRoles(ctx context.Context, gramOrgID, userID s
 			PhotoURL:     conv.FromPGText[string](connectedUser.PhotoUrl),
 			RoleIds:      afterRoleIDs,
 			JoinedAt:     conv.FromPGTimestamptz(existing.CreatedAt),
+			Department:   nil,
+			Groups:       nil,
 		},
 	}
 

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -121,9 +121,9 @@ func (r *RoleManager) ListMembers(ctx context.Context, gramOrgID string) (*gen.L
 				PhotoURL:     conv.FromPGText[string](row.PhotoUrl),
 				RoleIds:      nil,
 				JoinedAt:     conv.FromPGTimestamptz(row.JoinedAt),
-				// An attribute the directory does not report reads as an empty
-				// string from the query; leave it unset rather than send "" so
-				// clients can tell "not reported" from a real blank value.
+				// Null when no directory row was matched, or when the row
+				// reports no non-empty department — the query collapses both
+				// to an empty string, so the two cannot be told apart here.
 				Department: conv.PtrEmpty(row.Department),
 				Groups:     row.GroupNames,
 			}


### PR DESCRIPTION
## Summary

Seven new filters on the Identities index, alongside the kind and account-type ones already there:

- **Enrollment** and **Last activity** (last 7 days, last 30 days, over 30 days ago, never) read from the roster row the page already builds.
- **Roles** filters on the member's assigned role ids, offering only the roles someone in the organization actually holds.
- **Department** and **Team** come from the identity provider. `access.listMembers` now carries them: `department` from the directory user's `department_name` attribute, `groups` from their directory group memberships, joined with the same prefer-user-link-over-email lateral that `spendrules`' actor listing uses.
- **Device agent** classifies each identity by the agent coverage on their managed devices. There is no bulk per-identity coverage read, so the page walks the MDM inventory once (200 rows a page, ten pages), indexes it by both resolved user id and MDM-reported email — a device carries an id only when its email matched a member — and folds each identity to its best bucket, plus a synthetic "no managed device" for anyone the fleet holds no machine for.
- **Uses personal account** answers the yes/no question the account-type filter cannot: it selects the people holding no personal account as well as the people holding one.

A dimension whose option list comes back empty is dropped from the schema rather than rendered, so an organization with no device integration connected sees no device filter, and one with no directory synced sees neither department nor team.

## Motivation

The index is the roster — every person and agent the platform knows about, unwindowed — and it could only be narrowed by kind and account type. Every other question an administrator brings to it ("who has never worked here", "whose machines are running no agent", "who is in Support Engineering") meant reading the whole list, which defeats the point of having one page that holds everyone.

Department and team needed a server change because `AccessMember` carried no directory data at all. Extending the existing members read was cheaper than a second request per row and keeps the roster a join of the three reads it already makes; the coverage index is a fourth read only because the devices endpoint answers per user, which is the detail page's question, not the roster's.

https://claude.ai/code/session_018wqrpWtJ6yVyUKNEJRbXjU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seven filters to the Identities index — enrollment, last activity, roles, department, team, device agent coverage, and personal-account usage — so administrators can narrow the roster without reading the whole list.

**Server changes**
- `access.listMembers` now returns `department` and `groups` from the synced identity provider, preferring a linked profile over an email match.
- Both fields are absent when no directory is connected or the provider does not report the attribute.
- The new fields are read-only and excluded from role-change audit records.

**Client changes**
- The page walks the MDM inventory once (200 devices per page, up to 10 pages), indexes it by resolved user id and MDM-reported email, and drops the device filter when the walk is capped.
- Each identity is folded to its best coverage bucket; identities with no managed device get a "No managed device" bucket.
- A filter is hidden when its option list is empty, unless the URL still holds a value for it — so an org with no device integration sees no device filter, and one with no directory sees no department or team filter.
- Filter chips carry self-describing labels: the personal-account options read "Personal account" / "No personal account", and the never-active bucket names itself.

<sup>Written for commit b14c5bd16e704d8fc76e89aafdedf82ba9538a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

