### PR TITLE
feat: configure Codex telemetry and Claude traces

### DIFF
--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -555,14 +555,15 @@ function CodexInstallContent({
         <h3 className="mb-2 text-sm font-semibold">Quick install</h3>
         <p className="text-muted-foreground mb-3 text-sm">
           Download a one-command install script that registers the marketplace,
-          enables hooks, configures Codex OpenTelemetry logs, traces, and
-          metrics in{" "}
+          enables hooks, and configures compatible Codex OpenTelemetry logs,
+          traces, and metrics in{" "}
           <code className="bg-muted px-1 py-0.5 text-xs">
             ~/.codex/config.toml
           </code>
-          , and pre-approves all hook events — no manual Settings → Hooks step
-          required. Suitable for MDM deployment. This script sets up Speakeasy's
-          observability plugin specifically.
+          . Existing exporters are preserved and may require manual Gram setup.
+          The script also pre-approves all hook events, so no manual Settings →
+          Hooks step is required. Suitable for MDM deployment. This script sets
+          up Speakeasy's observability plugin specifically.
         </p>
         <Button
           variant="secondary"

--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -555,7 +555,8 @@ function CodexInstallContent({
         <h3 className="mb-2 text-sm font-semibold">Quick install</h3>
         <p className="text-muted-foreground mb-3 text-sm">
           Download a one-command install script that registers the marketplace,
-          enables hooks, configures Codex OpenTelemetry logs in{" "}
+          enables hooks, configures Codex OpenTelemetry logs, traces, and
+          metrics in{" "}
           <code className="bg-muted px-1 py-0.5 text-xs">
             ~/.codex/config.toml
           </code>

--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -555,7 +555,7 @@ function CodexInstallContent({
         <h3 className="mb-2 text-sm font-semibold">Quick install</h3>
         <p className="text-muted-foreground mb-3 text-sm">
           Download a one-command install script that registers the marketplace,
-          enables hooks in{" "}
+          enables hooks, configures Codex OpenTelemetry logs in{" "}
           <code className="bg-muted px-1 py-0.5 text-xs">
             ~/.codex/config.toml
           </code>

--- a/client/dashboard/src/pages/setup/components/platform-instrumentation-sheet.tsx
+++ b/client/dashboard/src/pages/setup/components/platform-instrumentation-sheet.tsx
@@ -11,7 +11,7 @@ import {
 import { useCreateAPIKeyMutation } from "@gram/client/react-query/createAPIKey";
 import { useMarketplaceSettings } from "@gram/client/react-query/marketplaceSettings";
 import { usePublishStatus } from "@gram/client/react-query/publishStatus";
-import { useSlugs } from "@/contexts/Sdk";
+import { useProjectSlugForRequests, useSlugs } from "@/contexts/Sdk";
 import { useOrgRoutes } from "@/routes";
 import { toast } from "sonner";
 import { codeToHtml, type BundledLanguage } from "shiki";
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 import { AgentProviderIcon } from "@/components/agent-providers/AgentProviderIcon";
 
 const API_KEY_PLACEHOLDER = "{{GRAM_API_KEY}}";
+const PROJECT_SLUG_PLACEHOLDER = "{{GRAM_PROJECT_SLUG}}";
 const MARKETPLACE_URL_PLACEHOLDER = "{{GRAM_MARKETPLACE_URL}}";
 const REPO_URL_PLACEHOLDER = "{{GRAM_REPO_URL}}";
 const REPO_NAME_PLACEHOLDER = "{{GRAM_REPO_NAME}}";
@@ -139,6 +140,7 @@ export function PlatformInstrumentationSheet({
   const { data: publishStatus } = usePublishStatus();
   const { data: marketplaceSettings } = useMarketplaceSettings();
   const { orgSlug = "" } = useSlugs();
+  const projectSlug = useProjectSlugForRequests();
   const deviceAgentUrl = useOrgRoutes().deviceAgent.href();
   const repoOwner = publishStatus?.repoOwner ?? "";
   const repoName = publishStatus?.repoName ?? "";
@@ -435,6 +437,7 @@ export function PlatformInstrumentationSheet({
               const needsKey = !!step.requiresApiKey;
               const substitutions: Array<[string, string]> = [
                 [API_KEY_PLACEHOLDER, platformKey ?? ""],
+                [PROJECT_SLUG_PLACEHOLDER, projectSlug],
                 [MARKETPLACE_URL_PLACEHOLDER, marketplaceUrl],
                 [REPO_URL_PLACEHOLDER, repoUrl],
                 [REPO_NAME_PLACEHOLDER, repoName],

--- a/client/dashboard/src/pages/setup/setup-data.test.ts
+++ b/client/dashboard/src/pages/setup/setup-data.test.ts
@@ -27,16 +27,11 @@ describe("AGENT_PLATFORMS", () => {
       CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
       OTEL_EXPORTER_OTLP_ENDPOINT: "https://app.getgram.ai/otel",
       OTEL_EXPORTER_OTLP_HEADERS:
-        "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
+        "Gram-Project={{GRAM_PROJECT_SLUG}},Gram-Key={{GRAM_API_KEY}}",
       OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
       OTEL_LOGS_EXPORTER: "otlp",
       OTEL_METRICS_EXPORTER: "otlp",
       OTEL_TRACES_EXPORTER: "otlp",
     });
-    for (const signal of ["logs", "metrics", "traces"]) {
-      expect(`${settings.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/${signal}`).toBe(
-        `https://app.getgram.ai/otel/v1/${signal}`,
-      );
-    }
   });
 });

--- a/client/dashboard/src/pages/setup/setup-data.test.ts
+++ b/client/dashboard/src/pages/setup/setup-data.test.ts
@@ -28,7 +28,7 @@ describe("AGENT_PLATFORMS", () => {
       OTEL_EXPORTER_OTLP_ENDPOINT: "https://app.getgram.ai/otel",
       OTEL_EXPORTER_OTLP_HEADERS:
         "Gram-Project={{GRAM_PROJECT_SLUG}},Gram-Key={{GRAM_API_KEY}}",
-      OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
+      OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
       OTEL_LOGS_EXPORTER: "otlp",
       OTEL_METRICS_EXPORTER: "otlp",
       OTEL_TRACES_EXPORTER: "otlp",

--- a/client/dashboard/src/pages/setup/setup-data.test.ts
+++ b/client/dashboard/src/pages/setup/setup-data.test.ts
@@ -25,7 +25,18 @@ describe("AGENT_PLATFORMS", () => {
     expect(settings.env).toMatchObject({
       CLAUDE_CODE_ENABLE_TELEMETRY: "1",
       CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "https://app.getgram.ai/otel",
+      OTEL_EXPORTER_OTLP_HEADERS:
+        "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
+      OTEL_EXPORTER_OTLP_PROTOCOL: "http/json",
+      OTEL_LOGS_EXPORTER: "otlp",
+      OTEL_METRICS_EXPORTER: "otlp",
       OTEL_TRACES_EXPORTER: "otlp",
     });
+    for (const signal of ["logs", "metrics", "traces"]) {
+      expect(`${settings.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/${signal}`).toBe(
+        `https://app.getgram.ai/otel/v1/${signal}`,
+      );
+    }
   });
 });

--- a/client/dashboard/src/pages/setup/setup-data.test.ts
+++ b/client/dashboard/src/pages/setup/setup-data.test.ts
@@ -10,4 +10,22 @@ describe("AGENT_PLATFORMS", () => {
       ),
     ).toEqual([...ACTIVE_AGENT_PROVIDER_IDS.setup]);
   });
+
+  it("enables Claude OpenTelemetry traces", () => {
+    const managedSettings = AGENT_PLATFORMS.find(
+      ({ id }) => id === "claude",
+    )?.setupSteps.find(({ code }) =>
+      code?.includes("CLAUDE_CODE_ENABLE_TELEMETRY"),
+    )?.code;
+
+    expect(managedSettings).toBeDefined();
+    const settings = JSON.parse(managedSettings ?? "{}") as {
+      env: Record<string, string>;
+    };
+    expect(settings.env).toMatchObject({
+      CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+      CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1",
+      OTEL_TRACES_EXPORTER: "otlp",
+    });
+  });
 });

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -49,7 +49,7 @@ const SETUP_AGENT_PLATFORMS: Array<{
       {
         title: "Update Managed settings on Claude.ai",
         description:
-          "Add your private marketplace to managed settings so every developer in your org gets the observability plugin automatically. The OTEL env block also pushes a Speakeasy API key to every install so tool traffic lands in your dashboard. If you already have managed settings, merge this block into the existing JSON.",
+          "Add your private marketplace to managed settings so every developer in your org gets the observability plugin automatically. The OTEL env block also pushes a Speakeasy API key to every install so logs, metrics, and traces land in your dashboard. If you already have managed settings, merge this block into the existing JSON.",
         screenshot: {
           src: "/setup/claude-managed-settings-editor.png",
           alt: "Claude Code Managed settings JSON editor dialog with Update settings button",
@@ -58,11 +58,13 @@ const SETUP_AGENT_PLATFORMS: Array<{
         code: `{
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.getgram.ai/rpc/hooks.otel",
     "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
     "OTEL_LOGS_EXPORTER": "otlp",
     "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_TRACES_EXPORTER": "otlp",
     "FORCE_AUTOUPDATE_PLUGINS": "1"
   },
   "extraKnownMarketplaces": {

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -61,7 +61,7 @@ const SETUP_AGENT_PLATFORMS: Array<{
     "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.getgram.ai/otel",
     "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project={{GRAM_PROJECT_SLUG}},Gram-Key={{GRAM_API_KEY}}",
-    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_LOGS_EXPORTER": "otlp",
     "OTEL_METRICS_EXPORTER": "otlp",
     "OTEL_TRACES_EXPORTER": "otlp",

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -60,7 +60,7 @@ const SETUP_AGENT_PLATFORMS: Array<{
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.getgram.ai/otel",
-    "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project={{GRAM_PROJECT_SLUG}},Gram-Key={{GRAM_API_KEY}}",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
     "OTEL_LOGS_EXPORTER": "otlp",
     "OTEL_METRICS_EXPORTER": "otlp",

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -59,7 +59,7 @@ const SETUP_AGENT_PLATFORMS: Array<{
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
-    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.getgram.ai/rpc/hooks.otel",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://app.getgram.ai/otel",
     "OTEL_EXPORTER_OTLP_HEADERS": "Gram-Project=default,Gram-Key={{GRAM_API_KEY}}",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
     "OTEL_LOGS_EXPORTER": "otlp",

--- a/server/internal/plugins/agent_plugins.go
+++ b/server/internal/plugins/agent_plugins.go
@@ -168,7 +168,7 @@ func classifyAgentPlugin(p PluginInfo) agentPluginCompatibility {
 
 func validateAgentPluginRemoteURL(raw string) error {
 	u, err := url.Parse(raw)
-	if err != nil || u.Host == "" || u.User != nil || u.Fragment != "" {
+	if err != nil || u.Host == "" || u.Hostname() == "" || u.User != nil || u.Fragment != "" {
 		return errors.New("url must be absolute and must not contain user information or a fragment")
 	}
 	if u.Scheme == "https" {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2572,7 +2572,7 @@ if OTEL_ENDPOINT_BASE and OTEL_API_KEY:
             print(f"  ⚠  Existing Codex OTEL {signal} exporter preserved; configure Speakeasy telemetry manually.")
             continue
         content = ensure_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT_BASE + "/" + signal))
-        content = ensure_table_entry(content, exporter_table, "protocol", '"json"')
+        content = ensure_table_entry(content, exporter_table, "protocol", '"binary"')
         content = ensure_table_entry(content, exporter_table, "headers", headers)
 
 # Qualified [hooks.state."…"] sections do not require a bare parent header.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2150,7 +2150,7 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 	if cfg.HooksAPIKey != "" {
 		serverURL, err := url.Parse(cfg.ServerURL)
 		if err != nil {
-			return nil, fmt.Errorf("invalid Codex OTLP server URL: %w", err)
+			return nil, errors.New("invalid Codex OTLP server URL")
 		}
 		if serverURL.ForceQuery || serverURL.RawQuery != "" {
 			return nil, errors.New("invalid Codex OTLP server URL: query parameters are not allowed")
@@ -2273,40 +2273,146 @@ content = open(config_path).read() if os.path.exists(config_path) else ""
 # with an explicit [table] header elsewhere in the file. Only the region
 # before the first table header is touched.
 def strip_root_dotted_key(text, key):
-    m = re.search(r'(?m)^[ \t]*\[', text)
-    root, rest = (text[:m.start()], text[m.start():]) if m else (text, "")
-    root = re.sub(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=.*\n?', '', root)
-    return root + rest
+    pattern = re.compile(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=.*\n?')
+    matches = list(pattern.finditer(searchable_root(text)))
+    if not matches:
+        return text
+    parts = []
+    start = 0
+    for match in matches:
+        parts.append(text[start:match.start()])
+        start = match.end()
+    parts.append(text[start:])
+    return ''.join(parts)
 
 def toml_dotted_key_pattern(key):
     components = []
     for component in key.split('.'):
         escaped = re.escape(component)
-        components.append(f"""(?:{escaped}|"{escaped}"|'{escaped}')""")
+        basic_chars = []
+        for char in component:
+            short_hex = f'{ord(char):04x}'
+            long_hex = f'{ord(char):08x}'
+            short_pattern = ''.join(
+                f'[{digit.lower()}{digit.upper()}]' if digit.isalpha() else digit
+                for digit in short_hex
+            )
+            long_pattern = ''.join(
+                f'[{digit.lower()}{digit.upper()}]' if digit.isalpha() else digit
+                for digit in long_hex
+            )
+            basic_chars.append(
+                '(?:' + re.escape(char) + r'|\\u' + short_pattern + r'|\\U' + long_pattern + ')'
+            )
+        basic = ''.join(basic_chars)
+        components.append(f"""(?:{escaped}|"{basic}"|'{escaped}')""")
     return r'[ \t]*\.[ \t]*'.join(components)
+
+TOML_KEY_COMPONENT_PATTERN = r"""(?:[A-Za-z0-9_-]+|"(?:\\[^\r\n]|[^"\\\r\n])*"|'[^'\r\n]*')"""
+TOML_DOTTED_KEY_PATTERN = (
+    TOML_KEY_COMPONENT_PATTERN
+    + r'(?:[ \t]*\.[ \t]*' + TOML_KEY_COMPONENT_PATTERN + r')*'
+)
+TOML_TABLE_HEADER_PATTERN = (
+    r'(?m)^[ \t]*(?:'
+    + r'\[\[[ \t]*' + TOML_DOTTED_KEY_PATTERN + r'[ \t]*\]\]'
+    + r'|\[[ \t]*' + TOML_DOTTED_KEY_PATTERN + r'[ \t]*\]'
+    + r')[ \t]*(?:#[^\r\n]*)?(?:\r?\n|$)'
+)
+
+def toml_assignment_value(line):
+    quote = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote == '"':
+            if char == '\\':
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+        elif quote == "'":
+            if char == "'":
+                quote = None
+        elif char in ('"', "'"):
+            quote = char
+        elif char == '#':
+            return None
+        elif char == '=':
+            return line[index + 1:]
+        index += 1
+    return None
+
+def scan_toml_value(value, nesting, multiline_delimiter):
+    quote = None
+    index = 0
+    while index < len(value):
+        if multiline_delimiter is not None:
+            end = value.find(multiline_delimiter, index)
+            if end < 0:
+                return nesting, multiline_delimiter
+            if multiline_delimiter == '"""':
+                backslashes = 0
+                cursor = end - 1
+                while cursor >= 0 and value[cursor] == '\\':
+                    backslashes += 1
+                    cursor -= 1
+                if backslashes % 2 == 1:
+                    index = end + len(multiline_delimiter)
+                    continue
+            index = end + len(multiline_delimiter)
+            multiline_delimiter = None
+            continue
+
+        char = value[index]
+        if quote == '"':
+            if char == '\\':
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+        elif quote == "'":
+            if char == "'":
+                quote = None
+        elif value.startswith('"""', index) or value.startswith("'''", index):
+            multiline_delimiter = value[index:index + 3]
+            index += 3
+            continue
+        elif char in ('"', "'"):
+            quote = char
+        elif char == '#':
+            break
+        elif char in '[{':
+            nesting.append(char)
+        elif char == ']' and nesting and nesting[-1] == '[':
+            nesting.pop()
+        elif char == '}' and nesting and nesting[-1] == '{':
+            nesting.pop()
+        index += 1
+    return nesting, multiline_delimiter
 
 def searchable_toml(text):
     lines = []
+    nesting = []
     multiline_delimiter = None
     for line in text.splitlines(keepends=True):
-        if multiline_delimiter is not None:
+        continuation = bool(nesting) or multiline_delimiter is not None
+        if continuation:
             lines.append(''.join(char if char in '\r\n' else ' ' for char in line))
-            if line.count(multiline_delimiter) % 2 == 1:
-                multiline_delimiter = None
-            continue
-        lines.append(line)
-        equals = line.find('=')
-        if equals < 0:
-            continue
-        value = line[equals + 1:].lstrip()
-        for delimiter in ('"""', "'''"):
-            if value.startswith(delimiter) and value.count(delimiter) % 2 == 1:
-                multiline_delimiter = delimiter
-                break
+            value = line
+        else:
+            lines.append(line)
+            value = toml_assignment_value(line)
+        if value is not None:
+            nesting, multiline_delimiter = scan_toml_value(
+                value,
+                nesting,
+                multiline_delimiter,
+            )
     return ''.join(lines)
 
 def root_end(text):
-    match = re.search(r'(?m)^[ \t]*\[', searchable_toml(text))
+    match = re.search(TOML_TABLE_HEADER_PATTERN, searchable_toml(text))
     return match.start() if match else len(text)
 
 def searchable_root(text):
@@ -2340,7 +2446,7 @@ def table_body_bounds(text, table_header):
     if not m:
         return None
     start = m.end()
-    m2 = re.search(r'(?m)^[ \t]*\[', searchable[start:])
+    m2 = re.search(TOML_TABLE_HEADER_PATTERN, searchable[start:])
     end = start + m2.start() if m2 else len(text)
     return start, end
 
@@ -2355,7 +2461,7 @@ def dotted_table_body_bounds(text, table):
     if match is None:
         return None
     start = match.end()
-    next_header = re.search(r'(?m)^[ \t]*\[', searchable[start:])
+    next_header = re.search(TOML_TABLE_HEADER_PATTERN, searchable[start:])
     end = start + next_header.start() if next_header else len(text)
     return start, end
 

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2131,7 +2131,7 @@ func codexHookCommandStringWindows(timeoutSeconds int, async, failOpen bool) str
 
 // GenerateCodexInstallScript produces a bash install script that:
 //   - Registers the Gram marketplace with the Codex CLI
-//   - Patches ~/.codex/config.toml with feature flags, plugin state, and OTLP log export
+//   - Patches ~/.codex/config.toml with feature flags, plugin state, and OTLP export
 //   - Pre-approves all hook events so users skip the manual Settings → Hooks step
 //
 // When marketplaceURL is empty the script uses the directory it was run from as
@@ -2146,15 +2146,15 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 		return nil, fmt.Errorf("compute hook approvals: %w", err)
 	}
 
-	otelEndpoint := ""
+	otelEndpointBase := ""
 	if cfg.HooksAPIKey != "" {
-		otelEndpoint = strings.TrimRight(cfg.ServerURL, "/") + "/rpc/hooks.otel/v1/logs"
+		otelEndpointBase = strings.TrimRight(cfg.ServerURL, "/") + "/otel/v1"
 	}
 
-	return renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpoint, cfg.ProjectSlug, cfg.HooksAPIKey, approvals), nil
+	return renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpointBase, cfg.ProjectSlug, cfg.HooksAPIKey, approvals), nil
 }
 
-func renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpoint, projectSlug, hooksAPIKey string, approvals []codexHookApproval) []byte {
+func renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpointBase, projectSlug, hooksAPIKey string, approvals []codexHookApproval) []byte {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "#!/usr/bin/env bash\n")
@@ -2313,7 +2313,7 @@ def has_table_header(text, header):
 	// Python literals — embedded at generation time, not expanded by bash.
 	fmt.Fprintf(&b, "PLUGIN_KEY = %q\n", plugin)
 	fmt.Fprintf(&b, "MARKETPLACE_KEY = %q\n", marketplace)
-	fmt.Fprintf(&b, "OTEL_ENDPOINT = %q\n", otelEndpoint)
+	fmt.Fprintf(&b, "OTEL_ENDPOINT_BASE = %q\n", otelEndpointBase)
 	fmt.Fprintf(&b, "OTEL_PROJECT = %q\n", projectSlug)
 	fmt.Fprintf(&b, "OTEL_API_KEY = %q\n\n", hooksAPIKey)
 
@@ -2322,16 +2322,24 @@ content = strip_root_dotted_key(content, "features.plugin_hooks")
 content = ensure_table_entry(content, "[features]", "hooks", "true")
 content = ensure_table_entry(content, "[features]", "plugin_hooks", "true")
 
-if OTEL_ENDPOINT and OTEL_API_KEY:
-    exporter_table = "[otel.exporter.otlp-http]"
-    has_inline_exporter = table_has_entry(content, "[otel]", "exporter")
-    has_other_exporter_table = re.search(r'(?m)^[ \t]*\[otel\.exporter\.', content) and not has_table_header(content, exporter_table)
-    if has_inline_exporter or has_other_exporter_table:
-        print("  ⚠  Existing Codex OTEL log exporter preserved; configure Speakeasy telemetry manually.")
-    else:
-        content = set_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT))
+if OTEL_ENDPOINT_BASE and OTEL_API_KEY:
+    headers = '{ "Gram-Project" = ' + json.dumps(OTEL_PROJECT) + ', "Gram-Key" = ' + json.dumps(OTEL_API_KEY) + ' }'
+    for exporter_key, signal in [
+        ("exporter", "logs"),
+        ("trace_exporter", "traces"),
+        ("metrics_exporter", "metrics"),
+    ]:
+        exporter_table = f"[otel.{exporter_key}.otlp-http]"
+        has_inline_exporter = table_has_entry(content, "[otel]", exporter_key)
+        has_other_exporter_table = (
+            re.search(r'(?m)^[ \t]*\[otel\.' + re.escape(exporter_key) + r'\.', content) is not None
+            and not has_table_header(content, exporter_table)
+        )
+        if has_inline_exporter or has_other_exporter_table:
+            print(f"  ⚠  Existing Codex OTEL {signal} exporter preserved; configure Speakeasy telemetry manually.")
+            continue
+        content = set_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT_BASE + "/" + signal))
         content = set_table_entry(content, exporter_table, "protocol", '"json"')
-        headers = '{ "Gram-Project" = ' + json.dumps(OTEL_PROJECT) + ', "Gram-Key" = ' + json.dumps(OTEL_API_KEY) + ' }'
         content = set_table_entry(content, exporter_table, "headers", headers)
 
 # Qualified [hooks.state."…"] sections do not require a bare parent header.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2131,7 +2131,7 @@ func codexHookCommandStringWindows(timeoutSeconds int, async, failOpen bool) str
 
 // GenerateCodexInstallScript produces a bash install script that:
 //   - Registers the Gram marketplace with the Codex CLI
-//   - Patches ~/.codex/config.toml with feature flags and plugin entry
+//   - Patches ~/.codex/config.toml with feature flags, plugin state, and OTLP log export
 //   - Pre-approves all hook events so users skip the manual Settings → Hooks step
 //
 // When marketplaceURL is empty the script uses the directory it was run from as
@@ -2146,10 +2146,15 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 		return nil, fmt.Errorf("compute hook approvals: %w", err)
 	}
 
-	return renderCodexInstallScript(marketplaceURL, marketplace, plugin, approvals), nil
+	otelEndpoint := ""
+	if cfg.HooksAPIKey != "" {
+		otelEndpoint = strings.TrimRight(cfg.ServerURL, "/") + "/rpc/hooks.otel/v1/logs"
+	}
+
+	return renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpoint, cfg.ProjectSlug, cfg.HooksAPIKey, approvals), nil
 }
 
-func renderCodexInstallScript(marketplaceURL, marketplace, plugin string, approvals []codexHookApproval) []byte {
+func renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpoint, projectSlug, hooksAPIKey string, approvals []codexHookApproval) []byte {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "#!/usr/bin/env bash\n")
@@ -2241,7 +2246,7 @@ case "$(uname -s)" in
 esac
 export SPEAKEASY_HOOKS_OS
 python3 - <<'PYTHON'
-import os, re
+import json, os, re
 
 WINDOWS = os.environ.get("SPEAKEASY_HOOKS_OS") == "windows"
 
@@ -2283,6 +2288,23 @@ def ensure_table_entry(text, table_header, key, value):
         prefix += '\n'
     return prefix + key + ' = ' + value + '\n' + text[bounds[0]:]
 
+def set_table_entry(text, table_header, key, value):
+    bounds = table_body_bounds(text, table_header)
+    if bounds is None:
+        return text.rstrip('\n') + '\n\n' + table_header + '\n' + key + ' = ' + value + '\n'
+    body = text[bounds[0]:bounds[1]]
+    pattern = re.compile(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=.*(?:\n|$)')
+    if pattern.search(body):
+        body = pattern.sub(key + ' = ' + value + '\n', body, count=1)
+        return text[:bounds[0]] + body + text[bounds[1]:]
+    return ensure_table_entry(text, table_header, key, value)
+
+def table_has_entry(text, table_header, key):
+    bounds = table_body_bounds(text, table_header)
+    if bounds is None:
+        return False
+    return re.search(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=', text[bounds[0]:bounds[1]]) is not None
+
 def has_table_header(text, header):
     return table_body_bounds(text, header) is not None
 
@@ -2290,12 +2312,27 @@ def has_table_header(text, header):
 
 	// Python literals — embedded at generation time, not expanded by bash.
 	fmt.Fprintf(&b, "PLUGIN_KEY = %q\n", plugin)
-	fmt.Fprintf(&b, "MARKETPLACE_KEY = %q\n\n", marketplace)
+	fmt.Fprintf(&b, "MARKETPLACE_KEY = %q\n", marketplace)
+	fmt.Fprintf(&b, "OTEL_ENDPOINT = %q\n", otelEndpoint)
+	fmt.Fprintf(&b, "OTEL_PROJECT = %q\n", projectSlug)
+	fmt.Fprintf(&b, "OTEL_API_KEY = %q\n\n", hooksAPIKey)
 
 	b.WriteString(`content = strip_root_dotted_key(content, "features.hooks")
 content = strip_root_dotted_key(content, "features.plugin_hooks")
 content = ensure_table_entry(content, "[features]", "hooks", "true")
 content = ensure_table_entry(content, "[features]", "plugin_hooks", "true")
+
+if OTEL_ENDPOINT and OTEL_API_KEY:
+    exporter_table = "[otel.exporter.otlp-http]"
+    has_inline_exporter = table_has_entry(content, "[otel]", "exporter")
+    has_other_exporter_table = re.search(r'(?m)^[ \t]*\[otel\.exporter\.', content) and not has_table_header(content, exporter_table)
+    if has_inline_exporter or has_other_exporter_table:
+        print("  ⚠  Existing Codex OTEL log exporter preserved; configure Speakeasy telemetry manually.")
+    else:
+        content = set_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT))
+        content = set_table_entry(content, exporter_table, "protocol", '"json"')
+        headers = '{ "Gram-Project" = ' + json.dumps(OTEL_PROJECT) + ', "Gram-Key" = ' + json.dumps(OTEL_API_KEY) + ' }'
+        content = set_table_entry(content, exporter_table, "headers", headers)
 
 # Qualified [hooks.state."…"] sections do not require a bare parent header.
 if not has_table_header(content, "[hooks.state]") and not re.search(r'(?m)^[ \t]*\[hooks\.state\.', content):

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -382,7 +382,7 @@ const platformMCPGeneratorVersion = "3"
 // line when it pins a new binary, because new checksums always change the
 // rendered bootstrap script. Any other change to hooks generation needs a
 // manual bump, which the Plugin Generate Check CI workflow enforces.
-const hooksGeneratorVersion = "38"
+const hooksGeneratorVersion = "39"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits
@@ -2148,7 +2148,17 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 
 	otelEndpointBase := ""
 	if cfg.HooksAPIKey != "" {
-		otelEndpointBase = strings.TrimRight(cfg.ServerURL, "/") + "/otel/v1"
+		serverURL, err := url.Parse(cfg.ServerURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Codex OTLP server URL: %w", err)
+		}
+		if serverURL.ForceQuery || serverURL.RawQuery != "" {
+			return nil, errors.New("invalid Codex OTLP server URL: query parameters are not allowed")
+		}
+		if err := validateAgentPluginRemoteURL(cfg.ServerURL); err != nil {
+			return nil, fmt.Errorf("invalid Codex OTLP server URL: %w", err)
+		}
+		otelEndpointBase = strings.TrimRight(serverURL.String(), "/") + "/otel/v1"
 	}
 
 	return renderCodexInstallScript(marketplaceURL, marketplace, plugin, otelEndpointBase, cfg.ProjectSlug, cfg.HooksAPIKey, approvals), nil
@@ -2268,42 +2278,146 @@ def strip_root_dotted_key(text, key):
     root = re.sub(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=.*\n?', '', root)
     return root + rest
 
+def toml_dotted_key_pattern(key):
+    components = []
+    for component in key.split('.'):
+        escaped = re.escape(component)
+        components.append(f"""(?:{escaped}|"{escaped}"|'{escaped}')""")
+    return r'[ \t]*\.[ \t]*'.join(components)
+
+def searchable_toml(text):
+    lines = []
+    multiline_delimiter = None
+    for line in text.splitlines(keepends=True):
+        if multiline_delimiter is not None:
+            lines.append(''.join(char if char in '\r\n' else ' ' for char in line))
+            if line.count(multiline_delimiter) % 2 == 1:
+                multiline_delimiter = None
+            continue
+        lines.append(line)
+        equals = line.find('=')
+        if equals < 0:
+            continue
+        value = line[equals + 1:].lstrip()
+        for delimiter in ('"""', "'''"):
+            if value.startswith(delimiter) and value.count(delimiter) % 2 == 1:
+                multiline_delimiter = delimiter
+                break
+    return ''.join(lines)
+
+def root_end(text):
+    match = re.search(r'(?m)^[ \t]*\[', searchable_toml(text))
+    return match.start() if match else len(text)
+
+def searchable_root(text):
+    return searchable_toml(text[:root_end(text)])
+
+def root_has_entry(text, key):
+    return re.search(
+        r'(?m)^[ \t]*' + toml_dotted_key_pattern(key) + r'[ \t]*=',
+        searchable_root(text),
+    ) is not None
+
+def root_has_dotted_table(text, table):
+    return re.search(
+        r'(?m)^[ \t]*' + toml_dotted_key_pattern(table) + r'[ \t]*\.[ \t]*',
+        searchable_root(text),
+    ) is not None
+
+def ensure_root_entry(text, key, value):
+    if root_has_entry(text, key):
+        return text
+    end = root_end(text)
+    root, rest = text[:end], text[end:]
+    root = root.rstrip('\n')
+    if root:
+        root += '\n'
+    return root + key + ' = ' + value + '\n\n' + rest.lstrip('\n')
+
 def table_body_bounds(text, table_header):
-    m = re.search(r'(?m)^[ \t]*' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?(?:\n|$)', text)
+    searchable = searchable_toml(text)
+    m = re.search(r'(?m)^[ \t]*' + re.escape(table_header) + r'(?:\s*(?:#.*)?)?(?:\n|$)', searchable)
     if not m:
         return None
     start = m.end()
-    m2 = re.search(r'(?m)^[ \t]*\[', text[start:])
+    m2 = re.search(r'(?m)^[ \t]*\[', searchable[start:])
     end = start + m2.start() if m2 else len(text)
     return start, end
 
-def ensure_table_entry(text, table_header, key, value):
-    bounds = table_body_bounds(text, table_header)
+def dotted_table_body_bounds(text, table):
+    pattern = (
+        r'(?m)^[ \t]*\[[ \t]*'
+        + toml_dotted_key_pattern(table)
+        + r'[ \t]*\][ \t]*(?:#.*)?(?:\n|$)'
+    )
+    searchable = searchable_toml(text)
+    match = re.search(pattern, searchable)
+    if match is None:
+        return None
+    start = match.end()
+    next_header = re.search(r'(?m)^[ \t]*\[', searchable[start:])
+    end = start + next_header.start() if next_header else len(text)
+    return start, end
+
+def dotted_table_has_entry(text, table, key):
+    bounds = dotted_table_body_bounds(text, table)
     if bounds is None:
-        return text.rstrip('\n') + '\n\n' + table_header + '\n' + key + ' = ' + value + '\n'
-    if re.search(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=', text[bounds[0]:bounds[1]]):
+        return False
+    pattern = r'(?m)^[ \t]*' + toml_dotted_key_pattern(key) + r'[ \t]*='
+    searchable = searchable_toml(text)
+    return re.search(pattern, searchable[bounds[0]:bounds[1]]) is not None
+
+def dotted_table_has_dotted_key_prefix(text, table, key):
+    bounds = dotted_table_body_bounds(text, table)
+    if bounds is None:
+        return False
+    pattern = (
+        r'(?m)^[ \t]*'
+        + toml_dotted_key_pattern(key)
+        + r'[ \t]*\.[ \t]*'
+    )
+    searchable = searchable_toml(text)
+    return re.search(pattern, searchable[bounds[0]:bounds[1]]) is not None
+
+def has_dotted_table_prefix(text, table):
+    pattern = (
+        r'(?m)^[ \t]*\[[ \t]*'
+        + toml_dotted_key_pattern(table)
+        + r'(?:[ \t]*\.|[ \t]*\])'
+    )
+    return re.search(pattern, searchable_toml(text)) is not None
+
+def ensure_dotted_table_entry(text, table, key, value):
+    bounds = dotted_table_body_bounds(text, table)
+    if bounds is None:
+        return ensure_table_entry(text, "[" + table + "]", key, value)
+    if dotted_table_has_entry(text, table, key):
         return text
     prefix = text[:bounds[0]]
     if not prefix.endswith('\n'):
         prefix += '\n'
     return prefix + key + ' = ' + value + '\n' + text[bounds[0]:]
 
-def set_table_entry(text, table_header, key, value):
+def ensure_table_entry(text, table_header, key, value):
     bounds = table_body_bounds(text, table_header)
     if bounds is None:
         return text.rstrip('\n') + '\n\n' + table_header + '\n' + key + ' = ' + value + '\n'
-    body = text[bounds[0]:bounds[1]]
-    pattern = re.compile(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=.*(?:\n|$)')
-    if pattern.search(body):
-        body = pattern.sub(key + ' = ' + value + '\n', body, count=1)
-        return text[:bounds[0]] + body + text[bounds[1]:]
-    return ensure_table_entry(text, table_header, key, value)
+    searchable = searchable_toml(text)
+    if re.search(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=', searchable[bounds[0]:bounds[1]]):
+        return text
+    prefix = text[:bounds[0]]
+    if not prefix.endswith('\n'):
+        prefix += '\n'
+    return prefix + key + ' = ' + value + '\n' + text[bounds[0]:]
+
 
 def table_has_entry(text, table_header, key):
     bounds = table_body_bounds(text, table_header)
     if bounds is None:
         return False
-    return re.search(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=', text[bounds[0]:bounds[1]]) is not None
+    searchable = searchable_toml(text)
+    return re.search(r'(?m)^[ \t]*' + re.escape(key) + r'\s*=', searchable[bounds[0]:bounds[1]]) is not None
+
 
 def has_table_header(text, header):
     return table_body_bounds(text, header) is not None
@@ -2323,6 +2437,14 @@ content = ensure_table_entry(content, "[features]", "hooks", "true")
 content = ensure_table_entry(content, "[features]", "plugin_hooks", "true")
 
 if OTEL_ENDPOINT_BASE and OTEL_API_KEY:
+    has_root_inline_otel = root_has_entry(content, "otel")
+    if has_root_inline_otel:
+        print("  ⚠  Existing root-level Codex OTEL configuration preserved; configure Speakeasy telemetry manually.")
+    elif root_has_dotted_table(content, "otel"):
+        content = ensure_root_entry(content, "otel.environment", '"prod"')
+    else:
+        content = ensure_dotted_table_entry(content, "otel", "environment", '"prod"')
+
     headers = '{ "Gram-Project" = ' + json.dumps(OTEL_PROJECT) + ', "Gram-Key" = ' + json.dumps(OTEL_API_KEY) + ' }'
     for exporter_key, signal in [
         ("exporter", "logs"),
@@ -2330,17 +2452,22 @@ if OTEL_ENDPOINT_BASE and OTEL_API_KEY:
         ("metrics_exporter", "metrics"),
     ]:
         exporter_table = f"[otel.{exporter_key}.otlp-http]"
-        has_inline_exporter = table_has_entry(content, "[otel]", exporter_key)
-        has_other_exporter_table = (
-            re.search(r'(?m)^[ \t]*\[otel\.' + re.escape(exporter_key) + r'\.', content) is not None
-            and not has_table_header(content, exporter_table)
+        has_root_dotted_exporter = (
+            root_has_entry(content, "otel." + exporter_key)
+            or root_has_dotted_table(content, "otel." + exporter_key)
         )
-        if has_inline_exporter or has_other_exporter_table:
+        has_inline_exporter = (
+            table_has_entry(content, "[otel]", exporter_key)
+            or dotted_table_has_entry(content, "otel", exporter_key)
+            or dotted_table_has_dotted_key_prefix(content, "otel", exporter_key)
+        )
+        has_exporter_table = has_dotted_table_prefix(content, "otel." + exporter_key)
+        if has_root_inline_otel or has_root_dotted_exporter or has_inline_exporter or has_exporter_table:
             print(f"  ⚠  Existing Codex OTEL {signal} exporter preserved; configure Speakeasy telemetry manually.")
             continue
-        content = set_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT_BASE + "/" + signal))
-        content = set_table_entry(content, exporter_table, "protocol", '"json"')
-        content = set_table_entry(content, exporter_table, "headers", headers)
+        content = ensure_table_entry(content, exporter_table, "endpoint", json.dumps(OTEL_ENDPOINT_BASE + "/" + signal))
+        content = ensure_table_entry(content, exporter_table, "protocol", '"json"')
+        content = ensure_table_entry(content, exporter_table, "headers", headers)
 
 # Qualified [hooks.state."…"] sections do not require a bare parent header.
 if not has_table_header(content, "[hooks.state]") and not re.search(r'(?m)^[ \t]*\[hooks\.state\.', content):

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2085,9 +2085,11 @@ func TestGenerateCodexInstallScriptRejectsUnsafeOTLPServerURLs(t *testing.T) {
 	for _, serverURL := range []string{
 		"http://app.getgram.ai",
 		"https://user:password@app.getgram.ai",
+		"https://user:password%zz@app.getgram.ai",
 		"https://app.getgram.ai/#fragment",
 		"://malformed",
 		"https://%zz",
+		"https://:443",
 		"https://app.getgram.ai?tenant=example",
 		"https://app.getgram.ai?",
 	} {
@@ -2173,6 +2175,87 @@ func TestGenerateCodexInstallScriptPreservesRootDottedOTELExporter(t *testing.T)
 	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
 }
 
+func TestGenerateCodexInstallScriptPreservesRootDottedOTELExporterAfterMultilineArray(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := `targets = [
+  [1, 2],
+  [3]
+]
+otel . "exporter" = "none"
+`
+	home, _ := runCodexInstallScript(t, script, existing)
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		Targets [][]int `toml:"targets"`
+		OTel    struct {
+			Environment     string                           `toml:"environment"`
+			Exporter        string                           `toml:"exporter"`
+			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
+		} `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, [][]int{{1, 2}, {3}}, decoded.Targets)
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Equal(t, "none", decoded.OTel.Exporter)
+	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
+func TestGenerateCodexInstallScriptPreservesOTELExporterAfterMultilineArray(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := `[otel]
+resource_attributes = [
+  ["region", "us-east"],
+  ["service"]
+]
+exporter = "none"
+`
+	home, _ := runCodexInstallScript(t, script, existing)
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel struct {
+			Environment        string                           `toml:"environment"`
+			ResourceAttributes [][]string                       `toml:"resource_attributes"`
+			Exporter           string                           `toml:"exporter"`
+			TraceExporter      map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+			MetricsExporter    map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
+		} `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Equal(t, [][]string{{"region", "us-east"}, {"service"}}, decoded.OTel.ResourceAttributes)
+	require.Equal(t, "none", decoded.OTel.Exporter)
+	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
 func TestGenerateCodexInstallScriptIgnoresOTELTextInMultilineString(t *testing.T) {
 	t.Parallel()
 
@@ -2252,7 +2335,7 @@ func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
 	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
 	require.NoError(t, err)
 
-	existing := `["otel"]
+	existing := `["ot\u0065l"]
 exporter . "otlp-http" . endpoint = "https://collector.example.com/v1/logs"
 exporter . "otlp-http" . protocol = "json"
 exporter . "otlp-http" . headers = { Authorization = "Bearer existing" }

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2053,7 +2053,7 @@ func TestGenerateCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 		exporter, ok := signalExporters["otlp-http"]
 		require.True(t, ok, "%s exporter missing", signal)
 		require.Equal(t, "https://app.getgram.ai/otel/v1/"+signal, exporter.Endpoint)
-		require.Equal(t, "json", exporter.Protocol)
+		require.Equal(t, "binary", exporter.Protocol)
 		require.Equal(t, map[string]string{
 			"Gram-Key":     cfg.HooksAPIKey,
 			"Gram-Project": cfg.ProjectSlug,

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2015,6 +2015,13 @@ type codexOTLPHTTPExporter struct {
 	Headers  map[string]string `toml:"headers"`
 }
 
+type codexOTELConfig struct {
+	Environment     string                           `toml:"environment"`
+	Exporter        map[string]codexOTLPHTTPExporter `toml:"exporter"`
+	TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+	MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
+}
+
 func TestGenerateCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 	t.Parallel()
 
@@ -2031,14 +2038,11 @@ func TestGenerateCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
 
 	var decoded struct {
-		OTel struct {
-			Exporter        map[string]codexOTLPHTTPExporter `toml:"exporter"`
-			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
-			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
-		} `toml:"otel"`
+		OTel codexOTELConfig `toml:"otel"`
 	}
 	_, err = toml.Decode(patched, &decoded)
 	require.NoError(t, err)
+	require.Equal(t, "prod", decoded.OTel.Environment)
 
 	exporters := map[string]map[string]codexOTLPHTTPExporter{
 		"logs":    decoded.OTel.Exporter,
@@ -2057,6 +2061,185 @@ func TestGenerateCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 	}
 }
 
+func TestGenerateCodexInstallScriptAcceptsSecureOTLPServerURLs(t *testing.T) {
+	t.Parallel()
+
+	for serverURL, endpoint := range map[string]string{
+		"https://app.getgram.ai/": "https://app.getgram.ai/otel/v1",
+		"http://localhost:8080":   "http://localhost:8080/otel/v1",
+	} {
+		script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", GenerateConfig{
+			OrgName:     "Example Org",
+			ServerURL:   serverURL,
+			HooksAPIKey: "gram_test_hooks_key",
+			ProjectSlug: "default",
+		})
+		require.NoError(t, err, serverURL)
+		require.Contains(t, string(script), fmt.Sprintf("OTEL_ENDPOINT_BASE = %q", endpoint), serverURL)
+	}
+}
+
+func TestGenerateCodexInstallScriptRejectsUnsafeOTLPServerURLs(t *testing.T) {
+	t.Parallel()
+
+	for _, serverURL := range []string{
+		"http://app.getgram.ai",
+		"https://user:password@app.getgram.ai",
+		"https://app.getgram.ai/#fragment",
+		"://malformed",
+		"https://%zz",
+		"https://app.getgram.ai?tenant=example",
+		"https://app.getgram.ai?",
+	} {
+		_, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", GenerateConfig{
+			OrgName:     "Example Org",
+			ServerURL:   serverURL,
+			HooksAPIKey: "gram_test_hooks_key",
+			ProjectSlug: "default",
+		})
+		require.Error(t, err, serverURL)
+		require.Contains(t, err.Error(), "invalid Codex OTLP server URL", serverURL)
+		require.NotContains(t, err.Error(), "password")
+	}
+}
+
+func TestGenerateCodexInstallScriptPreservesMultilineOTELExporter(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := `[otel . exporter . "otlp-http"]
+endpoint = "https://collector.example.com/v1/logs"
+protocol = "json"
+headers = {
+  "Authorization" = "Bearer existing",
+}
+`
+	home, _ := runCodexInstallScript(t, script, existing)
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel codexOTELConfig `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Equal(t, codexOTLPHTTPExporter{
+		Endpoint: "https://collector.example.com/v1/logs",
+		Protocol: "json",
+		Headers:  map[string]string{"Authorization": "Bearer existing"},
+	}, decoded.OTel.Exporter["otlp-http"])
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
+func TestGenerateCodexInstallScriptPreservesRootDottedOTELExporter(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	home, _ := runCodexInstallScript(t, script, "otel . \"exporter\" = \"none\"\n")
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel struct {
+			Environment     string                           `toml:"environment"`
+			Exporter        string                           `toml:"exporter"`
+			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
+		} `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Equal(t, "none", decoded.OTel.Exporter)
+	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
+	require.NotContains(t, patched, "\n[otel]\n")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
+func TestGenerateCodexInstallScriptIgnoresOTELTextInMultilineString(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := `hint = 'Use """ for Python strings'
+instructions = """
+otel = example
+[otel]
+"""
+`
+	home, _ := runCodexInstallScript(t, script, existing)
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		Hint         string          `toml:"hint"`
+		Instructions string          `toml:"instructions"`
+		OTel         codexOTELConfig `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, `Use """ for Python strings`, decoded.Hint)
+	require.Contains(t, decoded.Instructions, "otel = example")
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Contains(t, decoded.OTel.Exporter, "otlp-http")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
+func TestGenerateCodexInstallScriptIgnoresExporterTextInMultilineValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	existing := `[otel]
+environment = """
+exporter = "none"
+"""
+`
+	home, _ := runCodexInstallScript(t, script, existing)
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel codexOTELConfig `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Contains(t, decoded.OTel.Environment, `exporter = "none"`)
+	require.Contains(t, decoded.OTel.Exporter, "otlp-http")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
+}
+
 func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
 	t.Parallel()
 
@@ -2069,19 +2252,25 @@ func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
 	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
 	require.NoError(t, err)
 
-	home, _ := runCodexInstallScript(t, script, "[otel]\nexporter = \"none\"\n")
+	existing := `["otel"]
+exporter . "otlp-http" . endpoint = "https://collector.example.com/v1/logs"
+exporter . "otlp-http" . protocol = "json"
+exporter . "otlp-http" . headers = { Authorization = "Bearer existing" }
+`
+	home, _ := runCodexInstallScript(t, script, existing)
 	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
 
 	var decoded struct {
-		OTel struct {
-			Exporter        string                           `toml:"exporter"`
-			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
-			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
-		} `toml:"otel"`
+		OTel codexOTELConfig `toml:"otel"`
 	}
 	_, err = toml.Decode(patched, &decoded)
 	require.NoError(t, err)
-	require.Equal(t, "none", decoded.OTel.Exporter)
+	require.Equal(t, "prod", decoded.OTel.Environment)
+	require.Equal(t, codexOTLPHTTPExporter{
+		Endpoint: "https://collector.example.com/v1/logs",
+		Protocol: "json",
+		Headers:  map[string]string{"Authorization": "Bearer existing"},
+	}, decoded.OTel.Exporter["otlp-http"])
 	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
 	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
 	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2009,6 +2009,69 @@ func TestGenerateOpenClawObservabilityPluginPackage(t *testing.T) {
 	}
 }
 
+func TestGenerateCodexInstallScriptConfiguresOTELLogs(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai/",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	home, _ := runCodexInstallScript(t, script, "")
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel struct {
+			Exporter map[string]struct {
+				Endpoint string            `toml:"endpoint"`
+				Protocol string            `toml:"protocol"`
+				Headers  map[string]string `toml:"headers"`
+			} `toml:"exporter"`
+		} `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+
+	exporter, ok := decoded.OTel.Exporter["otlp-http"]
+	require.True(t, ok)
+	require.Equal(t, "https://app.getgram.ai/rpc/hooks.otel/v1/logs", exporter.Endpoint)
+	require.Equal(t, "json", exporter.Protocol)
+	require.Equal(t, map[string]string{
+		"Gram-Key":     cfg.HooksAPIKey,
+		"Gram-Project": cfg.ProjectSlug,
+	}, exporter.Headers)
+}
+
+func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	home, _ := runCodexInstallScript(t, script, "[otel]\nexporter = \"none\"\n")
+	patched := string(requireFileBytes(t, filepath.Join(home, ".codex", "config.toml")))
+
+	var decoded struct {
+		OTel struct {
+			Exporter string `toml:"exporter"`
+		} `toml:"otel"`
+	}
+	_, err = toml.Decode(patched, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, "none", decoded.OTel.Exporter)
+	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
+}
+
 // An upgraded install already carries [hooks.state] entries whose trusted_hash
 // was computed against the previous hook command. When the command changes
 // (for example, when a bootstrap argument changes) the installer must
@@ -2198,7 +2261,12 @@ func TestGenerateCodexInstallScriptCreatesFeaturesTable(t *testing.T) {
 func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
 	t.Parallel()
 
-	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	cfg := GenerateConfig{
+		OrgName:     "Example Org",
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_test_hooks_key",
+		ProjectSlug: "default",
+	}
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
@@ -2222,6 +2290,10 @@ func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
 	require.Equal(t, 1, countTableHeaderLines(patched, "[hooks.state]"))
 	require.Equal(t, 1, countTableHeaderLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace)))
 	require.Equal(t, 1, countTableKeyLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace), "enabled"))
+	require.Equal(t, 1, countTableHeaderLines(patched, "[otel.exporter.otlp-http]"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "endpoint"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "protocol"))
+	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "headers"))
 
 	for _, approval := range approvals {
 		section := fmt.Sprintf(`[hooks.state."%s"]`, approval.StateKey)

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2009,7 +2009,13 @@ func TestGenerateOpenClawObservabilityPluginPackage(t *testing.T) {
 	}
 }
 
-func TestGenerateCodexInstallScriptConfiguresOTELLogs(t *testing.T) {
+type codexOTLPHTTPExporter struct {
+	Endpoint string            `toml:"endpoint"`
+	Protocol string            `toml:"protocol"`
+	Headers  map[string]string `toml:"headers"`
+}
+
+func TestGenerateCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 	t.Parallel()
 
 	cfg := GenerateConfig{
@@ -2026,24 +2032,29 @@ func TestGenerateCodexInstallScriptConfiguresOTELLogs(t *testing.T) {
 
 	var decoded struct {
 		OTel struct {
-			Exporter map[string]struct {
-				Endpoint string            `toml:"endpoint"`
-				Protocol string            `toml:"protocol"`
-				Headers  map[string]string `toml:"headers"`
-			} `toml:"exporter"`
+			Exporter        map[string]codexOTLPHTTPExporter `toml:"exporter"`
+			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
 		} `toml:"otel"`
 	}
 	_, err = toml.Decode(patched, &decoded)
 	require.NoError(t, err)
 
-	exporter, ok := decoded.OTel.Exporter["otlp-http"]
-	require.True(t, ok)
-	require.Equal(t, "https://app.getgram.ai/rpc/hooks.otel/v1/logs", exporter.Endpoint)
-	require.Equal(t, "json", exporter.Protocol)
-	require.Equal(t, map[string]string{
-		"Gram-Key":     cfg.HooksAPIKey,
-		"Gram-Project": cfg.ProjectSlug,
-	}, exporter.Headers)
+	exporters := map[string]map[string]codexOTLPHTTPExporter{
+		"logs":    decoded.OTel.Exporter,
+		"traces":  decoded.OTel.TraceExporter,
+		"metrics": decoded.OTel.MetricsExporter,
+	}
+	for signal, signalExporters := range exporters {
+		exporter, ok := signalExporters["otlp-http"]
+		require.True(t, ok, "%s exporter missing", signal)
+		require.Equal(t, "https://app.getgram.ai/otel/v1/"+signal, exporter.Endpoint)
+		require.Equal(t, "json", exporter.Protocol)
+		require.Equal(t, map[string]string{
+			"Gram-Key":     cfg.HooksAPIKey,
+			"Gram-Project": cfg.ProjectSlug,
+		}, exporter.Headers)
+	}
 }
 
 func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
@@ -2063,13 +2074,17 @@ func TestGenerateCodexInstallScriptPreservesExistingOTELExporter(t *testing.T) {
 
 	var decoded struct {
 		OTel struct {
-			Exporter string `toml:"exporter"`
+			Exporter        string                           `toml:"exporter"`
+			TraceExporter   map[string]codexOTLPHTTPExporter `toml:"trace_exporter"`
+			MetricsExporter map[string]codexOTLPHTTPExporter `toml:"metrics_exporter"`
 		} `toml:"otel"`
 	}
 	_, err = toml.Decode(patched, &decoded)
 	require.NoError(t, err)
 	require.Equal(t, "none", decoded.OTel.Exporter)
 	require.NotContains(t, patched, "[otel.exporter.otlp-http]")
+	require.Contains(t, decoded.OTel.TraceExporter, "otlp-http")
+	require.Contains(t, decoded.OTel.MetricsExporter, "otlp-http")
 }
 
 // An upgraded install already carries [hooks.state] entries whose trusted_hash
@@ -2290,10 +2305,16 @@ func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
 	require.Equal(t, 1, countTableHeaderLines(patched, "[hooks.state]"))
 	require.Equal(t, 1, countTableHeaderLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace)))
 	require.Equal(t, 1, countTableKeyLines(patched, fmt.Sprintf(`[plugins."%s@%s"]`, plugin, marketplace), "enabled"))
-	require.Equal(t, 1, countTableHeaderLines(patched, "[otel.exporter.otlp-http]"))
-	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "endpoint"))
-	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "protocol"))
-	require.Equal(t, 1, countTableKeyLines(patched, "[otel.exporter.otlp-http]", "headers"))
+	for _, table := range []string{
+		"[otel.exporter.otlp-http]",
+		"[otel.trace_exporter.otlp-http]",
+		"[otel.metrics_exporter.otlp-http]",
+	} {
+		require.Equal(t, 1, countTableHeaderLines(patched, table))
+		require.Equal(t, 1, countTableKeyLines(patched, table, "endpoint"))
+		require.Equal(t, 1, countTableKeyLines(patched, table, "protocol"))
+		require.Equal(t, 1, countTableKeyLines(patched, table, "headers"))
+	}
 
 	for _, approval := range approvals {
 		section := fmt.Sprintf(`[hooks.state."%s"]`, approval.StateKey)

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1411,7 +1411,16 @@ func (s *Service) DownloadCodexInstallScript(ctx context.Context, payload *gen.D
 
 	marketplaceURL := fmt.Sprintf("%s%s%s.git", s.serverURL, marketplace.RoutePrefix, conn.MarketplaceToken.String)
 
+	candidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks-download")
+	if err != nil {
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "build hooks api key").LogError(ctx, s.logger)
+	}
+	if err := s.persistDownloadAPIKey(ctx, ac, candidate); err != nil {
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "persist hooks api key").LogError(ctx, s.logger)
+	}
+
 	cfg := s.generateConfig(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
+	cfg.HooksAPIKey = candidate.fullKey
 	// The script's plugin key and hook approvals must name the codex plugin as
 	// it exists in the published repo, which a rollout-gated carry may have
 	// pinned under a pre-rename org name.

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1415,9 +1415,6 @@ func (s *Service) DownloadCodexInstallScript(ctx context.Context, payload *gen.D
 	if err != nil {
 		return nil, nil, oops.E(oops.CodeUnexpected, err, "build hooks api key").LogError(ctx, s.logger)
 	}
-	if err := s.persistDownloadAPIKey(ctx, ac, candidate); err != nil {
-		return nil, nil, oops.E(oops.CodeUnexpected, err, "persist hooks api key").LogError(ctx, s.logger)
-	}
 
 	cfg := s.generateConfig(ctx, ac.ActiveOrganizationID, ac.OrganizationSlug, conv.PtrValOr(ac.ProjectSlug, ""), *ac.ProjectID)
 	cfg.HooksAPIKey = candidate.fullKey
@@ -1429,6 +1426,10 @@ func (s *Service) DownloadCodexInstallScript(ctx context.Context, payload *gen.D
 	script, err := GenerateCodexInstallScript(marketplaceURL, cfg)
 	if err != nil {
 		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate codex install script").LogError(ctx, s.logger)
+	}
+
+	if err := s.persistDownloadAPIKey(ctx, ac, candidate); err != nil {
+		return nil, nil, oops.E(oops.CodeUnexpected, err, "persist hooks api key").LogError(ctx, s.logger)
 	}
 
 	return &gen.DownloadCodexInstallScriptResult{

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -955,7 +955,7 @@ func TestPluginsService_DownloadPluginPackage(t *testing.T) {
 	require.NoError(t, body.Close())
 }
 
-func TestPluginsService_DownloadCodexInstallScriptConfiguresOTELLogs(t *testing.T) {
+func TestPluginsService_DownloadCodexInstallScriptConfiguresOTELSignals(t *testing.T) {
 	t.Parallel()
 
 	mock := &mockGitHubPublisher{}
@@ -985,7 +985,7 @@ func TestPluginsService_DownloadCodexInstallScriptConfiguresOTELLogs(t *testing.
 	require.NoError(t, body.Close())
 
 	scriptText := string(script)
-	require.Contains(t, scriptText, `OTEL_ENDPOINT = "https://app.getgram.ai/rpc/hooks.otel/v1/logs"`)
+	require.Contains(t, scriptText, `OTEL_ENDPOINT_BASE = "https://app.getgram.ai/otel/v1"`)
 	require.Contains(t, scriptText, fmt.Sprintf("OTEL_PROJECT = %q", *authCtx.ProjectSlug))
 	require.Contains(t, scriptText, `OTEL_API_KEY = "gram_local_`)
 }

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -988,6 +991,34 @@ func TestPluginsService_DownloadCodexInstallScriptConfiguresOTELSignals(t *testi
 	require.Contains(t, scriptText, `OTEL_ENDPOINT_BASE = "https://app.getgram.ai/otel/v1"`)
 	require.Contains(t, scriptText, fmt.Sprintf("OTEL_PROJECT = %q", *authCtx.ProjectSlug))
 	require.Contains(t, scriptText, `OTEL_API_KEY = "gram_local_`)
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "codex"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	cmd := exec.CommandContext(t.Context(), "bash")
+	cmd.Stdin = bytes.NewReader(script)
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"CODEX_HOME="+filepath.Join(home, ".codex"),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "run downloaded install script: %s", output)
+
+	config, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	require.NoError(t, err)
+	configText := string(config)
+	require.Contains(t, configText, "[otel]\nenvironment = \"prod\"")
+	for table, signal := range map[string]string{
+		"[otel.exporter.otlp-http]":         "logs",
+		"[otel.trace_exporter.otlp-http]":   "traces",
+		"[otel.metrics_exporter.otlp-http]": "metrics",
+	} {
+		require.Contains(t, configText, table)
+		require.Contains(t, configText, `endpoint = "https://app.getgram.ai/otel/v1/`+signal+`"`)
+	}
 }
 
 func TestPluginsService_AgentPluginCompatibilityIsConsistent(t *testing.T) {

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -952,6 +953,41 @@ func TestPluginsService_DownloadPluginPackage(t *testing.T) {
 	require.Contains(t, result.ContentDisposition, "download-test.zip")
 	require.NotNil(t, body)
 	require.NoError(t, body.Close())
+}
+
+func TestPluginsService_DownloadCodexInstallScriptConfiguresOTELLogs(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.ProjectSlug)
+
+	_, err := pluginsrepo.New(ti.conn).UpsertGitHubConnection(ctx, pluginsrepo.UpsertGitHubConnectionParams{
+		ProjectID:                *authCtx.ProjectID,
+		InstallationID:           12345,
+		RepoOwner:                "test-owner",
+		RepoName:                 "test-marketplace",
+		MarketplaceToken:         conv.ToPGText("marketplace-token"),
+		PublishedMcpFingerprints: []byte(`{}`),
+		PublishedHooksVersion:    pgtype.Text{},
+		PublishedHooksConfig:     nil,
+	})
+	require.NoError(t, err)
+
+	result, body, err := ti.service.DownloadCodexInstallScript(ctx, &gen.DownloadCodexInstallScriptPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "text/x-shellscript", result.ContentType)
+	script, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.NoError(t, body.Close())
+
+	scriptText := string(script)
+	require.Contains(t, scriptText, `OTEL_ENDPOINT = "https://app.getgram.ai/rpc/hooks.otel/v1/logs"`)
+	require.Contains(t, scriptText, fmt.Sprintf("OTEL_PROJECT = %q", *authCtx.ProjectSlug))
+	require.Contains(t, scriptText, `OTEL_API_KEY = "gram_local_`)
 }
 
 func TestPluginsService_AgentPluginCompatibilityIsConsistent(t *testing.T) {


### PR DESCRIPTION
## Summary
- configure downloaded Codex install scripts to send native OpenTelemetry logs, traces, and metrics to Gram with a generated hooks key
- enable Claude Code enhanced telemetry and OTLP trace export in managed setup settings
- use OTLP HTTP/protobuf for both clients, matching Gram's generic ingestion decoder
- preserve existing Codex exporters per signal and cover generated TOML plus the authenticated download path

## Motivation
The observability plugins already capture hook events, but Codex's quick installer does not configure its native OpenTelemetry exporters and Claude tracing remains disabled. This routes native Codex and Claude OTLP signals through Gram's generic telemetry ingestion path.

## Why the endpoint is `/otel`
OTLP exporters treat the configured value as a base URL and append `/v1/logs`, `/v1/metrics`, or `/v1/traces`. Configuring `https://app.getgram.ai/otel` therefore targets Gram's generic `/otel/v1/*` ingestion routes.

The previous `https://app.getgram.ai/rpc/hooks.otel` base was not provider-neutral: `/rpc/hooks.otel/v1/traces` is owned by the legacy LiteLLM trace handler. That handler stamps accepted spans with `hook_source = "litellm"`, the `litellm:otel:traces` resource URN, and LiteLLM tool metadata regardless of the producer's incoming `service.name`. Claude traffic sent there could therefore appear as LiteLLM even though it never traversed a LiteLLM proxy.

The generic `/otel/v1/traces` path preserves the producer's OTLP resource attributes, and downstream source attribution derives from `service.name`, allowing Claude Code telemetry to remain attributed to Claude Code. Claude is configured with `http/protobuf` and Codex with `binary`, so their payloads match these routes' protobuf decoder.