### PR TITLE
chore: color-code filter dimensions in the filter sheet

### DIFF
--- a/client/dashboard/src/components/filters/FilterSheet.tsx
+++ b/client/dashboard/src/components/filters/FilterSheet.tsx
@@ -27,6 +27,12 @@ interface FilterSheetProps {
   optionsById: OptionsById;
   onChange: (id: string, value: FilterValue) => void;
   onClearAll: () => void;
+  /**
+   * Dimension id -> accent color, the same map the chip row uses. Each control
+   * is labeled with its dimension's square so the sheet and the chips read as
+   * the same set of filters.
+   */
+  accents?: Record<string, string>;
   projectSlug?: string;
   /** Arbitrary attribute filters + a page-supplied builder (e.g. LogFilterBar). */
   customFilters?: ActiveLogFilter[];
@@ -48,6 +54,7 @@ export function FilterSheet({
   optionsById,
   onChange,
   onClearAll,
+  accents,
   projectSlug,
   customFilters,
   onEditCustomFilter,
@@ -99,7 +106,15 @@ export function FilterSheet({
         <div className="flex flex-col gap-4 px-4">
           {schema.map((dim) => (
             <div key={dim.id} className="flex flex-col gap-1.5">
-              <label className="text-foreground text-sm font-medium">
+              <label className="text-foreground flex items-center gap-2 text-sm font-medium">
+                <span
+                  aria-hidden="true"
+                  className="size-2 shrink-0"
+                  style={{
+                    backgroundColor:
+                      accents?.[dim.id] ?? "var(--color-muted-foreground)",
+                  }}
+                />
                 {dim.label}
               </label>
               {dim.description && (

--- a/client/dashboard/src/components/ui/Toolbar/index.tsx
+++ b/client/dashboard/src/components/ui/Toolbar/index.tsx
@@ -319,9 +319,14 @@ function ToolbarFilters({
     );
 
   // One brand hue per dimension, keyed on the dimension id so a filter keeps
-  // its color across pages, and de-duplicated within this bar.
+  // its color across pages, and de-duplicated within this bar. Every schema
+  // dimension gets a hue, not just the pilled ones, so the sheet can label
+  // each control with the same swatch its chip carries; pilled dims are asked
+  // for first so the visible bar keeps its colors when a sheet-only filter
+  // becomes active and joins the row.
   const accents = getFilterAccents([
     ...pillDims.map((d) => d.id),
+    ...schema.filter((d) => !pillDims.includes(d)).map((d) => d.id),
     ...customFilters.map((f) => f.path),
   ]);
 
@@ -397,6 +402,7 @@ function ToolbarFilters({
         optionsById={optionsById}
         onChange={onChange}
         onClearAll={onClearAll}
+        accents={accents}
         projectSlug={projectSlug}
         customFilters={customFilters}
         onEditCustomFilter={onEditCustomFilter}


### PR DESCRIPTION
## Summary

- The filter sheet now shows each dimension's accent square beside its label, the same square its chip carries in the toolbar.
- `ToolbarFilters` assigns hues over the whole schema instead of only the pilled dimensions, and passes the map to `FilterSheet` as `accents`. Pilled dimensions are asked for first, so the visible bar keeps its colors when a sheet-only filter becomes active and joins the chip row.

The sheet swatch is always solid — chips fade theirs at a default value, but the control below the label already shows whether the filter is set.

## Motivation

The chip row color-codes filter dimensions, but opening "More filters" dropped that coding entirely: a plain list of labels with no link back to the chip you clicked. Carrying the same square into the sheet ties the two views together, so a chip in the bar and its control in the sheet read as one filter.

https://claude.ai/code/session_01VsndaF58eSqMaQh52yCQrm


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Colors the filter sheet labels with the same accent swatches their chips carry in the toolbar, so a chip and its control in the sheet read as one filter.

- `ToolbarFilters` now assigns a hue to every schema dimension, not just the pilled ones, and passes the map to `FilterSheet` as `accents`.
- Pilled dimensions are requested first so the visible bar keeps its colors when a sheet-only filter becomes active and joins the row.
- Sheet swatches are always solid; chips fade theirs at a default value.

<sup>Written for commit ccfaaa10e6746e117940b04206b9d9eace80ecb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

