### PR TITLE
chore: publish plugins on change instead of every 10s

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1477,9 +1477,18 @@ func newStartCommand() *cli.Command {
 				logger.InfoContext(ctx, "GitHub publishing for plugins: disabled")
 			}
 			// Plugin changes signal a debounced per-project publish rather than
-			// waiting for the hourly rollout sweep to notice them.
-			pluginPublishSignaler := &background.TemporalPluginPublisher{TemporalEnv: temporalEnv}
-			pluginsSvc := plugins.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url"), featureFlags, pluginPublishSignaler)
+			// waiting for the hourly rollout sweep to notice them. Both stay nil
+			// when GitHub publishing is off: the worker has no publisher then, so
+			// an enqueued run could only fail. They are declared as the interface
+			// types on purpose — a typed nil pointer here would read as non-nil
+			// through the interface and defeat the services' own nil guards.
+			var pluginsPublishSignaler plugins.PluginPublishSignaler
+			var skillsPublishSignaler skills.PluginPublishSignaler
+			if pluginsGitHub != nil {
+				publishSignaler := &background.TemporalPluginPublisher{TemporalEnv: temporalEnv}
+				pluginsPublishSignaler, skillsPublishSignaler = publishSignaler, publishSignaler
+			}
+			pluginsSvc := plugins.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url"), featureFlags, pluginsPublishSignaler)
 			plugins.Attach(mux, pluginsSvc)
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine, auditLogger))
 			skillefficacy.Attach(mux, skillefficacy.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger, telemetryrepo.New(chDB)))
@@ -1502,7 +1511,7 @@ func newStartCommand() *cli.Command {
 			}
 			killswitchapi.Attach(mux, killswitchService)
 			skillsService := skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger,
-				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, pluginPublishSignaler, siteURL)
+				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, skillsPublishSignaler, siteURL)
 			skills.Attach(mux, skillsService)
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil)
 			toolsets.Attach(mux, toolsetsSvc)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1476,7 +1476,10 @@ func newStartCommand() *cli.Command {
 			} else {
 				logger.InfoContext(ctx, "GitHub publishing for plugins: disabled")
 			}
-			pluginsSvc := plugins.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url"), featureFlags)
+			// Plugin changes signal a debounced per-project publish rather than
+			// waiting for the hourly rollout sweep to notice them.
+			pluginPublishSignaler := &background.TemporalPluginPublisher{TemporalEnv: temporalEnv}
+			pluginsSvc := plugins.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url"), featureFlags, pluginPublishSignaler)
 			plugins.Attach(mux, pluginsSvc)
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine, auditLogger))
 			skillefficacy.Attach(mux, skillefficacy.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger, telemetryrepo.New(chDB)))
@@ -1499,7 +1502,7 @@ func newStartCommand() *cli.Command {
 			}
 			killswitchapi.Attach(mux, killswitchService)
 			skillsService := skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger,
-				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, siteURL)
+				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, pluginPublishSignaler, siteURL)
 			skills.Attach(mux, skillsService)
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil)
 			toolsets.Attach(mux, toolsetsSvc)

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -20,15 +20,21 @@ import (
 const (
 	pluginGeneratorRolloutScheduleID = "v1:plugin-generator-rollout-schedule"
 	pluginGeneratorRolloutWorkflowID = pluginGeneratorRolloutScheduleID + "/scheduled"
-	// The schedule cadence determines how long a generator or plugin-config
-	// change takes to propagate, since nothing else triggers the rollout. The
-	// fingerprint check keeps unchanged projects from doing any GitHub/key work,
-	// so each tick is cheap apart from the per-project scan (resolve + in-memory
-	// generate + fingerprint compare). SKIP overlap (below) gives us the
-	// "trigger every interval unless one is already running" behaviour without a
-	// separate triggering workflow: a run that outlasts the interval just defers
-	// the next tick.
-	pluginGeneratorRolloutInterval         = 10 * time.Second
+	// This sweep is the safety net, not the primary trigger: plugin and plugin
+	// membership changes signal a per-project publish directly (see
+	// plugin_publish.go), so the cadence here only bounds how long a change with
+	// NO database write takes to propagate — a hooks generator-version bump or a
+	// hooks-rollout pin advance in PostHog, neither of which any callsite can
+	// signal. At 10s this workflow dominated the Temporal action bill for work
+	// that was a no-op on almost every tick.
+	//
+	// The fingerprint check keeps unchanged projects from doing any GitHub/key
+	// work, so each tick is cheap apart from the per-project scan (resolve +
+	// in-memory generate + fingerprint compare). SKIP overlap (below) gives us
+	// the "trigger every interval unless one is already running" behaviour
+	// without a separate triggering workflow: a run that outlasts the interval
+	// just defers the next tick.
+	pluginGeneratorRolloutInterval         = 1 * time.Hour
 	pluginGeneratorRolloutDefaultBatchSize = int32(100)
 	pluginGeneratorRolloutConcurrency      = 5
 )

--- a/server/internal/background/plugin_initial_publish.go
+++ b/server/internal/background/plugin_initial_publish.go
@@ -1,36 +1,21 @@
 package background
 
 import (
-	"context"
 	"fmt"
 	"time"
 
-	"go.temporal.io/api/enums/v1"
-	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	"github.com/speakeasy-api/gram/server/internal/plugins"
-	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
-// ExecutePluginInitialPublishWorkflow kicks off the first-time GitHub publish
-// for a newly created project's Default plugin. The rollout schedule (see
-// plugin_generator_rollout.go) only republishes projects that already have a
-// GitHub connection, so a brand new project needs this one-shot trigger to
-// get its marketplace repo without waiting on a human to click Publish.
-func ExecutePluginInitialPublishWorkflow(ctx context.Context, temporalEnv *tenv.Environment, input plugins.PublishProjectInput) (client.WorkflowRun, error) {
-	return temporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                    fmt.Sprintf("v1:plugin-initial-publish/%s", input.ProjectID),
-		TaskQueue:             string(temporalEnv.Queue()),
-		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		// Must exceed the activity's worst-case retry budget (3 attempts x
-		// 5m StartToCloseTimeout + backoff ~= 16m), or the workflow can expire
-		// mid-retry and drop the final result.
-		WorkflowRunTimeout: 20 * time.Minute,
-	}, PluginInitialPublishWorkflow, input)
-}
-
+// Deprecated: PluginInitialPublishWorkflow is superseded by
+// PluginPublishWorkflowDebounced (see plugin_publish.go), which serializes and
+// debounces every publish for a project under one workflow ID instead of
+// racing a fresh execution per trigger. Nothing starts this any more; it stays
+// registered for one release so executions in flight across the deploy can
+// finish, and can be deleted once none are running.
 func PluginInitialPublishWorkflow(ctx workflow.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 5 * time.Minute,

--- a/server/internal/background/plugin_publish.go
+++ b/server/internal/background/plugin_publish.go
@@ -1,0 +1,165 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	domainskills "github.com/speakeasy-api/gram/server/internal/skills"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+// pluginPublishForceSignal is the signal payload that upgrades a pending run to
+// a forced publish. Any other payload leaves the run's SkipIfUnchanged as the
+// starter set it, so a burst of ordinary change signals stays a cheap
+// fingerprint check while a first publish (which has no fingerprint to compare
+// against) still republishes unconditionally.
+const pluginPublishForceSignal = "force"
+
+// PluginPublishParams identifies the project to publish. One debounce key per
+// project: every publish trigger for a project — a new plugin, a server or
+// skill added to one, a project's first publish — lands on the same execution,
+// so concurrent triggers can never race two publishes against the same GitHub
+// repo.
+type PluginPublishParams struct {
+	ProjectID       uuid.UUID
+	CreatedByUserID string
+	CommitMessage   string
+	// SkipIfUnchanged short-circuits the publish when the project's fingerprint
+	// matches what was last published. Change triggers set it (the publish is
+	// only worth doing if the generated output actually moved); a project's
+	// first publish clears it.
+	SkipIfUnchanged bool
+}
+
+func pluginPublishWorkflowID(params PluginPublishParams) string {
+	return fmt.Sprintf("v1:plugin-publish:%s", params.ProjectID)
+}
+
+func pluginPublishDebounceSignal(params PluginPublishParams) string {
+	return fmt.Sprintf("%s/signal", pluginPublishWorkflowID(params))
+}
+
+// ExecutePluginPublishWorkflowDebounced is the entry point for every
+// change-driven publish. It replaces waiting on the rollout sweep (see
+// plugin_generator_rollout.go, now an hourly safety net): a plugin or plugin
+// membership change signals the publish for its own project directly.
+//
+// Must only be called after the triggering transaction has committed —
+// enqueuing before commit risks Temporal publishing state that a later failure
+// in the same transaction rolls back.
+func ExecutePluginPublishWorkflowDebounced(ctx context.Context, temporalEnv *tenv.Environment, params PluginPublishParams) (client.WorkflowRun, error) {
+	id := pluginPublishWorkflowID(params)
+
+	message := "enqueue"
+	if !params.SkipIfUnchanged {
+		message = pluginPublishForceSignal
+	}
+
+	run, err := temporalEnv.Client().SignalWithStartWorkflow(
+		ctx,
+		id,
+		pluginPublishDebounceSignal(params),
+		message,
+		client.StartWorkflowOptions{
+			ID:                       id,
+			TaskQueue:                string(temporalEnv.Queue()),
+			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIDConflictPolicy: enums.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+			// Must exceed the activity's worst-case retry budget (3 attempts x
+			// 5m StartToCloseTimeout + backoff ~= 16m), or the workflow can
+			// expire mid-retry and drop the final result.
+			WorkflowRunTimeout: 20 * time.Minute,
+			// StartDelay is the debounce coalescing window. A single dashboard
+			// interaction fans out into several writes (create a plugin, add a
+			// server, add a skill), and each publish is a GitHub commit plus a
+			// fresh API key, so batching them is worth a few seconds of latency.
+			StartDelay: 10 * time.Second,
+		},
+		PluginPublishWorkflowDebounced,
+		params,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("signal with start plugin publish workflow: %w", err)
+	}
+	return run, nil
+}
+
+// PluginPublishWorkflowDebounced is the registered workflow. Signals that
+// arrive while a publish is in flight (another change landing mid-publish)
+// coalesce into exactly one follow-up run rather than being dropped, so the
+// repo always converges on the state that exists after the last change.
+func PluginPublishWorkflowDebounced(ctx workflow.Context, params PluginPublishParams) (*plugins.PublishProjectResult, error) {
+	return DebounceWithSignalCoalescing(
+		PluginPublishWorkflow,
+		PluginPublishWorkflowDebounced,
+		pluginPublishDebounceSignal,
+		func(PluginPublishParams, *plugins.PublishProjectResult) bool { return false },
+		func(params PluginPublishParams, message string) PluginPublishParams {
+			// A forced trigger folded into a pending run wins: skipping it would
+			// strand the publish that needed to happen regardless of fingerprint.
+			if message == pluginPublishForceSignal {
+				params.SkipIfUnchanged = false
+			}
+			return params
+		},
+	)(ctx, params)
+}
+
+// PluginPublishWorkflow runs one publish. It must not issue its own
+// ContinueAsNew — continuation is owned by the Debounce wrapper.
+func PluginPublishWorkflow(ctx workflow.Context, params PluginPublishParams) (*plugins.PublishProjectResult, error) {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    1 * time.Minute,
+		},
+	})
+
+	var a *Activities
+	var result plugins.PublishProjectResult
+	if err := workflow.ExecuteActivity(ctx, a.PublishPluginProject, plugins.PublishProjectInput{
+		ProjectID:       params.ProjectID,
+		CreatedByUserID: params.CreatedByUserID,
+		CommitMessage:   params.CommitMessage,
+		SkipIfUnchanged: params.SkipIfUnchanged,
+	}).Get(ctx, &result); err != nil {
+		return nil, fmt.Errorf("publish plugin project: %w", err)
+	}
+	return &result, nil
+}
+
+// TemporalPluginPublisher implements plugins.PluginPublishSignaler (and the
+// identical skills.PluginPublishSignaler — skills cannot import plugins) by
+// signal-with-starting the debounced per-project publish workflow.
+type TemporalPluginPublisher struct {
+	TemporalEnv *tenv.Environment
+}
+
+var _ plugins.PluginPublishSignaler = (*TemporalPluginPublisher)(nil)
+var _ domainskills.PluginPublishSignaler = (*TemporalPluginPublisher)(nil)
+
+// SignalPluginPublish enqueues a fingerprint-gated republish: the caller
+// changed plugin state, so the publish is worth attempting, but it does no
+// GitHub work if the generated output turns out to be unchanged.
+func (p *TemporalPluginPublisher) SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error {
+	if _, err := ExecutePluginPublishWorkflowDebounced(ctx, p.TemporalEnv, PluginPublishParams{
+		ProjectID:       projectID,
+		CreatedByUserID: createdByUserID,
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	}); err != nil {
+		return fmt.Errorf("signal plugin publish: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/plugin_publish.go
+++ b/server/internal/background/plugin_publish.go
@@ -3,6 +3,7 @@ package background
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,6 +12,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	domainskills "github.com/speakeasy-api/gram/server/internal/skills"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
@@ -22,6 +24,11 @@ import (
 // fingerprint check while a first publish (which has no fingerprint to compare
 // against) still republishes unconditionally.
 const pluginPublishForceSignal = "force"
+
+// pluginPublishEnqueueTimeout bounds the signal-with-start RPC. Enqueuing runs
+// inline on a request that has already committed, so it must fail fast rather
+// than hold the response open through a Temporal outage.
+const pluginPublishEnqueueTimeout = 10 * time.Second
 
 // PluginPublishParams identifies the project to publish. One debounce key per
 // project: every publish trigger for a project — a new plugin, a server or
@@ -56,6 +63,13 @@ func pluginPublishDebounceSignal(params PluginPublishParams) string {
 // enqueuing before commit risks Temporal publishing state that a later failure
 // in the same transaction rolls back.
 func ExecutePluginPublishWorkflowDebounced(ctx context.Context, temporalEnv *tenv.Environment, params PluginPublishParams) (client.WorkflowRun, error) {
+	// Callers enqueue after commit on a non-cancelable context so the request
+	// returning can't drop the signal, which leaves this RPC with no deadline
+	// of its own: bound it here, or a Temporal outage blocks the mutation
+	// request indefinitely instead of failing the best-effort enqueue.
+	ctx, cancel := context.WithTimeout(ctx, pluginPublishEnqueueTimeout)
+	defer cancel()
+
 	id := pluginPublishWorkflowID(params)
 
 	message := "enqueue"
@@ -162,4 +176,35 @@ func (p *TemporalPluginPublisher) SignalPluginPublish(ctx context.Context, proje
 		return fmt.Errorf("signal plugin publish: %w", err)
 	}
 	return nil
+}
+
+// TriggerPluginPublish enqueues the marketplace publish for a project whose
+// plugin membership just changed, shared by the mutation services (toolsets,
+// mcpservers, mcpendpoints, projects) so those paths cannot drift apart in how
+// they publish. A lazily created Default plugin (or a project's first publish)
+// passes force: there is no prior fingerprint to compare against and the repo
+// may not exist yet. Otherwise the publish is fingerprint-gated and does no
+// GitHub work when the generated output is unchanged.
+//
+// Must only be called after the triggering transaction has committed —
+// enqueuing before commit risks publishing state that a later failure in the
+// same transaction rolls back. Best-effort: the enqueue is logged and never
+// fails the request, since the rollout sweep still picks the project up on its
+// next tick.
+func TriggerPluginPublish(ctx context.Context, temporalEnv *tenv.Environment, logger *slog.Logger, projectID uuid.UUID, createdByUserID string, force bool) {
+	commitMessage := "Update plugin packages"
+	if force {
+		commitMessage = "Initial marketplace publish"
+	}
+
+	// The request returning shouldn't drop the enqueue.
+	if _, err := ExecutePluginPublishWorkflowDebounced(context.WithoutCancel(ctx), temporalEnv, PluginPublishParams{
+		ProjectID:       projectID,
+		CreatedByUserID: createdByUserID,
+		CommitMessage:   commitMessage,
+		SkipIfUnchanged: !force,
+	}); err != nil {
+		logger.WarnContext(ctx, "failed to enqueue plugin publish",
+			attr.SlogProjectID(projectID.String()), attr.SlogError(err))
+	}
 }

--- a/server/internal/background/plugin_publish_test.go
+++ b/server/internal/background/plugin_publish_test.go
@@ -1,0 +1,230 @@
+package background
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+)
+
+func TestPluginPublishWorkflowID(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	params := PluginPublishParams{ProjectID: projectID, CreatedByUserID: "", CommitMessage: "", SkipIfUnchanged: true}
+
+	// One workflow ID per project (and nothing else): every trigger for a
+	// project must land on the same execution, or two publishes race the same
+	// GitHub repo.
+	require.Equal(t, "v1:plugin-publish:00000000-0000-0000-0000-0000000000aa", pluginPublishWorkflowID(params))
+	require.Equal(t, "v1:plugin-publish:00000000-0000-0000-0000-0000000000aa/signal", pluginPublishDebounceSignal(params))
+
+	other := params
+	other.CommitMessage = "Initial marketplace publish"
+	other.SkipIfUnchanged = false
+	require.Equal(t, pluginPublishWorkflowID(params), pluginPublishWorkflowID(other))
+}
+
+// recordPublishInputs captures the activity inputs a publish workflow run sends.
+type recordPublishInputs struct {
+	mu     sync.Mutex
+	inputs []plugins.PublishProjectInput
+}
+
+func (r *recordPublishInputs) register(env *testsuite.TestWorkflowEnvironment, skipped bool) {
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			r.mu.Lock()
+			r.inputs = append(r.inputs, input)
+			r.mu.Unlock()
+			return &plugins.PublishProjectResult{RepoURL: "https://github.com/test-org/repo", Skipped: skipped}, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+}
+
+func (r *recordPublishInputs) captured() []plugins.PublishProjectInput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]plugins.PublishProjectInput(nil), r.inputs...)
+}
+
+func TestPluginPublishWorkflow_PassesParamsToActivity(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	recorder := &recordPublishInputs{mu: sync.Mutex{}, inputs: nil}
+	recorder.register(env, true)
+
+	projectID := uuid.New()
+	env.ExecuteWorkflow(PluginPublishWorkflow, PluginPublishParams{
+		ProjectID:       projectID,
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result plugins.PublishProjectResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.True(t, result.Skipped)
+
+	require.Equal(t, []plugins.PublishProjectInput{{
+		ProjectID:       projectID,
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	}}, recorder.captured())
+}
+
+func TestPluginPublishWorkflowDebounced_CompletesWithoutSignals(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	recorder := &recordPublishInputs{mu: sync.Mutex{}, inputs: nil}
+	recorder.register(env, true)
+
+	env.ExecuteWorkflow(PluginPublishWorkflowDebounced, PluginPublishParams{
+		ProjectID:       uuid.New(),
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	// A lone change trigger publishes exactly once and stops — no
+	// ContinueAsNew, so an idle project costs one run per burst of changes.
+	require.Len(t, recorder.captured(), 1)
+}
+
+func TestPluginPublishWorkflowDebounced_CoalescesSignalArrivingDuringRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	params := PluginPublishParams{
+		ProjectID:       uuid.New(),
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	}
+
+	// Signal from inside the activity so the signals provably land mid-publish
+	// (a delayed callback races the mocked activity's instant return). Two
+	// changes landing mid-publish must produce exactly one follow-up run, not
+	// one per change: the repo only has to converge on the final state.
+	var runs int
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			runs++
+			if runs == 1 {
+				env.SignalWorkflow(pluginPublishDebounceSignal(params), "enqueue")
+				env.SignalWorkflow(pluginPublishDebounceSignal(params), "enqueue")
+			}
+			return &plugins.PublishProjectResult{RepoURL: "https://github.com/test-org/repo", Skipped: true}, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginPublishWorkflowDebounced, params)
+
+	require.True(t, env.IsWorkflowCompleted())
+
+	// ContinueAsNew must target the wrapper, not the inner workflow, or the
+	// follow-up run loses debounce semantics.
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "PluginPublishWorkflowDebounced", canErr.WorkflowType.Name)
+
+	require.Equal(t, 1, runs, "the two signals coalesce into a single follow-up run")
+}
+
+func TestPluginPublishWorkflowDebounced_ForceSignalUpgradesPendingRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	params := PluginPublishParams{
+		ProjectID:       uuid.New(),
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	}
+
+	// A forced publish (a project's first, which has no fingerprint to compare
+	// against) folded into a pending fingerprint-gated run must win: otherwise
+	// the publish that had to happen gets skipped.
+	var runs int
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			runs++
+			if runs == 1 {
+				env.SignalWorkflow(pluginPublishDebounceSignal(params), pluginPublishForceSignal)
+			}
+			return &plugins.PublishProjectResult{RepoURL: "https://github.com/test-org/repo", Skipped: true}, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginPublishWorkflowDebounced, params)
+
+	require.True(t, env.IsWorkflowCompleted())
+
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+
+	var next PluginPublishParams
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(canErr.Input, &next))
+	require.False(t, next.SkipIfUnchanged, "the forced signal must clear SkipIfUnchanged on the next run")
+	require.Equal(t, params.ProjectID, next.ProjectID)
+}
+
+func TestPluginPublishWorkflowDebounced_StarterForceSignalAppliesToFirstRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	recorder := &recordPublishInputs{mu: sync.Mutex{}, inputs: nil}
+	recorder.register(env, false)
+
+	// SignalWithStartWorkflow delivers its own signal to the run it starts, so
+	// a fingerprint-gated starter that is immediately forced publishes
+	// unconditionally rather than deferring the force to a second run.
+	params := PluginPublishParams{
+		ProjectID:       uuid.New(),
+		CreatedByUserID: "user_01HZ",
+		CommitMessage:   "Initial marketplace publish",
+		SkipIfUnchanged: true,
+	}
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(pluginPublishDebounceSignal(params), pluginPublishForceSignal)
+	}, 0)
+
+	env.ExecuteWorkflow(PluginPublishWorkflowDebounced, params)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	captured := recorder.captured()
+	require.Len(t, captured, 1)
+	require.False(t, captured[0].SkipIfUnchanged)
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -616,6 +616,11 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(PublishOutboxWorkflow)
 	temporalWorker.RegisterWorkflow(PublishOutboxGCWorkflow)
 	temporalWorker.RegisterWorkflow(PluginGeneratorRolloutWorkflow)
+	temporalWorker.RegisterWorkflow(PluginPublishWorkflow)
+	temporalWorker.RegisterWorkflow(PluginPublishWorkflowDebounced)
+	// Deprecated: superseded by PluginPublishWorkflowDebounced. Kept registered
+	// for one release so executions in flight across the deploy can finish;
+	// nothing starts it any more. Safe to delete once none are running.
 	temporalWorker.RegisterWorkflow(PluginInitialPublishWorkflow)
 	// Spend rule evaluation workflows
 	temporalWorker.RegisterWorkflow(SessionQuarantineReassertWorkflow)

--- a/server/internal/mcpendpoints/createmcpendpoint_test.go
+++ b/server/internal/mcpendpoints/createmcpendpoint_test.go
@@ -438,7 +438,7 @@ func TestCreateMcpEndpoint_LegacyProject_TriggersInitialPublish(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	workflowID := fmt.Sprintf("v1:plugin-initial-publish/%s", authCtx.ProjectID.String())
+	workflowID := fmt.Sprintf("v1:plugin-publish:%s", authCtx.ProjectID.String())
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	require.NoError(t, temporalEnv.Client().GetWorkflow(waitCtx, workflowID, "").Get(waitCtx, nil), "initial publish workflow did not complete")

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -226,7 +226,7 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
 
 	return mv.BuildMcpEndpointView(created), nil
 }
@@ -267,25 +267,34 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 	return pluginCreated, nil
 }
 
-// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
-// publish for a project whose Default plugin was just lazily created. Must
-// only be called after the triggering transaction has committed — enqueuing
-// before commit risks Temporal running against state that a later failure
-// in the same transaction rolls back. Best-effort: a non-cancelable ctx
-// since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !pluginCreated || !s.pluginsGitHubEnabled {
+// triggerPluginPublish enqueues the marketplace publish for the project whose
+// Default plugin membership just changed. A lazily created Default plugin
+// (project predates the feature) forces the publish: there is no prior
+// fingerprint to compare against, and the repo itself may not exist yet.
+// Otherwise the attach may well have been a no-op, so the publish is
+// fingerprint-gated and does no GitHub work when the generated output is
+// unchanged. Must only be called after the triggering transaction has
+// committed — enqueuing before commit risks Temporal running against state
+// that a later failure in the same transaction rolls back. Best-effort: a
+// non-cancelable ctx since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !s.pluginsGitHubEnabled {
 		return
 	}
 
+	commitMessage := "Update plugin packages"
+	if pluginCreated {
+		commitMessage = "Initial marketplace publish"
+	}
+
 	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
 		ProjectID:       *authCtx.ProjectID,
 		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   "Initial marketplace publish",
-		SkipIfUnchanged: false,
+		CommitMessage:   commitMessage,
+		SkipIfUnchanged: !pluginCreated,
 	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
 	}
 }
 

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -214,9 +214,9 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 
 	// Meta-MCP-backed endpoints never participate in default-plugin attachment
 	// or marketplace publishing; that flow is exclusive to generic MCP servers.
-	var pluginCreated bool
+	attached, pluginCreated := false, false
 	if mcpServerID.Valid {
-		pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, mcpServerID.UUID)
+		attached, pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, mcpServerID.UUID)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +226,7 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, attached, pluginCreated)
 
 	return mv.BuildMcpEndpointView(created), nil
 }
@@ -241,16 +241,16 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 // callers should enqueue an initial publish for it, but only after their
 // own transaction commits, since this runs pre-commit and the DB writes
 // could still roll back.
-func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, mcpServerID uuid.UUID) (bool, error) {
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, mcpServerID uuid.UUID) (bool, bool, error) {
 	server, err := mcpserversrepo.New(dbtx).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
 		ID:        mcpServerID,
 		ProjectID: *authCtx.ProjectID,
 	})
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
+		return false, false, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, s.logger)
 	}
 	if server.Visibility == mcpservers.VisibilityDisabled {
-		return false, nil
+		return false, false, nil
 	}
 
 	pluginCreated, err := plugins.AttachToDefaultPluginAudited(ctx, dbtx, s.audit, authCtx, plugins.AttachToDefaultPluginParams{
@@ -261,41 +261,25 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		DisplayName:    mcpservers.ServerDisplayName(server),
 	})
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
+		return false, false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
 	}
 
-	return pluginCreated, nil
+	return true, pluginCreated, nil
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. A lazily created Default plugin
-// (project predates the feature) forces the publish: there is no prior
-// fingerprint to compare against, and the repo itself may not exist yet.
-// Otherwise the attach may well have been a no-op, so the publish is
-// fingerprint-gated and does no GitHub work when the generated output is
-// unchanged. Must only be called after the triggering transaction has
-// committed — enqueuing before commit risks Temporal running against state
-// that a later failure in the same transaction rolls back. Best-effort: a
-// non-cancelable ctx since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !s.pluginsGitHubEnabled {
+// Default plugin membership just changed. attached is false when the mutation
+// could not have changed generated plugin output (a Meta-MCP endpoint, a
+// non-MCP toolset, a disabled or endpointless server): those paths must not
+// enqueue at all, since a project with no GitHub connection yet treats any
+// publish as its first and would get a marketplace repo it has no packages
+// for.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
+	if !attached || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	commitMessage := "Update plugin packages"
-	if pluginCreated {
-		commitMessage = "Initial marketplace publish"
-	}
-
-	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
-		ProjectID:       *authCtx.ProjectID,
-		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   commitMessage,
-		SkipIfUnchanged: !pluginCreated,
-	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
-	}
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
 }
 
 func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpointPayload) (*types.McpEndpoint, error) {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -750,7 +750,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
 	if err := s.reconcileMcpServerCustomDomains(ctx, clearedRootDomainIDs); err != nil {
 		return nil, err
 	}
@@ -794,25 +794,34 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 	return pluginCreated, nil
 }
 
-// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
-// publish for a project whose Default plugin was just lazily created. Must
-// only be called after the triggering transaction has committed — enqueuing
-// before commit risks Temporal running against state that a later failure
-// in the same transaction rolls back. Best-effort: a non-cancelable ctx
-// since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !pluginCreated || !s.pluginsGitHubEnabled {
+// triggerPluginPublish enqueues the marketplace publish for the project whose
+// Default plugin membership just changed. A lazily created Default plugin
+// (project predates the feature) forces the publish: there is no prior
+// fingerprint to compare against, and the repo itself may not exist yet.
+// Otherwise the attach may well have been a no-op, so the publish is
+// fingerprint-gated and does no GitHub work when the generated output is
+// unchanged. Must only be called after the triggering transaction has
+// committed — enqueuing before commit risks Temporal running against state
+// that a later failure in the same transaction rolls back. Best-effort: a
+// non-cancelable ctx since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !s.pluginsGitHubEnabled {
 		return
 	}
 
+	commitMessage := "Update plugin packages"
+	if pluginCreated {
+		commitMessage = "Initial marketplace publish"
+	}
+
 	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
 		ProjectID:       *authCtx.ProjectID,
 		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   "Initial marketplace publish",
-		SkipIfUnchanged: false,
+		CommitMessage:   commitMessage,
+		SkipIfUnchanged: !pluginCreated,
 	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
 	}
 }
 

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -750,7 +750,12 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, attached, pluginCreated)
+	// A server that was already enabled is already a Default-plugin member, so
+	// renaming it (its display name is generated into the package) or disabling
+	// it (it drops out of the package) has to publish too — not just the
+	// enable transition this block attaches. A server disabled before and
+	// after contributes nothing either way and stays silent.
+	s.triggerPluginPublish(ctx, authCtx, attached || existing.Visibility != VisibilityDisabled, pluginCreated)
 	if err := s.reconcileMcpServerCustomDomains(ctx, clearedRootDomainIDs); err != nil {
 		return nil, err
 	}

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -738,9 +738,9 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// remote MCP flow pre-stages an endpoint while the server is parked
 	// disabled for auth configuration, so enabling is what completes
 	// publishability there).
-	pluginCreated := false
+	attached, pluginCreated := false, false
 	if existing.Visibility == VisibilityDisabled && updated.Visibility != VisibilityDisabled {
-		pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, updated)
+		attached, pluginCreated, err = s.attachToDefaultPlugin(ctx, dbtx, authCtx, updated)
 		if err != nil {
 			return nil, err
 		}
@@ -750,7 +750,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, attached, pluginCreated)
 	if err := s.reconcileMcpServerCustomDomains(ctx, clearedRootDomainIDs); err != nil {
 		return nil, err
 	}
@@ -764,20 +764,22 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 // publishability check: a server with no live endpoint isn't publishable and
 // is skipped (mcpendpoints.CreateMcpEndpoint attaches it later when it gets
 // its first endpoint while enabled). Already-attached servers are an
-// idempotent no-op. Returns pluginCreated=true if this call lazily created
-// the Default plugin (project predates the feature) — callers should enqueue
-// an initial publish for it, but only after their own transaction commits,
-// since this runs pre-commit and the DB writes could still roll back.
-func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, server repo.McpServer) (bool, error) {
+// idempotent no-op. Returns attached=true when the server is now a member of
+// the Default plugin (so a publish is worth enqueuing) and pluginCreated=true
+// if this call lazily created that plugin (project predates the feature) —
+// callers should enqueue the publish for it, but only after their own
+// transaction commits, since this runs pre-commit and the DB writes could
+// still roll back.
+func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCtx *contextvalues.AuthContext, server repo.McpServer) (bool, bool, error) {
 	endpoints, err := mcpendpointsrepo.New(dbtx).ListMCPEndpointsByMCPServerID(ctx, mcpendpointsrepo.ListMCPEndpointsByMCPServerIDParams{
 		ProjectID:   *authCtx.ProjectID,
 		McpServerID: server.ID,
 	})
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "list mcp server endpoints").LogError(ctx, s.logger)
+		return false, false, oops.E(oops.CodeUnexpected, err, "list mcp server endpoints").LogError(ctx, s.logger)
 	}
 	if len(endpoints) == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	pluginCreated, err := plugins.AttachToDefaultPluginAudited(ctx, dbtx, s.audit, authCtx, plugins.AttachToDefaultPluginParams{
@@ -788,41 +790,25 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 		DisplayName:    ServerDisplayName(server),
 	})
 	if err != nil {
-		return false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
+		return false, false, oops.E(oops.CodeUnexpected, err, "attach mcp server to default plugin").LogError(ctx, s.logger)
 	}
 
-	return pluginCreated, nil
+	return true, pluginCreated, nil
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. A lazily created Default plugin
-// (project predates the feature) forces the publish: there is no prior
-// fingerprint to compare against, and the repo itself may not exist yet.
-// Otherwise the attach may well have been a no-op, so the publish is
-// fingerprint-gated and does no GitHub work when the generated output is
-// unchanged. Must only be called after the triggering transaction has
-// committed — enqueuing before commit risks Temporal running against state
-// that a later failure in the same transaction rolls back. Best-effort: a
-// non-cancelable ctx since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !s.pluginsGitHubEnabled {
+// Default plugin membership just changed. attached is false when the mutation
+// could not have changed generated plugin output (a Meta-MCP endpoint, a
+// non-MCP toolset, a disabled or endpointless server): those paths must not
+// enqueue at all, since a project with no GitHub connection yet treats any
+// publish as its first and would get a marketplace repo it has no packages
+// for.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
+	if !attached || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	commitMessage := "Update plugin packages"
-	if pluginCreated {
-		commitMessage = "Initial marketplace publish"
-	}
-
-	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
-		ProjectID:       *authCtx.ProjectID,
-		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   commitMessage,
-		SkipIfUnchanged: !pluginCreated,
-	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
-	}
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
 }
 
 // ServerDisplayName derives a default plugin-server display name from an

--- a/server/internal/platformmcp/skills_integration_test.go
+++ b/server/internal/platformmcp/skills_integration_test.go
@@ -270,7 +270,7 @@ func newSkillsVerticalFixture(t *testing.T, ctx context.Context, name string, op
 	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
 	siteURL, err := url.Parse("https://app.getgram.test")
 	require.NoError(t, err)
-	skills := skillsservice.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), nil, siteURL)
+	skills := skillsservice.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), nil, nil, siteURL)
 
 	_, err = featurerepo.New(conn).EnableFeature(ctx, featurerepo.EnableFeatureParams{
 		OrganizationID: principal.OrganizationID,

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -162,6 +162,11 @@ type Service struct {
 	// eligible and carry their existing hooks — so a missing provider can never
 	// force-advance an org.
 	features feature.Provider
+	// publisher enqueues the republish that propagates a plugin change to the
+	// project's marketplace repo. Nil on the automated publisher (which is
+	// itself the thing doing the publishing) and in tests; signalPublish is a
+	// no-op then.
+	publisher PluginPublishSignaler
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -179,6 +184,7 @@ func NewService(
 	env string,
 	serverURL string,
 	features feature.Provider,
+	publisher PluginPublishSignaler,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("plugins"))
 
@@ -198,7 +204,8 @@ func NewService(
 		// rename via UpdateMarketplaceSettings, browser-login toggle via
 		// productfeatures) on the phased hooks rollout, mirroring the automated
 		// publisher. Fail-closed when nil: non-canary orgs defer those changes.
-		features: features,
+		features:  features,
+		publisher: publisher,
 	}
 }
 
@@ -226,6 +233,8 @@ func NewPublisher(
 		serverURL: serverURL,
 		keyPrefix: auth.APIKeyPrefix(env),
 		features:  features,
+		// The publisher runs the publish workflow itself; it never signals one.
+		publisher: nil,
 	}
 }
 
@@ -510,6 +519,8 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return pluginToGen(plugin, nil, nil, classifyAgentPlugin(PluginInfo{
 		Name: plugin.Name, Slug: plugin.Slug, Description: conv.FromPGTextOrEmpty[string](plugin.Description), Servers: nil, Skills: nil, AgentPluginsV1Issues: nil,
 	}).Compatible), nil
@@ -600,6 +611,8 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 	if err := tx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
+
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
 
 	servers, err := s.repo.ListPluginServers(ctx, pluginID)
 	if err != nil {
@@ -727,6 +740,9 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 	if err := tx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
+
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return nil
 }
 
@@ -861,6 +877,8 @@ func (s *Service) AddPluginServer(ctx context.Context, payload *gen.AddPluginSer
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return pluginServerToGen(row), nil
 }
 
@@ -990,6 +1008,8 @@ func (s *Service) UpdatePluginServer(ctx context.Context, payload *gen.UpdatePlu
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return pluginServerToGen(row), nil
 }
 
@@ -1058,6 +1078,9 @@ func (s *Service) RemovePluginServer(ctx context.Context, payload *gen.RemovePlu
 	if err := tx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
+
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return nil
 }
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -369,6 +369,12 @@ func (s *Service) ensureDefaultPlugin(ctx context.Context, ac *contextvalues.Aut
 	if err := tx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
+
+	// A legacy project gets its Default plugin here, on a read. That is a
+	// change to what a publish would generate like any other, so it signals
+	// too rather than waiting out the rollout sweep.
+	s.signalPublish(ctx, *ac.ProjectID, ac.UserID)
+
 	return nil
 }
 

--- a/server/internal/plugins/publish_signal.go
+++ b/server/internal/plugins/publish_signal.go
@@ -31,6 +31,7 @@ func (s *Service) signalPublish(ctx context.Context, projectID uuid.UUID, create
 
 	// The request returning shouldn't drop the enqueue.
 	if err := s.publisher.SignalPluginPublish(context.WithoutCancel(ctx), projectID, createdByUserID); err != nil {
-		s.logger.WarnContext(ctx, "failed to signal plugin publish", attr.SlogError(err))
+		s.logger.WarnContext(ctx, "failed to signal plugin publish",
+			attr.SlogProjectID(projectID.String()), attr.SlogError(err))
 	}
 }

--- a/server/internal/plugins/publish_signal.go
+++ b/server/internal/plugins/publish_signal.go
@@ -1,0 +1,36 @@
+package plugins
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// PluginPublishSignaler enqueues a republish of a project's marketplace
+// packages. Plugin state changes (a new plugin, a server or skill added to
+// one) change what a publish would generate, so every mutation signals its own
+// project instead of waiting for the periodic rollout sweep to notice.
+//
+// Implemented by background.TemporalPluginPublisher. The signal is debounced
+// per project, so a burst of changes collapses into one publish.
+type PluginPublishSignaler interface {
+	SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error
+}
+
+// signalPublish enqueues a republish for the project whose plugins just
+// changed. Best-effort: a failed enqueue is logged and never fails the request,
+// since the rollout sweep still picks the project up on its next tick. Must
+// only be called after the triggering transaction has committed — the publish
+// reads the project's live state, which a later rollback would take back.
+func (s *Service) signalPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) {
+	if s.publisher == nil || s.github == nil {
+		return
+	}
+
+	// The request returning shouldn't drop the enqueue.
+	if err := s.publisher.SignalPluginPublish(context.WithoutCancel(ctx), projectID, createdByUserID); err != nil {
+		s.logger.WarnContext(ctx, "failed to signal plugin publish", attr.SlogError(err))
+	}
+}

--- a/server/internal/plugins/publish_signal_test.go
+++ b/server/internal/plugins/publish_signal_test.go
@@ -63,3 +63,21 @@ func TestPluginsService_MutationsSignalRepublish(t *testing.T) {
 	require.NoError(t, ti.service.DeletePlugin(ctx, &gen.DeletePluginPayload{ID: plugin.ID}))
 	assertSignalled(t, 6, "deleting a plugin")
 }
+
+// ListPlugins lazily provisions the Default plugin for a project that predates
+// it. That changes what a publish would generate, so it must signal like any
+// explicit mutation — and must not keep signalling once the plugin exists.
+func TestPluginsService_LazyDefaultPluginSignalsRepublish(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+
+	_, err := ti.service.ListPlugins(ctx, &gen.ListPluginsPayload{SessionToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+	require.Len(t, ti.publisher.captured(), 1, "lazily creating the Default plugin should enqueue a republish")
+
+	_, err = ti.service.ListPlugins(ctx, &gen.ListPluginsPayload{SessionToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+	require.Len(t, ti.publisher.captured(), 1, "a read that creates nothing must not enqueue")
+}

--- a/server/internal/plugins/publish_signal_test.go
+++ b/server/internal/plugins/publish_signal_test.go
@@ -1,0 +1,65 @@
+package plugins_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/plugins"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// Every plugin mutation must enqueue a republish for its own project. Before
+// this, propagation waited on a rollout sweep that had to run every few
+// seconds to feel immediate; the sweep is now an hourly safety net, so a
+// missing signal here means a change silently sits unpublished for an hour.
+func TestPluginsService_MutationsSignalRepublish(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	assertSignalled := func(t *testing.T, count int, what string) {
+		t.Helper()
+		captured := ti.publisher.captured()
+		require.Len(t, captured, count, "%s should enqueue a republish", what)
+		last := captured[len(captured)-1]
+		require.Equal(t, *authCtx.ProjectID, last.projectID)
+		require.Equal(t, authCtx.UserID, last.createdByUserID)
+	}
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Signalled"})
+	require.NoError(t, err)
+	assertSignalled(t, 1, "creating a plugin")
+
+	_, err = ti.service.UpdatePlugin(ctx, &gen.UpdatePluginPayload{ID: plugin.ID, Name: "Signalled Renamed", Slug: "signalled-renamed"})
+	require.NoError(t, err)
+	assertSignalled(t, 2, "renaming a plugin")
+
+	toolset := createTestToolset(t, ctx, ti.conn, "signalled-server")
+	require.NoError(t, toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true, ID: toolset.ID, ProjectID: toolset.ProjectID,
+	}))
+
+	server, err := ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID: plugin.ID, ToolsetID: conv.PtrEmpty(toolset.ID.String()), Policy: "required", SortOrder: 0,
+	})
+	require.NoError(t, err)
+	assertSignalled(t, 3, "adding a server to a plugin")
+
+	_, err = ti.service.UpdatePluginServer(ctx, &gen.UpdatePluginServerPayload{
+		ID: server.ID, PluginID: plugin.ID, DisplayName: "Renamed Server", Policy: "optional", SortOrder: 1,
+	})
+	require.NoError(t, err)
+	assertSignalled(t, 4, "updating a plugin server")
+
+	require.NoError(t, ti.service.RemovePluginServer(ctx, &gen.RemovePluginServerPayload{ID: server.ID, PluginID: plugin.ID}))
+	assertSignalled(t, 5, "removing a plugin server")
+
+	require.NoError(t, ti.service.DeletePlugin(ctx, &gen.DeletePluginPayload{ID: plugin.ID}))
+	assertSignalled(t, 6, "deleting a plugin")
+}

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,6 +69,32 @@ type testInstance struct {
 	service        *plugins.Service
 	conn           *pgxpool.Pool
 	sessionManager *sessions.Manager
+	publisher      *capturePublishSignaler
+}
+
+// capturePublishSignaler records the republish enqueues a plugin mutation makes
+// in place of the real Temporal signal.
+type capturePublishSignaler struct {
+	mu      sync.Mutex
+	signals []capturedPublishSignal
+}
+
+type capturedPublishSignal struct {
+	projectID       uuid.UUID
+	createdByUserID string
+}
+
+func (c *capturePublishSignaler) SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.signals = append(c.signals, capturedPublishSignal{projectID: projectID, createdByUserID: createdByUserID})
+	return nil
+}
+
+func (c *capturePublishSignaler) captured() []capturedPublishSignal {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.signals)
 }
 
 func newTestPluginsService(t *testing.T) (context.Context, *testInstance) {
@@ -100,12 +128,13 @@ func newTestPluginsService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := plugins.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, "local", "https://app.getgram.ai", nil)
+	svc := plugins.NewService(logger, tracerProvider, conn, sessionManager, cache.NewRedisCacheAdapter(redisClient), authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, "local", "https://app.getgram.ai", nil, nil)
 
 	return ctx, &testInstance{
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
+		publisher:      nil,
 	}
 }
 
@@ -175,6 +204,8 @@ func newTestPluginsServiceWithGitHubAndFeatures(t *testing.T, ghClient plugins.G
 
 	auditLogger := audit.NewLogger()
 
+	publisher := &capturePublishSignaler{mu: sync.Mutex{}, signals: nil}
+
 	svc := plugins.NewService(
 		logger,
 		tracerProvider,
@@ -187,12 +218,14 @@ func newTestPluginsServiceWithGitHubAndFeatures(t *testing.T, ghClient plugins.G
 		"local",
 		"https://app.getgram.ai",
 		features,
+		publisher,
 	)
 
 	return ctx, &testInstance{
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
+		publisher:      publisher,
 	}
 }
 

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -244,15 +244,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 	// the request returning (or its caller disconnecting) right after commit
 	// can't drop the enqueue.
 	if s.pluginsGitHubEnabled {
-		enqueueCtx := context.WithoutCancel(ctx)
-		if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
-			ProjectID:       prj.ID,
-			CreatedByUserID: authCtx.UserID,
-			CommitMessage:   "Initial marketplace publish",
-			SkipIfUnchanged: false,
-		}); err != nil {
-			s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
-		}
+		background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, prj.ID, authCtx.UserID, true)
 	}
 
 	project := &gen.CreateProjectResult{

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -245,7 +245,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 	// can't drop the enqueue.
 	if s.pluginsGitHubEnabled {
 		enqueueCtx := context.WithoutCancel(ctx)
-		if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+		if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
 			ProjectID:       prj.ID,
 			CreatedByUserID: authCtx.UserID,
 			CommitMessage:   "Initial marketplace publish",

--- a/server/internal/skills/distribution_test.go
+++ b/server/internal/skills/distribution_test.go
@@ -526,3 +526,49 @@ func TestAssistantSkillDistributionTargetValidationAndRBAC(t *testing.T) {
 	_, err = ti.service.Distribute(ctx, &gen.DistributePayload{ID: created.Skill.ID, PluginID: new(plugin.ID.String()), SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
 	require.NoError(t, err)
 }
+
+// A skill distributed to a plugin changes that plugin's package contents, so
+// the distribution must enqueue a republish for its project rather than wait
+// for the hourly rollout sweep. Assistant-channel distributions publish
+// nothing and must stay silent.
+func TestSkillDistributionSignalsPluginRepublish(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "republished-skill", "First valid version.")
+	plugin := createPlugin(t, ctx, ti, ti.projectID, "republish-plugin")
+
+	_, err := ti.service.Distribute(ctx, &gen.DistributePayload{
+		ID: created.Skill.ID, PluginID: new(plugin.ID.String()), PinnedVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{ti.projectID}, ti.publisher.recorded())
+
+	// Re-distributing with a pin rewrites the distribution, so the package
+	// content moves and the republish must fire again.
+	_, err = ti.service.Distribute(ctx, &gen.DistributePayload{
+		ID: created.Skill.ID, PluginID: new(plugin.ID.String()), PinnedVersionID: &created.Version.ID,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, ti.publisher.recorded(), 2)
+
+	require.NoError(t, ti.service.Undistribute(ctx, &gen.UndistributePayload{
+		ID: created.Skill.ID, PluginID: new(plugin.ID.String()),
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	}))
+	require.Len(t, ti.publisher.recorded(), 3)
+
+	assistantCtx := authztest.WithExactGrants(t, ctx,
+		authz.NewGrant(authz.ScopeSkillRead, ti.projectID.String()),
+		authz.NewGrant(authz.ScopeProjectWrite, ti.projectID.String()),
+	)
+	assistant := createAssistant(t, assistantCtx, ti, ti.projectID, "Assistant target")
+	_, err = ti.service.Distribute(assistantCtx, &gen.DistributePayload{
+		ID: created.Skill.ID, AssistantID: new(assistant.ID.String()), PinnedVersionID: nil,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, ti.publisher.recorded(), 3, "an assistant distribution publishes no package")
+}

--- a/server/internal/skills/feedback.go
+++ b/server/internal/skills/feedback.go
@@ -11,6 +11,17 @@ type ManualSuggestionSignaler interface {
 	SignalManual(ctx context.Context, projectID, skillID uuid.UUID) error
 }
 
+// PluginPublishSignaler enqueues a republish of a project's marketplace
+// packages. A skill distributed to (or revoked from) a plugin changes what
+// that plugin's package contains, so the change signals its own project rather
+// than waiting for the periodic rollout sweep to notice.
+//
+// Implemented by background.TemporalPluginPublisher. Declared here rather than
+// reused from the plugins package, which already imports this one.
+type PluginPublishSignaler interface {
+	SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error
+}
+
 // MaxFeedbackNoteRunes caps a feedback note everywhere it is handled: the wire
 // contract, ingest validation, and the suggestion prompt all admit the full
 // note so recorded evidence is never silently truncated downstream.

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -62,7 +62,11 @@ type Service struct {
 	features *productfeatures.Client
 	audit    *audit.Logger
 	signaler ManualSuggestionSignaler
-	siteURL  *url.URL
+	// publisher republishes a project's marketplace packages after a skill is
+	// distributed to or revoked from a plugin. Nil in tests; signalPluginPublish
+	// is a no-op then.
+	publisher PluginPublishSignaler
+	siteURL   *url.URL
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -77,20 +81,22 @@ func NewService(
 	features *productfeatures.Client,
 	auditLogger *audit.Logger,
 	signaler ManualSuggestionSignaler,
+	publisher PluginPublishSignaler,
 	siteURL *url.URL,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("skills"))
 
 	return &Service{
-		tracer:   tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/skills"),
-		logger:   logger,
-		db:       db,
-		auth:     auth.New(logger, db, sessions, authzEngine),
-		authz:    authzEngine,
-		features: features,
-		audit:    auditLogger,
-		signaler: signaler,
-		siteURL:  siteURL,
+		tracer:    tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/skills"),
+		logger:    logger,
+		db:        db,
+		auth:      auth.New(logger, db, sessions, authzEngine),
+		authz:     authzEngine,
+		features:  features,
+		audit:     auditLogger,
+		signaler:  signaler,
+		publisher: publisher,
+		siteURL:   siteURL,
 	}
 }
 
@@ -348,6 +354,22 @@ func parseDistributionTarget(pluginID, assistantID *string) (distributionTarget,
 		return distributionTarget{}, oops.E(oops.CodeBadRequest, nil, "invalid assistant id")
 	}
 	return distributionTarget{channel: "assistant", pluginID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, assistantID: uuid.NullUUID{UUID: id, Valid: true}}, nil
+}
+
+// signalPluginPublish republishes the project's marketplace packages after a
+// plugin-channel distribution changed. Best-effort: a failed enqueue is logged
+// and never fails the request, since the rollout sweep still picks the project
+// up on its next tick. Must only be called after the triggering transaction
+// has committed — the publish reads live state a rollback would take back.
+func (s *Service) signalPluginPublish(ctx context.Context, target distributionTarget, authCtx *contextvalues.AuthContext) {
+	if s.publisher == nil || target.channel != "plugin" {
+		return
+	}
+
+	// The request returning shouldn't drop the enqueue.
+	if err := s.publisher.SignalPluginPublish(context.WithoutCancel(ctx), *authCtx.ProjectID, authCtx.UserID); err != nil {
+		s.logger.WarnContext(ctx, "failed to signal plugin publish", attr.SlogError(err))
+	}
 }
 
 func (s *Service) recordVersion(
@@ -1492,6 +1514,9 @@ func (s *Service) Distribute(ctx context.Context, payload *gen.DistributePayload
 		if err := dbtx.Commit(ctx); err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "commit skill distribution update transaction").LogError(ctx, logger)
 		}
+
+		s.signalPluginPublish(ctx, target, authCtx)
+
 		return mv.BuildSkillDistributionView(distribution, skill.Name, skill.DisplayName, pluginName, assistantName, resolvedVersionID), nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
@@ -1526,6 +1551,8 @@ func (s *Service) Distribute(ctx context.Context, payload *gen.DistributePayload
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit distribute skill transaction").LogError(ctx, logger)
 	}
+
+	s.signalPluginPublish(ctx, target, authCtx)
 
 	return mv.BuildSkillDistributionView(distribution, skill.Name, skill.DisplayName, pluginName, assistantName, resolvedVersionID), nil
 }
@@ -1603,6 +1630,8 @@ func (s *Service) Undistribute(ctx context.Context, payload *gen.UndistributePay
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit undistribute skill transaction").LogError(ctx, logger)
 	}
+
+	s.signalPluginPublish(ctx, target, authCtx)
 
 	return nil
 }

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -357,7 +357,9 @@ func parseDistributionTarget(pluginID, assistantID *string) (distributionTarget,
 }
 
 // signalPluginPublish republishes the project's marketplace packages after a
-// plugin-channel distribution changed. Best-effort: a failed enqueue is logged
+// plugin-channel distribution changed. The publisher is nil when GitHub
+// publishing is not configured, so a deployment without it enqueues nothing
+// rather than filling Temporal with runs that can only fail. Best-effort: a failed enqueue is logged
 // and never fails the request, since the rollout sweep still picks the project
 // up on its next tick. Must only be called after the triggering transaction
 // has committed — the publish reads live state a rollback would take back.
@@ -368,7 +370,8 @@ func (s *Service) signalPluginPublish(ctx context.Context, target distributionTa
 
 	// The request returning shouldn't drop the enqueue.
 	if err := s.publisher.SignalPluginPublish(context.WithoutCancel(ctx), *authCtx.ProjectID, authCtx.UserID); err != nil {
-		s.logger.WarnContext(ctx, "failed to signal plugin publish", attr.SlogError(err))
+		s.logger.WarnContext(ctx, "failed to signal plugin publish",
+			attr.SlogProjectID(authCtx.ProjectID.String()), attr.SlogError(err))
 	}
 }
 

--- a/server/internal/skills/setup_test.go
+++ b/server/internal/skills/setup_test.go
@@ -63,6 +63,27 @@ type testInstance struct {
 	authContext    *contextvalues.AuthContext
 	projectID      uuid.UUID
 	signaler       *captureSuggestionSignaler
+	publisher      *capturePublishSignaler
+}
+
+// capturePublishSignaler records the marketplace republishes a plugin-channel
+// distribution enqueues, in place of the real Temporal signal.
+type capturePublishSignaler struct {
+	mu      sync.Mutex
+	signals []uuid.UUID
+}
+
+func (c *capturePublishSignaler) SignalPluginPublish(_ context.Context, projectID uuid.UUID, _ string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.signals = append(c.signals, projectID)
+	return nil
+}
+
+func (c *capturePublishSignaler) recorded() []uuid.UUID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]uuid.UUID(nil), c.signals...)
 }
 
 type suggestionSignal struct {
@@ -132,9 +153,10 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
 	signaler := &captureSuggestionSignaler{signals: nil, err: nil}
+	publisher := &capturePublishSignaler{mu: sync.Mutex{}, signals: nil}
 	siteURL, err := url.Parse("https://app.getgram.test")
 	require.NoError(t, err)
-	service := skills.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), signaler, siteURL)
+	service := skills.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), signaler, publisher, siteURL)
 
 	ti := &testInstance{
 		service:        service,
@@ -145,6 +167,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		authContext:    authContext,
 		projectID:      *authContext.ProjectID,
 		signaler:       signaler,
+		publisher:      publisher,
 	}
 	enableSkills(t, ctx, ti)
 	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeSkillWrite, ti.projectID.String()))

--- a/server/internal/toolsets/createtoolset_test.go
+++ b/server/internal/toolsets/createtoolset_test.go
@@ -516,7 +516,7 @@ func TestToolsetsService_CreateToolset_LegacyProject_TriggersInitialPublish(t *t
 	})
 	require.NoError(t, err)
 
-	workflowID := fmt.Sprintf("v1:plugin-initial-publish/%s", authCtx.ProjectID.String())
+	workflowID := fmt.Sprintf("v1:plugin-publish:%s", authCtx.ProjectID.String())
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	require.NoError(t, ti.temporalEnv.Client().GetWorkflow(waitCtx, workflowID, "").Get(waitCtx, nil), "initial publish workflow did not complete")

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -240,7 +240,7 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").LogError(ctx, logger)
 	}
 
-	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
@@ -304,25 +304,34 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 	return pluginCreated, nil
 }
 
-// triggerInitialPublishIfNeeded enqueues the first-time GitHub marketplace
-// publish for a project whose Default plugin was just lazily created. Must
-// only be called after the triggering transaction has committed — enqueuing
-// before commit risks Temporal running against state that a later failure
-// in the same transaction rolls back. Best-effort: a non-cancelable ctx
-// since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerInitialPublishIfNeeded(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !pluginCreated || !s.pluginsGitHubEnabled {
+// triggerPluginPublish enqueues the marketplace publish for the project whose
+// Default plugin membership just changed. A lazily created Default plugin
+// (project predates the feature) forces the publish: there is no prior
+// fingerprint to compare against, and the repo itself may not exist yet.
+// Otherwise the attach may well have been a no-op, so the publish is
+// fingerprint-gated and does no GitHub work when the generated output is
+// unchanged. Must only be called after the triggering transaction has
+// committed — enqueuing before commit risks Temporal running against state
+// that a later failure in the same transaction rolls back. Best-effort: a
+// non-cancelable ctx since the request returning shouldn't drop the enqueue.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
+	if !s.pluginsGitHubEnabled {
 		return
 	}
 
+	commitMessage := "Update plugin packages"
+	if pluginCreated {
+		commitMessage = "Initial marketplace publish"
+	}
+
 	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginInitialPublishWorkflow(enqueueCtx, s.temporalEnv, plugins.PublishProjectInput{
+	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
 		ProjectID:       *authCtx.ProjectID,
 		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   "Initial marketplace publish",
-		SkipIfUnchanged: false,
+		CommitMessage:   commitMessage,
+		SkipIfUnchanged: !pluginCreated,
 	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue initial plugin publish", attr.SlogError(err))
+		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
 	}
 }
 
@@ -622,7 +631,7 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving updated toolset").LogError(ctx, logger)
 	}
 
-	s.triggerInitialPublishIfNeeded(ctx, authCtx, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
 
 	return toolsetDetails, nil
 }

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -618,8 +618,10 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	}
 
 	// An already-attached toolset publishes too: a rename or slug change moves
-	// its entry in the generated package even though no attach ran.
-	s.triggerPluginPublish(ctx, authCtx, updatedToolset.McpEnabled, pluginCreated)
+	// its entry in the generated package even though no attach ran, and
+	// disabling MCP drops the entry entirely — so the previous state counts as
+	// much as the new one.
+	s.triggerPluginPublish(ctx, authCtx, existingToolset.McpEnabled || updatedToolset.McpEnabled, pluginCreated)
 
 	return toolsetDetails, nil
 }

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -240,7 +240,9 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving toolset").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
+	// Only an MCP-enabled toolset reaches the Default plugin, so a plain
+	// toolset must not enqueue a publish.
+	s.triggerPluginPublish(ctx, authCtx, createToolParams.McpEnabled, pluginCreated)
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
@@ -305,34 +307,18 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. A lazily created Default plugin
-// (project predates the feature) forces the publish: there is no prior
-// fingerprint to compare against, and the repo itself may not exist yet.
-// Otherwise the attach may well have been a no-op, so the publish is
-// fingerprint-gated and does no GitHub work when the generated output is
-// unchanged. Must only be called after the triggering transaction has
-// committed — enqueuing before commit risks Temporal running against state
-// that a later failure in the same transaction rolls back. Best-effort: a
-// non-cancelable ctx since the request returning shouldn't drop the enqueue.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, pluginCreated bool) {
-	if !s.pluginsGitHubEnabled {
+// Default plugin membership just changed. attached is false when the mutation
+// could not have changed generated plugin output (a Meta-MCP endpoint, a
+// non-MCP toolset, a disabled or endpointless server): those paths must not
+// enqueue at all, since a project with no GitHub connection yet treats any
+// publish as its first and would get a marketplace repo it has no packages
+// for.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
+	if !attached || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	commitMessage := "Update plugin packages"
-	if pluginCreated {
-		commitMessage = "Initial marketplace publish"
-	}
-
-	enqueueCtx := context.WithoutCancel(ctx)
-	if _, err := background.ExecutePluginPublishWorkflowDebounced(enqueueCtx, s.temporalEnv, background.PluginPublishParams{
-		ProjectID:       *authCtx.ProjectID,
-		CreatedByUserID: authCtx.UserID,
-		CommitMessage:   commitMessage,
-		SkipIfUnchanged: !pluginCreated,
-	}); err != nil {
-		s.logger.WarnContext(ctx, "failed to enqueue plugin publish", attr.SlogError(err))
-	}
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
 }
 
 func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPayload) (*gen.ListToolsetsResult, error) {
@@ -631,7 +617,9 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 		return nil, oops.E(oops.CodeUnexpected, err, "error saving updated toolset").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, pluginCreated)
+	// An already-attached toolset publishes too: a rename or slug change moves
+	// its entry in the generated package even though no attach ran.
+	s.triggerPluginPublish(ctx, authCtx, updatedToolset.McpEnabled, pluginCreated)
 
 	return toolsetDetails, nil
 }


### PR DESCRIPTION
## Summary

Plugin marketplace publishes are now triggered by the changes that need them instead of by a tight polling schedule.

- Adds `PluginPublishWorkflowDebounced`, keyed on a per-project workflow id (`v1:plugin-publish:<project>`). Every trigger for a project lands on one execution, so concurrent triggers can no longer race two publishes against the same GitHub repo, and a burst of dashboard writes coalesces into a single publish (10s `StartDelay`). A `force` signal folded into a pending run clears `SkipIfUnchanged`, so a project's first publish is never skipped behind a fingerprint-gated one.
- Signals it, after commit and best-effort, from every mutation that moves generated output: create/rename/delete a plugin, add/update/remove a plugin server, distribute or revoke a skill on the plugin channel, attach a server to the Default plugin (toolsets, mcpservers, mcpendpoints), and create a project. A failed enqueue is logged and never fails the request.
- `PluginInitialPublishWorkflow` is superseded and no longer started. It stays registered for one release so executions in flight across the deploy can finish — dropping the registration would wedge them on workflow-task failures.
- Drops the rollout sweep from every 10s to hourly (8640 → 24 runs/day). The deploy updates the existing schedule spec in place.

Two behaviour notes for review:

- `UpdateToolset` and `CreateMcpEndpoint` now signal on every call rather than only when the Default plugin was lazily created — a toolset rename or slug change does move package contents. The publish is fingerprint-gated, so an unchanged project does no GitHub or key work.
- Change-to-published latency becomes ~10s (the debounce window) rather than ≤10s (the old tick).

## Motivation

Nothing but the schedule triggered a republish, so it ran every 10 seconds for every project to make plugin edits feel immediate. Almost every tick was a no-op — the fingerprint check skips unchanged projects — but the Temporal actions it burned made it the largest single line on the Temporal bill, and the cost grew with project count rather than with actual plugin activity.

Signalling on change gets the same propagation latency for roughly one workflow per change. The sweep is kept rather than deleted because two things change published output with no database write, so no callsite can signal them: a hooks generator-version bump, and a hooks-rollout pin advance in PostHog. Hourly bounds how long those take to reach an otherwise idle project while removing ~99.7% of the schedule's cost.

https://claude.ai/code/session_011G5NTsW2Qbm31ET9oRSMS9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plugin marketplace publishes now trigger from committed changes that can affect generated output instead of a 10-second polling sweep. A debounced per-project workflow coalesces bursts and serializes publishes, reducing no-op Temporal work; normal propagation uses a roughly 10-second debounce.

**Behavior**
- After commit, signals cover plugin and plugin-server mutations, plugin-channel skill distribution or revocation, project creation, lazy Default-plugin creation, and eligible Default-plugin attachments; `UpdateToolset` and `CreateMcpEndpoint` also signal when attached output can change.
- Existing attached MCP servers and MCP-enabled toolsets signal when updates change or remove their package entries; paths that remain disabled, are non-MCP, Meta-MCP, endpointless, or otherwise cannot affect output stay silent.
- Signal enqueues have a 10-second timeout, remain best-effort, and log failures without failing the request; GitHub-disabled deployments create no signalers.
- Fingerprint checks skip unchanged output, while a forced first publish overrides a pending skip; signals received during a publish trigger one follow-up run.

**Migration**
- The existing rollout schedule changes in place from every 10 seconds to hourly as a safety net for generator-version changes and PostHog rollout-pin updates.
- `PluginInitialPublishWorkflow` remains registered for one release so in-flight executions can finish; nothing starts it anymore.

<sup>Written for commit f78cdf588f94bd48e551a06855013b87de9cbe2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

