### PR TITLE
fix: never create the first marketplace repo from a change signal

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -420,7 +420,7 @@ func newPlatformMCPLifecycleVisibilityService(config platformMCPConfig, readines
 		if config.PluginPublisher == nil {
 			return fmt.Errorf("plugin publishing is not configured")
 		}
-		_, err := config.PluginPublisher.PublishProject(ctx, plugins.PublishProjectInput{ProjectID: projectID, CreatedByUserID: userID, CommitMessage: commitMessage, SkipIfUnchanged: true})
+		_, err := config.PluginPublisher.PublishProject(ctx, plugins.PublishProjectInput{ProjectID: projectID, CreatedByUserID: userID, CommitMessage: commitMessage, SkipIfUnchanged: true, AllowFirstPublish: false})
 		return err
 	}, func(ctx context.Context, domainIDs []uuid.UUID) error {
 		if config.TemporalEnv == nil {
@@ -454,7 +454,7 @@ func newPlatformMCPDistributionService(config platformMCPConfig, pluginTargets p
 			if config.PluginPublisher == nil {
 				return fmt.Errorf("plugin publishing is not configured")
 			}
-			_, err := config.PluginPublisher.PublishProject(ctx, plugins.PublishProjectInput{ProjectID: projectID, CreatedByUserID: userID, CommitMessage: commitMessage, SkipIfUnchanged: true})
+			_, err := config.PluginPublisher.PublishProject(ctx, plugins.PublishProjectInput{ProjectID: projectID, CreatedByUserID: userID, CommitMessage: commitMessage, SkipIfUnchanged: true, AllowFirstPublish: false})
 			return err
 		},
 		pluginTargets,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -245,7 +245,7 @@ func restoreLocalPluginRepositories(
 				CommitMessage:   "Restore local plugin marketplace",
 				SkipIfUnchanged: false,
 				// Local dev restore recreates the repo on purpose.
-				SkipIfUnpublished: false,
+				AllowFirstPublish: true,
 			}); err != nil {
 				logger.WarnContext(ctx, "restore local plugin repository",
 					attr.SlogProjectID(candidate.ProjectID.String()),

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -244,6 +244,8 @@ func restoreLocalPluginRepositories(
 				CreatedByUserID: candidate.CreatedByUserID,
 				CommitMessage:   "Restore local plugin marketplace",
 				SkipIfUnchanged: false,
+				// Local dev restore recreates the repo on purpose.
+				SkipIfUnpublished: false,
 			}); err != nil {
 				logger.WarnContext(ctx, "restore local plugin repository",
 					attr.SlogProjectID(candidate.ProjectID.String()),

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -155,6 +155,11 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 					CreatedByUserID: candidate.CreatedByUserID,
 					CommitMessage:   commitMessage,
 					SkipIfUnchanged: true,
+					// The sweep is the safety net for a lost initial-publish
+					// enqueue, so unlike a change signal it may create the repo.
+					// Its candidate list is already scoped to projects with a
+					// Default plugin or a previous publish.
+					SkipIfUnpublished: false,
 				}))
 			}
 

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -159,7 +159,7 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 					// enqueue, so unlike a change signal it may create the repo.
 					// Its candidate list is already scoped to projects with a
 					// Default plugin or a previous publish.
-					SkipIfUnpublished: false,
+					AllowFirstPublish: true,
 				}))
 			}
 

--- a/server/internal/background/plugin_publish.go
+++ b/server/internal/background/plugin_publish.go
@@ -44,6 +44,11 @@ type PluginPublishParams struct {
 	// only worth doing if the generated output actually moved); a project's
 	// first publish clears it.
 	SkipIfUnchanged bool
+	// SkipIfUnpublished refuses to create the project's first marketplace repo.
+	// Change triggers set it so a mutation that merely could have moved
+	// generated output never brings a repo into existence; the forced paths
+	// (project creation, first Default-plugin attach) clear it.
+	SkipIfUnpublished bool
 }
 
 func pluginPublishWorkflowID(params PluginPublishParams) string {
@@ -121,6 +126,7 @@ func PluginPublishWorkflowDebounced(ctx workflow.Context, params PluginPublishPa
 			// strand the publish that needed to happen regardless of fingerprint.
 			if message == pluginPublishForceSignal {
 				params.SkipIfUnchanged = false
+				params.SkipIfUnpublished = false
 			}
 			return params
 		},
@@ -143,10 +149,11 @@ func PluginPublishWorkflow(ctx workflow.Context, params PluginPublishParams) (*p
 	var a *Activities
 	var result plugins.PublishProjectResult
 	if err := workflow.ExecuteActivity(ctx, a.PublishPluginProject, plugins.PublishProjectInput{
-		ProjectID:       params.ProjectID,
-		CreatedByUserID: params.CreatedByUserID,
-		CommitMessage:   params.CommitMessage,
-		SkipIfUnchanged: params.SkipIfUnchanged,
+		ProjectID:         params.ProjectID,
+		CreatedByUserID:   params.CreatedByUserID,
+		CommitMessage:     params.CommitMessage,
+		SkipIfUnchanged:   params.SkipIfUnchanged,
+		SkipIfUnpublished: params.SkipIfUnpublished,
 	}).Get(ctx, &result); err != nil {
 		return nil, fmt.Errorf("publish plugin project: %w", err)
 	}
@@ -168,10 +175,11 @@ var _ domainskills.PluginPublishSignaler = (*TemporalPluginPublisher)(nil)
 // GitHub work if the generated output turns out to be unchanged.
 func (p *TemporalPluginPublisher) SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error {
 	if _, err := ExecutePluginPublishWorkflowDebounced(ctx, p.TemporalEnv, PluginPublishParams{
-		ProjectID:       projectID,
-		CreatedByUserID: createdByUserID,
-		CommitMessage:   "Update plugin packages",
-		SkipIfUnchanged: true,
+		ProjectID:         projectID,
+		CreatedByUserID:   createdByUserID,
+		CommitMessage:     "Update plugin packages",
+		SkipIfUnchanged:   true,
+		SkipIfUnpublished: true,
 	}); err != nil {
 		return fmt.Errorf("signal plugin publish: %w", err)
 	}
@@ -199,10 +207,11 @@ func TriggerPluginPublish(ctx context.Context, temporalEnv *tenv.Environment, lo
 
 	// The request returning shouldn't drop the enqueue.
 	if _, err := ExecutePluginPublishWorkflowDebounced(context.WithoutCancel(ctx), temporalEnv, PluginPublishParams{
-		ProjectID:       projectID,
-		CreatedByUserID: createdByUserID,
-		CommitMessage:   commitMessage,
-		SkipIfUnchanged: !force,
+		ProjectID:         projectID,
+		CreatedByUserID:   createdByUserID,
+		CommitMessage:     commitMessage,
+		SkipIfUnchanged:   !force,
+		SkipIfUnpublished: !force,
 	}); err != nil {
 		logger.WarnContext(ctx, "failed to enqueue plugin publish",
 			attr.SlogProjectID(projectID.String()), attr.SlogError(err))

--- a/server/internal/background/plugin_publish.go
+++ b/server/internal/background/plugin_publish.go
@@ -44,11 +44,11 @@ type PluginPublishParams struct {
 	// only worth doing if the generated output actually moved); a project's
 	// first publish clears it.
 	SkipIfUnchanged bool
-	// SkipIfUnpublished refuses to create the project's first marketplace repo.
-	// Change triggers set it so a mutation that merely could have moved
-	// generated output never brings a repo into existence; the forced paths
-	// (project creation, first Default-plugin attach) clear it.
-	SkipIfUnpublished bool
+	// AllowFirstPublish lets this publish create the project's marketplace repo
+	// when it has none yet. Opt-in on purpose: a params payload encoded before
+	// this field existed decodes as false, which defers the repo to the rollout
+	// sweep rather than creating one a change signal never intended.
+	AllowFirstPublish bool
 }
 
 func pluginPublishWorkflowID(params PluginPublishParams) string {
@@ -126,7 +126,7 @@ func PluginPublishWorkflowDebounced(ctx workflow.Context, params PluginPublishPa
 			// strand the publish that needed to happen regardless of fingerprint.
 			if message == pluginPublishForceSignal {
 				params.SkipIfUnchanged = false
-				params.SkipIfUnpublished = false
+				params.AllowFirstPublish = true
 			}
 			return params
 		},
@@ -153,7 +153,7 @@ func PluginPublishWorkflow(ctx workflow.Context, params PluginPublishParams) (*p
 		CreatedByUserID:   params.CreatedByUserID,
 		CommitMessage:     params.CommitMessage,
 		SkipIfUnchanged:   params.SkipIfUnchanged,
-		SkipIfUnpublished: params.SkipIfUnpublished,
+		AllowFirstPublish: params.AllowFirstPublish,
 	}).Get(ctx, &result); err != nil {
 		return nil, fmt.Errorf("publish plugin project: %w", err)
 	}
@@ -175,11 +175,12 @@ var _ domainskills.PluginPublishSignaler = (*TemporalPluginPublisher)(nil)
 // GitHub work if the generated output turns out to be unchanged.
 func (p *TemporalPluginPublisher) SignalPluginPublish(ctx context.Context, projectID uuid.UUID, createdByUserID string) error {
 	if _, err := ExecutePluginPublishWorkflowDebounced(ctx, p.TemporalEnv, PluginPublishParams{
-		ProjectID:         projectID,
-		CreatedByUserID:   createdByUserID,
-		CommitMessage:     "Update plugin packages",
-		SkipIfUnchanged:   true,
-		SkipIfUnpublished: true,
+		ProjectID:       projectID,
+		CreatedByUserID: createdByUserID,
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+		// A plain plugin edit never brings a marketplace into existence.
+		AllowFirstPublish: false,
 	}); err != nil {
 		return fmt.Errorf("signal plugin publish: %w", err)
 	}
@@ -189,17 +190,23 @@ func (p *TemporalPluginPublisher) SignalPluginPublish(ctx context.Context, proje
 // TriggerPluginPublish enqueues the marketplace publish for a project whose
 // plugin membership just changed, shared by the mutation services (toolsets,
 // mcpservers, mcpendpoints, projects) so those paths cannot drift apart in how
-// they publish. A lazily created Default plugin (or a project's first publish)
-// passes force: there is no prior fingerprint to compare against and the repo
-// may not exist yet. Otherwise the publish is fingerprint-gated and does no
-// GitHub work when the generated output is unchanged.
+// they publish.
+//
+// allowFirstPublish says the caller attached something to a plugin, so the
+// project may get its marketplace repo now rather than on the next sweep — a
+// legacy project whose Default plugin already existed (lazily provisioned by a
+// dashboard read) reaches its first attach with force false and still needs the
+// repo. force additionally republishes regardless of fingerprint, which only a
+// freshly created Default plugin or a brand new project needs: there is no
+// prior fingerprint to compare against. Otherwise the publish is
+// fingerprint-gated and does no GitHub work when the output is unchanged.
 //
 // Must only be called after the triggering transaction has committed —
 // enqueuing before commit risks publishing state that a later failure in the
 // same transaction rolls back. Best-effort: the enqueue is logged and never
 // fails the request, since the rollout sweep still picks the project up on its
 // next tick.
-func TriggerPluginPublish(ctx context.Context, temporalEnv *tenv.Environment, logger *slog.Logger, projectID uuid.UUID, createdByUserID string, force bool) {
+func TriggerPluginPublish(ctx context.Context, temporalEnv *tenv.Environment, logger *slog.Logger, projectID uuid.UUID, createdByUserID string, allowFirstPublish, force bool) {
 	commitMessage := "Update plugin packages"
 	if force {
 		commitMessage = "Initial marketplace publish"
@@ -211,7 +218,7 @@ func TriggerPluginPublish(ctx context.Context, temporalEnv *tenv.Environment, lo
 		CreatedByUserID:   createdByUserID,
 		CommitMessage:     commitMessage,
 		SkipIfUnchanged:   !force,
-		SkipIfUnpublished: !force,
+		AllowFirstPublish: allowFirstPublish,
 	}); err != nil {
 		logger.WarnContext(ctx, "failed to enqueue plugin publish",
 			attr.SlogProjectID(projectID.String()), attr.SlogError(err))

--- a/server/internal/background/plugin_publish_test.go
+++ b/server/internal/background/plugin_publish_test.go
@@ -68,10 +68,11 @@ func TestPluginPublishWorkflow_PassesParamsToActivity(t *testing.T) {
 
 	projectID := uuid.New()
 	env.ExecuteWorkflow(PluginPublishWorkflow, PluginPublishParams{
-		ProjectID:       projectID,
-		CreatedByUserID: "user_01HZ",
-		CommitMessage:   "Update plugin packages",
-		SkipIfUnchanged: true,
+		ProjectID:         projectID,
+		CreatedByUserID:   "user_01HZ",
+		CommitMessage:     "Update plugin packages",
+		SkipIfUnchanged:   true,
+		AllowFirstPublish: true,
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -81,11 +82,14 @@ func TestPluginPublishWorkflow_PassesParamsToActivity(t *testing.T) {
 	require.NoError(t, env.GetWorkflowResult(&result))
 	require.True(t, result.Skipped)
 
+	// Both flags reach the activity as given: nothing in the workflow may
+	// quietly upgrade a change signal into one that can create a repo.
 	require.Equal(t, []plugins.PublishProjectInput{{
-		ProjectID:       projectID,
-		CreatedByUserID: "user_01HZ",
-		CommitMessage:   "Update plugin packages",
-		SkipIfUnchanged: true,
+		ProjectID:         projectID,
+		CreatedByUserID:   "user_01HZ",
+		CommitMessage:     "Update plugin packages",
+		SkipIfUnchanged:   true,
+		AllowFirstPublish: true,
 	}}, recorder.captured())
 }
 
@@ -194,6 +198,7 @@ func TestPluginPublishWorkflowDebounced_ForceSignalUpgradesPendingRun(t *testing
 	var next PluginPublishParams
 	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(canErr.Input, &next))
 	require.False(t, next.SkipIfUnchanged, "the forced signal must clear SkipIfUnchanged on the next run")
+	require.True(t, next.AllowFirstPublish, "a forced publish may create the project's first repo")
 	require.Equal(t, params.ProjectID, next.ProjectID)
 }
 
@@ -227,4 +232,5 @@ func TestPluginPublishWorkflowDebounced_StarterForceSignalAppliesToFirstRun(t *t
 	captured := recorder.captured()
 	require.Len(t, captured, 1)
 	require.False(t, captured[0].SkipIfUnchanged)
+	require.True(t, captured[0].AllowFirstPublish)
 }

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -279,7 +279,7 @@ func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalu
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
 }
 
 func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpointPayload) (*types.McpEndpoint, error) {

--- a/server/internal/mcpendpoints/impl.go
+++ b/server/internal/mcpendpoints/impl.go
@@ -226,7 +226,7 @@ func (s *Service) CreateMcpEndpoint(ctx context.Context, payload *gen.CreateMcpE
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
-	s.triggerPluginPublish(ctx, authCtx, attached, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, attached, attached, pluginCreated)
 
 	return mv.BuildMcpEndpointView(created), nil
 }
@@ -268,18 +268,20 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. attached is false when the mutation
+// Default plugin membership just changed. publish is false when the mutation
 // could not have changed generated plugin output (a Meta-MCP endpoint, a
 // non-MCP toolset, a disabled or endpointless server): those paths must not
-// enqueue at all, since a project with no GitHub connection yet treats any
-// publish as its first and would get a marketplace repo it has no packages
-// for.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
-	if !attached || !s.pluginsGitHubEnabled {
+// enqueue at all. attached says this request actually ran the attach, which is
+// what licenses creating the project's first marketplace repo — a mutation
+// that only edits an existing member (a rename, a disable) must never hand an
+// unpublished project a repo, since nothing here proves it has anything to put
+// in one.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, publish, attached, pluginCreated bool) {
+	if !publish || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, attached, pluginCreated)
 }
 
 func (s *Service) GetMcpEndpoint(ctx context.Context, payload *gen.GetMcpEndpointPayload) (*types.McpEndpoint, error) {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -813,7 +813,7 @@ func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalu
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
 }
 
 // ServerDisplayName derives a default plugin-server display name from an

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -755,7 +755,7 @@ func (s *Service) UpdateMcpServer(ctx context.Context, payload *gen.UpdateMcpSer
 	// it (it drops out of the package) has to publish too — not just the
 	// enable transition this block attaches. A server disabled before and
 	// after contributes nothing either way and stays silent.
-	s.triggerPluginPublish(ctx, authCtx, attached || existing.Visibility != VisibilityDisabled, pluginCreated)
+	s.triggerPluginPublish(ctx, authCtx, attached || existing.Visibility != VisibilityDisabled, attached, pluginCreated)
 	if err := s.reconcileMcpServerCustomDomains(ctx, clearedRootDomainIDs); err != nil {
 		return nil, err
 	}
@@ -802,18 +802,20 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. attached is false when the mutation
+// Default plugin membership just changed. publish is false when the mutation
 // could not have changed generated plugin output (a Meta-MCP endpoint, a
 // non-MCP toolset, a disabled or endpointless server): those paths must not
-// enqueue at all, since a project with no GitHub connection yet treats any
-// publish as its first and would get a marketplace repo it has no packages
-// for.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
-	if !attached || !s.pluginsGitHubEnabled {
+// enqueue at all. attached says this request actually ran the attach, which is
+// what licenses creating the project's first marketplace repo — a mutation
+// that only edits an existing member (a rename, a disable) must never hand an
+// unpublished project a repo, since nothing here proves it has anything to put
+// in one.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, publish, attached, pluginCreated bool) {
+	if !publish || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, attached, pluginCreated)
 }
 
 // ServerDisplayName derives a default plugin-server display name from an

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1891,7 +1891,7 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 		// hooks upgrade onto an org the rollout hasn't cleared.
 		SkipIfUnchanged: false,
 		// A human clicking Publish is exactly how a project gets its first repo.
-		SkipIfUnpublished: false,
+		AllowFirstPublish: true,
 	})
 	if err != nil {
 		return nil, err
@@ -1915,16 +1915,20 @@ type PublishProjectInput struct {
 	// rollout hasn't cleared. The only lever to advance hooks is the
 	// FlagHooksRollout payload pin in PostHog (plus the hardcoded canary).
 	SkipIfUnchanged bool
-	// SkipIfUnpublished short-circuits the publish when the project has never
-	// published (no github connection row), so a publish can update a
-	// marketplace but never bring one into existence. Set by the change-driven
-	// signals: a mutation that merely *could* have moved generated output must
-	// not hand a project its first repo — a project with nothing attachable
-	// would get an empty one. Creating the repo stays with the paths that mean
-	// it (project creation and a first Default-plugin attach, both forced) and
-	// the rollout sweep, whose candidates are already scoped to projects with a
-	// Default plugin or a previous publish.
-	SkipIfUnpublished bool
+	// AllowFirstPublish lets the publish create the project's marketplace repo
+	// when it has none yet. It is deliberately opt-in — false must stay the
+	// safe value, because a workflow payload encoded before this field existed
+	// (or a call site that forgets it) decodes as false, and the failure mode
+	// of creating a repo is worse than the failure mode of deferring one to the
+	// rollout sweep.
+	//
+	// Set it on the paths that mean to create a marketplace: project creation,
+	// a Default-plugin attach, the dashboard Publish button, and the sweep
+	// (whose candidates are already scoped to projects with a Default plugin or
+	// a previous publish). A plain change signal leaves it off: the mutation
+	// behind it only means generated output may have moved, which is no reason
+	// to hand a project with nothing attachable an empty repo and an API key.
+	AllowFirstPublish bool
 }
 
 type PublishProjectResult struct {
@@ -1963,7 +1967,7 @@ func (s *Service) PublishProject(ctx context.Context, input PublishProjectInput)
 		GitHubUsernames:   nil,
 		CommitMessage:     conv.Default(input.CommitMessage, "Update plugin packages"),
 		SkipIfUnchanged:   input.SkipIfUnchanged,
-		SkipIfUnpublished: input.SkipIfUnpublished,
+		AllowFirstPublish: input.AllowFirstPublish,
 	})
 	if err != nil {
 		return nil, err
@@ -1989,9 +1993,9 @@ type publishProjectInput struct {
 	GitHubUsernames  []string
 	CommitMessage    string
 	SkipIfUnchanged  bool
-	// SkipIfUnpublished refuses to create the project's first marketplace repo;
-	// see PublishProjectInput.SkipIfUnpublished.
-	SkipIfUnpublished bool
+	// AllowFirstPublish permits creating the project's first marketplace repo;
+	// see PublishProjectInput.AllowFirstPublish.
+	AllowFirstPublish bool
 }
 
 // publishOutcome is the internal result of publishProject. Skipped is true when
@@ -2072,6 +2076,29 @@ type publishOutcome struct {
 }
 
 func (s *Service) publishProject(ctx context.Context, input publishProjectInput) (*publishOutcome, error) {
+	// GitHub repo owner/name are case-insensitive. Normalize at the boundary
+	// so the rows we persist round-trip cleanly through the case-insensitive
+	// unique index on (installation_id, LOWER(repo_owner), LOWER(repo_name)).
+	repoOwner := strings.ToLower(s.github.Org)
+	repoName := strings.ToLower(input.OrganizationSlug + "-" + input.ProjectSlug + "-plugins")
+	repoURL := fmt.Sprintf("https://github.com/%s/%s", repoOwner, repoName)
+
+	// Resolved before any plugin or config work so a change signal for an
+	// unpublished project costs one query rather than a full in-memory
+	// generate it is only going to throw away.
+	existing, connErr := s.repo.GetGitHubConnection(ctx, input.ProjectID)
+	if connErr != nil && !errors.Is(connErr, pgx.ErrNoRows) {
+		return nil, oops.E(oops.CodeUnexpected, connErr, "get github connection").LogError(ctx, s.logger)
+	}
+	firstPublish := errors.Is(connErr, pgx.ErrNoRows)
+	// A change-driven signal updates an existing marketplace but never creates
+	// one: the mutation that triggered it only means the generated output may
+	// have moved, which is no reason to hand a project a repo (and a fresh API
+	// key) it has never had. RepoURL is still reported so callers can log it.
+	if firstPublish && !input.AllowFirstPublish {
+		return &publishOutcome{RepoURL: repoURL, Skipped: true, HooksConfigDeferred: false}, nil
+	}
+
 	pluginInfos, err := s.resolvePluginInfos(ctx, input.ProjectID)
 	if err != nil {
 		return nil, err
@@ -2088,25 +2115,6 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 
 	cfg := s.generateConfig(ctx, input.OrganizationID, input.OrganizationSlug, input.ProjectSlug, input.ProjectID)
 
-	// GitHub repo owner/name are case-insensitive. Normalize at the boundary
-	// so the rows we persist round-trip cleanly through the case-insensitive
-	// unique index on (installation_id, LOWER(repo_owner), LOWER(repo_name)).
-	repoOwner := strings.ToLower(s.github.Org)
-	repoName := strings.ToLower(input.OrganizationSlug + "-" + input.ProjectSlug + "-plugins")
-	repoURL := fmt.Sprintf("https://github.com/%s/%s", repoOwner, repoName)
-
-	existing, connErr := s.repo.GetGitHubConnection(ctx, input.ProjectID)
-	if connErr != nil && !errors.Is(connErr, pgx.ErrNoRows) {
-		return nil, oops.E(oops.CodeUnexpected, connErr, "get github connection").LogError(ctx, s.logger)
-	}
-	firstPublish := errors.Is(connErr, pgx.ErrNoRows)
-	// A change-driven signal updates an existing marketplace but never creates
-	// one: the mutation that triggered it only means the generated output may
-	// have moved, which is no reason to hand a project a repo (and a fresh API
-	// key) it has never had. RepoURL is still reported so callers can log it.
-	if input.SkipIfUnpublished && firstPublish {
-		return &publishOutcome{RepoURL: repoURL, Skipped: true, HooksConfigDeferred: false}, nil
-	}
 	publishedMCPFingerprints := decodeMCPFingerprints(existing.PublishedMcpFingerprints)
 
 	// Package admission is available before the first Platform MCP connection,
@@ -2506,7 +2514,7 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 				CommitMessage:   "Update marketplace name",
 				// Only reached when a connection already exists (see the switch
 				// above), so this never creates a repo either way.
-				SkipIfUnpublished: false,
+				AllowFirstPublish: true,
 				// A human changed the marketplace name: always republish so the
 				// new name propagates to installed copies (MCP + marketplace.json).
 				// The hooks component is gated by the rollout inside publishProject:

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1890,6 +1890,8 @@ func (s *Service) PublishPlugins(ctx context.Context, payload *gen.PublishPlugin
 		// by the rollout inside publishProject — clicking Publish cannot force a
 		// hooks upgrade onto an org the rollout hasn't cleared.
 		SkipIfUnchanged: false,
+		// A human clicking Publish is exactly how a project gets its first repo.
+		SkipIfUnpublished: false,
 	})
 	if err != nil {
 		return nil, err
@@ -1913,6 +1915,16 @@ type PublishProjectInput struct {
 	// rollout hasn't cleared. The only lever to advance hooks is the
 	// FlagHooksRollout payload pin in PostHog (plus the hardcoded canary).
 	SkipIfUnchanged bool
+	// SkipIfUnpublished short-circuits the publish when the project has never
+	// published (no github connection row), so a publish can update a
+	// marketplace but never bring one into existence. Set by the change-driven
+	// signals: a mutation that merely *could* have moved generated output must
+	// not hand a project its first repo — a project with nothing attachable
+	// would get an empty one. Creating the repo stays with the paths that mean
+	// it (project creation and a first Default-plugin attach, both forced) and
+	// the rollout sweep, whose candidates are already scoped to projects with a
+	// Default plugin or a previous publish.
+	SkipIfUnpublished bool
 }
 
 type PublishProjectResult struct {
@@ -1948,9 +1960,10 @@ func (s *Service) PublishProject(ctx context.Context, input PublishProjectInput)
 			Slug:            nil,
 			CreatedByUserID: input.CreatedByUserID,
 		},
-		GitHubUsernames: nil,
-		CommitMessage:   conv.Default(input.CommitMessage, "Update plugin packages"),
-		SkipIfUnchanged: input.SkipIfUnchanged,
+		GitHubUsernames:   nil,
+		CommitMessage:     conv.Default(input.CommitMessage, "Update plugin packages"),
+		SkipIfUnchanged:   input.SkipIfUnchanged,
+		SkipIfUnpublished: input.SkipIfUnpublished,
 	})
 	if err != nil {
 		return nil, err
@@ -1976,6 +1989,9 @@ type publishProjectInput struct {
 	GitHubUsernames  []string
 	CommitMessage    string
 	SkipIfUnchanged  bool
+	// SkipIfUnpublished refuses to create the project's first marketplace repo;
+	// see PublishProjectInput.SkipIfUnpublished.
+	SkipIfUnpublished bool
 }
 
 // publishOutcome is the internal result of publishProject. Skipped is true when
@@ -2084,6 +2100,13 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 		return nil, oops.E(oops.CodeUnexpected, connErr, "get github connection").LogError(ctx, s.logger)
 	}
 	firstPublish := errors.Is(connErr, pgx.ErrNoRows)
+	// A change-driven signal updates an existing marketplace but never creates
+	// one: the mutation that triggered it only means the generated output may
+	// have moved, which is no reason to hand a project a repo (and a fresh API
+	// key) it has never had. RepoURL is still reported so callers can log it.
+	if input.SkipIfUnpublished && firstPublish {
+		return &publishOutcome{RepoURL: repoURL, Skipped: true, HooksConfigDeferred: false}, nil
+	}
 	publishedMCPFingerprints := decodeMCPFingerprints(existing.PublishedMcpFingerprints)
 
 	// Package admission is available before the first Platform MCP connection,
@@ -2481,6 +2504,9 @@ func (s *Service) UpdateMarketplaceSettings(ctx context.Context, payload *gen.Up
 				},
 				GitHubUsernames: nil,
 				CommitMessage:   "Update marketplace name",
+				// Only reached when a connection already exists (see the switch
+				// above), so this never creates a repo either way.
+				SkipIfUnpublished: false,
 				// A human changed the marketplace name: always republish so the
 				// new name propagates to installed copies (MCP + marketplace.json).
 				// The hooks component is gated by the rollout inside publishProject:

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -2490,6 +2490,8 @@ func TestPluginsService_PublishProject_SkipsWhenUnchanged(t *testing.T) {
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "Update plugin packages",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	}
 
 	// First publish: no fingerprint on record yet, so it must publish.
@@ -2600,6 +2602,8 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "Update plugin packages",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	}
 
 	first, err := ti.service.PublishProject(ctx, input)
@@ -2661,6 +2665,8 @@ func phasedRolloutFixture(t *testing.T, ctx context.Context, ti *testInstance, m
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "baseline",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 
@@ -2695,6 +2701,8 @@ func TestPluginsService_PublishProject_PhasedRollout_NonEligibleBlocksHooksBump(
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "phased",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 	require.True(t, res.Skipped, "non-eligible org with a pending hooks bump and no content change must skip")
@@ -2729,6 +2737,8 @@ func TestPluginsService_PublishProject_PhasedRollout_EligibleGetsHooksBump(t *te
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "phased",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 	require.False(t, res.Skipped, "eligible org must roll the pending hooks bump forward")
@@ -2775,6 +2785,8 @@ func TestPluginsService_PublishProject_PhasedRollout_MCPPublishesRegardlessOfPha
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "phased",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 	require.False(t, res.Skipped, "MCP content change must publish even for a phase-gated org")
@@ -2827,6 +2839,8 @@ func TestPluginsService_PublishProject_RegeneratesHooksOnBrowserLoginFlip(t *tes
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "Update plugin packages",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	}
 
 	first, err := ti.service.PublishProject(ctx, input)
@@ -2894,6 +2908,8 @@ func TestPluginsService_PublishProject_SkipsAfterDashboardPublish(t *testing.T) 
 		CreatedByUserID: authCtx.UserID,
 		CommitMessage:   "Update plugin packages",
 		SkipIfUnchanged: true,
+		// These exercise the automated publisher, which may create the repo.
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 	require.True(t, result.Skipped, "rollout must skip a project the dashboard just published unchanged")

--- a/server/internal/plugins/publish_signal_test.go
+++ b/server/internal/plugins/publish_signal_test.go
@@ -8,6 +8,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/plugins"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
@@ -80,4 +81,44 @@ func TestPluginsService_LazyDefaultPluginSignalsRepublish(t *testing.T) {
 	_, err = ti.service.ListPlugins(ctx, &gen.ListPluginsPayload{SessionToken: nil, ProjectSlugInput: nil})
 	require.NoError(t, err)
 	require.Len(t, ti.publisher.captured(), 1, "a read that creates nothing must not enqueue")
+}
+
+// A change-driven publish may update an existing marketplace but must never
+// create one: the mutation behind it only means the generated output *may*
+// have moved, and a project with nothing attachable would get an empty repo
+// and a fresh API key for it. Creating the repo belongs to the forced paths
+// and the rollout sweep.
+func TestPluginsService_PublishProjectSkipsUnpublishedProject(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	publisher := newTestPluginPublisher(t, ti, mock, nil)
+
+	result, err := publisher.PublishProject(ctx, plugins.PublishProjectInput{
+		ProjectID:         *authCtx.ProjectID,
+		CreatedByUserID:   authCtx.UserID,
+		CommitMessage:     "Update plugin packages",
+		SkipIfUnchanged:   true,
+		SkipIfUnpublished: true,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Skipped)
+	require.False(t, mock.createRepoCalled, "a change signal must not create the first marketplace repo")
+	require.False(t, mock.pushFilesCalled)
+
+	// The same project, published by a path that means it, still gets its repo.
+	forced, err := publisher.PublishProject(ctx, plugins.PublishProjectInput{
+		ProjectID:         *authCtx.ProjectID,
+		CreatedByUserID:   authCtx.UserID,
+		CommitMessage:     "Initial marketplace publish",
+		SkipIfUnchanged:   false,
+		SkipIfUnpublished: false,
+	})
+	require.NoError(t, err)
+	require.False(t, forced.Skipped)
+	require.True(t, mock.createRepoCalled)
 }

--- a/server/internal/plugins/publish_signal_test.go
+++ b/server/internal/plugins/publish_signal_test.go
@@ -1,6 +1,7 @@
 package plugins_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,6 +9,7 @@ import (
 	gen "github.com/speakeasy-api/gram/server/gen/plugins"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -103,12 +105,13 @@ func TestPluginsService_PublishProjectSkipsUnpublishedProject(t *testing.T) {
 		CreatedByUserID:   authCtx.UserID,
 		CommitMessage:     "Update plugin packages",
 		SkipIfUnchanged:   true,
-		SkipIfUnpublished: true,
+		AllowFirstPublish: false,
 	})
 	require.NoError(t, err)
 	require.True(t, result.Skipped)
 	require.False(t, mock.createRepoCalled, "a change signal must not create the first marketplace repo")
 	require.False(t, mock.pushFilesCalled)
+	require.Zero(t, countPluginAPIKeys(t, ctx, ti), "a skipped publish must not mint an API key")
 
 	// The same project, published by a path that means it, still gets its repo.
 	forced, err := publisher.PublishProject(ctx, plugins.PublishProjectInput{
@@ -116,9 +119,22 @@ func TestPluginsService_PublishProjectSkipsUnpublishedProject(t *testing.T) {
 		CreatedByUserID:   authCtx.UserID,
 		CommitMessage:     "Initial marketplace publish",
 		SkipIfUnchanged:   false,
-		SkipIfUnpublished: false,
+		AllowFirstPublish: true,
 	})
 	require.NoError(t, err)
 	require.False(t, forced.Skipped)
 	require.True(t, mock.createRepoCalled)
+	require.NotZero(t, countPluginAPIKeys(t, ctx, ti), "the publish that creates the repo mints its keys")
+}
+
+// countPluginAPIKeys reports how many API keys the project holds, so a skipped
+// publish can be shown to have minted none.
+func countPluginAPIKeys(t *testing.T, ctx context.Context, ti *testInstance) int {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	keys, err := keysrepo.New(ti.conn).ListAPIKeysByOrganization(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	return len(keys)
 }

--- a/server/internal/projects/impl.go
+++ b/server/internal/projects/impl.go
@@ -244,7 +244,7 @@ func (s *Service) CreateProject(ctx context.Context, payload *gen.CreateProjectP
 	// the request returning (or its caller disconnecting) right after commit
 	// can't drop the enqueue.
 	if s.pluginsGitHubEnabled {
-		background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, prj.ID, authCtx.UserID, true)
+		background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, prj.ID, authCtx.UserID, true, true)
 	}
 
 	project := &gen.CreateProjectResult{

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -318,7 +318,7 @@ func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalu
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
 }
 
 func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPayload) (*gen.ListToolsetsResult, error) {

--- a/server/internal/toolsets/impl.go
+++ b/server/internal/toolsets/impl.go
@@ -241,8 +241,9 @@ func (s *Service) CreateToolset(ctx context.Context, payload *gen.CreateToolsetP
 	}
 
 	// Only an MCP-enabled toolset reaches the Default plugin, so a plain
-	// toolset must not enqueue a publish.
-	s.triggerPluginPublish(ctx, authCtx, createToolParams.McpEnabled, pluginCreated)
+	// toolset must not enqueue a publish. The attach ran for exactly the same
+	// condition, so this call may also create the project's first marketplace.
+	s.triggerPluginPublish(ctx, authCtx, createToolParams.McpEnabled, createToolParams.McpEnabled, pluginCreated)
 
 	toolsetDetails, err := mv.DescribeToolset(ctx, logger, s.db, mv.ProjectID(*authCtx.ProjectID), mv.ToolsetSlug(createdToolset.Slug), &s.toolsetCache, nil)
 	if err != nil {
@@ -307,18 +308,20 @@ func (s *Service) attachToDefaultPlugin(ctx context.Context, dbtx pgx.Tx, authCt
 }
 
 // triggerPluginPublish enqueues the marketplace publish for the project whose
-// Default plugin membership just changed. attached is false when the mutation
+// Default plugin membership just changed. publish is false when the mutation
 // could not have changed generated plugin output (a Meta-MCP endpoint, a
 // non-MCP toolset, a disabled or endpointless server): those paths must not
-// enqueue at all, since a project with no GitHub connection yet treats any
-// publish as its first and would get a marketplace repo it has no packages
-// for.
-func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, attached, pluginCreated bool) {
-	if !attached || !s.pluginsGitHubEnabled {
+// enqueue at all. attached says this request actually ran the attach, which is
+// what licenses creating the project's first marketplace repo — a mutation
+// that only edits an existing member (a rename, a disable) must never hand an
+// unpublished project a repo, since nothing here proves it has anything to put
+// in one.
+func (s *Service) triggerPluginPublish(ctx context.Context, authCtx *contextvalues.AuthContext, publish, attached, pluginCreated bool) {
+	if !publish || !s.pluginsGitHubEnabled {
 		return
 	}
 
-	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, true, pluginCreated)
+	background.TriggerPluginPublish(ctx, s.temporalEnv, s.logger, *authCtx.ProjectID, authCtx.UserID, attached, pluginCreated)
 }
 
 func (s *Service) ListToolsets(ctx context.Context, payload *gen.ListToolsetsPayload) (*gen.ListToolsetsResult, error) {
@@ -620,8 +623,12 @@ func (s *Service) UpdateToolset(ctx context.Context, payload *gen.UpdateToolsetP
 	// An already-attached toolset publishes too: a rename or slug change moves
 	// its entry in the generated package even though no attach ran, and
 	// disabling MCP drops the entry entirely — so the previous state counts as
-	// much as the new one.
-	s.triggerPluginPublish(ctx, authCtx, existingToolset.McpEnabled || updatedToolset.McpEnabled, pluginCreated)
+	// much as the new one. Only the enable transition attached anything though,
+	// so only it may create the project's first marketplace.
+	s.triggerPluginPublish(ctx, authCtx,
+		existingToolset.McpEnabled || updatedToolset.McpEnabled,
+		!existingToolset.McpEnabled && updatedToolset.McpEnabled,
+		pluginCreated)
 
 	return toolsetDetails, nil
 }


### PR DESCRIPTION
Follow-up to #6009, which was already in the merge queue when this came out of review.

## Summary

Adds `PublishProjectInput.SkipIfUnpublished`: the publish short-circuits when the project has no `plugin_github_connections` row yet. Every change-driven signal sets it, so a signal can update a marketplace but never bring one into existence.

Creating the repo stays with the paths that mean it — project creation and a first Default-plugin attach (both forced), the dashboard Publish button, and the rollout sweep, whose candidate list is already scoped to projects with a Default plugin or a previous publish.

## Motivation

`publishProject` treats a project with no connection as `firstPublish`, which ignores `SkipIfUnchanged` and creates the repository. #6009 gates each mutation path on whether the server or toolset could contribute generated output, but "could contribute" is not the same as "is a plugin member": an enabled MCP server with no endpoint is never attached, so renaming one in a never-published project would create an empty marketplace repo and mint an API key for it. An MCP-enabled toolset that predates attach-on-enable has the same shape.

Gating at the publish boundary fixes the whole class in one place, rather than adding a membership lookup to each mutation path and leaving the next new callsite to rediscover the trap.

https://claude.ai/code/session_011G5NTsW2Qbm31ET9oRSMS9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes change-driven plugin publishes so they can update an existing marketplace repo but never create the first one. A project with no `plugin_github_connections` row previously took the first-publish path on signals like renaming an enabled MCP server with no endpoint, creating an empty repo and minting an API key; those publishes now short-circuit.

**Behavior**
- Adds `PublishProjectInput.AllowFirstPublish`, opt-in and false by default, so a change signal updates an existing marketplace but never creates one.
- `TriggerPluginPublish` takes `allowFirstPublish` separately from `force`, so a first attach can create the repo without a fingerprint-blind republish.
- `triggerPluginPublish` now takes `publish` and `attached` separately: only an actual Default-plugin attach may create the repo, so editing an existing member never does.
- First-repo creation stays with project creation, first Default-plugin attach, the dashboard Publish button, the rollout sweep, and local dev restore.
- The connection lookup now runs before plugin/config generation, so a skipped signal costs one query; tests cover a skipped signal without minting keys and a forced publish still creating the repo.

<sup>Written for commit 46fe5a4a8e849495284bbbfc065e31efc9165cdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

