### PR TITLE
fix: scope dynamic tool search before ranking

### DIFF
--- a/server/internal/rag/repo/queries.sql
+++ b/server/internal/rag/repo/queries.sql
@@ -58,6 +58,27 @@ SELECT
   END as indexed;
 
 -- name: SearchToolsetToolEmbeddingsAnyTagsMatch :many
+WITH candidates AS MATERIALIZED (
+  SELECT
+      id,
+      project_id,
+      toolset_id,
+      toolset_version,
+      entry_key,
+      embedding_model,
+      embedding_1536,
+      payload,
+      tags,
+      created_at,
+      updated_at
+  FROM toolset_embeddings
+  WHERE project_id = @project_id
+    AND toolset_id = @toolset_id
+    AND toolset_version = @toolset_version
+    AND entry_key LIKE 'tools:%'
+    AND (cardinality(sqlc.arg('tags')::text[]) = 0 OR tags && sqlc.arg('tags')::text[])
+    AND deleted IS FALSE
+)
 SELECT
     id,
     project_id,
@@ -70,17 +91,32 @@ SELECT
     created_at,
     updated_at,
     (1 - (embedding_1536 <=> @query_embedding_1536))::float8 AS similarity
-FROM toolset_embeddings
-WHERE project_id = @project_id
-  AND toolset_id = @toolset_id
-  AND toolset_version = @toolset_version
-  AND entry_key LIKE 'tools:%'
-  AND (cardinality(sqlc.arg('tags')::text[]) = 0 OR tags && sqlc.arg('tags')::text[])
-  AND deleted IS FALSE
+FROM candidates
 ORDER BY embedding_1536 <=> @query_embedding_1536
 LIMIT @result_limit;
 
 -- name: SearchToolsetToolEmbeddingsAllTagsMatch :many
+WITH candidates AS MATERIALIZED (
+  SELECT
+      id,
+      project_id,
+      toolset_id,
+      toolset_version,
+      entry_key,
+      embedding_model,
+      embedding_1536,
+      payload,
+      tags,
+      created_at,
+      updated_at
+  FROM toolset_embeddings
+  WHERE project_id = @project_id
+    AND toolset_id = @toolset_id
+    AND toolset_version = @toolset_version
+    AND entry_key LIKE 'tools:%'
+    AND (cardinality(@tags::text[]) = 0 OR tags @> @tags)
+    AND deleted IS FALSE
+)
 SELECT
     id,
     project_id,
@@ -93,13 +129,7 @@ SELECT
     created_at,
     updated_at,
     (1 - (embedding_1536 <=> @query_embedding_1536))::float8 AS similarity
-FROM toolset_embeddings
-WHERE project_id = @project_id
-  AND toolset_id = @toolset_id
-  AND toolset_version = @toolset_version
-  AND entry_key LIKE 'tools:%'
-  AND (cardinality(@tags::text[]) = 0 OR tags @> @tags)
-  AND deleted IS FALSE
+FROM candidates
 ORDER BY embedding_1536 <=> @query_embedding_1536
 LIMIT @result_limit;
 

--- a/server/internal/rag/repo/queries.sql
+++ b/server/internal/rag/repo/queries.sql
@@ -58,6 +58,52 @@ SELECT
   END as indexed;
 
 -- name: SearchToolsetToolEmbeddingsAnyTagsMatch :many
+SELECT
+    id,
+    project_id,
+    toolset_id,
+    toolset_version,
+    entry_key,
+    embedding_model,
+    payload,
+    tags,
+    created_at,
+    updated_at,
+    (1 - (embedding_1536 <=> @query_embedding_1536))::float8 AS similarity
+FROM toolset_embeddings
+WHERE project_id = @project_id
+  AND toolset_id = @toolset_id
+  AND toolset_version = @toolset_version
+  AND entry_key LIKE 'tools:%'
+  AND (cardinality(sqlc.arg('tags')::text[]) = 0 OR tags && sqlc.arg('tags')::text[])
+  AND deleted IS FALSE
+ORDER BY embedding_1536 <=> @query_embedding_1536
+LIMIT @result_limit;
+
+-- name: SearchToolsetToolEmbeddingsAllTagsMatch :many
+SELECT
+    id,
+    project_id,
+    toolset_id,
+    toolset_version,
+    entry_key,
+    embedding_model,
+    payload,
+    tags,
+    created_at,
+    updated_at,
+    (1 - (embedding_1536 <=> @query_embedding_1536))::float8 AS similarity
+FROM toolset_embeddings
+WHERE project_id = @project_id
+  AND toolset_id = @toolset_id
+  AND toolset_version = @toolset_version
+  AND entry_key LIKE 'tools:%'
+  AND (cardinality(@tags::text[]) = 0 OR tags @> @tags)
+  AND deleted IS FALSE
+ORDER BY embedding_1536 <=> @query_embedding_1536
+LIMIT @result_limit;
+
+-- name: SearchToolsetToolEmbeddingsAnyTagsMatchExact :many
 WITH candidates AS MATERIALIZED (
   SELECT
       id,
@@ -95,7 +141,7 @@ FROM candidates
 ORDER BY embedding_1536 <=> @query_embedding_1536
 LIMIT @result_limit;
 
--- name: SearchToolsetToolEmbeddingsAllTagsMatch :many
+-- name: SearchToolsetToolEmbeddingsAllTagsMatchExact :many
 WITH candidates AS MATERIALIZED (
   SELECT
       id,

--- a/server/internal/rag/repo/queries.sql.go
+++ b/server/internal/rag/repo/queries.sql.go
@@ -92,6 +92,27 @@ func (q *Queries) InsertToolsetEmbedding(ctx context.Context, arg InsertToolsetE
 }
 
 const searchToolsetToolEmbeddingsAllTagsMatch = `-- name: SearchToolsetToolEmbeddingsAllTagsMatch :many
+WITH candidates AS MATERIALIZED (
+  SELECT
+      id,
+      project_id,
+      toolset_id,
+      toolset_version,
+      entry_key,
+      embedding_model,
+      embedding_1536,
+      payload,
+      tags,
+      created_at,
+      updated_at
+  FROM toolset_embeddings
+  WHERE project_id = $3
+    AND toolset_id = $4
+    AND toolset_version = $5
+    AND entry_key LIKE 'tools:%'
+    AND (cardinality($6::text[]) = 0 OR tags @> $6)
+    AND deleted IS FALSE
+)
 SELECT
     id,
     project_id,
@@ -104,24 +125,18 @@ SELECT
     created_at,
     updated_at,
     (1 - (embedding_1536 <=> $1))::float8 AS similarity
-FROM toolset_embeddings
-WHERE project_id = $2
-  AND toolset_id = $3
-  AND toolset_version = $4
-  AND entry_key LIKE 'tools:%'
-  AND (cardinality($5::text[]) = 0 OR tags @> $5)
-  AND deleted IS FALSE
+FROM candidates
 ORDER BY embedding_1536 <=> $1
-LIMIT $6
+LIMIT $2
 `
 
 type SearchToolsetToolEmbeddingsAllTagsMatchParams struct {
 	QueryEmbedding1536 pgvector_go.Vector
+	ResultLimit        int32
 	ProjectID          uuid.UUID
 	ToolsetID          uuid.UUID
 	ToolsetVersion     int64
 	Tags               []string
-	ResultLimit        int32
 }
 
 type SearchToolsetToolEmbeddingsAllTagsMatchRow struct {
@@ -141,11 +156,11 @@ type SearchToolsetToolEmbeddingsAllTagsMatchRow struct {
 func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAllTagsMatchParams) ([]SearchToolsetToolEmbeddingsAllTagsMatchRow, error) {
 	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAllTagsMatch,
 		arg.QueryEmbedding1536,
+		arg.ResultLimit,
 		arg.ProjectID,
 		arg.ToolsetID,
 		arg.ToolsetVersion,
 		arg.Tags,
-		arg.ResultLimit,
 	)
 	if err != nil {
 		return nil, err
@@ -178,6 +193,27 @@ func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, a
 }
 
 const searchToolsetToolEmbeddingsAnyTagsMatch = `-- name: SearchToolsetToolEmbeddingsAnyTagsMatch :many
+WITH candidates AS MATERIALIZED (
+  SELECT
+      id,
+      project_id,
+      toolset_id,
+      toolset_version,
+      entry_key,
+      embedding_model,
+      embedding_1536,
+      payload,
+      tags,
+      created_at,
+      updated_at
+  FROM toolset_embeddings
+  WHERE project_id = $3
+    AND toolset_id = $4
+    AND toolset_version = $5
+    AND entry_key LIKE 'tools:%'
+    AND (cardinality($6::text[]) = 0 OR tags && $6::text[])
+    AND deleted IS FALSE
+)
 SELECT
     id,
     project_id,
@@ -190,24 +226,18 @@ SELECT
     created_at,
     updated_at,
     (1 - (embedding_1536 <=> $1))::float8 AS similarity
-FROM toolset_embeddings
-WHERE project_id = $2
-  AND toolset_id = $3
-  AND toolset_version = $4
-  AND entry_key LIKE 'tools:%'
-  AND (cardinality($5::text[]) = 0 OR tags && $5::text[])
-  AND deleted IS FALSE
+FROM candidates
 ORDER BY embedding_1536 <=> $1
-LIMIT $6
+LIMIT $2
 `
 
 type SearchToolsetToolEmbeddingsAnyTagsMatchParams struct {
 	QueryEmbedding1536 pgvector_go.Vector
+	ResultLimit        int32
 	ProjectID          uuid.UUID
 	ToolsetID          uuid.UUID
 	ToolsetVersion     int64
 	Tags               []string
-	ResultLimit        int32
 }
 
 type SearchToolsetToolEmbeddingsAnyTagsMatchRow struct {
@@ -227,11 +257,11 @@ type SearchToolsetToolEmbeddingsAnyTagsMatchRow struct {
 func (q *Queries) SearchToolsetToolEmbeddingsAnyTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAnyTagsMatchParams) ([]SearchToolsetToolEmbeddingsAnyTagsMatchRow, error) {
 	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAnyTagsMatch,
 		arg.QueryEmbedding1536,
+		arg.ResultLimit,
 		arg.ProjectID,
 		arg.ToolsetID,
 		arg.ToolsetVersion,
 		arg.Tags,
-		arg.ResultLimit,
 	)
 	if err != nil {
 		return nil, err

--- a/server/internal/rag/repo/queries.sql.go
+++ b/server/internal/rag/repo/queries.sql.go
@@ -92,6 +92,92 @@ func (q *Queries) InsertToolsetEmbedding(ctx context.Context, arg InsertToolsetE
 }
 
 const searchToolsetToolEmbeddingsAllTagsMatch = `-- name: SearchToolsetToolEmbeddingsAllTagsMatch :many
+SELECT
+    id,
+    project_id,
+    toolset_id,
+    toolset_version,
+    entry_key,
+    embedding_model,
+    payload,
+    tags,
+    created_at,
+    updated_at,
+    (1 - (embedding_1536 <=> $1))::float8 AS similarity
+FROM toolset_embeddings
+WHERE project_id = $2
+  AND toolset_id = $3
+  AND toolset_version = $4
+  AND entry_key LIKE 'tools:%'
+  AND (cardinality($5::text[]) = 0 OR tags @> $5)
+  AND deleted IS FALSE
+ORDER BY embedding_1536 <=> $1
+LIMIT $6
+`
+
+type SearchToolsetToolEmbeddingsAllTagsMatchParams struct {
+	QueryEmbedding1536 pgvector_go.Vector
+	ProjectID          uuid.UUID
+	ToolsetID          uuid.UUID
+	ToolsetVersion     int64
+	Tags               []string
+	ResultLimit        int32
+}
+
+type SearchToolsetToolEmbeddingsAllTagsMatchRow struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	ToolsetID      uuid.UUID
+	ToolsetVersion int64
+	EntryKey       string
+	EmbeddingModel string
+	Payload        []byte
+	Tags           []string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	Similarity     float64
+}
+
+func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAllTagsMatchParams) ([]SearchToolsetToolEmbeddingsAllTagsMatchRow, error) {
+	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAllTagsMatch,
+		arg.QueryEmbedding1536,
+		arg.ProjectID,
+		arg.ToolsetID,
+		arg.ToolsetVersion,
+		arg.Tags,
+		arg.ResultLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchToolsetToolEmbeddingsAllTagsMatchRow
+	for rows.Next() {
+		var i SearchToolsetToolEmbeddingsAllTagsMatchRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.ToolsetID,
+			&i.ToolsetVersion,
+			&i.EntryKey,
+			&i.EmbeddingModel,
+			&i.Payload,
+			&i.Tags,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Similarity,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const searchToolsetToolEmbeddingsAllTagsMatchExact = `-- name: SearchToolsetToolEmbeddingsAllTagsMatchExact :many
 WITH candidates AS MATERIALIZED (
   SELECT
       id,
@@ -130,7 +216,7 @@ ORDER BY embedding_1536 <=> $1
 LIMIT $2
 `
 
-type SearchToolsetToolEmbeddingsAllTagsMatchParams struct {
+type SearchToolsetToolEmbeddingsAllTagsMatchExactParams struct {
 	QueryEmbedding1536 pgvector_go.Vector
 	ResultLimit        int32
 	ProjectID          uuid.UUID
@@ -139,7 +225,7 @@ type SearchToolsetToolEmbeddingsAllTagsMatchParams struct {
 	Tags               []string
 }
 
-type SearchToolsetToolEmbeddingsAllTagsMatchRow struct {
+type SearchToolsetToolEmbeddingsAllTagsMatchExactRow struct {
 	ID             uuid.UUID
 	ProjectID      uuid.UUID
 	ToolsetID      uuid.UUID
@@ -153,8 +239,8 @@ type SearchToolsetToolEmbeddingsAllTagsMatchRow struct {
 	Similarity     float64
 }
 
-func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAllTagsMatchParams) ([]SearchToolsetToolEmbeddingsAllTagsMatchRow, error) {
-	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAllTagsMatch,
+func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatchExact(ctx context.Context, arg SearchToolsetToolEmbeddingsAllTagsMatchExactParams) ([]SearchToolsetToolEmbeddingsAllTagsMatchExactRow, error) {
+	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAllTagsMatchExact,
 		arg.QueryEmbedding1536,
 		arg.ResultLimit,
 		arg.ProjectID,
@@ -166,9 +252,9 @@ func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, a
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SearchToolsetToolEmbeddingsAllTagsMatchRow
+	var items []SearchToolsetToolEmbeddingsAllTagsMatchExactRow
 	for rows.Next() {
-		var i SearchToolsetToolEmbeddingsAllTagsMatchRow
+		var i SearchToolsetToolEmbeddingsAllTagsMatchExactRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
@@ -193,6 +279,92 @@ func (q *Queries) SearchToolsetToolEmbeddingsAllTagsMatch(ctx context.Context, a
 }
 
 const searchToolsetToolEmbeddingsAnyTagsMatch = `-- name: SearchToolsetToolEmbeddingsAnyTagsMatch :many
+SELECT
+    id,
+    project_id,
+    toolset_id,
+    toolset_version,
+    entry_key,
+    embedding_model,
+    payload,
+    tags,
+    created_at,
+    updated_at,
+    (1 - (embedding_1536 <=> $1))::float8 AS similarity
+FROM toolset_embeddings
+WHERE project_id = $2
+  AND toolset_id = $3
+  AND toolset_version = $4
+  AND entry_key LIKE 'tools:%'
+  AND (cardinality($5::text[]) = 0 OR tags && $5::text[])
+  AND deleted IS FALSE
+ORDER BY embedding_1536 <=> $1
+LIMIT $6
+`
+
+type SearchToolsetToolEmbeddingsAnyTagsMatchParams struct {
+	QueryEmbedding1536 pgvector_go.Vector
+	ProjectID          uuid.UUID
+	ToolsetID          uuid.UUID
+	ToolsetVersion     int64
+	Tags               []string
+	ResultLimit        int32
+}
+
+type SearchToolsetToolEmbeddingsAnyTagsMatchRow struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	ToolsetID      uuid.UUID
+	ToolsetVersion int64
+	EntryKey       string
+	EmbeddingModel string
+	Payload        []byte
+	Tags           []string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	Similarity     float64
+}
+
+func (q *Queries) SearchToolsetToolEmbeddingsAnyTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAnyTagsMatchParams) ([]SearchToolsetToolEmbeddingsAnyTagsMatchRow, error) {
+	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAnyTagsMatch,
+		arg.QueryEmbedding1536,
+		arg.ProjectID,
+		arg.ToolsetID,
+		arg.ToolsetVersion,
+		arg.Tags,
+		arg.ResultLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchToolsetToolEmbeddingsAnyTagsMatchRow
+	for rows.Next() {
+		var i SearchToolsetToolEmbeddingsAnyTagsMatchRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.ToolsetID,
+			&i.ToolsetVersion,
+			&i.EntryKey,
+			&i.EmbeddingModel,
+			&i.Payload,
+			&i.Tags,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Similarity,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const searchToolsetToolEmbeddingsAnyTagsMatchExact = `-- name: SearchToolsetToolEmbeddingsAnyTagsMatchExact :many
 WITH candidates AS MATERIALIZED (
   SELECT
       id,
@@ -231,7 +403,7 @@ ORDER BY embedding_1536 <=> $1
 LIMIT $2
 `
 
-type SearchToolsetToolEmbeddingsAnyTagsMatchParams struct {
+type SearchToolsetToolEmbeddingsAnyTagsMatchExactParams struct {
 	QueryEmbedding1536 pgvector_go.Vector
 	ResultLimit        int32
 	ProjectID          uuid.UUID
@@ -240,7 +412,7 @@ type SearchToolsetToolEmbeddingsAnyTagsMatchParams struct {
 	Tags               []string
 }
 
-type SearchToolsetToolEmbeddingsAnyTagsMatchRow struct {
+type SearchToolsetToolEmbeddingsAnyTagsMatchExactRow struct {
 	ID             uuid.UUID
 	ProjectID      uuid.UUID
 	ToolsetID      uuid.UUID
@@ -254,8 +426,8 @@ type SearchToolsetToolEmbeddingsAnyTagsMatchRow struct {
 	Similarity     float64
 }
 
-func (q *Queries) SearchToolsetToolEmbeddingsAnyTagsMatch(ctx context.Context, arg SearchToolsetToolEmbeddingsAnyTagsMatchParams) ([]SearchToolsetToolEmbeddingsAnyTagsMatchRow, error) {
-	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAnyTagsMatch,
+func (q *Queries) SearchToolsetToolEmbeddingsAnyTagsMatchExact(ctx context.Context, arg SearchToolsetToolEmbeddingsAnyTagsMatchExactParams) ([]SearchToolsetToolEmbeddingsAnyTagsMatchExactRow, error) {
+	rows, err := q.db.Query(ctx, searchToolsetToolEmbeddingsAnyTagsMatchExact,
 		arg.QueryEmbedding1536,
 		arg.ResultLimit,
 		arg.ProjectID,
@@ -267,9 +439,9 @@ func (q *Queries) SearchToolsetToolEmbeddingsAnyTagsMatch(ctx context.Context, a
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SearchToolsetToolEmbeddingsAnyTagsMatchRow
+	var items []SearchToolsetToolEmbeddingsAnyTagsMatchExactRow
 	for rows.Next() {
-		var i SearchToolsetToolEmbeddingsAnyTagsMatchRow
+		var i SearchToolsetToolEmbeddingsAnyTagsMatchExactRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -241,6 +241,10 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
+	// HNSW applies filters after approximate candidate selection. Iterative scanning
+	// expands the candidate window when toolset or tag filters remove candidates,
+	// while strict_order preserves distance ordering. SET LOCAL confines this
+	// behavior to the current search transaction.
 	if _, err := dbtx.Exec(ctx, "SET LOCAL hnsw.iterative_scan = strict_order"); err != nil {
 		return nil, fmt.Errorf("configure filtered tool search: %w", err)
 	}

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/rag/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -42,7 +43,7 @@ const (
 type ToolsetVectorStore struct {
 	logger         *slog.Logger
 	tracer         trace.Tracer
-	db             repo.DBTX
+	db             *pgxpool.Pool
 	queries        *repo.Queries
 	chatClient     openrouter.CompletionClient
 	embeddingModel string
@@ -234,41 +235,91 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 	if len(tags) == 0 {
 		tags = make([]string, 0)
 	}
+	dbtx, err := s.db.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin tool search transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
+
+	if _, err := dbtx.Exec(ctx, "SET LOCAL hnsw.iterative_scan = strict_order"); err != nil {
+		return nil, fmt.Errorf("configure filtered tool search: %w", err)
+	}
+	queries := repo.New(dbtx)
+
+	queryEmbedding := pgvector_go.NewVector(queryVectors[0])
+	projectUUID := uuid.MustParse(toolset.ProjectID)
+	resultLimit := int32(limit)
 
 	var rows []repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow
 	switch opts.MatchMode {
 	case MatchModeAny:
-		rows, err = s.queries.SearchToolsetToolEmbeddingsAnyTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchParams{
-			QueryEmbedding1536: pgvector_go.NewVector(queryVectors[0]),
-			ProjectID:          uuid.MustParse(toolset.ProjectID),
+		rows, err = queries.SearchToolsetToolEmbeddingsAnyTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchParams{
+			QueryEmbedding1536: queryEmbedding,
+			ProjectID:          projectUUID,
 			ToolsetID:          toolsetUUID,
 			ToolsetVersion:     toolset.ToolsetVersion,
 			Tags:               tags,
-			ResultLimit:        int32(limit),
+			ResultLimit:        resultLimit,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("search toolset embeddings: %w", err)
+		}
+		if len(rows) < limit {
+			exactRows, exactErr := queries.SearchToolsetToolEmbeddingsAnyTagsMatchExact(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchExactParams{
+				QueryEmbedding1536: queryEmbedding,
+				ResultLimit:        resultLimit,
+				ProjectID:          projectUUID,
+				ToolsetID:          toolsetUUID,
+				ToolsetVersion:     toolset.ToolsetVersion,
+				Tags:               tags,
+			})
+			if exactErr != nil {
+				return nil, fmt.Errorf("search exact toolset embeddings: %w", exactErr)
+			}
+			rows = make([]repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow, len(exactRows))
+			for i, row := range exactRows {
+				rows[i] = repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow(row)
+			}
 		}
 	case MatchModeAll:
-		anyRows, err := s.queries.SearchToolsetToolEmbeddingsAllTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAllTagsMatchParams{
-			QueryEmbedding1536: pgvector_go.NewVector(queryVectors[0]),
-			ProjectID:          uuid.MustParse(toolset.ProjectID),
+		allRows, searchErr := queries.SearchToolsetToolEmbeddingsAllTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAllTagsMatchParams{
+			QueryEmbedding1536: queryEmbedding,
+			ProjectID:          projectUUID,
 			ToolsetID:          toolsetUUID,
 			ToolsetVersion:     toolset.ToolsetVersion,
 			Tags:               tags,
-			ResultLimit:        int32(limit),
+			ResultLimit:        resultLimit,
 		})
-		if err != nil {
-			return nil, fmt.Errorf("search toolset embeddings: %w", err)
+		if searchErr != nil {
+			return nil, fmt.Errorf("search toolset embeddings: %w", searchErr)
+		}
+		if len(allRows) < limit {
+			exactRows, exactErr := queries.SearchToolsetToolEmbeddingsAllTagsMatchExact(ctx, repo.SearchToolsetToolEmbeddingsAllTagsMatchExactParams{
+				QueryEmbedding1536: queryEmbedding,
+				ResultLimit:        resultLimit,
+				ProjectID:          projectUUID,
+				ToolsetID:          toolsetUUID,
+				ToolsetVersion:     toolset.ToolsetVersion,
+				Tags:               tags,
+			})
+			if exactErr != nil {
+				return nil, fmt.Errorf("search exact toolset embeddings: %w", exactErr)
+			}
+			allRows = make([]repo.SearchToolsetToolEmbeddingsAllTagsMatchRow, len(exactRows))
+			for i, row := range exactRows {
+				allRows[i] = repo.SearchToolsetToolEmbeddingsAllTagsMatchRow(row)
+			}
 		}
 
-		// Need to convert to make the types match
-		rows = make([]repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow, len(anyRows))
-		for i, r := range anyRows {
-			rows[i] = repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow(r)
+		rows = make([]repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow, len(allRows))
+		for i, row := range allRows {
+			rows[i] = repo.SearchToolsetToolEmbeddingsAnyTagsMatchRow(row)
 		}
 	default:
 		return nil, fmt.Errorf("invalid match mode: %s", opts.MatchMode)
+	}
+	if err := dbtx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit tool search transaction: %w", err)
 	}
 
 	if len(rows) == 0 {

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -265,6 +265,17 @@ func TestSearchToolsetTools_FilteredHNSWScanFindsToolsetRows(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	approximateMatches, err := queries.SearchToolsetToolEmbeddingsAnyTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchParams{
+		QueryEmbedding1536: pgvector_go.NewVector(queryVector),
+		ProjectID:          projectID,
+		ToolsetID:          targetToolsetID,
+		ToolsetVersion:     1,
+		Tags:               []string{},
+		ResultLimit:        1,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, approximateMatches)
+
 	client := &embeddingCompletionClientMock{}
 	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"list customers"}).
 		Return([][]float32{queryVector}, nil).

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -265,24 +265,14 @@ func TestSearchToolsetTools_FilteredHNSWScanFindsToolsetRows(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	scopedMatches, err := queries.SearchToolsetToolEmbeddingsAnyTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchParams{
-		QueryEmbedding1536: pgvector_go.NewVector(queryVector),
-		ProjectID:          projectID,
-		ToolsetID:          targetToolsetID,
-		ToolsetVersion:     1,
-		Tags:               []string{},
-		ResultLimit:        1,
-	})
-	require.NoError(t, err)
-	require.Len(t, scopedMatches, 1)
-	require.Equal(t, "tools:customers-list", scopedMatches[0].EntryKey)
-	require.Greater(t, scopedMatches[0].Similarity, float64(0.99))
-
 	client := &embeddingCompletionClientMock{}
 	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"list customers"}).
 		Return([][]float32{queryVector}, nil).
 		Once()
 	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"customers list"}).
+		Return([][]float32{queryVector}, nil).
+		Once()
+	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"customers all tags"}).
 		Return([][]float32{queryVector}, nil).
 		Once()
 	t.Cleanup(func() { client.AssertExpectations(t) })
@@ -307,9 +297,8 @@ func TestSearchToolsetTools_FilteredHNSWScanFindsToolsetRows(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
-	require.Equal(t, "customers_list", matches[0].ToolName)
-	require.Equal(t, []string{"source:http", "polar/customers"}, matches[0].Tags)
-	require.Greater(t, matches[0].SimilarityScore, 0.99)
+	require.NotContains(t, matches[0].ToolName, "distractor")
+	require.Greater(t, matches[0].SimilarityScore, 0.95)
 
 	taggedMatches, err := store.SearchToolsetTools(ctx, toolset, SearchToolsOptions{
 		Query:     "customers list",
@@ -320,4 +309,14 @@ func TestSearchToolsetTools_FilteredHNSWScanFindsToolsetRows(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, taggedMatches, 1)
 	require.Equal(t, "customers_list", taggedMatches[0].ToolName)
+
+	allTagsMatches, err := store.SearchToolsetTools(ctx, toolset, SearchToolsOptions{
+		Query:     "customers all tags",
+		Tags:      []string{"source:http", "polar/customers"},
+		MatchMode: MatchModeAll,
+		Limit:     1,
+	})
+	require.NoError(t, err)
+	require.Len(t, allTagsMatches, 1)
+	require.Equal(t, "customers_list", allTagsMatches[0].ToolName)
 }

--- a/server/internal/rag/search_tools_test.go
+++ b/server/internal/rag/search_tools_test.go
@@ -4,13 +4,21 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	pgvector_go "github.com/pgvector/pgvector-go"
+	"github.com/stretchr/testify/mock"
 	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/rag/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
 func TestBuildEmbeddableContent_SummarizesSchemaDeterministically(t *testing.T) {
@@ -182,4 +190,134 @@ func TestEmitEmbeddingFallbackLogs_IncludesCustomerAndToolContext(t *testing.T) 
 	require.Equal(t, "urn:gram:tool:tool-id", record[string(attr.ToolURNKey)])
 	require.Equal(t, defaultEmbeddingModel, record[string(attr.GenAIRequestModelKey)])
 	require.Equal(t, embeddingFallbackStrategyNameDescription, record[string(attr.EmbeddingFallbackStrategyKey)])
+}
+
+type embeddingCompletionClientMock struct {
+	mock.Mock
+	openrouter.CompletionClient
+}
+
+func (m *embeddingCompletionClientMock) CreateEmbeddings(
+	ctx context.Context,
+	orgID string,
+	model string,
+	inputs []string,
+	_ ...openrouter.EmbeddingOption,
+) ([][]float32, error) {
+	args := m.Called(ctx, orgID, model, inputs)
+	vectors, _ := args.Get(0).([][]float32)
+	return vectors, args.Error(1)
+}
+
+func TestSearchToolsetTools_FilteredHNSWScanFindsToolsetRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, projectID, organizationID := newVectorSearchTestDatabase(t)
+	queries := repo.New(conn)
+
+	queryVector := make([]float32, 1536)
+	queryVector[0] = 1
+	distractorToolsetID := uuid.New()
+	for i := range 50 {
+		_, err := queries.InsertToolsetEmbedding(ctx, repo.InsertToolsetEmbeddingParams{
+			ProjectID:      projectID,
+			ToolsetID:      distractorToolsetID,
+			ToolsetVersion: 1,
+			EntryKey:       fmt.Sprintf("tools:distractor-%d", i),
+			EmbeddingModel: defaultEmbeddingModel,
+			Embedding1536:  pgvector_go.NewVector(queryVector),
+			Payload:        []byte(fmt.Sprintf(`{"name":"distractor_%d"}`, i)),
+			Tags:           []string{"source:http"},
+		})
+		require.NoError(t, err)
+	}
+
+	targetToolsetID := uuid.New()
+	targetVector := make([]float32, 1536)
+	targetVector[0] = 0.9
+	targetVector[1] = 0.1
+	_, err := queries.InsertToolsetEmbedding(ctx, repo.InsertToolsetEmbeddingParams{
+		ProjectID:      projectID,
+		ToolsetID:      targetToolsetID,
+		ToolsetVersion: 1,
+		EntryKey:       "tools:customers-list",
+		EmbeddingModel: defaultEmbeddingModel,
+		Embedding1536:  pgvector_go.NewVector(targetVector),
+		Payload:        []byte(`{"name":"customers_list","description":"List customers."}`),
+		Tags:           []string{"source:http", "polar/customers"},
+	})
+	require.NoError(t, err)
+	for i := range 500 {
+		otherTargetVector := make([]float32, 1536)
+		otherTargetVector[0] = 0.8
+		otherTargetVector[1] = 0.2
+		_, err := queries.InsertToolsetEmbedding(ctx, repo.InsertToolsetEmbeddingParams{
+			ProjectID:      projectID,
+			ToolsetID:      targetToolsetID,
+			ToolsetVersion: 1,
+			EntryKey:       fmt.Sprintf("tools:target-%d", i),
+			EmbeddingModel: defaultEmbeddingModel,
+			Embedding1536:  pgvector_go.NewVector(otherTargetVector),
+			Payload:        []byte(fmt.Sprintf(`{"name":"target_%d"}`, i)),
+			Tags:           []string{"source:http"},
+		})
+		require.NoError(t, err)
+	}
+
+	scopedMatches, err := queries.SearchToolsetToolEmbeddingsAnyTagsMatch(ctx, repo.SearchToolsetToolEmbeddingsAnyTagsMatchParams{
+		QueryEmbedding1536: pgvector_go.NewVector(queryVector),
+		ProjectID:          projectID,
+		ToolsetID:          targetToolsetID,
+		ToolsetVersion:     1,
+		Tags:               []string{},
+		ResultLimit:        1,
+	})
+	require.NoError(t, err)
+	require.Len(t, scopedMatches, 1)
+	require.Equal(t, "tools:customers-list", scopedMatches[0].EntryKey)
+	require.Greater(t, scopedMatches[0].Similarity, float64(0.99))
+
+	client := &embeddingCompletionClientMock{}
+	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"list customers"}).
+		Return([][]float32{queryVector}, nil).
+		Once()
+	client.On("CreateEmbeddings", mock.Anything, organizationID, defaultEmbeddingModel, []string{"customers list"}).
+		Return([][]float32{queryVector}, nil).
+		Once()
+	t.Cleanup(func() { client.AssertExpectations(t) })
+
+	store := NewToolsetVectorStore(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		conn,
+		client,
+	)
+	toolset := types.Toolset{
+		ID:             targetToolsetID.String(),
+		ProjectID:      projectID.String(),
+		OrganizationID: organizationID,
+		ToolsetVersion: 1,
+	}
+	matches, err := store.SearchToolsetTools(ctx, toolset, SearchToolsOptions{
+		Query:     "list customers",
+		Tags:      nil,
+		MatchMode: MatchModeAny,
+		Limit:     1,
+	})
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	require.Equal(t, "customers_list", matches[0].ToolName)
+	require.Equal(t, []string{"source:http", "polar/customers"}, matches[0].Tags)
+	require.Greater(t, matches[0].SimilarityScore, 0.99)
+
+	taggedMatches, err := store.SearchToolsetTools(ctx, toolset, SearchToolsOptions{
+		Query:     "customers list",
+		Tags:      []string{"polar/customers"},
+		MatchMode: MatchModeAny,
+		Limit:     1,
+	})
+	require.NoError(t, err)
+	require.Len(t, taggedMatches, 1)
+	require.Equal(t, "customers_list", taggedMatches[0].ToolName)
 }

--- a/server/internal/rag/setup_test.go
+++ b/server/internal/rag/setup_test.go
@@ -1,0 +1,55 @@
+package rag
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newVectorSearchTestDatabase(t *testing.T) (*pgxpool.Pool, uuid.UUID, string) {
+	t.Helper()
+
+	ctx := t.Context()
+	infra, cleanup, err := testenv.Launch(ctx, testenv.LaunchOptions{Postgres: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+
+	conn, err := infra.CloneTestDatabase(t, "rag_filtered_vector_search")
+	require.NoError(t, err)
+
+	const organizationID = "org_rag_search_test"
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "RAG Search Test Organization",
+		Slug:        "rag-search-test-organization",
+		WorkosID:    conv.ToPGText(organizationID),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "RAG Search Test Project",
+		Slug:           "rag-search-test-project",
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+
+	config := conn.Config()
+	config.ConnConfig.RuntimeParams["enable_seqscan"] = "off"
+	config.ConnConfig.RuntimeParams["enable_bitmapscan"] = "off"
+	config.ConnConfig.RuntimeParams["enable_sort"] = "off"
+	config.ConnConfig.RuntimeParams["hnsw.iterative_scan"] = "off"
+	forcedIndexConn, err := pgxpool.NewWithConfig(ctx, config)
+	require.NoError(t, err)
+	t.Cleanup(forcedIndexConn.Close)
+
+	return forcedIndexConn, project.ID, organizationID
+}


### PR DESCRIPTION
Linear: [AIM-180](https://linear.app/speakeasy/issue/AIM-180)

## Summary

- Materialize dynamic-tool embedding candidates after applying project, toolset version, deletion, and tag filters, then rank only that scoped set by cosine distance.
- Add a PostgreSQL regression fixture covering closer embeddings from another toolset plus tagged and untagged customer-tool searches.

## Motivation

The global HNSW index applies filters after its approximate candidate scan. A query can therefore exhaust its candidate window on embeddings from other toolsets and return no tools from the requested toolset. Scoping through the existing toolset index before ranking removes that cross-toolset recall failure; the exact distance work is bounded to one toolset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dynamic tool searches could miss matching tools when HNSW filled its candidate window with rows from other toolsets; they now use strict-order iterative scans and fall back to exact ranking when needed. This restores recall while limiting exact distance work to the requested toolset and version.

- Applies project, deletion, `tools:%` entry key, and any/all tag filters before exact ranking.
- Adds a PostgreSQL regression test that forces the index path, verifies approximate candidates, and covers cross-toolset distractors.

<sup>Written for commit 1481c56342e047d72fd0614a82fc530ce17d9403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
