### PR TITLE
chore: consolidate request logging into wide events

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -76,7 +76,6 @@ const (
 	RequestAuthSchemeSessionKey          = attribute.Key("req.auth_scheme_session")
 	RequestAuthSchemeProjectKey          = attribute.Key("req.auth_scheme_project")
 	RequestAuthSchemeAPIKeyKey           = attribute.Key("req.auth_scheme_api_key")
-	RequestAuthSessionIDKey              = attribute.Key("req.auth_session_id")
 	RequestAuthUserEmailKey              = attribute.Key("req.auth_user_email")
 	RequestAuthUserIDKey                 = attribute.Key("req.auth_user_id")
 	RequestAuthUserExternalIDKey         = attribute.Key("req.auth_external_user_id")
@@ -145,7 +144,6 @@ const (
 	AuthProjectIDKey         = attribute.Key("gram.auth.project_id")
 	AuthProjectSlugKey       = attribute.Key("gram.auth.project_slug")
 	AuthSchemeKey            = attribute.Key("gram.auth.scheme")
-	AuthSessionIDKey         = attribute.Key("gram.auth.session_id")
 	AuthUserEmailKey         = attribute.Key("gram.auth.user_email")
 	AuthUserIDKey            = attribute.Key("gram.auth.user_id")
 	AuthUserExternalIDKey    = attribute.Key("gram.auth.external_user_id")
@@ -1082,11 +1080,6 @@ func SlogRequestAuthAPIKeyScheme(matched bool) slog.Attr {
 	return slog.Bool(string(RequestAuthSchemeAPIKeyKey), matched)
 }
 
-func RequestAuthSessionID(v string) attribute.KeyValue { return RequestAuthSessionIDKey.String(v) }
-func SlogRequestAuthSessionID(v string) slog.Attr {
-	return slog.String(string(RequestAuthSessionIDKey), v)
-}
-
 func RequestAuthUserEmail(v string) attribute.KeyValue { return RequestAuthUserEmailKey.String(v) }
 func SlogRequestAuthUserEmail(v string) slog.Attr {
 	return slog.String(string(RequestAuthUserEmailKey), v)
@@ -1245,9 +1238,6 @@ func SlogAuthProjectSlug(v string) slog.Attr      { return slog.String(string(Au
 
 func AuthScheme(v string) attribute.KeyValue { return AuthSchemeKey.String(v) }
 func SlogAuthScheme(v string) slog.Attr      { return slog.String(string(AuthSchemeKey), v) }
-
-func AuthSessionID(v string) attribute.KeyValue { return AuthSessionIDKey.String(v) }
-func SlogAuthSessionID(v string) slog.Attr      { return slog.String(string(AuthSessionIDKey), v) }
 
 func AuthUserEmail(v string) attribute.KeyValue { return AuthUserEmailKey.String(v) }
 func SlogAuthUserEmail(v string) slog.Attr      { return slog.String(string(AuthUserEmailKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -12,6 +12,8 @@ import (
 type Key = attribute.Key
 
 const (
+	WideEventKey = attribute.Key("gram.wide_event")
+
 	ErrorIDKey                       = attribute.Key("error.id")
 	ErrorMessageKey                  = attribute.Key("error.message")
 	ErrorStackKey                    = attribute.Key("error.stack")
@@ -64,6 +66,25 @@ const (
 	UserIDKey                            = semconv.UserIDKey
 	UserEmailKey                         = semconv.UserEmailKey
 	UserRolesKey                         = semconv.UserRolesKey
+
+	RequestAuthAccountTypeKey            = attribute.Key("req.auth_account_type")
+	RequestAuthAPIKeyIDKey               = attribute.Key("req.auth_api_key_id")
+	RequestAuthOrganizationIDKey         = attribute.Key("req.auth_organization_id")
+	RequestAuthOrganizationSlugKey       = attribute.Key("req.auth_organization_slug")
+	RequestAuthProjectIDKey              = attribute.Key("req.auth_project_id")
+	RequestAuthProjectSlugKey            = attribute.Key("req.auth_project_slug")
+	RequestAuthSchemeSessionKey          = attribute.Key("req.auth_scheme_session")
+	RequestAuthSchemeProjectKey          = attribute.Key("req.auth_scheme_project")
+	RequestAuthSchemeAPIKeyKey           = attribute.Key("req.auth_scheme_api_key")
+	RequestAuthSessionIDKey              = attribute.Key("req.auth_session_id")
+	RequestAuthUserEmailKey              = attribute.Key("req.auth_user_email")
+	RequestAuthUserIDKey                 = attribute.Key("req.auth_user_id")
+	RequestAuthUserExternalIDKey         = attribute.Key("req.auth_external_user_id")
+	RequestAuthSchemeAPIKeyErrorKey      = attribute.Key("req.auth_api_key_error")
+	RequestAuthSchemeSessionErrorKey     = attribute.Key("req.auth_session_error")
+	RequestAuthSchemeProjectSlugErrorKey = attribute.Key("req.auth_project_slug_error")
+	RequestCustomDomainIDKey             = attribute.Key("req.custom_domain_id")
+	RequestCustomDomainNameKey           = attribute.Key("req.custom_domain_name")
 
 	// UserAttributesKey and UserGroupsKey carry the denormalized WorkOS
 	// Directory Sync snapshot stamped onto telemetry logs at write time.
@@ -746,6 +767,9 @@ const (
 	VisibilityInternalValue = "internal"
 )
 
+func WideEvent() attribute.KeyValue { return WideEventKey.Bool(true) }
+func SlogWideEvent() slog.Attr      { return slog.Bool(string(WideEventKey), true) }
+
 func Error(v error) attribute.KeyValue { return ErrorMessageKey.String(v.Error()) }
 func SlogError(v error) slog.Attr      { return slog.String(string(ErrorMessageKey), v.Error()) }
 
@@ -1004,6 +1028,112 @@ func SlogUserID(v string) slog.Attr      { return slog.String(string(UserIDKey),
 
 func ExternalUserID(v string) attribute.KeyValue { return ExternalUserIDKey.String(v) }
 func SlogExternalUserID(v string) slog.Attr      { return slog.String(string(ExternalUserIDKey), v) }
+
+func RequestAuthAccountType(v string) attribute.KeyValue { return RequestAuthAccountTypeKey.String(v) }
+func SlogRequestAuthAccountType(v string) slog.Attr {
+	return slog.String(string(RequestAuthAccountTypeKey), v)
+}
+
+func RequestAuthAPIKeyID(v string) attribute.KeyValue { return RequestAuthAPIKeyIDKey.String(v) }
+func SlogRequestAuthAPIKeyID(v string) slog.Attr {
+	return slog.String(string(RequestAuthAPIKeyIDKey), v)
+}
+
+func RequestAuthOrganizationID(v string) attribute.KeyValue {
+	return RequestAuthOrganizationIDKey.String(v)
+}
+func SlogRequestAuthOrganizationID(v string) slog.Attr {
+	return slog.String(string(RequestAuthOrganizationIDKey), v)
+}
+
+func RequestAuthOrganizationSlug(v string) attribute.KeyValue {
+	return RequestAuthOrganizationSlugKey.String(v)
+}
+func SlogRequestAuthOrganizationSlug(v string) slog.Attr {
+	return slog.String(string(RequestAuthOrganizationSlugKey), v)
+}
+
+func RequestAuthProjectID(v string) attribute.KeyValue { return RequestAuthProjectIDKey.String(v) }
+func SlogRequestAuthProjectID(v string) slog.Attr {
+	return slog.String(string(RequestAuthProjectIDKey), v)
+}
+
+func RequestAuthProjectSlug(v string) attribute.KeyValue { return RequestAuthProjectSlugKey.String(v) }
+func SlogRequestAuthProjectSlug(v string) slog.Attr {
+	return slog.String(string(RequestAuthProjectSlugKey), v)
+}
+
+func RequestAuthSessionScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeSessionKey.Bool(matched)
+}
+func SlogRequestAuthSessionScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeSessionKey), matched)
+}
+func RequestAuthProjectScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeProjectKey.Bool(matched)
+}
+func SlogRequestAuthProjectScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeProjectKey), matched)
+}
+func RequestAuthAPIKeyScheme(matched bool) attribute.KeyValue {
+	return RequestAuthSchemeAPIKeyKey.Bool(matched)
+}
+func SlogRequestAuthAPIKeyScheme(matched bool) slog.Attr {
+	return slog.Bool(string(RequestAuthSchemeAPIKeyKey), matched)
+}
+
+func RequestAuthSessionID(v string) attribute.KeyValue { return RequestAuthSessionIDKey.String(v) }
+func SlogRequestAuthSessionID(v string) slog.Attr {
+	return slog.String(string(RequestAuthSessionIDKey), v)
+}
+
+func RequestAuthUserEmail(v string) attribute.KeyValue { return RequestAuthUserEmailKey.String(v) }
+func SlogRequestAuthUserEmail(v string) slog.Attr {
+	return slog.String(string(RequestAuthUserEmailKey), v)
+}
+
+func RequestAuthUserID(v string) attribute.KeyValue { return RequestAuthUserIDKey.String(v) }
+func SlogRequestAuthUserID(v string) slog.Attr      { return slog.String(string(RequestAuthUserIDKey), v) }
+
+func RequestAuthUserExternalID(v string) attribute.KeyValue {
+	return RequestAuthUserExternalIDKey.String(v)
+}
+func SlogRequestAuthUserExternalID(v string) slog.Attr {
+	return slog.String(string(RequestAuthUserExternalIDKey), v)
+}
+
+func RequestAuthSchemeAPIKeyError(v string) attribute.KeyValue {
+	return RequestAuthSchemeAPIKeyErrorKey.String(v)
+}
+func SlogRequestAuthSchemeAPIKeyError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeAPIKeyErrorKey), v)
+}
+
+func RequestAuthSchemeSessionError(v string) attribute.KeyValue {
+	return RequestAuthSchemeSessionErrorKey.String(v)
+}
+func SlogRequestAuthSchemeSessionError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeSessionErrorKey), v)
+}
+
+func RequestAuthSchemeProjectSlugError(v string) attribute.KeyValue {
+	return RequestAuthSchemeProjectSlugErrorKey.String(v)
+}
+func SlogRequestAuthSchemeProjectSlugError(v string) slog.Attr {
+	return slog.String(string(RequestAuthSchemeProjectSlugErrorKey), v)
+}
+
+func RequestCustomDomainID(v string) attribute.KeyValue { return RequestCustomDomainIDKey.String(v) }
+func SlogRequestCustomDomainID(v string) slog.Attr {
+	return slog.String(string(RequestCustomDomainIDKey), v)
+}
+
+func RequestCustomDomainName(v string) attribute.KeyValue {
+	return RequestCustomDomainNameKey.String(v)
+}
+func SlogRequestCustomDomainName(v string) slog.Attr {
+	return slog.String(string(RequestCustomDomainNameKey), v)
+}
 
 func APIKeyID(v string) attribute.KeyValue { return APIKeyIDKey.String(v) }
 func SlogAPIKeyID(v string) slog.Attr      { return slog.String(string(APIKeyIDKey), v) }

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -18,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 )
 
 type Auth struct {
@@ -73,7 +73,8 @@ func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKe
 	// that project. When RBAC is off (or the caller is an API key), Require is
 	// a no-op and org/project-bound key scoping above remains authoritative.
 	if scheme.Name == constants.ProjectSlugSecuritySchema {
-		if err := s.requireResolvedProjectAccess(ctx); err != nil {
+		err = s.requireResolvedProjectAccess(ctx)
+		if err != nil {
 			return ctx, err
 		}
 	}
@@ -189,40 +190,58 @@ func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
 		return
 	}
 
-	attrs := []any{
-		attr.SlogAuthScheme(scheme),
-		attr.SlogAuthOrganizationID(authCtx.ActiveOrganizationID),
-		attr.SlogAuthOrganizationSlug(authCtx.OrganizationSlug),
-		attr.SlogAuthAccountType(authCtx.AccountType),
-	}
-	if err != nil {
-		attrs = append(attrs, attr.SlogError(err))
-	}
-	if authCtx.UserID != "" {
-		attrs = append(attrs, attr.SlogAuthUserID(authCtx.UserID))
-	}
-	if authCtx.ExternalUserID != "" {
-		attrs = append(attrs, attr.SlogAuthUserExternalID(authCtx.ExternalUserID))
-	}
-	if authCtx.Email != nil {
-		attrs = append(attrs, attr.SlogAuthUserEmail(*authCtx.Email))
-	}
-	if authCtx.APIKeyID != "" {
-		attrs = append(attrs, attr.SlogAuthAPIKeyID(authCtx.APIKeyID))
-	}
-	if authCtx.SessionID != nil {
-		attrs = append(attrs, attr.SlogAuthSessionID(*authCtx.SessionID))
-	}
-	if authCtx.ProjectID != nil {
-		attrs = append(attrs, attr.SlogAuthProjectID(authCtx.ProjectID.String()))
-	}
-	if authCtx.ProjectSlug != nil {
-		attrs = append(attrs, attr.SlogAuthProjectSlug(*authCtx.ProjectSlug))
+	var schemeAttr slog.Attr
+	var errAttr slog.Attr
+	switch scheme {
+	case constants.KeySecurityScheme:
+		schemeAttr = attr.SlogRequestAuthAPIKeyScheme(err == nil)
+		if err != nil {
+			errAttr = attr.SlogRequestAuthSchemeAPIKeyError(err.Error())
+		}
+	case constants.SessionSecurityScheme:
+		schemeAttr = attr.SlogRequestAuthSessionScheme(err == nil)
+		if err != nil {
+			errAttr = attr.SlogRequestAuthSchemeSessionError(err.Error())
+		}
+	case constants.ProjectSlugSecuritySchema:
+		schemeAttr = attr.SlogRequestAuthProjectScheme(err == nil)
+		if err != nil {
+			errAttr = attr.SlogRequestAuthSchemeProjectSlugError(err.Error())
+		}
+	default:
+		return
 	}
 
-	if err != nil {
-		s.logger.WarnContext(ctx, fmt.Sprintf("auth scheme check failed (%s)", scheme), attrs...)
-	} else {
-		s.logger.InfoContext(ctx, fmt.Sprintf("auth scheme check passed (%s)", scheme), attrs...)
+	attrs := []slog.Attr{
+		schemeAttr,
+		attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID),
+		attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug),
+		attr.SlogRequestAuthAccountType(authCtx.AccountType),
 	}
+	if err != nil {
+		attrs = append(attrs, errAttr)
+	}
+	if authCtx.UserID != "" {
+		attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
+	}
+	if authCtx.ExternalUserID != "" {
+		attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
+	}
+	if authCtx.Email != nil {
+		attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
+	}
+	if authCtx.APIKeyID != "" {
+		attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
+	}
+	if authCtx.SessionID != nil {
+		attrs = append(attrs, attr.SlogRequestAuthSessionID(*authCtx.SessionID))
+	}
+	if authCtx.ProjectID != nil {
+		attrs = append(attrs, attr.SlogRequestAuthProjectID(authCtx.ProjectID.String()))
+	}
+	if authCtx.ProjectSlug != nil {
+		attrs = append(attrs, attr.SlogRequestAuthProjectSlug(*authCtx.ProjectSlug))
+	}
+
+	wide.Push(ctx, attrs...)
 }

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -236,9 +236,6 @@ func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
 		if authCtx.APIKeyID != "" {
 			attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
 		}
-		if authCtx.SessionID != nil {
-			attrs = append(attrs, attr.SlogRequestAuthSessionID(*authCtx.SessionID))
-		}
 	}
 	if authCtx.ProjectID != nil && !wide.Contains(ctx, string(attr.RequestAuthProjectIDKey)) {
 		attrs = append(attrs, attr.SlogRequestAuthProjectID(authCtx.ProjectID.String()))

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -217,25 +217,26 @@ func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
 		attrs = append(attrs, errAttr)
 	}
 
-	if !wide.Contains(ctx, string(attr.RequestAuthOrganizationIDKey)) {
-		attrs = append(
-			attrs,
-			attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID),
-			attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug),
-			attr.SlogRequestAuthAccountType(authCtx.AccountType),
-		)
-		if authCtx.UserID != "" {
-			attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
-		}
-		if authCtx.ExternalUserID != "" {
-			attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
-		}
-		if authCtx.Email != nil {
-			attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
-		}
-		if authCtx.APIKeyID != "" {
-			attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
-		}
+	if authCtx.ActiveOrganizationID != "" && !wide.Contains(ctx, string(attr.RequestAuthOrganizationIDKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID))
+	}
+	if authCtx.OrganizationSlug != "" && !wide.Contains(ctx, string(attr.RequestAuthOrganizationSlugKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug))
+	}
+	if authCtx.AccountType != "" && !wide.Contains(ctx, string(attr.RequestAuthAccountTypeKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthAccountType(authCtx.AccountType))
+	}
+	if authCtx.UserID != "" && !wide.Contains(ctx, string(attr.RequestAuthUserIDKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
+	}
+	if authCtx.ExternalUserID != "" && !wide.Contains(ctx, string(attr.RequestAuthUserExternalIDKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
+	}
+	if authCtx.Email != nil && *authCtx.Email != "" && !wide.Contains(ctx, string(attr.RequestAuthUserEmailKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
+	}
+	if authCtx.APIKeyID != "" && !wide.Contains(ctx, string(attr.RequestAuthAPIKeyIDKey)) {
+		attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
 	}
 	if authCtx.ProjectID != nil && !wide.Contains(ctx, string(attr.RequestAuthProjectIDKey)) {
 		attrs = append(attrs, attr.SlogRequestAuthProjectID(authCtx.ProjectID.String()))

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -212,34 +212,38 @@ func (s *Auth) logAuthContext(ctx context.Context, err error, scheme string) {
 		return
 	}
 
-	attrs := []slog.Attr{
-		schemeAttr,
-		attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID),
-		attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug),
-		attr.SlogRequestAuthAccountType(authCtx.AccountType),
-	}
+	attrs := []slog.Attr{schemeAttr}
 	if err != nil {
 		attrs = append(attrs, errAttr)
 	}
-	if authCtx.UserID != "" {
-		attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
+
+	if !wide.Contains(ctx, string(attr.RequestAuthOrganizationIDKey)) {
+		attrs = append(
+			attrs,
+			attr.SlogRequestAuthOrganizationID(authCtx.ActiveOrganizationID),
+			attr.SlogRequestAuthOrganizationSlug(authCtx.OrganizationSlug),
+			attr.SlogRequestAuthAccountType(authCtx.AccountType),
+		)
+		if authCtx.UserID != "" {
+			attrs = append(attrs, attr.SlogRequestAuthUserID(authCtx.UserID))
+		}
+		if authCtx.ExternalUserID != "" {
+			attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
+		}
+		if authCtx.Email != nil {
+			attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
+		}
+		if authCtx.APIKeyID != "" {
+			attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
+		}
+		if authCtx.SessionID != nil {
+			attrs = append(attrs, attr.SlogRequestAuthSessionID(*authCtx.SessionID))
+		}
 	}
-	if authCtx.ExternalUserID != "" {
-		attrs = append(attrs, attr.SlogRequestAuthUserExternalID(authCtx.ExternalUserID))
-	}
-	if authCtx.Email != nil {
-		attrs = append(attrs, attr.SlogRequestAuthUserEmail(*authCtx.Email))
-	}
-	if authCtx.APIKeyID != "" {
-		attrs = append(attrs, attr.SlogRequestAuthAPIKeyID(authCtx.APIKeyID))
-	}
-	if authCtx.SessionID != nil {
-		attrs = append(attrs, attr.SlogRequestAuthSessionID(*authCtx.SessionID))
-	}
-	if authCtx.ProjectID != nil {
+	if authCtx.ProjectID != nil && !wide.Contains(ctx, string(attr.RequestAuthProjectIDKey)) {
 		attrs = append(attrs, attr.SlogRequestAuthProjectID(authCtx.ProjectID.String()))
 	}
-	if authCtx.ProjectSlug != nil {
+	if authCtx.ProjectSlug != nil && !wide.Contains(ctx, string(attr.RequestAuthProjectSlugKey)) {
 		attrs = append(attrs, attr.SlogRequestAuthProjectSlug(*authCtx.ProjectSlug))
 	}
 

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -137,7 +137,7 @@ func TestAuthorizeSessionCanSelectGrantedOrganizationProjects(t *testing.T) {
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
 
-	firstCtx, err := instance.authorizer.Authorize(t.Context(), session.SessionID, sessionScheme)
+	firstCtx, err := instance.authorizer.Authorize(wide.Start(t.Context()), session.SessionID, sessionScheme)
 	require.NoError(t, err)
 	firstCtx, err = instance.authorizer.Authorize(firstCtx, projects[0].Slug, projectSlugScheme)
 	require.NoError(t, err)
@@ -145,6 +145,9 @@ func TestAuthorizeSessionCanSelectGrantedOrganizationProjects(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, projects[0].ID, *firstAuthCtx.ProjectID)
 
+	for _, eventAttr := range wide.Emit(firstCtx) {
+		require.NotEqual(t, session.SessionID, eventAttr.Value.Any(), "session token must not be logged")
+	}
 	secondCtx, err := instance.authorizer.Authorize(t.Context(), session.SessionID, sessionScheme)
 	require.NoError(t, err)
 	secondCtx, err = instance.authorizer.Authorize(secondCtx, projects[1].Slug, projectSlugScheme)

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -157,6 +157,41 @@ func TestAuthorizeSessionCanSelectGrantedOrganizationProjects(t *testing.T) {
 	require.Equal(t, projects[1].ID, *secondAuthCtx.ProjectID)
 }
 
+func TestAuthorizeOrganizationlessSessionOmitsEmptyWideAttrs(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	userInfo.Organizations = nil
+	ctx, instance := newTestAuthService(t, userInfo)
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+
+	session := sessions.Session{
+		SessionID: "organizationless-session",
+		UserID:    userInfo.UserID,
+	}
+	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
+
+	ctx = wide.Start(ctx)
+	ctx, err := instance.authorizer.Authorize(ctx, session.SessionID, sessionScheme)
+	require.NoError(t, err)
+
+	emptyAuthKeys := map[string]struct{}{
+		string(attr.RequestAuthOrganizationIDKey):   {},
+		string(attr.RequestAuthOrganizationSlugKey): {},
+		string(attr.RequestAuthAccountTypeKey):      {},
+	}
+	var userIDFound bool
+	for _, eventAttr := range wide.Emit(ctx) {
+		_, isEmptyAuthAttr := emptyAuthKeys[eventAttr.Key]
+		require.False(t, isEmptyAuthAttr, "empty attribute %q must be omitted", eventAttr.Key)
+		if eventAttr.Key == string(attr.RequestAuthUserIDKey) {
+			userIDFound = true
+			require.Equal(t, userInfo.UserID, eventAttr.Value.String())
+		}
+	}
+	require.True(t, userIDFound)
+}
+
 func TestAuthorizeSessionRejectsUngrantedOrganizationProject(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -9,6 +9,7 @@ import (
 	"goa.design/goa/v3/security"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -18,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 )
 
 var (
@@ -42,6 +44,7 @@ func TestAuthorizeProjectBoundKeyAllowsBoundProjectSlug(t *testing.T) {
 	t.Parallel()
 
 	ctx, instance, projects := newProjectAccessTest(t, "bound-project")
+	ctx = wide.Start(ctx)
 	key := createTestAPIKey(t, ctx, instance, &projects[0].ID)
 
 	ctx, err := instance.authorizer.Authorize(ctx, key, apiKeyScheme)
@@ -53,6 +56,20 @@ func TestAuthorizeProjectBoundKeyAllowsBoundProjectSlug(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, projects[0].ID, *authCtx.ProjectID)
 	require.Equal(t, projects[0].Slug, *authCtx.ProjectSlug)
+
+	var apiKeySchemeFound, projectSchemeFound bool
+	for _, eventAttr := range wide.Emit(ctx) {
+		switch eventAttr.Key {
+		case string(attr.RequestAuthSchemeAPIKeyKey):
+			apiKeySchemeFound = true
+			require.True(t, eventAttr.Value.Bool())
+		case string(attr.RequestAuthSchemeProjectKey):
+			projectSchemeFound = true
+			require.True(t, eventAttr.Value.Bool())
+		}
+	}
+	require.True(t, apiKeySchemeFound)
+	require.True(t, projectSchemeFound)
 }
 
 func TestAuthorizeProjectBoundKeyRejectsSiblingProjectSlugWithoutRepointing(t *testing.T) {

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -57,8 +57,10 @@ func TestAuthorizeProjectBoundKeyAllowsBoundProjectSlug(t *testing.T) {
 	require.Equal(t, projects[0].ID, *authCtx.ProjectID)
 	require.Equal(t, projects[0].Slug, *authCtx.ProjectSlug)
 
+	attrCounts := make(map[string]int)
 	var apiKeySchemeFound, projectSchemeFound bool
 	for _, eventAttr := range wide.Emit(ctx) {
+		attrCounts[eventAttr.Key]++
 		switch eventAttr.Key {
 		case string(attr.RequestAuthSchemeAPIKeyKey):
 			apiKeySchemeFound = true
@@ -70,6 +72,16 @@ func TestAuthorizeProjectBoundKeyAllowsBoundProjectSlug(t *testing.T) {
 	}
 	require.True(t, apiKeySchemeFound)
 	require.True(t, projectSchemeFound)
+	for _, key := range []string{
+		string(attr.RequestAuthOrganizationIDKey),
+		string(attr.RequestAuthOrganizationSlugKey),
+		string(attr.RequestAuthAccountTypeKey),
+		string(attr.RequestAuthAPIKeyIDKey),
+		string(attr.RequestAuthProjectIDKey),
+		string(attr.RequestAuthProjectSlugKey),
+	} {
+		require.Equal(t, 1, attrCounts[key], "attribute %q must be emitted once", key)
+	}
 }
 
 func TestAuthorizeProjectBoundKeyRejectsSiblingProjectSlugWithoutRepointing(t *testing.T) {

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -61,11 +61,15 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 				return
 			}
 
+			domainAttrs := make([]slog.Attr, 0, 2)
 			if domain.ID != uuid.Nil {
-				wide.Push(ctx, attr.SlogRequestCustomDomainID(domain.ID.String()))
+				domainAttrs = append(domainAttrs, attr.SlogRequestCustomDomainID(domain.ID.String()))
 			}
 			if domain.Domain != "" {
-				wide.Push(ctx, attr.SlogRequestCustomDomainName(domain.Domain))
+				domainAttrs = append(domainAttrs, attr.SlogRequestCustomDomainName(domain.Domain))
+			}
+			if len(domainAttrs) > 0 {
+				wide.Push(ctx, domainAttrs...)
 			}
 
 			if !domain.Activated || !domain.Verified {

--- a/server/internal/customdomains/middleware.go
+++ b/server/internal/customdomains/middleware.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	domainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 )
 
 func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *url.URL) func(next http.Handler) http.Handler {
@@ -57,6 +59,13 @@ func Middleware(logger *slog.Logger, db *pgxpool.Pool, env string, serverURL *ur
 				}
 
 				return
+			}
+
+			if domain.ID != uuid.Nil {
+				wide.Push(ctx, attr.SlogRequestCustomDomainID(domain.ID.String()))
+			}
+			if domain.Domain != "" {
+				wide.Push(ctx, attr.SlogRequestCustomDomainName(domain.Domain))
 			}
 
 			if !domain.Activated || !domain.Verified {

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/wide"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -242,6 +243,12 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
+			ctx = wide.Start(ctx, attr.SlogWideEvent())
+
+			defer func() {
+				logger.LogAttrs(ctx, slog.LevelInfo, "response", wide.Emit(ctx)...)
+			}()
+
 			requestID := conv.TruncateString(r.Header.Get("X-Request-ID"), 64)
 
 			spanCtx := trace.SpanContextFromContext(ctx)
@@ -281,10 +288,14 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 
 			rw := newResponseWriter(w)
 			r = r.WithContext(ctx)
-			attrs := []any{
+
+			attrs := []slog.Attr{
 				attr.SlogHTTPRequestMethod(r.Method),
 				attr.SlogURLOriginal(safeURL),
 				attr.SlogHostName(r.Host),
+			}
+			if r.Pattern != "" {
+				attrs = append(attrs, attr.SlogHTTPRoute(r.Pattern))
 			}
 			if requestContext.ReqID != "" {
 				attrs = append(attrs, attr.SlogHTTPRequestID(requestContext.ReqID))
@@ -298,8 +309,7 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 			if requestContext.RefererHost != "" {
 				attrs = append(attrs, attr.SlogHTTPReferrerHost(requestContext.RefererHost))
 			}
-
-			logger.InfoContext(ctx, "request", attrs...)
+			wide.Push(ctx, attrs...)
 
 			next.ServeHTTP(rw, r)
 
@@ -308,23 +318,26 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				code = 499
 			}
 
-			attrs = append(attrs, attr.SlogHTTPResponseStatusCode(code), attr.SlogHTTPServerRequestDuration(time.Since(start).Seconds()))
+			responseAttrs := []slog.Attr{
+				attr.SlogHTTPResponseStatusCode(code),
+				attr.SlogHTTPServerRequestDuration(time.Since(start).Seconds()),
+			}
 
 			if code != rw.statusCode {
-				attrs = append(attrs, attr.SlogHTTPResponseOriginalStatusCode(rw.statusCode))
+				responseAttrs = append(responseAttrs, attr.SlogHTTPResponseOriginalStatusCode(rw.statusCode))
 			}
 
 			proxied := conv.Default(rw.Header().Get(constants.HeaderProxiedResponse), "0")
 			if ok, err := strconv.ParseBool(proxied); err == nil && ok {
-				attrs = append(attrs, attr.SlogHTTPResponseExternal(true))
+				responseAttrs = append(responseAttrs, attr.SlogHTTPResponseExternal(true))
 			}
 
 			filtered := conv.Default(rw.Header().Get(constants.HeaderFilteredResponse), "0")
 			if ok, err := strconv.ParseBool(filtered); err == nil && ok {
-				attrs = append(attrs, attr.SlogHTTPResponseFiltered(true))
+				responseAttrs = append(responseAttrs, attr.SlogHTTPResponseFiltered(true))
 			}
 
-			logger.InfoContext(ctx, "response", attrs...)
+			wide.Push(ctx, responseAttrs...)
 		})
 	}
 }

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -294,8 +294,8 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attr.SlogURLOriginal(safeURL),
 				attr.SlogHostName(r.Host),
 			}
-			if r.Pattern != "" {
-				attrs = append(attrs, attr.SlogHTTPRoute(r.Pattern))
+			if idx := strings.IndexByte(r.Pattern, '/'); idx >= 0 {
+				attrs = append(attrs, attr.SlogHTTPRoute(r.Pattern[idx:]))
 			}
 			if requestContext.ReqID != "" {
 				attrs = append(attrs, attr.SlogHTTPRequestID(requestContext.ReqID))

--- a/server/internal/middleware/logging_test.go
+++ b/server/internal/middleware/logging_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -273,6 +274,24 @@ func TestHTTPLoggingMiddlewareOmitsEmptyOptionalAttributes(t *testing.T) {
 	require.NotContains(t, logs, string(attr.HTTPRequestHeaderRefererKey))
 	require.NotContains(t, logs, string(attr.HTTPRequestHeaderUserAgentKey))
 	require.NotContains(t, logs, string(attr.HTTPRefererHostKey))
+}
+
+func TestHTTPLoggingMiddlewareNormalizesRoutePattern(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	handler := NewHTTPLoggingMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/rpc/widgets.list", nil)
+	req.Pattern = "POST /rpc/widgets.list"
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &event))
+	require.Equal(t, "/rpc/widgets.list", event[string(attr.HTTPRouteKey)])
 }
 
 // The request context is the second sink: every downstream handler that logs

--- a/server/internal/middleware/logging_test.go
+++ b/server/internal/middleware/logging_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/stretchr/testify/require"
@@ -224,6 +225,54 @@ func TestHTTPLoggingMiddlewareKeepsPersonalDataOutOfLogs(t *testing.T) {
 	}
 	require.NotContains(t, logs, "supersecret", "token reached the logs")
 	require.Contains(t, logs, "REDACTED")
+}
+
+func TestHTTPLoggingMiddlewarePropagatesPanics(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHTTPLoggingMiddleware(testenv.NewLogger(t))(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	require.PanicsWithValue(t, "boom", func() {
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+}
+
+func TestHTTPLoggingMiddlewarePreservesAbortHandlerPanic(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	handler := NewHTTPLoggingMiddleware(logger)(NewRecovery(logger)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	})))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	require.PanicsWithValue(t, http.ErrAbortHandler, func() {
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+}
+
+func TestHTTPLoggingMiddlewareOmitsEmptyOptionalAttributes(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	handler := NewHTTPLoggingMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	logs := buf.String()
+	require.NotEmpty(t, logs)
+	require.NotContains(t, logs, string(attr.HTTPRouteKey))
+	require.NotContains(t, logs, string(attr.HTTPRequestIDKey))
+	require.NotContains(t, logs, string(attr.HTTPRequestHeaderRefererKey))
+	require.NotContains(t, logs, string(attr.HTTPRequestHeaderUserAgentKey))
+	require.NotContains(t, logs, string(attr.HTTPRefererHostKey))
 }
 
 // The request context is the second sink: every downstream handler that logs

--- a/server/internal/wide/context.go
+++ b/server/internal/wide/context.go
@@ -1,0 +1,72 @@
+package wide
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"sync/atomic"
+)
+
+type ctxKey struct{}
+
+var eventCtxKey ctxKey
+
+type node struct {
+	attrs []slog.Attr
+	next  atomic.Pointer[node]
+}
+
+type ctxState struct {
+	head atomic.Pointer[node]
+}
+
+func Start(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &ctxState{head: atomic.Pointer[node]{}}
+	if len(attrs) > 0 {
+		n := &node{attrs: attrs, next: atomic.Pointer[node]{}}
+		ev.head.Store(n)
+	}
+
+	return context.WithValue(ctx, eventCtxKey, ev)
+}
+
+func Push(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
+	if !ok {
+		return
+	}
+
+	n := &node{attrs: attrs, next: atomic.Pointer[node]{}}
+	for {
+		old := ev.head.Load()
+		n.next.Store(old)
+		if ev.head.CompareAndSwap(old, n) {
+			return
+		}
+	}
+}
+
+func Emit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
+	if !ok {
+		return nil
+	}
+
+	var nodes []*node
+	total := 0
+	for n := ev.head.Load(); n != nil; n = n.next.Load() {
+		nodes = append(nodes, n)
+		total += len(n.attrs)
+	}
+
+	// List is in prepend-order (newest first). Reverse node pointers so the
+	// forward walk yields attrs in oldest-first order while preserving the
+	// attr order within each Push call.
+	slices.Reverse(nodes)
+	out := make([]slog.Attr, 0, total)
+	for _, n := range nodes {
+		out = append(out, n.attrs...)
+	}
+
+	return out
+}

--- a/server/internal/wide/context.go
+++ b/server/internal/wide/context.go
@@ -46,6 +46,24 @@ func Push(ctx context.Context, attrs ...slog.Attr) {
 	}
 }
 
+// Contains reports whether the event already has an attribute with key.
+func Contains(ctx context.Context, key string) bool {
+	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
+	if !ok {
+		return false
+	}
+
+	for n := ev.head.Load(); n != nil; n = n.next.Load() {
+		for _, eventAttr := range n.attrs {
+			if eventAttr.Key == key {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 func Emit(ctx context.Context) []slog.Attr {
 	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
 	if !ok {

--- a/server/internal/wide/context.go
+++ b/server/internal/wide/context.go
@@ -20,6 +20,8 @@ type ctxState struct {
 	head atomic.Pointer[node]
 }
 
+// Start creates an attribute collector on ctx. It retains attrs; callers must
+// not modify the slice or its elements after calling Start.
 func Start(ctx context.Context, attrs ...slog.Attr) context.Context {
 	ev := &ctxState{head: atomic.Pointer[node]{}}
 	if len(attrs) > 0 {
@@ -30,6 +32,8 @@ func Start(ctx context.Context, attrs ...slog.Attr) context.Context {
 	return context.WithValue(ctx, eventCtxKey, ev)
 }
 
+// Push adds attrs to the collector on ctx. It retains attrs; callers must not
+// modify the slice or its elements after calling Push.
 func Push(ctx context.Context, attrs ...slog.Attr) {
 	ev, ok := ctx.Value(eventCtxKey).(*ctxState)
 	if !ok {

--- a/server/internal/wide/context_batch_test.go
+++ b/server/internal/wide/context_batch_test.go
@@ -1,0 +1,247 @@
+package wide_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+// ---------------------------------------------------------------------------
+// Baseline: no synchronisation (unsafe under concurrency)
+// ---------------------------------------------------------------------------
+
+type baselineCtxKey string
+
+const baselineKey baselineCtxKey = "baseline"
+
+type baselineState struct {
+	attrs []slog.Attr
+}
+
+func baselineStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &baselineState{attrs: make([]slog.Attr, 0, len(attrs))}
+	ev.attrs = append(ev.attrs, attrs...)
+	return context.WithValue(ctx, baselineKey, ev)
+}
+
+func baselinePush(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(baselineKey).(*baselineState)
+	if !ok {
+		return
+	}
+	ev.attrs = append(ev.attrs, attrs...)
+}
+
+func baselineEmit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(baselineKey).(*baselineState)
+	if !ok {
+		return nil
+	}
+	return ev.attrs
+}
+
+// ---------------------------------------------------------------------------
+// Mutex variant
+// ---------------------------------------------------------------------------
+
+type mutexCtxKey string
+
+const mutexKey mutexCtxKey = "mutex"
+
+type mutexState struct {
+	mu    sync.Mutex
+	attrs []slog.Attr
+}
+
+func mutexStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	ev := &mutexState{attrs: make([]slog.Attr, 0, len(attrs))}
+	ev.attrs = append(ev.attrs, attrs...)
+	return context.WithValue(ctx, mutexKey, ev)
+}
+
+func mutexPush(ctx context.Context, attrs ...slog.Attr) {
+	ev, ok := ctx.Value(mutexKey).(*mutexState)
+	if !ok {
+		return
+	}
+	ev.mu.Lock()
+	ev.attrs = append(ev.attrs, attrs...)
+	ev.mu.Unlock()
+}
+
+func mutexEmit(ctx context.Context) []slog.Attr {
+	ev, ok := ctx.Value(mutexKey).(*mutexState)
+	if !ok {
+		return nil
+	}
+	ev.mu.Lock()
+	out := make([]slog.Attr, len(ev.attrs))
+	copy(out, ev.attrs)
+	ev.mu.Unlock()
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Lock-free linked list: the real wide package implementation
+// ---------------------------------------------------------------------------
+
+// Defined as a variant so it sits alongside the others in benchmark output.
+func lockfreeStart(ctx context.Context, attrs ...slog.Attr) context.Context {
+	return wide.Start(ctx, attrs...)
+}
+
+func lockfreePush(ctx context.Context, attrs ...slog.Attr) {
+	wide.Push(ctx, attrs...)
+}
+
+func lockfreeEmit(ctx context.Context) []slog.Attr {
+	return wide.Emit(ctx)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark helpers
+// ---------------------------------------------------------------------------
+
+var sinkAttrs []slog.Attr
+
+type variant struct {
+	name  string
+	start func(context.Context, ...slog.Attr) context.Context
+	push  func(context.Context, ...slog.Attr)
+	emit  func(context.Context) []slog.Attr
+}
+
+var variants = []variant{
+	{"Baseline", baselineStart, baselinePush, baselineEmit},
+	{"Mutex", mutexStart, mutexPush, mutexEmit},
+	{"LockFree", lockfreeStart, lockfreePush, lockfreeEmit},
+}
+
+func testAttrs(i int) []slog.Attr {
+	return []slog.Attr{
+		slog.String(testBenchmarkKey, "value"),
+		slog.Int(testIndexKey, i),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serial: Push N attrs then Emit (single goroutine, the common case)
+// ---------------------------------------------------------------------------
+
+func BenchmarkSerialPushEmit(b *testing.B) {
+	const pushes = 10
+
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			for b.Loop() {
+				ctx := v.start(context.Background())
+				for i := range pushes {
+					v.push(ctx, testAttrs(i)...)
+				}
+				sinkAttrs = v.emit(ctx)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serial: Push only (measures raw insert cost)
+// ---------------------------------------------------------------------------
+
+func BenchmarkSerialPush(b *testing.B) {
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			ctx := v.start(context.Background())
+			for b.Loop() {
+				v.push(ctx, slog.String(testGenericKey, "v"))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent: N goroutines each push attrs, then one Emit
+// ---------------------------------------------------------------------------
+
+func BenchmarkConcurrentPush(b *testing.B) {
+	goroutines := []int{2, 4, 8}
+
+	for _, v := range variants {
+		// Skip baseline under concurrency — it's unsafe and only here for
+		// serial comparison.
+		if v.name == "Baseline" {
+			continue
+		}
+		for _, g := range goroutines {
+			b.Run(v.name+"/goroutines="+itoa(g), func(b *testing.B) {
+				ctx := v.start(context.Background())
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						v.push(ctx, testAttrs(i)...)
+						i++
+					}
+				})
+				sinkAttrs = v.emit(ctx)
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent: interleaved Push + Emit
+// ---------------------------------------------------------------------------
+
+func BenchmarkConcurrentPushWithEmit(b *testing.B) {
+	goroutines := []int{2, 4, 8}
+	const pushesPerIter = 10 // typical attrs per request cycle
+
+	for _, v := range variants {
+		if v.name == "Baseline" {
+			continue
+		}
+		for _, g := range goroutines {
+			b.Run(v.name+"/goroutines="+itoa(g), func(b *testing.B) {
+				for b.Loop() {
+					// One fresh ctx per iteration models a request lifecycle and
+					// keeps Emit cost bounded — otherwise the accumulator grows
+					// across iterations and Emit becomes O(b.N).
+					ctx := v.start(context.Background())
+
+					var wg sync.WaitGroup
+					wg.Add(g)
+					for range g {
+						go func() {
+							defer wg.Done()
+							for i := range pushesPerIter {
+								v.push(ctx, testAttrs(i)...)
+								if i%5 == 0 {
+									sinkAttrs = v.emit(ctx)
+								}
+							}
+						}()
+					}
+					wg.Wait()
+					sinkAttrs = v.emit(ctx)
+				}
+			})
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/server/internal/wide/context_batch_test.go
+++ b/server/internal/wide/context_batch_test.go
@@ -3,6 +3,7 @@ package wide_test
 import (
 	"context"
 	"log/slog"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -148,26 +149,31 @@ func BenchmarkSerialPushEmit(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
-// Serial: Push only (measures raw insert cost)
+// Serial: create an accumulator and Push a fixed batch (no Emit)
 // ---------------------------------------------------------------------------
 
 func BenchmarkSerialPush(b *testing.B) {
+	const pushes = 10
+
 	for _, v := range variants {
 		b.Run(v.name, func(b *testing.B) {
-			ctx := v.start(context.Background())
 			for b.Loop() {
-				v.push(ctx, slog.String(testGenericKey, "v"))
+				ctx := v.start(context.Background())
+				for i := range pushes {
+					v.push(ctx, testAttrs(i)...)
+				}
 			}
 		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Concurrent: N goroutines each push attrs, then one Emit
+// Concurrent: N goroutines each push a fixed batch
 // ---------------------------------------------------------------------------
 
 func BenchmarkConcurrentPush(b *testing.B) {
 	goroutines := []int{2, 4, 8}
+	const pushesPerGoroutine = 10
 
 	for _, v := range variants {
 		// Skip baseline under concurrency — it's unsafe and only here for
@@ -177,15 +183,20 @@ func BenchmarkConcurrentPush(b *testing.B) {
 		}
 		for _, g := range goroutines {
 			b.Run(v.name+"/goroutines="+itoa(g), func(b *testing.B) {
-				ctx := v.start(context.Background())
-				b.RunParallel(func(pb *testing.PB) {
-					i := 0
-					for pb.Next() {
-						v.push(ctx, testAttrs(i)...)
-						i++
+				for b.Loop() {
+					ctx := v.start(context.Background())
+					var wg sync.WaitGroup
+					wg.Add(g)
+					for worker := range g {
+						go func() {
+							defer wg.Done()
+							for i := range pushesPerGoroutine {
+								v.push(ctx, testAttrs(worker*pushesPerGoroutine+i)...)
+							}
+						}()
 					}
-				})
-				sinkAttrs = v.emit(ctx)
+					wg.Wait()
+				}
 			})
 		}
 	}
@@ -216,12 +227,14 @@ func BenchmarkConcurrentPushWithEmit(b *testing.B) {
 					for range g {
 						go func() {
 							defer wg.Done()
+							var emitted []slog.Attr
 							for i := range pushesPerIter {
 								v.push(ctx, testAttrs(i)...)
 								if i%5 == 0 {
-									sinkAttrs = v.emit(ctx)
+									emitted = v.emit(ctx)
 								}
 							}
+							runtime.KeepAlive(emitted)
 						}()
 					}
 					wg.Wait()

--- a/server/internal/wide/context_concurrent_test.go
+++ b/server/internal/wide/context_concurrent_test.go
@@ -1,0 +1,166 @@
+package wide_test
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+func TestConcurrentPushAllAttrsDelivered(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			goroutines = 16
+			pushesEach = 64
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range goroutines {
+			go func() {
+				for i := range pushesEach {
+					wide.Push(ctx, slog.String(testValueKey, fmt.Sprintf("g%d-i%d", g, i)))
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, goroutines*pushesEach)
+
+		seen := make(map[string]bool, goroutines*pushesEach)
+		for _, a := range got {
+			v := a.Value.String()
+			require.False(t, seen[v], "duplicate value: %s", v)
+			seen[v] = true
+		}
+		require.Len(t, seen, goroutines*pushesEach)
+	})
+}
+
+func TestConcurrentPushWithinBatchOrderPreserved(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			goroutines = 16
+			batches    = 10
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range goroutines {
+			go func() {
+				for b := range batches {
+					prefix := fmt.Sprintf("g%d-b%d", g, b)
+					wide.Push(ctx,
+						slog.String(testValueKey, prefix+"-A"),
+						slog.String(testValueKey, prefix+"-B"),
+						slog.String(testValueKey, prefix+"-C"),
+					)
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, goroutines*batches*3)
+
+		// Walk the output in triples. Cross-batch ordering is unspecified, but
+		// each 3-tuple must be a contiguous (A, B, C) of the same batch prefix —
+		// this is the regression surface for the intra-node reversal bug.
+		for k := 0; k < len(got); k += 3 {
+			a := got[k].Value.String()
+			b := got[k+1].Value.String()
+			c := got[k+2].Value.String()
+
+			require.True(t, strings.HasSuffix(a, "-A"), "pos %d: got %q, want suffix -A", k, a)
+			require.True(t, strings.HasSuffix(b, "-B"), "pos %d: got %q, want suffix -B", k+1, b)
+			require.True(t, strings.HasSuffix(c, "-C"), "pos %d: got %q, want suffix -C", k+2, c)
+
+			aPfx := strings.TrimSuffix(a, "-A")
+			bPfx := strings.TrimSuffix(b, "-B")
+			cPfx := strings.TrimSuffix(c, "-C")
+			require.Equal(t, aPfx, bPfx, "batch prefix drift at pos %d", k)
+			require.Equal(t, bPfx, cPfx, "batch prefix drift at pos %d", k)
+		}
+	})
+}
+
+func TestConcurrentPushAndEmit(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			writers   = 4
+			perWriter = 32
+		)
+
+		ctx := wide.Start(t.Context())
+
+		for g := range writers {
+			go func() {
+				for i := range perWriter {
+					wide.Push(ctx, slog.String(testValueKey, fmt.Sprintf("w%d-i%d", g, i)))
+					_ = wide.Emit(ctx) // interleave reads with writes
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, writers*perWriter)
+
+		seen := make(map[string]bool, writers*perWriter)
+		for _, a := range got {
+			v := a.Value.String()
+			require.False(t, seen[v], "duplicate: %s", v)
+			seen[v] = true
+		}
+	})
+}
+
+func TestConcurrentEmitNoTornReads(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			pushes    = 128
+			emitters  = 4
+			emitsEach = 16
+		)
+
+		ctx := wide.Start(t.Context())
+
+		go func() {
+			for i := range pushes {
+				wide.Push(ctx, slog.String(testValueKey, fmt.Sprintf("p%d", i)))
+			}
+		}()
+
+		for range emitters {
+			go func() {
+				for range emitsEach {
+					snap := wide.Emit(ctx)
+					for _, a := range snap {
+						if a.Key == "" {
+							t.Errorf("torn read: empty attr key in snapshot of len %d", len(snap))
+							return
+						}
+					}
+				}
+			}()
+		}
+		synctest.Wait()
+
+		got := wide.Emit(ctx)
+		require.Len(t, got, pushes)
+	})
+}

--- a/server/internal/wide/context_test.go
+++ b/server/internal/wide/context_test.go
@@ -112,24 +112,6 @@ func TestPushEmptyVariadic(t *testing.T) {
 	require.Equal(t, []string{"a"}, keysOf(wide.Emit(ctx)))
 }
 
-func TestPushedAttrsAliasing(t *testing.T) {
-	t.Parallel()
-
-	// Characterization: Push stores the caller's slice header by reference, so
-	// post-Push mutation of the caller-owned slice is visible through Emit.
-	// design.md describes attrs as "fixed at allocation" but that is an internal
-	// invariant, not a caller-facing contract. Update this test if Push ever
-	// copies.
-	ctx := wide.Start(t.Context())
-	attrs := []slog.Attr{slog.String(testGenericKey, "original")}
-	wide.Push(ctx, attrs...)
-	attrs[0] = slog.String(testGenericKey, "mutated")
-
-	got := wide.Emit(ctx)
-	require.Len(t, got, 1)
-	require.Equal(t, "mutated", got[0].Value.String())
-}
-
 func TestCancelledContextEmitStillWorks(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/wide/context_test.go
+++ b/server/internal/wide/context_test.go
@@ -112,6 +112,27 @@ func TestPushEmptyVariadic(t *testing.T) {
 	require.Equal(t, []string{"a"}, keysOf(wide.Emit(ctx)))
 }
 
+func TestAttrsRetainedWithoutCopy(t *testing.T) {
+	t.Parallel()
+
+	// Characterization: Start and Push retain the caller's attribute slices.
+	// Mutation after either call violates the caller contract; doing so here
+	// verifies that the zero-copy implementation does not silently regress.
+	startAttrs := []slog.Attr{slog.String(testAKey, "start-original")}
+	ctx := wide.Start(t.Context(), startAttrs...)
+
+	pushedAttrs := []slog.Attr{slog.String(testBKey, "push-original")}
+	wide.Push(ctx, pushedAttrs...)
+
+	startAttrs[0] = slog.String(testAKey, "start-mutated")
+	pushedAttrs[0] = slog.String(testBKey, "push-mutated")
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, 2)
+	require.Equal(t, "start-mutated", got[0].Value.String())
+	require.Equal(t, "push-mutated", got[1].Value.String())
+}
+
 func TestCancelledContextEmitStillWorks(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/wide/context_test.go
+++ b/server/internal/wide/context_test.go
@@ -66,6 +66,18 @@ func TestEmitEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
+func TestContains(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String(testAKey, "1"))
+	wide.Push(ctx, slog.String(testBKey, "2"))
+
+	require.True(t, wide.Contains(ctx, testAKey))
+	require.True(t, wide.Contains(ctx, testBKey))
+	require.False(t, wide.Contains(ctx, testCKey))
+	require.False(t, wide.Contains(t.Context(), testAKey))
+}
+
 func TestPushNoStart(t *testing.T) {
 	t.Parallel()
 	// No panic, no observable error. Push on a ctx without Start is a no-op.

--- a/server/internal/wide/context_test.go
+++ b/server/internal/wide/context_test.go
@@ -1,0 +1,198 @@
+package wide_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/wide"
+)
+
+const (
+	testEventKey      = "event"
+	testSchemeKey     = "scheme"
+	testOrgIDKey      = "org.id"
+	testOrgSlugKey    = "org.slug"
+	testMethodKey     = "method"
+	testURLKey        = "url"
+	testStatusCodeKey = "status_code"
+	testGenericKey    = "k"
+	testAKey          = "a"
+	testBKey          = "b"
+	testCKey          = "c"
+	testOneKey        = "one"
+	testTwoKey        = "two"
+	testExtraKey      = "extra"
+	testIndexKey      = "i"
+	testBenchmarkKey  = "key"
+	testValueKey      = "v"
+)
+
+func TestEmitOrdering(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String(testEventKey, "WideEvent"))
+	wide.Push(ctx,
+		slog.String(testSchemeKey, "https"),
+		slog.String(testOrgIDKey, "org_123"),
+		slog.String(testOrgSlugKey, "acme"),
+	)
+	wide.Push(ctx,
+		slog.String(testMethodKey, "GET"),
+		slog.String(testURLKey, "/v1/widgets"),
+		slog.Int(testStatusCodeKey, 200),
+	)
+
+	want := []string{
+		"event",
+		"scheme", "org.id", "org.slug",
+		"method", "url", "status_code",
+	}
+	require.Equal(t, want, keysOf(wide.Emit(ctx)))
+}
+
+func TestEmitNoStart(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, wide.Emit(t.Context()))
+}
+
+func TestEmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	got := wide.Emit(wide.Start(t.Context()))
+	require.NotNil(t, got)
+	require.Empty(t, got)
+}
+
+func TestPushNoStart(t *testing.T) {
+	t.Parallel()
+	// No panic, no observable error. Push on a ctx without Start is a no-op.
+	wide.Push(t.Context(), slog.String(testGenericKey, "v"))
+}
+
+func TestEmitIsRepeatable(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String(testAKey, "1"))
+	wide.Push(ctx, slog.String(testBKey, "2"))
+	first := wide.Emit(ctx)
+	wide.Push(ctx, slog.String(testCKey, "3"))
+	second := wide.Emit(ctx)
+
+	require.Equal(t, []string{"a", "b"}, keysOf(first), "first snapshot must not see later pushes")
+	require.Equal(t, []string{"a", "b", "c"}, keysOf(second))
+}
+
+func TestStartWithAttrsNoPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String(testAKey, "1"), slog.String(testBKey, "2"))
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestPushEmptyVariadic(t *testing.T) {
+	t.Parallel()
+
+	ctx := wide.Start(t.Context(), slog.String(testAKey, "1"))
+	wide.Push(ctx)
+	require.Equal(t, []string{"a"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestPushedAttrsAliasing(t *testing.T) {
+	t.Parallel()
+
+	// Characterization: Push stores the caller's slice header by reference, so
+	// post-Push mutation of the caller-owned slice is visible through Emit.
+	// design.md describes attrs as "fixed at allocation" but that is an internal
+	// invariant, not a caller-facing contract. Update this test if Push ever
+	// copies.
+	ctx := wide.Start(t.Context())
+	attrs := []slog.Attr{slog.String(testGenericKey, "original")}
+	wide.Push(ctx, attrs...)
+	attrs[0] = slog.String(testGenericKey, "mutated")
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, 1)
+	require.Equal(t, "mutated", got[0].Value.String())
+}
+
+func TestCancelledContextEmitStillWorks(t *testing.T) {
+	t.Parallel()
+
+	parent := wide.Start(t.Context(), slog.String(testAKey, "1"))
+	ctx, cancel := context.WithCancel(parent)
+	wide.Push(ctx, slog.String(testBKey, "2"))
+	cancel()
+
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(ctx)))
+}
+
+func TestDerivedContextSharesState(t *testing.T) {
+	t.Parallel()
+
+	type otherKey struct{}
+	parent := wide.Start(t.Context(), slog.String(testAKey, "1"))
+	child := context.WithValue(parent, otherKey{}, "v")
+	wide.Push(child, slog.String(testBKey, "2"))
+
+	// The *ctxState pointer is shared across context.WithValue layers, so a
+	// Push on the child is visible from the parent.
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(parent)))
+	require.Equal(t, []string{"a", "b"}, keysOf(wide.Emit(child)))
+}
+
+func TestIndependentStartsAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	ctx1 := wide.Start(t.Context(), slog.String(testOneKey, "1"))
+	ctx2 := wide.Start(t.Context(), slog.String(testTwoKey, "2"))
+	wide.Push(ctx1, slog.String(testExtraKey, "e"))
+
+	require.Equal(t, []string{"one", "extra"}, keysOf(wide.Emit(ctx1)))
+	require.Equal(t, []string{"two"}, keysOf(wide.Emit(ctx2)))
+}
+
+func TestLargeNumberOfPushes(t *testing.T) {
+	t.Parallel()
+
+	const n = 10_000
+	ctx := wide.Start(t.Context())
+	for i := range n {
+		wide.Push(ctx, slog.Int(testIndexKey, i))
+	}
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, n)
+	for i := range n {
+		require.Equal(t, int64(i), got[i].Value.Int64(), "position %d", i)
+	}
+}
+
+func TestLargeBatchPerPush(t *testing.T) {
+	t.Parallel()
+
+	const n = 1_000
+	attrs := make([]slog.Attr, n)
+	for i := range n {
+		attrs[i] = slog.Int(testIndexKey, i)
+	}
+
+	ctx := wide.Start(t.Context())
+	wide.Push(ctx, attrs...)
+
+	got := wide.Emit(ctx)
+	require.Len(t, got, n)
+	for i := range n {
+		require.Equal(t, int64(i), got[i].Value.Int64(), "position %d", i)
+	}
+}
+
+func keysOf(attrs []slog.Attr) []string {
+	out := make([]string, len(attrs))
+	for i, a := range attrs {
+		out[i] = a.Key
+	}
+	return out
+}

--- a/server/internal/wide/design.md
+++ b/server/internal/wide/design.md
@@ -1,0 +1,58 @@
+# wide: collection design
+
+## Goal
+
+Provide a concurrency-safe attribute collector where the dominant workload is
+serial pushes followed by a single emit — the pattern seen in HTTP request
+handling.
+
+## Approach: lock-free prepend list
+
+Each `Push` allocates a small node and atomically prepends it to a singly
+linked list via `CompareAndSwap` on the head pointer. `Emit` walks the list,
+collects all attributes into a slice, and reverses it to restore insertion
+order.
+
+```
+head ──▶ [node C] ──▶ [node B] ──▶ [node A] ──▶ nil
+          (newest)                   (oldest)
+```
+
+## Why not a mutex-guarded slice?
+
+A mutex adds overhead to every `Push` and `Emit` call even when there is no
+contention, which is the common case (single-goroutine request handlers).
+Benchmarks show the mutex variant is ~35% slower than the lock-free list in the
+serial push+emit path.
+
+## Why not a growing context chain?
+
+An alternative is to have `Push` return a new `context.Context` via
+`context.WithValue` on every call. This avoids shared mutable state entirely
+but builds a long context chain — one extra layer per push — which increases
+the cost of every subsequent `context.Value` lookup for all context keys, not
+just ours.
+
+## Trade-offs
+
+| Property                   | Lock-free list                         | Mutex slice              | Context chain                                       |
+| -------------------------- | -------------------------------------- | ------------------------ | --------------------------------------------------- |
+| Serial push+emit speed     | Fastest                                | ~35% slower              | Comparable, but degrades `context.Value` lookups    |
+| Concurrent push            | Safe (CAS retry)                       | Safe (lock)              | Safe (immutable)                                    |
+| Concurrent push throughput | Lower than mutex under high contention | Higher under contention  | N/A (no shared state)                               |
+| Memory per push            | 80 B node alloc                        | Amortised (slice growth) | `context.WithValue` wrapper + state copy            |
+| Emit cost                  | List walk + reverse                    | Slice copy under lock    | Chain walk + collect                                |
+| API                        | `Push(ctx, attrs...)`                  | Same                     | `ctx = Push(ctx, attrs...)` — caller must propagate |
+
+## Benchmark summary (10 pushes + 1 emit, arm64)
+
+| Variant            | ns/op      | B/op      | allocs/op |
+| ------------------ | ---------- | --------- | --------- |
+| Baseline (unsafe)  | ~1,580     | 3,544     | 17        |
+| Mutex              | ~2,115     | 4,448     | 18        |
+| **Lock-free list** | **~1,010** | **2,072** | **23**    |
+
+The lock-free list trades a higher allocation count (one node per push) for
+lower total bytes and faster throughput. The benchmark suite in
+`context_batch_test.go` covers serial and concurrent scenarios across all three
+variants.

--- a/server/internal/wide/design.md
+++ b/server/internal/wide/design.md
@@ -8,10 +8,14 @@ handling.
 
 ## Approach: lock-free prepend list
 
-Each `Push` allocates a small node and atomically prepends it to a singly
-linked list via `CompareAndSwap` on the head pointer. `Emit` walks the list,
-collects all attributes into a slice, and reverses it to restore insertion
-order.
+Each `Push` stores its attributes in a small node and atomically prepends the
+node to a singly linked list via `CompareAndSwap` on the head pointer. `Emit`
+walks the list, collects all attributes into a slice, and reverses it to
+restore insertion order.
+
+To avoid an allocation and copy on every `Push`, the node retains the provided
+attribute slice. Callers must not modify the slice or its elements after
+passing it to `Start` or `Push`.
 
 ```
 head ──▶ [node C] ──▶ [node B] ──▶ [node A] ──▶ nil
@@ -22,8 +26,8 @@ head ──▶ [node C] ──▶ [node B] ──▶ [node A] ──▶ nil
 
 A mutex adds overhead to every `Push` and `Emit` call even when there is no
 contention, which is the common case (single-goroutine request handlers).
-Benchmarks show the mutex variant is ~35% slower than the lock-free list in the
-serial push+emit path.
+Controlled benchmarks show the lock-free list has ~37% lower latency than the
+mutex variant in the serial push+emit path.
 
 ## Why not a growing context chain?
 
@@ -37,10 +41,10 @@ just ours.
 
 | Property                   | Lock-free list                         | Mutex slice              | Context chain                                       |
 | -------------------------- | -------------------------------------- | ------------------------ | --------------------------------------------------- |
-| Serial push+emit speed     | Fastest                                | ~35% slower              | Comparable, but degrades `context.Value` lookups    |
+| Serial push+emit speed     | ~37% lower latency than mutex          | Slower                   | Comparable, but degrades `context.Value` lookups    |
 | Concurrent push            | Safe (CAS retry)                       | Safe (lock)              | Safe (immutable)                                    |
 | Concurrent push throughput | Lower than mutex under high contention | Higher under contention  | N/A (no shared state)                               |
-| Memory per push            | 80 B node alloc                        | Amortised (slice growth) | `context.WithValue` wrapper + state copy            |
+| Memory per push            | One node; retains caller attrs         | Amortised (slice growth) | `context.WithValue` wrapper + state copy            |
 | Emit cost                  | List walk + reverse                    | Slice copy under lock    | Chain walk + collect                                |
 | API                        | `Push(ctx, attrs...)`                  | Same                     | `ctx = Push(ctx, attrs...)` — caller must propagate |
 
@@ -48,11 +52,11 @@ just ours.
 
 | Variant            | ns/op      | B/op      | allocs/op |
 | ------------------ | ---------- | --------- | --------- |
-| Baseline (unsafe)  | ~1,580     | 3,544     | 17        |
-| Mutex              | ~2,115     | 4,448     | 18        |
-| **Lock-free list** | **~1,010** | **2,072** | **23**    |
+| Baseline (unsafe)  | ~3,850     | 3,544     | 17        |
+| Mutex              | ~4,530     | 4,448     | 18        |
+| **Lock-free list** | **~2,850** | **2,264** | **25**    |
 
-The lock-free list trades a higher allocation count (one node per push) for
-lower total bytes and faster throughput. The benchmark suite in
-`context_batch_test.go` covers serial and concurrent scenarios across all three
-variants.
+The lock-free list trades one node allocation per push for lower total bytes
+and faster throughput. The benchmark suite in `context_batch_test.go` covers
+all three variants in serial scenarios; concurrent scenarios cover only the
+concurrency-safe Mutex and LockFree variants.

--- a/server/internal/wide/doc.go
+++ b/server/internal/wide/doc.go
@@ -1,0 +1,25 @@
+// Package wide implements wide-event logging.
+//
+// A wide event collects structured attributes ([log/slog.Attr]) from
+// multiple layers of a call stack into a single log line emitted once at
+// the end. This replaces scattered per-layer log calls with one
+// information-dense record that is easier to query and correlate.
+//
+// Usage follows a three-phase lifecycle:
+//
+//  1. An outer caller invokes [Start] to initialise the event on a
+//     [context.Context].
+//  2. Inner callees call [Push] to attach attributes as they become
+//     available.
+//  3. Once the work is complete, the outer caller invokes [Emit] to
+//     collect every accumulated attribute and log them together.
+//
+// A prime use case is HTTP middleware: the logging middleware starts the
+// event, handlers and auth layers push attributes throughout the request,
+// and the middleware emits a single wide log line after the response is
+// written.
+//
+// The underlying collection is a lock-free linked list, so [Push] may be
+// called from multiple goroutines without synchronisation. In the common
+// single-goroutine case each push completes one uncontended CAS loop.
+package wide


### PR DESCRIPTION
## Summary

- add a context-scoped wide-event collector that safely accumulates structured attributes across request layers and emits them in insertion order
- consolidate separate HTTP request, response, and authentication logs into one information-dense response event enriched with auth and custom-domain context
- preserve panic propagation, omit empty optional attributes, and cover serial, concurrent, and middleware behavior

## Motivation

Request handling currently emits several related log lines for one operation, repeating event metadata while splitting useful context across records. Wide events collect attributes as the request moves through middleware and authentication, then emit one correlated record at completion. This reduces duplicate high-volume events while making each retained event easier to query.

The collector uses a lock-free prepend list because the dominant workload is serial pushes followed by one emit. Benchmarks show that approach is about 35% faster than a mutex-backed slice in that path and uses fewer total bytes, while remaining safe when request work pushes attributes concurrently. It also avoids extending the context chain for every collected attribute.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates request, response, and authentication logs into one wide `response` event emitted at request completion, reducing duplicate high-volume records while adding auth and custom-domain context. It also stops logging session IDs and deduplicates auth attributes when the same scheme is checked more than once.

**Details**

- Adds a context-scoped, lock-free collector that is safe for concurrent pushes, emits attributes in insertion order, and retains caller slices without copying (callers must not mutate them after pushing).
- Records auth scheme outcomes, account identifiers, custom-domain info, and response metadata; empty optional fields stay omitted and panics still propagate.
- Strips the HTTP method prefix from route patterns so the recorded route is the path only.

<sup>Written for commit 5c410846313aa2a2fbf44731a7763bb928109c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

