### PR TITLE
fix: wait for demo seed deletes before inserting

### DIFF
--- a/server/internal/demoseed/clickhouse.sql
+++ b/server/internal/demoseed/clickhouse.sql
@@ -82,6 +82,15 @@ DELETE FROM risk_findings WHERE organization_id = 'org_gram_demo_workspace';
 DELETE FROM skill_session_versions WHERE organization_id = 'org_gram_demo_workspace';
 DELETE FROM skill_efficacy_scores WHERE organization_id = 'org_gram_demo_workspace';
 
+-- Inserts must never race rows from the previous seed generation. The Go
+-- runner polls this same condition before advancing past the delete phase, and
+-- this preflight keeps the invariant explicit for every script executor.
+SELECT throwIf(
+  (SELECT count() FROM telemetry_logs WHERE gram_project_id IN
+     (toUUID('dec0de00-0000-4000-a000-000000000001'))
+   ) != 0,
+  'demo seed preflight: telemetry rows remain after scoped deletes');
+
 -- Tool-execution rows: 3-12 per chat (hash-picked, so busy chats and quick
 -- ones both exist). gram.toolset.slug makes the Insights CTE's direct branch
 -- classify each trace as hosted MCP traffic; unique per-call trace ids keep

--- a/server/internal/demoseed/demoseed.go
+++ b/server/internal/demoseed/demoseed.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -31,6 +32,11 @@ var clickhouseSQL string
 
 //go:embed openapi.yaml
 var openapiDoc []byte
+
+const (
+	clickHouseDeleteVisibilityTimeout = 30 * time.Second
+	clickHouseDeleteVisibilityPoll    = 250 * time.Millisecond
+)
 
 // Run applies the seed for spec's tenant: Postgres first (installs and
 // executes demo.ensure_demo_org(), whose pre/postflight asserts abort the
@@ -117,9 +123,35 @@ func Run(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, ch driver.C
 		"lightweight_deletes_sync": 2,
 		"max_execution_time":       600,
 	}))
+	deleted := false
+	deleteVisible := false
 	for _, stmt := range splitStatements(spec.Rewrite(clickhouseSQL)) {
-		if strings.HasPrefix(strings.ToUpper(stmt), "SET ") {
+		upperStmt := strings.ToUpper(stmt)
+		if strings.HasPrefix(upperStmt, "SET ") {
 			continue
+		}
+		if strings.HasPrefix(upperStmt, "DELETE ") {
+			deleted = true
+		} else if deleted && !deleteVisible {
+			if err := waitForClickHouseTelemetryDelete(
+				chCtx,
+				clickHouseDeleteVisibilityTimeout,
+				clickHouseDeleteVisibilityPoll,
+				func(queryCtx context.Context) (uint64, error) {
+					var remaining uint64
+					err := ch.QueryRow(queryCtx, `
+						SELECT count()
+						FROM telemetry_logs
+						WHERE gram_project_id = toUUID(?)`, spec.ProjectID()).Scan(&remaining)
+					if err != nil {
+						return 0, fmt.Errorf("count demo telemetry rows: %w", err)
+					}
+					return remaining, nil
+				},
+			); err != nil {
+				return fmt.Errorf("apply demo seed to clickhouse: %w", err)
+			}
+			deleteVisible = true
 		}
 		if err := ch.Exec(chCtx, stmt); err != nil {
 			return fmt.Errorf("apply demo seed to clickhouse: %w: %.120s", err, stmt)
@@ -128,6 +160,35 @@ func Run(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, ch driver.C
 	logger.InfoContext(ctx, "demo seed applied to clickhouse")
 
 	return nil
+}
+
+func waitForClickHouseTelemetryDelete(
+	ctx context.Context,
+	timeout time.Duration,
+	pollInterval time.Duration,
+	countRows func(context.Context) (uint64, error),
+) error {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		remaining, err := countRows(waitCtx)
+		if err != nil {
+			return fmt.Errorf("check demo telemetry delete visibility: %w", err)
+		}
+		if remaining == 0 {
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("wait for demo telemetry delete visibility with %d rows remaining: %w", remaining, context.Cause(waitCtx))
+		case <-ticker.C:
+		}
+	}
 }
 
 // splitStatements strips -- line comments and splits the script into

--- a/server/internal/demoseed/demoseed_test.go
+++ b/server/internal/demoseed/demoseed_test.go
@@ -1,0 +1,92 @@
+package demoseed
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForClickHouseTelemetryDeleteRetriesUntilNoRowsRemain(t *testing.T) {
+	t.Parallel()
+
+	counts := []uint64{7, 2, 0}
+	calls := 0
+
+	err := waitForClickHouseTelemetryDelete(
+		t.Context(),
+		time.Second,
+		time.Millisecond,
+		func(context.Context) (uint64, error) {
+			count := counts[calls]
+			calls++
+			return count, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, len(counts), calls)
+}
+
+func TestWaitForClickHouseTelemetryDeleteReturnsQueryError(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("query unavailable")
+
+	err := waitForClickHouseTelemetryDelete(
+		t.Context(),
+		time.Second,
+		time.Millisecond,
+		func(context.Context) (uint64, error) {
+			return 0, queryErr
+		},
+	)
+
+	require.ErrorIs(t, err, queryErr)
+	require.ErrorContains(t, err, "check demo telemetry delete visibility")
+}
+
+func TestWaitForClickHouseTelemetryDeleteTimesOut(t *testing.T) {
+	t.Parallel()
+
+	err := waitForClickHouseTelemetryDelete(
+		t.Context(),
+		20*time.Millisecond,
+		time.Millisecond,
+		func(context.Context) (uint64, error) {
+			return 3, nil
+		},
+	)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "3 rows remaining")
+}
+
+func TestClickHouseDeletePreflightPrecedesInserts(t *testing.T) {
+	t.Parallel()
+
+	statements := splitStatements(clickhouseSQL)
+	lastDelete := -1
+	preflight := -1
+	firstInsert := -1
+	for i, stmt := range statements {
+		upperStmt := strings.ToUpper(stmt)
+		switch {
+		case strings.HasPrefix(upperStmt, "DELETE "):
+			lastDelete = i
+		case strings.Contains(stmt, "demo seed preflight: telemetry rows remain after scoped deletes"):
+			preflight = i
+		case firstInsert == -1 && strings.HasPrefix(upperStmt, "INSERT "):
+			firstInsert = i
+		}
+	}
+
+	require.NotEqual(t, -1, lastDelete)
+	require.NotEqual(t, -1, preflight)
+	require.NotEqual(t, -1, firstInsert)
+	require.Less(t, lastDelete, preflight)
+	require.Less(t, preflight, firstInsert)
+}


### PR DESCRIPTION
## Summary

- Wait for ClickHouse demo telemetry deletions to become visible before advancing to seed inserts.
- Add a SQL preflight guard and regression coverage for retries, query errors, timeouts, and statement ordering.

## Motivation

ClickHouse delete visibility could lag behind statement execution, allowing a reseed to insert while rows from the previous seed generation were still present. Polling the scoped telemetry count preserves the seed's idempotent delete-then-insert contract and fails with a bounded timeout if cleanup does not become visible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the demo seed where ClickHouse inserts could run while rows from the previous seed generation were still present. The runner now waits for scoped telemetry deletes to become visible before advancing, with a 30-second timeout.

- Polls the remaining telemetry row count after deletes before allowing inserts.
- Adds a SQL preflight guard so the invariant holds for any script executor.
- Adds regression tests for retries, query errors, timeouts, and statement ordering.

<sup>Written for commit fecbd42b67e833ce5f4b2f7c91afd6693adafade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

