### PR TITLE
fix: run changeset versioning through aube

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
+  "format": false,
   "commit": [
     "@changesets/cli/commit",
     {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           title: "chore: version packages"
+          version: mise exec -- aube exec changeset -- version
           publish: mise exec --env viteprod -- aube exec changeset -- publish
           setupGitUser: false
         env:

--- a/mise.lock
+++ b/mise.lock
@@ -74,37 +74,31 @@ backend = "aqua:jdx/aube"
 checksum = "sha256:dda1d6ac8d4c9cba58b52be8f86ceb222bb3b28ca79b76fb4ca0d46633f44212"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508113920"
-provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
 checksum = "sha256:c19365e4dd68f1177da4dc36e9b3e5dad623b12bfa252298c907564ab0cfa099"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-aarch64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508077830"
-provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
 checksum = "sha256:1f10a0a7bd38d94b348b52f785a7496dab6985775b3dfc2ba74914d1c739fba9"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-x86_64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508095865"
-provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
 checksum = "sha256:3557dc1c64f47479440eda76c41bee23998ea3336a70aee22749d298a95938cf"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508091774"
-provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
 checksum = "sha256:120989b5613a48333424c0aa4c3518573baec74836ba700d8d791900b974004b"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508129180"
-provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
 checksum = "sha256:3eadbe826a79184792f423c52e6ad3a20575f0c408ede66612f6db175339a180"
 url = "https://github.com/jdx/aube/releases/download/v1.38.1/aube-v1.38.1-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/aube/releases/assets/508093335"
-provenance = "github-attestations"
 
 [[tools.buf]]
 version = "1.72.0"

--- a/mise.toml
+++ b/mise.toml
@@ -31,13 +31,10 @@ melange = "0.56.5"
 # mirror it falls through to whatever `node` is first on PATH.
 nodejs = "24.16.0"
 aube = "1.38.1"
-# Kept for `changeset publish` only, which shells out to a package manager by
-# name and has no aube branch — it picks between pnpm, yarn and npm. Both
-# versions resolve to pnpm here, off different inputs: 2.31.0 (what we pin)
-# asks package-manager-detector, which answers pnpm because pnpm-lock.yaml is
-# on disk; 3.0.0 asks manypkg for the workspace tool, which answers pnpm
-# because pnpm-workspace.yaml is. aube keeps writing both files in place, so
-# releases need a real pnpm on PATH either way.
+# Kept for `changeset publish` only. Changesets v3 asks manypkg for the
+# workspace tool, which answers pnpm because pnpm-workspace.yaml is present.
+# Release versioning uses the custom aube command in the release workflow.
+# Changesets formatting is disabled because oxfmt ignores CHANGELOG.md files.
 #
 # Publishing via npm instead is not a drop-in: our public packages carry
 # `workspace:` and `catalog:` specifiers that pnpm rewrites at pack time and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,7 +601,7 @@ importers:
     devDependencies:
       '@gram-ai/functions':
         specifier: workspace:^
-        version: 0.18.1
+        version: link:../functions
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)


### PR DESCRIPTION
## Summary

- run Changesets versioning through aube in the release workflow
- disable Changesets' redundant automatic changelog formatting, since oxfmt excludes changelogs
- repair the workspace link in the pnpm-compatible lockfile
- remove stale GitHub-attestation provenance from the aube lock entries
- update the package-manager rationale for the split versioning and publishing paths

## Motivation

Changesets 3 attempted to format generated changelogs with `pnpm exec`, which caused pnpm to validate and reject a workspace dependency that aube had resolved. Versioning should use the repository's installed aube toolchain while preserving pnpm for Changesets' package publishing behavior.

The aube release artifacts do not have matching GitHub attestations, but the legacy mise lockfile required them. Mise 2026.9.1 correctly rejects that mismatch, so the lock entries now retain checksum verification without claiming unavailable provenance.
