### PR TITLE
feat: re-orient Shadow MCP around Policy and Gateway use cases

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -227,7 +227,6 @@ export function AppSidebar({
                   ]),
               { item: routes.riskEvents, ...accessFor(routes.riskEvents) },
               { item: routes.policyCenter, ...accessFor(routes.policyCenter) },
-              { item: routes.shadowMCP, ...accessFor(routes.shadowMCP) },
             ]}
           />
 

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPGatewayUseCaseSection.test.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPGatewayUseCaseSection.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ShadowMCPGatewayUseCaseSection } from "./ShadowMCPGatewayUseCaseSection";
+import { testAccessSummary } from "./shadowMCPInventoryTestFixtures";
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useShadowMCPPolicyInventory: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock("./useShadowMCPPolicyInventory", () => ({
+  useShadowMCPPolicyInventory: mocks.useShadowMCPPolicyInventory,
+}));
+
+vi.mock("@/components/ui/Skeleton", () => ({
+  SkeletonTable: () => <div>Loading table</div>,
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    shadowMCP: {
+      href: () => "/shadow-mcp",
+      detail: { goTo: vi.fn() },
+    },
+  }),
+}));
+
+describe("ShadowMCPGatewayUseCaseSection", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mocks.useProject.mockReturnValue({ id: "project-1" });
+  });
+
+  it("renders concentrated usage candidates for the gateway journey", () => {
+    mocks.useShadowMCPPolicyInventory.mockReturnValue({
+      data: [
+        {
+          access: "none",
+          accessSummary: testAccessSummary("none"),
+          allowedPolicyIds: [],
+          blockedPolicyIds: [],
+          canonicalServerUrl: "https://okta.example/mcp",
+          firstSeen: new Date("2026-01-01T00:00:00Z"),
+          lastCalled: new Date("2026-01-03T00:00:00Z"),
+          lastSeen: new Date("2026-01-03T00:00:00Z"),
+          observedUseCount: 40,
+          requestCount: 0,
+          serverName: "Okta Example",
+          serverSlug: "okta-example",
+          topUsers: [],
+          urlHost: "okta.example",
+          userCount: 2,
+        },
+      ],
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <ShadowMCPGatewayUseCaseSection />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText("Shadow MCP distribution opportunities"),
+    ).toBeTruthy();
+    expect(screen.getByText("Okta Example")).toBeTruthy();
+    expect(screen.getByText("Open full inventory")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPGatewayUseCaseSection.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPGatewayUseCaseSection.tsx
@@ -1,0 +1,152 @@
+import { InlineEmptyState } from "@/components/inline-empty-state";
+import { Card } from "@/components/ui/Card";
+import { MetricCard } from "@/components/ui/MetricCard";
+import { Button } from "@/components/ui/Button";
+import { type Column, Table } from "@/components/ui/Table";
+import { SkeletonTable } from "@/components/ui/Skeleton";
+import { Text } from "@/components/ui/Text";
+import { useProject } from "@/contexts/Auth";
+import { useRoutes } from "@/routes";
+import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
+import { useMemo } from "react";
+import { useNavigate } from "react-router";
+import {
+  ShadowMCPInventoryServerCell,
+  ShadowMCPInventoryUsageCell,
+} from "./ShadowMCPInventoryCells";
+import { useShadowMCPPolicyInventory } from "./useShadowMCPPolicyInventory";
+import {
+  shadowMCPGatewayUseCaseMetrics,
+  shadowMCPOpportunityServers,
+} from "./shadowMCPUseCases";
+
+const EMPTY_INVENTORY: ShadowMCPInventoryServer[] = [];
+
+export function ShadowMCPGatewayUseCaseSection({
+  compact = false,
+  action,
+}: {
+  compact?: boolean;
+  action?: { label: string; onClick: () => void };
+}): JSX.Element {
+  const project = useProject();
+  const routes = useRoutes();
+  const navigate = useNavigate();
+  const inventoryQuery = useShadowMCPPolicyInventory(project.id, true);
+  const inventory = inventoryQuery.data ?? EMPTY_INVENTORY;
+  const opportunityServers = useMemo(
+    () => shadowMCPOpportunityServers(inventory, compact ? 5 : 8),
+    [inventory, compact],
+  );
+  const { totalObservedCalls, concentratedUsageCount } = useMemo(
+    () => shadowMCPGatewayUseCaseMetrics(inventory),
+    [inventory],
+  );
+
+  const columns: Column<ShadowMCPInventoryServer>[] = [
+    {
+      key: "server",
+      header: "Server",
+      width: "3fr",
+      render: (server) => <ShadowMCPInventoryServerCell server={server} />,
+    },
+    {
+      key: "usage",
+      header: "Usage",
+      width: "1fr",
+      render: (server) => <ShadowMCPInventoryUsageCell server={server} />,
+    },
+    {
+      key: "leverage",
+      header: "Calls / user",
+      width: "1fr",
+      render: (server) => (
+        <Text variant="small">
+          {(server.observedUseCount / Math.max(server.userCount, 1)).toFixed(1)}
+        </Text>
+      ),
+    },
+  ];
+
+  return (
+    <div className={compact ? "space-y-4" : "space-y-6"}>
+      <MetricCard.Group className="flex-wrap">
+        <MetricCard
+          label="Tracked servers"
+          value={inventory.length}
+          tone="information"
+          size="xs"
+        />
+        <MetricCard
+          label="Observed calls"
+          value={totalObservedCalls}
+          tone="neutral"
+          size="xs"
+        />
+        <MetricCard
+          label="Concentrated usage"
+          value={concentratedUsageCount}
+          tone={concentratedUsageCount > 0 ? "warning" : "neutral"}
+          size="xs"
+          description="10+ calls from 3 users or fewer"
+        />
+      </MetricCard.Group>
+      <Card.Dashboard
+        title="Shadow MCP distribution opportunities"
+        action={
+          action ? (
+            <Button size="sm" variant="secondary" onClick={action.onClick}>
+              <Button.Text>{action.label}</Button.Text>
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() =>
+                void navigate(`${routes.shadowMCP.href()}?tab=inventory`)
+              }
+            >
+              <Button.Text>Open full inventory</Button.Text>
+            </Button>
+          )
+        }
+      >
+        {inventoryQuery.isPending ? (
+          <div
+            aria-label="Loading Shadow MCP distribution opportunities"
+            className="flex flex-col gap-4"
+            role="status"
+          >
+            <SkeletonTable />
+          </div>
+        ) : inventoryQuery.isError ? (
+          <InlineEmptyState
+            icon="triangle-alert"
+            heading="Shadow MCP inventory couldn't be loaded"
+            description="Retry to detect concentrated server usage for distribution."
+            action={
+              <Button size="sm" onClick={() => void inventoryQuery.refetch()}>
+                <Button.Text>Retry</Button.Text>
+              </Button>
+            }
+          />
+        ) : opportunityServers.length === 0 ? (
+          <InlineEmptyState
+            icon="network"
+            heading="No usage opportunities yet"
+            description="Once users call external servers, Shadow MCP can highlight candidates to spread through gateways."
+          />
+        ) : (
+          <Table
+            columns={columns}
+            data={opportunityServers}
+            rowKey={(server) => server.serverSlug}
+            onRowClick={(server) =>
+              routes.shadowMCP.detail.goTo(server.serverSlug)
+            }
+          />
+        )}
+      </Card.Dashboard>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyUseCaseSection.test.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyUseCaseSection.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ShadowMCPPolicyUseCaseSection } from "./ShadowMCPPolicyUseCaseSection";
+import { testAccessSummary } from "./shadowMCPInventoryTestFixtures";
+
+const mocks = vi.hoisted(() => ({
+  useProject: vi.fn(),
+  useShadowMCPPolicyInventory: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useProject: mocks.useProject,
+}));
+
+vi.mock("./useShadowMCPPolicyInventory", () => ({
+  useShadowMCPPolicyInventory: mocks.useShadowMCPPolicyInventory,
+}));
+
+vi.mock("@/components/ui/Skeleton", () => ({
+  SkeletonTable: () => <div>Loading table</div>,
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    shadowMCP: {
+      href: () => "/shadow-mcp",
+      detail: { goTo: vi.fn() },
+    },
+  }),
+}));
+
+describe("ShadowMCPPolicyUseCaseSection", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mocks.useProject.mockReturnValue({ id: "project-1" });
+  });
+
+  it("renders risky servers for the policy journey", () => {
+    mocks.useShadowMCPPolicyInventory.mockReturnValue({
+      data: [
+        {
+          access: "none",
+          accessSummary: testAccessSummary("none"),
+          allowedPolicyIds: [],
+          blockedPolicyIds: [],
+          canonicalServerUrl: "https://shadow.example/mcp",
+          firstSeen: new Date("2026-01-01T00:00:00Z"),
+          lastCalled: new Date("2026-01-03T00:00:00Z"),
+          lastSeen: new Date("2026-01-03T00:00:00Z"),
+          observedUseCount: 4,
+          requestCount: 2,
+          serverName: "Risky Example",
+          serverSlug: "risky-example",
+          topUsers: [],
+          urlHost: "shadow.example",
+          userCount: 1,
+        },
+      ],
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <ShadowMCPPolicyUseCaseSection />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Top risky Shadow MCP servers")).toBeTruthy();
+    expect(screen.getByText("Risky Example")).toBeTruthy();
+    expect(screen.getByText("Open full inventory")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyUseCaseSection.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyUseCaseSection.tsx
@@ -1,0 +1,168 @@
+import { InlineEmptyState } from "@/components/inline-empty-state";
+import { Card } from "@/components/ui/Card";
+import { MetricCard } from "@/components/ui/MetricCard";
+import { Button } from "@/components/ui/Button";
+import { Badge } from "@/components/ui/Badge";
+import { type Column, Table } from "@/components/ui/Table";
+import { SkeletonTable } from "@/components/ui/Skeleton";
+import { Text } from "@/components/ui/Text";
+import { useProject } from "@/contexts/Auth";
+import { useRoutes } from "@/routes";
+import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
+import { useMemo } from "react";
+import { useNavigate } from "react-router";
+import {
+  ShadowMCPInventoryServerCell,
+  ShadowMCPInventoryUsageCell,
+} from "./ShadowMCPInventoryCells";
+import {
+  shadowMCPInventoryStatus,
+  shadowMCPInventoryStatusBadgeVariant,
+  shadowMCPInventoryStatusDescription,
+  shadowMCPInventoryStatusLabel,
+} from "./shadowMCPInventoryStatus";
+import { useShadowMCPPolicyInventory } from "./useShadowMCPPolicyInventory";
+import {
+  shadowMCPPolicyUseCaseMetrics,
+  shadowMCPRiskyServers,
+} from "./shadowMCPUseCases";
+
+const EMPTY_INVENTORY: ShadowMCPInventoryServer[] = [];
+
+function statusColumn(server: ShadowMCPInventoryServer): JSX.Element {
+  const status = shadowMCPInventoryStatus(server);
+  return (
+    <div className="space-y-1">
+      <Badge variant={shadowMCPInventoryStatusBadgeVariant(status)}>
+        <Badge.Text>{shadowMCPInventoryStatusLabel(status)}</Badge.Text>
+      </Badge>
+      <Text small muted className="text-xs">
+        {shadowMCPInventoryStatusDescription(server)}
+      </Text>
+    </div>
+  );
+}
+
+export function ShadowMCPPolicyUseCaseSection({
+  compact = false,
+  action,
+}: {
+  compact?: boolean;
+  action?: { label: string; onClick: () => void };
+}): JSX.Element {
+  const project = useProject();
+  const routes = useRoutes();
+  const navigate = useNavigate();
+  const inventoryQuery = useShadowMCPPolicyInventory(project.id, true);
+  const inventory = inventoryQuery.data ?? EMPTY_INVENTORY;
+  const riskyServers = useMemo(
+    () => shadowMCPRiskyServers(inventory, compact ? 5 : 8),
+    [inventory, compact],
+  );
+  const { totalPendingRequests, restrictedOrBlockedCount } = useMemo(
+    () => shadowMCPPolicyUseCaseMetrics(inventory),
+    [inventory],
+  );
+
+  const columns: Column<ShadowMCPInventoryServer>[] = [
+    {
+      key: "server",
+      header: "Server",
+      width: "3fr",
+      render: (server) => <ShadowMCPInventoryServerCell server={server} />,
+    },
+    {
+      key: "status",
+      header: "Risk",
+      width: "2fr",
+      render: (server) => statusColumn(server),
+    },
+    {
+      key: "usage",
+      header: "Usage",
+      width: "1fr",
+      render: (server) => <ShadowMCPInventoryUsageCell server={server} />,
+    },
+  ];
+
+  return (
+    <div className={compact ? "space-y-4" : "space-y-6"}>
+      <MetricCard.Group className="flex-wrap">
+        <MetricCard
+          label="Tracked servers"
+          value={inventory.length}
+          tone="information"
+          size="xs"
+        />
+        <MetricCard
+          label="Pending requests"
+          value={totalPendingRequests}
+          tone={totalPendingRequests > 0 ? "destructive" : "neutral"}
+          size="xs"
+        />
+        <MetricCard
+          label="Blocked or restricted"
+          value={restrictedOrBlockedCount}
+          tone={restrictedOrBlockedCount > 0 ? "warning" : "neutral"}
+          size="xs"
+        />
+      </MetricCard.Group>
+      <Card.Dashboard
+        title="Top risky Shadow MCP servers"
+        action={
+          action ? (
+            <Button size="sm" variant="secondary" onClick={action.onClick}>
+              <Button.Text>{action.label}</Button.Text>
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() =>
+                void navigate(`${routes.shadowMCP.href()}?tab=inventory`)
+              }
+            >
+              <Button.Text>Open full inventory</Button.Text>
+            </Button>
+          )
+        }
+      >
+        {inventoryQuery.isPending ? (
+          <div
+            aria-label="Loading risky Shadow MCP servers"
+            className="flex flex-col gap-4"
+            role="status"
+          >
+            <SkeletonTable />
+          </div>
+        ) : inventoryQuery.isError ? (
+          <InlineEmptyState
+            icon="triangle-alert"
+            heading="Shadow MCP inventory couldn't be loaded"
+            description="Retry to rank risky servers by review and enforcement state."
+            action={
+              <Button size="sm" onClick={() => void inventoryQuery.refetch()}>
+                <Button.Text>Retry</Button.Text>
+              </Button>
+            }
+          />
+        ) : riskyServers.length === 0 ? (
+          <InlineEmptyState
+            icon="shield-check"
+            heading="No risky servers right now"
+            description="Shadow MCP has no pending, blocked, or restricted servers in this project."
+          />
+        ) : (
+          <Table
+            columns={columns}
+            data={riskyServers}
+            rowKey={(server) => server.serverSlug}
+            onRowClick={(server) =>
+              routes.shadowMCP.detail.goTo(server.serverSlug)
+            }
+          />
+        )}
+      </Card.Dashboard>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPUseCases.test.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPUseCases.test.ts
@@ -1,0 +1,108 @@
+import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
+import { describe, expect, it } from "vitest";
+import { testAccessSummary } from "./shadowMCPInventoryTestFixtures";
+import {
+  shadowMCPGatewayUseCaseMetrics,
+  shadowMCPOpportunityServers,
+  shadowMCPPolicyUseCaseMetrics,
+  shadowMCPRiskRank,
+  shadowMCPRiskyServers,
+} from "./shadowMCPUseCases";
+
+function inventoryServer(
+  overrides: Partial<ShadowMCPInventoryServer> = {},
+): ShadowMCPInventoryServer {
+  return {
+    access: "none",
+    accessSummary: testAccessSummary("none"),
+    allowedPolicyIds: [],
+    blockedPolicyIds: [],
+    canonicalServerUrl: "https://shadow.example/mcp",
+    firstSeen: new Date("2026-01-01T00:00:00Z"),
+    lastCalled: new Date("2026-01-03T00:00:00Z"),
+    lastSeen: new Date("2026-01-03T00:00:00Z"),
+    observedUseCount: 12,
+    requestCount: 0,
+    serverName: "Shadow Example",
+    serverSlug: "shadow-example",
+    topUsers: [],
+    urlHost: "shadow.example",
+    userCount: 2,
+    ...overrides,
+  };
+}
+
+describe("shadowMCPUseCases", () => {
+  it("ranks pending servers above observed servers", () => {
+    const pending = inventoryServer({
+      serverSlug: "pending",
+      requestCount: 1,
+      observedUseCount: 1,
+    });
+    const observed = inventoryServer({
+      serverSlug: "observed",
+      requestCount: 0,
+      observedUseCount: 100,
+    });
+
+    expect(shadowMCPRiskRank(pending)).toBeGreaterThan(
+      shadowMCPRiskRank(observed),
+    );
+  });
+
+  it("selects risky servers by review state", () => {
+    const inventory = [
+      inventoryServer({ serverSlug: "observed-only", requestCount: 0 }),
+      inventoryServer({ serverSlug: "pending", requestCount: 2 }),
+      inventoryServer({
+        serverSlug: "blocked",
+        access: "blocked",
+        accessSummary: testAccessSummary("blocked"),
+      }),
+    ];
+
+    expect(
+      shadowMCPRiskyServers(inventory).map((server) => server.serverSlug),
+    ).toEqual(["pending", "blocked"]);
+  });
+
+  it("selects opportunity servers by calls per user", () => {
+    const inventory = [
+      inventoryServer({
+        serverSlug: "low-leverage",
+        observedUseCount: 4,
+        userCount: 4,
+      }),
+      inventoryServer({
+        serverSlug: "high-leverage",
+        observedUseCount: 40,
+        userCount: 2,
+      }),
+    ];
+
+    expect(
+      shadowMCPOpportunityServers(inventory).map((server) => server.serverSlug),
+    ).toEqual(["high-leverage", "low-leverage"]);
+  });
+
+  it("computes policy and gateway metrics", () => {
+    const inventory = [
+      inventoryServer({ requestCount: 3, observedUseCount: 1, userCount: 10 }),
+      inventoryServer({
+        access: "blocked",
+        accessSummary: testAccessSummary("blocked"),
+        observedUseCount: 12,
+        userCount: 2,
+      }),
+    ];
+
+    expect(shadowMCPPolicyUseCaseMetrics(inventory)).toEqual({
+      totalPendingRequests: 3,
+      restrictedOrBlockedCount: 1,
+    });
+    expect(shadowMCPGatewayUseCaseMetrics(inventory)).toEqual({
+      totalObservedCalls: 13,
+      concentratedUsageCount: 1,
+    });
+  });
+});

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPUseCases.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPUseCases.ts
@@ -1,0 +1,88 @@
+import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
+import { shadowMCPInventoryStatus } from "./shadowMCPInventoryStatus";
+
+export function shadowMCPRiskRank(server: ShadowMCPInventoryServer): number {
+  const status = shadowMCPInventoryStatus(server);
+  const statusWeight =
+    status === "pending"
+      ? 5
+      : status === "blocked"
+        ? 4
+        : status === "restricted"
+          ? 3
+          : status === "observed"
+            ? 2
+            : 1;
+  return (
+    statusWeight * 1000 +
+    server.requestCount * 100 +
+    server.observedUseCount * 10 +
+    server.userCount
+  );
+}
+
+export function shadowMCPRiskyServers(
+  inventory: ShadowMCPInventoryServer[],
+  limit = 8,
+): ShadowMCPInventoryServer[] {
+  return [...inventory]
+    .sort((a, b) => shadowMCPRiskRank(b) - shadowMCPRiskRank(a))
+    .filter((server) => {
+      const status = shadowMCPInventoryStatus(server);
+      return (
+        status === "pending" || status === "blocked" || status === "restricted"
+      );
+    })
+    .slice(0, limit);
+}
+
+export function shadowMCPOpportunityServers(
+  inventory: ShadowMCPInventoryServer[],
+  limit = 8,
+): ShadowMCPInventoryServer[] {
+  return [...inventory]
+    .filter((server) => server.observedUseCount > 0 && server.userCount > 0)
+    .sort((a, b) => {
+      const ratioA = a.observedUseCount / a.userCount;
+      const ratioB = b.observedUseCount / b.userCount;
+      if (ratioA !== ratioB) return ratioB - ratioA;
+      return b.observedUseCount - a.observedUseCount;
+    })
+    .slice(0, limit);
+}
+
+export function shadowMCPPolicyUseCaseMetrics(
+  inventory: ShadowMCPInventoryServer[],
+): {
+  totalPendingRequests: number;
+  restrictedOrBlockedCount: number;
+} {
+  const totalPendingRequests = inventory.reduce(
+    (sum, server) => sum + server.requestCount,
+    0,
+  );
+  const restrictedOrBlockedCount = inventory.filter((server) => {
+    const status = shadowMCPInventoryStatus(server);
+    return status === "blocked" || status === "restricted";
+  }).length;
+  return { totalPendingRequests, restrictedOrBlockedCount };
+}
+
+export function shadowMCPGatewayUseCaseMetrics(
+  inventory: ShadowMCPInventoryServer[],
+): {
+  totalObservedCalls: number;
+  concentratedUsageCount: number;
+} {
+  const totalObservedCalls = inventory.reduce(
+    (sum, server) => sum + server.observedUseCount,
+    0,
+  );
+  const concentratedUsageCount = inventory.filter(
+    (server) =>
+      server.observedUseCount >= 10 &&
+      server.userCount > 0 &&
+      server.userCount <= 3,
+  ).length;
+  return { totalObservedCalls, concentratedUsageCount };
+}

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -46,7 +46,7 @@ const routes = {
   riskOverview: route("Risk Overview", "risk"),
   watchdog: route("Watchdog", "watchdog"),
   settings: route("Project settings", "settings"),
-  shadowMCP: route("Shadow MCP", "shadow-mcp"),
+  shadowMCP: route("Shadow MCP Inventory", "shadow-mcp"),
   sources: route("Sources", "sources"),
 };
 
@@ -93,12 +93,13 @@ describe("useProjectNavRoutes", () => {
     ).toBe(false);
   });
 
-  it("uses Shadow MCP as the sidebar destination while leaving Approval Requests out of nav", () => {
+  it("does not include Shadow MCP in primary project navigation", () => {
     const { result } = renderHook(() => useProjectNavRoutes());
 
     const navTitles = result.current.map((entry) => entry.route.title);
 
-    expect(navTitles).toContain("Shadow MCP");
+    expect(navTitles).not.toContain("Shadow MCP");
+    expect(navTitles).not.toContain("Shadow MCP Inventory");
     expect(navTitles).not.toContain("Approval Requests");
   });
 

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -96,7 +96,6 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
         : [{ route: routes.riskOverview, scope: read }]),
       { route: routes.riskEvents, scope: ["org:admin"] as Scope[] },
       { route: routes.policyCenter, scope: readWrite },
-      { route: routes.shadowMCP, scope: readWrite },
       { route: routes.settings, scope: ["project:write"] },
     ];
   }, [

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -1,4 +1,5 @@
 import { InputDialog } from "@/components/input-dialog";
+import { ShadowMCPGatewayUseCaseSection } from "@/components/shadow-mcp/ShadowMCPGatewayUseCaseSection";
 import { RequireScope } from "@/components/require-scope";
 import { BuiltInMCPCard } from "@/components/mcp/BuiltInMCPCard";
 import { GatewayCard } from "@/components/mcp/GatewayCard";
@@ -517,6 +518,18 @@ function MCPOverview() {
   ) {
     return (
       <>
+        <Page.Section>
+          <Page.Section.Title area="" className="text-display-xs">
+            Shadow MCP distribution
+          </Page.Section.Title>
+          <Page.Section.Description>
+            External MCP servers observed in this project that may benefit from
+            broader distribution through managed gateways.
+          </Page.Section.Description>
+          <Page.Section.Body>
+            <ShadowMCPGatewayUseCaseSection compact />
+          </Page.Section.Body>
+        </Page.Section>
         <MCPEmptyState cta={newMcpServerButton} />
         {builtInSection}
         {newMcpServerDialog}
@@ -527,6 +540,18 @@ function MCPOverview() {
 
   return (
     <>
+      <Page.Section>
+        <Page.Section.Title area="" className="text-display-xs">
+          Shadow MCP distribution
+        </Page.Section.Title>
+        <Page.Section.Description>
+          External MCP servers observed in this project that may benefit from
+          broader distribution through managed gateways.
+        </Page.Section.Description>
+        <Page.Section.Body>
+          <ShadowMCPGatewayUseCaseSection compact />
+        </Page.Section.Body>
+      </Page.Section>
       <Page.Section>
         <Page.Section.Title>Hosted MCP Servers</Page.Section.Title>
         {hasRefreshError ? (

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -2,6 +2,7 @@ import { IdentityLink } from "@/components/identity-link";
 import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { TabbedPage } from "@/components/page-templates";
+import { ShadowMCPPolicyUseCaseSection } from "@/components/shadow-mcp/ShadowMCPPolicyUseCaseSection";
 import { RequireScope } from "@/components/require-scope";
 import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import type { Action } from "@/components/ui/MoreActions";
@@ -1224,7 +1225,12 @@ function PolicyCenterContent() {
           subtitle="Ask about policy status, coverage, and detector capabilities. Match content is redacted before it reaches the assistant."
         />
       )}
-      {activeTab === "policies" && policiesBody}
+      {activeTab === "policies" && (
+        <div className="space-y-8">
+          <ShadowMCPPolicyUseCaseSection compact />
+          {policiesBody}
+        </div>
+      )}
       {activeTab === "detection-rules" && (
         <DetectionRulesTab
           createOpen={ruleCreateOpen}

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
@@ -1,72 +1,43 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
-import type { ReactElement, ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ShadowMCP from "./ShadowMCP";
+import { testAccessSummary } from "@/components/shadow-mcp/shadowMCPInventoryTestFixtures";
 
 const mocks = vi.hoisted(() => ({
   useProject: vi.fn(),
   useRBAC: vi.fn(),
+  useShadowMCPPolicyInventory: vi.fn(),
   useMembers: vi.fn(),
   useRiskListPolicies: vi.fn(),
   useRoles: vi.fn(),
 }));
 
-vi.mock("@/components/page-layout", () => {
-  function Page({ children }: { children: ReactNode }) {
-    return <div>{children}</div>;
-  }
-
-  function Header({ children }: { children?: ReactNode }) {
-    return <div>{children}</div>;
-  }
-  Header.Breadcrumbs = () => null;
-
-  function Body({ children }: { children: ReactNode }) {
-    return <div>{children}</div>;
-  }
-
-  function Section({ children }: { children: ReactNode }) {
-    let title: ReactElement | null = null;
-    let description: ReactElement | null = null;
-    let cta: ReactElement | null = null;
-    let body: ReactElement | null = null;
-
-    for (const child of Array.isArray(children) ? children : [children]) {
-      if (typeof child === "object" && child && "type" in child) {
-        if (child.type === Section.Title) title = child;
-        if (child.type === Section.Description) description = child;
-        if (child.type === Section.CTA) cta = child;
-        if (child.type === Section.Body) body = child;
-      }
-    }
-
-    return (
-      <section>
-        <div data-testid="section-header">
-          {title}
-          <div data-testid="section-cta">{cta}</div>
-        </div>
-        {description}
-        {body}
-      </section>
-    );
-  }
-  Section.Title = ({ children }: { children: ReactNode }) => (
-    <h1>{children}</h1>
-  );
-  Section.Description = ({ children }: { children: ReactNode }) => (
-    <p>{children}</p>
-  );
-  Section.CTA = ({ children }: { children: ReactNode }) => <>{children}</>;
-  Section.Body = ({ children }: { children: ReactNode }) => <>{children}</>;
-
+vi.mock("@/components/page-templates", () => {
   return {
-    Page: Object.assign(Page, {
-      Header,
-      Body,
-      Section,
-    }),
+    TabbedPage: ({
+      title,
+      tabs,
+      activeTab,
+      children,
+    }: {
+      title: string;
+      tabs: Array<{ value: string; label: string }>;
+      activeTab: string;
+      children: ReactNode;
+    }) => (
+      <section>
+        <h1>{title}</h1>
+        <div data-testid="tabs">
+          {tabs.map((tab) => (
+            <span key={tab.value}>{tab.label}</span>
+          ))}
+        </div>
+        <div data-testid="active-tab">{activeTab}</div>
+        {children}
+      </section>
+    ),
   };
 });
 
@@ -82,14 +53,21 @@ vi.mock("@gram/client/react-query/roles.js", () => ({
   useRoles: mocks.useRoles,
 }));
 
+vi.mock("@/components/shadow-mcp/useShadowMCPPolicyInventory", () => ({
+  useShadowMCPPolicyInventory: mocks.useShadowMCPPolicyInventory,
+}));
+
 vi.mock("@/components/ui/Skeleton", () => ({
   SkeletonTable: () => <div>Loading table</div>,
 }));
 
 vi.mock("@/routes", () => ({
   useRoutes: () => ({
+    mcp: { goTo: vi.fn(), href: () => "/mcp" },
+    policyCenter: { goTo: vi.fn(), href: () => "/risk-policies" },
     shadowMCP: {
       detail: {
+        goTo: vi.fn(),
         href: (serverURL: string) => `/shadow-mcp/${serverURL}`,
       },
     },
@@ -166,6 +144,12 @@ describe("ShadowMCP", () => {
       isError: false,
       isLoading: false,
     });
+    mocks.useShadowMCPPolicyInventory.mockReturnValue({
+      data: [],
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
     mocks.useMembers.mockReturnValue({
       data: { members: [{ name: "Admin User" }] },
     });
@@ -174,31 +158,51 @@ describe("ShadowMCP", () => {
     });
   });
 
-  it("renders the Shadow MCP inventory management page", () => {
+  function inventoryServer(overrides: Record<string, unknown> = {}) {
+    return {
+      access: "none",
+      accessSummary: testAccessSummary("none"),
+      allowedPolicyIds: [],
+      blockedPolicyIds: [],
+      canonicalServerUrl: "https://shadow.example/mcp",
+      firstSeen: new Date("2026-01-01T00:00:00Z"),
+      lastCalled: new Date("2026-01-03T00:00:00Z"),
+      lastSeen: new Date("2026-01-03T00:00:00Z"),
+      observedUseCount: 12,
+      requestCount: 0,
+      serverName: "Shadow Example",
+      serverSlug: "shadow-example",
+      topUsers: [],
+      urlHost: "shadow.example",
+      userCount: 2,
+      ...overrides,
+    };
+  }
+
+  it("defaults to the policy use case tab", () => {
     render(
       <MemoryRouter>
         <ShadowMCP />
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: "Shadow MCP" })).toBeTruthy();
     expect(
-      screen.getByText(/Every MCP server this project knows about/),
+      screen.getByRole("heading", { name: "Shadow MCP Inventory" }),
     ).toBeTruthy();
-    expect(screen.getByText("No Policy")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "No policy is enabled. All Shadow MCP servers are allowed.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Shadow MCP inventory for project-1")).toBeTruthy();
+    expect(screen.getByTestId("active-tab").textContent).toBe("policy");
+    expect(screen.getByText("Policy Use Case")).toBeTruthy();
+    expect(screen.getByText("Gateway Use Case")).toBeTruthy();
+    expect(screen.getByText("Full Inventory")).toBeTruthy();
+    expect(screen.getByText("Top risky Shadow MCP servers")).toBeTruthy();
+    expect(screen.getByText("Open Guardrails")).toBeTruthy();
   });
 
-  it("blocks inventory rendering until policy data loads", () => {
-    mocks.useRiskListPolicies.mockReturnValue({
+  it("shows loading state while policy use case inventory is pending", () => {
+    mocks.useShadowMCPPolicyInventory.mockReturnValue({
       data: undefined,
+      isPending: true,
       isError: false,
-      isLoading: true,
+      refetch: vi.fn(),
     });
 
     render(
@@ -208,114 +212,41 @@ describe("ShadowMCP", () => {
     );
 
     expect(screen.getByRole("status").getAttribute("aria-label")).toBe(
-      "Loading Shadow MCP policies",
+      "Loading risky Shadow MCP servers",
     );
     expect(screen.getByText("Loading table")).toBeTruthy();
-    expect(screen.queryByText("No Policy")).toBeNull();
-    expect(screen.queryByText(/Shadow MCP inventory for/)).toBeNull();
-    expect(
-      within(screen.getByTestId("section-cta")).queryByText(/./),
-    ).toBeNull();
   });
 
-  it("renders blocking policy status in the section header", () => {
+  it("renders inventory tab with policy status and table", () => {
     mocks.useRiskListPolicies.mockReturnValue({
       data: {
-        policies: [
-          riskPolicy({ action: "flag" }),
-          riskPolicy({ action: "block", enabled: false, id: "disabled-block" }),
-          riskPolicy({ action: "block", id: "block-policy-1" }),
-        ],
+        policies: [riskPolicy({ action: "block", id: "block-policy-1" })],
       },
       isError: false,
       isLoading: false,
     });
+    mocks.useShadowMCPPolicyInventory.mockReturnValue({
+      data: [inventoryServer()],
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
 
     render(
-      <MemoryRouter>
+      <MemoryRouter
+        initialEntries={["/org/projects/demo/shadow-mcp?tab=inventory"]}
+      >
         <ShadowMCP />
       </MemoryRouter>,
     );
 
-    const sectionCTA = within(screen.getByTestId("section-cta"));
-    expect(sectionCTA.getByText("Blocking")).toBeTruthy();
-    expect(
-      sectionCTA.getByText(
-        "Block policy is enabled. Servers without allow rules are not allowed.",
-      ),
-    ).toBeTruthy();
+    expect(screen.getByTestId("active-tab").textContent).toBe("inventory");
+    expect(screen.getByText("Blocking")).toBeTruthy();
     expect(screen.getByText("Shadow MCP inventory for project-1")).toBeTruthy();
     expect(
       screen.getByText("Shadow MCP policies: block-policy-1"),
     ).toBeTruthy();
     expect(screen.getByText("Roles: Admin")).toBeTruthy();
     expect(screen.getByText("Members: Admin User")).toBeTruthy();
-  });
-
-  it("renders warning policy status when no blocking policy is enabled", () => {
-    mocks.useRiskListPolicies.mockReturnValue({
-      data: { policies: [riskPolicy({ action: "warn" })] },
-      isError: false,
-      isLoading: false,
-    });
-
-    render(
-      <MemoryRouter>
-        <ShadowMCP />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("Warning")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Warn policy is enabled. Users must acknowledge warnings before continuing.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Shadow MCP inventory for project-1")).toBeTruthy();
-  });
-
-  it("renders flagging policy status when no blocking policy is enabled", () => {
-    mocks.useRiskListPolicies.mockReturnValue({
-      data: { policies: [riskPolicy({ action: "flag" })] },
-      isError: false,
-      isLoading: false,
-    });
-
-    render(
-      <MemoryRouter>
-        <ShadowMCP />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("Flagging")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Flagging policy is enabled. Servers without allow rules are only flagged.",
-      ),
-    ).toBeTruthy();
-    expect(screen.getByText("Shadow MCP inventory for project-1")).toBeTruthy();
-  });
-
-  it("renders no policy when no enabled Shadow MCP policy exists", () => {
-    mocks.useRiskListPolicies.mockReturnValue({
-      data: {
-        policies: [
-          riskPolicy({ action: "block", enabled: false }),
-          riskPolicy({ action: "block", sources: ["prompt_injection"] }),
-        ],
-      },
-      isError: false,
-      isLoading: false,
-    });
-
-    render(
-      <MemoryRouter>
-        <ShadowMCP />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText("No Policy")).toBeTruthy();
-    expect(screen.getByText("Shadow MCP inventory for project-1")).toBeTruthy();
-    expect(screen.getByText("Shadow MCP policies: none")).toBeTruthy();
   });
 });

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
@@ -1,7 +1,9 @@
-import { Page } from "@/components/page-layout";
+import { TabbedPage } from "@/components/page-templates";
 import { RequireScope } from "@/components/require-scope";
 import { ShadowMCPInventoryTable } from "@/components/shadow-mcp/ShadowMCPInventoryTable";
 import { ShadowMCPPolicyStatus } from "@/components/shadow-mcp/ShadowMCPPolicyStatus";
+import { ShadowMCPPolicyUseCaseSection } from "@/components/shadow-mcp/ShadowMCPPolicyUseCaseSection";
+import { ShadowMCPGatewayUseCaseSection } from "@/components/shadow-mcp/ShadowMCPGatewayUseCaseSection";
 import {
   eligibleShadowMCPAllowRulePolicies,
   shadowMCPBlockingPolicyDisposition,
@@ -15,43 +17,52 @@ import { useMembers } from "@gram/client/react-query/members.js";
 import { useRiskListPolicies } from "@gram/client/react-query/riskListPolicies.js";
 import { useRoles } from "@gram/client/react-query/roles.js";
 import { Outlet } from "react-router";
+import { useSearchParams } from "react-router";
 
 export function ShadowMCPRoot(): JSX.Element {
   return <Outlet />;
 }
 
-function ShadowMCPLoadingState(): JSX.Element {
+const SHADOW_MCP_TABS = ["policy", "gateway", "inventory"] as const;
+type ShadowMCPTab = (typeof SHADOW_MCP_TABS)[number];
+
+function activeTabFromSearchParams(
+  searchParams: URLSearchParams,
+): ShadowMCPTab {
+  const tab = searchParams.get("tab");
+  return tab != null && SHADOW_MCP_TABS.includes(tab as ShadowMCPTab)
+    ? (tab as ShadowMCPTab)
+    : "policy";
+}
+
+function ShadowMCPLoadingState({
+  label = "Loading Shadow MCP policies",
+}: {
+  label?: string;
+}): JSX.Element {
   return (
-    <div
-      aria-label="Loading Shadow MCP policies"
-      className="flex flex-col gap-4 pb-8"
-      role="status"
-    >
+    <div aria-label={label} className="flex flex-col gap-4 pb-8" role="status">
       <SkeletonTable />
     </div>
   );
 }
 
 export default function ShadowMCP(): JSX.Element {
-  const pageTitle = "Shadow MCP";
+  const [searchParams] = useSearchParams();
+  const activeTab = activeTabFromSearchParams(searchParams);
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs
-          substitutions={{ ["shadow-mcp"]: pageTitle }}
-        />
-      </Page.Header>
-      <Page.Body fullHeight className="pb-8">
-        <RequireScope scope="org:admin" level="page">
-          <ShadowMCPInventory pageTitle={pageTitle} />
-        </RequireScope>
-      </Page.Body>
-    </Page>
+    <RequireScope scope="org:admin" level="page">
+      <ShadowMCPUseCases activeTab={activeTab} />
+    </RequireScope>
   );
 }
 
-function ShadowMCPInventory({ pageTitle }: { pageTitle: string }): JSX.Element {
+function ShadowMCPUseCases({
+  activeTab,
+}: {
+  activeTab: ShadowMCPTab;
+}): JSX.Element {
   const project = useProject();
   const routes = useRoutes();
   const policiesQuery = useRiskListPolicies();
@@ -69,26 +80,49 @@ function ShadowMCPInventory({ pageTitle }: { pageTitle: string }): JSX.Element {
   const disposition = shadowMCPBlockingPolicyDisposition(shadowMCPPolicies);
 
   return (
-    <Page.Section>
-      <Page.Section.Title stage="beta" area="">
-        {pageTitle}
-      </Page.Section.Title>
-      <Page.Section.Description>
-        Every MCP server this project knows about — observed in agent traffic or
-        raised in an access request — with its review state. Click a server for
-        its evidence, requesters, and decision history.
-      </Page.Section.Description>
-      {policyDataReady ? (
-        <Page.Section.CTA>
-          <ShadowMCPPolicyStatus
-            disposition={disposition}
-            policyState={policyState}
+    <TabbedPage
+      title="Shadow MCP Inventory"
+      stage="beta"
+      area=""
+      description="Power-user inventory and use-case views for Shadow MCP servers observed outside managed gateways."
+      activeTab={activeTab}
+      tabs={[
+        { value: "policy", label: "Policy Use Case", href: "?tab=policy" },
+        { value: "gateway", label: "Gateway Use Case", href: "?tab=gateway" },
+        {
+          value: "inventory",
+          label: "Full Inventory",
+          href: "?tab=inventory",
+        },
+      ]}
+    >
+      {activeTab === "policy" && (
+        <div className="py-6">
+          <ShadowMCPPolicyUseCaseSection
+            action={{
+              label: "Open Guardrails",
+              onClick: () => routes.policyCenter.goTo(),
+            }}
           />
-        </Page.Section.CTA>
-      ) : null}
-      <Page.Section.Body>
-        {policyDataReady ? (
-          <div className="flex flex-col pb-8">
+        </div>
+      )}
+      {activeTab === "gateway" && (
+        <div className="py-6">
+          <ShadowMCPGatewayUseCaseSection
+            action={{
+              label: "Open MCP & Gateways",
+              onClick: () => routes.mcp.goTo(),
+            }}
+          />
+        </div>
+      )}
+      {activeTab === "inventory" &&
+        (policyDataReady ? (
+          <div className="flex flex-col gap-4 pb-8 py-6">
+            <ShadowMCPPolicyStatus
+              disposition={disposition}
+              policyState={policyState}
+            />
             <ShadowMCPInventoryTable
               members={membersQuery.data?.members ?? []}
               onOpenServer={(server) =>
@@ -101,8 +135,7 @@ function ShadowMCPInventory({ pageTitle }: { pageTitle: string }): JSX.Element {
           </div>
         ) : (
           <ShadowMCPLoadingState />
-        )}
-      </Page.Section.Body>
-    </Page.Section>
+        ))}
+    </TabbedPage>
   );
 }

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -821,7 +821,7 @@ const ROUTE_STRUCTURE = {
     component: RiskEventsPage,
   },
   shadowMCP: {
-    title: "Shadow MCP",
+    title: "Shadow MCP Inventory",
     url: "shadow-mcp",
     icon: "shield",
     component: ShadowMCPRoot,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AIS-677: Shadow MCP was an unstructured first-touch inventory. This reorients it around the two journeys that actually use the data, and demotes the raw inventory to a power-user surface.

- **Guardrails (Policy)** now consumes Shadow MCP as a “top risky servers” panel: pending, blocked, and restricted servers ranked for review, with a path into the full inventory.
- **MCP & Gateways** now consume Shadow MCP as a “distribution opportunities” panel: servers with high calls-per-user / concentrated usage that may be worth spreading more broadly.
- **Shadow MCP Inventory** is no longer a Secure sidebar / command-palette destination. The route stays reachable from those journey CTAs and by URL, with Policy, Gateway, and Full Inventory tabs.

## How to verify

1. Open **Guardrails → Policies**. Confirm “Top risky Shadow MCP servers” appears above the policy list, then use **Open full inventory**.
2. Open **MCP**. Confirm the **Shadow MCP distribution** section appears on both empty and populated listings.
3. Confirm **Shadow MCP** is gone from the Secure sidebar and command palette.
4. Visit `/shadow-mcp` directly. Confirm **Shadow MCP Inventory** with Policy / Gateway / Full Inventory tabs, plus CTAs back into Guardrails and MCP.

## Screenshots

![Guardrails consuming risky Shadow MCP servers](https://cursor.com/artifacts/c/art-a944fb09-8f92-4416-aac6-15de1fd43234)
![Shadow MCP Inventory policy use case](https://cursor.com/artifacts/c/art-8fcf53a8-f08f-4372-a427-52502f5c3e6a)
![Shadow MCP Inventory gateway use case](https://cursor.com/artifacts/c/art-e1d62843-19eb-45ce-971a-31d8575cbc44)

<a href="https://cursor.com/agents/bc-9494c5e4-bf88-45f0-bda1-97c04dddc87c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshadow_mcp_use_case_taxonomy_manual_verification.mp4"><img src="https://cursor.com/artifacts/c/art-fe54f29a-c6b4-4a8f-897b-54c23d0a51af" alt="shadow_mcp_use_case_taxonomy_manual_verification.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-677](https://linear.app/speakeasy/issue/AIS-677/feat-re-orient-shadowmcp-taxonomy-around-use-case)

<div><a href="https://cursor.com/agents/bc-9494c5e4-bf88-45f0-bda1-97c04dddc87c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9494c5e4-bf88-45f0-bda1-97c04dddc87c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorients Shadow MCP around the Policy and Gateway journeys instead of treating the raw inventory as the first touchpoint. Guardrails and MCP & Gateways now surface curated Shadow MCP panels, and the standalone inventory is demoted to a power-user surface.

- Guardrails now shows a "Top risky Shadow MCP servers" panel ranking pending, blocked, and restricted servers for review.
- MCP & Gateways now shows a "Shadow MCP distribution" panel ranking servers by calls per user as gateway candidates.
- Shadow MCP is removed from the Secure sidebar and command palette.
- The inventory page stays reachable by URL and from both panels' "Open full inventory" CTAs, now with Policy, Gateway, and Full Inventory tabs.

<sup>Written for commit 2a856b2b08d4516d23d29c9f612f6e63b5c59c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

