### PR TITLE
mig: classify new OpenRouter keys by default

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2655,7 +2655,9 @@ CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   key_hash TEXT NOT NULL,
   monthly_credits BIGINT NOT NULL DEFAULT 0,
   disabled BOOLEAN NOT NULL DEFAULT FALSE,
-  disable_causes TEXT[],
+  -- NULL is reserved for legacy rows awaiting provenance classification. New
+  -- writes must start classified and enabled.
+  disable_causes TEXT[] DEFAULT '{}'::text[],
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/migrations/20260903163542_openrouter-disable-causes-default.sql
+++ b/server/migrations/20260903163542_openrouter-disable-causes-default.sql
@@ -1,0 +1,2 @@
+-- Modify "openrouter_api_keys" table
+ALTER TABLE "openrouter_api_keys" ALTER COLUMN "disable_causes" SET DEFAULT '{}';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WSsacfXez3IFqaPvrUWqETMbRAPI3maeBhUedluNTz8=
+h1:OZKElL6xjff9i7wWLUdj+RZt8YiFG7zoP3CvRXCl4aY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -381,3 +381,4 @@ h1:WSsacfXez3IFqaPvrUWqETMbRAPI3maeBhUedluNTz8=
 20260831182126_aim-78-remote-session-client-jwks.sql h1:s39s09GZ0Zjh20gDECQj9ZmkSOsXZsHxpADmdM8uRrI=
 20260901222548_remote-session-issuer-tunnel-binding.sql h1:3JREClrlXOmZInBZO8aup9+fz/QjQka7XxTuJmGnzjA=
 20260902212254_public-tunnel-rate-limits.sql h1:nZB403TMLx/lHT2gVqVrlsN1Iw4CBhrGJjcNcaOxMuI=
+20260903163542_openrouter-disable-causes-default.sql h1:LS+zQwFykPPu8UqRaH4IGmyaioQr3GhQrLGuoi32B1o=


### PR DESCRIPTION
Incident: [INC-452](https://linear.app/speakeasy/issue/INC-452)

## Purpose

Prevent newly inserted OpenRouter keys from entering the ambiguous legacy state that blocks expired-trial demotion. This is the migration-only first step of the incident fix.

## Summary

- default omitted `disable_causes` values to the classified enabled state, `{}`
- keep the column nullable so genuinely ambiguous historical rows remain fail-closed for the provenance classifier
- do not backfill data or add a `NOT NULL` constraint

## Rollout role

Deploy this PR first. The default is safe while production still contains `NULL` rows because it affects only future inserts. After it lands, deploy #6026 to remove the remaining application write that can explicitly reintroduce `NULL`. Run the separately managed production classifier only after all old application and worker instances have drained.

## Motivation

The incident exposed a gap in the rollout contract: application inserts that omit `disable_causes` could create new unclassified rows while historical classification was still in progress. A nullable default closes that gap without guessing why existing keys are disabled.
