### PR TITLE
fix: offer hosted MCP servers in the gateway add member picker

### DIFF
--- a/.changeset/gateway-add-hosted-toolset-member.md
+++ b/.changeset/gateway-add-hosted-toolset-member.md
@@ -3,4 +3,4 @@
 "server": patch
 ---
 
-Gateways can now add hosted MCP servers as members directly from the Add member picker; previously only servers that already had a standalone MCP server entry were offered. A gateway also no longer serves a hosted member whose MCP server is turned off.
+Gateways can now add hosted MCP servers as members directly from the Add member picker; previously only servers that already had a standalone MCP server entry were offered. A gateway also no longer serves a hosted member whose MCP server is turned off. The detail sidebar's readiness and at-a-glance counts now update live when members change, instead of waiting for a reload.

--- a/.changeset/gateway-add-hosted-toolset-member.md
+++ b/.changeset/gateway-add-hosted-toolset-member.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Gateways can now add hosted MCP servers as members directly from the Add member picker; previously only servers that already had a standalone MCP server entry were offered. A gateway also no longer serves a hosted member whose MCP server is turned off.

--- a/client/dashboard/src/elements/contexts/ElementsProvider.tsx
+++ b/client/dashboard/src/elements/contexts/ElementsProvider.tsx
@@ -43,7 +43,11 @@ import {
   useChatRuntime,
 } from "@assistant-ui/react-ai-sdk";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientContext,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -62,6 +66,7 @@ type UIMessagePart = UIMessage["parts"][number];
 import {
   ReactNode,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -955,13 +960,17 @@ const ElementsProviderWithoutHistory = ({
   );
 };
 
-const queryClient = new QueryClient();
+const standaloneQueryClient = new QueryClient();
 
 export const ElementsProvider = (
   props: ElementsProviderProps,
 ): React.JSX.Element => {
+  // Share a host app's QueryClient so content rendered inside this provider
+  // (the dashboard mounts it around the page outlet) stays in one cache with
+  // the rest of the app. Standalone embeds get their own.
+  const hostQueryClient = useContext(QueryClientContext);
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={hostQueryClient ?? standaloneQueryClient}>
       <ConnectionStatusProvider>
         <ToolApprovalProvider>
           <MarkdownLinkProvider

--- a/client/dashboard/src/elements/hooks/useMCPTools.ts
+++ b/client/dashboard/src/elements/hooks/useMCPTools.ts
@@ -166,6 +166,9 @@ export function useMCPTools({
     },
     enabled: !auth.isLoading && servers.length > 0,
     staleTime: () => (partialFailureRef.current ? 0 : Infinity),
+    // Errors surface inline via mcpToolsError, not an error boundary, even
+    // under a host QueryClient that defaults to throwing.
+    throwOnError: false,
     gcTime: Infinity,
   });
 

--- a/client/dashboard/src/elements/hooks/useSession.ts
+++ b/client/dashboard/src/elements/hooks/useSession.ts
@@ -29,6 +29,9 @@ export const useSession = ({
     enabled: !hasData && getSession !== null,
     staleTime: Infinity, // Session tokens don't need to be refetched
     gcTime: Infinity, // Keep in cache indefinitely
+    // A host QueryClient may default to throwing; a missing token is handled
+    // inline (null), not by an error boundary.
+    throwOnError: false,
   });
 
   return fetchedSessionToken ?? null;

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
@@ -37,7 +37,7 @@ import {
   Server,
   Trash2,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import {
@@ -475,6 +475,7 @@ export function GatewayMembersSection({
         servers={servers}
         toolsets={toolsets}
         isLoading={isLoading || toolsets.isLoading}
+        toolsetsFailed={toolsets.isError}
         memberServerIds={new Set(rows.map((row) => row.member.mcpServerId))}
         onAdd={(server) => void handleAdd(server)}
         onAddToolset={(toolset) => void handleAddToolset(toolset)}
@@ -541,6 +542,7 @@ function AddMemberSheet({
   servers,
   toolsets,
   isLoading,
+  toolsetsFailed,
   memberServerIds,
   onAdd,
   onAddToolset,
@@ -553,6 +555,7 @@ function AddMemberSheet({
   servers: McpServer[];
   toolsets: ToolsetEntry[];
   isLoading: boolean;
+  toolsetsFailed: boolean;
   memberServerIds: Set<string>;
   onAdd: (server: McpServer) => void;
   onAddToolset: (toolset: ToolsetEntry) => void;
@@ -606,11 +609,18 @@ function AddMemberSheet({
         </div>
 
         <div className="flex-1 space-y-2 overflow-y-auto px-6 py-4">
+          {toolsetsFailed && (
+            <Text className="text-destructive text-xs">
+              Couldn't load hosted MCP servers. Only servers with their own
+              entry are listed.
+            </Text>
+          )}
           {isLoading ? (
             <Text muted className="py-8 text-center">
               Loading MCP servers…
             </Text>
-          ) : candidates.length === 0 ? (
+          ) : candidates.length === 0 &&
+            toolsetsFailed ? null : candidates.length === 0 ? (
             <Text muted className="py-8 text-center">
               {search
                 ? `No MCP servers matching \u201c${search}\u201d`
@@ -627,9 +637,20 @@ function AddMemberSheet({
                     slug={toolset.slug}
                     label={CLASSIFICATION_LABEL.hosted}
                     badge={toolset.mcpEnabled ? undefined : "MCP off"}
-                    canAdd
-                    adding={adding}
-                    onAdd={() => onAddToolset(toolset)}
+                    action={
+                      // Minting the server row is a project-level write, so
+                      // gate on the project rather than the gateway.
+                      <RequireScope
+                        scope="mcp:write"
+                        resourceId={projectId}
+                        level="component"
+                      >
+                        <AddButton
+                          disabled={adding}
+                          onClick={() => onAddToolset(toolset)}
+                        />
+                      </RequireScope>
+                    }
                   />
                 );
               }
@@ -652,9 +673,12 @@ function AddMemberSheet({
                   slug={server.slug}
                   label={CLASSIFICATION_LABEL[classification]}
                   badge={servable ? undefined : "Excluded"}
-                  canAdd={canAdd}
-                  adding={adding}
-                  onAdd={() => onAdd(server)}
+                  action={
+                    <AddButton
+                      disabled={adding || !canAdd}
+                      onClick={() => onAdd(server)}
+                    />
+                  }
                 />
               );
             })
@@ -671,18 +695,14 @@ function CandidateRow({
   slug,
   label,
   badge,
-  canAdd,
-  adding,
-  onAdd,
+  action,
 }: {
   mcpServerId?: string;
   name: string;
   slug: string | undefined;
   label: string;
   badge: string | undefined;
-  canAdd: boolean;
-  adding: boolean;
-  onAdd: () => void;
+  action: ReactNode;
 }): JSX.Element {
   return (
     <div className="border-border/60 hover:border-border hover:bg-muted/40 trans flex items-center gap-3 border px-3 py-2.5">
@@ -708,14 +728,21 @@ function CandidateRow({
           <Badge.Text>{badge}</Badge.Text>
         </Badge>
       )}
-      <Button
-        variant="secondary"
-        size="sm"
-        disabled={adding || !canAdd}
-        onClick={onAdd}
-      >
-        <Button.Text>Add</Button.Text>
-      </Button>
+      {action}
     </div>
+  );
+}
+
+function AddButton({
+  disabled,
+  onClick,
+}: {
+  disabled: boolean;
+  onClick: () => void;
+}): JSX.Element {
+  return (
+    <Button variant="secondary" size="sm" disabled={disabled} onClick={onClick}>
+      <Button.Text>Add</Button.Text>
+    </Button>
   );
 }

--- a/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayMembersSection.tsx
@@ -22,6 +22,8 @@ import { useRoutes } from "@/routes";
 import { useNavigate } from "react-router";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
+import type { ToolsetEntry } from "@gram/client/models/components/toolsetentry.js";
+import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { invalidateAllMetaMcpMembers } from "@gram/client/react-query/metaMcpMembers.js";
 
 import { useQueryClient } from "@tanstack/react-query";
@@ -39,14 +41,16 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import {
+  type MemberClassification,
+  type MemberRow,
+  buildAddCandidates,
   classifyMemberServer,
   memberBackendKind,
   nextSortOrder,
   planReorder,
-  type MemberClassification,
-  type MemberRow,
 } from "./memberRows";
 import { useGatewayMemberRows } from "./useGatewayMemberRows";
+import { useToolsets } from "../../toolsets/useToolsets";
 
 const CLASSIFICATION_LABEL: Record<MemberClassification, string> = {
   hosted: "Hosted",
@@ -99,7 +103,7 @@ const STATUS_BY_CLASSIFICATION: Record<
   proxied: {
     label: "Unknown",
     variant: "neutral",
-    why: "The gateway can't reach this member's upstream yet, so it reports no health rather than guessing. Drill-down and execution arrive with per-upstream credential routing.",
+    why: "The gateway can't reach this member's upstream yet, so it reports no health. Drill-down and execution arrive with per-upstream credential routing.",
   },
   disabled: {
     label: "Excluded",
@@ -195,6 +199,7 @@ export function GatewayMembersSection({
   const client = useSdkClient();
   const queryClient = useQueryClient();
   const { rows, isLoading, servers } = useGatewayMemberRows(metaMcpServer.id);
+  const toolsets = useToolsets();
 
   const [addOpen, setAddOpen] = useState(false);
   const [removeTarget, setRemoveTarget] = useState<MemberRow | null>(null);
@@ -207,6 +212,8 @@ export function GatewayMembersSection({
       // endpoint and caches it; membership changes what those return.
       queryClient.invalidateQueries({ queryKey: ["gatewayInspection"] }),
       queryClient.invalidateQueries({ queryKey: ["gatewayDescribeServer"] }),
+      // Adding a toolset mints an mcp_servers wrapper the picker keys on.
+      invalidateAllMcpServers(queryClient, { refetchType: "all" }),
     ]);
 
   const runMutation = async (work: () => Promise<void>, failure: string) => {
@@ -257,6 +264,37 @@ export function GatewayMembersSection({
         },
       });
       toast.success(`Added ${server.name || "server"} to the gateway`);
+    }, "Failed to add member");
+
+  // Members are keyed by mcp_server_id: mint the toolset's server row, then
+  // attach it. Private is the only visibility a toolset-backed row can hold
+  // from its own page; the gateway defers access to the toolset's MCP gate.
+  const handleAddToolset = (toolset: ToolsetEntry) =>
+    runMutation(async () => {
+      const wrapper = await client.mcpServers.create({
+        createMcpServerForm: {
+          name: toolset.name,
+          toolsetId: toolset.id,
+          visibility: "private",
+        },
+      });
+      try {
+        await client.metaMcp.addMember({
+          addMetaMcpMemberForm: {
+            metaMcpServerId: metaMcpServer.id,
+            mcpServerId: wrapper.id,
+            sortOrder: nextSortOrder(rows.map((row) => row.member)),
+          },
+        });
+      } catch (error) {
+        // The row now exists and is offered as a regular server candidate.
+        throw new Error(
+          `Created an MCP server for ${toolset.name} but couldn't add it to the gateway: ${
+            error instanceof Error ? error.message : "unknown error"
+          }. Add it again from the list.`,
+        );
+      }
+      toast.success(`Added ${toolset.name} to the gateway`);
     }, "Failed to add member");
 
   const indexByMemberId = new Map(
@@ -435,8 +473,11 @@ export function GatewayMembersSection({
         open={addOpen}
         onOpenChange={setAddOpen}
         servers={servers}
+        toolsets={toolsets}
+        isLoading={isLoading || toolsets.isLoading}
         memberServerIds={new Set(rows.map((row) => row.member.mcpServerId))}
         onAdd={(server) => void handleAdd(server)}
+        onAddToolset={(toolset) => void handleAddToolset(toolset)}
         onAddFromCatalog={() =>
           void navigate(
             routes.sources.addFromCatalog.href() +
@@ -498,8 +539,11 @@ function AddMemberSheet({
   open,
   onOpenChange,
   servers,
+  toolsets,
+  isLoading,
   memberServerIds,
   onAdd,
+  onAddToolset,
   onAddFromCatalog,
   adding,
   projectId,
@@ -507,26 +551,21 @@ function AddMemberSheet({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   servers: McpServer[];
+  toolsets: ToolsetEntry[];
+  isLoading: boolean;
   memberServerIds: Set<string>;
   onAdd: (server: McpServer) => void;
+  onAddToolset: (toolset: ToolsetEntry) => void;
   onAddFromCatalog: () => void;
   adding: boolean;
   projectId: string;
 }): JSX.Element {
   const [search, setSearch] = useState("");
 
-  const candidates = useMemo(() => {
-    const query = search.toLowerCase();
-    return servers
-      .filter((server) => !memberServerIds.has(server.id))
-      .filter(
-        (server) =>
-          !query ||
-          (server.name?.toLowerCase().includes(query) ?? false) ||
-          (server.slug?.toLowerCase().includes(query) ?? false),
-      )
-      .sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
-  }, [servers, memberServerIds, search]);
+  const candidates = useMemo(
+    () => buildAddCandidates(servers, toolsets, memberServerIds, search),
+    [servers, toolsets, memberServerIds, search],
+  );
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -537,9 +576,10 @@ function AddMemberSheet({
         <SheetHeader className="px-6 pt-6 pb-0">
           <SheetTitle>Add member</SheetTitle>
           <SheetDescription>
-            Front another MCP server through this gateway. Disabled servers can
-            be added but won't serve until enabled; unproxied and slugless
-            servers can't be added.
+            Front another MCP server through this gateway. Hosted servers are
+            set up as members when added. Disabled servers, and hosted servers
+            with MCP turned off, can be added but won't serve until enabled;
+            unproxied and slugless servers can't be added.
           </SheetDescription>
         </SheetHeader>
 
@@ -566,14 +606,34 @@ function AddMemberSheet({
         </div>
 
         <div className="flex-1 space-y-2 overflow-y-auto px-6 py-4">
-          {candidates.length === 0 ? (
+          {isLoading ? (
+            <Text muted className="py-8 text-center">
+              Loading MCP servers…
+            </Text>
+          ) : candidates.length === 0 ? (
             <Text muted className="py-8 text-center">
               {search
                 ? `No MCP servers matching \u201c${search}\u201d`
                 : "Every MCP server is already a member."}
             </Text>
           ) : (
-            candidates.map((server) => {
+            candidates.map((candidate) => {
+              if (candidate.kind === "toolset") {
+                const { toolset } = candidate;
+                return (
+                  <CandidateRow
+                    key={`toolset-${toolset.id}`}
+                    name={toolset.name}
+                    slug={toolset.slug}
+                    label={CLASSIFICATION_LABEL.hosted}
+                    badge={toolset.mcpEnabled ? undefined : "MCP off"}
+                    canAdd
+                    adding={adding}
+                    onAdd={() => onAddToolset(toolset)}
+                  />
+                );
+              }
+              const { server } = candidate;
               const classification = classifyMemberServer(server);
               const servable =
                 classification === "hosted" || classification === "proxied";
@@ -585,48 +645,77 @@ function AddMemberSheet({
               const canAdd =
                 Boolean(server.slug) && !server.unproxiedMcpServerId;
               return (
-                <div
-                  key={server.id}
-                  className="border-border/60 hover:border-border hover:bg-muted/40 trans flex items-center gap-3 border px-3 py-2.5"
-                >
-                  <SourceMcpIcon
-                    mcpServerId={server.id}
-                    className="size-6 shrink-0 object-contain"
-                  />
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <Text className="truncate text-sm font-medium">
-                      {server.name || "MCP server"}
-                    </Text>
-                    <div className="flex items-center gap-2">
-                      {server.slug && (
-                        <Text muted className="truncate font-mono text-xs">
-                          {server.slug}
-                        </Text>
-                      )}
-                      <Text muted className="text-xs">
-                        {CLASSIFICATION_LABEL[classification]}
-                      </Text>
-                    </div>
-                  </div>
-                  {!servable && (
-                    <Badge variant="warning">
-                      <Badge.Text>Excluded</Badge.Text>
-                    </Badge>
-                  )}
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    disabled={adding || !canAdd}
-                    onClick={() => onAdd(server)}
-                  >
-                    <Button.Text>Add</Button.Text>
-                  </Button>
-                </div>
+                <CandidateRow
+                  key={`server-${server.id}`}
+                  mcpServerId={server.id}
+                  name={server.name || "MCP server"}
+                  slug={server.slug}
+                  label={CLASSIFICATION_LABEL[classification]}
+                  badge={servable ? undefined : "Excluded"}
+                  canAdd={canAdd}
+                  adding={adding}
+                  onAdd={() => onAdd(server)}
+                />
               );
             })
           )}
         </div>
       </SheetContent>
     </Sheet>
+  );
+}
+
+function CandidateRow({
+  mcpServerId,
+  name,
+  slug,
+  label,
+  badge,
+  canAdd,
+  adding,
+  onAdd,
+}: {
+  mcpServerId?: string;
+  name: string;
+  slug: string | undefined;
+  label: string;
+  badge: string | undefined;
+  canAdd: boolean;
+  adding: boolean;
+  onAdd: () => void;
+}): JSX.Element {
+  return (
+    <div className="border-border/60 hover:border-border hover:bg-muted/40 trans flex items-center gap-3 border px-3 py-2.5">
+      <SourceMcpIcon
+        mcpServerId={mcpServerId}
+        className="size-6 shrink-0 object-contain"
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text className="truncate text-sm font-medium">{name}</Text>
+        <div className="flex items-center gap-2">
+          {slug && (
+            <Text muted className="truncate font-mono text-xs">
+              {slug}
+            </Text>
+          )}
+          <Text muted className="text-xs">
+            {label}
+          </Text>
+        </div>
+      </div>
+      {badge && (
+        <Badge variant="warning">
+          <Badge.Text>{badge}</Badge.Text>
+        </Badge>
+      )}
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={adding || !canAdd}
+        onClick={onAdd}
+      >
+        <Button.Text>Add</Button.Text>
+      </Button>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { MetaMcpMember } from "@gram/client/models/components/metamcpmember.js";
+import type { ToolsetEntry } from "@gram/client/models/components/toolsetentry.js";
 import {
+  buildAddCandidates,
   buildMemberRows,
   classifyMemberServer,
   memberBackendKind,
@@ -195,5 +197,72 @@ describe("memberBackendKind", () => {
         server({ tunneledMcpServerId: "t-1", remoteMcpServerId: "r-1" }),
       ),
     ).toBe("tunneled");
+  });
+});
+
+describe("buildAddCandidates", () => {
+  const toolset = (overrides: Partial<ToolsetEntry> = {}): ToolsetEntry =>
+    ({
+      id: "ts-1",
+      name: "Linear",
+      slug: "linear",
+      mcpEnabled: true,
+      ...overrides,
+    }) as ToolsetEntry;
+
+  it("offers toolsets that have no mcp_servers wrapper yet", () => {
+    const candidates = buildAddCandidates(
+      [server({ id: "s-1", name: "Linear David", slug: "linear-david" })],
+      [toolset()],
+      new Set(),
+      "linear",
+    );
+    expect(candidates.map((c) => c.kind)).toEqual(["toolset", "server"]);
+  });
+
+  it("hides toolsets already represented by a wrapper row", () => {
+    const candidates = buildAddCandidates(
+      [server({ id: "s-1", name: "Linear", toolsetId: "ts-1" })],
+      [toolset()],
+      new Set(),
+      "",
+    );
+    expect(candidates).toEqual([
+      { kind: "server", server: expect.objectContaining({ id: "s-1" }) },
+    ]);
+  });
+
+  it("drops servers that are already members and trims the search", () => {
+    const candidates = buildAddCandidates(
+      [server({ id: "s-1", name: "Linear" })],
+      [toolset(), toolset({ id: "ts-2", name: "Other", slug: "other" })],
+      new Set(["s-1"]),
+      "  LINEAR ",
+    );
+    expect(candidates).toEqual([
+      { kind: "toolset", toolset: expect.objectContaining({ id: "ts-1" }) },
+    ]);
+  });
+
+  it("interleaves kinds by display name, treating a nameless server as empty", () => {
+    const candidates = buildAddCandidates(
+      [
+        server({ id: "s-1", name: "Zulu" }),
+        server({ id: "s-2", name: undefined, slug: "nameless" }),
+      ],
+      [
+        toolset({ id: "ts-1", name: "Alpha" }),
+        toolset({ id: "ts-2", name: "Mike" }),
+      ],
+      new Set(),
+      "",
+    );
+    expect(
+      candidates.map((c) =>
+        c.kind === "server"
+          ? `server:${c.server.id}`
+          : `toolset:${c.toolset.id}`,
+      ),
+    ).toEqual(["server:s-2", "toolset:ts-1", "toolset:ts-2", "server:s-1"]);
   });
 });

--- a/client/dashboard/src/pages/mcp/gateway/memberRows.ts
+++ b/client/dashboard/src/pages/mcp/gateway/memberRows.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { MetaMcpMember } from "@gram/client/models/components/metamcpmember.js";
+import type { ToolsetEntry } from "@gram/client/models/components/toolsetentry.js";
 
 /**
  * Backend-attested member classification. "hosted" (toolset-backed) members
@@ -106,4 +107,45 @@ export function memberBackendKind(
   if (server.tunneledMcpServerId) return "tunneled";
   if (server.remoteMcpServerId) return "remote";
   return undefined;
+}
+
+/**
+ * Add member candidates: existing mcp_servers rows, plus toolsets with no
+ * toolset-backed row yet (adding one mints the row, then attaches it).
+ */
+export type AddCandidate =
+  | { kind: "server"; server: McpServer }
+  | { kind: "toolset"; toolset: ToolsetEntry };
+
+export function buildAddCandidates(
+  servers: McpServer[],
+  toolsets: ToolsetEntry[],
+  memberServerIds: Set<string>,
+  search: string,
+): AddCandidate[] {
+  const query = search.trim().toLowerCase();
+  const matches = (...fields: (string | undefined)[]) =>
+    !query || fields.some((f) => f?.toLowerCase().includes(query));
+  const wrappedToolsetIds = new Set(
+    servers.flatMap((s) => (s.toolsetId ? [s.toolsetId] : [])),
+  );
+
+  const serverCandidates: AddCandidate[] = servers
+    .filter((s) => !memberServerIds.has(s.id))
+    .filter((s) => matches(s.name, s.slug))
+    .map((server) => ({ kind: "server", server }));
+  const toolsetCandidates: AddCandidate[] = toolsets
+    .filter((t) => !wrappedToolsetIds.has(t.id))
+    .filter((t) => matches(t.name, t.slug))
+    .map((toolset) => ({ kind: "toolset", toolset }));
+
+  return [...serverCandidates, ...toolsetCandidates].sort((a, b) =>
+    candidateName(a).localeCompare(candidateName(b)),
+  );
+}
+
+function candidateName(candidate: AddCandidate): string {
+  return candidate.kind === "server"
+    ? (candidate.server.name ?? "")
+    : candidate.toolset.name;
 }

--- a/server/internal/mcp/serve_meta_runtime_test.go
+++ b/server/internal/mcp/serve_meta_runtime_test.go
@@ -590,6 +590,55 @@ func setToolsetMcpPrivate(t *testing.T, ctx context.Context, ti *testInstance, t
 	require.NoError(t, err)
 }
 
+func setToolsetMcpDisabled(t *testing.T, ctx context.Context, ti *testInstance, toolsetID uuid.UUID, projectID uuid.UUID) {
+	t.Helper()
+	repo := toolsets_repo.New(ti.conn)
+	toolset, err := repo.GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        toolsetID,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+		Name:                   toolset.Name,
+		Description:            toolset.Description,
+		DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+		McpSlug:                toolset.McpSlug,
+		McpIsPublic:            toolset.McpIsPublic,
+		McpEnabled:             false,
+		Slug:                   toolset.Slug,
+		ProjectID:              toolset.ProjectID,
+	})
+	require.NoError(t, err)
+}
+
+// A hosted member whose toolset has MCP turned off is not servable through
+// the gateway, matching the toolset's own endpoint.
+func TestServePublic_MetaEndpoint_HostedMember_McpDisabledNotServable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	slug := "meta-" + uuid.NewString()
+	meta := createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, uuid.Nil)
+	member := seedHostedMetaMember(t, ctx, ti, meta.ID, "hosted member", 1, mcpservers.VisibilityPublic, "alpha_tool")
+	setToolsetMcpDisabled(t, ctx, ti, member.toolsetID, *authCtx.ProjectID)
+
+	envelope := callMetaTool(t, ctx, ti, slug, "describe_server", map[string]any{"server": member.slug})
+	text, isError := metaToolResultText(t, envelope)
+	require.True(t, isError)
+	require.Contains(t, text, "not currently servable")
+
+	envelope = callMetaTool(t, ctx, ti, slug, "execute_tool", map[string]any{
+		"name":      member.slug + "--alpha_tool",
+		"arguments": map[string]any{},
+	})
+	text, isError = metaToolResultText(t, envelope)
+	require.True(t, isError)
+	require.Contains(t, text, "not currently servable")
+}
+
 // Snapshot RBAC: a private-visibility member is invisible without
 // mcp:connect and visible with it.
 func TestServePublic_MetaEndpoint_ListServers_RBACFiltersPrivateMembers(t *testing.T) {

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -510,6 +510,10 @@ func (s *Service) loadMemberToolset(
 	case err != nil:
 		return nil, uuid.Nil, oops.E(oops.CodeUnexpected, err, "load member toolset").LogError(ctx, logger)
 	}
+	// Matches loadToolset: a toolset with MCP turned off is not servable.
+	if !toolset.McpEnabled {
+		return nil, uuid.Nil, &metaMemberError{message: fmt.Sprintf("server %q is not currently servable", member.slug)}
+	}
 	if !toolset.McpIsPublic && !gate.authenticated {
 		// Unauthorized reads as nonexistent (as in ServeToolsetResolved).
 		return nil, uuid.Nil, oops.E(oops.CodeNotFound, nil, "unknown server %q; call list_servers to see available servers", member.slug).LogWarn(ctx, logger)


### PR DESCRIPTION
## Summary

- The gateway **Add member** picker now lists hosted MCP servers (toolsets) that have no standalone MCP server entry yet, alongside the existing entries. Clicking Add creates the toolset-backed `mcp_servers` row with `private` visibility and attaches it as a member in one step. Toolsets that already have a row are hidden so the row itself is the only candidate.
- The picker shows a loading state while servers and toolsets load, marks toolsets whose MCP is turned off with an `MCP off` badge, and shares one row component between both candidate kinds.
- If the row is created but the attach fails, the error explains that the new server now exists and can be added from the list, since the picker refetches and offers it as a regular candidate.
- Server: `loadMemberToolset` now treats a hosted member whose toolset has `mcp_enabled = false` as not servable, matching the toolset's own endpoint. Previously the gateway path only checked the member row's visibility and the toolset's public/connect gate.
- The toolset Add button is gated on project-scoped `mcp:write` (minting the row is a project write), and a failed toolset fetch shows an inline error instead of falling through to the empty state.
- Sidebar readiness now updates live. The insights dock mounts `GramElementsProvider` around the page outlet, and that provider created its own `QueryClient`, so page content and the detail sidebar were on two caches: adding a member refreshed the table but the sidebar's Members check stayed orange until a reload. `ElementsProvider` now reuses a host `QueryClient` from context when one exists and keeps its own only for standalone embeds. Its two queries set `throwOnError: false` so they keep handling errors inline under the dashboard's throwing default.
- Copy: the "Unknown" member status tooltip drops "rather than guessing".

## Motivation

The Hosted MCP Servers page merges toolsets and `mcp_servers` rows, but the gateway picker read only `mcp_servers`. A toolset created through the normal dashboard flow never gets a row (only remote provisioning and the public create API mint one), so it showed up in the page search yet could not be added to a gateway. Members are keyed by `mcp_server_id`, so the fix mints the row on demand rather than waiting for the AGE-1880 backfill.

Always minting `private` keeps the new row within what its own settings page can express (public is only offered for tunneled-backed servers) and lets the gateway defer access to the toolset's existing public/`mcp:connect` gate. Because this is the first dashboard path that mints hosted wrappers, the server gains the `mcp_enabled` check so turning MCP off on a toolset also stops it serving through a gateway.

Follow-up worth noting: the members table classifies a hosted member from its row alone, so a member whose toolset has MCP off still reads as Hosted/Available there even though drill-down now reports it as not servable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHyo4pXUNMFXpTqJGfbE5s
