### PR TITLE
fix: resolve dynamic tool search results by URN

### DIFF
--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -186,51 +186,9 @@ func handleSearchToolsCall(
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to search tools").LogError(ctx, logger)
 	}
 
-	// Build a map of tools by name for quick lookup
-	toolsByName := make(map[string]*types.Tool)
-	for _, tool := range toolset.Tools {
-		if conv.IsProxyTool(tool) {
-			return nil, fmt.Errorf("search tools with external mcp proxy: %s", tool.ExternalMcpToolDefinition.Name)
-		}
-
-		baseTool, err := conv.ToBaseTool(tool)
-		if err != nil {
-			continue
-		}
-		toolsByName[baseTool.Name] = tool
-	}
-
-	// construct full tool entries with similarity scores
-	results := make([]*toolListEntry, 0, len(searchResults))
-	for _, searchResult := range searchResults {
-		tool, exists := toolsByName[searchResult.ToolName]
-		if !exists {
-			continue
-		}
-
-		toolEntry, err := conv.ToToolListEntry(tool)
-		if err != nil {
-			continue
-		}
-		if toolEntry.Name == "" {
-			continue
-		}
-
-		// Add similarity score and tags to meta
-		meta := toolEntry.Meta
-		if meta == nil {
-			meta = make(map[string]any)
-		}
-		meta["similarity_score"] = searchResult.SimilarityScore
-		meta["tags"] = searchResult.Tags
-
-		results = append(results, &toolListEntry{
-			Name:        toolEntry.Name,
-			Description: toolEntry.Description,
-			Meta:        meta,
-			InputSchema: nil, // Intentional don't return to keep token usage down
-			Annotations: nil,
-		})
+	results, err := buildToolSearchResultEntries(toolset.Tools, searchResults)
+	if err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(toolsListResultTools{Tools: results})
@@ -264,6 +222,54 @@ func handleSearchToolsCall(
 	}
 
 	return response, nil
+}
+
+func buildToolSearchResultEntries(tools []*types.Tool, searchResults []*rag.ToolSearchResult) ([]*toolListEntry, error) {
+	toolsByURN := make(map[string]*types.Tool, len(tools))
+	for _, tool := range tools {
+		if conv.IsProxyTool(tool) {
+			return nil, fmt.Errorf("search tools with external mcp proxy: %s", tool.ExternalMcpToolDefinition.Name)
+		}
+
+		baseTool, err := conv.ToBaseTool(tool)
+		if err != nil {
+			continue
+		}
+		toolsByURN[baseTool.ToolUrn] = tool
+	}
+
+	results := make([]*toolListEntry, 0, len(searchResults))
+	for _, searchResult := range searchResults {
+		tool, exists := toolsByURN[searchResult.ToolURN]
+		if !exists {
+			continue
+		}
+
+		toolEntry, err := conv.ToToolListEntry(tool)
+		if err != nil {
+			continue
+		}
+		if toolEntry.Name == "" {
+			continue
+		}
+
+		meta := toolEntry.Meta
+		if meta == nil {
+			meta = make(map[string]any)
+		}
+		meta["similarity_score"] = searchResult.SimilarityScore
+		meta["tags"] = searchResult.Tags
+
+		results = append(results, &toolListEntry{
+			Name:        toolEntry.Name,
+			Description: toolEntry.Description,
+			Meta:        meta,
+			InputSchema: nil,
+			Annotations: nil,
+		})
+	}
+
+	return results, nil
 }
 
 func waitForIndexing(ctx context.Context, logger *slog.Logger, toolset *types.Toolset, vectorToolStore *rag.ToolsetVectorStore, temporalEnv *temporal.Environment) error {

--- a/server/internal/mcp/dynamic_tool_calling_test.go
+++ b/server/internal/mcp/dynamic_tool_calling_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -329,4 +330,42 @@ func TestHandleDescribeToolsCall(t *testing.T) {
 		require.NotNil(t, response)
 		require.Contains(t, string(response), "my-tool")
 	})
+}
+
+func TestBuildToolSearchResultEntriesUsesStableURN(t *testing.T) {
+	t.Parallel()
+
+	const toolURN = "tools:http:billing:billing_customers_list"
+	runtimeName := "customers_list"
+	tools := []*types.Tool{
+		{
+			HTTPToolDefinition: &types.HTTPToolDefinition{
+				ToolUrn:       toolURN,
+				Name:          runtimeName,
+				CanonicalName: "billing_customers_list",
+				Description:   "List customers.",
+				Variation: &types.ToolVariation{
+					SrcToolUrn:  toolURN,
+					SrcToolName: "billing_customers_list",
+					Name:        &runtimeName,
+				},
+			},
+		},
+	}
+	searchResults := []*rag.ToolSearchResult{
+		{
+			ToolURN:         toolURN,
+			ToolName:        "billing_customers_list",
+			Tags:            []string{"billing/customers"},
+			SimilarityScore: 0.9,
+		},
+	}
+
+	entries, err := buildToolSearchResultEntries(tools, searchResults)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, runtimeName, entries[0].Name)
+	require.Equal(t, "List customers.", entries[0].Description)
+	require.InDelta(t, 0.9, entries[0].Meta["similarity_score"], 0)
+	require.Equal(t, []string{"billing/customers"}, entries[0].Meta["tags"])
 }

--- a/server/internal/rag/search_tools.go
+++ b/server/internal/rag/search_tools.go
@@ -189,10 +189,18 @@ type SearchToolsOptions struct {
 	Limit     int
 }
 
-// ToolSearchResult represents a search result with tool name and similarity score.
+// ToolSearchResult represents a search result with stable tool identity and ranking metadata.
 type ToolSearchResult struct {
-	ToolName        string
-	Tags            []string
+	// ToolURN identifies the source tool independently of runtime variations.
+	ToolURN string
+
+	// ToolName is the name stored in the embedding payload.
+	ToolName string
+
+	// Tags are the indexed tags associated with the tool.
+	Tags []string
+
+	// SimilarityScore is the vector similarity between the query and tool.
 	SimilarityScore float64
 }
 
@@ -338,9 +346,10 @@ func (s *ToolsetVectorStore) SearchToolsetTools(ctx context.Context, toolset typ
 		}
 
 		matches = append(matches, &ToolSearchResult{
+			ToolURN:         row.EntryKey,
 			ToolName:        entry.Name,
-			SimilarityScore: float64(row.Similarity),
 			Tags:            row.Tags,
+			SimilarityScore: float64(row.Similarity),
 		})
 	}
 


### PR DESCRIPTION
Fixes AIM-180

## Summary

Dynamic `search_tools` results now resolve back to runtime tools by stable tool URN instead of tool name.

- Propagate the embedding row's `entry_key` as `ToolSearchResult.ToolURN`.
- Build the runtime lookup by `baseTool.ToolUrn`.
- Return the current runtime-varied name and description after matching by URN.
- Add regression coverage for an indexed tool whose runtime variation has renamed it.

## Motivation

Tool names are mutable. An embedding may contain the name used when it was indexed, while project-level variations can give the same tool a different runtime name.

Previously, the MCP handler keyed runtime tools by their varied names, then looked them up using names from embedding payloads. A renamed tool did not match and was silently discarded. If every candidate was renamed, a successful vector search became an empty `search_tools` response.

Tool URNs are stable across variations. Matching by URN preserves tool identity while still returning the latest runtime name, description, and metadata. This fixes result assembly without changing vector ranking or requiring re-indexing for correctness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dynamic tool search matching by using stable tool URNs instead of names, so project-level renames no longer cause valid vector matches to be silently dropped and `search_tools` to return an empty list.

- Carries each indexed tool's URN through vector search results.
- Resolves search matches against runtime tools by URN while returning the runtime-varied name and description.
- Adds a regression test for tool-name variations.

<sup>Written for commit ea788fe24b8579a98461d90ba266262788e8ac09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
