### PR TITLE
fix: label gateway activity panels as dispatched calls and explain discovery-only ranges

### DIFF
--- a/.changeset/gateway-activity-dispatched-calls-copy.md
+++ b/.changeset/gateway-activity-dispatched-calls-copy.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The gateway Activity section now labels its stat tiles and time series as dispatched calls, and when agents used the discovery tools without executing anything, the empty states say so instead of reporting no tool calls beside a populated gateway tool usage chart.

--- a/client/dashboard/src/components/chart/ToolCallsTimeSeriesChart.tsx
+++ b/client/dashboard/src/components/chart/ToolCallsTimeSeriesChart.tsx
@@ -61,6 +61,8 @@ export interface ToolCallsTimeSeriesChartProps {
   onRangeSelect?: (from: Date, to: Date) => void;
   isZoomed?: boolean;
   onResetZoom?: () => void;
+  /** Shown when the range has no buckets; defaults to a generic message. */
+  emptyMessage?: string;
 }
 
 /**
@@ -78,6 +80,7 @@ export function ToolCallsTimeSeriesChart({
   onRangeSelect,
   isZoomed,
   onResetZoom,
+  emptyMessage = "No tool calls for the selected time range",
 }: ToolCallsTimeSeriesChartProps): JSX.Element {
   const isExpanded = expandedChart === chartId;
   const height = isExpanded ? 420 : 260;
@@ -234,10 +237,7 @@ export function ToolCallsTimeSeriesChart({
       onResetZoom={onResetZoom}
     >
       {!hasData ? (
-        <WidgetEmptyState
-          message="No tool calls for the selected time range"
-          className="h-[260px]"
-        />
+        <WidgetEmptyState message={emptyMessage} className="h-[260px]" />
       ) : (
         <div style={{ height }}>
           {/* `<Chart>` (not `<Bar>`) because this mixes a stacked bar series

--- a/client/dashboard/src/pages/mcp/gateway/GatewayActivitySection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayActivitySection.tsx
@@ -188,13 +188,18 @@ export function GatewayActivitySection({
   );
   // The stat tiles, time series and member table count execute_tool
   // dispatches only; the funnel chart also counts discovery. Say so when the
-  // two disagree, or an empty chart above a busy funnel reads as a bug.
-  const stoppedAtDiscovery = discoveredWithoutExecuting(usage.data?.funnel);
+  // two disagree, or an empty chart above a busy funnel reads as a bug. Both
+  // queries keep previous data across a range change, so only trust the
+  // funnel once neither side is still showing the previous range.
+  const stoppedAtDiscovery =
+    !usage.isPlaceholderData &&
+    !overview.isPlaceholderData &&
+    discoveredWithoutExecuting(usage.data?.funnel);
   const noDispatchMessage = stoppedAtDiscovery
-    ? "Agents discovered tools through this gateway but didn't execute any. Gateway tool usage below shows the discovery steps."
+    ? "Agents used the discovery tools in this range, but no execute_tool calls were observed. Gateway tool usage below shows the discovery steps."
     : "No dispatched calls for the selected time range";
   const noMemberCallsMessage = stoppedAtDiscovery
-    ? "No member received a call; agents stopped at discovery."
+    ? "No execute_tool calls were observed in the selected range; agents only used the discovery tools."
     : "No member calls in the selected range.";
 
   return (

--- a/client/dashboard/src/pages/mcp/gateway/GatewayActivitySection.tsx
+++ b/client/dashboard/src/pages/mcp/gateway/GatewayActivitySection.tsx
@@ -20,6 +20,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import {
   memberUsageRows,
+  discoveredWithoutExecuting,
   metaToolUsageItems,
   type MemberUsageRow,
 } from "./gatewayActivity";
@@ -185,6 +186,16 @@ export function GatewayActivitySection({
     () => memberUsageRows(usage.data?.members ?? [], memberRows),
     [usage.data, memberRows],
   );
+  // The stat tiles, time series and member table count execute_tool
+  // dispatches only; the funnel chart also counts discovery. Say so when the
+  // two disagree, or an empty chart above a busy funnel reads as a bug.
+  const stoppedAtDiscovery = discoveredWithoutExecuting(usage.data?.funnel);
+  const noDispatchMessage = stoppedAtDiscovery
+    ? "Agents discovered tools through this gateway but didn't execute any. Gateway tool usage below shows the discovery steps."
+    : "No dispatched calls for the selected time range";
+  const noMemberCallsMessage = stoppedAtDiscovery
+    ? "No member received a call; agents stopped at discovery."
+    : "No member calls in the selected range.";
 
   return (
     <Page.Section>
@@ -194,8 +205,8 @@ export function GatewayActivitySection({
         Activity
       </Page.Section.Title>
       <Page.Section.Description>
-        Calls dispatched through this gateway, the discovery steps agents took
-        to reach them, and how the load spread across members.
+        Calls dispatched to members through execute_tool, the discovery steps
+        agents took to reach them, and how the load spread across members.
       </Page.Section.Description>
       <Page.Section.CTA>
         <TimeRangePicker
@@ -231,7 +242,7 @@ export function GatewayActivitySection({
                   ) : (
                     <>
                       <StatTile
-                        title="Tool calls"
+                        title="Dispatched calls"
                         value={summary?.totalToolCalls ?? 0}
                         tone="information"
                         previousValue={comparison?.totalToolCalls}
@@ -276,8 +287,9 @@ export function GatewayActivitySection({
                 </StatTileGroup>
 
                 <ToolCallsTimeSeriesChart
-                  title="Tool calls over time"
+                  title="Dispatched calls over time"
                   chartId="gateway-overview-tool-calls"
+                  emptyMessage={noDispatchMessage}
                   timeSeries={timeSeries}
                   timeRangeMs={timeRangeMs}
                   expandedChart={expandedChart}
@@ -312,7 +324,7 @@ export function GatewayActivitySection({
                       data={members}
                       rowKey={(row) => row.mcpServerId}
                       noResultsMessage={
-                        <WidgetEmptyState message="No member calls in the selected range." />
+                        <WidgetEmptyState message={noMemberCallsMessage} />
                       }
                     />
                   )}

--- a/client/dashboard/src/pages/mcp/gateway/gatewayActivity.test.ts
+++ b/client/dashboard/src/pages/mcp/gateway/gatewayActivity.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { MemberRow } from "./memberRows";
-import { memberUsageRows, metaToolUsageItems } from "./gatewayActivity";
+import {
+  discoveredWithoutExecuting,
+  memberUsageRows,
+  metaToolUsageItems,
+} from "./gatewayActivity";
 
 function row(
   mcpServerId: string,
@@ -71,5 +75,38 @@ describe("memberUsageRows", () => {
     );
     expect(rows[0]?.errorRate).toBe(25);
     expect(rows[1]?.errorRate).toBe(0);
+  });
+});
+
+describe("discoveredWithoutExecuting", () => {
+  it("is true when discovery ran but execute_tool never did", () => {
+    expect(
+      discoveredWithoutExecuting({
+        listServers: 1,
+        describeServer: 3,
+        describeTools: 0,
+        executeTool: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false with no activity, with executions, or without data", () => {
+    expect(
+      discoveredWithoutExecuting({
+        listServers: 0,
+        describeServer: 0,
+        describeTools: 0,
+        executeTool: 0,
+      }),
+    ).toBe(false);
+    expect(
+      discoveredWithoutExecuting({
+        listServers: 1,
+        describeServer: 1,
+        describeTools: 1,
+        executeTool: 2,
+      }),
+    ).toBe(false);
+    expect(discoveredWithoutExecuting(undefined)).toBe(false);
   });
 });

--- a/client/dashboard/src/pages/mcp/gateway/gatewayActivity.ts
+++ b/client/dashboard/src/pages/mcp/gateway/gatewayActivity.ts
@@ -29,6 +29,18 @@ export function metaToolUsageItems(
   ];
 }
 
+// True when agents walked the discovery tools but never reached execute_tool.
+// The dispatched-call panels are empty in that case even though the funnel
+// chart is not, so their empty states should say so.
+export function discoveredWithoutExecuting(
+  funnel: MetaMcpDiscoveryFunnel | undefined,
+): boolean {
+  if (!funnel) return false;
+  const discovery =
+    funnel.listServers + funnel.describeServer + funnel.describeTools;
+  return funnel.executeTool === 0 && discovery > 0;
+}
+
 export interface MemberUsageRow {
   mcpServerId: string;
   label: string;


### PR DESCRIPTION
## Summary

- The gateway Activity section's stat tile and time-series chart are now titled **Dispatched calls** / **Dispatched calls over time**, and the section description says the calls are those dispatched to members through `execute_tool`.
- When the discovery funnel has activity but `execute_tool` was never called, the time-series empty state and the **Calls by member** empty state say agents discovered tools without executing any and point at the Gateway tool usage chart, instead of reporting no tool calls.
- `ToolCallsTimeSeriesChart` gains an optional `emptyMessage` prop (default unchanged), and `discoveredWithoutExecuting` in `gatewayActivity.ts` carries the condition with unit tests.

## Motivation

The stat tiles, time series, and member table count rows with a `tools:` URN, which only exist for `execute_tool` dispatches to a member. The Gateway tool usage chart reads the discovery funnel (`list_servers`, `describe_server`, `describe_tools`) plus executions. A range where an agent listed and described servers but never executed a tool therefore shows an empty "No tool calls" chart directly above a populated usage chart, which reads as a bug. The numbers were right; the labels and empty states did not say what population they counted. Copy-only change, no query changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHyo4pXUNMFXpTqJGfbE5s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The gateway Activity section now labels its stat tiles and time series as dispatched calls, and its empty states explain discovery-only ranges instead of showing "No tool calls" above a populated tool usage chart.

- Section description now says calls are dispatched to members through `execute_tool`.
- When agents used discovery tools but never executed one, the time-series and member-table empty states say agents stopped at discovery and point to the Gateway tool usage chart.
- The discovery-only empty state shows only once both range queries settle, so it doesn't appear against a previous range's data.
- `ToolCallsTimeSeriesChart` gains an optional `emptyMessage` prop with an unchanged default, and `gatewayActivity.ts` gains a `discoveredWithoutExecuting` helper with unit tests.
- Copy-only change; no query changes.

<sup>Written for commit 2adab839909a2a2aca8bac52b64ca0689cb285c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

