### PR TITLE
mig: add upstream OAuth issuer storage

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1650,6 +1650,7 @@ CREATE TABLE IF NOT EXISTS external_oauth_server_metadata (
 
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 100),
   metadata JSONB NOT NULL,
+  authorization_server_issuer TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1657,7 +1658,13 @@ CREATE TABLE IF NOT EXISTS external_oauth_server_metadata (
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
   CONSTRAINT external_oauth_server_metadata_pkey PRIMARY KEY (id),
-  CONSTRAINT external_oauth_server_metadata_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE
+  CONSTRAINT external_oauth_server_metadata_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT external_oauth_server_metadata_authorization_server_issuer_check CHECK (
+    authorization_server_issuer IS NULL OR (
+      authorization_server_issuer <> '' AND
+      CHAR_LENGTH(authorization_server_issuer) <= 500
+    )
+  )
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS external_oauth_server_metadata_project_slug_key

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1649,7 +1649,7 @@ CREATE TABLE IF NOT EXISTS external_oauth_server_metadata (
   project_id uuid NOT NULL,
 
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 100),
-  metadata JSONB NOT NULL,
+  metadata JSONB,
   authorization_server_issuer TEXT,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1659,6 +1659,9 @@ CREATE TABLE IF NOT EXISTS external_oauth_server_metadata (
 
   CONSTRAINT external_oauth_server_metadata_pkey PRIMARY KEY (id),
   CONSTRAINT external_oauth_server_metadata_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT external_oauth_server_metadata_source_check CHECK (
+    (metadata IS NULL) <> (authorization_server_issuer IS NULL)
+  ),
   CONSTRAINT external_oauth_server_metadata_authorization_server_issuer_check CHECK (
     authorization_server_issuer IS NULL OR (
       authorization_server_issuer <> '' AND

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1662,7 +1662,7 @@ CREATE TABLE IF NOT EXISTS external_oauth_server_metadata (
   CONSTRAINT external_oauth_server_metadata_source_check CHECK (
     (metadata IS NULL) <> (authorization_server_issuer IS NULL)
   ),
-  CONSTRAINT external_oauth_server_metadata_authorization_server_issuer_check CHECK (
+  CONSTRAINT external_oauth_server_metadata_authorization_server_issuer_chec CHECK (
     authorization_server_issuer IS NULL OR (
       authorization_server_issuer <> '' AND
       CHAR_LENGTH(authorization_server_issuer) <= 500

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -878,14 +878,15 @@ type ExternalOauthClientRegistration struct {
 }
 
 type ExternalOauthServerMetadatum struct {
-	ID        uuid.UUID
-	ProjectID uuid.UUID
-	Slug      string
-	Metadata  []byte
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	Deleted   bool
+	ID                        uuid.UUID
+	ProjectID                 uuid.UUID
+	Slug                      string
+	Metadata                  []byte
+	AuthorizationServerIssuer pgtype.Text
+	CreatedAt                 pgtype.Timestamptz
+	UpdatedAt                 pgtype.Timestamptz
+	DeletedAt                 pgtype.Timestamptz
+	Deleted                   bool
 }
 
 type FlyApp struct {

--- a/server/internal/oauth/repo/constraints_test.go
+++ b/server/internal/oauth/repo/constraints_test.go
@@ -1,0 +1,85 @@
+package repo_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("Failed to launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("Failed to cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func TestExternalOAuthServerMetadataSourceConstraint(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	orgID := fmt.Sprintf("org-%s", uuid.NewString()[:8])
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID: orgID, Name: "Test Org", Slug: orgID, WorkosID: pgtype.Text{}, Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name: "Test Project", Slug: fmt.Sprintf("test-%s", uuid.NewString()[:8]), OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		metadata any
+		issuer   any
+		valid    bool
+	}{
+		{name: "metadata only", metadata: []byte(`{}`), valid: true},
+		{name: "issuer only", issuer: "https://auth.example.com", valid: true},
+		{name: "both", metadata: []byte(`{}`), issuer: "https://auth.example.com"},
+		{name: "neither"},
+		{name: "empty issuer", issuer: ""},
+		{name: "issuer over 500 characters", issuer: strings.Repeat("a", 501)},
+		{name: "issuer at 500 characters", issuer: strings.Repeat("a", 500), valid: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := conn.Exec(ctx, `
+				INSERT INTO external_oauth_server_metadata
+				  (project_id, slug, metadata, authorization_server_issuer)
+				VALUES ($1, $2, $3::jsonb, $4::text)
+			`, project.ID, fmt.Sprintf("server-%d", i), tt.metadata, tt.issuer)
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/server/internal/oauth/repo/constraints_test.go
+++ b/server/internal/oauth/repo/constraints_test.go
@@ -70,7 +70,10 @@ func TestExternalOAuthServerMetadataSourceConstraint(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := conn.Exec(ctx, `
+			t.Parallel()
+
+			_, err := conn.Exec( //nolint:glint // notestingrawsql: directly exercises schema-invalid source combinations unavailable through current SQLc methods
+				ctx, `
 				INSERT INTO external_oauth_server_metadata
 				  (project_id, slug, metadata, authorization_server_issuer)
 				VALUES ($1, $2, $3::jsonb, $4::text)

--- a/server/internal/oauth/repo/models.go
+++ b/server/internal/oauth/repo/models.go
@@ -10,12 +10,13 @@ import (
 )
 
 type ExternalOauthServerMetadatum struct {
-	ID        uuid.UUID
-	ProjectID uuid.UUID
-	Slug      string
-	Metadata  []byte
-	CreatedAt pgtype.Timestamptz
-	UpdatedAt pgtype.Timestamptz
-	DeletedAt pgtype.Timestamptz
-	Deleted   bool
+	ID                        uuid.UUID
+	ProjectID                 uuid.UUID
+	Slug                      string
+	Metadata                  []byte
+	AuthorizationServerIssuer pgtype.Text
+	CreatedAt                 pgtype.Timestamptz
+	UpdatedAt                 pgtype.Timestamptz
+	DeletedAt                 pgtype.Timestamptz
+	Deleted                   bool
 }

--- a/server/internal/oauth/repo/queries.sql.go
+++ b/server/internal/oauth/repo/queries.sql.go
@@ -21,7 +21,7 @@ INSERT INTO external_oauth_server_metadata (
     $1,
     $2,
     $3
-) RETURNING id, project_id, slug, metadata, created_at, updated_at, deleted_at, deleted
+) RETURNING id, project_id, slug, metadata, authorization_server_issuer, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateExternalOAuthServerMetadataParams struct {
@@ -39,6 +39,7 @@ func (q *Queries) CreateExternalOAuthServerMetadata(ctx context.Context, arg Cre
 		&i.ProjectID,
 		&i.Slug,
 		&i.Metadata,
+		&i.AuthorizationServerIssuer,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -73,7 +74,7 @@ func (q *Queries) DeleteExternalOAuthServerMetadata(ctx context.Context, arg Del
 }
 
 const getExternalOAuthServerMetadata = `-- name: GetExternalOAuthServerMetadata :one
-SELECT id, project_id, slug, metadata, created_at, updated_at, deleted_at, deleted FROM external_oauth_server_metadata
+SELECT id, project_id, slug, metadata, authorization_server_issuer, created_at, updated_at, deleted_at, deleted FROM external_oauth_server_metadata
 WHERE project_id = $1 AND id = $2 AND deleted IS FALSE
 `
 
@@ -90,6 +91,7 @@ func (q *Queries) GetExternalOAuthServerMetadata(ctx context.Context, arg GetExt
 		&i.ProjectID,
 		&i.Slug,
 		&i.Metadata,
+		&i.AuthorizationServerIssuer,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260903184652_add_external_oauth_authorization_server_issuer.sql
+++ b/server/migrations/20260903184652_add_external_oauth_authorization_server_issuer.sql
@@ -1,5 +1,0 @@
--- atlas:txmode none
-
--- Modify "external_oauth_server_metadata" table
-ALTER TABLE "external_oauth_server_metadata" ADD CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec" CHECK ((authorization_server_issuer IS NULL) OR ((authorization_server_issuer <> ''::text) AND (char_length(authorization_server_issuer) <= 500))) NOT VALID, ADD COLUMN "authorization_server_issuer" text NULL;
-ALTER TABLE "external_oauth_server_metadata" VALIDATE CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec";

--- a/server/migrations/20260903184652_add_external_oauth_authorization_server_issuer.sql
+++ b/server/migrations/20260903184652_add_external_oauth_authorization_server_issuer.sql
@@ -1,0 +1,5 @@
+-- atlas:txmode none
+
+-- Modify "external_oauth_server_metadata" table
+ALTER TABLE "external_oauth_server_metadata" ADD CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec" CHECK ((authorization_server_issuer IS NULL) OR ((authorization_server_issuer <> ''::text) AND (char_length(authorization_server_issuer) <= 500))) NOT VALID, ADD COLUMN "authorization_server_issuer" text NULL;
+ALTER TABLE "external_oauth_server_metadata" VALIDATE CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec";

--- a/server/migrations/20260903194055_add_external_oauth_authorization_server_issuer.sql
+++ b/server/migrations/20260903194055_add_external_oauth_authorization_server_issuer.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "external_oauth_server_metadata" table
+ALTER TABLE "external_oauth_server_metadata" ADD CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec" CHECK ((authorization_server_issuer IS NULL) OR ((authorization_server_issuer <> ''::text) AND (char_length(authorization_server_issuer) <= 500))) NOT VALID, ADD CONSTRAINT "external_oauth_server_metadata_source_check" CHECK ((metadata IS NULL) <> (authorization_server_issuer IS NULL)) NOT VALID, ALTER COLUMN "metadata" DROP NOT NULL, ADD COLUMN "authorization_server_issuer" text NULL;
+ALTER TABLE "external_oauth_server_metadata" VALIDATE CONSTRAINT "external_oauth_server_metadata_authorization_server_issuer_chec";
+ALTER TABLE "external_oauth_server_metadata" VALIDATE CONSTRAINT "external_oauth_server_metadata_source_check";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0gMYJUqGSliX79YkindObFUGK4KJyK4ugVd7gt93ChA=
+h1:H8lLNk4mYn3ga9sWUrXy9POZ/6lS/Sf44wy6OThmWws=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -382,4 +382,5 @@ h1:0gMYJUqGSliX79YkindObFUGK4KJyK4ugVd7gt93ChA=
 20260901222548_remote-session-issuer-tunnel-binding.sql h1:3JREClrlXOmZInBZO8aup9+fz/QjQka7XxTuJmGnzjA=
 20260902212254_public-tunnel-rate-limits.sql h1:nZB403TMLx/lHT2gVqVrlsN1Iw4CBhrGJjcNcaOxMuI=
 20260903163542_openrouter-disable-causes-default.sql h1:LS+zQwFykPPu8UqRaH4IGmyaioQr3GhQrLGuoi32B1o=
-20260903190252_dno1005-device-agent-environment-syncs.sql h1:kUaZL31hQY1vrBt5UvtGefk/D8r1kDGpYAhFFBaNoLk=
+20260903184652_add_external_oauth_authorization_server_issuer.sql h1:uWWxUp+5IQjAJk35JA9ahIdzFQtlWolnnz5ki3MuTtc=
+20260903190252_dno1005-device-agent-environment-syncs.sql h1:4kU88rqVmFDjNIzP0GdnmQQDhwq0/TTWwD7X3drcjYI=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:H8lLNk4mYn3ga9sWUrXy9POZ/6lS/Sf44wy6OThmWws=
+h1:X/J7GzYcbMZSeSqJgojO8BZTbjMUelegAQyGF++XY18=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -382,5 +382,5 @@ h1:H8lLNk4mYn3ga9sWUrXy9POZ/6lS/Sf44wy6OThmWws=
 20260901222548_remote-session-issuer-tunnel-binding.sql h1:3JREClrlXOmZInBZO8aup9+fz/QjQka7XxTuJmGnzjA=
 20260902212254_public-tunnel-rate-limits.sql h1:nZB403TMLx/lHT2gVqVrlsN1Iw4CBhrGJjcNcaOxMuI=
 20260903163542_openrouter-disable-causes-default.sql h1:LS+zQwFykPPu8UqRaH4IGmyaioQr3GhQrLGuoi32B1o=
-20260903184652_add_external_oauth_authorization_server_issuer.sql h1:uWWxUp+5IQjAJk35JA9ahIdzFQtlWolnnz5ki3MuTtc=
-20260903190252_dno1005-device-agent-environment-syncs.sql h1:4kU88rqVmFDjNIzP0GdnmQQDhwq0/TTWwD7X3drcjYI=
+20260903190252_dno1005-device-agent-environment-syncs.sql h1:kUaZL31hQY1vrBt5UvtGefk/D8r1kDGpYAhFFBaNoLk=
+20260903194055_add_external_oauth_authorization_server_issuer.sql h1:ulax1MM1HwC0e9Gdxf8gRp6GVh7cZ3dtpyOG0VKfmIU=


### PR DESCRIPTION
## Summary

- make external OAuth metadata nullable and add nullable upstream authorization-server issuer storage
- require exactly one metadata source: embedded metadata or an upstream issuer
- enforce non-empty issuer values up to 500 characters with a deployment-safe validation sequence
- include generated SQLc parity updates and focused database constraint coverage

## Motivation

External OAuth configurations need either Gram-hosted metadata or provider-hosted metadata discovered from an explicit issuer, but never both. Existing metadata-backed rows remain valid while the additive migration establishes the invariant before server behavior starts writing issuer-backed configurations.
