### PR TITLE
feat: link account menu to platform admin

### DIFF
--- a/client/dashboard/.dockerignore
+++ b/client/dashboard/.dockerignore
@@ -2,3 +2,4 @@
 
 !/dist
 !nginx.conf
+!40-admin-server-url.sh

--- a/client/dashboard/40-admin-server-url.sh
+++ b/client/dashboard/40-admin-server-url.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+index=/usr/share/nginx/html/index.html
+GRAM_ADMIN_SERVER_URL=$(
+  printf %s "$GRAM_ADMIN_SERVER_URL" | sed 's/&/\&amp;/g; s/"/\&quot;/g; s/</\&lt;/g; s/>/\&gt;/g'
+)
+export GRAM_ADMIN_SERVER_URL
+envsubst '$GRAM_ADMIN_SERVER_URL' <"$index" >/tmp/index.html
+cat /tmp/index.html >"$index"

--- a/client/dashboard/Dockerfile
+++ b/client/dashboard/Dockerfile
@@ -4,13 +4,15 @@ FROM nginxinc/nginx-unprivileged:alpine
 COPY dist /usr/share/nginx/html
 
 # nginx.conf is an envsubst template: the image entrypoint renders it to
-# /etc/nginx/conf.d/default.conf at startup, substituting ${GRAM_CDN_URL}.
+# /etc/nginx/conf.d/default.conf at startup, substituting ${GRAM_CDN_URL} and
+# ${GRAM_ADMIN_SERVER_URL}.
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 
-# Default: no CDN rewrite. Must always be defined — envsubst only substitutes
-# variables present in the environment, and an unsubstituted ${GRAM_CDN_URL}
-# would be parsed by nginx as an (undefined) nginx variable and fail startup.
+# Defaults: no CDN rewrite or admin link. Both must always be defined — envsubst
+# only substitutes variables present in the environment, and unsubstituted
+# values would be parsed by nginx as undefined nginx variables at startup.
 ENV GRAM_CDN_URL=""
+ENV GRAM_ADMIN_SERVER_URL=""
 
 EXPOSE 3000
 

--- a/client/dashboard/Dockerfile
+++ b/client/dashboard/Dockerfile
@@ -2,11 +2,13 @@ FROM nginxinc/nginx-unprivileged:alpine
 
 # Copy the build output to nginx
 COPY dist /usr/share/nginx/html
+COPY --chown=nginx:nginx dist/index.html /usr/share/nginx/html/index.html
 
 # nginx.conf is an envsubst template: the image entrypoint renders it to
-# /etc/nginx/conf.d/default.conf at startup, substituting ${GRAM_CDN_URL} and
-# ${GRAM_ADMIN_SERVER_URL}.
+# /etc/nginx/conf.d/default.conf at startup, substituting ${GRAM_CDN_URL}.
+# A later entrypoint script substitutes ${GRAM_ADMIN_SERVER_URL} in index.html.
 COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY --chmod=755 40-admin-server-url.sh /docker-entrypoint.d/
 
 # Defaults: no CDN rewrite or admin link. Both must always be defined — envsubst
 # only substitutes variables present in the environment, and unsubstituted

--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -15,7 +15,7 @@
     <!-- Nothing on this host wants search indexing: the app is behind login
          and /shared/* pages are tokenized capability URLs. -->
     <meta name="robots" content="noindex, nofollow" />
-    <meta name="gram-admin-server-url" content="__GRAM_ADMIN_SERVER_URL__" />
+    <meta name="gram-admin-server-url" content="${GRAM_ADMIN_SERVER_URL}" />
 
     <meta property="og:title" content="Speakeasy AI Control Plane" />
     <meta

--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -15,6 +15,7 @@
     <!-- Nothing on this host wants search indexing: the app is behind login
          and /shared/* pages are tokenized capability URLs. -->
     <meta name="robots" content="noindex, nofollow" />
+    <meta name="gram-admin-server-url" content="__GRAM_ADMIN_SERVER_URL__" />
 
     <meta property="og:title" content="Speakeasy AI Control Plane" />
     <meta

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -5,16 +5,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # When GRAM_CDN_URL is set (e.g. https://cdn.dev.getgram.ai), rewrite
-    # asset URLs in HTML responses so browsers fetch static assets through
-    # the CDN. This file ships as an envsubst template (see Dockerfile): the
-    # nginx entrypoint substitutes ${GRAM_CDN_URL} at container start, and
-    # with it empty the rewrite is a no-op and assets stay same-origin. Only
-    # HTML is rewritten (sub_filter_types defaults to text/html); JS and CSS
-    # reference their sub-resources relative to their own URL, so they follow
-    # automatically (see renderBuiltUrl in vite.config.ts).
+    # Runtime values are substituted into this template by the nginx
+    # entrypoint at container start. GRAM_CDN_URL rewrites asset URLs so
+    # browsers fetch static assets through the CDN; when empty, assets stay
+    # same-origin. GRAM_ADMIN_SERVER_URL is exposed to the dashboard through
+    # index.html. Only HTML is rewritten (sub_filter_types defaults to
+    # text/html); JS and CSS reference their sub-resources relative to their
+    # own URL, so they follow automatically (see renderBuiltUrl in
+    # vite.config.ts).
     sub_filter_once off;
     sub_filter '"/assets/' '"${GRAM_CDN_URL}/assets/';
+    sub_filter '__GRAM_ADMIN_SERVER_URL__' '${GRAM_ADMIN_SERVER_URL}';
 
     # Public resources embedded by customer-hosted pages. Keep both CORS and
     # CORP permissive: the sticker logo is intentionally loaded cross-site.

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -8,14 +8,13 @@ server {
     # Runtime values are substituted into this template by the nginx
     # entrypoint at container start. GRAM_CDN_URL rewrites asset URLs so
     # browsers fetch static assets through the CDN; when empty, assets stay
-    # same-origin. GRAM_ADMIN_SERVER_URL is exposed to the dashboard through
-    # index.html. Only HTML is rewritten (sub_filter_types defaults to
-    # text/html); JS and CSS reference their sub-resources relative to their
-    # own URL, so they follow automatically (see renderBuiltUrl in
+    # same-origin. GRAM_ADMIN_SERVER_URL is written to index.html by the
+    # container entrypoint. Only HTML is rewritten here (sub_filter_types
+    # defaults to text/html); JS and CSS reference their sub-resources relative
+    # to their own URL, so they follow automatically (see renderBuiltUrl in
     # vite.config.ts).
     sub_filter_once off;
     sub_filter '"/assets/' '"${GRAM_CDN_URL}/assets/';
-    sub_filter '__GRAM_ADMIN_SERVER_URL__' '${GRAM_ADMIN_SERVER_URL}';
 
     # Public resources embedded by customer-hosted pages. Keep both CORS and
     # CORP permissive: the sticker logo is intentionally loaded cross-site.

--- a/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
@@ -51,6 +51,7 @@ it("keyboard navigation focuses and activates the real Platform admin menu item"
     name: "Platform admin",
   });
   expect(document.activeElement).toBe(adminLink);
+  expect(adminLink.getAttribute("href")).toBe("https://admin.example.invalid");
   expect(adminLink.className).toContain("focus-visible:ring-2");
   expect(adminLink.className).toContain("focus-visible:ring-ring");
 

--- a/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
@@ -51,6 +51,8 @@ it("keyboard navigation focuses and activates the real Platform admin menu item"
     name: "Platform admin",
   });
   expect(document.activeElement).toBe(adminLink);
+  expect(adminLink.className).toContain("focus-visible:ring-2");
+  expect(adminLink.className).toContain("focus-visible:ring-ring");
 
   const activated = vi.fn((event: Event) => event.preventDefault());
   adminLink.addEventListener("click", activated);

--- a/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.integration.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/Auth", () => ({
+  useUser: () => ({
+    displayName: "Admin User",
+    email: "admin@example.invalid",
+  }),
+  useSession: () => ({ organizations: [{ id: "org" }] }),
+  useOrganization: () => ({ slug: "org" }),
+  useIsPlatformAdmin: () => true,
+}));
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ projectSlug: "project" }),
+  useSdkClient: () => ({ auth: { logout: vi.fn() } }),
+}));
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({ hasAnyScope: () => true }),
+}));
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    settings: { goTo: vi.fn() },
+    exploreDemo: { goTo: vi.fn() },
+  }),
+  useOrgRoutes: () => ({ billing: { goTo: vi.fn() } }),
+}));
+vi.mock("react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@/components/ui/ThemeSwitcher", () => ({ ThemeSwitcher: () => null }));
+
+import { SidebarUserMenu } from "./sidebar-user-menu";
+
+afterEach(() => {
+  cleanup();
+  document.querySelector('meta[name="gram-admin-server-url"]')?.remove();
+});
+
+it("keyboard navigation focuses and activates the real Platform admin menu item", async () => {
+  const meta = document.createElement("meta");
+  meta.name = "gram-admin-server-url";
+  meta.content = "https://admin.example.invalid";
+  document.head.append(meta);
+  const user = userEvent.setup();
+  render(<SidebarUserMenu />);
+
+  const trigger = screen.getByRole("button", { name: "Account menu" });
+  trigger.focus();
+  await user.keyboard("{ArrowDown}");
+
+  const adminLink = await screen.findByRole("menuitem", {
+    name: "Platform admin",
+  });
+  expect(document.activeElement).toBe(adminLink);
+
+  const activated = vi.fn((event: Event) => event.preventDefault());
+  adminLink.addEventListener("click", activated);
+  await user.keyboard("{Enter}");
+  expect(activated).toHaveBeenCalledOnce();
+});

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -99,6 +99,18 @@ describe("SidebarUserMenu", () => {
     expect(screen.getAllByText("Sagar").length).toBeGreaterThan(0);
   });
 
+  it("links the crown icon to Platform admin in a new tab", () => {
+    render(<SidebarUserMenu />);
+    const platformAdmin = screen.getByRole("link", { name: "Platform admin" });
+
+    expect(platformAdmin.getAttribute("href")).toBe(
+      "https://gram-admin.tail7d394.ts.net",
+    );
+    expect(platformAdmin.getAttribute("target")).toBe("_blank");
+    expect(platformAdmin.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(platformAdmin.querySelector(".lucide-crown")).toBeTruthy();
+  });
+
   it("links Roadmap to roadmap.speakeasy.com and has no GitHub issues link", () => {
     render(<SidebarUserMenu />);
     fireEvent.click(screen.getByTestId("user-menu-trigger"));

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -8,12 +8,14 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const orgSlug = vi.hoisted(() => ({ current: "acme" }));
+const isPlatformAdmin = vi.hoisted(() => vi.fn(() => true));
 const exploreDemoGoTo = vi.hoisted(() => vi.fn());
 
 vi.mock("@/contexts/Auth", () => ({
   useUser: () => ({ displayName: "Sagar", email: "s@x.dev", photoUrl: "" }),
   useSession: () => ({ organizations: [{ id: "o1" }] }),
   useOrganization: () => ({ slug: orgSlug.current }),
+  useIsPlatformAdmin: () => isPlatformAdmin(),
 }));
 vi.mock("@/contexts/Sdk", () => ({
   useSlugs: () => ({ projectSlug: "proj" }),
@@ -89,6 +91,8 @@ afterEach(() => {
   cleanup();
   Reflect.deleteProperty(window, "Pylon");
   orgSlug.current = "acme";
+  isPlatformAdmin.mockReset();
+  isPlatformAdmin.mockReturnValue(true);
   exploreDemoGoTo.mockReset();
 });
 
@@ -109,6 +113,14 @@ describe("SidebarUserMenu", () => {
     expect(platformAdmin.getAttribute("target")).toBe("_blank");
     expect(platformAdmin.getAttribute("rel")).toBe("noopener noreferrer");
     expect(platformAdmin.querySelector(".lucide-crown")).toBeTruthy();
+  });
+
+  it("hides the Platform admin link from regular users", () => {
+    isPlatformAdmin.mockReturnValue(false);
+
+    render(<SidebarUserMenu />);
+
+    expect(screen.queryByRole("link", { name: "Platform admin" })).toBeNull();
   });
 
   it("links Roadmap to roadmap.speakeasy.com and has no GitHub issues link", () => {

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -84,11 +84,19 @@ import { installMockPylon } from "@/lib/pylon-test-mock";
 
 import { SidebarUserMenu } from "./sidebar-user-menu";
 
+function configureAdminServerUrl(url = "https://admin.example.invalid"): void {
+  const meta = document.createElement("meta");
+  meta.name = "gram-admin-server-url";
+  meta.content = url;
+  document.head.append(meta);
+}
+
 afterEach(() => {
   if (isPylonChatOpen()) {
     togglePylonChat();
   }
   cleanup();
+  document.querySelector('meta[name="gram-admin-server-url"]')?.remove();
   Reflect.deleteProperty(window, "Pylon");
   orgSlug.current = "acme";
   isPlatformAdmin.mockReset();
@@ -104,11 +112,12 @@ describe("SidebarUserMenu", () => {
   });
 
   it("links the crown icon to Platform admin in a new tab", () => {
+    configureAdminServerUrl();
     render(<SidebarUserMenu />);
     const platformAdmin = screen.getByRole("link", { name: "Platform admin" });
 
     expect(platformAdmin.getAttribute("href")).toBe(
-      "https://gram-admin.tail7d394.ts.net",
+      "https://admin.example.invalid",
     );
     expect(platformAdmin.getAttribute("target")).toBe("_blank");
     expect(platformAdmin.getAttribute("rel")).toBe("noopener noreferrer");
@@ -116,8 +125,15 @@ describe("SidebarUserMenu", () => {
   });
 
   it("hides the Platform admin link from regular users", () => {
+    configureAdminServerUrl();
     isPlatformAdmin.mockReturnValue(false);
 
+    render(<SidebarUserMenu />);
+
+    expect(screen.queryByRole("link", { name: "Platform admin" })).toBeNull();
+  });
+
+  it("hides the Platform admin link when its URL is not configured", () => {
     render(<SidebarUserMenu />);
 
     expect(screen.queryByRole("link", { name: "Platform admin" })).toBeNull();

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -139,6 +139,30 @@ describe("SidebarUserMenu", () => {
     expect(screen.queryByRole("link", { name: "Platform admin" })).toBeNull();
   });
 
+  it.each(["not a URL", "javascript:alert(1)", "http://admin.example.invalid"])(
+    "hides the Platform admin link for unsafe URL %s",
+    (url) => {
+      configureAdminServerUrl(url);
+      render(<SidebarUserMenu />);
+
+      expect(screen.queryByRole("link", { name: "Platform admin" })).toBeNull();
+    },
+  );
+
+  it.each(["localhost", "127.0.0.1", "[::1]"])(
+    "allows HTTP for the development loopback host %s",
+    (host) => {
+      configureAdminServerUrl(`http://${host}:8080`);
+      render(<SidebarUserMenu />);
+
+      expect(
+        screen
+          .getByRole("link", { name: "Platform admin" })
+          .getAttribute("href"),
+      ).toBe(`http://${host}:8080`);
+    },
+  );
+
   it("links Roadmap to roadmap.speakeasy.com and has no GitHub issues link", () => {
     render(<SidebarUserMenu />);
     fireEvent.click(screen.getByTestId("user-menu-trigger"));

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -45,6 +45,11 @@ import {
 export function SidebarUserMenu(): JSX.Element {
   const user = useUser();
   const isPlatformAdmin = useIsPlatformAdmin();
+  const adminServerUrl = document
+    .querySelector<HTMLMetaElement>('meta[name="gram-admin-server-url"]')
+    ?.getAttribute("content");
+  const hasAdminServerUrl =
+    adminServerUrl && adminServerUrl !== "__GRAM_ADMIN_SERVER_URL__";
   const session = useSession();
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -132,9 +137,9 @@ export function SidebarUserMenu(): JSX.Element {
                   {user.email}
                 </p>
               </div>
-              {isPlatformAdmin && (
+              {isPlatformAdmin && hasAdminServerUrl && (
                 <a
-                  href="https://gram-admin.tail7d394.ts.net"
+                  href={adminServerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Platform admin"

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -19,6 +19,7 @@ import {
   BuildingIcon,
   CompassIcon,
   CreditCardIcon,
+  CrownIcon,
   LogOutIcon,
   MailIcon,
   MapIcon,
@@ -125,16 +126,15 @@ export function SidebarUserMenu(): JSX.Element {
                   {user.email}
                 </p>
               </div>
-              {projectSlug && (
-                <button
-                  type="button"
-                  aria-label="Project Settings"
-                  onClick={() => routes.settings.goTo()}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <SettingsIcon className="h-4 w-4" />
-                </button>
-              )}
+              <a
+                href="https://gram-admin.tail7d394.ts.net"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Platform admin"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <CrownIcon className="h-4 w-4" />
+              </a>
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -1,4 +1,9 @@
-import { useOrganization, useSession, useUser } from "@/contexts/Auth";
+import {
+  useIsPlatformAdmin,
+  useOrganization,
+  useSession,
+  useUser,
+} from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
 import { DEMO_ORG_SLUG } from "@/lib/demo";
@@ -39,6 +44,7 @@ import {
 
 export function SidebarUserMenu(): JSX.Element {
   const user = useUser();
+  const isPlatformAdmin = useIsPlatformAdmin();
   const session = useSession();
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -126,15 +132,17 @@ export function SidebarUserMenu(): JSX.Element {
                   {user.email}
                 </p>
               </div>
-              <a
-                href="https://gram-admin.tail7d394.ts.net"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Platform admin"
-                className="text-muted-foreground hover:text-foreground"
-              >
-                <CrownIcon className="h-4 w-4" />
-              </a>
+              {isPlatformAdmin && (
+                <a
+                  href="https://gram-admin.tail7d394.ts.net"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Platform admin"
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <CrownIcon className="h-4 w-4" />
+                </a>
+              )}
             </div>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/contexts/Auth";
 import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
+import { getAdminServerUrl } from "@/lib/admin-server-url";
 import { DEMO_ORG_SLUG } from "@/lib/demo";
 import { useOrgRoutes, useRoutes } from "@/routes";
 import {
@@ -45,11 +46,12 @@ import {
 export function SidebarUserMenu(): JSX.Element {
   const user = useUser();
   const isPlatformAdmin = useIsPlatformAdmin();
-  const adminServerUrl = document
-    .querySelector<HTMLMetaElement>('meta[name="gram-admin-server-url"]')
-    ?.getAttribute("content");
-  const hasAdminServerUrl =
-    adminServerUrl && adminServerUrl !== "__GRAM_ADMIN_SERVER_URL__";
+  const adminServerUrl = getAdminServerUrl(
+    document
+      .querySelector<HTMLMetaElement>('meta[name="gram-admin-server-url"]')
+      ?.getAttribute("content"),
+    import.meta.env.DEV,
+  );
   const session = useSession();
   const organization = useOrganization();
   const navigate = useNavigate();
@@ -138,7 +140,7 @@ export function SidebarUserMenu(): JSX.Element {
                 </p>
               </div>
             </DropdownMenuLabel>
-            {isPlatformAdmin && hasAdminServerUrl && (
+            {isPlatformAdmin && adminServerUrl && (
               <DropdownMenuItem
                 asChild
                 className="text-muted-foreground hover:text-foreground absolute top-1.5 right-2 size-4 cursor-pointer p-0 focus:bg-transparent focus:text-foreground"

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -127,8 +127,8 @@ export function SidebarUserMenu(): JSX.Element {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="top" align="end" className="w-56">
-          <DropdownMenuLabel className="font-normal">
-            <div className="flex items-start justify-between gap-2">
+          <DropdownMenuGroup className="relative">
+            <DropdownMenuLabel className="pr-8 font-normal">
               <div className="flex flex-col space-y-1">
                 <p className="text-sm leading-none font-medium">
                   {user.displayName || "User"}
@@ -137,19 +137,23 @@ export function SidebarUserMenu(): JSX.Element {
                   {user.email}
                 </p>
               </div>
-              {isPlatformAdmin && hasAdminServerUrl && (
+            </DropdownMenuLabel>
+            {isPlatformAdmin && hasAdminServerUrl && (
+              <DropdownMenuItem
+                asChild
+                className="text-muted-foreground hover:text-foreground absolute top-1.5 right-2 size-4 cursor-pointer p-0 focus:bg-transparent focus:text-foreground"
+              >
                 <a
                   href={adminServerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Platform admin"
-                  className="text-muted-foreground hover:text-foreground"
                 >
                   <CrownIcon className="h-4 w-4" />
                 </a>
-              )}
-            </div>
-          </DropdownMenuLabel>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
             {projectSlug && (

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -143,7 +143,7 @@ export function SidebarUserMenu(): JSX.Element {
             {isPlatformAdmin && adminServerUrl && (
               <DropdownMenuItem
                 asChild
-                className="text-muted-foreground hover:text-foreground absolute top-1.5 right-2 size-4 cursor-pointer p-0 focus:bg-transparent focus:text-foreground"
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1.5 right-2 size-4 cursor-pointer p-0 focus:bg-transparent focus:text-foreground focus-visible:rounded focus-visible:ring-2 focus-visible:ring-offset-1"
               >
                 <a
                   href={adminServerUrl}

--- a/client/dashboard/src/lib/admin-server-url.test.ts
+++ b/client/dashboard/src/lib/admin-server-url.test.ts
@@ -6,6 +6,15 @@ describe("getAdminServerUrl", () => {
   it("rejects loopback HTTP outside development", () => {
     expect(getAdminServerUrl("http://localhost:8080", false)).toBeNull();
   });
+
+  it.each([
+    "https://user@admin.example.invalid",
+    "https://:password@admin.example.invalid",
+    "http://user@localhost:8080",
+    "http://:password@localhost:8080",
+  ])("rejects URL userinfo in %s", (value) => {
+    expect(getAdminServerUrl(value, true)).toBeNull();
+  });
 });
 
 describe("replaceAdminServerUrl", () => {

--- a/client/dashboard/src/lib/admin-server-url.test.ts
+++ b/client/dashboard/src/lib/admin-server-url.test.ts
@@ -9,12 +9,21 @@ describe("getAdminServerUrl", () => {
 });
 
 describe("replaceAdminServerUrl", () => {
-  it("inserts dollar signs literally", () => {
+  it("escapes HTML while inserting dollar signs literally", () => {
+    const value = 'https://admin.example.invalid/$&-$1-$$?label="<admin>"';
+    const html = replaceAdminServerUrl(
+      '<meta name="admin-url" content="${GRAM_ADMIN_SERVER_URL}">',
+      value,
+    );
+
+    expect(html).toBe(
+      '<meta name="admin-url" content="https://admin.example.invalid/$&amp;-$1-$$?label=&quot;&lt;admin&gt;&quot;">',
+    );
+
+    const document = new DOMParser().parseFromString(html, "text/html");
     expect(
-      replaceAdminServerUrl(
-        '<meta content="${GRAM_ADMIN_SERVER_URL}">',
-        "https://admin.example.invalid/$&-$1-$$",
-      ),
-    ).toBe('<meta content="https://admin.example.invalid/$&-$1-$$">');
+      document.querySelector<HTMLMetaElement>('meta[name="admin-url"]')
+        ?.content,
+    ).toBe(value);
   });
 });

--- a/client/dashboard/src/lib/admin-server-url.test.ts
+++ b/client/dashboard/src/lib/admin-server-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getAdminServerUrl, replaceAdminServerUrl } from "./admin-server-url";
+
+describe("getAdminServerUrl", () => {
+  it("rejects loopback HTTP outside development", () => {
+    expect(getAdminServerUrl("http://localhost:8080", false)).toBeNull();
+  });
+});
+
+describe("replaceAdminServerUrl", () => {
+  it("inserts dollar signs literally", () => {
+    expect(
+      replaceAdminServerUrl(
+        '<meta content="${GRAM_ADMIN_SERVER_URL}">',
+        "https://admin.example.invalid/$&-$1-$$",
+      ),
+    ).toBe('<meta content="https://admin.example.invalid/$&-$1-$$">');
+  });
+});

--- a/client/dashboard/src/lib/admin-server-url.ts
+++ b/client/dashboard/src/lib/admin-server-url.ts
@@ -20,5 +20,10 @@ export function getAdminServerUrl(
 }
 
 export function replaceAdminServerUrl(html: string, value: string): string {
-  return html.replace("${GRAM_ADMIN_SERVER_URL}", () => value);
+  const escaped = value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  return html.replace("${GRAM_ADMIN_SERVER_URL}", () => escaped);
 }

--- a/client/dashboard/src/lib/admin-server-url.ts
+++ b/client/dashboard/src/lib/admin-server-url.ts
@@ -1,0 +1,24 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export function getAdminServerUrl(
+  value: string | null | undefined,
+  isDev: boolean,
+): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:") return value;
+    if (isDev && url.protocol === "http:" && LOOPBACK_HOSTS.has(url.hostname)) {
+      return value;
+    }
+  } catch {
+    // Invalid URLs fail closed.
+  }
+
+  return null;
+}
+
+export function replaceAdminServerUrl(html: string, value: string): string {
+  return html.replace("${GRAM_ADMIN_SERVER_URL}", () => value);
+}

--- a/client/dashboard/src/lib/admin-server-url.ts
+++ b/client/dashboard/src/lib/admin-server-url.ts
@@ -8,6 +8,7 @@ export function getAdminServerUrl(
 
   try {
     const url = new URL(value);
+    if (url.username || url.password) return null;
     if (url.protocol === "https:") return value;
     if (isDev && url.protocol === "http:" && LOOPBACK_HOSTS.has(url.hostname)) {
       return value;

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -261,7 +261,21 @@ export default defineConfig(({ command }) => {
           }
         : undefined,
     },
-    plugins: [themeInitPlugin(), react(), tailwindcss()],
+    plugins: [
+      {
+        name: "admin-server-url",
+        transformIndexHtml(html) {
+          if (command !== "serve") return html;
+          return html.replace(
+            "__GRAM_ADMIN_SERVER_URL__",
+            process.env["GRAM_ADMIN_SERVER_URL"] || "",
+          );
+        },
+      },
+      themeInitPlugin(),
+      react(),
+      tailwindcss(),
+    ],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import { defineConfig, normalizePath, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { replaceAdminServerUrl } from "./src/lib/admin-server-url";
 
 // Manually grouped vendor chunks. CAUTION: never group a package whose dist
 // contains a top-level `await import(...)` (check before adding). Grouping
@@ -266,8 +267,8 @@ export default defineConfig(({ command }) => {
         name: "admin-server-url",
         transformIndexHtml(html) {
           if (command !== "serve") return html;
-          return html.replace(
-            "__GRAM_ADMIN_SERVER_URL__",
+          return replaceAdminServerUrl(
+            html,
             process.env["GRAM_ADMIN_SERVER_URL"] || "",
           );
         },


### PR DESCRIPTION
Depends on speakeasy-api/gram-infra#3051.

## Summary

- Replace the redundant project-settings cog beside the account identity with a crown icon.
- Show the crown only to users recognized by the existing platform-admin authorization hook.
- Source its destination from runtime environment configuration supplied by infrastructure.
- Hide the crown when the admin URL is absent, preserving the existing Project Settings menu item.

## Motivation

The cog duplicated the Project Settings menu item. For authorized employees, the same space is more useful as a direct shortcut to the matching platform administration environment without baking an environment-specific URL into the shared dashboard build.
