### PR TITLE
fix: wire hosted gateway members to their OAuth provider

### DIFF
--- a/.changeset/gateway-hosted-member-oauth.md
+++ b/.changeset/gateway-hosted-member-oauth.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Adding a hosted MCP server to a gateway now wires the OAuth provider its external MCP tools authenticate against: the gateway registers a client with that provider (reusing one the project already has), offers it on the gateway's connect page, and forwards the user's token to the member's tools. The hosted server's own endpoint is unchanged. Previously such members listed and described fine but every call was refused upstream with an opaque error. The add is refused with an explanation when the gateway could route no single credential to the member: several OAuth upstreams in one toolset, OpenAPI or function tools that also take OAuth, another member on the same provider, or a provider without client registration. A tool call an external MCP server rejects for missing or expired credentials now says so instead of reporting a generic failure.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1541,7 +1541,7 @@ func newStartCommand() *cli.Command {
 			mcpServersService := mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, toolDispositionCache, pluginsGitHub != nil, assetsService, upstreamRevoker)
 			mcpservers.Attach(mux, mcpServersService)
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
-			metamcp.Attach(mux, metamcp.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv))
+			metamcp.Attach(mux, metamcp.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, platformmcp.NewCatalogIdentityProviderAttachmentService(db, encryptionClient, guardianPolicy, auditLogger, serverURL)))
 			remoteSessionsCache := cache.NewRedisCacheAdapter(redisClient)
 			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache), productFeatures)
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient)))

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -887,6 +887,12 @@ func externalMCPErrorSummary(content []json.RawMessage) string {
 	return rendered
 }
 
+// externalMCPAuthRejected names the missing or refused upstream credential
+// instead of a generic failure, as the proxied-backend relay does.
+func externalMCPAuthRejected(ctx context.Context, logger *slog.Logger, toolName string, rejected *externalmcp.AuthRejectedError) error {
+	return oops.E(oops.CodeFailedPrecondition, rejected, "the external MCP server behind tool %q rejected the request credentials (status %d); connect or reconnect its OAuth provider", toolName, rejected.StatusCode).LogWarn(ctx, logger)
+}
+
 func (tp *ToolProxy) doExternalMCP(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -954,6 +960,9 @@ func (tp *ToolProxy) doExternalMCP(
 	// Connect to the external MCP server
 	client, err := externalmcp.NewClient(ctx, logger, tp.policy, plan.RemoteURL, plan.TransportType, opts)
 	if err != nil {
+		if rejected, ok := errors.AsType[*externalmcp.AuthRejectedError](err); ok {
+			return externalMCPAuthRejected(ctx, logger, toolName, rejected)
+		}
 		return oops.E(oops.CodeUnexpected, err, "failed to connect to external MCP server").LogError(ctx, logger)
 	}
 	defer o11y.LogDefer(ctx, logger, "failed to close external mcp client", client.Close)
@@ -961,6 +970,9 @@ func (tp *ToolProxy) doExternalMCP(
 	// Call the tool on the external MCP server
 	callResult, err := client.CallTool(ctx, toolName, arguments)
 	if err != nil {
+		if rejected, ok := errors.AsType[*externalmcp.AuthRejectedError](err); ok {
+			return externalMCPAuthRejected(ctx, logger, toolName, rejected)
+		}
 		return oops.E(oops.CodeUnexpected, err, "failed to call external MCP tool").LogError(ctx, logger)
 	}
 

--- a/server/internal/mcp/serve_meta_tools.go
+++ b/server/internal/mcp/serve_meta_tools.go
@@ -11,10 +11,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	environmentsrepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
@@ -22,9 +24,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/metamcp"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
@@ -407,7 +411,11 @@ func (s *Service) buildMemberDispatch(
 	// consented for a specific member must never reach another member's
 	// tools. No entry degrades to no token rather than an error, so partially
 	// connected meta sessions keep hosted members callable.
-	tokenInputs, err := appendRemoteSessionTokenInputs(nil, hostedMemberTokens(gate.tokens, member))
+	tokens := hostedMemberTokens(gate.tokens, member)
+	if len(tokens) > 0 && !s.hostedProviderCurrent(ctx, logger, projectID, toolset.OrganizationID, member) {
+		tokens = nil
+	}
+	tokenInputs, err := appendRemoteSessionTokenInputs(nil, tokens)
 	if err != nil {
 		return nil, nil, oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for meta MCP member").LogError(ctx, logger)
 	}
@@ -478,6 +486,37 @@ func (s *Service) buildMemberDispatch(
 // forward a sibling's bearer once partial resolution leaves gaps in the map,
 // and a resource-qualified token is audience-bound to the remote upstream it
 // was consented for; both cases yield no token.
+// hostedProviderCurrent reports whether the provider recorded on a hosted
+// member when it joined still matches the OAuth upstream of the tools deployed
+// now, by token endpoint. The record is written at add time only, so a toolset
+// that moved to another provider must not receive the old provider's bearer.
+func (s *Service) hostedProviderCurrent(ctx context.Context, logger *slog.Logger, projectID uuid.UUID, organizationID string, member metaMember) bool {
+	if !member.toolsetID.Valid || !member.remoteSessionIssuerID.Valid {
+		return false
+	}
+	provider, err := mcpservers.ResolveHostedOAuthProvider(ctx, s.db, projectID, member.toolsetID.UUID)
+	if err != nil || provider == nil {
+		logger.WarnContext(ctx, "hosted member credential withheld: current tools have no single OAuth upstream", attr.SlogMcpServerID(member.serverID.String()), attr.SlogError(err))
+		return false
+	}
+	issuer, err := remotesessions_repo.New(s.db).GetRemoteSessionIssuerByID(ctx, remotesessions_repo.GetRemoteSessionIssuerByIDParams{
+		ID:                    member.remoteSessionIssuerID.UUID,
+		ProjectID:             conv.ToNullUUID(projectID),
+		IncludeOrganizational: true,
+		OrganizationID:        conv.ToPGText(organizationID),
+		IncludeGlobal:         true,
+	})
+	if err != nil {
+		logger.WarnContext(ctx, "hosted member credential withheld: provider issuer not found", attr.SlogMcpServerID(member.serverID.String()), attr.SlogError(err))
+		return false
+	}
+	if strings.TrimRight(issuer.TokenEndpoint.String, "/") != provider.TokenEndpoint {
+		logger.WarnContext(ctx, "hosted member credential withheld: tools moved to another OAuth provider since the member joined", attr.SlogMcpServerID(member.serverID.String()))
+		return false
+	}
+	return true
+}
+
 func hostedMemberTokens(tokens map[uuid.UUID]remotesessions.UpstreamToken, member metaMember) map[uuid.UUID]remotesessions.UpstreamToken {
 	if !member.remoteSessionIssuerID.Valid {
 		return nil

--- a/server/internal/mcpservers/hostedprovider.go
+++ b/server/internal/mcpservers/hostedprovider.go
@@ -1,0 +1,163 @@
+package mcpservers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/functions"
+	toolsrepo "github.com/speakeasy-api/gram/server/internal/tools/repo"
+	"github.com/speakeasy-api/gram/server/internal/tools/security"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// HostedOAuthProvider is the one upstream OAuth provider a hosted server's
+// materialized external MCP tools authenticate with. TokenEndpoint identifies
+// the authorization server, so a stored provider issuer can be checked against
+// the tools currently deployed.
+type HostedOAuthProvider struct {
+	// Name is the external MCP server's name, for labeling the provider.
+	Name          string
+	ResourceURL   string
+	TokenEndpoint string
+}
+
+// HostedProviderError is a toolset OAuth shape a gateway cannot serve with one
+// credential: dispatch injects one token per hosted member into every
+// OAuth-shaped tool, so the tools must agree on a single https upstream and no
+// OpenAPI or function tool may take OAuth alongside them.
+type HostedProviderError struct{ Reason string }
+
+func (e *HostedProviderError) Error() string { return e.Reason }
+
+// ResolveHostedOAuthProvider inspects the toolset's latest version against the
+// project's active deployment. Nil when no materialized external MCP tool
+// requires OAuth (the meta surface never dispatches passthrough ones).
+func ResolveHostedOAuthProvider(ctx context.Context, db *pgxpool.Pool, projectID, toolsetID uuid.UUID) (*HostedOAuthProvider, error) {
+	version, err := toolsetsrepo.New(db).GetLatestToolsetVersion(ctx, toolsetID)
+	if errors.Is(err, pgx.ErrNoRows) || (err == nil && len(version.ToolUrns) == 0) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load toolset version: %w", err)
+	}
+	deploymentID, err := deploymentsrepo.New(db).GetActiveDeploymentID(ctx, projectID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load active deployment: %w", err)
+	}
+	oauthTools, err := externalmcprepo.New(db).GetExternalMCPToolsRequiringOAuth(ctx, deploymentID)
+	if err != nil {
+		return nil, fmt.Errorf("load external mcp tools requiring oauth: %w", err)
+	}
+
+	urns := make([]string, 0, len(version.ToolUrns))
+	for _, toolURN := range version.ToolUrns {
+		urns = append(urns, toolURN.String())
+	}
+	var provider *HostedOAuthProvider
+	for _, tool := range oauthTools {
+		resource := strings.TrimRight(tool.RemoteUrl, "/")
+		if tool.Type == "proxy" || resource == "" || !slices.Contains(urns, tool.ToolUrn) {
+			continue
+		}
+		// Discovery output decides where Gram registers a client; never trust
+		// it over cleartext.
+		if !secureURL(resource) {
+			return nil, &HostedProviderError{Reason: fmt.Sprintf("external MCP tool upstream %s must use https", resource)}
+		}
+		tokenEndpoint := strings.TrimRight(tool.OauthTokenEndpoint.String, "/")
+		if tokenEndpoint == "" {
+			return nil, &HostedProviderError{Reason: fmt.Sprintf("external MCP tool upstream %s has no OAuth token endpoint recorded; redeploy the toolset", resource)}
+		}
+		switch {
+		case provider == nil:
+			provider = &HostedOAuthProvider{Name: tool.RegistryServerName, ResourceURL: resource, TokenEndpoint: tokenEndpoint}
+		case provider.ResourceURL != resource || provider.TokenEndpoint != tokenEndpoint:
+			return nil, &HostedProviderError{Reason: fmt.Sprintf("external MCP tools span several OAuth upstreams (%s, %s); a gateway routes one credential per member", provider.ResourceURL, resource)}
+		}
+	}
+	if provider == nil {
+		return nil, nil
+	}
+
+	mixed, err := toolsetTakesOAuthElsewhere(ctx, db, projectID, urns)
+	if err != nil {
+		return nil, err
+	}
+	if mixed {
+		return nil, &HostedProviderError{Reason: fmt.Sprintf("OpenAPI or function tools take OAuth alongside external MCP tools on %s; a gateway routes one credential per member", provider.ResourceURL)}
+	}
+	return provider, nil
+}
+
+// toolsetTakesOAuthElsewhere reports whether a selected OpenAPI or function
+// tool would also receive the member's token (see resolveUserConfiguration).
+func toolsetTakesOAuthElsewhere(ctx context.Context, db *pgxpool.Pool, projectID uuid.UUID, urns []string) (bool, error) {
+	httpTools, err := toolsrepo.New(db).FindHttpToolsByUrn(ctx, toolsrepo.FindHttpToolsByUrnParams{ProjectID: projectID, Urns: urns})
+	if err != nil {
+		return false, fmt.Errorf("load http tools: %w", err)
+	}
+	for _, row := range httpTools {
+		def := row.HttpToolDefinition
+		keys, _, err := security.ParseHTTPToolSecurityKeys(def.Security)
+		if err != nil {
+			return false, fmt.Errorf("parse http tool security: %w", err)
+		}
+		if len(keys) == 0 {
+			continue
+		}
+		var docIDs []uuid.UUID
+		if def.Openapiv3DocumentID.Valid {
+			docIDs = []uuid.UUID{def.Openapiv3DocumentID.UUID}
+		}
+		entries, err := toolsetsrepo.New(db).GetHTTPSecurityDefinitions(ctx, toolsetsrepo.GetHTTPSecurityDefinitionsParams{SecurityKeys: keys, DeploymentIds: []uuid.UUID{def.DeploymentID}, Openapiv3DocumentIds: docIDs})
+		if err != nil {
+			return false, fmt.Errorf("load http security definitions: %w", err)
+		}
+		for _, entry := range entries {
+			if entry.Type.String == "openIdConnect" || slices.Contains(entry.OauthTypes, "authorization_code") {
+				return true, nil
+			}
+		}
+	}
+
+	functionTools, err := toolsrepo.New(db).FindFunctionToolsByUrn(ctx, toolsrepo.FindFunctionToolsByUrnParams{ProjectID: projectID, Urns: urns})
+	if err != nil {
+		return false, fmt.Errorf("load function tools: %w", err)
+	}
+	for _, row := range functionTools {
+		if len(row.FunctionToolDefinition.AuthInput) == 0 {
+			continue
+		}
+		var authInput functions.ManifestAuthInputAttributeV0
+		if err := json.Unmarshal(row.FunctionToolDefinition.AuthInput, &authInput); err != nil {
+			return false, fmt.Errorf("parse function tool auth input: %w", err)
+		}
+		if authInput.Type == "oauth2" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func secureURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return u.Scheme == "https" || (u.Scheme == "http" && (host == "localhost" || host == "127.0.0.1" || host == "::1"))
+}

--- a/server/internal/mcpservers/hostedprovider_test.go
+++ b/server/internal/mcpservers/hostedprovider_test.go
@@ -1,0 +1,208 @@
+package mcpservers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type hostedProviderTool struct {
+	slug          string
+	kind          string
+	remoteURL     string
+	tokenEndpoint string
+	requiresOAuth bool
+}
+
+// seedHostedProviderToolset deploys the given external MCP tools and selects
+// them all in a new toolset's latest version.
+func seedHostedProviderToolset(t *testing.T, ctx context.Context, ti *testInstance, tools ...hostedProviderTool) uuid.UUID {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	deploymentID, err := deploymentsrepo.New(ti.conn).InsertDeployment(ctx, deploymentsrepo.InsertDeploymentParams{
+		ProjectID:      projectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         "test-user",
+		IdempotencyKey: uuid.New().String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, deploymentsrepo.New(ti.conn).CreateDeploymentStatus(ctx, deploymentsrepo.CreateDeploymentStatusParams{
+		DeploymentID: deploymentID,
+		Status:       "completed",
+	}))
+
+	extRepo := externalmcprepo.New(ti.conn)
+	toolURNs := make([]urn.Tool, 0, len(tools))
+	for _, tool := range tools {
+		attachment, err := extRepo.CreateExternalMCPAttachment(ctx, externalmcprepo.CreateExternalMCPAttachmentParams{
+			DeploymentID:            deploymentID,
+			RegistryID:              uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+			Name:                    tool.slug,
+			Slug:                    tool.slug,
+			RegistryServerSpecifier: tool.slug,
+		})
+		require.NoError(t, err)
+		toolURN := urn.NewTool(urn.ToolKindExternalMCP, tool.slug, "call")
+		toolURNs = append(toolURNs, toolURN)
+		_, err = extRepo.CreateExternalMCPToolDefinition(ctx, externalmcprepo.CreateExternalMCPToolDefinitionParams{
+			ExternalMcpAttachmentID:    attachment.ID,
+			ToolUrn:                    toolURN.String(),
+			Type:                       tool.kind,
+			Name:                       pgtype.Text{String: tool.slug, Valid: true},
+			Description:                pgtype.Text{String: "tool", Valid: true},
+			Schema:                     []byte(`{"type":"object"}`),
+			RemoteUrl:                  tool.remoteURL,
+			TransportType:              externalmcptypes.TransportTypeStreamableHTTP,
+			RequiresOauth:              tool.requiresOAuth,
+			OauthVersion:               "2.1",
+			OauthAuthorizationEndpoint: pgtype.Text{},
+			OauthTokenEndpoint:         conv.ToPGTextEmpty(tool.tokenEndpoint),
+			OauthRegistrationEndpoint:  pgtype.Text{},
+			OauthScopesSupported:       []string{},
+			HeaderDefinitions:          nil,
+			Title:                      pgtype.Text{},
+			ReadOnlyHint:               pgtype.Bool{},
+			DestructiveHint:            pgtype.Bool{},
+			IdempotentHint:             pgtype.Bool{},
+			OpenWorldHint:              pgtype.Bool{},
+		})
+		require.NoError(t, err)
+	}
+
+	slug := "hosted-provider-" + uuid.NewString()[:8]
+	toolset, err := toolsetsrepo.New(ti.conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      projectID,
+		Name:           slug,
+		Slug:           slug,
+		McpSlug:        conv.ToPGText(slug),
+		McpEnabled:     true,
+	})
+	require.NoError(t, err)
+	_, err = toolsetsrepo.New(ti.conn).CreateToolsetVersion(ctx, toolsetsrepo.CreateToolsetVersionParams{
+		ToolsetID:     toolset.ID,
+		Version:       1,
+		ToolUrns:      toolURNs,
+		ResourceUrns:  []urn.Resource{},
+		PredecessorID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+	require.NoError(t, err)
+	return toolset.ID
+}
+
+// Each case owns a database clone: the active deployment is per project, so
+// cases seeding deployments cannot share one.
+func newHostedProviderCase(t *testing.T) (context.Context, *testInstance, uuid.UUID) {
+	t.Helper()
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	return ctx, ti, *authCtx.ProjectID
+}
+
+func TestResolveHostedOAuthProvider(t *testing.T) {
+	t.Parallel()
+
+	const notes = "https://notes.example.test/mcp"
+	const notesToken = "https://notes.example.test/oauth/token"
+
+	t.Run("single provider", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "notes-a", kind: "direct", remoteURL: notes, tokenEndpoint: notesToken, requiresOAuth: true},
+			hostedProviderTool{slug: "notes-b", kind: "direct", remoteURL: notes + "/", tokenEndpoint: notesToken + "/", requiresOAuth: true},
+			hostedProviderTool{slug: "open", kind: "direct", remoteURL: "https://open.example.test/mcp", tokenEndpoint: "", requiresOAuth: false},
+		)
+		provider, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		require.NoError(t, err)
+		require.Equal(t, &mcpservers.HostedOAuthProvider{Name: "notes-a", ResourceURL: notes, TokenEndpoint: notesToken}, provider)
+	})
+
+	t.Run("no oauth tools", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "open", kind: "direct", remoteURL: "https://open.example.test/mcp", tokenEndpoint: "", requiresOAuth: false},
+		)
+		provider, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		require.NoError(t, err)
+		require.Nil(t, provider)
+	})
+
+	t.Run("passthrough tools are not dispatched by the gateway", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "proxy", kind: "proxy", remoteURL: notes, tokenEndpoint: notesToken, requiresOAuth: true},
+		)
+		provider, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		require.NoError(t, err)
+		require.Nil(t, provider)
+	})
+
+	t.Run("several providers", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "notes", kind: "direct", remoteURL: notes, tokenEndpoint: notesToken, requiresOAuth: true},
+			hostedProviderTool{slug: "tasks", kind: "direct", remoteURL: "https://tasks.example.test/mcp", tokenEndpoint: "https://tasks.example.test/oauth/token", requiresOAuth: true},
+		)
+		_, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		var cfg *mcpservers.HostedProviderError
+		require.ErrorAs(t, err, &cfg)
+		require.Contains(t, cfg.Reason, "several OAuth upstreams")
+	})
+
+	t.Run("same resource, different authorization server", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "notes-a", kind: "direct", remoteURL: notes, tokenEndpoint: notesToken, requiresOAuth: true},
+			hostedProviderTool{slug: "notes-b", kind: "direct", remoteURL: notes, tokenEndpoint: "https://other-as.example.test/token", requiresOAuth: true},
+		)
+		_, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		var cfg *mcpservers.HostedProviderError
+		require.ErrorAs(t, err, &cfg)
+	})
+
+	t.Run("cleartext upstream", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "plain", kind: "direct", remoteURL: "http://notes.example.test/mcp", tokenEndpoint: notesToken, requiresOAuth: true},
+		)
+		_, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		var cfg *mcpservers.HostedProviderError
+		require.ErrorAs(t, err, &cfg)
+		require.Contains(t, cfg.Reason, "must use https")
+	})
+
+	t.Run("missing token endpoint", func(t *testing.T) {
+		t.Parallel()
+		ctx, ti, projectID := newHostedProviderCase(t)
+		toolsetID := seedHostedProviderToolset(t, ctx, ti,
+			hostedProviderTool{slug: "bare", kind: "direct", remoteURL: notes, tokenEndpoint: "", requiresOAuth: true},
+		)
+		_, err := mcpservers.ResolveHostedOAuthProvider(ctx, ti.conn, projectID, toolsetID)
+		var cfg *mcpservers.HostedProviderError
+		require.ErrorAs(t, err, &cfg)
+		require.Contains(t, cfg.Reason, "no OAuth token endpoint")
+	})
+}

--- a/server/internal/mcpservers/queries.sql
+++ b/server/internal/mcpservers/queries.sql
@@ -193,6 +193,20 @@ SET
 WHERE id = @id AND project_id = @project_id AND deleted IS FALSE
 RETURNING *;
 
+-- name: StampHostedMCPServerProviderIssuer :execrows
+-- A hosted server has no client bindings to derive remote_session_issuer_id
+-- from, so the gateway records the provider its OAuth tools authenticate with
+-- as the member token-routing key. Rows carrying an issuer keep the
+-- binding-derived value (ResyncMCPServerRemoteSessionIssuers).
+UPDATE mcp_servers
+SET remote_session_issuer_id = @remote_session_issuer_id,
+    updated_at = clock_timestamp()
+WHERE id = @id
+  AND project_id = @project_id
+  AND deleted IS FALSE
+  AND toolset_id = @toolset_id
+  AND user_session_issuer_id IS NULL;
+
 -- name: DeleteMCPServer :one
 UPDATE mcp_servers
 SET deleted_at = clock_timestamp()

--- a/server/internal/mcpservers/repo/queries.sql.go
+++ b/server/internal/mcpservers/repo/queries.sql.go
@@ -1204,6 +1204,41 @@ func (q *Queries) SetMCPServerToolMetadata(ctx context.Context, arg SetMCPServer
 	return items, nil
 }
 
+const stampHostedMCPServerProviderIssuer = `-- name: StampHostedMCPServerProviderIssuer :execrows
+UPDATE mcp_servers
+SET remote_session_issuer_id = $1,
+    updated_at = clock_timestamp()
+WHERE id = $2
+  AND project_id = $3
+  AND deleted IS FALSE
+  AND toolset_id = $4
+  AND user_session_issuer_id IS NULL
+`
+
+type StampHostedMCPServerProviderIssuerParams struct {
+	RemoteSessionIssuerID uuid.NullUUID
+	ID                    uuid.UUID
+	ProjectID             uuid.UUID
+	ToolsetID             uuid.NullUUID
+}
+
+// A hosted server has no client bindings to derive remote_session_issuer_id
+// from, so the gateway records the provider its OAuth tools authenticate with
+// as the member token-routing key. Rows carrying an issuer keep the
+// binding-derived value (ResyncMCPServerRemoteSessionIssuers).
+func (q *Queries) StampHostedMCPServerProviderIssuer(ctx context.Context, arg StampHostedMCPServerProviderIssuerParams) (int64, error) {
+	result, err := q.db.Exec(ctx, stampHostedMCPServerProviderIssuer,
+		arg.RemoteSessionIssuerID,
+		arg.ID,
+		arg.ProjectID,
+		arg.ToolsetID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateMCPServer = `-- name: UpdateMCPServer :one
 UPDATE mcp_servers
 SET

--- a/server/internal/metamcp/hostedmember.go
+++ b/server/internal/metamcp/hostedmember.go
@@ -1,0 +1,240 @@
+// A hosted (toolset-backed) member has no issuer of its own, so the gateway
+// registers an OAuth client for its tools' provider on the gateway issuer and
+// records that provider on the member row, which consent cards and
+// hostedMemberTokens key on. The hosted server's own endpoint is untouched.
+
+package metamcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// HostedMemberProviderAttacher registers and binds an OAuth client for the
+// provider protecting an upstream resource. Implemented by
+// platformmcp.CatalogIdentityProviderAttachmentService.
+type HostedMemberProviderAttacher interface {
+	AttachUpstreamProvider(ctx context.Context, principal platformmcp.Principal, project platformmcp.ResolvedProject, input platformmcp.UpstreamProviderAttachmentInput) (platformmcp.UpstreamProviderAttachment, error)
+}
+
+// hostedProviderWiring is what wireHostedMemberProvider bound, so the add
+// transaction can rebind it if the gateway issuer moved meanwhile and undo it
+// if the add does not commit.
+type hostedProviderWiring struct {
+	clientID       uuid.UUID
+	issuerID       uuid.UUID
+	remoteIssuerID uuid.UUID
+	unbind         func()
+}
+
+// wireHostedMemberProvider gives a hosted member the provider identity the
+// gateway routes by. No-op for proxied members and hosted members needing no
+// upstream OAuth. Runs before the add transaction: discovery and registration
+// are network calls.
+func (s *Service) wireHostedMemberProvider(ctx context.Context, logger *slog.Logger, authCtx *contextvalues.AuthContext, metaID, mcpServerID uuid.UUID) (hostedProviderWiring, error) {
+	none := hostedProviderWiring{clientID: uuid.Nil, issuerID: uuid.Nil, remoteIssuerID: uuid.Nil, unbind: func() {}}
+	projectID := *authCtx.ProjectID
+	server, err := mcpserversrepo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{ID: mcpServerID, ProjectID: projectID})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return none, nil // the add transaction reports it
+	case err != nil:
+		return none, oops.E(oops.CodeUnexpected, err, "load mcp server").LogError(ctx, logger)
+	}
+	if !server.ToolsetID.Valid {
+		return none, nil
+	}
+
+	provider, err := mcpservers.ResolveHostedOAuthProvider(ctx, s.db, projectID, server.ToolsetID.UUID)
+	if cfg, ok := errors.AsType[*mcpservers.HostedProviderError](err); ok {
+		return none, oops.E(oops.CodeInvalid, err, "hosted server %q: %s", server.Slug.String, cfg.Reason).LogError(ctx, logger)
+	}
+	if err != nil {
+		return none, oops.E(oops.CodeUnexpected, err, "resolve hosted member provider").LogError(ctx, logger)
+	}
+	if provider == nil {
+		return none, nil
+	}
+	logger = logger.With(attr.SlogMcpServerID(server.ID.String()), attr.SlogURL(provider.ResourceURL))
+	if s.providers == nil {
+		return none, oops.E(oops.CodeInvalid, nil, "hosted server %q authenticates users with %s, and this deployment cannot register OAuth clients for gateway members", server.Slug.String, provider.ResourceURL).LogError(ctx, logger)
+	}
+
+	meta, err := repo.New(s.db).GetMetaMCPServer(ctx, repo.GetMetaMCPServerParams{ID: metaID, OrganizationID: authCtx.ActiveOrganizationID, ProjectID: projectID})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return none, oops.E(oops.CodeNotFound, err, "meta mcp server not found").LogError(ctx, logger)
+	case err != nil:
+		return none, oops.E(oops.CodeUnexpected, err, "load meta mcp server").LogError(ctx, logger)
+	case !meta.UserSessionIssuerID.Valid:
+		return none, oops.E(oops.CodeInvalid, nil, "meta mcp server has no issuer; update it to mint one before adding a hosted member that needs OAuth").LogError(ctx, logger)
+	}
+
+	// A hosted row that already carries an issuer is wired like a proxied
+	// member: client on its own issuer, derived issuer resynced, and the add
+	// transaction's auto-attach copies it to the gateway.
+	bindIssuerID := meta.UserSessionIssuerID.UUID
+	if server.UserSessionIssuerID.Valid {
+		bindIssuerID = server.UserSessionIssuerID.UUID
+	}
+	attached, err := s.providers.AttachUpstreamProvider(ctx,
+		platformmcp.Principal{UserID: authCtx.UserID, OrganizationID: authCtx.ActiveOrganizationID, ConnectionID: "", Generation: "", ClientID: "", Surface: platformmcp.SurfaceDashboard},
+		platformmcp.ResolvedProject{ID: projectID, Name: "", Slug: ""},
+		platformmcp.UpstreamProviderAttachmentInput{UserSessionIssuerID: bindIssuerID, ResourceURL: provider.ResourceURL, IssuerSlug: hostedProviderIssuerSlug, IssuerName: provider.Name})
+	if err != nil {
+		return none, hostedMemberProviderError(ctx, logger, server.Slug.String, provider.ResourceURL, err)
+	}
+	wiring := hostedProviderWiring{clientID: attached.ClientID, issuerID: bindIssuerID, remoteIssuerID: attached.RemoteSessionIssuerID, unbind: func() {}}
+	if attached.Bound {
+		wiring.unbind = func() {
+			// Another hosted member committed on this provider meanwhile: the
+			// binding is theirs now.
+			if n, cerr := repo.New(s.db).CountHostedMetaMCPMembersOnProvider(ctx, repo.CountHostedMetaMCPMembersOnProviderParams{
+				MetaMcpServerID: metaID,
+				ProjectID:       projectID,
+				RemoteIssuerID:  uuid.NullUUID{UUID: attached.RemoteSessionIssuerID, Valid: true},
+			}); cerr != nil || n > 0 {
+				return
+			}
+			if _, derr := remotesessionsrepo.New(s.db).DetachRemoteSessionClientFromUserSessionIssuer(ctx, remotesessionsrepo.DetachRemoteSessionClientFromUserSessionIssuerParams{
+				RemoteSessionClientID: attached.ClientID,
+				UserSessionIssuerID:   bindIssuerID,
+			}); derr != nil {
+				logger.ErrorContext(ctx, "unbind hosted member provider client after failed add", attr.SlogError(derr))
+			}
+		}
+	}
+
+	if reason, err := s.hostedGrantQualifiedBy(ctx, authCtx, metaID, bindIssuerID, attached.RemoteSessionIssuerID); err != nil {
+		wiring.unbind()
+		return none, oops.E(oops.CodeUnexpected, err, "check hosted member provider routing").LogError(ctx, logger)
+	} else if reason != "" {
+		wiring.unbind()
+		return none, oops.E(oops.CodeConflict, nil, "%s already authenticates with %s; a gateway routes one credential per provider", reason, attached.IssuerURL).LogError(ctx, logger)
+	}
+
+	if server.UserSessionIssuerID.Valid {
+		err = remotesessions.ResyncMCPServerRemoteSessionIssuers(ctx, s.db, authCtx.ActiveOrganizationID, projectID, []uuid.UUID{bindIssuerID})
+	} else {
+		var stamped int64
+		stamped, err = mcpserversrepo.New(s.db).StampHostedMCPServerProviderIssuer(ctx, mcpserversrepo.StampHostedMCPServerProviderIssuerParams{
+			RemoteSessionIssuerID: uuid.NullUUID{UUID: attached.RemoteSessionIssuerID, Valid: true},
+			ID:                    server.ID,
+			ProjectID:             projectID,
+			ToolsetID:             server.ToolsetID,
+		})
+		if err == nil && stamped != 1 {
+			err = fmt.Errorf("stamped %d rows", stamped)
+		}
+	}
+	if err != nil {
+		wiring.unbind()
+		return none, oops.E(oops.CodeUnexpected, err, "record hosted member provider").LogError(ctx, logger)
+	}
+
+	logger.InfoContext(ctx, "wired hosted member upstream provider",
+		attr.SlogMetaMcpServerID(metaID.String()),
+		attr.SlogRemoteSessionIssuerID(attached.RemoteSessionIssuerID.String()))
+	return wiring, nil
+}
+
+// rebindHostedProvider moves the provider binding onto the gateway issuer the
+// add transaction locked when an issuer change landed between wiring and the
+// lock, so the new member is never left bound to an issuer the gateway no
+// longer uses.
+func rebindHostedProvider(ctx context.Context, dbtx pgx.Tx, wiring hostedProviderWiring, gatewayIssuerID uuid.UUID) error {
+	if wiring.clientID == uuid.Nil || wiring.issuerID == gatewayIssuerID {
+		return nil
+	}
+	q := remotesessionsrepo.New(dbtx)
+	if err := q.LockRemoteSessionIssuerForClientBinding(ctx, wiring.remoteIssuerID); err != nil {
+		return fmt.Errorf("lock remote session issuer for client binding: %w", err)
+	}
+	if err := q.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{RemoteSessionClientID: wiring.clientID, UserSessionIssuerID: gatewayIssuerID}); err != nil {
+		return fmt.Errorf("bind provider client to gateway issuer: %w", err)
+	}
+	if _, err := q.DetachRemoteSessionClientFromUserSessionIssuer(ctx, remotesessionsrepo.DetachRemoteSessionClientFromUserSessionIssuerParams{RemoteSessionClientID: wiring.clientID, UserSessionIssuerID: wiring.issuerID}); err != nil {
+		return fmt.Errorf("unbind provider client from previous gateway issuer: %w", err)
+	}
+	return nil
+}
+
+// hostedGrantQualifiedBy mirrors consent-time resource derivation and names
+// what would qualify the grant to a URL: a proxied member claiming the provider
+// (resolveMetaMemberResource) or a remote server sharing the client
+// (FallbackResourceForClient). hostedMemberTokens accepts unqualified grants
+// only. Empty when nothing does.
+func (s *Service) hostedGrantQualifiedBy(ctx context.Context, authCtx *contextvalues.AuthContext, metaID, issuerID, remoteIssuerID uuid.UUID) (string, error) {
+	projectID := *authCtx.ProjectID
+	claimants, err := repo.New(s.db).ListMetaMCPMembersForRemoteSessionIssuer(ctx, repo.ListMetaMCPMembersForRemoteSessionIssuerParams{
+		MetaMcpServerID:       metaID,
+		ProjectID:             projectID,
+		RemoteSessionIssuerID: uuid.NullUUID{UUID: remoteIssuerID, Valid: true},
+	})
+	if err != nil {
+		return "", fmt.Errorf("list meta mcp members for provider: %w", err)
+	}
+	if len(claimants) > 0 {
+		return "another member of this meta mcp server", nil
+	}
+
+	rsRepo := remotesessionsrepo.New(s.db)
+	clients, err := rsRepo.ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
+		UserSessionIssuerID: issuerID,
+		ProjectID:           conv.ToNullUUID(projectID),
+		OrganizationID:      conv.ToPGText(authCtx.ActiveOrganizationID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("list provider clients: %w", err)
+	}
+	for _, client := range clients {
+		if client.RemoteSessionIssuerID != remoteIssuerID {
+			continue
+		}
+		servers, err := rsRepo.ListOrganizationMcpServersForClient(ctx, client.ClientID)
+		if err != nil {
+			return "", fmt.Errorf("list servers for provider client: %w", err)
+		}
+		for _, server := range servers {
+			if server.Url != "" {
+				return "a remote server sharing the same OAuth client", nil
+			}
+		}
+	}
+	return "", nil
+}
+
+func hostedMemberProviderError(ctx context.Context, logger *slog.Logger, serverSlug, resourceURL string, err error) error {
+	switch {
+	case errors.Is(err, platformmcp.ErrIdentityProviderAttachmentUnsupported):
+		return oops.E(oops.CodeInvalid, err, "hosted server %q authenticates users with %s, which offers no OAuth client registration Gram can use, so it cannot join a gateway", serverSlug, resourceURL).LogError(ctx, logger)
+	case errors.Is(err, platformmcp.ErrIdentityProviderAttachmentConflict):
+		return oops.E(oops.CodeConflict, err, "the OAuth provider for hosted server %q (%s) conflicts with one already registered in this project", serverSlug, resourceURL).LogError(ctx, logger)
+	default:
+		return oops.E(oops.CodeUnavailable, err, "could not register an OAuth client with %s for hosted server %q; retry shortly", resourceURL, serverSlug).LogError(ctx, logger)
+	}
+}
+
+func hostedProviderIssuerSlug(issuerURL string) string {
+	sum := sha256.Sum256([]byte(strings.TrimRight(issuerURL, "/")))
+	return "gateway-provider-" + hex.EncodeToString(sum[:8])
+}

--- a/server/internal/metamcp/hostedmember_test.go
+++ b/server/internal/metamcp/hostedmember_test.go
@@ -1,0 +1,662 @@
+package metamcp_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/meta_mcp"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	deploymentsrepo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	externalmcprepo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	externalmcptypes "github.com/speakeasy-api/gram/server/internal/externalmcp/repo/types"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/metamcp"
+	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	remotesessionsrepo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// fakeProvider is an MCP resource server plus its authorization server on one
+// TLS origin: RFC 9728 protected-resource metadata under /mcp, RFC 8414
+// authorization-server metadata, and an RFC 7591 registration endpoint.
+type fakeProvider struct {
+	server        *httptest.Server
+	registrations atomic.Int32
+	registerCode  int
+	publicClient  bool
+}
+
+func newFakeProvider(t *testing.T) *fakeProvider {
+	t.Helper()
+
+	p := &fakeProvider{registerCode: http.StatusCreated}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"resource":              p.resourceURL(),
+			"authorization_servers": []string{p.issuer()},
+			"scopes_supported":      []string{"read"},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"issuer":                                p.issuer(),
+			"authorization_endpoint":                p.issuer() + "/authorize",
+			"token_endpoint":                        p.issuer() + "/token",
+			"registration_endpoint":                 p.issuer() + "/register",
+			"response_types_supported":              []string{"code"},
+			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+			"code_challenge_methods_supported":      []string{"S256"},
+			"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "none"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		p.registrations.Add(1)
+		if p.registerCode != http.StatusCreated {
+			w.WriteHeader(p.registerCode)
+			_, _ = w.Write([]byte(`{"error":"invalid_client_metadata"}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		if p.publicClient {
+			writeJSON(t, w, map[string]any{
+				"client_id":                  "hosted-member-public-client",
+				"token_endpoint_auth_method": "none",
+			})
+			return
+		}
+		writeJSON(t, w, map[string]any{
+			"client_id":                  "hosted-member-client",
+			"client_secret":              "hosted-member-secret",
+			"token_endpoint_auth_method": "client_secret_basic",
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	p.server = httptest.NewTLSServer(mux)
+	t.Cleanup(p.server.Close)
+	return p
+}
+
+func (p *fakeProvider) issuer() string      { return p.server.URL }
+func (p *fakeProvider) resourceURL() string { return p.server.URL + "/mcp" }
+
+func (p *fakeProvider) policy(t *testing.T) *guardian.Policy {
+	t.Helper()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(p.server.Certificate())
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{}, guardian.WithTLSRootCAs(pool))
+	require.NoError(t, err)
+	return policy
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
+// newTestServiceWithProviders builds the service with the real platform
+// attachment service reaching the fake provider through policy.
+func newTestServiceWithProviders(t *testing.T, policy *guardian.Policy) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	billingClient := billing.NewStubClient(logger, tracerProvider)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
+	ctx = authztest.InitAuthContext(t, ctx, conn, sessionManager)
+
+	auditLogger := audit.NewLogger()
+	serverURL, err := url.Parse("https://gram.test")
+	require.NoError(t, err)
+	providers := platformmcp.NewCatalogIdentityProviderAttachmentService(conn, testenv.NewEncryptionClient(t), policy, auditLogger, serverURL)
+	svc := metamcp.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, providers)
+
+	return ctx, &testInstance{service: svc, conn: conn, sessionManager: sessionManager}
+}
+
+type externalMCPTool struct {
+	slug          string
+	remoteURL     string
+	issuer        string
+	requiresOAuth bool
+}
+
+// seedHostedServer creates a toolset whose latest version selects the given
+// external MCP tools and an issuer-less mcp_servers row fronting it, as the
+// gateway add-member picker does.
+func seedHostedServer(t *testing.T, ctx context.Context, ti *testInstance, tools ...externalMCPTool) uuid.UUID {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	deploymentID, err := deploymentsrepo.New(ti.conn).InsertDeployment(ctx, deploymentsrepo.InsertDeploymentParams{
+		ProjectID:      projectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         "test-user",
+		IdempotencyKey: uuid.New().String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, deploymentsrepo.New(ti.conn).CreateDeploymentStatus(ctx, deploymentsrepo.CreateDeploymentStatusParams{
+		DeploymentID: deploymentID,
+		Status:       "completed",
+	}))
+
+	extRepo := externalmcprepo.New(ti.conn)
+	toolURNs := make([]urn.Tool, 0, len(tools))
+	for _, tool := range tools {
+		attachment, err := extRepo.CreateExternalMCPAttachment(ctx, externalmcprepo.CreateExternalMCPAttachmentParams{
+			DeploymentID:            deploymentID,
+			RegistryID:              uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+			Name:                    tool.slug,
+			Slug:                    tool.slug,
+			RegistryServerSpecifier: tool.slug,
+		})
+		require.NoError(t, err)
+
+		toolURN := urn.NewTool(urn.ToolKindExternalMCP, tool.slug, "call")
+		toolURNs = append(toolURNs, toolURN)
+		_, err = extRepo.CreateExternalMCPToolDefinition(ctx, externalmcprepo.CreateExternalMCPToolDefinitionParams{
+			ExternalMcpAttachmentID:    attachment.ID,
+			ToolUrn:                    toolURN.String(),
+			Type:                       "direct",
+			Name:                       pgtype.Text{String: tool.slug, Valid: true},
+			Description:                pgtype.Text{String: "proxy tool", Valid: true},
+			Schema:                     []byte(`{"type":"object"}`),
+			RemoteUrl:                  tool.remoteURL,
+			TransportType:              externalmcptypes.TransportTypeStreamableHTTP,
+			RequiresOauth:              tool.requiresOAuth,
+			OauthVersion:               "2.1",
+			OauthAuthorizationEndpoint: conv.ToPGText(tool.issuer + "/authorize"),
+			OauthTokenEndpoint:         conv.ToPGText(tool.issuer + "/token"),
+			OauthRegistrationEndpoint:  conv.ToPGText(tool.issuer + "/register"),
+			OauthScopesSupported:       []string{},
+			HeaderDefinitions:          nil,
+			Title:                      pgtype.Text{},
+			ReadOnlyHint:               pgtype.Bool{},
+			DestructiveHint:            pgtype.Bool{},
+			IdempotentHint:             pgtype.Bool{},
+			OpenWorldHint:              pgtype.Bool{},
+		})
+		require.NoError(t, err)
+	}
+
+	toolsetID := seedToolsetBackend(t, ctx, ti.conn, authCtx.ActiveOrganizationID, projectID)
+	_, err = toolsetsrepo.New(ti.conn).CreateToolsetVersion(ctx, toolsetsrepo.CreateToolsetVersionParams{
+		ToolsetID:     toolsetID,
+		Version:       1,
+		ToolUrns:      toolURNs,
+		ResourceUrns:  []urn.Resource{},
+		PredecessorID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+	require.NoError(t, err)
+
+	return seedHostedRow(t, ctx, ti, projectID, toolsetID, uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+}
+
+// seedHostedRow creates an mcp_servers row fronting toolsetID; issuer-less
+// unless issuerID is set.
+func seedHostedRow(t *testing.T, ctx context.Context, ti *testInstance, projectID, toolsetID uuid.UUID, issuerID uuid.NullUUID) uuid.UUID {
+	t.Helper()
+
+	serverID, err := uuid.NewV7()
+	require.NoError(t, err)
+	server, err := mcpserversrepo.New(ti.conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:                    serverID,
+		ProjectID:             projectID,
+		Name:                  conv.ToPGText("hosted member"),
+		Slug:                  conv.ToPGText("hosted-member-" + uuid.NewString()[:8]),
+		EnvironmentID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		UserSessionIssuerID:   issuerID,
+		RemoteMcpServerID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		TunneledMcpServerID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ToolsetID:             conv.ToNullUUID(toolsetID),
+		UnproxiedMcpServerID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ToolVariationsGroupID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		Visibility:            "private",
+	})
+	require.NoError(t, err)
+	return server.ID
+}
+
+// seedProviderIssuer inserts a remote_session_issuer for a specific
+// authorization server URL.
+func seedProviderIssuer(t *testing.T, ctx context.Context, ti *testInstance, issuerURL string) uuid.UUID {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	issuer, err := remotesessionsrepo.New(ti.conn).CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         conv.ToNullUUID(*authCtx.ProjectID),
+		OrganizationID:                    conv.ToPGText(authCtx.ActiveOrganizationID),
+		Slug:                              "provider-" + uuid.NewString()[:8],
+		Issuer:                            issuerURL,
+		Name:                              conv.ToPGTextEmpty(""),
+		LogoAssetID:                       uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ClientSetupDocumentationUrl:       conv.ToPGTextEmpty(""),
+		AuthorizationEndpoint:             conv.ToPGText(issuerURL + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(issuerURL + "/token"),
+		RevocationEndpoint:                conv.ToPGTextEmpty(""),
+		RegistrationEndpoint:              conv.ToPGText(issuerURL + "/register"),
+		JwksUri:                           conv.ToPGTextEmpty(""),
+		ServiceDocumentation:              conv.ToPGTextEmpty(""),
+		OpPolicyUri:                       conv.ToPGTextEmpty(""),
+		OpTosUri:                          conv.ToPGTextEmpty(""),
+		ScopesSupported:                   []string{},
+		GrantTypesSupported:               []string{"authorization_code"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		ClientIDMetadataDocumentSupported: false,
+		Oidc:                              false,
+		Passthrough:                       false,
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
+func loadServer(t *testing.T, ctx context.Context, ti *testInstance, serverID uuid.UUID) mcpserversrepo.McpServer {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	server, err := mcpserversrepo.New(ti.conn).GetMCPServerByIDAndProjectID(ctx, mcpserversrepo.GetMCPServerByIDAndProjectIDParams{
+		ID:        serverID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	return server
+}
+
+func listMembers(t *testing.T, ctx context.Context, ti *testInstance, metaID string) []metamcprepo.ListMetaMCPMembersRow {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	members, err := metamcprepo.New(ti.conn).ListMetaMCPMembers(ctx, metamcprepo.ListMetaMCPMembersParams{
+		MetaMcpServerID: uuid.MustParse(metaID),
+		ProjectID:       *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	return members
+}
+
+func addMember(ctx context.Context, ti *testInstance, metaID string, serverID uuid.UUID) error {
+	_, err := ti.service.AddMetaMcpMember(ctx, &gen.AddMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		MetaMcpServerID:  metaID,
+		McpServerID:      serverID.String(),
+		SortOrder:        nil,
+	})
+	if err != nil {
+		return fmt.Errorf("add meta mcp member: %w", err)
+	}
+	return nil
+}
+
+func TestAddMetaMcpMember_HostedMemberWiresUpstreamProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted oauth host")
+	gatewayIssuerID := uuid.MustParse(*meta.UserSessionIssuerID)
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "notes", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+
+	server := loadServer(t, ctx, ti, serverID)
+	require.False(t, server.UserSessionIssuerID.Valid, "the hosted server's own endpoint stays as it was")
+	require.True(t, server.RemoteSessionIssuerID.Valid, "provider issuer is stamped for member token routing")
+	require.Equal(t, int32(1), provider.registrations.Load(), "one dynamic client registration")
+
+	rsRepo := remotesessionsrepo.New(ti.conn)
+	issuer, err := rsRepo.GetRemoteSessionIssuerByID(ctx, remotesessionsrepo.GetRemoteSessionIssuerByIDParams{
+		ID:                    server.RemoteSessionIssuerID.UUID,
+		ProjectID:             conv.ToNullUUID(projectID),
+		IncludeOrganizational: false,
+		OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:         false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, strings.TrimRight(provider.issuer(), "/"), strings.TrimRight(issuer.Issuer, "/"))
+	require.Equal(t, provider.issuer()+"/register", issuer.RegistrationEndpoint.String)
+
+	gatewayClients, err := rsRepo.ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
+		UserSessionIssuerID: gatewayIssuerID,
+		ProjectID:           conv.ToNullUUID(projectID),
+		OrganizationID:      conv.ToPGText(authCtx.ActiveOrganizationID),
+	})
+	require.NoError(t, err)
+	require.Len(t, gatewayClients, 1, "registered client is offered on the gateway's consent page")
+	require.Equal(t, "hosted-member-client", gatewayClients[0].ExternalClientID)
+	require.Equal(t, server.RemoteSessionIssuerID.UUID, gatewayClients[0].RemoteSessionIssuerID)
+
+	members := listMembers(t, ctx, ti, meta.ID)
+	require.Len(t, members, 1)
+
+	// Removal unbinds the provider from the gateway; re-adding rebinds the
+	// existing registration instead of registering another.
+	require.NoError(t, ti.service.RemoveMetaMcpMember(ctx, &gen.RemoveMetaMcpMemberPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		ID:               members[0].ID.String(),
+	}))
+	require.Equal(t, 0, countGatewayClientsForUpstream(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, gatewayIssuerID, server.RemoteSessionIssuerID.UUID))
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+	require.Equal(t, int32(1), provider.registrations.Load(), "existing registration is reused")
+	require.Equal(t, 1, countGatewayClientsForUpstream(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, gatewayIssuerID, server.RemoteSessionIssuerID.UUID))
+	require.Equal(t, server.RemoteSessionIssuerID, loadServer(t, ctx, ti, serverID).RemoteSessionIssuerID)
+}
+
+func TestAddMetaMcpMember_HostedMemberAcceptsPublicClient(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	provider.publicClient = true
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted public host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "public-client", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+	require.True(t, loadServer(t, ctx, ti, serverID).RemoteSessionIssuerID.Valid)
+	require.Equal(t, int32(1), provider.registrations.Load())
+}
+
+func TestAddMetaMcpMember_HostedMemberWithoutOAuthToolsIsUntouched(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted plain host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "public", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: false})
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+
+	server := loadServer(t, ctx, ti, serverID)
+	require.False(t, server.UserSessionIssuerID.Valid)
+	require.False(t, server.RemoteSessionIssuerID.Valid)
+	require.Equal(t, int32(0), provider.registrations.Load())
+}
+
+func TestAddMetaMcpMember_ProxiedMemberIgnoresProviderWiring(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	meta := seedMetaMcpServer(t, ctx, ti, "remote host")
+	serverID := seedMcpServer(t, ctx, ti.conn, *authCtx.ProjectID)
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+	require.Equal(t, int32(0), provider.registrations.Load())
+	require.Len(t, listMembers(t, ctx, ti, meta.ID), 1)
+}
+
+func TestAddMetaMcpMember_HostedMemberRegistrationRefusedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	provider.registerCode = http.StatusBadRequest
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted refused host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "refused", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+
+	err := addMember(ctx, ti, meta.ID, serverID)
+	requireOopsCode(t, err, oops.CodeInvalid)
+	require.Contains(t, err.Error(), provider.resourceURL())
+	require.Empty(t, listMembers(t, ctx, ti, meta.ID), "a member that cannot route a credential is not added")
+
+	server := loadServer(t, ctx, ti, serverID)
+	require.False(t, server.UserSessionIssuerID.Valid)
+	require.False(t, server.RemoteSessionIssuerID.Valid)
+}
+
+func TestAddMetaMcpMember_HostedMemberRegistrationOutageIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	provider.registerCode = http.StatusServiceUnavailable
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted outage host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "outage", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+
+	requireOopsCode(t, addMember(ctx, ti, meta.ID, serverID), oops.CodeUnavailable)
+	require.Empty(t, listMembers(t, ctx, ti, meta.ID))
+
+	provider.registerCode = http.StatusCreated
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+	require.Len(t, listMembers(t, ctx, ti, meta.ID), 1)
+}
+
+func TestAddMetaMcpMember_HostedMemberRejectedAddKeepsGatewayClean(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "unknown-meta", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+	requireOopsCode(t, addMember(ctx, ti, uuid.NewString(), serverID), oops.CodeNotFound)
+	require.Equal(t, int32(0), provider.registrations.Load(), "no provider traffic without a gateway to bind to")
+
+	// The add transaction rejects a second hosted server on the same toolset;
+	// the binding the first member owns survives, nothing else is left behind.
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted shared backend host")
+	gatewayIssuerID := uuid.MustParse(*meta.UserSessionIssuerID)
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+	first := loadServer(t, ctx, ti, serverID)
+
+	twinID := seedHostedRow(t, ctx, ti, projectID, first.ToolsetID.UUID, uuid.NullUUID{UUID: uuid.Nil, Valid: false})
+	requireOopsCode(t, addMember(ctx, ti, meta.ID, twinID), oops.CodeConflict)
+	require.Equal(t, int32(1), provider.registrations.Load(), "the existing registration is reused")
+	require.Equal(t, 1, countGatewayClientsForUpstream(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, gatewayIssuerID, first.RemoteSessionIssuerID.UUID))
+	require.Len(t, listMembers(t, ctx, ti, meta.ID), 1)
+}
+
+func TestAddMetaMcpMember_HostedMemberSeveralProvidersRejected(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted multi host")
+	serverID := seedHostedServer(t, ctx, ti,
+		externalMCPTool{slug: "first", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true},
+		externalMCPTool{slug: "second", remoteURL: "https://other.example.test/mcp", issuer: "https://other.example.test", requiresOAuth: true},
+	)
+
+	err := addMember(ctx, ti, meta.ID, serverID)
+	requireOopsCode(t, err, oops.CodeInvalid)
+	require.Contains(t, err.Error(), "several OAuth upstreams")
+	require.Equal(t, int32(0), provider.registrations.Load())
+	require.False(t, loadServer(t, ctx, ti, serverID).RemoteSessionIssuerID.Valid)
+}
+
+func TestAddMetaMcpMember_HostedMemberConflictsWithProxiedMemberOnSameProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted shared provider host")
+
+	// A remote member already authenticates with the fake provider.
+	providerIssuerID := seedProviderIssuer(t, ctx, ti, provider.issuer())
+	remoteID := seedMcpServer(t, ctx, ti.conn, projectID)
+	stampAndWireMemberClient(t, ctx, ti.conn, projectID, remoteID, providerIssuerID, createRemoteSessionClient(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, providerIssuerID, "remote-member-client"))
+	require.NoError(t, addMember(ctx, ti, meta.ID, remoteID))
+
+	hostedID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "shared", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+	err := addMember(ctx, ti, meta.ID, hostedID)
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Contains(t, err.Error(), "one credential per provider")
+	require.Equal(t, int32(0), provider.registrations.Load(), "the project's existing registration is reused, never duplicated")
+	require.Len(t, listMembers(t, ctx, ti, meta.ID), 1)
+}
+
+func TestAddMetaMcpMember_HostedMemberWithoutAttacherIsRefused(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestService(t)
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted no attacher host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "orphan", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+
+	requireOopsCode(t, addMember(ctx, ti, meta.ID, serverID), oops.CodeInvalid)
+	require.Equal(t, int32(0), provider.registrations.Load())
+	require.Empty(t, listMembers(t, ctx, ti, meta.ID))
+}
+
+func TestAddMetaMcpMember_HostedMemberWithIssuerBindsOnItsOwnIssuer(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted gated host")
+	gatewayIssuerID := uuid.MustParse(*meta.UserSessionIssuerID)
+	orphanID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "gated", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+	toolsetID := loadServer(t, ctx, ti, orphanID).ToolsetID.UUID
+	memberIssuerID := seedUserSessionIssuer(t, ctx, ti.conn, projectID)
+	serverID := seedHostedRow(t, ctx, ti, projectID, toolsetID, conv.ToNullUUID(memberIssuerID))
+
+	require.NoError(t, addMember(ctx, ti, meta.ID, serverID))
+
+	server := loadServer(t, ctx, ti, serverID)
+	require.Equal(t, memberIssuerID, server.UserSessionIssuerID.UUID, "existing issuer is kept")
+	require.True(t, server.RemoteSessionIssuerID.Valid, "derived from the member issuer's binding")
+	memberClients, err := remotesessionsrepo.New(ti.conn).ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
+		UserSessionIssuerID: memberIssuerID,
+		ProjectID:           conv.ToNullUUID(projectID),
+		OrganizationID:      conv.ToPGText(authCtx.ActiveOrganizationID),
+	})
+	require.NoError(t, err)
+	require.Len(t, memberClients, 1, "client is bound to the member's own issuer")
+	require.Equal(t, 1, countGatewayClientsForUpstream(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, gatewayIssuerID, server.RemoteSessionIssuerID.UUID), "auto-attach copies it onto the gateway")
+}
+
+func TestAddMetaMcpMember_ProxiedMemberConflictsWithHostedOnSameProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted first host")
+	hostedID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "first", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+	require.NoError(t, addMember(ctx, ti, meta.ID, hostedID))
+	providerIssuerID := loadServer(t, ctx, ti, hostedID).RemoteSessionIssuerID.UUID
+
+	remoteID := seedMcpServer(t, ctx, ti.conn, projectID)
+	stampAndWireMemberClient(t, ctx, ti.conn, projectID, remoteID, providerIssuerID, createRemoteSessionClient(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, providerIssuerID, "late-remote-client"))
+
+	err := addMember(ctx, ti, meta.ID, remoteID)
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Contains(t, err.Error(), "one credential per provider")
+	require.Len(t, listMembers(t, ctx, ti, meta.ID), 1)
+}
+
+func TestAddMetaMcpMember_HostedMemberUnbindsSharedClientOnConflict(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := *authCtx.ProjectID
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted shared client host")
+	gatewayIssuerID := uuid.MustParse(*meta.UserSessionIssuerID)
+
+	// A remote server outside the gateway already holds the project's client
+	// for the provider, so any grant on that client is qualified to its URL.
+	providerIssuerID := seedProviderIssuer(t, ctx, ti, provider.issuer())
+	remoteID := seedMcpServer(t, ctx, ti.conn, projectID)
+	stampAndWireMemberClient(t, ctx, ti.conn, projectID, remoteID, providerIssuerID, createRemoteSessionClient(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, providerIssuerID, "shared-client"))
+
+	hostedID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "shared", remoteURL: provider.resourceURL(), issuer: provider.issuer(), requiresOAuth: true})
+	err := addMember(ctx, ti, meta.ID, hostedID)
+	requireOopsCode(t, err, oops.CodeConflict)
+	require.Contains(t, err.Error(), "sharing the same OAuth client")
+	require.Equal(t, int32(0), provider.registrations.Load(), "the existing client was reused rather than re-registered")
+	require.Equal(t, 0, countGatewayClientsForUpstream(t, ctx, ti.conn, projectID, authCtx.ActiveOrganizationID, gatewayIssuerID, providerIssuerID), "the binding this add created is removed again")
+	require.Empty(t, listMembers(t, ctx, ti, meta.ID))
+	require.False(t, loadServer(t, ctx, ti, hostedID).RemoteSessionIssuerID.Valid)
+}
+
+func TestAddMetaMcpMember_HostedMemberCleartextUpstreamRejected(t *testing.T) {
+	t.Parallel()
+
+	provider := newFakeProvider(t)
+	ctx, ti := newTestServiceWithProviders(t, provider.policy(t))
+
+	meta := seedMetaMcpServer(t, ctx, ti, "hosted cleartext host")
+	serverID := seedHostedServer(t, ctx, ti, externalMCPTool{slug: "plain", remoteURL: "http://insecure.example.test/mcp", issuer: "http://insecure.example.test", requiresOAuth: true})
+
+	err := addMember(ctx, ti, meta.ID, serverID)
+	requireOopsCode(t, err, oops.CodeInvalid)
+	require.Contains(t, err.Error(), "must use https")
+	require.Equal(t, int32(0), provider.registrations.Load())
+}

--- a/server/internal/metamcp/impl.go
+++ b/server/internal/metamcp/impl.go
@@ -50,6 +50,7 @@ type Service struct {
 	authz       *authz.Engine
 	audit       *audit.Logger
 	temporalEnv *tenv.Environment
+	providers   HostedMemberProviderAttacher
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -63,6 +64,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
 	temporalEnv *tenv.Environment,
+	providers HostedMemberProviderAttacher,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("metamcp"))
 
@@ -74,6 +76,7 @@ func NewService(
 		authz:       authzEngine,
 		audit:       auditLogger,
 		temporalEnv: temporalEnv,
+		providers:   providers,
 	}
 }
 
@@ -297,13 +300,21 @@ func (s *Service) UpdateMetaMcpServer(ctx context.Context, payload *gen.UpdateMe
 			return nil, oops.E(oops.CodeUnexpected, ierr, "list member provider identities").LogError(ctx, logger)
 		}
 		for _, identity := range identities {
+			// A hosted member's client lives on the previous gateway issuer.
+			memberIssuerID := identity.UserSessionIssuerID
+			if !memberIssuerID.Valid {
+				memberIssuerID = existing.UserSessionIssuerID
+			}
+			if !memberIssuerID.Valid {
+				continue
+			}
 			if lerr := remotesessionsrepo.New(dbtx).LockRemoteSessionIssuerForClientBinding(ctx, identity.RemoteSessionIssuerID.UUID); lerr != nil {
 				return nil, oops.E(oops.CodeUnexpected, lerr, "lock remote session issuer for client binding").LogError(ctx, logger)
 			}
 			if _, aerr := txRepo.AutoAttachMemberProviderClient(ctx, repo.AutoAttachMemberProviderClientParams{
 				GatewayIssuerID: issuerID.UUID,
 				ProjectID:       *authCtx.ProjectID,
-				MemberIssuerID:  identity.UserSessionIssuerID.UUID,
+				MemberIssuerID:  memberIssuerID.UUID,
 				RemoteIssuerID:  identity.RemoteSessionIssuerID.UUID,
 			}); aerr != nil {
 				return nil, oops.E(oops.CodeUnexpected, aerr, "attach member provider client").LogError(ctx, logger)
@@ -566,6 +577,19 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid sort_order").LogError(ctx, logger)
 	}
 
+	// Registering with the member's upstream provider is a network call, so
+	// it runs before the locked transaction below reads the stamped identity.
+	wiring, err := s.wireHostedMemberProvider(ctx, logger, authCtx, metaID, mcpServerID)
+	if err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			wiring.unbind()
+		}
+	}()
+
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "begin transaction").LogError(ctx, logger)
@@ -597,6 +621,12 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 		return nil, oops.E(oops.CodeUnexpected, err, "lock mcp server").LogError(ctx, logger)
 	}
 
+	if !server.UserSessionIssuerID.Valid && meta.UserSessionIssuerID.Valid {
+		if err := rebindHostedProvider(ctx, dbtx, wiring, meta.UserSessionIssuerID.UUID); err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "rebind hosted member provider").LogError(ctx, logger)
+		}
+	}
+
 	// The gateway addresses members by qualified serverslug--toolname, so a
 	// slugless server (legacy pre-2026-05 rows never updated since) can never
 	// be reached; updating the server generates a slug. Unproxied backends
@@ -624,6 +654,23 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 	}
 	if sharing > 0 {
 		return nil, oops.E(oops.CodeConflict, nil, "another member of this meta mcp server already fronts the same backend").LogError(ctx, logger)
+	}
+
+	// A hosted member routes an unqualified grant; a proxied member on the
+	// same provider would qualify new grants to its URL (see
+	// requireUnqualifiedHostedGrant for the reverse direction).
+	if !server.ToolsetID.Valid && server.RemoteSessionIssuerID.Valid {
+		hosted, err := txRepo.CountHostedMetaMCPMembersOnProvider(ctx, repo.CountHostedMetaMCPMembersOnProviderParams{
+			MetaMcpServerID: metaID,
+			ProjectID:       *authCtx.ProjectID,
+			RemoteIssuerID:  server.RemoteSessionIssuerID,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "count hosted meta mcp members on provider").LogError(ctx, logger)
+		}
+		if hosted > 0 {
+			return nil, oops.E(oops.CodeConflict, nil, "a hosted member of this meta mcp server already authenticates with this server's OAuth provider; a gateway routes one credential per provider").LogError(ctx, logger)
+		}
 	}
 
 	member, err := txRepo.CreateMetaMCPMember(ctx, repo.CreateMetaMCPMemberParams{
@@ -693,6 +740,7 @@ func (s *Service) AddMetaMcpMember(ctx context.Context, payload *gen.AddMetaMcpM
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
+	committed = true
 
 	// Every client-binding writer follows its commit with this resync so the
 	// denormalized mcp_servers.remote_session_issuer_id cannot go stale when
@@ -835,7 +883,9 @@ func (s *Service) RemoveMetaMcpMember(ctx context.Context, payload *gen.RemoveMe
 		return oops.E(oops.CodeUnexpected, err, "lock meta mcp membership").LogError(ctx, logger)
 	}
 
-	meta, err := txRepo.GetMetaMCPServer(ctx, repo.GetMetaMCPServerParams{
+	// Locked, not read: UpdateMetaMcpServer rewires member providers under
+	// the same lock, so a removal cannot slip between its listing and attach.
+	meta, err := txRepo.LockMetaMCPServer(ctx, repo.LockMetaMCPServerParams{
 		ID:             existing.MetaMcpServerID,
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
@@ -844,7 +894,7 @@ func (s *Service) RemoveMetaMcpMember(ctx context.Context, payload *gen.RemoveMe
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "meta mcp server not found").LogError(ctx, logger)
 		}
-		return oops.E(oops.CodeUnexpected, err, "get meta mcp server").LogError(ctx, logger)
+		return oops.E(oops.CodeUnexpected, err, "lock meta mcp server").LogError(ctx, logger)
 	}
 
 	deleted, err := txRepo.DeleteMetaMCPMember(ctx, repo.DeleteMetaMCPMemberParams{

--- a/server/internal/metamcp/queries.sql
+++ b/server/internal/metamcp/queries.sql
@@ -329,6 +329,10 @@ ORDER BY m.sort_order, m.created_at, m.id;
 -- holds a client for that upstream (one client per upstream per issuer), or
 -- when the member has no derivable client. Tenancy mirrors the resync
 -- derivation: the member's own project client, or an org-level client.
+--
+-- A hosted member carries no issuer; on a gateway issuer change the caller
+-- passes the previous gateway issuer instead, which holds the client the
+-- gateway bound when the member joined.
 INSERT INTO remote_session_client_user_session_issuers (remote_session_client_id, user_session_issuer_id)
 SELECT c.id, @gateway_issuer_id
 FROM remote_session_clients AS c
@@ -394,10 +398,27 @@ WHERE l.remote_session_client_id = c.id
       )
   );
 
+-- name: CountHostedMetaMCPMembersOnProvider :one
+-- Live hosted members of @meta_mcp_server_id whose tools authenticate with
+-- @remote_issuer_id. A proxied member joining on the same provider would
+-- qualify every new grant to its own URL, which hosted routing cannot accept.
+SELECT count(*)
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = @meta_mcp_server_id
+  AND m.project_id = @project_id
+  AND m.deleted IS FALSE
+  AND s.toolset_id IS NOT NULL
+  AND s.remote_session_issuer_id = @remote_issuer_id;
+
 -- name: ListMemberProviderIdentities :many
 -- Distinct provider identity pairs across a meta server's live members, for
 -- re-running consent wiring when the gateway's issuer changes. Ordered so
--- callers take the per-remote-issuer binding locks deterministically.
+-- callers take the per-remote-issuer binding locks deterministically. A hosted
+-- member contributes its stamped provider with a NULL issuer.
 SELECT DISTINCT s.remote_session_issuer_id, s.user_session_issuer_id
 FROM meta_mcp_server_members m
 JOIN mcp_servers s
@@ -408,5 +429,5 @@ WHERE m.meta_mcp_server_id = @meta_mcp_server_id
   AND m.project_id = @project_id
   AND m.deleted IS FALSE
   AND s.remote_session_issuer_id IS NOT NULL
-  AND s.user_session_issuer_id IS NOT NULL
+  AND (s.user_session_issuer_id IS NOT NULL OR s.toolset_id IS NOT NULL)
 ORDER BY s.remote_session_issuer_id, s.user_session_issuer_id;

--- a/server/internal/metamcp/repo/queries.sql.go
+++ b/server/internal/metamcp/repo/queries.sql.go
@@ -51,6 +51,10 @@ type AutoAttachMemberProviderClientParams struct {
 // holds a client for that upstream (one client per upstream per issuer), or
 // when the member has no derivable client. Tenancy mirrors the resync
 // derivation: the member's own project client, or an org-level client.
+//
+// A hosted member carries no issuer; on a gateway issuer change the caller
+// passes the previous gateway issuer instead, which holds the client the
+// gateway bound when the member joined.
 func (q *Queries) AutoAttachMemberProviderClient(ctx context.Context, arg AutoAttachMemberProviderClientParams) (int64, error) {
 	result, err := q.db.Exec(ctx, autoAttachMemberProviderClient,
 		arg.GatewayIssuerID,
@@ -117,6 +121,36 @@ func (q *Queries) AutoDetachMemberProviderClient(ctx context.Context, arg AutoDe
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const countHostedMetaMCPMembersOnProvider = `-- name: CountHostedMetaMCPMembersOnProvider :one
+SELECT count(*)
+FROM meta_mcp_server_members m
+JOIN mcp_servers s
+  ON s.id = m.mcp_server_id
+ AND s.project_id = m.project_id
+ AND s.deleted IS FALSE
+WHERE m.meta_mcp_server_id = $1
+  AND m.project_id = $2
+  AND m.deleted IS FALSE
+  AND s.toolset_id IS NOT NULL
+  AND s.remote_session_issuer_id = $3
+`
+
+type CountHostedMetaMCPMembersOnProviderParams struct {
+	MetaMcpServerID uuid.UUID
+	ProjectID       uuid.UUID
+	RemoteIssuerID  uuid.NullUUID
+}
+
+// Live hosted members of @meta_mcp_server_id whose tools authenticate with
+// @remote_issuer_id. A proxied member joining on the same provider would
+// qualify every new grant to its own URL, which hosted routing cannot accept.
+func (q *Queries) CountHostedMetaMCPMembersOnProvider(ctx context.Context, arg CountHostedMetaMCPMembersOnProviderParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countHostedMetaMCPMembersOnProvider, arg.MetaMcpServerID, arg.ProjectID, arg.RemoteIssuerID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const countMetaMCPMembersSharingBackend = `-- name: CountMetaMCPMembersSharingBackend :one
@@ -605,7 +639,7 @@ WHERE m.meta_mcp_server_id = $1
   AND m.project_id = $2
   AND m.deleted IS FALSE
   AND s.remote_session_issuer_id IS NOT NULL
-  AND s.user_session_issuer_id IS NOT NULL
+  AND (s.user_session_issuer_id IS NOT NULL OR s.toolset_id IS NOT NULL)
 ORDER BY s.remote_session_issuer_id, s.user_session_issuer_id
 `
 
@@ -621,7 +655,8 @@ type ListMemberProviderIdentitiesRow struct {
 
 // Distinct provider identity pairs across a meta server's live members, for
 // re-running consent wiring when the gateway's issuer changes. Ordered so
-// callers take the per-remote-issuer binding locks deterministically.
+// callers take the per-remote-issuer binding locks deterministically. A hosted
+// member contributes its stamped provider with a NULL issuer.
 func (q *Queries) ListMemberProviderIdentities(ctx context.Context, arg ListMemberProviderIdentitiesParams) ([]ListMemberProviderIdentitiesRow, error) {
 	rows, err := q.db.Query(ctx, listMemberProviderIdentities, arg.MetaMcpServerID, arg.ProjectID)
 	if err != nil {

--- a/server/internal/metamcp/setup_test.go
+++ b/server/internal/metamcp/setup_test.go
@@ -84,7 +84,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := metamcp.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil)
+	svc := metamcp.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, nil)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/platformmcp/catalog_identity_provider_attachment.go
+++ b/server/internal/platformmcp/catalog_identity_provider_attachment.go
@@ -131,26 +131,125 @@ func (s *CatalogIdentityProviderAttachmentService) attachLocked(ctx context.Cont
 		return CatalogIdentityProviderAttachmentResult{}, ErrIdentityProviderAttachmentUnsupported
 	}
 
-	resourceMetadata, _, err := wellknown.DiscoverProtectedResourceMetadata(ctx, s.policy, remote.Url)
+	attached, err := s.attachProvider(ctx, lockQ, principal, project, registration.UserSessionIssuerID.UUID, remote.Url, providerAttachMode{
+		requireConfidential: true,
+		sharedIssuer:        false,
+		issuerSlug:          func(string) string { return attachmentIssuerSlug(registrationID) },
+		issuerName:          "",
+	})
 	if err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, fmt.Errorf("discover registered MCP identity provider: %w: %w", ErrIdentityProviderAttachmentUnsupported, err)
+		return CatalogIdentityProviderAttachmentResult{}, err
+	}
+	return CatalogIdentityProviderAttachmentResult{Attached: true, ProviderURL: attached.IssuerURL}, nil
+}
+
+// UpstreamProviderAttachment is the client attachProvider bound. Bound is true
+// when this call created the binding, so a caller that fails afterwards knows
+// it is its own to remove.
+type UpstreamProviderAttachment struct {
+	Bound                 bool
+	IssuerURL             string
+	RemoteSessionIssuerID uuid.UUID
+	ClientID              uuid.UUID
+}
+
+// UpstreamProviderAttachmentInput names the issuer to bind and the resource
+// whose provider to register with. IssuerSlug names a newly discovered
+// provider's issuer row from its issuer URL.
+type UpstreamProviderAttachmentInput struct {
+	UserSessionIssuerID uuid.UUID
+	ResourceURL         string
+	IssuerSlug          func(issuerURL string) string
+	// IssuerName labels a newly discovered provider on consent pages.
+	IssuerName string
+}
+
+// providerAttachMode is the per-caller shape of attachProvider.
+type providerAttachMode struct {
+	// requireConfidential rejects public clients, as the browser catalog does.
+	requireConfidential bool
+	// sharedIssuer: the issuer fronts several providers, so only clients for
+	// this provider are matched and an existing project client for it is
+	// bound rather than registering another.
+	sharedIssuer bool
+	issuerSlug   func(issuerURL string) string
+	issuerName   string
+}
+
+// AttachUpstreamProvider binds the OAuth provider protecting input.ResourceURL
+// to an issuer that may already front other providers, reusing a client this
+// project registered with it and registering one otherwise. Trusted
+// server-side callers only: the resource URL must come from a persisted
+// definition, never from an MCP or browser input. Safe to retry.
+func (s *CatalogIdentityProviderAttachmentService) AttachUpstreamProvider(ctx context.Context, principal Principal, project ResolvedProject, input UpstreamProviderAttachmentInput) (UpstreamProviderAttachment, error) {
+	if s == nil || s.db == nil || s.enc == nil || s.policy == nil || s.audit == nil || s.serverURL == nil || principal.UserID == "" || principal.OrganizationID == "" || project.ID == uuid.Nil || input.UserSessionIssuerID == uuid.Nil || input.ResourceURL == "" || input.IssuerSlug == nil {
+		return UpstreamProviderAttachment{}, ErrIdentityProviderAttachmentUnavailable
+	}
+
+	// Before any upstream registration, so a stale issuer cannot orphan one.
+	if _, err := remotesessionsrepo.New(s.db).GetUserSessionIssuerForProject(ctx, remotesessionsrepo.GetUserSessionIssuerForProjectParams{ID: input.UserSessionIssuerID, ProjectID: project.ID, OrganizationID: principal.OrganizationID}); err != nil {
+		return UpstreamProviderAttachment{}, fmt.Errorf("validate registered MCP session issuer: %w: %w", ErrIdentityProviderAttachmentConflict, err)
+	}
+
+	lockTx, err := s.db.Begin(ctx)
+	if err != nil {
+		return UpstreamProviderAttachment{}, fmt.Errorf("begin identity-provider attachment lock: %w", err)
+	}
+	defer func() { _ = lockTx.Rollback(ctx) }()
+
+	result, err := s.attachProvider(ctx, platformrepo.New(lockTx), principal, project, input.UserSessionIssuerID, input.ResourceURL, providerAttachMode{
+		requireConfidential: false,
+		sharedIssuer:        true,
+		issuerSlug:          input.IssuerSlug,
+		issuerName:          input.IssuerName,
+	})
+	if err != nil {
+		return UpstreamProviderAttachment{}, err
+	}
+	if err := lockTx.Commit(ctx); err != nil {
+		return UpstreamProviderAttachment{}, fmt.Errorf("commit identity-provider attachment lock: %w", err)
+	}
+	return result, nil
+}
+
+// attachProvider discovers the authorization server protecting resourceURL and
+// binds a client for it to userSessionIssuerID, registering one when needed.
+func (s *CatalogIdentityProviderAttachmentService) attachProvider(ctx context.Context, lockQ *platformrepo.Queries, principal Principal, project ResolvedProject, userSessionIssuerID uuid.UUID, resourceURL string, mode providerAttachMode) (UpstreamProviderAttachment, error) {
+	resourceMetadata, _, err := wellknown.DiscoverProtectedResourceMetadata(ctx, s.policy, resourceURL)
+	if err != nil {
+		return UpstreamProviderAttachment{}, fmt.Errorf("discover registered MCP identity provider: %w: %w", discoveryFailureKind(err), err)
 	}
 	metadata, err := s.discoverSupportedIssuerMetadata(ctx, resourceMetadata.AuthorizationServers)
 	if err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, err
+		return UpstreamProviderAttachment{}, err
 	}
 	if err := lockQ.LockPlatformMCPRemoteIssuerAttachment(ctx, platformrepo.LockPlatformMCPRemoteIssuerAttachmentParams{
 		OrganizationID: principal.OrganizationID,
 		ProjectID:      project.ID.String(),
 		Issuer:         strings.TrimRight(metadata.Issuer, "/"),
 	}); err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, fmt.Errorf("lock identity-provider issuer attachment: %w", err)
+		return UpstreamProviderAttachment{}, fmt.Errorf("lock identity-provider issuer attachment: %w", err)
 	}
 
-	if attached, err := s.matchingAttachment(ctx, principal.OrganizationID, project, registration.UserSessionIssuerID.UUID, metadata.Issuer); err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, err
+	if match, attached, err := s.matchingAttachment(ctx, principal.OrganizationID, project, userSessionIssuerID, metadata.Issuer, mode.sharedIssuer); err != nil {
+		return UpstreamProviderAttachment{}, err
 	} else if attached {
-		return CatalogIdentityProviderAttachmentResult{Attached: true, ProviderURL: metadata.Issuer}, nil
+		return UpstreamProviderAttachment{Bound: false, IssuerURL: metadata.Issuer, RemoteSessionIssuerID: match.RemoteSessionIssuerID, ClientID: match.ClientID}, nil
+	}
+
+	// A shared issuer reuses a client the project already registered with
+	// the provider rather than registering another; ensureIssuer is idempotent
+	// so running it ahead of registration costs nothing.
+	if mode.sharedIssuer {
+		issuer, err := s.ensureIssuer(ctx, principal, project, mode.issuerSlug(metadata.Issuer), mode.issuerName, metadata)
+		if err != nil {
+			return UpstreamProviderAttachment{}, err
+		}
+		if clientID, bound, ok, err := s.bindExistingProjectClient(ctx, principal, project, userSessionIssuerID, issuer.ID); err != nil {
+			return UpstreamProviderAttachment{}, err
+		} else if ok {
+			return UpstreamProviderAttachment{Bound: bound, IssuerURL: metadata.Issuer, RemoteSessionIssuerID: issuer.ID, ClientID: clientID}, nil
+		}
 	}
 
 	// This is server-to-server; any client secret stays in the stack frame only
@@ -162,21 +261,76 @@ func (s *CatalogIdentityProviderAttachmentService) attachLocked(ctx context.Cont
 		TokenEndpointAuthMethod: optionalString(browserCatalogDCRAuthMethod),
 	})
 	if err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, identityProviderDynamicRegistrationError(err)
+		return UpstreamProviderAttachment{}, identityProviderDynamicRegistrationError(err)
 	}
-	if !validBrowserCatalogDynamicClient(registered) {
-		return CatalogIdentityProviderAttachmentResult{}, ErrIdentityProviderAttachmentUnsupported
+	if mode.requireConfidential && !validBrowserCatalogDynamicClient(registered) {
+		return UpstreamProviderAttachment{}, ErrIdentityProviderAttachmentUnsupported
 	}
-	issuer, err := s.ensureIssuer(ctx, principal, project, registrationID, metadata)
+	if !mode.requireConfidential && !validDynamicClient(registered) {
+		return UpstreamProviderAttachment{}, ErrIdentityProviderAttachmentUnsupported
+	}
+	issuer, err := s.ensureIssuer(ctx, principal, project, mode.issuerSlug(metadata.Issuer), mode.issuerName, metadata)
 	if err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, err
+		return UpstreamProviderAttachment{}, err
 	}
 
-	attached, err := s.createAndAttachClient(ctx, principal, project, registration.UserSessionIssuerID.UUID, issuer.ID, resourceMetadata.ScopesSupported, registered)
+	clientID, bound, err := s.createAndAttachClient(ctx, principal, project, userSessionIssuerID, issuer.ID, resourceMetadata.ScopesSupported, registered)
 	if err != nil {
-		return CatalogIdentityProviderAttachmentResult{}, err
+		return UpstreamProviderAttachment{}, err
 	}
-	return CatalogIdentityProviderAttachmentResult{Attached: attached, ProviderURL: metadata.Issuer}, nil
+	return UpstreamProviderAttachment{Bound: bound, IssuerURL: metadata.Issuer, RemoteSessionIssuerID: issuer.ID, ClientID: clientID}, nil
+}
+
+// bindExistingProjectClient binds a client this project already registered
+// with the provider, reporting the client and whether this call bound it.
+// ok is false when the project holds none.
+func (s *CatalogIdentityProviderAttachmentService) bindExistingProjectClient(ctx context.Context, principal Principal, project ResolvedProject, userSessionIssuerID, issuerID uuid.UUID) (clientID uuid.UUID, bound, ok bool, err error) {
+	clients, err := remotesessionsrepo.New(s.db).ListRemoteSessionClientsByProjectID(ctx, remotesessionsrepo.ListRemoteSessionClientsByProjectIDParams{
+		ProjectID:             project.ID,
+		OrganizationID:        principal.OrganizationID,
+		RemoteSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+		Cursor:                uuid.NullUUID{},
+		LimitValue:            1,
+	})
+	if err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("list identity-provider clients: %w", err)
+	}
+	if len(clients) == 0 {
+		return uuid.Nil, false, false, nil
+	}
+	clientID = clients[0].RemoteSessionClient.ID
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("begin identity-provider client binding: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := remotesessionsrepo.New(tx)
+	if err := q.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("lock identity provider for client binding: %w", err)
+	}
+	// Under the lock: a concurrent writer may have bound a client already.
+	already, err := q.ListRemoteSessionClientsByProjectIDForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsByProjectIDForUserSessionIssuerParams{
+		ProjectID:             project.ID,
+		UserSessionIssuerID:   userSessionIssuerID,
+		OrganizationID:        principal.OrganizationID,
+		RemoteSessionIssuerID: uuid.NullUUID{UUID: issuerID, Valid: true},
+		Cursor:                uuid.NullUUID{},
+		LimitValue:            1,
+	})
+	if err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("check existing identity-provider client attachment: %w", err)
+	}
+	if len(already) > 0 {
+		return already[0].RemoteSessionClient.ID, false, true, nil
+	}
+	if err := q.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{RemoteSessionClientID: clientID, UserSessionIssuerID: userSessionIssuerID}); err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("bind identity-provider client: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, false, false, fmt.Errorf("commit identity-provider client binding: %w", err)
+	}
+	return clientID, true, true, nil
 }
 
 func (s *CatalogIdentityProviderAttachmentService) discoverSupportedIssuerMetadata(ctx context.Context, authorizationServers []string) (remotesessions.DiscoveredIssuerMetadata, error) {
@@ -197,25 +351,36 @@ func (s *CatalogIdentityProviderAttachmentService) discoverSupportedIssuerMetada
 	return remotesessions.DiscoveredIssuerMetadata{}, ErrIdentityProviderAttachmentUnsupported
 }
 
-func (s *CatalogIdentityProviderAttachmentService) matchingAttachment(ctx context.Context, organizationID string, project ResolvedProject, userSessionIssuerID uuid.UUID, issuerURL string) (bool, error) {
+// matchingAttachment reports the provider client already bound to the issuer.
+// A single-provider issuer holding a client for another provider conflicts; a
+// shared issuer only counts clients for this provider.
+func (s *CatalogIdentityProviderAttachmentService) matchingAttachment(ctx context.Context, organizationID string, project ResolvedProject, userSessionIssuerID uuid.UUID, issuerURL string, sharedIssuer bool) (remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerRow, bool, error) {
 	clients, err := remotesessionsrepo.New(s.db).ListRemoteSessionClientsForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerParams{
 		UserSessionIssuerID: userSessionIssuerID,
 		ProjectID:           conv.ToNullUUID(project.ID),
 		OrganizationID:      conv.ToPGText(organizationID),
 	})
 	if err != nil {
-		return false, fmt.Errorf("list registered identity providers: %w", err)
+		return remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerRow{}, false, fmt.Errorf("list registered identity providers: %w", err)
+	}
+	if sharedIssuer {
+		clients = slices.DeleteFunc(clients, func(c remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerRow) bool {
+			return !sameIssuerURL(c.IssuerUrl, issuerURL)
+		})
 	}
 	if len(clients) == 0 {
-		return false, nil
+		return remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerRow{}, false, nil
 	}
 	if len(clients) != 1 || !sameIssuerURL(clients[0].IssuerUrl, issuerURL) {
-		return false, ErrIdentityProviderAttachmentConflict
+		return remotesessionsrepo.ListRemoteSessionClientsForUserSessionIssuerRow{}, false, ErrIdentityProviderAttachmentConflict
 	}
-	return true, nil
+	return clients[0], true, nil
 }
 
-func (s *CatalogIdentityProviderAttachmentService) ensureIssuer(ctx context.Context, principal Principal, project ResolvedProject, registrationID uuid.UUID, metadata remotesessions.DiscoveredIssuerMetadata) (remotesessionsrepo.RemoteSessionIssuer, error) {
+func (s *CatalogIdentityProviderAttachmentService) ensureIssuer(ctx context.Context, principal Principal, project ResolvedProject, issuerSlug, issuerName string, metadata remotesessions.DiscoveredIssuerMetadata) (remotesessionsrepo.RemoteSessionIssuer, error) {
+	if strings.TrimSpace(issuerName) == "" {
+		issuerName = "Remote identity provider"
+	}
 	issuers, err := remotesessionsrepo.New(s.db).ListRemoteSessionIssuersByIssuerURL(ctx, remotesessionsrepo.ListRemoteSessionIssuersByIssuerURLParams{
 		Issuers:               []string{metadata.Issuer},
 		ProjectID:             conv.ToNullUUID(project.ID),
@@ -244,30 +409,27 @@ func (s *CatalogIdentityProviderAttachmentService) ensureIssuer(ctx context.Cont
 	defer func() { _ = tx.Rollback(ctx) }()
 	q := remotesessionsrepo.New(tx)
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, remotesessionsrepo.CreateRemoteSessionIssuerParams{
-		ProjectID:                         conv.ToNullUUID(project.ID),
-		OrganizationID:                    conv.ToPGText(principal.OrganizationID),
-		Slug:                              attachmentIssuerSlug(registrationID),
-		Issuer:                            metadata.Issuer,
-		Name:                              conv.ToPGText("Remote identity provider"),
-		LogoAssetID:                       uuid.NullUUID{},
-		ClientSetupDocumentationUrl:       pgtype.Text{},
-		AuthorizationEndpoint:             conv.ToPGText(metadata.AuthorizationEndpoint),
-		TokenEndpoint:                     conv.ToPGText(metadata.TokenEndpoint),
-		RegistrationEndpoint:              conv.ToPGText(metadata.RegistrationEndpoint),
-		JwksUri:                           pgtype.Text{},
-		ServiceDocumentation:              pgtype.Text{},
-		OpPolicyUri:                       pgtype.Text{},
-		OpTosUri:                          pgtype.Text{},
-		ScopesSupported:                   append([]string(nil), metadata.ScopesSupported...),
-		GrantTypesSupported:               append([]string(nil), metadata.GrantTypesSupported...),
-		ResponseTypesSupported:            append([]string(nil), metadata.ResponseTypesSupported...),
-		TokenEndpointAuthMethodsSupported: append([]string(nil), metadata.TokenEndpointAuthMethodsSupported...),
-		// An empty advertised list must survive as empty here: discovery ran,
-		// so the nullable column should record "advertises no methods" ({})
-		// rather than "not captured" (NULL). The plain append copy used by the
-		// sibling fields collapses an empty slice to nil, so this field uses
-		// slices.Clone, which preserves emptiness — and
-		// DiscoveredIssuerMetadata guarantees the field non-nil.
+		ProjectID:                   conv.ToNullUUID(project.ID),
+		OrganizationID:              conv.ToPGText(principal.OrganizationID),
+		Slug:                        issuerSlug,
+		Issuer:                      metadata.Issuer,
+		Name:                        conv.ToPGText(issuerName),
+		LogoAssetID:                 uuid.NullUUID{},
+		ClientSetupDocumentationUrl: pgtype.Text{},
+		AuthorizationEndpoint:       conv.ToPGText(metadata.AuthorizationEndpoint),
+		TokenEndpoint:               conv.ToPGText(metadata.TokenEndpoint),
+		RegistrationEndpoint:        conv.ToPGText(metadata.RegistrationEndpoint),
+		JwksUri:                     pgtype.Text{},
+		ServiceDocumentation:        pgtype.Text{},
+		OpPolicyUri:                 pgtype.Text{},
+		OpTosUri:                    pgtype.Text{},
+		// NOT NULL columns: an issuer document that omits a list must persist {}.
+		ScopesSupported:                   nonNilStrings(metadata.ScopesSupported),
+		GrantTypesSupported:               nonNilStrings(metadata.GrantTypesSupported),
+		ResponseTypesSupported:            nonNilStrings(metadata.ResponseTypesSupported),
+		TokenEndpointAuthMethodsSupported: nonNilStrings(metadata.TokenEndpointAuthMethodsSupported),
+		// Nullable column: {} records "advertises no methods", NULL "not
+		// captured"; DiscoveredIssuerMetadata guarantees the field non-nil.
 		CodeChallengeMethodsSupported:     slices.Clone(metadata.CodeChallengeMethodsSupported),
 		ClientIDMetadataDocumentSupported: metadata.ClientIDMetadataDocumentSupported,
 		Oidc:                              false,
@@ -295,18 +457,20 @@ func (s *CatalogIdentityProviderAttachmentService) ensureIssuer(ctx context.Cont
 	return issuer, nil
 }
 
-func (s *CatalogIdentityProviderAttachmentService) createAndAttachClient(ctx context.Context, principal Principal, project ResolvedProject, userSessionIssuerID, issuerID uuid.UUID, scopes []string, registered remotesessions.ProxyRegisterResponse) (bool, error) {
+// createAndAttachClient persists the registered client bound to the issuer,
+// returning the bound client and whether this call created the binding.
+func (s *CatalogIdentityProviderAttachmentService) createAndAttachClient(ctx context.Context, principal Principal, project ResolvedProject, userSessionIssuerID, issuerID uuid.UUID, scopes []string, registered remotesessions.ProxyRegisterResponse) (uuid.UUID, bool, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
-		return false, fmt.Errorf("begin identity-provider client transaction: %w", err)
+		return uuid.Nil, false, fmt.Errorf("begin identity-provider client transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	q := remotesessionsrepo.New(tx)
 	if err := q.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
-		return false, fmt.Errorf("lock identity provider for client attachment: %w", err)
+		return uuid.Nil, false, fmt.Errorf("lock identity provider for client attachment: %w", err)
 	}
 	if _, err := q.GetUserSessionIssuerForProject(ctx, remotesessionsrepo.GetUserSessionIssuerForProjectParams{ID: userSessionIssuerID, ProjectID: project.ID, OrganizationID: principal.OrganizationID}); err != nil {
-		return false, fmt.Errorf("validate registered MCP session issuer: %w", err)
+		return uuid.Nil, false, fmt.Errorf("validate registered MCP session issuer: %w", err)
 	}
 	bound, err := q.ListRemoteSessionClientsByProjectIDForUserSessionIssuer(ctx, remotesessionsrepo.ListRemoteSessionClientsByProjectIDForUserSessionIssuerParams{
 		ProjectID:             project.ID,
@@ -317,26 +481,26 @@ func (s *CatalogIdentityProviderAttachmentService) createAndAttachClient(ctx con
 		LimitValue:            2,
 	})
 	if err != nil {
-		return false, fmt.Errorf("check existing identity-provider client attachment: %w", err)
+		return uuid.Nil, false, fmt.Errorf("check existing identity-provider client attachment: %w", err)
 	}
 	if len(bound) == 1 {
 		if bound[0].RemoteSessionClient.RemoteSessionIssuerID != issuerID {
-			return false, ErrIdentityProviderAttachmentConflict
+			return uuid.Nil, false, ErrIdentityProviderAttachmentConflict
 		}
 		if err := tx.Commit(ctx); err != nil {
-			return false, fmt.Errorf("commit existing identity-provider attachment: %w", err)
+			return uuid.Nil, false, fmt.Errorf("commit existing identity-provider attachment: %w", err)
 		}
-		return true, nil
+		return bound[0].RemoteSessionClient.ID, false, nil
 	}
 	if len(bound) > 1 {
-		return false, ErrIdentityProviderAttachmentConflict
+		return uuid.Nil, false, ErrIdentityProviderAttachmentConflict
 	}
 
 	var secret pgtype.Text
 	if registered.ClientSecret != "" {
 		ciphertext, err := s.enc.Encrypt([]byte(registered.ClientSecret))
 		if err != nil {
-			return false, fmt.Errorf("encrypt identity-provider client secret: %w", err)
+			return uuid.Nil, false, fmt.Errorf("encrypt identity-provider client secret: %w", err)
 		}
 		secret = conv.ToPGText(ciphertext)
 	}
@@ -354,10 +518,10 @@ func (s *CatalogIdentityProviderAttachmentService) createAndAttachClient(ctx con
 		LegacyCallbackUrl:       false,
 	})
 	if err != nil {
-		return false, fmt.Errorf("create identity-provider client: %w", err)
+		return uuid.Nil, false, fmt.Errorf("create identity-provider client: %w", err)
 	}
 	if err := q.AttachRemoteSessionClientToUserSessionIssuer(ctx, remotesessionsrepo.AttachRemoteSessionClientToUserSessionIssuerParams{RemoteSessionClientID: client.ID, UserSessionIssuerID: userSessionIssuerID}); err != nil {
-		return false, fmt.Errorf("attach identity-provider client to registered MCP: %w", err)
+		return uuid.Nil, false, fmt.Errorf("attach identity-provider client to registered MCP: %w", err)
 	}
 	if err := s.audit.LogRemoteSessionClientCreate(ctx, tx, audit.LogRemoteSessionClientCreateEvent{
 		OrganizationID:         principal.OrganizationID,
@@ -368,12 +532,12 @@ func (s *CatalogIdentityProviderAttachmentService) createAndAttachClient(ctx con
 		RemoteSessionClientURN: urn.NewRemoteSessionClient(client.ID),
 		ClientID:               client.ClientID,
 	}); err != nil {
-		return false, fmt.Errorf("audit identity-provider client: %w", err)
+		return uuid.Nil, false, fmt.Errorf("audit identity-provider client: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return false, fmt.Errorf("commit identity-provider client attachment: %w", err)
+		return uuid.Nil, false, fmt.Errorf("commit identity-provider client attachment: %w", err)
 	}
-	return true, nil
+	return client.ID, true, nil
 }
 
 // identityProviderDynamicRegistrationError preserves the important distinction
@@ -387,6 +551,23 @@ func identityProviderDynamicRegistrationError(err error) error {
 		return fmt.Errorf("register identity-provider client: %w", ErrIdentityProviderAttachmentUnsupported)
 	}
 	return fmt.Errorf("register identity-provider client: %w", ErrIdentityProviderAttachmentUnavailable)
+}
+
+// discoveryFailureKind keeps a transient probe failure retryable; anything
+// the resource answered with is a property of the resource.
+func discoveryFailureKind(err error) error {
+	var probe *wellknown.ProtectedResourceDiscoveryError
+	if errors.As(err, &probe) {
+		switch probe.Code() {
+		case "timeout", "transport_error":
+			return ErrIdentityProviderAttachmentUnavailable
+		case "http_error":
+			if probe.Status >= http.StatusInternalServerError {
+				return ErrIdentityProviderAttachmentUnavailable
+			}
+		}
+	}
+	return ErrIdentityProviderAttachmentUnsupported
 }
 
 func attachmentIssuerSlug(registrationID uuid.UUID) string {
@@ -410,6 +591,26 @@ func validBrowserCatalogDynamicClient(registered remotesessions.ProxyRegisterRes
 	return registered.ClientID != "" &&
 		registered.ClientSecret != "" &&
 		(registered.TokenEndpointAuthMethod == "" || registered.TokenEndpointAuthMethod == browserCatalogDCRAuthMethod)
+}
+
+// validDynamicClient accepts the confidential and public client shapes the
+// remote-session token exchange can drive.
+func validDynamicClient(registered remotesessions.ProxyRegisterResponse) bool {
+	if registered.ClientID == "" {
+		return false
+	}
+	switch registered.TokenEndpointAuthMethod {
+	case "", string(remotesessions.TokenEndpointAuthMethodBasic), string(remotesessions.TokenEndpointAuthMethodPost):
+		return registered.ClientSecret != ""
+	case string(remotesessions.TokenEndpointAuthMethodNone):
+		return true
+	default:
+		return false
+	}
+}
+
+func nonNilStrings(values []string) []string {
+	return append([]string{}, values...)
 }
 
 func optionalString(value string) *string {


### PR DESCRIPTION
## Summary

- Adding a hosted (toolset-backed) server with OAuth-requiring external MCP tools to a gateway now registers an OAuth client with the tools' provider, binds it to the gateway's issuer, and records the provider on the member row. The connect page offers the provider and calls forward the user's token. The hosted server's own endpoint is unchanged.
- Runs before the add transaction (network calls). No-op for remote/tunneled members and hosted members without OAuth tools. A binding created by an add that does not commit is removed again, unless another member came to depend on it; if the gateway's issuer changed in between, the binding is moved under the add's lock.
- At dispatch, the recorded provider is checked against the tools deployed now (`mcpservers.ResolveHostedOAuthProvider`, by OAuth token endpoint). A toolset that moved to another provider, gained a second one, or added OpenAPI/function OAuth tools gets no token rather than the old provider's bearer.
- Fails closed when one credential cannot be routed to the member: several OAuth upstreams in one toolset, OpenAPI/function tools that also take OAuth, a non-https upstream, or a proxied member / remote server already on the same provider (either way the grant would be qualified to a URL hosted routing rejects). The reverse check applies when a proxied member joins later.
- `platformmcp.AttachUpstreamProvider` exposes the existing catalog discover → register → attach flow for reuse; the browser path is unchanged. Also fixes issuer inserts for providers that omit `scopes_supported`, and classifies transient discovery failures as retryable.
- Upstream 401/403 on a tool call now returns a failed-precondition error naming the tool instead of "failed to execute tool call".

Hosted members added before this change keep no provider and must be removed and re-added once. The only such members in prod are this week's internal test gateways.

## Motivation

Gateway consent and per-member token routing key on `mcp_servers.remote_session_issuer_id`, which hosted rows never get (no issuer, no bindings). Hosted members with OAuth tools listed and described fine but every call went upstream anonymously and got 401. The gateway holds a Gram token for the caller, so Gram must be a registered client at the provider; this wires that automatically, reusing the platform catalog's flow, without minting an issuer on the hosted row (which would flip its standalone endpoint to Gram-gated OAuth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZyGMk9kNj5P35PKVccXyV
