### PR TITLE
mig: add tenant-bound agent principals

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3951,6 +3951,10 @@ CREATE INDEX IF NOT EXISTS agents_organization_owner_idx
 ON agents (organization_id, owner_user_id)
 WHERE deleted IS FALSE;
 
+-- Supports foreign-key checks for every agent, including deleted agents.
+CREATE INDEX IF NOT EXISTS agents_organization_owner_all_idx
+ON agents (organization_id, owner_user_id);
+
 CREATE TABLE IF NOT EXISTS organization_invitations (
   id UUID NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3909,6 +3909,48 @@ CREATE INDEX IF NOT EXISTS organization_user_relationships_org_workos_user_idx
 ON organization_user_relationships (organization_id, workos_user_id)
 WHERE workos_user_id IS NOT NULL AND deleted IS FALSE;
 
+CREATE TABLE IF NOT EXISTS agents (
+  id UUID NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  owner_user_id TEXT NOT NULL,
+
+  name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 120),
+
+  suspended_at timestamptz,
+  revoked_at timestamptz,
+
+  -- Owner eligibility is evaluated live. These columns record only the durable
+  -- barrier established by owner deletion, inactivation, or membership loss.
+  -- Reactivation does not clear the barrier; explicit reassignment does.
+  owner_reassignment_required_at timestamptz,
+  owner_reassignment_reason TEXT,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+  deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
+
+  CONSTRAINT agents_pkey PRIMARY KEY (id),
+  CONSTRAINT agents_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT agents_owner_tenant_fkey FOREIGN KEY (organization_id, owner_user_id) REFERENCES organization_user_relationships (organization_id, user_id) ON DELETE RESTRICT,
+  CONSTRAINT agents_lifecycle_state_check CHECK (revoked_at IS NULL OR suspended_at IS NULL),
+  CONSTRAINT agents_owner_reassignment_state_check CHECK ((owner_reassignment_required_at IS NULL) = (owner_reassignment_reason IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agents_organization_id_id_key
+ON agents (organization_id, id);
+
+-- Names remain reserved through suspension and revocation; deletion releases them.
+CREATE UNIQUE INDEX IF NOT EXISTS agents_organization_name_key
+ON agents (organization_id, LOWER(name))
+WHERE deleted IS FALSE;
+
+-- Supports owner-scoped listing and active-agent selection. Owner eligibility and
+-- the reassignment latch remain authoritative predicates evaluated by the service.
+CREATE INDEX IF NOT EXISTS agents_organization_owner_idx
+ON agents (organization_id, owner_user_id)
+WHERE deleted IS FALSE;
+
 CREATE TABLE IF NOT EXISTS organization_invitations (
   id UUID NOT NULL DEFAULT generate_uuidv7(),
   organization_id TEXT NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -14,6 +14,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+type Agent struct {
+	ID                          uuid.UUID
+	OrganizationID              string
+	OwnerUserID                 string
+	Name                        string
+	SuspendedAt                 pgtype.Timestamptz
+	RevokedAt                   pgtype.Timestamptz
+	OwnerReassignmentRequiredAt pgtype.Timestamptz
+	OwnerReassignmentReason     pgtype.Text
+	CreatedAt                   pgtype.Timestamptz
+	UpdatedAt                   pgtype.Timestamptz
+	DeletedAt                   pgtype.Timestamptz
+	Deleted                     bool
+}
+
 type AgentExecution struct {
 	ID           string
 	ProjectID    uuid.UUID

--- a/server/migrations/20260903215231_aim-183-agent-principals.sql
+++ b/server/migrations/20260903215231_aim-183-agent-principals.sql
@@ -1,0 +1,27 @@
+-- Create "agents" table
+CREATE TABLE "agents" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "owner_user_id" text NOT NULL,
+  "name" text NOT NULL,
+  "suspended_at" timestamptz NULL,
+  "revoked_at" timestamptz NULL,
+  "owner_reassignment_required_at" timestamptz NULL,
+  "owner_reassignment_reason" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  "deleted" boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) STORED,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "agents_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "agents_owner_tenant_fkey" FOREIGN KEY ("organization_id", "owner_user_id") REFERENCES "organization_user_relationships" ("organization_id", "user_id") ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT "agents_lifecycle_state_check" CHECK ((revoked_at IS NULL) OR (suspended_at IS NULL)),
+  CONSTRAINT "agents_name_check" CHECK ((name <> ''::text) AND (char_length(name) <= 120)),
+  CONSTRAINT "agents_owner_reassignment_state_check" CHECK ((owner_reassignment_required_at IS NULL) = (owner_reassignment_reason IS NULL))
+);
+-- Create index "agents_organization_id_id_key" to table: "agents"
+CREATE UNIQUE INDEX "agents_organization_id_id_key" ON "agents" ("organization_id", "id");
+-- Create index "agents_organization_name_key" to table: "agents"
+CREATE UNIQUE INDEX "agents_organization_name_key" ON "agents" ("organization_id", (lower(name))) WHERE (deleted IS FALSE);
+-- Create index "agents_organization_owner_idx" to table: "agents"
+CREATE INDEX "agents_organization_owner_idx" ON "agents" ("organization_id", "owner_user_id") WHERE (deleted IS FALSE);

--- a/server/migrations/20260903215231_aim-183-agent-principals.sql
+++ b/server/migrations/20260903215231_aim-183-agent-principals.sql
@@ -25,3 +25,5 @@ CREATE UNIQUE INDEX "agents_organization_id_id_key" ON "agents" ("organization_i
 CREATE UNIQUE INDEX "agents_organization_name_key" ON "agents" ("organization_id", (lower(name))) WHERE (deleted IS FALSE);
 -- Create index "agents_organization_owner_idx" to table: "agents"
 CREATE INDEX "agents_organization_owner_idx" ON "agents" ("organization_id", "owner_user_id") WHERE (deleted IS FALSE);
+-- Create index "agents_organization_owner_all_idx" to table: "agents"
+CREATE INDEX "agents_organization_owner_all_idx" ON "agents" ("organization_id", "owner_user_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bHXJJ2OXznF8EMEofQnz7ZtvzL6zVbxbRHw5HARP+r0=
+h1:InbaxkQouRj86xEIIEWHBynp/n5HfALF+o7nBS+cOLo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -385,3 +385,4 @@ h1:bHXJJ2OXznF8EMEofQnz7ZtvzL6zVbxbRHw5HARP+r0=
 20260903190252_dno1005-device-agent-environment-syncs.sql h1:kUaZL31hQY1vrBt5UvtGefk/D8r1kDGpYAhFFBaNoLk=
 20260903194055_add_external_oauth_authorization_server_issuer.sql h1:ulax1MM1HwC0e9Gdxf8gRp6GVh7cZ3dtpyOG0VKfmIU=
 20260903214520_organization-setup-tasks.sql h1:VOA01E6IifoXX5dkmwFgU3gskEG6LeSeuP7N9E7eZWo=
+20260903215231_aim-183-agent-principals.sql h1:jjQ84AmkDTW+EH0X11YR91SjtsOtLW0l7jHlXM3udJ8=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:InbaxkQouRj86xEIIEWHBynp/n5HfALF+o7nBS+cOLo=
+h1:ipzsaLVtO2Q9y6p2a89t5b1j2Ck02c1LsFhPR63fTaI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -385,4 +385,4 @@ h1:InbaxkQouRj86xEIIEWHBynp/n5HfALF+o7nBS+cOLo=
 20260903190252_dno1005-device-agent-environment-syncs.sql h1:kUaZL31hQY1vrBt5UvtGefk/D8r1kDGpYAhFFBaNoLk=
 20260903194055_add_external_oauth_authorization_server_issuer.sql h1:ulax1MM1HwC0e9Gdxf8gRp6GVh7cZ3dtpyOG0VKfmIU=
 20260903214520_organization-setup-tasks.sql h1:VOA01E6IifoXX5dkmwFgU3gskEG6LeSeuP7N9E7eZWo=
-20260903215231_aim-183-agent-principals.sql h1:jjQ84AmkDTW+EH0X11YR91SjtsOtLW0l7jHlXM3udJ8=
+20260903215231_aim-183-agent-principals.sql h1:l7hdBwam2aqT3pIjK2eBBje7J1z8ow8+/gZ7YpRyp7U=


### PR DESCRIPTION
## Summary

Adds the organization-scoped `agents` table for AIM-183 with a tenant-pinned current human owner, timestamp-derived lifecycle state, and the durable owner-reassignment latch. The expand-only migration also adds tenant lookup, active-name uniqueness, and owner-listing indexes without changing existing credential or principal tables.

## Impact

This migration is the schema prerequisite for agent principal readers and writers. It introduces only a new table and indexes, so existing application behavior remains unchanged.

## Technical details

### Owner integrity

The composite owner foreign key prevents cross-organization ownership and deliberately restricts physical membership deletion so an agent cannot be cascaded away or orphaned.

### Name reservation

The case-insensitive partial unique index reserves names through suspension and revocation while releasing them after soft deletion.

Linear: AIM-183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the organization-scoped `agents` table for AIM-183, the schema prerequisite for agent principal readers and writers. This expand-only migration adds a new table and indexes without changing existing credential or principal tables.

- Tenant-pins the current human owner with a composite foreign key to `organization_user_relationships` and uses `ON DELETE RESTRICT` so agents can't be cascaded away or orphaned.
- Reserves active names case-insensitively per organization through suspension and revocation, then releases them on soft deletion.
- Stores the owner-reassignment latch as paired timestamp and reason columns that must be present or absent together.
- Derives lifecycle from `suspended_at`, `revoked_at`, and `deleted_at` rather than storing a status label.
- Adds the `Agent` model and indexes for tenant lookup, active-name uniqueness, and owner listing, including a full-coverage index that also references deleted agents.
- The migration can be deployed independently before application readers and writers land.

<sup>Written for commit ecb40f0bb244a6d70a794844f3924fb6e57eda28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

