### PR TITLE
fix: account menu log out now redirects to /login

### DIFF
--- a/.changeset/logout-menu-redirect.md
+++ b/.changeset/logout-menu-redirect.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Redirect to the login page after account-menu logout. Chromium never settles a fetch whose response includes Clear-Site-Data: "cache", so that directive is omitted and the page always navigates even if the logout request rejects.

--- a/.changeset/logout-menu-redirect.md
+++ b/.changeset/logout-menu-redirect.md
@@ -3,4 +3,4 @@
 "server": patch
 ---
 
-Redirect to the login page after account-menu logout. Chromium never settles a fetch whose response includes Clear-Site-Data: "cache", so that directive is omitted and the page always navigates even if the logout request rejects.
+Redirect to the login page after account-menu logout. Chromium never settles a fetch whose response includes Clear-Site-Data: "cache", so that directive is omitted. The page still navigates if logout rejects or stalls.

--- a/client/dashboard/src/components/app-layout.test.tsx
+++ b/client/dashboard/src/components/app-layout.test.tsx
@@ -27,10 +27,13 @@ vi.mock("@/contexts/Sdk.tsx", () => ({
   }),
 }));
 
+import {
+  restoreLocation,
+  stubLocationReplace,
+} from "@/lib/stub-location-replace";
+
 import { ImpersonationBanner, LoginCheck } from "./app-layout";
 import { useShowsImpersonationBanner } from "./impersonation-banner-state";
-
-let originalLocation: Location | undefined;
 
 const baseSession = {
   impersonatorEmail: undefined,
@@ -55,13 +58,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
-  if (originalLocation) {
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: originalLocation,
-    });
-    originalLocation = undefined;
-  }
+  restoreLocation();
 });
 
 describe("trusted support banner", () => {
@@ -94,18 +91,7 @@ describe("trusted support banner", () => {
       ...baseSession,
       organizationOverride: true,
     });
-    originalLocation = window.location;
-    const replace = vi.fn();
-    // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
-    delete window.location;
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
-        ...originalLocation,
-        replace,
-      },
-    });
+    const replace = stubLocationReplace();
 
     render(<ImpersonationBanner />);
     await userEvent.click(

--- a/client/dashboard/src/components/app-layout.test.tsx
+++ b/client/dashboard/src/components/app-layout.test.tsx
@@ -95,7 +95,7 @@ describe("trusted support banner", () => {
       organizationOverride: true,
     });
     originalLocation = window.location;
-    const hrefSetter = vi.fn();
+    const replace = vi.fn();
     // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
     delete window.location;
     Object.defineProperty(window, "location", {
@@ -103,9 +103,7 @@ describe("trusted support banner", () => {
       value: {
         // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
         ...originalLocation,
-        set href(value: string) {
-          hrefSetter(value);
-        },
+        replace,
       },
     });
 
@@ -116,7 +114,7 @@ describe("trusted support banner", () => {
 
     await waitFor(() => {
       expect(mocks.logout).toHaveBeenCalledOnce();
-      expect(hrefSetter).toHaveBeenCalledWith("/login");
+      expect(replace).toHaveBeenCalledWith("/login");
     });
   });
 

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -2,6 +2,7 @@ import { useOrganization, useSession } from "@/contexts/Auth.tsx";
 import { useSdkClient } from "@/contexts/Sdk.tsx";
 import { cn } from "@/lib/utils";
 import { DEMO_ORG_SLUG, PRE_DEMO_ORG_KEY } from "@/lib/demo";
+import { logoutToLogin } from "@/lib/logout-to-login";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { Icon } from "@/components/ui/Icon";
@@ -109,8 +110,7 @@ export const ImpersonationBanner = (): JSX.Element => {
         window.location.replace("/");
         return;
       }
-      await client.auth.logout();
-      window.location.href = "/login";
+      await logoutToLogin(client);
     })();
   };
 
@@ -229,10 +229,7 @@ const MembershipSyncGuard = ({ children }: { children: React.ReactNode }) => {
           type="button"
           className="bg-primary text-primary-foreground hover:bg-primary/90 mt-2 px-4 py-2 text-sm font-medium"
           onClick={() => {
-            void (async () => {
-              await client.auth.logout();
-              window.location.href = "/login";
-            })();
+            void logoutToLogin(client);
           }}
         >
           Log out

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const orgSlug = vi.hoisted(() => ({ current: "acme" }));
 const isPlatformAdmin = vi.hoisted(() => vi.fn(() => true));
 const exploreDemoGoTo = vi.hoisted(() => vi.fn());
+const logout = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("@/contexts/Auth", () => ({
   useUser: () => ({ displayName: "Sagar", email: "s@x.dev", photoUrl: "" }),
@@ -19,7 +20,7 @@ vi.mock("@/contexts/Auth", () => ({
 }));
 vi.mock("@/contexts/Sdk", () => ({
   useSlugs: () => ({ projectSlug: "proj" }),
-  useSdkClient: () => ({ auth: { logout: vi.fn() } }),
+  useSdkClient: () => ({ auth: { logout } }),
 }));
 vi.mock("@/hooks/useRBAC", () => ({
   useRBAC: () => ({ hasAnyScope: () => true }),
@@ -102,6 +103,7 @@ afterEach(() => {
   isPlatformAdmin.mockReset();
   isPlatformAdmin.mockReturnValue(true);
   exploreDemoGoTo.mockReset();
+  logout.mockReset().mockResolvedValue(undefined);
 });
 
 describe("SidebarUserMenu", () => {
@@ -212,6 +214,68 @@ describe("SidebarUserMenu", () => {
 
     fireEvent.click(screen.getByText("Explore demo org"));
     expect(exploreDemoGoTo).toHaveBeenCalledOnce();
+  });
+
+  it("logs out and leaves the page when Log out is clicked", async () => {
+    const originalLocation = window.location;
+    const replace = vi.fn();
+    // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
+        ...originalLocation,
+        replace,
+      },
+    });
+
+    try {
+      render(<SidebarUserMenu />);
+      fireEvent.click(screen.getByTestId("user-menu-trigger"));
+      fireEvent.click(screen.getByText("Log out"));
+
+      await vi.waitFor(() => {
+        expect(logout).toHaveBeenCalledOnce();
+        expect(replace).toHaveBeenCalledWith("/login");
+      });
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it("still leaves the page when logout rejects", async () => {
+    logout.mockRejectedValueOnce(new Error("aborted"));
+    const originalLocation = window.location;
+    const replace = vi.fn();
+    // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
+        ...originalLocation,
+        replace,
+      },
+    });
+
+    try {
+      render(<SidebarUserMenu />);
+      fireEvent.click(screen.getByTestId("user-menu-trigger"));
+      fireEvent.click(screen.getByText("Log out"));
+
+      await vi.waitFor(() => {
+        expect(replace).toHaveBeenCalledWith("/login");
+      });
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
   });
 
   it("hides Explore demo org while already in the demo org", () => {

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -7,6 +7,11 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import {
+  restoreLocation,
+  stubLocationReplace,
+} from "@/lib/stub-location-replace";
+
 const orgSlug = vi.hoisted(() => ({ current: "acme" }));
 const isPlatformAdmin = vi.hoisted(() => vi.fn(() => true));
 const exploreDemoGoTo = vi.hoisted(() => vi.fn());
@@ -104,6 +109,7 @@ afterEach(() => {
   isPlatformAdmin.mockReturnValue(true);
   exploreDemoGoTo.mockReset();
   logout.mockReset().mockResolvedValue(undefined);
+  restoreLocation();
 });
 
 describe("SidebarUserMenu", () => {
@@ -217,65 +223,29 @@ describe("SidebarUserMenu", () => {
   });
 
   it("logs out and leaves the page when Log out is clicked", async () => {
-    const originalLocation = window.location;
-    const replace = vi.fn();
-    // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
-    delete window.location;
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
-        ...originalLocation,
-        replace,
-      },
+    const replace = stubLocationReplace();
+
+    render(<SidebarUserMenu />);
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+    fireEvent.click(screen.getByText("Log out"));
+
+    await vi.waitFor(() => {
+      expect(logout).toHaveBeenCalledOnce();
+      expect(replace).toHaveBeenCalledWith("/login");
     });
-
-    try {
-      render(<SidebarUserMenu />);
-      fireEvent.click(screen.getByTestId("user-menu-trigger"));
-      fireEvent.click(screen.getByText("Log out"));
-
-      await vi.waitFor(() => {
-        expect(logout).toHaveBeenCalledOnce();
-        expect(replace).toHaveBeenCalledWith("/login");
-      });
-    } finally {
-      Object.defineProperty(window, "location", {
-        configurable: true,
-        value: originalLocation,
-      });
-    }
   });
 
   it("still leaves the page when logout rejects", async () => {
-    logout.mockRejectedValueOnce(new Error("aborted"));
-    const originalLocation = window.location;
-    const replace = vi.fn();
-    // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
-    delete window.location;
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: {
-        // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
-        ...originalLocation,
-        replace,
-      },
+    logout.mockRejectedValueOnce(new Error("network"));
+    const replace = stubLocationReplace();
+
+    render(<SidebarUserMenu />);
+    fireEvent.click(screen.getByTestId("user-menu-trigger"));
+    fireEvent.click(screen.getByText("Log out"));
+
+    await vi.waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/login");
     });
-
-    try {
-      render(<SidebarUserMenu />);
-      fireEvent.click(screen.getByTestId("user-menu-trigger"));
-      fireEvent.click(screen.getByText("Log out"));
-
-      await vi.waitFor(() => {
-        expect(replace).toHaveBeenCalledWith("/login");
-      });
-    } finally {
-      Object.defineProperty(window, "location", {
-        configurable: true,
-        value: originalLocation,
-      });
-    }
   });
 
   it("hides Explore demo org while already in the demo org", () => {

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -8,6 +8,7 @@ import { useSdkClient, useSlugs } from "@/contexts/Sdk";
 import { useRBAC } from "@/hooks/useRBAC";
 import { getAdminServerUrl } from "@/lib/admin-server-url";
 import { DEMO_ORG_SLUG } from "@/lib/demo";
+import { logoutToLogin } from "@/lib/logout-to-login";
 import { useOrgRoutes, useRoutes } from "@/routes";
 import {
   DropdownMenu,
@@ -245,10 +246,7 @@ export function SidebarUserMenu(): JSX.Element {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={() => {
-              void (async () => {
-                await client.auth.logout();
-                window.location.href = "/login";
-              })();
+              void logoutToLogin(client);
             }}
           >
             <LogOutIcon className="mr-2 h-4 w-4" />

--- a/client/dashboard/src/lib/logout-to-login.test.ts
+++ b/client/dashboard/src/lib/logout-to-login.test.ts
@@ -24,17 +24,20 @@ describe("logoutToLogin", () => {
 
   it("still replaces the page with /login when logout rejects", async () => {
     const replace = stubLocationReplace();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     const logout = vi.fn().mockRejectedValue(new Error("network"));
 
     await logoutToLogin({ auth: { logout } });
 
     expect(logout).toHaveBeenCalledOnce();
     expect(replace).toHaveBeenCalledWith("/login");
+    expect(logged).toHaveBeenCalledOnce();
   });
 
   it("still replaces the page with /login when logout never settles", async () => {
     vi.useFakeTimers();
     const replace = stubLocationReplace();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     const logout = vi.fn().mockReturnValue(new Promise(() => {}));
 
     const done = logoutToLogin({ auth: { logout } });
@@ -43,5 +46,6 @@ describe("logoutToLogin", () => {
 
     expect(logout).toHaveBeenCalledOnce();
     expect(replace).toHaveBeenCalledWith("/login");
+    expect(logged).toHaveBeenCalledOnce();
   });
 });

--- a/client/dashboard/src/lib/logout-to-login.test.ts
+++ b/client/dashboard/src/lib/logout-to-login.test.ts
@@ -46,7 +46,7 @@ describe("logoutToLogin", () => {
 
   it("still replaces the page with /login when logout rejects", async () => {
     const replace = stubLocationReplace();
-    const logout = vi.fn().mockRejectedValue(new Error("aborted"));
+    const logout = vi.fn().mockRejectedValue(new Error("network"));
 
     await logoutToLogin({ auth: { logout } });
 

--- a/client/dashboard/src/lib/logout-to-login.test.ts
+++ b/client/dashboard/src/lib/logout-to-login.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { logoutToLogin } from "./logout-to-login";
+
+let originalLocation: Location | undefined;
+
+function stubLocationReplace() {
+  originalLocation = window.location;
+  const replace = vi.fn();
+  // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
+      ...originalLocation,
+      replace,
+    },
+  });
+  return replace;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalLocation) {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    originalLocation = undefined;
+  }
+});
+
+describe("logoutToLogin", () => {
+  it("replaces the page with /login after logout succeeds", async () => {
+    const replace = stubLocationReplace();
+    const logout = vi.fn().mockResolvedValue(undefined);
+
+    await logoutToLogin({ auth: { logout } });
+
+    expect(logout).toHaveBeenCalledOnce();
+    expect(replace).toHaveBeenCalledWith("/login");
+  });
+
+  it("still replaces the page with /login when logout rejects", async () => {
+    const replace = stubLocationReplace();
+    const logout = vi.fn().mockRejectedValue(new Error("aborted"));
+
+    await logoutToLogin({ auth: { logout } });
+
+    expect(logout).toHaveBeenCalledOnce();
+    expect(replace).toHaveBeenCalledWith("/login");
+  });
+});

--- a/client/dashboard/src/lib/logout-to-login.test.ts
+++ b/client/dashboard/src/lib/logout-to-login.test.ts
@@ -2,35 +2,13 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { logoutToLogin } from "./logout-to-login";
-
-let originalLocation: Location | undefined;
-
-function stubLocationReplace() {
-  originalLocation = window.location;
-  const replace = vi.fn();
-  // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
-  delete window.location;
-  Object.defineProperty(window, "location", {
-    configurable: true,
-    value: {
-      // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
-      ...originalLocation,
-      replace,
-    },
-  });
-  return replace;
-}
+import { LOGOUT_WAIT_MS, logoutToLogin } from "./logout-to-login";
+import { restoreLocation, stubLocationReplace } from "./stub-location-replace";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
-  if (originalLocation) {
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: originalLocation,
-    });
-    originalLocation = undefined;
-  }
+  restoreLocation();
 });
 
 describe("logoutToLogin", () => {
@@ -49,6 +27,19 @@ describe("logoutToLogin", () => {
     const logout = vi.fn().mockRejectedValue(new Error("network"));
 
     await logoutToLogin({ auth: { logout } });
+
+    expect(logout).toHaveBeenCalledOnce();
+    expect(replace).toHaveBeenCalledWith("/login");
+  });
+
+  it("still replaces the page with /login when logout never settles", async () => {
+    vi.useFakeTimers();
+    const replace = stubLocationReplace();
+    const logout = vi.fn().mockReturnValue(new Promise(() => {}));
+
+    const done = logoutToLogin({ auth: { logout } });
+    await vi.advanceTimersByTimeAsync(LOGOUT_WAIT_MS);
+    await done;
 
     expect(logout).toHaveBeenCalledOnce();
     expect(replace).toHaveBeenCalledWith("/login");

--- a/client/dashboard/src/lib/logout-to-login.ts
+++ b/client/dashboard/src/lib/logout-to-login.ts
@@ -4,21 +4,35 @@ export type LogoutClient = {
   };
 };
 
+/** Upper bound so a hung logout fetch cannot trap the UI on the dashboard. */
+export const LOGOUT_WAIT_MS = 8_000;
+
 /**
  * Invalidates the dashboard session and leaves the app.
  *
  * Await logout so cookies/storage Clear-Site-Data can run, then always
- * navigate. A reject (network, 5xx, SDK unwrap) must not strand the UI
- * on a dashboard page. This does not survive a hung fetch — Chromium
- * never settles a response that includes Clear-Site-Data: "cache", so
- * that directive must stay off the logout XHR.
+ * navigate. A reject or stall (network, 5xx, SDK unwrap, hung fetch) must
+ * not leave the UI on a dashboard page. Chromium never settles a response
+ * that includes Clear-Site-Data: "cache", so that directive must stay off
+ * the logout XHR — the timeout is a backstop, not a reason to put it back.
  */
 export async function logoutToLogin(client: LogoutClient): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    await client.auth.logout();
+    await Promise.race([
+      client.auth.logout(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error("logout timed out"));
+        }, LOGOUT_WAIT_MS);
+      }),
+    ]);
   } catch {
-    // Logout may have failed before the session was cleared. Still leave
-    // so a dead or half-torn-down session is not left on the dashboard.
+    // Logout may have failed or stalled before the session was cleared.
+    // Still leave so a dead or half-torn-down session is not left on
+    // the dashboard.
+  } finally {
+    clearTimeout(timeout);
   }
   window.location.replace("/login");
 }

--- a/client/dashboard/src/lib/logout-to-login.ts
+++ b/client/dashboard/src/lib/logout-to-login.ts
@@ -7,15 +7,18 @@ export type LogoutClient = {
 /**
  * Invalidates the dashboard session and leaves the app.
  *
- * The logout response can reject after the session is already gone
- * (Chromium aborts a fetch once Clear-Site-Data runs). Navigation must
- * not depend on that promise settling successfully.
+ * Await logout so cookies/storage Clear-Site-Data can run, then always
+ * navigate. A reject (network, 5xx, SDK unwrap) must not strand the UI
+ * on a dashboard page. This does not survive a hung fetch — Chromium
+ * never settles a response that includes Clear-Site-Data: "cache", so
+ * that directive must stay off the logout XHR.
  */
 export async function logoutToLogin(client: LogoutClient): Promise<void> {
   try {
     await client.auth.logout();
   } catch {
-    // Session teardown already happened server-side; still leave the page.
+    // Logout may have failed before the session was cleared. Still leave
+    // so a dead or half-torn-down session is not left on the dashboard.
   }
   window.location.replace("/login");
 }

--- a/client/dashboard/src/lib/logout-to-login.ts
+++ b/client/dashboard/src/lib/logout-to-login.ts
@@ -27,10 +27,11 @@ export async function logoutToLogin(client: LogoutClient): Promise<void> {
         }, LOGOUT_WAIT_MS);
       }),
     ]);
-  } catch {
+  } catch (error) {
     // Logout may have failed or stalled before the session was cleared.
     // Still leave so a dead or half-torn-down session is not left on
     // the dashboard.
+    console.error("logoutToLogin: logout did not complete", error);
   } finally {
     clearTimeout(timeout);
   }

--- a/client/dashboard/src/lib/logout-to-login.ts
+++ b/client/dashboard/src/lib/logout-to-login.ts
@@ -1,0 +1,21 @@
+export type LogoutClient = {
+  auth: {
+    logout: () => Promise<unknown>;
+  };
+};
+
+/**
+ * Invalidates the dashboard session and leaves the app.
+ *
+ * The logout response can reject after the session is already gone
+ * (Chromium aborts a fetch once Clear-Site-Data runs). Navigation must
+ * not depend on that promise settling successfully.
+ */
+export async function logoutToLogin(client: LogoutClient): Promise<void> {
+  try {
+    await client.auth.logout();
+  } catch {
+    // Session teardown already happened server-side; still leave the page.
+  }
+  window.location.replace("/login");
+}

--- a/client/dashboard/src/lib/stub-location-replace.ts
+++ b/client/dashboard/src/lib/stub-location-replace.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+
+let originalLocation: Location | undefined;
+
+export function stubLocationReplace() {
+  originalLocation = window.location;
+  const replace = vi.fn();
+  // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
+  delete window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      // oxlint-disable-next-line typescript/no-misused-spread -- happy-dom Location is plain enough for tests
+      ...originalLocation,
+      replace,
+    },
+  });
+  return replace;
+}
+
+export function restoreLocation() {
+  if (!originalLocation) {
+    return;
+  }
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  originalLocation = undefined;
+}

--- a/client/dashboard/src/lib/stub-location-replace.ts
+++ b/client/dashboard/src/lib/stub-location-replace.ts
@@ -1,8 +1,8 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
 let originalLocation: Location | undefined;
 
-export function stubLocationReplace() {
+export function stubLocationReplace(): Mock {
   originalLocation = window.location;
   const replace = vi.fn();
   // @ts-expect-error happy-dom-compatible location replacement for redirect assertion
@@ -18,7 +18,7 @@ export function stubLocationReplace() {
   return replace;
 }
 
-export function restoreLocation() {
+export function restoreLocation(): void {
   if (!originalLocation) {
     return;
   }

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/Button";
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { logoutToLogin } from "@/lib/logout-to-login";
 import { useCaptureEnterpriseGateViewed } from "@/contexts/Telemetry";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
@@ -16,10 +17,7 @@ export default function BookDemo(): JSX.Element {
     organizationSlug: session?.organization?.slug ?? "",
   });
 
-  const handleLogout = async () => {
-    await client.auth.logout();
-    window.location.href = "/login";
-  };
+  const handleLogout = () => logoutToLogin(client);
 
   return (
     <AuthShell

--- a/client/dashboard/src/pages/demo/SwitchOrg.tsx
+++ b/client/dashboard/src/pages/demo/SwitchOrg.tsx
@@ -1,5 +1,6 @@
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { logoutToLogin } from "@/lib/logout-to-login";
 import { cn } from "@/lib/utils";
 import { AUTH_BUTTON_CLASSES } from "@/pages/login/components/auth-constants";
 import { AuthShell } from "@/pages/login/components/auth-shell";
@@ -106,10 +107,7 @@ export default function SwitchOrg({
     }
   };
 
-  const handleLogout = async () => {
-    await client.auth.logout();
-    window.location.href = "/login";
-  };
+  const handleLogout = () => logoutToLogin(client);
 
   const currentOrg = allOrgs.find((org) => org.id === currentOrgId);
   const currentOrgName =

--- a/client/dashboard/src/pages/demo/TrialEnded.tsx
+++ b/client/dashboard/src/pages/demo/TrialEnded.tsx
@@ -8,6 +8,7 @@ import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useTrialNow } from "@/hooks/useTrialNow";
+import { logoutToLogin } from "@/lib/logout-to-login";
 import { getTrialLifecycleFromDates } from "@/lib/trial-status";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { BookingCalendarModal } from "./components/booking-calendar/BookingCalendarModal";
@@ -74,10 +75,7 @@ function ExpiredTrialEnded(): JSX.Element {
     if (paygCheckout.error) setChoice(null);
   }, [paygCheckout.error]);
 
-  const handleLogout = async () => {
-    await client.auth.logout();
-    window.location.href = "/login";
-  };
+  const handleLogout = () => logoutToLogin(client);
 
   const handleChoiceChange = (value: string) => {
     const nextChoice = value as TrialEndedChoice;

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -220,8 +220,8 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// context so validateAuthNonce() can verify it.
 	server.Callback = callbackNonceBindingMiddleware(server.Callback)
 
-	// Wrap Logout handler: have the browser drop the origin's cached data,
-	// cookies, and client-side storage once the session has been invalidated server-side.
+	// Wrap Logout handler: have the browser drop the origin's cookies and
+	// client-side storage once the session has been invalidated server-side.
 	server.Logout = middleware.ClearSiteDataOnLogout(server.Logout)
 
 	srv.Mount(mux, server)

--- a/server/internal/middleware/clear_site_data.go
+++ b/server/internal/middleware/clear_site_data.go
@@ -6,7 +6,11 @@ import (
 )
 
 const clearSiteDataHeader = "Clear-Site-Data"
-const clearSiteDataLogout = `"cache", "cookies", "storage"`
+
+// cookies and storage only. "cache" on a fetch/XHR response leaves Chromium
+// waiting for the HTTP cache wipe before the request settles, so the dashboard
+// never reaches the /login navigation that follows logout.
+const clearSiteDataLogout = `"cookies", "storage"`
 
 func ClearSiteDataOnLogout(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/middleware/clear_site_data_test.go
+++ b/server/internal/middleware/clear_site_data_test.go
@@ -29,7 +29,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnOK(t *testing.T) {
 
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
 
-	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // Any success status carries the directive, not just 200 — a bodiless logout
@@ -44,7 +44,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnNoContent(t *testing.T) {
 
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
 
-	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // A handler that writes a body without calling WriteHeader still sends a 200,
@@ -62,7 +62,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnImplicitOK(t *testing.T) {
 
 	require.NoError(t, writeErr)
 	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // A logout that never invalidated anything must leave the caller's state alone:
@@ -127,7 +127,7 @@ func TestClearSiteDataOnLogout_SetsDirectiveAfterEarlyHints(t *testing.T) {
 	// Only the header is asserted: httptest.ResponseRecorder records the first
 	// WriteHeader it sees, so rec.Code reports the 103 that a real server would
 	// have sent as an informational response ahead of the final status.
-	require.Equal(t, `"cache", "cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }
 
 // 101 is terminal, not informational: nothing follows it, and a protocol switch
@@ -154,12 +154,12 @@ func TestClearSiteDataOnLogout_SetsDirectiveBeforeFlush(t *testing.T) {
 	w.Flush()
 
 	require.True(t, inner.flushed)
-	require.Equal(t, `"cache", "cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
 
 	// The flush committed the headers, so a later error status must not be
 	// able to un-commit them — but it must not gain a directive either.
 	w.WriteHeader(http.StatusInternalServerError)
-	require.Equal(t, `"cache", "cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
 }
 
 // A flush the underlying writer cannot serve commits nothing, so the directive


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linear: [GRW-68](https://linear.app/speakeasy/issue/GRW-68/fix-using-the-log-out-button-in-menu-has-no-visible-effect)

## Summary

Log out from the dashboard now actually leaves the app. The session is still torn down — cookies and storage are cleared — and the browser replaces the current page with `/login`, so Back does not return to a stale dashboard.

Every dashboard logout used to `await auth.logout()` and then assign `location.href`. Those call sites now share `logoutToLogin`: the account menu (the reported bug), support/impersonation exit, membership-sync recovery, and the demo pages.

The logout XHR still sends `Clear-Site-Data: "cookies", "storage"`. `"cache"` is omitted because Chromium will not settle a fetch that includes that directive. If logout rejects or stalls for 8s, the page still navigates.

![Account menu with Log out](https://cursor.com/artifacts/c/art-a9c14779-ed48-4694-88d9-c3433409898e)
![Login page after logout](https://cursor.com/artifacts/c/art-31e99532-18e7-4331-8199-daa49bb06c79)

## Motivation

Clicking **Log out** looked like a no-op. The server had already cleared the session; a refresh showed the login page. The client never ran the `/login` navigation, so the UI stayed on the authenticated dashboard.

The hang came from pairing `await client.auth.logout()` with `Clear-Site-Data: "cache"` on that XHR (added in `#5911` for an HTTP cache wipe). Chromium waits for the cache wipe before completing the fetch, and in practice the promise never settles, so the following `location` assignment never runs.

AIS-551’s documented contract was already cookies + storage — Cache Storage is covered by `"storage"`. Dropping `"cache"` from the XHR restores navigation without giving up the session wipe. A document response (for example `/login` itself) is the right place if HTTP cache eviction is still wanted later; an XHR is not.

`location.replace` is used so a logged-out user cannot Back into an in-memory dashboard. Logout still awaits the request first so cookies/storage clearing can run; the 8s bound is a backstop so a future hung fetch cannot trap the UI again.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-68](https://linear.app/speakeasy/issue/GRW-68/fix-using-the-log-out-button-in-menu-has-no-visible-effect)

<div><a href="https://cursor.com/agents/bc-51f3b9fe-68d9-4c5b-8fc1-281b160f9e26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51f3b9fe-68d9-4c5b-8fc1-281b160f9e26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GRW-68: clicking **Log out** in the account menu now redirects to `/login`. Previously the session was invalidated but the dashboard stayed on screen until refresh because Chromium never settled the logout fetch when the response included `Clear-Site-Data: "cache"`.

- Removed `"cache"` from the `Clear-Site-Data` header on logout; cookies and storage are still cleared.
- Added `logoutToLogin` helper that always replaces the page with `/login`, racing the logout against an 8s timeout so a stalled fetch can't trap the UI. Logout failures are logged so timeouts surface in diagnostics.
- Routed the account menu, impersonation exit, membership guard, and demo pages through it.
- Added a changeset marking `dashboard` and `server` as patched.

<sup>Written for commit d2d2b04b90b87c15397212ae8bc85c456e47f34c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

