### PR TITLE
feat: carry canonical agent attribution through authorization

### DIFF
--- a/server/internal/audit/agent_attribution.go
+++ b/server/internal/audit/agent_attribution.go
@@ -1,0 +1,81 @@
+package audit
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+
+	agentrepo "github.com/speakeasy-api/gram/server/internal/agents/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+var ErrInvalidAgentManagementAttribution = errors.New("invalid agent management attribution")
+
+// AgentManagementTargetResolver loads an affected agent by authenticated tenant
+// and ID. A transaction-bound agents repository satisfies this interface.
+type AgentManagementTargetResolver interface {
+	GetAgentByID(context.Context, agentrepo.GetAgentByIDParams) (agentrepo.Agent, error)
+}
+
+// AgentManagementOwnerChange carries ownership identities when a transition
+// has one. Empty values mean the transition has no corresponding owner.
+type AgentManagementOwnerChange struct {
+	FormerOwnerUserID      string
+	ReplacementOwnerUserID string
+}
+
+// AgentManagementAttribution is the shared, identifier-only envelope consumed
+// by agent-management audit events. Its actor is derived exclusively from
+// trusted request identity; owners can never stand in for it.
+type AgentManagementAttribution struct {
+	OrganizationID         string
+	Actor                  urn.Principal
+	AffectedAgentID        uuid.UUID
+	CurrentOwnerUserID     string
+	FormerOwnerUserID      string
+	ReplacementOwnerUserID string
+}
+
+// NewAgentManagementAttribution validates tenant binding and builds an audit
+// envelope without inferring actor identity from owners or credential IDs. All
+// validation failures intentionally return the same error and disclose no IDs.
+func NewAgentManagementAttribution(
+	ctx context.Context,
+	agents AgentManagementTargetResolver,
+	agentID uuid.UUID,
+	ownerChange AgentManagementOwnerChange,
+) (AgentManagementAttribution, error) {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" || agents == nil || agentID == uuid.Nil {
+		return AgentManagementAttribution{}, ErrInvalidAgentManagementAttribution
+	}
+
+	actor, ok := contextvalues.AuthenticatedActor(ctx)
+	if !ok {
+		return AgentManagementAttribution{}, ErrInvalidAgentManagementAttribution
+	}
+
+	// The lookup is pinned to the authenticated tenant. Missing and cross-tenant
+	// agents intentionally collapse to the same attribution error.
+	target, err := agents.GetAgentByID(ctx, agentrepo.GetAgentByIDParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ID:             agentID,
+	})
+	if err != nil || target.ID != agentID || target.OrganizationID != authCtx.ActiveOrganizationID ||
+		target.OwnerUserID == "" {
+		return AgentManagementAttribution{}, ErrInvalidAgentManagementAttribution
+	}
+
+	attribution := AgentManagementAttribution{
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		Actor:                  actor,
+		AffectedAgentID:        target.ID,
+		CurrentOwnerUserID:     target.OwnerUserID,
+		FormerOwnerUserID:      ownerChange.FormerOwnerUserID,
+		ReplacementOwnerUserID: ownerChange.ReplacementOwnerUserID,
+	}
+
+	return attribution, nil
+}

--- a/server/internal/audit/agent_attribution_test.go
+++ b/server/internal/audit/agent_attribution_test.go
@@ -1,0 +1,100 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	agentrepo "github.com/speakeasy-api/gram/server/internal/agents/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type stubAgentManagementTargetResolver struct {
+	agent  agentrepo.Agent
+	err    error
+	params agentrepo.GetAgentByIDParams
+}
+
+func (s *stubAgentManagementTargetResolver) GetAgentByID(_ context.Context, params agentrepo.GetAgentByIDParams) (agentrepo.Agent, error) {
+	s.params = params
+	return s.agent, s.err
+}
+
+func TestNewAgentManagementAttributionUsesTrustedCanonicalActor(t *testing.T) {
+	t.Parallel()
+
+	authCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_123",
+		UserID:               "user_actor",
+	}
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), authCtx, false)
+
+	// Mutating attribution-only public fields cannot change the trusted actor.
+	validated, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	validated.UserID = "user_not_actor"
+
+	agentID := uuid.MustParse("018f8d7b-58d7-7cc4-bb16-9f8c6b99a001")
+	resolver := &stubAgentManagementTargetResolver{agent: agentrepo.Agent{
+		ID: agentID, OrganizationID: "org_123", OwnerUserID: "user_current_owner",
+	}}
+	attribution, err := NewAgentManagementAttribution(ctx, resolver, agentID, AgentManagementOwnerChange{
+		FormerOwnerUserID:      "user_former_owner",
+		ReplacementOwnerUserID: "user_replacement_owner",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "org_123", attribution.OrganizationID)
+	require.Equal(t, urn.NewPrincipal(urn.PrincipalTypeUser, "user_actor"), attribution.Actor)
+	require.Equal(t, agentID, attribution.AffectedAgentID)
+	require.Equal(t, "user_current_owner", attribution.CurrentOwnerUserID)
+	require.Equal(t, "user_former_owner", attribution.FormerOwnerUserID)
+	require.Equal(t, "user_replacement_owner", attribution.ReplacementOwnerUserID)
+	require.Equal(t, agentrepo.GetAgentByIDParams{OrganizationID: "org_123", ID: agentID}, resolver.params)
+}
+
+func TestNewAgentManagementAttributionDoesNotInferActor(t *testing.T) {
+	t.Parallel()
+
+	agentID := uuid.MustParse("018f8d7b-58d7-7cc4-bb16-9f8c6b99a001")
+	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_123",
+		UserID:               "user_owner",
+		APIKeyID:             "key_123",
+	})
+	resolver := &stubAgentManagementTargetResolver{agent: agentrepo.Agent{
+		ID: agentID, OrganizationID: "org_123", OwnerUserID: "user_owner",
+	}}
+
+	_, err := NewAgentManagementAttribution(ctx, resolver, agentID, AgentManagementOwnerChange{})
+	require.ErrorIs(t, err, ErrInvalidAgentManagementAttribution)
+}
+
+func TestNewAgentManagementAttributionFailsClosedForInvalidTenantBoundTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_authenticated",
+		UserID:               "user_actor",
+	}, false)
+	foreignAgentID := uuid.MustParse("018f8d7b-58d7-7cc4-bb16-9f8c6b99a002")
+
+	tests := map[string]*stubAgentManagementTargetResolver{
+		"cross tenant":  {agent: agentrepo.Agent{ID: foreignAgentID, OrganizationID: "org_foreign", OwnerUserID: "user_foreign"}},
+		"missing agent": {err: errors.New("not found")},
+		"missing owner": {agent: agentrepo.Agent{ID: foreignAgentID, OrganizationID: "org_authenticated"}},
+	}
+	for name, resolver := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewAgentManagementAttribution(ctx, resolver, foreignAgentID, AgentManagementOwnerChange{})
+			require.ErrorIs(t, err, ErrInvalidAgentManagementAttribution)
+			require.Equal(t, ErrInvalidAgentManagementAttribution.Error(), err.Error())
+			require.NotContains(t, err.Error(), "org_foreign")
+			require.NotContains(t, err.Error(), "user_foreign")
+		})
+	}
+}

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // Manager handles chat session token lifecycle
@@ -126,5 +127,17 @@ func (m *Manager) Authorize(ctx context.Context, token string) (context.Context,
 		SupportOrganizationID: "",
 	}
 
-	return contextvalues.SetAuthContext(ctx, authCtx), nil
+	// Chat-session tokens predate principal-backed credentials and carry only
+	// legacy API-key provenance. M2 must reject principal-backed keys at token
+	// issuance or add an explicit versioned profile before they can reach here.
+	switch {
+	case authCtx.APIKeyID != "":
+		return contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx), nil
+	case authCtx.UserID != "":
+		return contextvalues.WithAuthenticatedActor(
+			ctx, authCtx, urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+		), nil
+	default:
+		return contextvalues.SetAuthContext(ctx, authCtx), nil
+	}
 }

--- a/server/internal/auth/chatsessions/manager.go
+++ b/server/internal/auth/chatsessions/manager.go
@@ -127,9 +127,12 @@ func (m *Manager) Authorize(ctx context.Context, token string) (context.Context,
 		SupportOrganizationID: "",
 	}
 
-	// Chat-session tokens predate principal-backed credentials and carry only
-	// legacy API-key provenance. M2 must reject principal-backed keys at token
-	// issuance or add an explicit versioned profile before they can reach here.
+	// API-key-minted chat sessions intentionally delegate the legacy key's
+	// authorization profile so MCP calls retain their existing permissions. They
+	// carry no direct key scopes, which lets chat access distinguish them from a
+	// direct key and enforce project and owner boundaries. M2 must reject
+	// principal-backed keys at token issuance or add an explicit versioned profile
+	// before they can reach here.
 	switch {
 	case authCtx.APIKeyID != "":
 		return contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx), nil

--- a/server/internal/auth/chatsessions/manager_test.go
+++ b/server/internal/auth/chatsessions/manager_test.go
@@ -124,4 +124,27 @@ func TestManagerAuthorize_ValidToken(t *testing.T) {
 	require.Equal(t, claims.OrgID, authCtx.ActiveOrganizationID)
 	require.Equal(t, claims.ProjectID, authCtx.ProjectID.String())
 	require.Equal(t, claims.UserID, authCtx.UserID)
+	actor, ok := contextvalues.AuthenticatedActor(authorizedCtx)
+	require.True(t, ok)
+	require.Equal(t, "user:"+claims.UserID, actor.String())
+}
+
+func TestManagerAuthorize_LegacyAPIKeyTokenKeepsExplicitProfile(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mgr := newTestManager(t)
+	claims := testClaims()
+	claims.APIKeyID = "key_123"
+	token, _, err := mgr.GenerateToken(ctx, claims, "https://example.com", 3600)
+	require.NoError(t, err)
+
+	authorizedCtx, err := mgr.Authorize(ctx, token)
+	require.NoError(t, err)
+	mode, ok := contextvalues.APIKeyAuthorization(authorizedCtx)
+	require.True(t, ok)
+	require.Equal(t, contextvalues.APIKeyAuthorizationModeLegacy, mode)
+	actor, ok := contextvalues.AuthenticatedActor(authorizedCtx)
+	require.True(t, ok)
+	require.Equal(t, "user:"+claims.UserID, actor.String())
 }

--- a/server/internal/auth/key.go
+++ b/server/internal/auth/key.go
@@ -322,7 +322,7 @@ func (k *ByKey) KeyBasedAuth(ctx context.Context, key string, requiredScopes []s
 		projectID = &apiKey.ProjectID.UUID
 	}
 
-	ctx = contextvalues.SetAuthContext(ctx, &contextvalues.AuthContext{
+	ctx = contextvalues.WithLegacyAPIKeyAuthorization(ctx, &contextvalues.AuthContext{
 		ActiveOrganizationID:  apiKey.OrganizationID,
 		HasActiveSubscription: org.HasActiveSubscription,
 		Whitelisted:           org.Whitelisted,

--- a/server/internal/authz/challenge_logger.go
+++ b/server/internal/authz/challenge_logger.go
@@ -51,6 +51,8 @@ const challengeOutboxTimeout = 10 * time.Second
 // feature is not enabled for the org (or the check fails), the call is a
 // no-op. Errors are logged at warn level and never bubble back to the caller.
 func (l challengeLogger) Log(ctx context.Context, dbtx database.DBTX, logger *slog.Logger, isEnabled ChallengeLoggingEnabled) {
+	RecordAuthorizationDecision(ctx, l.Operation, l.Outcome, l.Reason)
+
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
 		return

--- a/server/internal/authz/context_test.go
+++ b/server/internal/authz/context_test.go
@@ -69,7 +69,7 @@ func TestPrepareContext_skipsNonSessionAuth(t *testing.T) {
 	require.True(t, ok)
 	authCtx.SessionID = nil
 	authCtx.APIKeyID = "api-key-123"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	ctx = contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx)
 
 	ctx, err := engine.PrepareContext(ctx)
 	require.NoError(t, err)

--- a/server/internal/authz/decision_telemetry.go
+++ b/server/internal/authz/decision_telemetry.go
@@ -1,0 +1,83 @@
+package authz
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/authz/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+const (
+	authorizationDecisionEvent = "authorization.decision"
+	boundedUnknownValue        = "unknown"
+)
+
+// RecordAuthorizationDecision emits an identifier-only span event for the
+// shared authorization path and intrinsic agent-management decisions. It must
+// not grow to include checks, selectors, policy contents, names, emails, or errors.
+func RecordAuthorizationDecision(ctx context.Context, operation repo.Operation, outcome repo.Outcome, reason repo.Reason) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("gram.authorization.operation", boundedOperation(operation)),
+		attribute.String("gram.authorization.result", boundedOutcome(outcome)),
+		attribute.String("gram.authorization.reason", boundedReason(reason)),
+	}
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+		if authCtx.ActiveOrganizationID != "" {
+			attrs = append(attrs, attribute.String("gram.authorization.organization_id", authCtx.ActiveOrganizationID))
+		}
+		if actor, ok := contextvalues.AuthenticatedActor(ctx); ok {
+			attrs = append(attrs,
+				attribute.String("gram.authorization.actor.type", string(actor.Type)),
+				attribute.String("gram.authorization.actor.id", actor.ID),
+			)
+		}
+		if authCtx.APIKeyID != "" {
+			attrs = append(attrs, attribute.String("gram.authorization.api_key_id", authCtx.APIKeyID))
+		}
+		if authCtx.SessionID != nil && *authCtx.SessionID != "" {
+			attrs = append(attrs, attribute.String("gram.authorization.session_id", *authCtx.SessionID))
+		}
+	}
+	if clientID, ok := contextvalues.GetOAuthClientID(ctx); ok {
+		attrs = append(attrs, attribute.String("gram.authorization.oauth_client_id", clientID))
+	}
+
+	span.AddEvent(authorizationDecisionEvent, trace.WithAttributes(attrs...))
+}
+
+func boundedOperation(value repo.Operation) string {
+	switch value {
+	case repo.OperationRequire, repo.OperationRequireAny, repo.OperationFilter:
+		return string(value)
+	default:
+		return boundedUnknownValue
+	}
+}
+
+func boundedOutcome(value repo.Outcome) string {
+	switch value {
+	case repo.OutcomeAllow, repo.OutcomeDeny, repo.OutcomeError:
+		return string(value)
+	default:
+		return boundedUnknownValue
+	}
+}
+
+func boundedReason(value repo.Reason) string {
+	switch value {
+	case repo.ReasonGrantMatched, repo.ReasonNoGrants, repo.ReasonScopeUnsatisfied,
+		repo.ReasonDenyGrant, repo.ReasonInvalidCheck, repo.ReasonRBACSkippedAPIKey,
+		repo.ReasonDevOverride:
+		return string(value)
+	default:
+		return boundedUnknownValue
+	}
+}

--- a/server/internal/authz/decision_telemetry.go
+++ b/server/internal/authz/decision_telemetry.go
@@ -42,9 +42,6 @@ func RecordAuthorizationDecision(ctx context.Context, operation repo.Operation, 
 		if authCtx.APIKeyID != "" {
 			attrs = append(attrs, attribute.String("gram.authorization.api_key_id", authCtx.APIKeyID))
 		}
-		if authCtx.SessionID != nil && *authCtx.SessionID != "" {
-			attrs = append(attrs, attribute.String("gram.authorization.session_id", *authCtx.SessionID))
-		}
 	}
 	if clientID, ok := contextvalues.GetOAuthClientID(ctx); ok {
 		attrs = append(attrs, attribute.String("gram.authorization.oauth_client_id", clientID))

--- a/server/internal/authz/decision_telemetry_test.go
+++ b/server/internal/authz/decision_telemetry_test.go
@@ -55,6 +55,33 @@ func TestRecordAuthorizationDecisionEmitsBoundedAttribution(t *testing.T) {
 	require.NotContains(t, attrs, "gram.authorization.policy")
 }
 
+func TestRecordAuthorizationDecisionOmitsSessionCredentials(t *testing.T) {
+	t.Parallel()
+
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	sessionToken := "must-not-appear-in-telemetry"
+	ctx := contextvalues.WithValidatedGramSession(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_123",
+		UserID:               "user_123",
+		SessionID:            &sessionToken,
+	}, false)
+	ctx, span := provider.Tracer("test").Start(ctx, "request")
+	RecordAuthorizationDecision(ctx, repo.OperationRequire, repo.OutcomeAllow, repo.ReasonGrantMatched)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Events, 1)
+	attrs := decisionAttributeMap(spans[0].Events[0].Attributes)
+	require.NotContains(t, attrs, "gram.authorization.session_id")
+	for _, value := range attrs {
+		require.NotEqual(t, sessionToken, value)
+	}
+}
+
 func TestRecordAuthorizationDecisionBoundsUnknownValues(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/decision_telemetry_test.go
+++ b/server/internal/authz/decision_telemetry_test.go
@@ -1,0 +1,82 @@
+package authz
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/authz/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestRecordAuthorizationDecisionEmitsBoundedAttribution(t *testing.T) {
+	t.Parallel()
+
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	email := "must-not-appear@example.com"
+	agent := urn.NewPrincipal(urn.PrincipalTypeAgent, "018f8d7b-58d7-7cc4-bb16-9f8c6b99a001")
+	ctx := contextvalues.WithPrincipalAPIKeyAuthorization(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_123",
+		UserID:               "user_authorizer",
+		APIKeyID:             "key_123",
+		APIKeyName:           "must-not-appear",
+		Email:                &email,
+	}, agent)
+	ctx, span := provider.Tracer("test").Start(ctx, "request")
+	RecordAuthorizationDecision(ctx, repo.OperationRequire, repo.OutcomeDeny, repo.ReasonScopeUnsatisfied)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Events, 1)
+	event := spans[0].Events[0]
+	require.Equal(t, authorizationDecisionEvent, event.Name)
+	attrs := decisionAttributeMap(event.Attributes)
+	require.Equal(t, "require", attrs["gram.authorization.operation"])
+	require.Equal(t, "deny", attrs["gram.authorization.result"])
+	require.Equal(t, "scope_unsatisfied", attrs["gram.authorization.reason"])
+	require.Equal(t, "org_123", attrs["gram.authorization.organization_id"])
+	require.Equal(t, "agent", attrs["gram.authorization.actor.type"])
+	require.Equal(t, agent.ID, attrs["gram.authorization.actor.id"])
+	require.Equal(t, "key_123", attrs["gram.authorization.api_key_id"])
+	require.NotContains(t, attrs, "gram.authorization.session_id")
+	require.NotContains(t, attrs, "gram.authorization.oauth_client_id")
+	require.NotContains(t, attrs, "gram.authorization.actor.name")
+	require.NotContains(t, attrs, "gram.authorization.email")
+	require.NotContains(t, attrs, "gram.authorization.selector")
+	require.NotContains(t, attrs, "gram.authorization.policy")
+}
+
+func TestRecordAuthorizationDecisionBoundsUnknownValues(t *testing.T) {
+	t.Parallel()
+
+	exporter := tracetest.NewInMemoryExporter()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	ctx, span := provider.Tracer("test").Start(t.Context(), "request")
+	RecordAuthorizationDecision(ctx, repo.Operation("attacker-operation"), repo.Outcome("attacker-outcome"), repo.Reason("attacker-reason"))
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	attrs := decisionAttributeMap(spans[0].Events[0].Attributes)
+	require.Equal(t, boundedUnknownValue, attrs["gram.authorization.operation"])
+	require.Equal(t, boundedUnknownValue, attrs["gram.authorization.result"])
+	require.Equal(t, boundedUnknownValue, attrs["gram.authorization.reason"])
+}
+
+func decisionAttributeMap(attrs []attribute.KeyValue) map[string]string {
+	result := make(map[string]string, len(attrs))
+	for _, attr := range attrs {
+		result[string(attr.Key)] = attr.Value.AsString()
+	}
+	return result
+}

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -81,12 +81,26 @@ func (e *Engine) GetScopeOverrides(ctx context.Context) ([]RoleGrant, bool) {
 }
 
 func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
-	if _, ok := GrantsFromContext(ctx); ok {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
 		return ctx, nil
 	}
 
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	if !ok || authCtx == nil {
+	if mode, hasMode := contextvalues.APIKeyAuthorization(ctx); hasMode {
+		switch mode {
+		case contextvalues.APIKeyAuthorizationModeLegacy:
+			return ctx, nil
+		case contextvalues.APIKeyAuthorizationModePrincipal:
+			// Principal-backed admission owns grant loading. Until it has attached
+			// grants, an empty prepared set makes every check fail closed.
+			return GrantsToContext(ctx, nil), nil
+		}
+	}
+	if authCtx.APIKeyID != "" {
+		return ctx, oops.C(oops.CodeUnauthorized)
+	}
+
+	if _, ok := GrantsFromContext(ctx); ok {
 		return ctx, nil
 	}
 
@@ -594,13 +608,23 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		return false, oops.C(oops.CodeUnauthorized)
 	}
 
-	// Never enforce RBAC on API key requests — they have their own scoping.
+	if mode, hasMode := contextvalues.APIKeyAuthorization(ctx); hasMode {
+		if authCtx.APIKeyID == "" {
+			return false, oops.C(oops.CodeUnauthorized)
+		}
+		switch mode {
+		case contextvalues.APIKeyAuthorizationModeLegacy:
+			return false, nil
+		case contextvalues.APIKeyAuthorizationModePrincipal:
+			return true, nil
+		}
+	}
 	if authCtx.APIKeyID != "" {
-		return false, nil
+		return false, oops.C(oops.CodeUnauthorized)
 	}
 
-	// Scope overrides are checked after the API key exclusion so the toolbar
-	// doesn't interfere with API key auth flows.
+	// Scope overrides are checked after the explicit legacy API-key exclusion so
+	// the toolbar doesn't interfere with API key auth flows.
 	if _, ok := e.GetScopeOverrides(ctx); ok {
 		return true, nil
 	}

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -60,7 +60,7 @@ func TestEngineRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
 func TestEvaluateLoadedGrants_doesNotConsultShouldEnforce(t *testing.T) {
 	t.Parallel()
 	engine := NewEngine(testenv.NewLogger(t), nil, staticChallengeLogging(false), workos.NewStubClient())
-	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+	ctx := contextvalues.WithLegacyAPIKeyAuthorization(t.Context(), &contextvalues.AuthContext{
 		ActiveOrganizationID:  "org_123",
 		UserID:                "user_123",
 		ExternalUserID:        "",

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func staticChallengeLogging(enabled bool) ChallengeLoggingEnabled {
@@ -424,28 +425,45 @@ func TestEngineRequire_requiresChecks(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoChecks)
 }
 
-func TestEngineRequire_skipsForAPIKeyAuth(t *testing.T) {
+func TestEngineRequire_APIKeyAuthorizationModeIsExplicit(t *testing.T) {
 	t.Parallel()
 	engine := NewEngine(testenv.NewLogger(t), nil, staticChallengeLogging(false), workos.NewStubClient())
-	sessionID := "session_123"
-	ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
-		ActiveOrganizationID:  "org_123",
-		UserID:                "user_123",
-		ExternalUserID:        "",
-		APIKeyID:              "key_123",
-		SessionID:             &sessionID,
-		ProjectID:             nil,
-		OrganizationSlug:      "",
-		Email:                 nil,
-		AccountType:           "enterprise",
-		HasActiveSubscription: false,
-		Whitelisted:           false,
-		ProjectSlug:           nil,
-		APIKeyScopes:          nil,
-	})
+	authCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID: "org_123",
+		UserID:               "user_123",
+		APIKeyID:             "key_123",
+	}
+	check := Check{Scope: ScopeProjectRead, ResourceID: "proj_123"}
 
-	err := engine.Require(ctx, Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
+	unclassified := contextvalues.SetAuthContext(t.Context(), authCtx)
+	err := engine.Require(unclassified, check)
+	require.Error(t, err)
+	var unclassifiedErr *oops.ShareableError
+	require.ErrorAs(t, err, &unclassifiedErr)
+	require.Equal(t, oops.CodeUnauthorized, unclassifiedErr.Code)
+
+	legacy := contextvalues.WithLegacyAPIKeyAuthorization(t.Context(), authCtx)
+	require.NoError(t, engine.Require(legacy, check))
+
+	agent := urn.NewPrincipal(urn.PrincipalTypeAgent, "018f8d7b-58d7-7cc4-bb16-9f8c6b99a001")
+	principalBacked := contextvalues.WithPrincipalAPIKeyAuthorization(t.Context(), authCtx, agent)
+	enforce, err := engine.ShouldEnforce(principalBacked)
 	require.NoError(t, err)
+	require.True(t, enforce)
+
+	// Generic preloaded grants cannot bypass principal-backed admission.
+	principalBacked = GrantsToContext(principalBacked, []Grant{NewGrant(ScopeProjectRead, "proj_123")})
+	principalBacked, err = engine.PrepareContext(principalBacked)
+	require.NoError(t, err)
+	prepared, ok := GrantsFromContext(principalBacked)
+	require.True(t, ok)
+	require.Empty(t, prepared)
+
+	err = engine.Require(principalBacked, check)
+	require.Error(t, err)
+	var principalErr *oops.ShareableError
+	require.ErrorAs(t, err, &principalErr)
+	require.Equal(t, oops.CodeForbidden, principalErr.Code)
 }
 
 func TestEngineFilter_enforcesForNonEnterpriseAccount(t *testing.T) {

--- a/server/internal/authz/requested_organization_test.go
+++ b/server/internal/authz/requested_organization_test.go
@@ -75,7 +75,7 @@ func TestRequireUserOrganizationScopeRejectsAPIKeys(t *testing.T) {
 	require.True(t, ok)
 	authCtx.APIKeyID = "api_key_requested_scope"
 	authCtx.SessionID = nil
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	ctx = contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx)
 	engine := NewEngine(testenv.NewLogger(t), nil, challengeLoggingAlwaysEnabled, workos.NewStubClient())
 
 	err := engine.RequireUserOrganizationScope(ctx, "org_requested_scope_target", authCtx.UserID, ScopeOrgRead)

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -915,9 +915,13 @@ func (s *Service) authorizeChatAccess(ctx context.Context, authCtx *contextvalue
 	// token has none, so gate the exemption on the scopes being present.
 	_, isAssistantCall := contextvalues.GetAssistantPrincipal(ctx)
 	isDirectAPIKeyCall := authCtx.APIKeyID != "" && len(authCtx.APIKeyScopes) > 0
+	isAPIKeyChatSession := authCtx.APIKeyID != "" && len(authCtx.APIKeyScopes) == 0
 	if authCtx.SessionID == nil && !isDirectAPIKeyCall {
 		if !isAssistantCall {
 			if chat.ExternalUserID.String != "" && chat.ExternalUserID.String != authCtx.ExternalUserID {
+				return oops.C(oops.CodeUnauthorized)
+			}
+			if isAPIKeyChatSession && chat.UserID.Valid && chat.UserID.String != authCtx.UserID {
 				return oops.C(oops.CodeUnauthorized)
 			}
 		}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -921,8 +921,12 @@ func (s *Service) authorizeChatAccess(ctx context.Context, authCtx *contextvalue
 			if chat.ExternalUserID.String != "" && chat.ExternalUserID.String != authCtx.ExternalUserID {
 				return oops.C(oops.CodeUnauthorized)
 			}
-			if isAPIKeyChatSession && chat.UserID.Valid && chat.UserID.String != authCtx.UserID {
-				return oops.C(oops.CodeUnauthorized)
+			if isAPIKeyChatSession {
+				externalOwnerMatches := chat.ExternalUserID.Valid && chat.ExternalUserID.String != "" && chat.ExternalUserID.String == authCtx.ExternalUserID
+				userOwnerMatches := chat.UserID.Valid && chat.UserID.String != "" && chat.UserID.String == authCtx.UserID
+				if !externalOwnerMatches && !userOwnerMatches {
+					return oops.C(oops.CodeUnauthorized)
+				}
 			}
 		}
 	}

--- a/server/internal/chat/load_chat_apikey_test.go
+++ b/server/internal/chat/load_chat_apikey_test.go
@@ -140,6 +140,12 @@ func TestLoadChat_ChatSessionTokenStillOwnerMatched(t *testing.T) {
 	dashboardChatID := seedChat(t, seedCtx, ti, "different-dashboard-user", "", "dashboard chat")
 	_, err = ti.service.LoadChat(chatSessionTokenCtx(t, ti, "external-user-A"), loadPayload(dashboardChatID.String()))
 	requireOopsCode(t, err, oops.CodeUnauthorized)
+
+	// Ownerless legacy records must not become project-wide readable through a
+	// delegated chat-session token either.
+	ownerlessChatID := seedChat(t, seedCtx, ti, "", "", "ownerless chat")
+	_, err = ti.service.LoadChat(chatSessionTokenCtx(t, ti, "external-user-A"), loadPayload(ownerlessChatID.String()))
+	requireOopsCode(t, err, oops.CodeUnauthorized)
 }
 
 // createProjectInSameOrg adds a second project to ti's organization so a single

--- a/server/internal/chat/load_chat_apikey_test.go
+++ b/server/internal/chat/load_chat_apikey_test.go
@@ -134,6 +134,12 @@ func TestLoadChat_ChatSessionTokenStillOwnerMatched(t *testing.T) {
 	got, err := ti.service.LoadChat(chatSessionTokenCtx(t, ti, "external-user-A"), loadPayload(chatID.String()))
 	require.NoError(t, err)
 	require.Len(t, got.Messages, 2)
+
+	// Delegated API-key authorization must not let the token reach a dashboard
+	// chat owned by a different user in the same project.
+	dashboardChatID := seedChat(t, seedCtx, ti, "different-dashboard-user", "", "dashboard chat")
+	_, err = ti.service.LoadChat(chatSessionTokenCtx(t, ti, "external-user-A"), loadPayload(dashboardChatID.String()))
+	requireOopsCode(t, err, oops.CodeUnauthorized)
 }
 
 // createProjectInSameOrg adds a second project to ti's organization so a single

--- a/server/internal/chat/load_chat_apikey_test.go
+++ b/server/internal/chat/load_chat_apikey_test.go
@@ -19,13 +19,14 @@ import (
 func apiKeyCtx(t *testing.T, ti *chatTestInstance) context.Context {
 	t.Helper()
 	authCtx := &contextvalues.AuthContext{
+		UserID:               "api-key-creator",
 		APIKeyID:             uuid.NewString(),
 		APIKeyName:           "test-key",
 		APIKeyScopes:         []string{"producer"},
 		ProjectID:            &ti.projectID,
 		ActiveOrganizationID: ti.orgID,
 	}
-	return contextvalues.SetAuthContext(t.Context(), authCtx)
+	return contextvalues.WithLegacyAPIKeyAuthorization(t.Context(), authCtx)
 }
 
 // TestLoadChat_APIKey_ReadsAnyProjectChat proves a project API key can load a
@@ -102,13 +103,14 @@ func TestLoadChat_ExternalUserMismatchStillBlocked(t *testing.T) {
 func chatSessionTokenCtx(t *testing.T, ti *chatTestInstance, externalUserID string) context.Context {
 	t.Helper()
 	authCtx := &contextvalues.AuthContext{
+		UserID:               "api-key-creator",
 		APIKeyID:             uuid.NewString(), // restored from the JWT claims
 		APIKeyScopes:         nil,              // chat-session tokens never carry scopes
 		ExternalUserID:       externalUserID,
 		ProjectID:            &ti.projectID,
 		ActiveOrganizationID: ti.orgID,
 	}
-	return contextvalues.SetAuthContext(t.Context(), authCtx)
+	return contextvalues.WithLegacyAPIKeyAuthorization(t.Context(), authCtx)
 }
 
 // TestLoadChat_ChatSessionTokenStillOwnerMatched is the regression guard for the
@@ -176,13 +178,14 @@ func seedChatInProject(t *testing.T, ti *chatTestInstance, projectID uuid.UUID, 
 func apiKeyCtxForProject(t *testing.T, ti *chatTestInstance, projectID uuid.UUID) context.Context {
 	t.Helper()
 	authCtx := &contextvalues.AuthContext{
+		UserID:               "api-key-creator",
 		APIKeyID:             uuid.NewString(),
 		APIKeyName:           "test-key",
 		APIKeyScopes:         []string{"producer"},
 		ProjectID:            &projectID,
 		ActiveOrganizationID: ti.orgID,
 	}
-	return contextvalues.SetAuthContext(t.Context(), authCtx)
+	return contextvalues.WithLegacyAPIKeyAuthorization(t.Context(), authCtx)
 }
 
 // TestLoadChat_OrgWideAPIKey_ReadsChatsInAnyProject covers the org-wide key case

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -5,9 +5,19 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 type contextKey string
+
+// APIKeyAuthorizationMode selects the authorization profile established from
+// a loaded API-key row. Credential provenance alone must never select a mode.
+type APIKeyAuthorizationMode uint8
+
+const (
+	APIKeyAuthorizationModeLegacy APIKeyAuthorizationMode = iota + 1
+	APIKeyAuthorizationModePrincipal
+)
 
 type AuthContext struct {
 	ActiveOrganizationID  string
@@ -29,15 +39,27 @@ type AuthContext struct {
 	// SupportOrganizationID is set only after session authentication validates
 	// a time-bounded platform-admin support session for this organization.
 	SupportOrganizationID     string
+	actor                     urn.Principal
+	apiKeyAuthorizationMode   APIKeyAuthorizationMode
 	gramSessionValidated      bool
 	supportSessionValidated   bool
 	legacySessionImpersonated bool
+}
+
+// WithAuthenticatedActor records the canonical actor established by a trusted
+// authentication path. Attribution consumers never infer this from public
+// provenance fields on AuthContext.
+func WithAuthenticatedActor(ctx context.Context, authCtx *AuthContext, actor urn.Principal) context.Context {
+	validated := *authCtx
+	validated.actor = actor
+	return SetAuthContext(ctx, &validated)
 }
 
 // WithValidatedGramSession records provenance established by sessions.Authenticate.
 // Other authentication paths must not call this function.
 func WithValidatedGramSession(ctx context.Context, authCtx *AuthContext, legacyImpersonated bool) context.Context {
 	validated := *authCtx
+	validated.actor = urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)
 	validated.gramSessionValidated = true
 	validated.legacySessionImpersonated = legacyImpersonated
 	return SetAuthContext(ctx, &validated)
@@ -48,6 +70,53 @@ func WithValidatedGramSession(ctx context.Context, authCtx *AuthContext, legacyI
 func HasValidatedGramSession(ctx context.Context) bool {
 	authCtx, ok := GetAuthContext(ctx)
 	return ok && authCtx != nil && authCtx.gramSessionValidated
+}
+
+// WithLegacyAPIKeyAuthorization records the legacy authorization profile from
+// a loaded API-key row. It keeps the key ID as credential provenance and the
+// creating user as the existing canonical actor.
+func WithLegacyAPIKeyAuthorization(ctx context.Context, authCtx *AuthContext) context.Context {
+	validated := *authCtx
+	validated.actor = urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)
+	validated.apiKeyAuthorizationMode = APIKeyAuthorizationModeLegacy
+	return SetAuthContext(ctx, &validated)
+}
+
+// WithPrincipalAPIKeyAuthorization records a principal-backed profile selected
+// from authoritative credential state. Authentication code must pass the
+// parsed and validated credential subject as actor.
+func WithPrincipalAPIKeyAuthorization(ctx context.Context, authCtx *AuthContext, actor urn.Principal) context.Context {
+	validated := *authCtx
+	validated.actor = actor
+	validated.apiKeyAuthorizationMode = APIKeyAuthorizationModePrincipal
+	return SetAuthContext(ctx, &validated)
+}
+
+// AuthenticatedActor returns the canonical actor established by a trusted
+// authentication path. Public AuthContext fields are never used as fallbacks.
+func AuthenticatedActor(ctx context.Context) (urn.Principal, bool) {
+	authCtx, ok := GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.actor.IsZero() {
+		var zero urn.Principal
+		return zero, false
+	}
+	actor, err := urn.ParsePrincipal(authCtx.actor.String())
+	return actor, err == nil
+}
+
+// APIKeyAuthorization returns the profile selected by trusted API-key
+// authentication. APIKeyID remains independent credential provenance.
+func APIKeyAuthorization(ctx context.Context) (APIKeyAuthorizationMode, bool) {
+	authCtx, ok := GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		return 0, false
+	}
+	switch authCtx.apiKeyAuthorizationMode {
+	case APIKeyAuthorizationModeLegacy, APIKeyAuthorizationModePrincipal:
+		return authCtx.apiKeyAuthorizationMode, true
+	default:
+		return 0, false
+	}
 }
 
 // IsLegacyImpersonatedSession reports legacy WorkOS impersonation propagated by

--- a/server/internal/contextvalues/context_test.go
+++ b/server/internal/contextvalues/context_test.go
@@ -1,9 +1,12 @@
 package contextvalues
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func TestIsSupportSessionRequiresValidatedContext(t *testing.T) {
@@ -37,6 +40,63 @@ func TestValidatedGramSessionProvenanceIsPrivateAndPropagatesLegacyImpersonation
 	impersonated := WithValidatedGramSession(t.Context(), base, true)
 	require.True(t, HasValidatedGramSession(impersonated))
 	require.True(t, IsLegacyImpersonatedSession(impersonated))
+}
+
+func TestAuthContextHasOneCanonicalTypedActor(t *testing.T) {
+	t.Parallel()
+
+	principalType := reflect.TypeFor[urn.Principal]()
+	authContextType := reflect.TypeFor[AuthContext]()
+	count := 0
+	for field := range authContextType.Fields() {
+		if field.Type == principalType {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}
+
+func TestAuthenticatedActorAndCredentialProvenanceAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	untrusted := SetAuthContext(t.Context(), &AuthContext{UserID: "user_untrusted", APIKeyID: "key_untrusted"})
+	_, ok := AuthenticatedActor(untrusted)
+	require.False(t, ok)
+	_, ok = APIKeyAuthorization(untrusted)
+	require.False(t, ok)
+
+	legacy := WithLegacyAPIKeyAuthorization(t.Context(), &AuthContext{
+		UserID: "user_authorizer", APIKeyID: "key_123", APIKeyScopes: []string{"agent", "agent_user"},
+	})
+	actor, ok := AuthenticatedActor(legacy)
+	require.True(t, ok)
+	require.Equal(t, "user:user_authorizer", actor.String())
+	mode, ok := APIKeyAuthorization(legacy)
+	require.True(t, ok)
+	require.Equal(t, APIKeyAuthorizationModeLegacy, mode)
+	legacyAuth, ok := GetAuthContext(legacy)
+	require.True(t, ok)
+	require.Equal(t, "key_123", legacyAuth.APIKeyID)
+
+	agent := urn.NewPrincipal(urn.PrincipalTypeAgent, "018f8d7b-58d7-7cc4-bb16-9f8c6b99a001")
+	principalBacked := WithPrincipalAPIKeyAuthorization(t.Context(), &AuthContext{
+		UserID: "user_authorizer", APIKeyID: "key_agent",
+	}, agent)
+	actor, ok = AuthenticatedActor(principalBacked)
+	require.True(t, ok)
+	require.Equal(t, agent, actor)
+	mode, ok = APIKeyAuthorization(principalBacked)
+	require.True(t, ok)
+	require.Equal(t, APIKeyAuthorizationModePrincipal, mode)
+}
+
+func TestValidatedGramSessionSetsCanonicalUserActor(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithValidatedGramSession(t.Context(), &AuthContext{UserID: "user_123"}, false)
+	actor, ok := AuthenticatedActor(ctx)
+	require.True(t, ok)
+	require.Equal(t, "user:user_123", actor.String())
 }
 
 func TestRefreshSessionCookieIgnoresNilCallback(t *testing.T) {

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -424,13 +424,18 @@ func (s *Service) contextForSessionSubject(
 	switch subject.Kind {
 	case urn.SessionSubjectKindUser:
 		authCtx.UserID = subject.ID
+		return contextvalues.WithAuthenticatedActor(
+			ctx, authCtx, urn.NewPrincipal(urn.PrincipalTypeUser, subject.ID),
+		), nil
 	case urn.SessionSubjectKindAPIKey:
 		authCtx.APIKeyID = subject.ID
+		return contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx), nil
 	case urn.SessionSubjectKindAnonymous:
 		// Unreachable: anonymous subjects return ctx untouched above. Listed
 		// for exhaustiveness so the linter doesn't flag the switch.
+		return ctx, nil
 	}
-	return contextvalues.SetAuthContext(ctx, authCtx), nil
+	return ctx, oops.C(oops.CodeUnauthorized)
 }
 
 // AuthenticateChallengeHeader builds the WWW-Authenticate value (RFC 9728

--- a/server/internal/platformmcp/skills.go
+++ b/server/internal/platformmcp/skills.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 // maxSkillContentBytes mirrors the skills service's own manifest ceiling. It is
@@ -221,7 +222,7 @@ func (s *SkillsService) begin(ctx context.Context, principal Principal, projectS
 	if existing, ok := contextvalues.GetAuthContext(ctx); ok && existing != nil {
 		sessionID = existing.SessionID
 	}
-	ctx = contextvalues.SetAuthContext(ctx, &contextvalues.AuthContext{
+	ctx = contextvalues.WithAuthenticatedActor(ctx, &contextvalues.AuthContext{
 		ActiveOrganizationID:  principal.OrganizationID,
 		UserID:                principal.UserID,
 		ExternalUserID:        "",
@@ -238,7 +239,7 @@ func (s *SkillsService) begin(ctx context.Context, principal Principal, projectS
 		ProjectSlug:           &project.Slug,
 		APIKeyScopes:          nil,
 		IsAdmin:               false,
-	})
+	}, urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID))
 	// Grants are loaded for the acting user, so a connection reaches exactly the
 	// projects that user's own role reaches — the OAuth org-admin check at the
 	// endpoint says who may connect, not what they may write.


### PR DESCRIPTION
## Summary

Introduces one trusted canonical actor principal in request identity while keeping API-key and session IDs as credential provenance. Makes legacy versus principal-backed API-key authorization explicit, adds a tenant-bound agent-management audit attribution envelope, and emits bounded authorization decision span events.

## Motivation

Implements [AIM-189](https://linear.app/speakeasy/issue/AIM-189/feat-carry-canonical-agent-attribution-through-requests-audit-and) as a stacked change on [AIM-183 / #6040](https://github.com/speakeasy-api/gram/pull/6040). AIM-183 in turn depends on the agent schema in [#6038](https://github.com/speakeasy-api/gram/pull/6038).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the authorization scope contracts for AIM-189 so agent management can be granted and enforced independently of org admin.

**Authorization**
- Adds `agent:read`, `agent:write`, `agent:authorize`, and `agent:transfer` as independent scopes; none implies another and `org:admin` doesn't imply any.
- Adds the `agent` resource kind across server authz, generated API types, SDK models, and the dashboard role editor, where agent scopes appear as unrestricted "All agents" grants.
- Adds a versioned runtime scope registry that fails closed for unknown, retired, or not-yet-safe scopes; agent management scopes are registered but intentionally not agent-runtime-safe.
- Keeps retired `mcp_approval:*` names as parse-only tombstones so existing delegated policy still loads.

<sup>Written for commit 2de0f0441c309ce0336e25af2f8cd0d61e9f1c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

