### PR TITLE
chore: backfill agent management grants for organization admins

### DIFF
--- a/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
+++ b/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
@@ -14,8 +14,8 @@ The migration targets every active role with the reserved `admin` slug that can 
 - The default mode is a non-writing dry run.
 - Apply writes in keyset-ordered organization batches. Each batch commits independently. Inserts use the existing grant uniqueness key and normalize only a conflicting canonical grant's legacy effect, so restarting from the beginning after interruption is safe.
 - Apply adds canonical grants only. It does not remove unexpected rows, replace existing role policy, change custom roles, or change unrelated grants.
-- Every apply ends with complete-population verification at a repeatable-read snapshot.
-- Verification reports aggregate counts and at most `-sample-limit` internal organization-ID/principal-URN/scope records per defect category. It never reads or reports organization names, user IDs, emails, role names, or selectors.
+- Every successful apply ends with complete-population verification at a repeatable-read snapshot. After an interrupted or failed apply, rerun apply and then run standalone verification before opening the rollout gate.
+- Verification reports aggregate counts and at most `-sample-limit` internal organization-ID/principal-URN/scope records per defect category. It never reads or reports organization names, user IDs, emails, role names, or selector values.
 - Verification fails unless every organization has at least one active administrator role, every active administrator principal has all four canonical unrestricted allow grants, and no other `agent:*` rows exist on those roles. Noncanonical selectors or effects on one of the four scopes are unexpected rows.
 - `-apply` requires `GRAM_ENVIRONMENT` and `-confirm-environment` to exactly match `-environment`. Production apply also requires `-confirm-production=production`. Database credentials come only from `GRAM_DATABASE_URL`.
 
@@ -25,7 +25,7 @@ Agent-management endpoints must remain disabled for a target environment or coho
 
 If verification is blocked, investigate the bounded samples internally, repair the role data through the existing role/grant machinery, rerun apply if required grants are missing, and repeat verification. Do not add an `org:admin` runtime fallback or enable a partially verified cohort.
 
-Set `GRAM_ENVIRONMENT` to the actual target environment. Set `GRAM_CODE_SHA` to the published commit being run so retained aggregate output identifies the implementation revision.
+Set `GRAM_DATABASE_URL` to the target PostgreSQL URL with `sslmode=require`, `sslmode=verify-ca`, or `sslmode=verify-full`; plaintext and fallback-to-plaintext connections are rejected. Keep credentials in this environment variable, not in command flags. Set `GRAM_ENVIRONMENT` to the actual target environment. Set `GRAM_CODE_SHA` to the published commit being run so retained aggregate output identifies the implementation revision.
 
 ## Procedure
 

--- a/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
+++ b/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
@@ -1,0 +1,64 @@
+# Agent management grants backfill
+
+`agent-management-grants` is a PostgreSQL-only operator migration for the built-in organization administrator role. It adds these unrestricted grants to every recognized active administrator role:
+
+- `agent:read`
+- `agent:write`
+- `agent:authorize`
+- `agent:transfer`
+
+The migration targets every active role with the reserved `admin` slug that can authorize users in an organization, including both global and organization-scoped administrator principals when both remain active. It never targets any other role slug or principal.
+
+## Safety model
+
+- The default mode is a non-writing dry run.
+- Apply writes in keyset-ordered organization batches. Each batch commits independently. Inserts use the existing grant uniqueness key and normalize only a conflicting canonical grant's legacy effect, so restarting from the beginning after interruption is safe.
+- Apply adds canonical grants only. It does not remove unexpected rows, replace existing role policy, change custom roles, or change unrelated grants.
+- Every apply ends with complete-population verification at a repeatable-read snapshot.
+- Verification reports aggregate counts and at most `-sample-limit` internal organization-ID/principal-URN/scope records per defect category. It never reads or reports organization names, user IDs, emails, role names, or selectors.
+- Verification fails unless every organization has at least one active administrator role, every active administrator principal has all four canonical unrestricted allow grants, and no other `agent:*` rows exist on those roles. Noncanonical selectors or effects on one of the four scopes are unexpected rows.
+- `-apply` requires `GRAM_ENVIRONMENT` and `-confirm-environment` to exactly match `-environment`. Production apply also requires `-confirm-production=production`. Database credentials come only from `GRAM_DATABASE_URL`.
+
+## Rollout gate
+
+Agent-management endpoints must remain disabled for a target environment or cohort until `-verify` exits zero against that complete target database and the output has `summary.verification.ready_for_enforcement=true`. A dry run is evidence for planning only; it does not open the gate. Apply also blocks if its final verification finds unexpected rows or unresolved administrator roles.
+
+If verification is blocked, investigate the bounded samples internally, repair the role data through the existing role/grant machinery, rerun apply if required grants are missing, and repeat verification. Do not add an `org:admin` runtime fallback or enable a partially verified cohort.
+
+Set `GRAM_ENVIRONMENT` to the actual target environment. Set `GRAM_CODE_SHA` to the published commit being run so retained aggregate output identifies the implementation revision.
+
+## Procedure
+
+1. Dry-run in staging and retain the bounded aggregate output:
+
+   ```sh
+   go run ./server/cmd/tools/migrations agent-management-grants \
+     -environment=staging
+   ```
+
+2. Apply in staging:
+
+   ```sh
+   go run ./server/cmd/tools/migrations agent-management-grants \
+     -apply -environment=staging -confirm-environment=staging
+   ```
+
+3. Run the rollout gate separately. Do not enable enforcement unless this exits zero and reports readiness:
+
+   ```sh
+   go run ./server/cmd/tools/migrations agent-management-grants \
+     -verify -environment=staging
+   ```
+
+4. Repeat dry-run, apply, and verify in production. Production apply requires both confirmations:
+
+   ```sh
+   go run ./server/cmd/tools/migrations agent-management-grants \
+     -apply -environment=production -confirm-environment=production \
+     -confirm-production=production
+
+   go run ./server/cmd/tools/migrations agent-management-grants \
+     -verify -environment=production
+   ```
+
+An interrupted run can be restarted with the same apply command. Previously committed batches are no-ops, and missing later batches are filled. Keep `-batch-size` between 1 and 1000 and `-sample-limit` between 1 and 100.

--- a/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
+++ b/server/cmd/tools/migrations/AGENT_MANAGEMENT_GRANTS_MIGRATION.md
@@ -21,7 +21,7 @@ The migration targets every active role with the reserved `admin` slug that can 
 
 ## Rollout gate
 
-Agent-management endpoints must remain disabled for a target environment or cohort until `-verify` exits zero against that complete target database and the output has `summary.verification.ready_for_enforcement=true`. A dry run is evidence for planning only; it does not open the gate. Apply also blocks if its final verification finds unexpected rows or unresolved administrator roles.
+Agent-management endpoints fail closed behind the `agent-management` feature flag. Keep that flag disabled for a target environment or cohort until `-verify` exits zero against that complete target database and the output has `summary.verification.ready_for_enforcement=true`. A dry run is evidence for planning only; it does not open the gate. Apply also blocks if its final verification finds unexpected rows or unresolved administrator roles.
 
 If verification is blocked, investigate the bounded samples internally, repair the role data through the existing role/grant machinery, rerun apply if required grants are missing, and repeat verification. Do not add an `org:admin` runtime fallback or enable a partially verified cohort.
 
@@ -43,7 +43,7 @@ Set `GRAM_DATABASE_URL` to the target PostgreSQL URL with `sslmode=require`, `ss
      -apply -environment=staging -confirm-environment=staging
    ```
 
-3. Run the rollout gate separately. Do not enable enforcement unless this exits zero and reports readiness:
+3. Run database verification separately. Do not enable the `agent-management` feature flag unless this command exits zero and reports readiness:
 
    ```sh
    go run ./server/cmd/tools/migrations agent-management-grants \

--- a/server/cmd/tools/migrations/README.md
+++ b/server/cmd/tools/migrations/README.md
@@ -6,12 +6,12 @@ reusable **Source → Transform → Sink** pipeline.
 Each concrete migration is a set of three small implementations wired together by
 the shared harness. The migrations shipped today:
 
-| Migration                                                                           | Doc                                                                    |
-| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Postgres `risk_results` → ClickHouse `risk_findings`                                | [RISK_RESULTS_MIGRATION.md](./RISK_RESULTS_MIGRATION.md)               |
-| `risk_findings` `message_created_at`/`assistant_id` column backfill (via mutations) | [RISKFINDINGS_COLS_MIGRATION.md](./RISKFINDINGS_COLS_MIGRATION.md)     |
-| Legacy risk policy scope folded into per-category detection scopes                  | [LEGACY_POLICY_SCOPE_MIGRATION.md](./LEGACY_POLICY_SCOPE_MIGRATION.md) |
-| Built-in administrator agent-management grant backfill and rollout gate | [AGENT_MANAGEMENT_GRANTS_MIGRATION.md](./AGENT_MANAGEMENT_GRANTS_MIGRATION.md) |
+| Migration                                                                           | Doc                                                                            |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Postgres `risk_results` → ClickHouse `risk_findings`                                | [RISK_RESULTS_MIGRATION.md](./RISK_RESULTS_MIGRATION.md)                       |
+| `risk_findings` `message_created_at`/`assistant_id` column backfill (via mutations) | [RISKFINDINGS_COLS_MIGRATION.md](./RISKFINDINGS_COLS_MIGRATION.md)             |
+| Legacy risk policy scope folded into per-category detection scopes                  | [LEGACY_POLICY_SCOPE_MIGRATION.md](./LEGACY_POLICY_SCOPE_MIGRATION.md)         |
+| Built-in administrator agent-management grant backfill and rollout gate             | [AGENT_MANAGEMENT_GRANTS_MIGRATION.md](./AGENT_MANAGEMENT_GRANTS_MIGRATION.md) |
 
 ## Concepts
 

--- a/server/cmd/tools/migrations/README.md
+++ b/server/cmd/tools/migrations/README.md
@@ -11,6 +11,7 @@ the shared harness. The migrations shipped today:
 | Postgres `risk_results` → ClickHouse `risk_findings`                                | [RISK_RESULTS_MIGRATION.md](./RISK_RESULTS_MIGRATION.md)               |
 | `risk_findings` `message_created_at`/`assistant_id` column backfill (via mutations) | [RISKFINDINGS_COLS_MIGRATION.md](./RISKFINDINGS_COLS_MIGRATION.md)     |
 | Legacy risk policy scope folded into per-category detection scopes                  | [LEGACY_POLICY_SCOPE_MIGRATION.md](./LEGACY_POLICY_SCOPE_MIGRATION.md) |
+| Built-in administrator agent-management grant backfill and rollout gate | [AGENT_MANAGEMENT_GRANTS_MIGRATION.md](./AGENT_MANAGEMENT_GRANTS_MIGRATION.md) |
 
 ## Concepts
 

--- a/server/cmd/tools/migrations/agent_management_grants_cmd.go
+++ b/server/cmd/tools/migrations/agent_management_grants_cmd.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/agentmanagementgrants"
+)
+
+const agentManagementGrantContractVersion = "v1"
+
+type agentManagementGrantsConfig struct {
+	dbURL            string
+	environment      string
+	codeSHA          string
+	mode             agentmanagementgrants.Mode
+	batchSize        int
+	sampleLimit      int
+	lockTimeout      time.Duration
+	statementTimeout time.Duration
+}
+
+type agentManagementGrantsCommandSummary struct {
+	RunID           string                        `json:"run_id"`
+	Environment     string                        `json:"environment"`
+	CodeSHA         string                        `json:"code_sha"`
+	ContractVersion string                        `json:"contract_version"`
+	Result          string                        `json:"result"`
+	ElapsedMS       int64                         `json:"elapsed_ms"`
+	Summary         agentmanagementgrants.Summary `json:"summary"`
+}
+
+func parseAgentManagementGrantsFlags(args []string, getenv func(string) string) (agentManagementGrantsConfig, error) {
+	fs := flag.NewFlagSet("agent-management-grants", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	apply := fs.Bool("apply", false, "write missing canonical grants")
+	verify := fs.Bool("verify", false, "gate enforcement on complete-population verification")
+	environment := fs.String("environment", "", "explicit target environment")
+	confirmEnvironment := fs.String("confirm-environment", "", "must exactly match environment for a write")
+	confirmProduction := fs.String("confirm-production", "", "must equal production for a production write")
+	batchSize := fs.Int("batch-size", 100, "organization keyset batch size")
+	sampleLimit := fs.Int("sample-limit", 20, "maximum defect samples in each category")
+	lockTimeout := fs.Duration("lock-timeout", 2*time.Second, "per-transaction lock timeout")
+	statementTimeout := fs.Duration("statement-timeout", 30*time.Second, "per-transaction statement timeout")
+	if err := fs.Parse(args); err != nil || fs.NArg() != 0 {
+		return agentManagementGrantsConfig{}, errors.New("invalid agent-management-grants flags")
+	}
+	if *apply && *verify {
+		return agentManagementGrantsConfig{}, errors.New("apply and verify modes are mutually exclusive")
+	}
+	if *environment == "" || strings.IndexFunc(*environment, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		return agentManagementGrantsConfig{}, errors.New("environment is required and must not contain control characters")
+	}
+	if *batchSize <= 0 || *batchSize > 1000 {
+		return agentManagementGrantsConfig{}, errors.New("batch-size must be between 1 and 1000")
+	}
+	if *sampleLimit <= 0 || *sampleLimit > 100 {
+		return agentManagementGrantsConfig{}, errors.New("sample-limit must be between 1 and 100")
+	}
+	if *lockTimeout < time.Millisecond || *statementTimeout < time.Millisecond {
+		return agentManagementGrantsConfig{}, errors.New("timeouts must be at least 1ms")
+	}
+	if *apply {
+		runtimeEnvironment := getenv("GRAM_ENVIRONMENT")
+		if runtimeEnvironment == "" || runtimeEnvironment != *environment {
+			return agentManagementGrantsConfig{}, errors.New("GRAM_ENVIRONMENT must exactly match environment for apply mode")
+		}
+		if *confirmEnvironment != *environment {
+			return agentManagementGrantsConfig{}, errors.New("confirm-environment must exactly match environment for apply mode")
+		}
+		if *environment == "production" && *confirmProduction != "production" {
+			return agentManagementGrantsConfig{}, errors.New("production apply requires confirm-production=production")
+		}
+	}
+
+	mode := agentmanagementgrants.ModeDryRun
+	if *apply {
+		mode = agentmanagementgrants.ModeApply
+	} else if *verify {
+		mode = agentmanagementgrants.ModeVerify
+	}
+	dbURL := getenv("GRAM_DATABASE_URL")
+	if dbURL == "" {
+		return agentManagementGrantsConfig{}, errors.New("GRAM_DATABASE_URL is required")
+	}
+	return agentManagementGrantsConfig{
+		dbURL: dbURL, environment: *environment, codeSHA: getenv("GRAM_CODE_SHA"), mode: mode,
+		batchSize: *batchSize, sampleLimit: *sampleLimit, lockTimeout: *lockTimeout, statementTimeout: *statementTimeout,
+	}, nil
+}
+
+func runAgentManagementGrants(args []string, stdout io.Writer, getenv func(string) string) int {
+	cfg, err := parseAgentManagementGrantsFlags(args, getenv)
+	if err != nil {
+		log.Printf("invalid agent-management-grants configuration: %v", err)
+		return 2
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool, err := pgxpool.New(ctx, cfg.dbURL)
+	if err != nil {
+		log.Print("connect postgres for agent-management-grants failed")
+		return 1
+	}
+	defer pool.Close()
+
+	started := time.Now()
+	runner := agentmanagementgrants.NewRunner(pool, agentmanagementgrants.Options{
+		BatchSize: cfg.batchSize, SampleLimit: cfg.sampleLimit, LockTimeout: cfg.lockTimeout, StatementTimeout: cfg.statementTimeout,
+	})
+	summary, runErr := runner.Run(ctx, cfg.mode)
+	result := "success"
+	if runErr != nil {
+		result = "blocked"
+	}
+	commandSummary := agentManagementGrantsCommandSummary{
+		RunID: uuid.NewString(), Environment: cfg.environment, CodeSHA: cfg.codeSHA,
+		ContractVersion: agentManagementGrantContractVersion, Result: result,
+		ElapsedMS: time.Since(started).Milliseconds(), Summary: summary,
+	}
+	if err := writeAgentManagementGrantsSummary(stdout, commandSummary); err != nil {
+		log.Printf("write bounded agent-management-grants summary: %v", err)
+		return 1
+	}
+	if runErr != nil {
+		log.Printf("agent-management-grants blocked; error_category=%s; inspect bounded summary", agentManagementGrantsErrorCategory(runErr))
+		return 1
+	}
+	return 0
+}
+
+func agentManagementGrantsErrorCategory(err error) string {
+	switch {
+	case errors.Is(err, agentmanagementgrants.ErrVerificationFailed):
+		return "verification_failed"
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "database_or_timeout"
+	default:
+		if _, ok := errors.AsType[*pgconn.PgError](err); ok {
+			return "database_or_timeout"
+		}
+		return "unexpected"
+	}
+}
+
+func writeAgentManagementGrantsSummary(writer io.Writer, summary agentManagementGrantsCommandSummary) error {
+	if err := json.NewEncoder(writer).Encode(summary); err != nil {
+		return fmt.Errorf("encode agent management grants summary: %w", err)
+	}
+	return nil
+}

--- a/server/cmd/tools/migrations/agent_management_grants_cmd.go
+++ b/server/cmd/tools/migrations/agent_management_grants_cmd.go
@@ -94,10 +94,29 @@ func parseAgentManagementGrantsFlags(args []string, getenv func(string) string) 
 	if dbURL == "" {
 		return agentManagementGrantsConfig{}, errors.New("GRAM_DATABASE_URL is required")
 	}
+	if err := validateAgentManagementGrantsDatabaseURL(dbURL); err != nil {
+		return agentManagementGrantsConfig{}, err
+	}
 	return agentManagementGrantsConfig{
 		dbURL: dbURL, environment: *environment, codeSHA: getenv("GRAM_CODE_SHA"), mode: mode,
 		batchSize: *batchSize, sampleLimit: *sampleLimit, lockTimeout: *lockTimeout, statementTimeout: *statementTimeout,
 	}, nil
+}
+
+func validateAgentManagementGrantsDatabaseURL(databaseURL string) error {
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return errors.New("GRAM_DATABASE_URL is invalid")
+	}
+	if config.ConnConfig.TLSConfig == nil {
+		return errors.New("GRAM_DATABASE_URL must require TLS without plaintext fallbacks")
+	}
+	for _, fallback := range config.ConnConfig.Fallbacks {
+		if fallback.TLSConfig == nil {
+			return errors.New("GRAM_DATABASE_URL must require TLS without plaintext fallbacks")
+		}
+	}
+	return nil
 }
 
 func runAgentManagementGrants(args []string, stdout io.Writer, getenv func(string) string) int {
@@ -148,6 +167,9 @@ func agentManagementGrantsErrorCategory(err error) string {
 		return "database_or_timeout"
 	default:
 		if _, ok := errors.AsType[*pgconn.PgError](err); ok {
+			return "database_or_timeout"
+		}
+		if _, ok := errors.AsType[*pgconn.ConnectError](err); ok {
 			return "database_or_timeout"
 		}
 		return "unexpected"

--- a/server/cmd/tools/migrations/agent_management_grants_cmd_test.go
+++ b/server/cmd/tools/migrations/agent_management_grants_cmd_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/agentmanagementgrants"
+)
+
+func TestParseAgentManagementGrantsFlags(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		args        []string
+		environment string
+		mode        agentmanagementgrants.Mode
+	}{
+		{name: "dry run", args: []string{"-environment=staging"}, environment: "staging", mode: agentmanagementgrants.ModeDryRun},
+		{name: "verify", args: []string{"-verify", "-environment=production"}, environment: "production", mode: agentmanagementgrants.ModeVerify},
+		{name: "staging apply", args: []string{"-apply", "-environment=staging", "-confirm-environment=staging"}, environment: "staging", mode: agentmanagementgrants.ModeApply},
+		{name: "production apply", args: []string{"-apply", "-environment=production", "-confirm-environment=production", "-confirm-production=production"}, environment: "production", mode: agentmanagementgrants.ModeApply},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			getenv := func(key string) string {
+				switch key {
+				case "GRAM_DATABASE_URL":
+					return "postgres://test"
+				case "GRAM_ENVIRONMENT":
+					return test.environment
+				default:
+					return ""
+				}
+			}
+			cfg, err := parseAgentManagementGrantsFlags(test.args, getenv)
+			require.NoError(t, err)
+			require.Equal(t, test.mode, cfg.mode)
+		})
+	}
+}
+
+func TestParseAgentManagementGrantsFlagsRejectsUnsafeModes(t *testing.T) {
+	t.Parallel()
+	getenv := func(key string) string {
+		switch key {
+		case "GRAM_DATABASE_URL":
+			return "postgres://test"
+		case "GRAM_ENVIRONMENT":
+			return "staging"
+		default:
+			return ""
+		}
+	}
+
+	for _, args := range [][]string{
+		{"-environment=staging", "-apply", "-verify"},
+		{"-environment=staging", "-apply"},
+		{"-environment=production", "-apply", "-confirm-environment=production"},
+		{"-environment=staging", "-sample-limit=101"},
+		{"-environment=staging", "-batch-size=0"},
+		{"-environment=staging", "-lock-timeout=500us"},
+		{"-environment=production", "-apply", "-confirm-environment=production", "-confirm-production=production"},
+	} {
+		_, err := parseAgentManagementGrantsFlags(args, getenv)
+		require.Error(t, err)
+	}
+}
+
+func TestAgentManagementGrantsSummaryIsBoundedAndContainsNoUserData(t *testing.T) {
+	t.Parallel()
+	samples := make([]agentmanagementgrants.DefectSample, 100)
+	for i := range samples {
+		samples[i] = agentmanagementgrants.DefectSample{OrganizationID: "org-test", Scope: "agent:unexpected"}
+	}
+	var out bytes.Buffer
+	err := writeAgentManagementGrantsSummary(&out, agentManagementGrantsCommandSummary{
+		RunID: "run-test", Environment: "staging", CodeSHA: "sha-test", ContractVersion: agentManagementGrantContractVersion, Result: "blocked",
+		Summary: agentmanagementgrants.Summary{
+			Mode:         agentmanagementgrants.ModeVerify,
+			Verification: agentmanagementgrants.Verification{UnexpectedGrantSamples: samples},
+		},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, out.String(), "email")
+	require.NotContains(t, out.String(), "name")
+
+	var decoded agentManagementGrantsCommandSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &decoded))
+	require.Len(t, decoded.Summary.Verification.UnexpectedGrantSamples, 100)
+}

--- a/server/cmd/tools/migrations/agent_management_grants_cmd_test.go
+++ b/server/cmd/tools/migrations/agent_management_grants_cmd_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/agentmanagementgrants"
@@ -28,7 +30,7 @@ func TestParseAgentManagementGrantsFlags(t *testing.T) {
 			getenv := func(key string) string {
 				switch key {
 				case "GRAM_DATABASE_URL":
-					return "postgres://test"
+					return "postgres://test?sslmode=require"
 				case "GRAM_ENVIRONMENT":
 					return test.environment
 				default:
@@ -47,7 +49,7 @@ func TestParseAgentManagementGrantsFlagsRejectsUnsafeModes(t *testing.T) {
 	getenv := func(key string) string {
 		switch key {
 		case "GRAM_DATABASE_URL":
-			return "postgres://test"
+			return "postgres://test?sslmode=require"
 		case "GRAM_ENVIRONMENT":
 			return "staging"
 		default:
@@ -67,6 +69,32 @@ func TestParseAgentManagementGrantsFlagsRejectsUnsafeModes(t *testing.T) {
 		_, err := parseAgentManagementGrantsFlags(args, getenv)
 		require.Error(t, err)
 	}
+}
+
+func TestParseAgentManagementGrantsFlagsRejectsPlaintextDatabaseConnections(t *testing.T) {
+	t.Parallel()
+
+	for _, databaseURL := range []string{
+		"postgres://test",
+		"postgres://test?sslmode=allow",
+		"postgres://test?sslmode=disable",
+		"postgres://test?sslmode=prefer",
+	} {
+		getenv := func(key string) string {
+			if key == "GRAM_DATABASE_URL" {
+				return databaseURL
+			}
+			return ""
+		}
+		_, err := parseAgentManagementGrantsFlags([]string{"-environment=staging"}, getenv)
+		require.ErrorContains(t, err, "must require TLS")
+	}
+}
+
+func TestAgentManagementGrantsErrorCategoryIncludesConnectionErrors(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("connect: %w", &pgconn.ConnectError{})
+	require.Equal(t, "database_or_timeout", agentManagementGrantsErrorCategory(err))
 }
 
 func TestAgentManagementGrantsSummaryIsBoundedAndContainsNoUserData(t *testing.T) {

--- a/server/cmd/tools/migrations/agentmanagementgrants/runner.go
+++ b/server/cmd/tools/migrations/agentmanagementgrants/runner.go
@@ -1,0 +1,405 @@
+package agentmanagementgrants
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Mode string
+
+const (
+	ModeDryRun Mode = "dry-run"
+	ModeApply  Mode = "apply"
+	ModeVerify Mode = "verify"
+)
+
+var ErrVerificationFailed = errors.New("agent management grant verification failed")
+
+var requiredScopes = []string{
+	"agent:read",
+	"agent:write",
+	"agent:authorize",
+	"agent:transfer",
+}
+
+const canonicalSelector = `{"resource_kind":"agent","resource_id":"*"}`
+
+type Options struct {
+	BatchSize        int
+	SampleLimit      int
+	LockTimeout      time.Duration
+	StatementTimeout time.Duration
+}
+
+type DefectSample struct {
+	OrganizationID string `json:"organization_id"`
+	PrincipalURN   string `json:"principal_urn,omitempty"`
+	Scope          string `json:"scope,omitempty"`
+}
+
+type Verification struct {
+	TotalOrganizations        int64          `json:"total_organizations"`
+	TargetAdminRoles          int64          `json:"target_admin_roles"`
+	MissingAdminRoles         int64          `json:"missing_admin_roles"`
+	MissingAdminRoleSamples   []DefectSample `json:"missing_admin_role_samples"`
+	MissingRequiredGrants     int64          `json:"missing_required_grants"`
+	MissingGrantOrganizations int64          `json:"missing_grant_organizations"`
+	MissingGrantSamples       []DefectSample `json:"missing_grant_samples"`
+	UnexpectedAgentGrants     int64          `json:"unexpected_agent_grants"`
+	UnexpectedOrganizations   int64          `json:"unexpected_organizations"`
+	UnexpectedGrantSamples    []DefectSample `json:"unexpected_grant_samples"`
+	ReadyForEnforcement       bool           `json:"ready_for_enforcement"`
+}
+
+type Summary struct {
+	Mode                 Mode         `json:"mode"`
+	OrganizationsScanned int64        `json:"organizations_scanned"`
+	GrantRowsChanged     int64        `json:"grant_rows_changed"`
+	Batches              int64        `json:"batches"`
+	LastCursor           string       `json:"last_cursor,omitempty"`
+	Verification         Verification `json:"verification"`
+}
+
+type Runner struct {
+	pool       *pgxpool.Pool
+	options    Options
+	afterBatch func() error
+}
+
+func NewRunner(pool *pgxpool.Pool, options Options) *Runner {
+	if options.BatchSize <= 0 {
+		options.BatchSize = 100
+	}
+	if options.SampleLimit <= 0 {
+		options.SampleLimit = 20
+	}
+	if options.SampleLimit > 100 {
+		options.SampleLimit = 100
+	}
+	if options.LockTimeout < time.Millisecond {
+		options.LockTimeout = 2 * time.Second
+	}
+	if options.StatementTimeout < time.Millisecond {
+		options.StatementTimeout = 30 * time.Second
+	}
+	return &Runner{pool: pool, options: options, afterBatch: nil}
+}
+
+func (r *Runner) Run(ctx context.Context, mode Mode) (Summary, error) {
+	var emptyVerification Verification
+	summary := Summary{
+		Mode: mode, OrganizationsScanned: 0, GrantRowsChanged: 0, Batches: 0,
+		LastCursor: "", Verification: emptyVerification,
+	}
+	switch mode {
+	case ModeDryRun, ModeVerify:
+		verification, err := r.Verify(ctx)
+		summary.OrganizationsScanned = verification.TotalOrganizations
+		summary.Verification = verification
+		if err != nil {
+			return summary, err
+		}
+		if mode == ModeVerify && !verification.ReadyForEnforcement {
+			return summary, ErrVerificationFailed
+		}
+		return summary, nil
+	case ModeApply:
+	default:
+		return summary, fmt.Errorf("unsupported migration mode %q", mode)
+	}
+
+	for {
+		batch, changed, err := r.applyBatch(ctx, summary.LastCursor)
+		if err != nil {
+			return summary, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		organizations := countOrganizations(batch)
+		summary.OrganizationsScanned += int64(organizations)
+		summary.GrantRowsChanged += changed
+		summary.Batches++
+		summary.LastCursor = batch[len(batch)-1].organizationID
+		if r.afterBatch != nil {
+			if err := r.afterBatch(); err != nil {
+				return summary, fmt.Errorf("after committed agent management grant batch: %w", err)
+			}
+		}
+		if organizations < r.options.BatchSize {
+			break
+		}
+	}
+
+	verification, err := r.Verify(ctx)
+	summary.Verification = verification
+	summary.OrganizationsScanned = verification.TotalOrganizations
+	if err != nil {
+		return summary, err
+	}
+	if !verification.ReadyForEnforcement {
+		return summary, ErrVerificationFailed
+	}
+	return summary, nil
+}
+
+type adminRoleTarget struct {
+	organizationID string
+	principalURN   string
+}
+
+func (r *Runner) applyBatch(ctx context.Context, afterOrganizationID string) ([]adminRoleTarget, int64, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: "", AccessMode: "", DeferrableMode: "", BeginQuery: "", CommitQuery: "",
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("begin agent management grant batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := r.configureTransaction(ctx, tx); err != nil {
+		return nil, 0, fmt.Errorf("set agent management grant batch timeouts: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, targetAdminRolesCTE+`,
+batch_organizations AS (
+  SELECT DISTINCT organization_id
+  FROM target_admin_roles
+  WHERE organization_id > $1
+  ORDER BY organization_id
+  LIMIT $2
+)
+SELECT target.organization_id, target.principal_urn
+FROM target_admin_roles AS target
+JOIN batch_organizations AS batch USING (organization_id)
+ORDER BY target.organization_id, target.principal_urn`, afterOrganizationID, r.options.BatchSize)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list administrator role batch: %w", err)
+	}
+	targets, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (adminRoleTarget, error) {
+		var target adminRoleTarget
+		if err := row.Scan(&target.organizationID, &target.principalURN); err != nil {
+			return target, fmt.Errorf("scan administrator role target: %w", err)
+		}
+		return target, nil
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("read administrator role batch: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil, 0, nil
+	}
+
+	organizationIDs := make([]string, 0, len(targets))
+	principalURNs := make([]string, 0, len(targets))
+	for _, target := range targets {
+		organizationIDs = append(organizationIDs, target.organizationID)
+		principalURNs = append(principalURNs, target.principalURN)
+	}
+
+	result, err := tx.Exec(ctx, `
+INSERT INTO principal_grants (organization_id, principal_urn, scope, selectors)
+SELECT target.organization_id, target.principal_urn, required.scope, $4::jsonb
+FROM unnest($1::text[], $2::text[]) AS target(organization_id, principal_urn)
+CROSS JOIN unnest($3::text[]) AS required(scope)
+ON CONFLICT (organization_id, principal_urn, scope, selectors)
+DO UPDATE SET
+  effect = NULL,
+  updated_at = clock_timestamp()
+WHERE principal_grants.effect IS NOT NULL`, organizationIDs, principalURNs, requiredScopes, canonicalSelector)
+	if err != nil {
+		return nil, 0, fmt.Errorf("backfill agent management grants: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, 0, fmt.Errorf("commit agent management grant batch: %w", err)
+	}
+	return targets, result.RowsAffected(), nil
+}
+
+func (r *Runner) Verify(ctx context.Context) (Verification, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly, DeferrableMode: "", BeginQuery: "", CommitQuery: "",
+	})
+	if err != nil {
+		return Verification{}, fmt.Errorf("begin agent management grant verification: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := r.configureTransaction(ctx, tx); err != nil {
+		return Verification{}, err
+	}
+
+	verification := Verification{
+		TotalOrganizations: 0, TargetAdminRoles: 0, MissingAdminRoles: 0, MissingAdminRoleSamples: nil,
+		MissingRequiredGrants: 0, MissingGrantOrganizations: 0, MissingGrantSamples: nil,
+		UnexpectedAgentGrants: 0, UnexpectedOrganizations: 0, UnexpectedGrantSamples: nil, ReadyForEnforcement: false,
+	}
+	if err := tx.QueryRow(ctx, targetAdminRolesCTE+`
+SELECT
+  (SELECT COUNT(*) FROM organization_metadata),
+  (SELECT COUNT(*) FROM target_admin_roles),
+  (SELECT COUNT(*) FROM organization_metadata) - (SELECT COUNT(DISTINCT organization_id) FROM target_admin_roles)`).Scan(
+		&verification.TotalOrganizations, &verification.TargetAdminRoles, &verification.MissingAdminRoles,
+	); err != nil {
+		return Verification{}, fmt.Errorf("count administrator role targets: %w", err)
+	}
+
+	missingAdminRows, err := tx.Query(ctx, targetAdminRolesCTE+`
+SELECT om.id
+FROM organization_metadata AS om
+LEFT JOIN target_admin_roles AS target ON target.organization_id = om.id
+WHERE target.organization_id IS NULL
+ORDER BY om.id
+LIMIT $1`, r.options.SampleLimit)
+	if err != nil {
+		return Verification{}, fmt.Errorf("sample missing administrator roles: %w", err)
+	}
+	missingAdminIDs, err := pgx.CollectRows(missingAdminRows, pgx.RowTo[string])
+	if err != nil {
+		return Verification{}, fmt.Errorf("read missing administrator role samples: %w", err)
+	}
+	verification.MissingAdminRoleSamples = make([]DefectSample, 0, len(missingAdminIDs))
+	for _, organizationID := range missingAdminIDs {
+		verification.MissingAdminRoleSamples = append(verification.MissingAdminRoleSamples, DefectSample{
+			OrganizationID: organizationID, PrincipalURN: "", Scope: "",
+		})
+	}
+
+	if err := tx.QueryRow(ctx, missingRequiredGrantsCTE+`
+SELECT COUNT(*), COUNT(DISTINCT organization_id)
+FROM missing_required_grants`, requiredScopes, canonicalSelector).Scan(&verification.MissingRequiredGrants, &verification.MissingGrantOrganizations); err != nil {
+		return Verification{}, fmt.Errorf("count missing agent management grants: %w", err)
+	}
+	missingRows, err := tx.Query(ctx, missingRequiredGrantsCTE+`
+SELECT organization_id, principal_urn, scope
+FROM missing_required_grants
+ORDER BY organization_id, principal_urn, scope
+LIMIT $3`, requiredScopes, canonicalSelector, r.options.SampleLimit)
+	if err != nil {
+		return Verification{}, fmt.Errorf("sample missing agent management grants: %w", err)
+	}
+	verification.MissingGrantSamples, err = collectDefectSamples(missingRows)
+	if err != nil {
+		return Verification{}, fmt.Errorf("read missing agent management grant samples: %w", err)
+	}
+
+	if err := tx.QueryRow(ctx, unexpectedAgentGrantsCTE+`
+SELECT COUNT(*), COUNT(DISTINCT organization_id)
+FROM unexpected_agent_grants`, requiredScopes, canonicalSelector).Scan(&verification.UnexpectedAgentGrants, &verification.UnexpectedOrganizations); err != nil {
+		return Verification{}, fmt.Errorf("count unexpected agent management grants: %w", err)
+	}
+	unexpectedRows, err := tx.Query(ctx, unexpectedAgentGrantsCTE+`
+SELECT organization_id, principal_urn, scope
+FROM unexpected_agent_grants
+ORDER BY organization_id, principal_urn, scope
+LIMIT $3`, requiredScopes, canonicalSelector, r.options.SampleLimit)
+	if err != nil {
+		return Verification{}, fmt.Errorf("sample unexpected agent management grants: %w", err)
+	}
+	verification.UnexpectedGrantSamples, err = collectDefectSamples(unexpectedRows)
+	if err != nil {
+		return Verification{}, fmt.Errorf("read unexpected agent management grant samples: %w", err)
+	}
+
+	verification.ReadyForEnforcement = verification.MissingAdminRoles == 0 &&
+		verification.MissingRequiredGrants == 0 && verification.UnexpectedAgentGrants == 0
+	if err := tx.Commit(ctx); err != nil {
+		return Verification{}, fmt.Errorf("commit agent management grant verification: %w", err)
+	}
+	return verification, nil
+}
+
+func (r *Runner) configureTransaction(ctx context.Context, tx pgx.Tx) error {
+	_, err := tx.Exec(ctx, `SELECT set_config('lock_timeout', $1, true), set_config('statement_timeout', $2, true)`,
+		strconv.FormatInt(r.options.LockTimeout.Milliseconds(), 10)+"ms",
+		strconv.FormatInt(r.options.StatementTimeout.Milliseconds(), 10)+"ms")
+	if err != nil {
+		return fmt.Errorf("set agent management grant transaction timeouts: %w", err)
+	}
+	return nil
+}
+
+func countOrganizations(targets []adminRoleTarget) int {
+	count := 0
+	previous := ""
+	for _, target := range targets {
+		if count == 0 || target.organizationID != previous {
+			count++
+			previous = target.organizationID
+		}
+	}
+	return count
+}
+
+func collectDefectSamples(rows pgx.Rows) ([]DefectSample, error) {
+	samples, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (DefectSample, error) {
+		var sample DefectSample
+		if err := row.Scan(&sample.OrganizationID, &sample.PrincipalURN, &sample.Scope); err != nil {
+			return sample, fmt.Errorf("scan agent management grant defect: %w", err)
+		}
+		return sample, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("collect agent management grant defects: %w", err)
+	}
+	return samples, nil
+}
+
+const targetAdminRolesCTE = `
+WITH target_admin_roles AS (
+  SELECT
+    organization.id AS organization_id,
+    'role:global:' || global_role.id::text AS principal_urn
+  FROM organization_metadata AS organization
+  JOIN global_roles AS global_role
+    ON global_role.workos_slug = 'admin'
+    AND global_role.deleted IS FALSE
+    AND global_role.workos_deleted IS FALSE
+  UNION ALL
+  SELECT
+    organization.id AS organization_id,
+    'role:organization:' || organization_role.id::text AS principal_urn
+  FROM organization_metadata AS organization
+  JOIN organization_roles AS organization_role
+    ON organization_role.organization_id = organization.id
+    AND organization_role.workos_slug = 'admin'
+    AND organization_role.deleted IS FALSE
+    AND organization_role.workos_deleted IS FALSE
+)`
+
+const missingRequiredGrantsCTE = targetAdminRolesCTE + `,
+required_scopes AS (
+  SELECT unnest($1::text[]) AS scope
+),
+missing_required_grants AS (
+  SELECT target.organization_id, target.principal_urn, required.scope
+  FROM target_admin_roles AS target
+  CROSS JOIN required_scopes AS required
+  LEFT JOIN principal_grants AS principal_grant
+    ON principal_grant.organization_id = target.organization_id
+    AND principal_grant.principal_urn = target.principal_urn
+    AND principal_grant.scope = required.scope
+    AND COALESCE(principal_grant.effect, 'allow') = 'allow'
+    AND principal_grant.selectors = $2::jsonb
+  WHERE principal_grant.id IS NULL
+)`
+
+const unexpectedAgentGrantsCTE = targetAdminRolesCTE + `,
+unexpected_agent_grants AS (
+  SELECT principal_grant.organization_id, principal_grant.principal_urn, principal_grant.scope
+  FROM target_admin_roles AS target
+  JOIN principal_grants AS principal_grant
+    ON principal_grant.organization_id = target.organization_id
+    AND principal_grant.principal_urn = target.principal_urn
+  WHERE principal_grant.scope LIKE 'agent:%'
+    AND NOT (
+      principal_grant.scope = ANY($1::text[])
+      AND COALESCE(principal_grant.effect, 'allow') = 'allow'
+      AND principal_grant.selectors = $2::jsonb
+    )
+)`

--- a/server/cmd/tools/migrations/agentmanagementgrants/runner_test.go
+++ b/server/cmd/tools/migrations/agentmanagementgrants/runner_test.go
@@ -2,7 +2,6 @@
 package agentmanagementgrants
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -202,7 +201,7 @@ WHERE id = $1`, id).Scan(
 func countCanonicalGrants(t *testing.T, pool *pgxpool.Pool, organizationID, principalURN string) int64 {
 	t.Helper()
 	var count int64
-	err := pool.QueryRow(context.Background(), `
+	err := pool.QueryRow(t.Context(), `
 SELECT COUNT(*)
 FROM principal_grants
 WHERE organization_id = $1

--- a/server/cmd/tools/migrations/agentmanagementgrants/runner_test.go
+++ b/server/cmd/tools/migrations/agentmanagementgrants/runner_test.go
@@ -1,0 +1,223 @@
+//nolint:glint // Integration fixtures intentionally seed, corrupt, and inspect isolated migration rows.
+package agentmanagementgrants
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+type grantSnapshot struct {
+	ID             uuid.UUID
+	OrganizationID string
+	PrincipalURN   string
+	Scope          string
+	Selectors      string
+	Effect         *string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func TestRunnerBackfillsRecognizedAdminRolesIdempotently(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	ctx := t.Context()
+
+	for _, organizationID := range []string{"org-global-admin", "org-local-admin", "org-partial-admin"} {
+		seedOrganization(t, pool, organizationID)
+	}
+	globalAdminURN := seedGlobalRole(t, pool, "admin")
+	localAdminURN := seedOrganizationRole(t, pool, "org-local-admin", "admin")
+	customRoleURN := seedOrganizationRole(t, pool, "org-local-admin", "operator")
+
+	unrelatedID := seedGrant(t, pool, "org-global-admin", globalAdminURN, "project:read", `{"resource_kind":"project","resource_id":"project-test"}`, nil)
+	customID := seedGrant(t, pool, "org-local-admin", customRoleURN, "agent:unexpected", canonicalSelector, nil)
+	for _, scope := range requiredScopes[:2] {
+		seedGrant(t, pool, "org-partial-admin", globalAdminURN, scope, canonicalSelector, nil)
+	}
+	unrelatedBefore := loadGrant(t, pool, unrelatedID)
+	customBefore := loadGrant(t, pool, customID)
+
+	runner := NewRunner(pool, Options{BatchSize: 2, SampleLimit: 2})
+	dryRun, err := runner.Run(ctx, ModeDryRun)
+	require.NoError(t, err)
+	require.False(t, dryRun.Verification.ReadyForEnforcement)
+	require.Equal(t, int64(14), dryRun.Verification.MissingRequiredGrants)
+	require.Len(t, dryRun.Verification.MissingGrantSamples, 2)
+
+	first, err := runner.Run(ctx, ModeApply)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), first.OrganizationsScanned)
+	require.Equal(t, int64(14), first.GrantRowsChanged)
+	require.Equal(t, int64(2), first.Batches)
+	require.True(t, first.Verification.ReadyForEnforcement)
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-global-admin", globalAdminURN))
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-local-admin", localAdminURN))
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-local-admin", globalAdminURN))
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-partial-admin", globalAdminURN))
+	require.Equal(t, unrelatedBefore, loadGrant(t, pool, unrelatedID))
+	require.Equal(t, customBefore, loadGrant(t, pool, customID))
+
+	second, err := runner.Run(ctx, ModeApply)
+	require.NoError(t, err)
+	require.Zero(t, second.GrantRowsChanged)
+	require.True(t, second.Verification.ReadyForEnforcement)
+	require.Equal(t, unrelatedBefore, loadGrant(t, pool, unrelatedID))
+	require.Equal(t, customBefore, loadGrant(t, pool, customID))
+}
+
+func TestRunnerResumesAfterCommittedBatchFailure(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	for _, organizationID := range []string{"org-resume-a", "org-resume-b", "org-resume-c"} {
+		seedOrganization(t, pool, organizationID)
+	}
+	adminURN := seedGlobalRole(t, pool, "admin")
+
+	runner := NewRunner(pool, Options{BatchSize: 2})
+	runner.afterBatch = func() error { return errors.New("simulated interruption") }
+	partial, err := runner.Run(t.Context(), ModeApply)
+	require.ErrorContains(t, err, "simulated interruption")
+	require.Equal(t, int64(1), partial.Batches)
+	require.Equal(t, int64(8), partial.GrantRowsChanged)
+	require.Equal(t, "org-resume-b", partial.LastCursor)
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-resume-a", adminURN))
+	require.Equal(t, int64(4), countCanonicalGrants(t, pool, "org-resume-b", adminURN))
+	require.Zero(t, countCanonicalGrants(t, pool, "org-resume-c", adminURN))
+
+	runner.afterBatch = nil
+	resumed, err := runner.Run(t.Context(), ModeApply)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), resumed.GrantRowsChanged)
+	require.True(t, resumed.Verification.ReadyForEnforcement)
+}
+
+func TestRunnerVerificationIndependentlyDetectsMissingAndUnexpectedGrants(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	seedOrganization(t, pool, "org-verification")
+	adminURN := seedGlobalRole(t, pool, "admin")
+	runner := NewRunner(pool, Options{SampleLimit: 1})
+
+	_, err := runner.Run(t.Context(), ModeApply)
+	require.NoError(t, err)
+	_, err = pool.Exec(t.Context(), `
+DELETE FROM principal_grants
+WHERE organization_id = $1 AND principal_urn = $2 AND scope = $3 AND selectors = $4::jsonb`,
+		"org-verification", adminURN, requiredScopes[0], canonicalSelector)
+	require.NoError(t, err)
+	seedGrant(t, pool, "org-verification", adminURN, "agent:unexpected", canonicalSelector, nil)
+
+	summary, err := runner.Run(t.Context(), ModeVerify)
+	require.ErrorIs(t, err, ErrVerificationFailed)
+	require.False(t, summary.Verification.ReadyForEnforcement)
+	require.Equal(t, int64(1), summary.Verification.MissingRequiredGrants)
+	require.Equal(t, int64(1), summary.Verification.MissingGrantOrganizations)
+	require.Equal(t, []DefectSample{{OrganizationID: "org-verification", PrincipalURN: adminURN, Scope: requiredScopes[0]}}, summary.Verification.MissingGrantSamples)
+	require.Equal(t, int64(1), summary.Verification.UnexpectedAgentGrants)
+	require.Equal(t, int64(1), summary.Verification.UnexpectedOrganizations)
+	require.Equal(t, []DefectSample{{OrganizationID: "org-verification", PrincipalURN: adminURN, Scope: "agent:unexpected"}}, summary.Verification.UnexpectedGrantSamples)
+}
+
+func TestRunnerVerificationBlocksOrganizationsWithoutRecognizedAdminRole(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	seedOrganization(t, pool, "org-missing-admin")
+
+	runner := NewRunner(pool, Options{SampleLimit: 1})
+	summary, err := runner.Run(t.Context(), ModeVerify)
+	require.ErrorIs(t, err, ErrVerificationFailed)
+	require.Equal(t, int64(1), summary.Verification.TotalOrganizations)
+	require.Zero(t, summary.Verification.TargetAdminRoles)
+	require.Equal(t, int64(1), summary.Verification.MissingAdminRoles)
+	require.Equal(t, []DefectSample{{OrganizationID: "org-missing-admin"}}, summary.Verification.MissingAdminRoleSamples)
+}
+
+func TestRunnerApplyNormalizesExistingRequiredDenyGrant(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	seedOrganization(t, pool, "org-deny-admin")
+	adminURN := seedGlobalRole(t, pool, "admin")
+	deny := "deny"
+	seedGrant(t, pool, "org-deny-admin", adminURN, requiredScopes[0], canonicalSelector, &deny)
+
+	summary, err := NewRunner(pool, Options{}).Run(t.Context(), ModeApply)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), summary.GrantRowsChanged)
+	require.True(t, summary.Verification.ReadyForEnforcement)
+}
+
+func seedGlobalRole(t *testing.T, pool *pgxpool.Pool, slug string) string {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(t.Context(), `
+INSERT INTO global_roles (workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at)
+VALUES ($1, $1, '', clock_timestamp(), clock_timestamp())
+RETURNING id`, slug).Scan(&id)
+	require.NoError(t, err)
+	return "role:global:" + id.String()
+}
+
+func seedOrganizationRole(t *testing.T, pool *pgxpool.Pool, organizationID, slug string) string {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(t.Context(), `
+INSERT INTO organization_roles (organization_id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at)
+VALUES ($1, $2, $2, '', clock_timestamp(), clock_timestamp())
+RETURNING id`, organizationID, slug).Scan(&id)
+	require.NoError(t, err)
+	return "role:organization:" + id.String()
+}
+
+func seedGrant(t *testing.T, pool *pgxpool.Pool, organizationID, principalURN, scope, selectors string, effect *string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(t.Context(), `
+INSERT INTO principal_grants (organization_id, principal_urn, scope, selectors, effect)
+VALUES ($1, $2, $3, $4::jsonb, $5)
+RETURNING id`, organizationID, principalURN, scope, selectors, effect).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func loadGrant(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) grantSnapshot {
+	t.Helper()
+	var snapshot grantSnapshot
+	err := pool.QueryRow(t.Context(), `
+SELECT id, organization_id, principal_urn, scope, selectors::text, effect, created_at, updated_at
+FROM principal_grants
+WHERE id = $1`, id).Scan(
+		&snapshot.ID, &snapshot.OrganizationID, &snapshot.PrincipalURN, &snapshot.Scope,
+		&snapshot.Selectors, &snapshot.Effect, &snapshot.CreatedAt, &snapshot.UpdatedAt,
+	)
+	require.NoError(t, err)
+	return snapshot
+}
+
+func countCanonicalGrants(t *testing.T, pool *pgxpool.Pool, organizationID, principalURN string) int64 {
+	t.Helper()
+	var count int64
+	err := pool.QueryRow(context.Background(), `
+SELECT COUNT(*)
+FROM principal_grants
+WHERE organization_id = $1
+  AND principal_urn = $2
+  AND scope = ANY($3::text[])
+  AND COALESCE(effect, 'allow') = 'allow'
+  AND selectors = $4::jsonb`, organizationID, principalURN, requiredScopes, canonicalSelector).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func TestUnsupportedMode(t *testing.T) {
+	t.Parallel()
+	pool := newTestDB(t)
+	_, err := NewRunner(pool, Options{}).Run(t.Context(), Mode("unknown"))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrVerificationFailed)
+}

--- a/server/cmd/tools/migrations/agentmanagementgrants/setup_test.go
+++ b/server/cmd/tools/migrations/agentmanagementgrants/setup_test.go
@@ -1,0 +1,50 @@
+package agentmanagementgrants
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var cloneTestDatabase testenv.PostgresDBCloneFunc
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	container, clone, err := testenv.NewTestPostgres(ctx)
+	if err != nil {
+		log.Fatalf("launch test postgres: %v", err)
+	}
+	cloneTestDatabase = clone
+
+	code := m.Run()
+	if err := container.Terminate(ctx); err != nil {
+		log.Fatalf("terminate test postgres: %v", err)
+	}
+	os.Exit(code)
+}
+
+func newTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool, err := cloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	return pool
+}
+
+func seedOrganization(t *testing.T, pool *pgxpool.Pool, organizationID string) {
+	t.Helper()
+	_, err := orgrepo.New(pool).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID:       organizationID,
+		Name:     "Test Organization",
+		Slug:     organizationID,
+		WorkosID: conv.PtrToPGText(conv.PtrEmpty("workos-" + organizationID)),
+	})
+	require.NoError(t, err)
+}

--- a/server/cmd/tools/migrations/main.go
+++ b/server/cmd/tools/migrations/main.go
@@ -9,6 +9,8 @@
 //     OPENROUTER_DISABLE_CAUSES_MIGRATION.md. It defaults to a non-writing dry
 //     run. Writes use -apply or -manual-override and require explicit target
 //     confirmation.
+//   - agent-management-grants: PostgreSQL-only built-in administrator grant
+//     backfill and rollout gate; see AGENT_MANAGEMENT_GRANTS_MIGRATION.md.
 //   - pro-entitlements: PostgreSQL application-data backfill; see
 //     PRO_ENTITLEMENTS_BACKFILL.md. It defaults to a non-writing dry run.
 //
@@ -91,11 +93,13 @@ func run() int {
 		return runOpenRouterDisableCauses(args, os.Stdin, os.Stdout, os.Getenv)
 	case "legacy-policy-scope":
 		return runLegacyPolicyScope(args, os.Stdout, os.Getenv)
+	case "agent-management-grants":
+		return runAgentManagementGrants(args, os.Stdout, os.Getenv)
 	case "pro-entitlements":
 		return runProEntitlements(args, os.Stdout, os.Getenv)
 	default:
 		// The unrecognized name is deliberately not echoed (log injection).
-		log.Printf("unknown migration subcommand (available: riskfindings, riskfindingscols, openrouter-disable-causes, legacy-policy-scope, pro-entitlements)")
+		log.Printf("unknown migration subcommand (available: riskfindings, riskfindingscols, openrouter-disable-causes, legacy-policy-scope, pro-entitlements, agent-management-grants)")
 		return 2
 	}
 }


### PR DESCRIPTION
## Summary

Adds a safeguarded PostgreSQL operator migration that backfills every active built-in organization administrator principal with the four explicit agent-management grants. Complete-population verification emits bounded internal identifiers and aggregate counts, then fails closed until all required grants are present and no unexpected `agent:*` rows remain.

## Motivation

[AIM-187](https://linear.app/speakeasy/issue/AIM-187/chore-backfill-explicit-agent-management-grants-for-organization) requires existing organizations to receive explicit `agent:read`, `agent:write`, `agent:authorize`, and `agent:transfer` grants before agent-management enforcement is enabled, without treating `org:admin` as a runtime wildcard.

## Technical details

### Rollout gate

Apply mode writes keyset-ordered, independently committed batches using idempotent inserts, preserves unrelated and custom-role grants, and can restart safely after interruption. Dry-run and verify modes are non-writing; enforcement must remain disabled until standalone verification reports `ready_for_enforcement=true` for the complete target database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PostgreSQL operator migration that backfills the four explicit agent-management grants (`agent:read`, `agent:write`, `agent:authorize`, `agent:transfer`) onto existing built-in organization administrator roles. Existing orgs predate the canonical grant set, and agent-management enforcement must not treat `org:admin` as an implicit wildcard, so this prepares the target population before enforcement is enabled. Implements [AIM-187](https://linear.app/speakeasy/issue/AIM-187/chore-backfill-explicit-agent-management-grants-for-organization).

**Migration behavior**

- Defaults to a non-writing dry run; apply and verify are separate opt-in modes.
- Apply is idempotent and writes keyset-ordered batches that commit independently, so an interrupted run can restart safely.
- Preserves unrelated grants and never touches custom roles or non-admin role slugs.
- Normalizes a conflicting canonical deny/effect row on the four scopes to the canonical allow grant.
- Requires `GRAM_DATABASE_URL` with TLS and no plaintext fallbacks; apply also requires `GRAM_ENVIRONMENT` to exactly match the target.
- Emits a bounded JSON summary that records the run ID, environment, and `GRAM_CODE_SHA`.

**Rollout gate**

- Verification fails closed unless every organization has an active admin role, all four canonical grants, and no unexpected `agent:*` rows on those roles.
- Enforcement must stay disabled until `-verify` exits zero and reports `ready_for_enforcement=true`.
- Output is bounded to aggregate counts and at most `-sample-limit` internal organization/principal/scope identifiers, with no names, emails, or user data.
- Production apply requires exact environment confirmations plus `-confirm-production=production`.

<sup>Written for commit e13cbcfc8f7af0e21293a88b3de9839a76bb1f18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

