### PR TITLE
feat: support issuer-only OAuth readers

### DIFF
--- a/.changeset/external-oauth-upstream-issuer-readers.md
+++ b/.changeset/external-oauth-upstream-issuer-readers.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Advertise provider-hosted OAuth authorization server issuers for existing external OAuth configurations while retaining compatibility with metadata-backed configurations.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -69969,6 +69969,11 @@ components:
     ExternalOAuthServer:
       type: object
       properties:
+        authorization_server_issuer:
+          type: string
+          description: The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery. Exactly one of authorization_server_issuer and metadata is present.
+          format: uri
+          maxLength: 500
         created_at:
           type: string
           description: When the external OAuth server was created.
@@ -69977,7 +69982,7 @@ components:
           type: string
           description: The ID of the external OAuth server
         metadata:
-          description: The metadata for the external OAuth server
+          description: The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly one of metadata and authorization_server_issuer is present.
         project_id:
           type: string
           description: The project ID this external OAuth server belongs to
@@ -69994,7 +69999,6 @@ components:
         - id
         - project_id
         - slug
-        - metadata
         - created_at
         - updated_at
     ExternalOAuthServerForm:

--- a/client/dashboard/src/sdk/src/models/components/externaloauthserver.ts
+++ b/client/dashboard/src/sdk/src/models/components/externaloauthserver.ts
@@ -10,6 +10,10 @@ import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 export type ExternalOAuthServer = {
   /**
+   * The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery. Exactly one of authorization_server_issuer and metadata is present.
+   */
+  authorizationServerIssuer?: string | undefined;
+  /**
    * When the external OAuth server was created.
    */
   createdAt: Date;
@@ -18,9 +22,9 @@ export type ExternalOAuthServer = {
    */
   id: string;
   /**
-   * The metadata for the external OAuth server
+   * The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly one of metadata and authorization_server_issuer is present.
    */
-  metadata: any;
+  metadata?: any | undefined;
   /**
    * The project ID this external OAuth server belongs to
    */
@@ -41,12 +45,13 @@ export const ExternalOAuthServer$inboundSchema: z.ZodMiniType<
   unknown
 > = z.pipe(
   z.object({
+    authorization_server_issuer: z.optional(z.string()),
     created_at: z.pipe(
       z.iso.datetime({ offset: true }),
       z.transform(v => new Date(v)),
     ),
     id: z.string(),
-    metadata: z.any(),
+    metadata: z.optional(z.any()),
     project_id: z.string(),
     slug: z.string(),
     updated_at: z.pipe(
@@ -56,6 +61,7 @@ export const ExternalOAuthServer$inboundSchema: z.ZodMiniType<
   }),
   z.transform((v) => {
     return remap$(v, {
+      "authorization_server_issuer": "authorizationServerIssuer",
       "created_at": "createdAt",
       "project_id": "projectId",
       "updated_at": "updatedAt",

--- a/server/design/shared/toolset.go
+++ b/server/design/shared/toolset.go
@@ -176,7 +176,11 @@ var ExternalOAuthServer = Type("ExternalOAuthServer", func() {
 	Attribute("id", String, "The ID of the external OAuth server")
 	Attribute("project_id", String, "The project ID this external OAuth server belongs to")
 	Attribute("slug", Slug, "The slug of the external OAuth server")
-	Attribute("metadata", Any, "The metadata for the external OAuth server")
+	Attribute("metadata", Any, "The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly one of metadata and authorization_server_issuer is present.")
+	Attribute("authorization_server_issuer", String, "The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery. Exactly one of authorization_server_issuer and metadata is present.", func() {
+		Format(FormatURI)
+		MaxLength(500)
+	})
 	Attribute("created_at", String, func() {
 		Description("When the external OAuth server was created.")
 		Format(FormatDateTime)
@@ -185,7 +189,7 @@ var ExternalOAuthServer = Type("ExternalOAuthServer", func() {
 		Description("When the external OAuth server was last updated.")
 		Format(FormatDateTime)
 	})
-	Required("id", "project_id", "slug", "metadata", "created_at", "updated_at")
+	Required("id", "project_id", "slug", "created_at", "updated_at")
 })
 
 var ExternalOAuthServerForm = Type("ExternalOAuthServerForm", func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -71422,6 +71422,11 @@ components:
         ExternalOAuthServer:
             type: object
             properties:
+                authorization_server_issuer:
+                    type: string
+                    description: The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery. Exactly one of authorization_server_issuer and metadata is present.
+                    format: uri
+                    maxLength: 500
                 created_at:
                     type: string
                     description: When the external OAuth server was created.
@@ -71430,7 +71435,7 @@ components:
                     type: string
                     description: The ID of the external OAuth server
                 metadata:
-                    description: The metadata for the external OAuth server
+                    description: The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly one of metadata and authorization_server_issuer is present.
                 project_id:
                     type: string
                     description: The project ID this external OAuth server belongs to
@@ -71447,7 +71452,6 @@ components:
                 - id
                 - project_id
                 - slug
-                - metadata
                 - created_at
                 - updated_at
         ExternalOAuthServerForm:

--- a/server/gen/http/toolsets/client/encode_decode.go
+++ b/server/gen/http/toolsets/client/encode_decode.go
@@ -3936,12 +3936,13 @@ func unmarshalExternalOAuthServerResponseBodyToTypesExternalOAuthServer(v *Exter
 		return nil
 	}
 	res := &types.ExternalOAuthServer{
-		ID:        *v.ID,
-		ProjectID: *v.ProjectID,
-		Slug:      types.Slug(*v.Slug),
-		Metadata:  v.Metadata,
-		CreatedAt: *v.CreatedAt,
-		UpdatedAt: *v.UpdatedAt,
+		ID:                        *v.ID,
+		ProjectID:                 *v.ProjectID,
+		Slug:                      types.Slug(*v.Slug),
+		Metadata:                  v.Metadata,
+		AuthorizationServerIssuer: v.AuthorizationServerIssuer,
+		CreatedAt:                 *v.CreatedAt,
+		UpdatedAt:                 *v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/toolsets/client/types.go
+++ b/server/gen/http/toolsets/client/types.go
@@ -3801,8 +3801,12 @@ type ExternalOAuthServerResponseBody struct {
 	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
 	// The slug of the external OAuth server
 	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
-	// The metadata for the external OAuth server
+	// The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly
+	// one of metadata and authorization_server_issuer is present.
 	Metadata any `form:"metadata,omitempty" json:"metadata,omitempty" xml:"metadata,omitempty"`
+	// The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery.
+	// Exactly one of authorization_server_issuer and metadata is present.
+	AuthorizationServerIssuer *string `form:"authorization_server_issuer,omitempty" json:"authorization_server_issuer,omitempty" xml:"authorization_server_issuer,omitempty"`
 	// When the external OAuth server was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the external OAuth server was last updated.
@@ -12458,9 +12462,6 @@ func ValidateExternalOAuthServerResponseBody(body *ExternalOAuthServerResponseBo
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
 	}
-	if body.Metadata == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("metadata", "body"))
-	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
@@ -12473,6 +12474,14 @@ func ValidateExternalOAuthServerResponseBody(body *ExternalOAuthServerResponseBo
 	if body.Slug != nil {
 		if utf8.RuneCountInString(*body.Slug) > 40 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.slug", *body.Slug, utf8.RuneCountInString(*body.Slug), 40, false))
+		}
+	}
+	if body.AuthorizationServerIssuer != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.authorization_server_issuer", *body.AuthorizationServerIssuer, goa.FormatURI))
+	}
+	if body.AuthorizationServerIssuer != nil {
+		if utf8.RuneCountInString(*body.AuthorizationServerIssuer) > 500 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.authorization_server_issuer", *body.AuthorizationServerIssuer, utf8.RuneCountInString(*body.AuthorizationServerIssuer), 500, false))
 		}
 	}
 	if body.CreatedAt != nil {

--- a/server/gen/http/toolsets/server/encode_decode.go
+++ b/server/gen/http/toolsets/server/encode_decode.go
@@ -3846,12 +3846,13 @@ func marshalTypesExternalOAuthServerToExternalOAuthServerResponseBody(v *types.E
 		return nil
 	}
 	res := &ExternalOAuthServerResponseBody{
-		ID:        v.ID,
-		ProjectID: v.ProjectID,
-		Slug:      string(v.Slug),
-		Metadata:  v.Metadata,
-		CreatedAt: v.CreatedAt,
-		UpdatedAt: v.UpdatedAt,
+		ID:                        v.ID,
+		ProjectID:                 v.ProjectID,
+		Slug:                      string(v.Slug),
+		Metadata:                  v.Metadata,
+		AuthorizationServerIssuer: v.AuthorizationServerIssuer,
+		CreatedAt:                 v.CreatedAt,
+		UpdatedAt:                 v.UpdatedAt,
 	}
 
 	return res

--- a/server/gen/http/toolsets/server/types.go
+++ b/server/gen/http/toolsets/server/types.go
@@ -3795,8 +3795,12 @@ type ExternalOAuthServerResponseBody struct {
 	ProjectID string `form:"project_id" json:"project_id" xml:"project_id"`
 	// The slug of the external OAuth server
 	Slug string `form:"slug" json:"slug" xml:"slug"`
-	// The metadata for the external OAuth server
-	Metadata any `form:"metadata" json:"metadata" xml:"metadata"`
+	// The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly
+	// one of metadata and authorization_server_issuer is present.
+	Metadata any `form:"metadata,omitempty" json:"metadata,omitempty" xml:"metadata,omitempty"`
+	// The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery.
+	// Exactly one of authorization_server_issuer and metadata is present.
+	AuthorizationServerIssuer *string `form:"authorization_server_issuer,omitempty" json:"authorization_server_issuer,omitempty" xml:"authorization_server_issuer,omitempty"`
 	// When the external OAuth server was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the external OAuth server was last updated.

--- a/server/gen/types/externaloauth_server.go
+++ b/server/gen/types/externaloauth_server.go
@@ -14,8 +14,12 @@ type ExternalOAuthServer struct {
 	ProjectID string
 	// The slug of the external OAuth server
 	Slug Slug
-	// The metadata for the external OAuth server
+	// The validated RFC 8414 metadata Gram hosts in compatibility mode. Exactly
+	// one of metadata and authorization_server_issuer is present.
 	Metadata any
+	// The exact HTTPS issuer clients use for provider-hosted RFC 8414 discovery.
+	// Exactly one of authorization_server_issuer and metadata is present.
+	AuthorizationServerIssuer *string
 	// When the external OAuth server was created.
 	CreatedAt string
 	// When the external OAuth server was last updated.

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -353,8 +353,8 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 // serveLegacyToolsetProtectedResource resolves and writes RFC 9728
 // protected-resource metadata for a toolset via the legacy wellknown
 // resolver. A nil result means the toolset carries no OAuth configuration —
-// 404. resourceURL is emitted verbatim as `resource`; legacy metadata-backed
-// configurations also use it in `authorization_servers`, while issuer-only
+// 404. resourceURL is emitted verbatim as `resource`; metadata-based
+// configurations also use it in `authorization_servers`, while issuer-based
 // configurations advertise their stored provider issuer.
 func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
 	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(ctx, logger, s.db, &s.toolsetCache, toolset, resourceURL)

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -353,8 +353,9 @@ func (s *Service) loadToolsetForServer(ctx context.Context, logger *slog.Logger,
 // serveLegacyToolsetProtectedResource resolves and writes RFC 9728
 // protected-resource metadata for a toolset via the legacy wellknown
 // resolver. A nil result means the toolset carries no OAuth configuration —
-// 404. resourceURL is the runtime URL the caller addressed; it is emitted
-// verbatim as both `resource` and `authorization_servers`.
+// 404. resourceURL is emitted verbatim as `resource`; legacy metadata-backed
+// configurations also use it in `authorization_servers`, while issuer-only
+// configurations advertise their stored provider issuer.
 func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, resourceURL string) error {
 	metadata, err := wellknown.ResolveOAuthProtectedResourceFromToolset(ctx, logger, s.db, &s.toolsetCache, toolset, resourceURL)
 	if err != nil {

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -308,7 +308,7 @@ func TestHandleGetProtectedResource_ToolsetBackendWithExternalOAuth(t *testing.T
 		upstreamIssuer *string
 	}{
 		{name: "upstream issuer", slug: "mcp-pr-external", upstreamIssuer: &upstreamIssuer},
-		{name: "Gram-hosted", slug: "mcp-pr-legacy-external"},
+		{name: "metadata-based", slug: "mcp-pr-metadata-external"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -298,6 +298,49 @@ func TestHandleGetProtectedResource_ToolsetBackendWithoutOAuth(t *testing.T) {
 	require.Empty(t, w.Body.String())
 }
 
+func TestHandleGetProtectedResource_ToolsetBackendWithExternalOAuth(t *testing.T) {
+	t.Parallel()
+
+	upstreamIssuer := "https://issuer.example.com/Tenant/CaseSensitive"
+	for _, tc := range []struct {
+		name           string
+		slug           string
+		upstreamIssuer *string
+	}{
+		{name: "upstream issuer", slug: "mcp-pr-external", upstreamIssuer: &upstreamIssuer},
+		{name: "Gram-hosted", slug: "mcp-pr-legacy-external"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, ti := newTestMCPService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+			require.NotNil(t, authCtx.ProjectID)
+
+			external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+				Slug: tc.slug, IsPublic: true, AuthorizationServerIssuer: tc.upstreamIssuer,
+			})
+			slug := external.Toolset.McpSlug.String
+			createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, external.Toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+
+			w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetProtectedResource, slug)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var metadata map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+			resourceURL := "http://0.0.0.0/mcp/" + slug
+			expectedIssuer := resourceURL
+			if tc.upstreamIssuer != nil {
+				expectedIssuer = *tc.upstreamIssuer
+			}
+			require.Equal(t, resourceURL, metadata["resource"])
+			require.Equal(t, []any{expectedIssuer}, metadata["authorization_servers"])
+		})
+	}
+}
+
 // TestHandleGetProtectedResource_IssuerGatedRemoteBackend is the
 // protected-resource companion of the AGE-2624 regression: an issuer-gated
 // remote-backed mcp_server at /mcp/{slug} serves RFC 9728 metadata whose

--- a/server/internal/mv/toolset.go
+++ b/server/internal/mv/toolset.go
@@ -704,22 +704,26 @@ func DescribeToolset(
 			ProjectID: pid,
 			ID:        toolset.ExternalOauthServerID.UUID,
 		})
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.E(oops.CodeUnexpected, err, "failed to get external oauth server metadata").LogError(ctx, logger)
-		}
-		if len(externalOauthMetadata.Metadata) > 0 {
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return nil, oops.E(oops.CodeUnexpected, err, "failed to get external oauth server metadata").LogError(ctx, logger)
+			}
+		} else {
 			var metadata any
-			if err := json.Unmarshal(externalOauthMetadata.Metadata, &metadata); err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal external oauth metadata").LogError(ctx, logger)
+			if len(externalOauthMetadata.Metadata) > 0 {
+				if err := json.Unmarshal(externalOauthMetadata.Metadata, &metadata); err != nil {
+					return nil, oops.E(oops.CodeUnexpected, err, "failed to unmarshal external oauth metadata").LogError(ctx, logger)
+				}
 			}
 
 			externalOAuthServer = &types.ExternalOAuthServer{
-				ID:        externalOauthMetadata.ID.String(),
-				ProjectID: externalOauthMetadata.ProjectID.String(),
-				Slug:      types.Slug(externalOauthMetadata.Slug),
-				Metadata:  metadata,
-				CreatedAt: externalOauthMetadata.CreatedAt.Time.Format(time.RFC3339),
-				UpdatedAt: externalOauthMetadata.UpdatedAt.Time.Format(time.RFC3339),
+				ID:                        externalOauthMetadata.ID.String(),
+				ProjectID:                 externalOauthMetadata.ProjectID.String(),
+				Slug:                      types.Slug(externalOauthMetadata.Slug),
+				Metadata:                  metadata,
+				AuthorizationServerIssuer: conv.PtrEmpty(externalOauthMetadata.AuthorizationServerIssuer.String),
+				CreatedAt:                 externalOauthMetadata.CreatedAt.Time.Format(time.RFC3339),
+				UpdatedAt:                 externalOauthMetadata.UpdatedAt.Time.Format(time.RFC3339),
 			}
 		}
 	}

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -99,8 +99,8 @@ type OAuthRepo interface {
 // URL uses an `mcp_endpoints.slug` instead — see the companion
 // resourceURL argument on [ResolveOAuthProtectedResourceFromToolset].
 //
-// resourceURL is the absolute URL of the protected resource. For legacy
-// metadata-backed external OAuth configurations, protected-resource metadata
+// resourceURL is the absolute URL of the protected resource. For metadata-based
+// External OAuth configurations, protected-resource metadata
 // also advertises this value as its authorization server, so it becomes the
 // served document's `issuer` so the metadata satisfies RFC 8414 §3.3 (the
 // served `issuer` must equal the issuer identifier the client fetched it
@@ -136,7 +136,7 @@ func ResolveOAuthServerMetadataFromToolset(
 		// `/.well-known/oauth-authorization-server/...` URL. RFC 8414 §3.3
 		// requires the served `issuer` to equal the issuer identifier the
 		// client used to fetch the document — here the Gram resource URL that
-		// legacy protected-resource metadata advertises in
+		// metadata-based protected-resource metadata advertises in
 		// `authorization_servers` — so a spec-compliant MCP client does not
 		// reject the metadata on a mismatch. The upstream's own
 		// authorization/token/registration endpoints are preserved verbatim;
@@ -192,9 +192,9 @@ func rewriteMetadataIssuer(raw json.RawMessage, issuer string) (json.RawMessage,
 // Metadata for a toolset, or nil if the toolset is not OAuth-protected.
 //
 // resourceURL is the absolute URL of the protected resource (the runtime MCP
-// endpoint). It is always emitted verbatim as `resource`. Legacy metadata-backed
+// endpoint). It is always emitted verbatim as `resource`. Metadata-based
 // configurations also advertise it as their Gram-hosted authorization server;
-// provider-hosted configurations advertise their exact stored issuer instead.
+// issuer-based configurations advertise their exact stored issuer instead.
 func ResolveOAuthProtectedResourceFromToolset(
 	ctx context.Context,
 	logger *slog.Logger,

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -99,9 +99,9 @@ type OAuthRepo interface {
 // URL uses an `mcp_endpoints.slug` instead — see the companion
 // resourceURL argument on [ResolveOAuthProtectedResourceFromToolset].
 //
-// resourceURL is the absolute URL of the protected resource — the same value
-// [ResolveOAuthProtectedResourceFromToolset] emits as `resource` and
-// `authorization_servers`. For the external-OAuth-server case it becomes the
+// resourceURL is the absolute URL of the protected resource. For legacy
+// metadata-backed external OAuth configurations, protected-resource metadata
+// also advertises this value as its authorization server, so it becomes the
 // served document's `issuer` so the metadata satisfies RFC 8414 §3.3 (the
 // served `issuer` must equal the issuer identifier the client fetched it
 // under); the proxy case ignores it and keys its issuer off oauthSlug.
@@ -125,12 +125,18 @@ func ResolveOAuthServerMetadataFromToolset(
 			return nil, fmt.Errorf("get external oauth server metadata: %w", err)
 		}
 
+		// Issuer-only configurations use upstream discovery and deliberately do
+		// not expose this retained Gram-hosted RFC 8414 compatibility route.
+		if externalOAuthServer.AuthorizationServerIssuer.Valid {
+			return nil, nil
+		}
+
 		// The captured upstream document's `issuer` identifies the upstream
 		// authorization server, but Gram re-serves that document from its own
 		// `/.well-known/oauth-authorization-server/...` URL. RFC 8414 §3.3
 		// requires the served `issuer` to equal the issuer identifier the
 		// client used to fetch the document — here the Gram resource URL that
-		// the protected-resource metadata advertises in
+		// legacy protected-resource metadata advertises in
 		// `authorization_servers` — so a spec-compliant MCP client does not
 		// reject the metadata on a mismatch. The upstream's own
 		// authorization/token/registration endpoints are preserved verbatim;
@@ -186,11 +192,9 @@ func rewriteMetadataIssuer(raw json.RawMessage, issuer string) (json.RawMessage,
 // Metadata for a toolset, or nil if the toolset is not OAuth-protected.
 //
 // resourceURL is the absolute URL of the protected resource (the runtime MCP
-// endpoint). For /mcp callers this is `<baseURL>/mcp/<toolset.mcp_slug>`; for
-// /x/mcp callers this is `<baseURL>/x/mcp/<mcp_endpoint.slug>`. It is used
-// verbatim for both `resource` and `authorization_servers` so that the
-// `/.well-known/...` discovery path on the protected resource resolves back
-// to the Gram-hosted authorization server metadata.
+// endpoint). It is always emitted verbatim as `resource`. Legacy metadata-backed
+// configurations also advertise it as their Gram-hosted authorization server;
+// provider-hosted configurations advertise their exact stored issuer instead.
 func ResolveOAuthProtectedResourceFromToolset(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -199,11 +203,24 @@ func ResolveOAuthProtectedResourceFromToolset(
 	toolset *toolsets_repo.Toolset,
 	resourceURL string,
 ) (*OAuthProtectedResourceMetadata, error) {
-	// Check for external OAuth server configuration
+	// Check for external OAuth server configuration.
 	if toolset.ExternalOauthServerID.Valid {
+		external, err := repo.New(db).GetExternalOAuthServerMetadata(ctx, repo.GetExternalOAuthServerMetadataParams{
+			ProjectID: toolset.ProjectID,
+			ID:        toolset.ExternalOauthServerID.UUID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get external oauth server metadata: %w", err)
+		}
+
+		authorizationServer := resourceURL
+		if external.AuthorizationServerIssuer.Valid {
+			authorizationServer = external.AuthorizationServerIssuer.String
+		}
+
 		return &OAuthProtectedResourceMetadata{
 			Resource:               resourceURL,
-			AuthorizationServers:   []string{resourceURL},
+			AuthorizationServers:   []string{authorizationServer},
 			ScopesSupported:        nil,
 			BearerMethodsSupported: nil,
 			ResourceDocumentation:  "",

--- a/server/internal/oauth/wellknown/wellknown_rewrite_test.go
+++ b/server/internal/oauth/wellknown/wellknown_rewrite_test.go
@@ -1,10 +1,16 @@
 package wellknown
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
+
+	oauthrepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
 // TestRewriteMetadataIssuer_Object rewrites the top-level issuer while leaving
@@ -20,6 +26,22 @@ func TestRewriteMetadataIssuer_Object(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out, &got))
 	require.Equal(t, "https://gram.example.com/mcp/foo", got["issuer"])
 	require.Equal(t, "https://upstream.example.com/token", got["token_endpoint"])
+}
+
+type issuerOnlyOAuthRepo struct{}
+
+func (issuerOnlyOAuthRepo) GetExternalOAuthServerMetadata(context.Context, oauthrepo.GetExternalOAuthServerMetadataParams) (oauthrepo.ExternalOauthServerMetadatum, error) {
+	return oauthrepo.ExternalOauthServerMetadatum{AuthorizationServerIssuer: pgtype.Text{String: "https://auth.example.com", Valid: true}}, nil
+}
+
+func TestResolveOAuthServerMetadataFromToolset_IssuerOnlyIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	result, err := ResolveOAuthServerMetadataFromToolset(t.Context(), nil, nil, issuerOnlyOAuthRepo{}, nil, &toolsetsrepo.Toolset{
+		ProjectID: uuid.New(), ExternalOauthServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+	}, "", "", "https://gram.example.com/mcp/foo")
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 // TestRewriteMetadataIssuer_NullPayload verifies a JSON null document, which

--- a/server/internal/oauthtest/oauthtest.go
+++ b/server/internal/oauthtest/oauthtest.go
@@ -34,6 +34,9 @@ type ExternalOAuthToolsetOpts struct {
 	// (e.g. dev-idp via devidptest) should pass the bytes returned by the
 	// server's metadata helper here (e.g. inst.OAuth21Metadata(t)).
 	Metadata []byte
+	// AuthorizationServerIssuer configures provider-hosted discovery. When set,
+	// Metadata must be nil to preserve the database source XOR.
+	AuthorizationServerIssuer *string
 }
 
 // CreateExternalOAuthToolset creates a toolset linked to an external OAuth server.
@@ -52,7 +55,8 @@ func CreateExternalOAuthToolset(
 	}
 	slug := opts.Slug + "-" + suffix
 
-	if opts.Metadata == nil {
+	var err error
+	if opts.Metadata == nil && opts.AuthorizationServerIssuer == nil {
 		meta := map[string]any{
 			"issuer":                   "https://test-oauth-server.example.com",
 			"authorization_endpoint":   "https://test-oauth-server.example.com/authorize",
@@ -60,7 +64,6 @@ func CreateExternalOAuthToolset(
 			"response_types_supported": []string{"code"},
 			"grant_types_supported":    []string{"authorization_code"},
 		}
-		var err error
 		opts.Metadata, err = json.Marshal(meta)
 		require.NoError(t, err)
 	}
@@ -68,11 +71,24 @@ func CreateExternalOAuthToolset(
 	oauthRepo := oauth_repo.New(conn)
 	toolsetsRepo := toolsets_repo.New(conn)
 
-	serverMetadata, err := oauthRepo.CreateExternalOAuthServerMetadata(ctx, oauth_repo.CreateExternalOAuthServerMetadataParams{
-		ProjectID: *authCtx.ProjectID,
-		Slug:      "external-oauth-" + suffix,
-		Metadata:  opts.Metadata,
-	})
+	var serverMetadata oauth_repo.ExternalOauthServerMetadatum
+	if opts.AuthorizationServerIssuer == nil {
+		serverMetadata, err = oauthRepo.CreateExternalOAuthServerMetadata(ctx, oauth_repo.CreateExternalOAuthServerMetadataParams{
+			ProjectID: *authCtx.ProjectID,
+			Slug:      "external-oauth-" + suffix,
+			Metadata:  opts.Metadata,
+		})
+	} else {
+		err = conn.QueryRow(ctx, `
+			INSERT INTO external_oauth_server_metadata (project_id, slug, authorization_server_issuer)
+			VALUES ($1, $2, $3)
+			RETURNING id, project_id, slug, metadata, authorization_server_issuer, created_at, updated_at, deleted_at, deleted
+		`, *authCtx.ProjectID, "external-oauth-"+suffix, *opts.AuthorizationServerIssuer).Scan(
+			&serverMetadata.ID, &serverMetadata.ProjectID, &serverMetadata.Slug, &serverMetadata.Metadata,
+			&serverMetadata.AuthorizationServerIssuer, &serverMetadata.CreatedAt, &serverMetadata.UpdatedAt,
+			&serverMetadata.DeletedAt, &serverMetadata.Deleted,
+		)
+	}
 	require.NoError(t, err)
 
 	toolset, err := toolsetsRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{

--- a/server/internal/toolsets/gettoolset_test.go
+++ b/server/internal/toolsets/gettoolset_test.go
@@ -97,7 +97,7 @@ func TestToolsetsService_GetToolset_ExternalOAuthResponseSources(t *testing.T) {
 		require.Equal(t, issuer, *result.ExternalOauthServer.AuthorizationServerIssuer)
 	})
 
-	t.Run("legacy metadata", func(t *testing.T) {
+	t.Run("metadata-based configuration", func(t *testing.T) {
 		t.Parallel()
 
 		ctx, ti := newTestToolsetsService(t)

--- a/server/internal/toolsets/gettoolset_test.go
+++ b/server/internal/toolsets/gettoolset_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	environmentsRepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+	oauthRepo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 )
 
@@ -72,6 +74,61 @@ func TestToolsetsService_GetToolset_Success(t *testing.T) {
 	afterCount, err := audittest.AuditLogCount(ctx, ti.conn)
 	require.NoError(t, err)
 	require.Equal(t, beforeCount, afterCount)
+}
+
+func TestToolsetsService_GetToolset_ExternalOAuthResponseSources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("issuer only", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, ti := newTestToolsetsService(t)
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok)
+		issuer := "https://auth.example.com/Tenant/CaseSensitive"
+		external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+			Slug: "issuer-response", AuthorizationServerIssuer: &issuer,
+		})
+
+		result, err := ti.service.GetToolset(ctx, &gen.GetToolsetPayload{Slug: types.Slug(external.Toolset.Slug)})
+		require.NoError(t, err)
+		require.NotNil(t, result.ExternalOauthServer)
+		require.Nil(t, result.ExternalOauthServer.Metadata)
+		require.Equal(t, issuer, *result.ExternalOauthServer.AuthorizationServerIssuer)
+	})
+
+	t.Run("legacy metadata", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, ti := newTestToolsetsService(t)
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok)
+		external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{Slug: "metadata-response"})
+
+		result, err := ti.service.GetToolset(ctx, &gen.GetToolsetPayload{Slug: types.Slug(external.Toolset.Slug)})
+		require.NoError(t, err)
+		require.NotNil(t, result.ExternalOauthServer)
+		require.NotNil(t, result.ExternalOauthServer.Metadata)
+		require.Nil(t, result.ExternalOauthServer.AuthorizationServerIssuer)
+	})
+
+	t.Run("missing row does not produce phantom object", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, ti := newTestToolsetsService(t)
+		authCtx, ok := contextvalues.GetAuthContext(ctx)
+		require.True(t, ok)
+		external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{Slug: "missing-response"})
+		_, err := oauthRepo.New(ti.conn).DeleteExternalOAuthServerMetadata(ctx, oauthRepo.DeleteExternalOAuthServerMetadataParams{
+			ProjectID: external.ServerMetadata.ProjectID,
+			ID:        external.ServerMetadata.ID,
+		})
+		require.NoError(t, err)
+
+		result, err := ti.service.GetToolset(ctx, &gen.GetToolsetPayload{Slug: types.Slug(external.Toolset.Slug)})
+		require.NoError(t, err)
+		require.Nil(t, result.ExternalOauthServer)
+	})
 }
 
 func TestToolsetsService_GetToolset_IncludesOrigin(t *testing.T) {

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -328,10 +328,11 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDom
 	require.NotNil(t, authCtx.ProjectID)
 
 	domain := seedCustomDomain(t, ctx, ti, authCtx.ActiveOrganizationID, "xmcp-pr-cd-"+uuid.NewString()[:8]+".example.com")
+	upstreamIssuer := "https://issuer.example.com/Tenant/CaseSensitive"
 	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
-		Slug:     "xmcp-pr-cd",
-		IsPublic: true,
-		Metadata: nil,
+		Slug:                      "xmcp-pr-cd",
+		IsPublic:                  true,
+		AuthorizationServerIssuer: &upstreamIssuer,
 	})
 	slug, _ := seedToolsetMCPEndpointOnDomain(t, ctx, ti, *authCtx.ProjectID, external.Toolset, "public", uuid.NullUUID{UUID: domain.ID, Valid: true})
 
@@ -353,7 +354,7 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDom
 
 	authServers, ok := metadata["authorization_servers"].([]any)
 	require.True(t, ok)
-	require.Equal(t, []any{expectedResource}, authServers)
+	require.Equal(t, []any{upstreamIssuer}, authServers)
 }
 
 func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithExternalOAuth(t *testing.T) {
@@ -377,7 +378,9 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithExterna
 
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
-	require.Equal(t, "http://0.0.0.0/x/mcp/"+slug, metadata["resource"])
+	resourceURL := "http://0.0.0.0/x/mcp/" + slug
+	require.Equal(t, resourceURL, metadata["resource"])
+	require.Equal(t, []any{resourceURL}, metadata["authorization_servers"])
 }
 
 // TestHandleWellKnownOAuthProtectedResourceMetadata_IssuerGatedRemoteBackend

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -319,7 +319,7 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithoutOAut
 	require.Empty(t, w.Body.String())
 }
 
-func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDomain(t *testing.T) {
+func TestHandleWellKnownOAuthProtectedResourceMetadata_IssuerOnlyToolsetBackendOnCustomDomain(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
@@ -355,6 +355,43 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDom
 	authServers, ok := metadata["authorization_servers"].([]any)
 	require.True(t, ok)
 	require.Equal(t, []any{upstreamIssuer}, authServers)
+}
+
+func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	domain := seedCustomDomain(t, ctx, ti, authCtx.ActiveOrganizationID, "xmcp-pr-cd-"+uuid.NewString()[:8]+".example.com")
+	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug:     "xmcp-pr-cd",
+		IsPublic: true,
+		Metadata: nil,
+	})
+	slug, _ := seedToolsetMCPEndpointOnDomain(t, ctx, ti, *authCtx.ProjectID, external.Toolset, "public", uuid.NullUUID{UUID: domain.ID, Valid: true})
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	w, err := runWellKnown(t, domainCtx, ti.service.HandleWellKnownOAuthProtectedResourceMetadata, "/.well-known/oauth-protected-resource/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+
+	expectedResource := "https://" + domain.Domain + "/x/mcp/" + slug
+	require.Equal(t, expectedResource, metadata["resource"])
+
+	authServers, ok := metadata["authorization_servers"].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{expectedResource}, authServers)
 }
 
 func TestHandleWellKnownOAuthProtectedResourceMetadata_ToolsetBackendWithExternalOAuth(t *testing.T) {


### PR DESCRIPTION
## Why this PR comes first

Users reported that Codex refused to authenticate with some MCP servers. The OAuth provider used a canonical issuer that was different from the Gram MCP resource URL. Codex compared these values and rejected the authentication response.

Gram must advertise the provider issuer without changing the MCP resource identity. However, Gram cannot create issuer-only records while an older server can still read them. An older server could fail when it finds a record without embedded metadata.

This first PR prepares the read path. It lets every server read and advertise an issuer-only record, but it does not add a way to create one. After this version is deployed everywhere, the next PR can add write operations without a rollout flag.

## Summary

- accept metadata-backed and issuer-only external OAuth rows in toolset responses
- advertise a stored upstream issuer through RFC 9728 while preserving Gram resource URLs
- return not found from Gram-hosted RFC 8414 route for issuer-only rows
- keep external OAuth create and update inputs metadata-only

## Motivation

Reader compatibility must reach every environment before issuer-only writes begin. This release makes existing services safe to read and advertise issuer-only rows without adding a production path that creates them.

## Release order

Deploy this reader release everywhere before the stacked writer/API release. Do not create issuer-only rows until that deployment is complete.