### PR TITLE
fix: restore access after WorkOS delete-and-signup

### DIFF
--- a/.changeset/reactivate-deleted-workos-user.md
+++ b/.changeset/reactivate-deleted-workos-user.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Signing up again with an email that was deleted in WorkOS now reactivates the Gram user, restores RBAC access, and keeps signup off the book-a-demo gate.

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -987,6 +987,7 @@ func TestCallback_SignupAfterWorkOSDeleteWhitelistsActiveOrg(t *testing.T) {
 		staleOrgID  = "org-stale-unwhitelisted"
 	)
 	gramUserID := uuid.New().String()
+	workosOrgID := "workos_org_stale_signup"
 
 	userInfo := &MockUserInfo{
 		UserID:        newWorkosID,
@@ -1012,7 +1013,7 @@ func TestCallback_SignupAfterWorkOSDeleteWhitelistsActiveOrg(t *testing.T) {
 		ID:                 staleOrgID,
 		Name:               "Stale Org",
 		Slug:               staleOrgID,
-		WorkosID:           nil,
+		WorkosID:           &workosOrgID,
 		UserWorkspaceSlugs: nil,
 	}, gramUserID))
 	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
@@ -1033,7 +1034,7 @@ func TestCallback_SignupAfterWorkOSDeleteWhitelistsActiveOrg(t *testing.T) {
 	require.NoError(t, err)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
-	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+	require.Equal(t, staleOrgID, authCtx.ActiveOrganizationID)
 	require.True(t, authCtx.Whitelisted, "signup after WorkOS deletion must clear the book-a-demo gate")
 
 	org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
@@ -1097,7 +1098,48 @@ func TestCallback_LoginAfterWorkOSDeleteKeepsUnwhitelistedOrg(t *testing.T) {
 	require.False(t, authCtx.Whitelisted, "ordinary login must not whitelist a gated organization")
 }
 
-func TestCallback_SignupPrefersExistingWhitelistedOrg(t *testing.T) {
+func TestCallback_SignupIntentDoesNotWhitelistActiveUserOrg(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "active-signup@example.com"
+		organizationID = "org-active-signup"
+	)
+	userInfo := &MockUserInfo{
+		UserID:        "user_01ACTIVE_SIGNUP",
+		Email:         email,
+		Organizations: nil,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+		ID:                 organizationID,
+		Name:               "Gated Org",
+		Slug:               organizationID,
+		WorkosID:           nil,
+		UserWorkspaceSlugs: nil,
+	}, userInfo.UserID))
+
+	ctx, stateParam := instance.stateWithSignupIntent(ctx, t, "", "Should Not Whitelist")
+	result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+		Code:  "mock_code",
+		State: &stateParam,
+	})
+	require.NoError(t, err)
+
+	ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, organizationID, authCtx.ActiveOrganizationID)
+	require.False(t, authCtx.Whitelisted)
+
+	org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.False(t, org.Whitelisted, "signup intent alone must not bypass the book-a-demo gate")
+}
+
+func TestCallback_ReactivatedSignupPrefersExistingWhitelistedOrg(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -1113,6 +1155,16 @@ func TestCallback_SignupPrefersExistingWhitelistedOrg(t *testing.T) {
 	}
 	ctx, instance := newTestAuthService(t, userInfo)
 	require.NoError(t, instance.createTestUser(ctx, userInfo))
+	usersQueries := usersRepo.New(instance.conn)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       userInfo.UserID,
+		WorkosID: conv.ToPGText(userInfo.UserID),
+	}))
+	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosID:        conv.ToPGText(userInfo.UserID),
+	}))
 	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
 		ID:                 staleOrgID,
 		Name:               "Stale Org",

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	redisCache "github.com/go-redis/cache/v9"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/supporthandoff"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	usersRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 func nonceStateFromLocation(t *testing.T, location string) string {
@@ -973,4 +975,183 @@ func TestService_Callback_SignupIntent(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, session.ActiveOrganizationID, "no intent means no org, as today")
 	})
+}
+
+func TestCallback_SignupAfterWorkOSDeleteWhitelistsActiveOrg(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email       = "stale-org-signup@example.com"
+		oldWorkosID = "user_01STALE_DELETED"
+		newWorkosID = "user_01STALE_SIGNUP"
+		staleOrgID  = "org-stale-unwhitelisted"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID:        newWorkosID,
+		Email:         email,
+		Organizations: nil,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+		ID:                 staleOrgID,
+		Name:               "Stale Org",
+		Slug:               staleOrgID,
+		WorkosID:           nil,
+		UserWorkspaceSlugs: nil,
+	}, gramUserID))
+	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosID:        conv.ToPGText(oldWorkosID),
+	}))
+
+	ctx, stateParam := instance.stateWithSignupIntent(ctx, t, "", "Fresh Signup Corp")
+	result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+		Code:  "mock_code",
+		State: &stateParam,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, result.Location, "signin_error=")
+
+	ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotEmpty(t, authCtx.ActiveOrganizationID)
+	require.True(t, authCtx.Whitelisted, "signup after WorkOS deletion must clear the book-a-demo gate")
+
+	org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.True(t, org.Whitelisted)
+}
+
+func TestCallback_LoginAfterWorkOSDeleteKeepsUnwhitelistedOrg(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email       = "stale-org-login@example.com"
+		oldWorkosID = "user_01STALE_LOGIN_DELETED"
+		newWorkosID = "user_01STALE_LOGIN"
+		staleOrgID  = "org-stale-login-unwhitelisted"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID:        newWorkosID,
+		Email:         email,
+		Organizations: nil,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+		ID:                 staleOrgID,
+		Name:               "Stale Org",
+		Slug:               staleOrgID,
+		WorkosID:           nil,
+		UserWorkspaceSlugs: nil,
+	}, gramUserID))
+	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosID:        conv.ToPGText(oldWorkosID),
+	}))
+
+	result, err := instance.callbackWithNonce(ctx, t)
+	require.NoError(t, err)
+	require.NotContains(t, result.Location, "signin_error=")
+
+	ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, staleOrgID, authCtx.ActiveOrganizationID)
+	require.False(t, authCtx.Whitelisted, "ordinary login must not whitelist a gated organization")
+}
+
+func TestCallback_SignupPrefersExistingWhitelistedOrg(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email         = "prefer-whitelisted@example.com"
+		staleOrgID    = "org-prefer-stale"
+		whitelistedID = "org-prefer-whitelisted"
+	)
+
+	userInfo := &MockUserInfo{
+		UserID:        "user_01PREFER_WL",
+		Email:         email,
+		Organizations: nil,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+		ID:                 staleOrgID,
+		Name:               "Stale Org",
+		Slug:               staleOrgID,
+		WorkosID:           nil,
+		UserWorkspaceSlugs: nil,
+	}, userInfo.UserID))
+	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
+		ID:                 whitelistedID,
+		Name:               "Live Org",
+		Slug:               whitelistedID,
+		WorkosID:           nil,
+		UserWorkspaceSlugs: nil,
+	}, userInfo.UserID))
+	_, err := orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          whitelistedID,
+		Name:        "Live Org",
+		Slug:        whitelistedID,
+		WorkosID:    pgtype.Text{},
+		Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+
+	ctx, stateParam := instance.stateWithSignupIntent(ctx, t, "", "Should Not Create")
+	result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+		Code:  "mock_code",
+		State: &stateParam,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, result.Location, "signin_error=")
+
+	ctx, err = instance.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, whitelistedID, authCtx.ActiveOrganizationID)
+	require.True(t, authCtx.Whitelisted)
+
+	stale, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, staleOrgID)
+	require.NoError(t, err)
+	require.False(t, stale.Whitelisted, "signup must not whitelist a stale org when a live one exists")
 }

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -1016,11 +1016,12 @@ func TestCallback_SignupAfterWorkOSDeleteWhitelistsActiveOrg(t *testing.T) {
 		WorkosID:           &workosOrgID,
 		UserWorkspaceSlugs: nil,
 	}, gramUserID))
-	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+	_, err = usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
 		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosID:        conv.ToPGText(oldWorkosID),
-	}))
+	})
+	require.NoError(t, err)
 
 	ctx, stateParam := instance.stateWithSignupIntent(ctx, t, "", "Fresh Signup Corp")
 	result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
@@ -1080,11 +1081,12 @@ func TestCallback_LoginAfterWorkOSDeleteKeepsUnwhitelistedOrg(t *testing.T) {
 		WorkosID:           nil,
 		UserWorkspaceSlugs: nil,
 	}, gramUserID))
-	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+	_, err = usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
 		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosID:        conv.ToPGText(oldWorkosID),
-	}))
+	})
+	require.NoError(t, err)
 
 	result, err := instance.callbackWithNonce(ctx, t)
 	require.NoError(t, err)
@@ -1160,11 +1162,12 @@ func TestCallback_ReactivatedSignupPrefersExistingWhitelistedOrg(t *testing.T) {
 		ID:       userInfo.UserID,
 		WorkosID: conv.ToPGText(userInfo.UserID),
 	}))
-	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+	_, err := usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
 		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosID:        conv.ToPGText(userInfo.UserID),
-	}))
+	})
+	require.NoError(t, err)
 	require.NoError(t, instance.createTestOrganization(ctx, MockOrganizationEntry{
 		ID:                 staleOrgID,
 		Name:               "Stale Org",
@@ -1179,7 +1182,7 @@ func TestCallback_ReactivatedSignupPrefersExistingWhitelistedOrg(t *testing.T) {
 		WorkosID:           nil,
 		UserWorkspaceSlugs: nil,
 	}, userInfo.UserID))
-	_, err := orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
 		ID:          whitelistedID,
 		Name:        "Live Org",
 		Slug:        whitelistedID,

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -264,9 +264,22 @@ func extractSessionIDFromJWT(token string) string {
 	return claims.SID
 }
 
+// UpsertUserResult describes the Gram user selected for an IDP identity.
+type UpsertUserResult struct {
+	UserID      string
+	Reactivated bool
+}
+
 // UpsertUserFromIDP upserts a user record from OIDC identity claims and
 // returns the user ID.
-func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) (_ string, err error) {
+func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) (string, error) {
+	result, err := r.UpsertUserFromIDPWithResult(ctx, idpUser)
+	return result.UserID, err
+}
+
+// UpsertUserFromIDPWithResult also reports whether login reactivated a user
+// previously deleted by WorkOS.
+func (r *Resolver) UpsertUserFromIDPWithResult(ctx context.Context, idpUser *IDPUserInfo) (_ UpsertUserResult, err error) {
 	ctx, span := r.tracer.Start(ctx, "identity.upsertUserFromIDP")
 	defer func() {
 		if err != nil {
@@ -275,7 +288,7 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		span.End()
 	}()
 
-	gramUserID, admin := r.resolveGramUserID(ctx, idpUser)
+	gramUserID, admin, reactivated := r.resolveGramUserID(ctx, idpUser)
 	span.SetAttributes(
 		attr.AuthUserID(gramUserID),
 		attr.WorkOSUserID(idpUser.Sub),
@@ -290,17 +303,17 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		Admin:       admin,
 	})
 	if err != nil {
-		return "", fmt.Errorf("upsert user: %w", err)
+		return UpsertUserResult{}, fmt.Errorf("upsert user: %w", err)
 	}
 
 	if err := r.userRepo.OverwriteUserWorkosID(ctx, userRepo.OverwriteUserWorkosIDParams{
 		ID:       gramUserID,
 		WorkosID: pgtype.Text{String: idpUser.Sub, Valid: true},
 	}); err != nil {
-		return "", fmt.Errorf("set workos_id on user: %w", err)
+		return UpsertUserResult{}, fmt.Errorf("set workos_id on user: %w", err)
 	}
 	if err := r.reassignWorkOSIdentity(ctx, gramUserID, idpUser.Sub); err != nil {
-		return "", err
+		return UpsertUserResult{}, err
 	}
 
 	if r.workosClient != nil {
@@ -324,7 +337,7 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		r.emitSignup(ctx, user.Email, user.DisplayName)
 	}
 
-	return user.ID, nil
+	return UpsertUserResult{UserID: user.ID, Reactivated: reactivated}, nil
 }
 
 func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID, newWorkosID string) error {
@@ -367,14 +380,14 @@ func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID, newWo
 	return nil
 }
 
-func (r *Resolver) resolveGramUserID(ctx context.Context, idpUser *IDPUserInfo) (string, bool) {
+func (r *Resolver) resolveGramUserID(ctx context.Context, idpUser *IDPUserInfo) (string, bool, bool) {
 	if existing, err := r.userRepo.GetUserByEmail(ctx, idpUser.Email); err == nil {
-		return existing.ID, existing.Admin
+		return existing.ID, existing.Admin, existing.WorkosDeletedAt.Valid
 	}
 	if idpUser.ExternalID != "" {
-		return idpUser.ExternalID, false
+		return idpUser.ExternalID, false, false
 	}
-	return users.UserIDFromWorkOSID(idpUser.Sub), false
+	return users.UserIDFromWorkOSID(idpUser.Sub), false, false
 }
 
 // BuildUserInfoFromDB constructs a CachedUserInfo by querying user data and
@@ -439,6 +452,16 @@ func (r *Resolver) BuildUserInfoFromDB(ctx context.Context, userID string) (*ses
 // SyncMembershipsFromWorkOS refreshes local WorkOS organization memberships
 // and invalidates cached user info so the next read observes the synced rows.
 func (r *Resolver) SyncMembershipsFromWorkOS(ctx context.Context, gramUserID, workosUserID string) error {
+	return r.syncMembershipsFromWorkOS(ctx, gramUserID, workosUserID, false)
+}
+
+// SyncMembershipsFromWorkOSPreservingExisting imports current WorkOS
+// memberships without pruning access restored from a deleted WorkOS identity.
+func (r *Resolver) SyncMembershipsFromWorkOSPreservingExisting(ctx context.Context, gramUserID, workosUserID string) error {
+	return r.syncMembershipsFromWorkOS(ctx, gramUserID, workosUserID, true)
+}
+
+func (r *Resolver) syncMembershipsFromWorkOS(ctx context.Context, gramUserID, workosUserID string, preserveExisting bool) error {
 	if r.workosClient == nil || workosUserID == "" {
 		return nil
 	}
@@ -468,6 +491,7 @@ func (r *Resolver) SyncMembershipsFromWorkOS(ctx context.Context, gramUserID, wo
 	qtx := orgRepo.New(tx)
 	lost, err := qtx.SetUserWorkOSMemberships(ctx, orgRepo.SetUserWorkOSMembershipsParams{
 		UserID:              pgtype.Text{String: gramUserID, Valid: gramUserID != ""},
+		PreserveExisting:    preserveExisting,
 		WorkosOrgIds:        workosOrgIDs,
 		WorkosMembershipIds: membershipIDs,
 	})

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -298,6 +298,8 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		WorkosID: pgtype.Text{String: idpUser.Sub, Valid: true},
 	}); err != nil {
 		r.logger.ErrorContext(ctx, "failed to set workos_id on user", attr.SlogError(err))
+	} else if err := r.reassignWorkOSIdentity(ctx, gramUserID, user.WorkosID, idpUser.Sub); err != nil {
+		return "", err
 	}
 
 	if r.workosClient != nil {
@@ -322,6 +324,30 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 	}
 
 	return user.ID, nil
+}
+
+func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID string, previousWorkosID pgtype.Text, newWorkosID string) error {
+	if !previousWorkosID.Valid || previousWorkosID.String == "" || previousWorkosID.String == newWorkosID || newWorkosID == "" {
+		return nil
+	}
+
+	if err := r.orgRepo.ReassignOrganizationUserWorkOSID(ctx, orgRepo.ReassignOrganizationUserWorkOSIDParams{
+		NewWorkosUserID: conv.ToPGText(newWorkosID),
+		UserID:          conv.ToPGText(gramUserID),
+		OldWorkosUserID: conv.ToPGText(previousWorkosID.String),
+	}); err != nil {
+		return fmt.Errorf("reassign organization memberships to workos user: %w", err)
+	}
+
+	if err := r.orgRepo.ReassignOrganizationRoleAssignmentWorkOSID(ctx, orgRepo.ReassignOrganizationRoleAssignmentWorkOSIDParams{
+		NewWorkosUserID: newWorkosID,
+		UserID:          conv.ToPGText(gramUserID),
+		OldWorkosUserID: previousWorkosID.String,
+	}); err != nil {
+		return fmt.Errorf("reassign organization role assignments to workos user: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Resolver) resolveGramUserID(ctx context.Context, idpUser *IDPUserInfo) (string, bool) {

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -297,8 +297,9 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		ID:       gramUserID,
 		WorkosID: pgtype.Text{String: idpUser.Sub, Valid: true},
 	}); err != nil {
-		r.logger.ErrorContext(ctx, "failed to set workos_id on user", attr.SlogError(err))
-	} else if err := r.reassignWorkOSIdentity(ctx, gramUserID, user.WorkosID, idpUser.Sub); err != nil {
+		return "", fmt.Errorf("set workos_id on user: %w", err)
+	}
+	if err := r.reassignWorkOSIdentity(ctx, gramUserID, idpUser.Sub); err != nil {
 		return "", err
 	}
 
@@ -326,23 +327,27 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 	return user.ID, nil
 }
 
-func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID string, previousWorkosID pgtype.Text, newWorkosID string) error {
-	if !previousWorkosID.Valid || previousWorkosID.String == "" || previousWorkosID.String == newWorkosID || newWorkosID == "" {
+func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID, newWorkosID string) error {
+	if gramUserID == "" || newWorkosID == "" {
 		return nil
 	}
 
 	if err := r.orgRepo.ReassignOrganizationUserWorkOSID(ctx, orgRepo.ReassignOrganizationUserWorkOSIDParams{
 		NewWorkosUserID: conv.ToPGText(newWorkosID),
 		UserID:          conv.ToPGText(gramUserID),
-		OldWorkosUserID: conv.ToPGText(previousWorkosID.String),
 	}); err != nil {
 		return fmt.Errorf("reassign organization memberships to workos user: %w", err)
 	}
 
+	if err := r.orgRepo.RetireCollidingOrganizationRoleAssignments(ctx, orgRepo.RetireCollidingOrganizationRoleAssignmentsParams{
+		UserID:          conv.ToPGText(gramUserID),
+		NewWorkosUserID: newWorkosID,
+	}); err != nil {
+		return fmt.Errorf("retire colliding organization role assignments: %w", err)
+	}
 	if err := r.orgRepo.ReassignOrganizationRoleAssignmentWorkOSID(ctx, orgRepo.ReassignOrganizationRoleAssignmentWorkOSIDParams{
 		NewWorkosUserID: newWorkosID,
 		UserID:          conv.ToPGText(gramUserID),
-		OldWorkosUserID: previousWorkosID.String,
 	}); err != nil {
 		return fmt.Errorf("reassign organization role assignments to workos user: %w", err)
 	}

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -339,11 +339,23 @@ func (r *Resolver) reassignWorkOSIdentity(ctx context.Context, gramUserID, newWo
 		return fmt.Errorf("reassign organization memberships to workos user: %w", err)
 	}
 
+	if err := r.orgRepo.LinkRoleAssignmentsToUser(ctx, orgRepo.LinkRoleAssignmentsToUserParams{
+		UserID:       conv.ToPGText(gramUserID),
+		WorkosUserID: newWorkosID,
+	}); err != nil {
+		return fmt.Errorf("link organization role assignments to user: %w", err)
+	}
 	if err := r.orgRepo.RetireCollidingOrganizationRoleAssignments(ctx, orgRepo.RetireCollidingOrganizationRoleAssignmentsParams{
 		UserID:          conv.ToPGText(gramUserID),
 		NewWorkosUserID: newWorkosID,
 	}); err != nil {
 		return fmt.Errorf("retire colliding organization role assignments: %w", err)
+	}
+	if err := r.orgRepo.RetireDuplicateLeftoverOrganizationRoleAssignments(ctx, orgRepo.RetireDuplicateLeftoverOrganizationRoleAssignmentsParams{
+		UserID:          conv.ToPGText(gramUserID),
+		NewWorkosUserID: newWorkosID,
+	}); err != nil {
+		return fmt.Errorf("retire duplicate leftover organization role assignments: %w", err)
 	}
 	if err := r.orgRepo.ReassignOrganizationRoleAssignmentWorkOSID(ctx, orgRepo.ReassignOrganizationRoleAssignmentWorkOSIDParams{
 		NewWorkosUserID: newWorkosID,

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -520,6 +520,13 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		return redirectWithError(authErrInit, errors.New("this organization is disabled, please reach out to support@speakeasy.com for more information"))
 	}
 
+	if intent != nil && intent.OrgName != "" {
+		activeOrgID, orgMetadata, err = s.applySignupWhitelist(ctx, userInfo.Organizations, activeOrgID, orgMetadata)
+		if err != nil {
+			return s.redirectSignupError(ctx, payload, err)
+		}
+	}
+
 	session.ActiveOrganizationID = activeOrgID
 	if err := s.sessions.StoreSession(ctx, session); err != nil {
 		return redirectWithError(authErrInit, err)
@@ -1126,6 +1133,37 @@ func loadTrial(
 			EndsAt:    conv.FromPGTimestamptz(trial.EndsAt),
 		}
 	}
+}
+
+// applySignupWhitelist keeps the book-a-demo gate off for a signup that
+// reused a Gram identity. Prefer an already-whitelisted membership; otherwise
+// whitelist the org the session is about to activate.
+func (s *Service) applySignupWhitelist(ctx context.Context, organizations []sessions.Organization, activeOrgID string, orgMetadata orgRepo.OrganizationMetadatum) (string, orgRepo.OrganizationMetadatum, error) {
+	if orgMetadata.Whitelisted {
+		return activeOrgID, orgMetadata, nil
+	}
+
+	for _, org := range organizations {
+		meta, err := s.orgRepo.GetOrganizationMetadata(ctx, org.ID)
+		if err != nil {
+			return "", orgRepo.OrganizationMetadatum{}, fmt.Errorf("get organization metadata: %w", err)
+		}
+		if meta.Whitelisted {
+			return org.ID, meta, nil
+		}
+	}
+
+	whitelisted, err := s.orgRepo.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          orgMetadata.ID,
+		Name:        orgMetadata.Name,
+		Slug:        orgMetadata.Slug,
+		WorkosID:    orgMetadata.WorkosID,
+		Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	if err != nil {
+		return "", orgRepo.OrganizationMetadatum{}, fmt.Errorf("whitelist organization for signup: %w", err)
+	}
+	return whitelisted.ID, whitelisted, nil
 }
 
 // orgProvisionOptions carries the per-caller choices for a new organization.

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -370,10 +370,11 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		trace.SpanFromContext(ctx).SetAttributes(attr.AuthImpersonatorEmail(ie))
 	}
 
-	userID, err := s.identity.UpsertUserFromIDP(ctx, idpUser)
+	upsertResult, err := s.identity.UpsertUserFromIDPWithResult(ctx, idpUser)
 	if err != nil {
 		return redirectWithError(authErrInit, err)
 	}
+	userID := upsertResult.UserID
 
 	userInfo, _, err := s.identity.GetUserInfo(ctx, userID)
 	if err != nil {
@@ -388,7 +389,11 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 	}
 
 	if supportOrgID == "" && idpUser.Sub != "" {
-		if err := s.identity.SyncMembershipsFromWorkOS(ctx, userID, idpUser.Sub); err != nil {
+		syncMemberships := s.identity.SyncMembershipsFromWorkOS
+		if upsertResult.Reactivated {
+			syncMemberships = s.identity.SyncMembershipsFromWorkOSPreservingExisting
+		}
+		if err := syncMemberships(ctx, userID, idpUser.Sub); err != nil {
 			return redirectWithError(authErrInit, err)
 		}
 		userInfo, _, err = s.identity.GetUserInfo(ctx, userID)
@@ -520,7 +525,7 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		return redirectWithError(authErrInit, errors.New("this organization is disabled, please reach out to support@speakeasy.com for more information"))
 	}
 
-	if intent != nil && intent.OrgName != "" {
+	if upsertResult.Reactivated && intent != nil && intent.OrgName != "" {
 		activeOrgID, orgMetadata, err = s.applySignupWhitelist(ctx, userInfo.Organizations, activeOrgID, orgMetadata)
 		if err != nil {
 			return s.redirectSignupError(ctx, payload, err)

--- a/server/internal/auth/speakeasyclient/client.go
+++ b/server/internal/auth/speakeasyclient/client.go
@@ -338,6 +338,7 @@ func (c *Client) syncWorkOSMemberships(ctx context.Context, user userRepo.Upsert
 	qtx := orgRepo.New(tx)
 	lost, err := qtx.SetUserWorkOSMemberships(ctx, orgRepo.SetUserWorkOSMembershipsParams{
 		UserID:              conv.ToPGText(user.ID),
+		PreserveExisting:    false,
 		WorkosOrgIds:        workosOrgIDs,
 		WorkosMembershipIds: membershipIDs,
 	})

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -177,6 +177,12 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 		UserID:         conv.ToPGText(gramUserID),
 	})
 	require.NoError(t, err)
+	_, err = instance.conn.Exec(ctx, `
+		UPDATE organization_user_relationships
+		SET workos_user_id = $1
+		WHERE organization_id = $2 AND user_id = $3 AND deleted_at IS NULL
+	`, oldWorkosID, organizationID, gramUserID)
+	require.NoError(t, err)
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
 	_, err = accessrepo.New(instance.conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
 		OrganizationID:     organizationID,
@@ -242,6 +248,14 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 	require.Equal(t, gramUserID, reassigned[0].UserID.String)
 	require.False(t, reassigned[0].DeletedAt.Valid)
 
+	membership, err := orgRepo.New(instance.conn).GetOrganizationUserRelationship(ctx, orgRepo.GetOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.True(t, membership.WorkosUserID.Valid)
+	require.Equal(t, newWorkosID, membership.WorkosUserID.String)
+
 	isMember, err = orgRepo.New(instance.conn).HasActiveOrganizationUser(ctx, orgRepo.HasActiveOrganizationUserParams{
 		UserID:         gramUserID,
 		OrganizationID: organizationID,
@@ -259,4 +273,168 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 	}
 	require.Contains(t, principalURNs, urn.NewPrincipal(urn.PrincipalTypeUser, gramUserID).String())
 	require.Contains(t, principalURNs, "role:global:"+memberRole.ID.String())
+}
+
+func TestUpsertUserFromIDP_MergesRoleWhenNewWorkOSIdentityAlreadyHasAssignment(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "reactivate-collision@example.com"
+		oldWorkosID    = "user_01COLLISION_OLD"
+		newWorkosID    = "user_01COLLISION_NEW"
+		organizationID = "org_reactivate_role_collision"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID: newWorkosID,
+		Email:  email,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Collision Org",
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText("org_01COLLISION"),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
+	assignments := accessrepo.New(instance.conn)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       oldWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01COLLISION_OLD"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       newWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01COLLISION_NEW"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "test-code")
+	require.NoError(t, err)
+	_, err = instance.identityResolver.UpsertUserFromIDP(ctx, idpUser)
+	require.NoError(t, err)
+
+	stale, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   oldWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+	require.True(t, stale[0].DeletedAt.Valid, "colliding leftover assignment must be retired")
+
+	current, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   newWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, current, 1)
+	require.False(t, current[0].DeletedAt.Valid)
+}
+
+func TestUpsertUserFromIDP_ReassignsLeftoverRolesAfterWorkOSIDAlreadyUpdated(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "reactivate-retry@example.com"
+		oldWorkosID    = "user_01RETRY_OLD"
+		newWorkosID    = "user_01RETRY_NEW"
+		organizationID = "org_reactivate_role_retry"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID: newWorkosID,
+		Email:  email,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(newWorkosID),
+	}))
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Retry Org",
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText("org_01RETRY"),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
+	_, err = accessrepo.New(instance.conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       oldWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01RETRY"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "test-code")
+	require.NoError(t, err)
+	_, err = instance.identityResolver.UpsertUserFromIDP(ctx, idpUser)
+	require.NoError(t, err)
+
+	stale, err := accessrepo.New(instance.conn).ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   oldWorkosID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, stale, "retry must still move leftover assignments off the old WorkOS id")
+
+	current, err := accessrepo.New(instance.conn).ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   newWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, current, 1)
+	require.False(t, current[0].DeletedAt.Valid)
 }

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -177,12 +177,11 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 		UserID:         conv.ToPGText(gramUserID),
 	})
 	require.NoError(t, err)
-	_, err = instance.conn.Exec(ctx, `
-		UPDATE organization_user_relationships
-		SET workos_user_id = $1
-		WHERE organization_id = $2 AND user_id = $3 AND deleted_at IS NULL
-	`, oldWorkosID, organizationID, gramUserID)
-	require.NoError(t, err)
+	require.NoError(t, orgRepo.New(instance.conn).SetOrganizationUserWorkOSID(ctx, orgRepo.SetOrganizationUserWorkOSIDParams{
+		WorkosUserID:   conv.ToPGText(oldWorkosID),
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	}))
 	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
 	_, err = accessrepo.New(instance.conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
 		OrganizationID:     organizationID,

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -226,6 +226,22 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 	require.True(t, reactivated.WorkosID.Valid)
 	require.Equal(t, newWorkosID, reactivated.WorkosID.String)
 
+	staleAssignments, err := accessrepo.New(instance.conn).ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   oldWorkosID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, staleAssignments, "role assignments must move off the deleted WorkOS identity")
+
+	reassigned, err := accessrepo.New(instance.conn).ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   newWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, reassigned, 1)
+	require.Equal(t, gramUserID, reassigned[0].UserID.String)
+	require.False(t, reassigned[0].DeletedAt.Valid)
+
 	isMember, err = orgRepo.New(instance.conn).HasActiveOrganizationUser(ctx, orgRepo.HasActiveOrganizationUserParams{
 		UserID:         gramUserID,
 		OrganizationID: organizationID,

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -437,3 +437,210 @@ func TestUpsertUserFromIDP_ReassignsLeftoverRolesAfterWorkOSIDAlreadyUpdated(t *
 	require.Len(t, current, 1)
 	require.False(t, current[0].DeletedAt.Valid)
 }
+
+func TestUpsertUserFromIDP_LinksUnlinkedSurvivorBeforeRetiringCollision(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "reactivate-unlinked@example.com"
+		oldWorkosID    = "user_01UNLINKED_OLD"
+		newWorkosID    = "user_01UNLINKED_NEW"
+		organizationID = "org_reactivate_unlinked_survivor"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID: newWorkosID,
+		Email:  email,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Unlinked Survivor Org",
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText("org_01UNLINKED"),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
+	assignments := accessrepo.New(instance.conn)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       oldWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01UNLINKED_OLD"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       newWorkosID,
+		UserID:             pgtype.Text{},
+		WorkosMembershipID: conv.ToPGText("om_01UNLINKED_NEW"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "test-code")
+	require.NoError(t, err)
+	_, err = instance.identityResolver.UpsertUserFromIDP(ctx, idpUser)
+	require.NoError(t, err)
+
+	stale, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   oldWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+	require.True(t, stale[0].DeletedAt.Valid, "colliding leftover assignment must be retired")
+
+	current, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   newWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, current, 1)
+	require.False(t, current[0].DeletedAt.Valid)
+	require.True(t, current[0].UserID.Valid, "surviving new-id assignment must be linked to the Gram user")
+	require.Equal(t, gramUserID, current[0].UserID.String)
+
+	memberRole, err := assignments.GetGlobalRoleBySlug(ctx, authz.SystemRoleMember)
+	require.NoError(t, err)
+	principals, err := authz.ResolveUserPrincipals(ctx, instance.conn, organizationID, gramUserID)
+	require.NoError(t, err)
+	principalURNs := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		principalURNs = append(principalURNs, principal.String())
+	}
+	require.Contains(t, principalURNs, "role:global:"+memberRole.ID.String())
+}
+
+func TestUpsertUserFromIDP_DedupesLeftoverRolesBeforeRemap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "reactivate-dup-leftover@example.com"
+		oldWorkosID    = "user_01DUP_OLD"
+		olderWorkosID  = "user_01DUP_OLDER"
+		newWorkosID    = "user_01DUP_NEW"
+		organizationID = "org_reactivate_dup_leftover"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID: newWorkosID,
+		Email:  email,
+	}
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Duplicate Leftover Org",
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText("org_01DUP"),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
+	assignments := accessrepo.New(instance.conn)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       olderWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01DUP_OLDER"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+	_, err = assignments.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       oldWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01DUP_OLD"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "test-code")
+	require.NoError(t, err)
+	_, err = instance.identityResolver.UpsertUserFromIDP(ctx, idpUser)
+	require.NoError(t, err)
+
+	older, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   olderWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, older, 1)
+	require.True(t, older[0].DeletedAt.Valid, "older leftover assignment must be retired")
+
+	stale, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   oldWorkosID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, stale, "newest leftover assignment must remap onto the new WorkOS id")
+
+	current, err := assignments.ListOrganizationRoleAssignmentRecordsByWorkosUser(ctx, accessrepo.ListOrganizationRoleAssignmentRecordsByWorkosUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   newWorkosID,
+	})
+	require.NoError(t, err)
+	require.Len(t, current, 1)
+	require.False(t, current[0].DeletedAt.Valid)
+	require.Equal(t, gramUserID, current[0].UserID.String)
+
+	memberRole, err := assignments.GetGlobalRoleBySlug(ctx, authz.SystemRoleMember)
+	require.NoError(t, err)
+	principals, err := authz.ResolveUserPrincipals(ctx, instance.conn, organizationID, gramUserID)
+	require.NoError(t, err)
+	principalURNs := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		principalURNs = append(principalURNs, principal.String())
+	}
+	require.Contains(t, principalURNs, "role:global:"+memberRole.ID.String())
+}

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -2,11 +2,17 @@ package auth_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/users"
 	usersRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
@@ -124,4 +130,117 @@ func TestUpsertUserFromIDP_PreservesAdminStatus(t *testing.T) {
 	dbUser, err := usersQueries.GetUser(ctx, legacyUUID)
 	require.NoError(t, err)
 	require.True(t, dbUser.Admin, "admin flag must survive the ID migration")
+}
+
+func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email          = "reactivate@example.com"
+		oldWorkosID    = "user_01DELETED_WORKOS"
+		newWorkosID    = "user_01RECREATED_WORKOS"
+		organizationID = "org_reactivate_deleted_user"
+	)
+	gramUserID := uuid.New().String()
+
+	userInfo := &MockUserInfo{
+		UserID: newWorkosID,
+		Email:  email,
+	}
+
+	ctx, instance := newTestAuthService(t, userInfo)
+	usersQueries := usersRepo.New(instance.conn)
+
+	_, err := usersQueries.UpsertUser(ctx, usersRepo.UpsertUserParams{
+		ID:          gramUserID,
+		Email:       email,
+		DisplayName: "Deleted User",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, usersQueries.OverwriteUserWorkosID(ctx, usersRepo.OverwriteUserWorkosIDParams{
+		ID:       gramUserID,
+		WorkosID: conv.ToPGText(oldWorkosID),
+	}))
+
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          organizationID,
+		Name:        "Reactivate Org",
+		Slug:        organizationID,
+		WorkosID:    conv.ToPGText("org_01REACTIVATE"),
+		Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+	_, err = orgRepo.New(instance.conn).UpsertOrganizationUserRelationship(ctx, orgRepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.SeedSystemRoleGrants(ctx, instance.conn, organizationID))
+	_, err = accessrepo.New(instance.conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       oldWorkosID,
+		UserID:             conv.ToPGText(gramUserID),
+		WorkosMembershipID: conv.ToPGText("om_01REACTIVATE"),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     authz.SystemRoleMember,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+		WorkosID:        conv.ToPGText(oldWorkosID),
+	}))
+
+	deleted, err := usersQueries.GetUser(ctx, gramUserID)
+	require.NoError(t, err)
+	require.True(t, deleted.DeletedAt.Valid)
+	require.True(t, deleted.WorkosDeletedAt.Valid)
+
+	isMember, err := orgRepo.New(instance.conn).HasActiveOrganizationUser(ctx, orgRepo.HasActiveOrganizationUserParams{
+		UserID:         gramUserID,
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+	require.False(t, isMember, "soft-deleted users must stay RBAC-inactive until they sign up again")
+
+	principals, err := authz.ResolveUserPrincipals(ctx, instance.conn, organizationID, gramUserID)
+	require.NoError(t, err)
+	require.Equal(t, []urn.Principal{authz.AllUsersPrincipal()}, principals)
+
+	idpUser, err := instance.identityResolver.ExchangeCodeForTokens(ctx, "test-code")
+	require.NoError(t, err)
+	require.Equal(t, newWorkosID, idpUser.Sub)
+
+	returnedID, err := instance.identityResolver.UpsertUserFromIDP(ctx, idpUser)
+	require.NoError(t, err)
+	require.Equal(t, gramUserID, returnedID)
+
+	reactivated, err := usersQueries.GetUser(ctx, gramUserID)
+	require.NoError(t, err)
+	require.False(t, reactivated.DeletedAt.Valid, "login must clear users.deleted_at")
+	require.False(t, reactivated.WorkosDeletedAt.Valid, "login must clear users.workos_deleted_at")
+	require.True(t, reactivated.WorkosID.Valid)
+	require.Equal(t, newWorkosID, reactivated.WorkosID.String)
+
+	isMember, err = orgRepo.New(instance.conn).HasActiveOrganizationUser(ctx, orgRepo.HasActiveOrganizationUserParams{
+		UserID:         gramUserID,
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+	require.True(t, isMember)
+
+	memberRole, err := accessrepo.New(instance.conn).GetGlobalRoleBySlug(ctx, authz.SystemRoleMember)
+	require.NoError(t, err)
+	principals, err = authz.ResolveUserPrincipals(ctx, instance.conn, organizationID, gramUserID)
+	require.NoError(t, err)
+	principalURNs := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		principalURNs = append(principalURNs, principal.String())
+	}
+	require.Contains(t, principalURNs, urn.NewPrincipal(urn.PrincipalTypeUser, gramUserID).String())
+	require.Contains(t, principalURNs, "role:global:"+memberRole.ID.String())
 }

--- a/server/internal/auth/upsert_user_test.go
+++ b/server/internal/auth/upsert_user_test.go
@@ -194,11 +194,12 @@ func TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
+	_, err = usersQueries.DisableUser(ctx, usersRepo.DisableUserParams{
 		WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosDeletedAt: conv.ToPGTimestamptz(time.Now().UTC()),
 		WorkosID:        conv.ToPGText(oldWorkosID),
-	}))
+	})
+	require.NoError(t, err)
 
 	deleted, err := usersQueries.GetUser(ctx, gramUserID)
 	require.NoError(t, err)

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -673,6 +673,29 @@ WHERE old.user_id = @user_id
         AND neu.deleted_at IS NULL
   );
 
+-- name: RetireDuplicateLeftoverOrganizationRoleAssignments :exec
+-- Soft-delete extra leftover assignments that share org+role so remapping
+-- them onto one WorkOS id cannot unique-violate. Keeps the newest leftover.
+UPDATE organization_role_assignments AS dest
+SET deleted_at = COALESCE(dest.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+FROM (
+  SELECT id
+  FROM (
+    SELECT leftover.id,
+           ROW_NUMBER() OVER (
+             PARTITION BY leftover.organization_id, leftover.role_urn
+             ORDER BY leftover.created_at DESC, leftover.id DESC
+           ) AS rn
+    FROM organization_role_assignments leftover
+    WHERE leftover.user_id = sqlc.arg(user_id)
+      AND leftover.workos_user_id <> sqlc.arg(new_workos_user_id)
+      AND leftover.deleted_at IS NULL
+  ) ranked
+  WHERE rn > 1
+) extras
+WHERE dest.id = extras.id;
+
 -- name: ReassignOrganizationRoleAssignmentWorkOSID :exec
 -- Move leftover assignments onto the new WorkOS id after colliding rows
 -- have been retired.

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -636,6 +636,25 @@ WHERE user_id = @user_id
 ORDER BY updated_at DESC
 LIMIT 1;
 
+-- name: ReassignOrganizationUserWorkOSID :exec
+-- Login reuses a Gram user after WorkOS delete-and-signup, so membership
+-- rows must follow the new WorkOS user id.
+UPDATE organization_user_relationships
+SET workos_user_id = @new_workos_user_id,
+    updated_at = clock_timestamp()
+WHERE user_id = @user_id
+  AND workos_user_id = @old_workos_user_id;
+
+-- name: ReassignOrganizationRoleAssignmentWorkOSID :exec
+-- Role assignments are keyed by workos_user_id. Move them when a recreated
+-- WorkOS user reuses the Gram identity so roster and sync joins still match.
+UPDATE organization_role_assignments
+SET workos_user_id = @new_workos_user_id,
+    updated_at = clock_timestamp()
+WHERE user_id = @user_id
+  AND workos_user_id = @old_workos_user_id
+  AND deleted_at IS NULL;
+
 -- name: ListOrganizationRoleAssignmentsByWorkOSUser :many
 SELECT *
 FROM organization_role_assignments

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -636,6 +636,14 @@ WHERE user_id = @user_id
 ORDER BY updated_at DESC
 LIMIT 1;
 
+-- name: SetOrganizationUserWorkOSID :exec
+UPDATE organization_user_relationships
+SET workos_user_id = @workos_user_id,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND user_id = @user_id
+  AND deleted_at IS NULL;
+
 -- name: ReassignOrganizationUserWorkOSID :exec
 -- Login reuses a Gram user after WorkOS delete-and-signup, so membership
 -- rows still pointing at a previous WorkOS user id must follow the new one.

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -187,9 +187,9 @@ WHERE organization_user_relationships.deleted_at IS NULL;
 -- name: SetUserWorkOSMemberships :many
 -- Declaratively set all WorkOS memberships for a user. Takes WorkOS org IDs
 -- (not Speakeasy org IDs) and resolves them via organization_metadata. Upserts
--- the provided (workos_org_id, workos_membership_id) pairs and soft-deletes any
--- other relationships where the org has a non-NULL workos_id. Orgs without a
--- workos_id are unaffected. Other users' memberships are never modified.
+-- the provided (workos_org_id, workos_membership_id) pairs and, unless
+-- preserve_existing is true, soft-deletes any other relationships where the org
+-- has a non-NULL workos_id. Other users' memberships are never modified.
 WITH input_memberships AS (
     SELECT unnest(@workos_org_ids::text[]) AS workos_org_id,
            unnest(@workos_membership_ids::text[]) AS workos_membership_id
@@ -240,6 +240,7 @@ UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE organization_user_relationships.user_id = @user_id
+  AND NOT @preserve_existing::boolean
   AND organization_user_relationships.deleted IS FALSE
   AND organization_user_relationships.organization_id NOT IN (SELECT organization_id FROM resolved)
   AND organization_user_relationships.organization_id IN (

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -638,21 +638,41 @@ LIMIT 1;
 
 -- name: ReassignOrganizationUserWorkOSID :exec
 -- Login reuses a Gram user after WorkOS delete-and-signup, so membership
--- rows must follow the new WorkOS user id.
+-- rows still pointing at a previous WorkOS user id must follow the new one.
+-- Matches any leftover id so a retry after overwrite still converges.
 UPDATE organization_user_relationships
 SET workos_user_id = @new_workos_user_id,
     updated_at = clock_timestamp()
 WHERE user_id = @user_id
-  AND workos_user_id = @old_workos_user_id;
+  AND workos_user_id IS NOT NULL
+  AND workos_user_id IS DISTINCT FROM @new_workos_user_id;
+
+-- name: RetireCollidingOrganizationRoleAssignments :exec
+-- Soft-delete leftover assignments that would unique-violate if remapped
+-- onto a WorkOS id that already holds the same org+role.
+UPDATE organization_role_assignments AS old
+SET deleted_at = COALESCE(old.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE old.user_id = @user_id
+  AND old.workos_user_id <> @new_workos_user_id
+  AND old.deleted_at IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM organization_role_assignments AS neu
+      WHERE neu.organization_id = old.organization_id
+        AND neu.workos_user_id = @new_workos_user_id
+        AND neu.role_urn = old.role_urn
+        AND neu.deleted_at IS NULL
+  );
 
 -- name: ReassignOrganizationRoleAssignmentWorkOSID :exec
--- Role assignments are keyed by workos_user_id. Move them when a recreated
--- WorkOS user reuses the Gram identity so roster and sync joins still match.
+-- Move leftover assignments onto the new WorkOS id after colliding rows
+-- have been retired.
 UPDATE organization_role_assignments
 SET workos_user_id = @new_workos_user_id,
     updated_at = clock_timestamp()
 WHERE user_id = @user_id
-  AND workos_user_id = @old_workos_user_id
+  AND workos_user_id <> @new_workos_user_id
   AND deleted_at IS NULL;
 
 -- name: ListOrganizationRoleAssignmentsByWorkOSUser :many

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1768,8 +1768,8 @@ func (q *Queries) SetSSOEnabled(ctx context.Context, arg SetSSOEnabledParams) er
 
 const setUserWorkOSMemberships = `-- name: SetUserWorkOSMemberships :many
 WITH input_memberships AS (
-    SELECT unnest($2::text[]) AS workos_org_id,
-           unnest($3::text[]) AS workos_membership_id
+    SELECT unnest($3::text[]) AS workos_org_id,
+           unnest($4::text[]) AS workos_membership_id
 ),
 resolved AS (
     SELECT organization_metadata.id AS organization_id,
@@ -1817,6 +1817,7 @@ UPDATE organization_user_relationships
 SET deleted_at = clock_timestamp(),
     updated_at = clock_timestamp()
 WHERE organization_user_relationships.user_id = $1
+  AND NOT $2::boolean
   AND organization_user_relationships.deleted IS FALSE
   AND organization_user_relationships.organization_id NOT IN (SELECT organization_id FROM resolved)
   AND organization_user_relationships.organization_id IN (
@@ -1827,6 +1828,7 @@ RETURNING organization_id, user_id
 
 type SetUserWorkOSMembershipsParams struct {
 	UserID              pgtype.Text
+	PreserveExisting    bool
 	WorkosOrgIds        []string
 	WorkosMembershipIds []string
 }
@@ -1838,11 +1840,11 @@ type SetUserWorkOSMembershipsRow struct {
 
 // Declaratively set all WorkOS memberships for a user. Takes WorkOS org IDs
 // (not Speakeasy org IDs) and resolves them via organization_metadata. Upserts
-// the provided (workos_org_id, workos_membership_id) pairs and soft-deletes any
-// other relationships where the org has a non-NULL workos_id. Orgs without a
-// workos_id are unaffected. Other users' memberships are never modified.
+// the provided (workos_org_id, workos_membership_id) pairs and, unless
+// preserve_existing is true, soft-deletes any other relationships where the org
+// has a non-NULL workos_id. Other users' memberships are never modified.
 func (q *Queries) SetUserWorkOSMemberships(ctx context.Context, arg SetUserWorkOSMembershipsParams) ([]SetUserWorkOSMembershipsRow, error) {
-	rows, err := q.db.Query(ctx, setUserWorkOSMemberships, arg.UserID, arg.WorkosOrgIds, arg.WorkosMembershipIds)
+	rows, err := q.db.Query(ctx, setUserWorkOSMemberships, arg.UserID, arg.PreserveExisting, arg.WorkosOrgIds, arg.WorkosMembershipIds)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1670,6 +1670,26 @@ func (q *Queries) SetOrganizationRelationshipWorkOSCursor(ctx context.Context, a
 	return err
 }
 
+const setOrganizationUserWorkOSID = `-- name: SetOrganizationUserWorkOSID :exec
+UPDATE organization_user_relationships
+SET workos_user_id = $1,
+    updated_at = clock_timestamp()
+WHERE organization_id = $2
+  AND user_id = $3
+  AND deleted_at IS NULL
+`
+
+type SetOrganizationUserWorkOSIDParams struct {
+	WorkosUserID   pgtype.Text
+	OrganizationID string
+	UserID         pgtype.Text
+}
+
+func (q *Queries) SetOrganizationUserWorkOSID(ctx context.Context, arg SetOrganizationUserWorkOSIDParams) error {
+	_, err := q.db.Exec(ctx, setOrganizationUserWorkOSID, arg.WorkosUserID, arg.OrganizationID, arg.UserID)
+	return err
+}
+
 const setSCIMEnabled = `-- name: SetSCIMEnabled :exec
 UPDATE organization_metadata
 SET scim_enabled = $1,

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1497,6 +1497,40 @@ func (q *Queries) RetireCollidingOrganizationRoleAssignments(ctx context.Context
 	return err
 }
 
+const retireDuplicateLeftoverOrganizationRoleAssignments = `-- name: RetireDuplicateLeftoverOrganizationRoleAssignments :exec
+UPDATE organization_role_assignments AS dest
+SET deleted_at = COALESCE(dest.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+FROM (
+  SELECT id
+  FROM (
+    SELECT leftover.id,
+           ROW_NUMBER() OVER (
+             PARTITION BY leftover.organization_id, leftover.role_urn
+             ORDER BY leftover.created_at DESC, leftover.id DESC
+           ) AS rn
+    FROM organization_role_assignments leftover
+    WHERE leftover.user_id = $1
+      AND leftover.workos_user_id <> $2
+      AND leftover.deleted_at IS NULL
+  ) ranked
+  WHERE rn > 1
+) extras
+WHERE dest.id = extras.id
+`
+
+type RetireDuplicateLeftoverOrganizationRoleAssignmentsParams struct {
+	UserID          pgtype.Text
+	NewWorkosUserID string
+}
+
+// Soft-delete extra leftover assignments that share org+role so remapping
+// them onto one WorkOS id cannot unique-violate. Keeps the newest leftover.
+func (q *Queries) RetireDuplicateLeftoverOrganizationRoleAssignments(ctx context.Context, arg RetireDuplicateLeftoverOrganizationRoleAssignmentsParams) error {
+	_, err := q.db.Exec(ctx, retireDuplicateLeftoverOrganizationRoleAssignments, arg.UserID, arg.NewWorkosUserID)
+	return err
+}
+
 const revokeInvitation = `-- name: RevokeInvitation :exec
 UPDATE organization_invitations
 SET state = 'revoked',

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1844,7 +1844,12 @@ type SetUserWorkOSMembershipsRow struct {
 // preserve_existing is true, soft-deletes any other relationships where the org
 // has a non-NULL workos_id. Other users' memberships are never modified.
 func (q *Queries) SetUserWorkOSMemberships(ctx context.Context, arg SetUserWorkOSMembershipsParams) ([]SetUserWorkOSMembershipsRow, error) {
-	rows, err := q.db.Query(ctx, setUserWorkOSMemberships, arg.UserID, arg.PreserveExisting, arg.WorkosOrgIds, arg.WorkosMembershipIds)
+	rows, err := q.db.Query(ctx, setUserWorkOSMemberships,
+		arg.UserID,
+		arg.PreserveExisting,
+		arg.WorkosOrgIds,
+		arg.WorkosMembershipIds,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1430,20 +1430,19 @@ UPDATE organization_role_assignments
 SET workos_user_id = $1,
     updated_at = clock_timestamp()
 WHERE user_id = $2
-  AND workos_user_id = $3
+  AND workos_user_id <> $1
   AND deleted_at IS NULL
 `
 
 type ReassignOrganizationRoleAssignmentWorkOSIDParams struct {
 	NewWorkosUserID string
 	UserID          pgtype.Text
-	OldWorkosUserID string
 }
 
-// Role assignments are keyed by workos_user_id. Move them when a recreated
-// WorkOS user reuses the Gram identity so roster and sync joins still match.
+// Move leftover assignments onto the new WorkOS id after colliding rows
+// have been retired.
 func (q *Queries) ReassignOrganizationRoleAssignmentWorkOSID(ctx context.Context, arg ReassignOrganizationRoleAssignmentWorkOSIDParams) error {
-	_, err := q.db.Exec(ctx, reassignOrganizationRoleAssignmentWorkOSID, arg.NewWorkosUserID, arg.UserID, arg.OldWorkosUserID)
+	_, err := q.db.Exec(ctx, reassignOrganizationRoleAssignmentWorkOSID, arg.NewWorkosUserID, arg.UserID)
 	return err
 }
 
@@ -1452,19 +1451,49 @@ UPDATE organization_user_relationships
 SET workos_user_id = $1,
     updated_at = clock_timestamp()
 WHERE user_id = $2
-  AND workos_user_id = $3
+  AND workos_user_id IS NOT NULL
+  AND workos_user_id IS DISTINCT FROM $1
 `
 
 type ReassignOrganizationUserWorkOSIDParams struct {
 	NewWorkosUserID pgtype.Text
 	UserID          pgtype.Text
-	OldWorkosUserID pgtype.Text
 }
 
 // Login reuses a Gram user after WorkOS delete-and-signup, so membership
-// rows must follow the new WorkOS user id.
+// rows still pointing at a previous WorkOS user id must follow the new one.
+// Matches any leftover id so a retry after overwrite still converges.
 func (q *Queries) ReassignOrganizationUserWorkOSID(ctx context.Context, arg ReassignOrganizationUserWorkOSIDParams) error {
-	_, err := q.db.Exec(ctx, reassignOrganizationUserWorkOSID, arg.NewWorkosUserID, arg.UserID, arg.OldWorkosUserID)
+	_, err := q.db.Exec(ctx, reassignOrganizationUserWorkOSID, arg.NewWorkosUserID, arg.UserID)
+	return err
+}
+
+const retireCollidingOrganizationRoleAssignments = `-- name: RetireCollidingOrganizationRoleAssignments :exec
+UPDATE organization_role_assignments AS old
+SET deleted_at = COALESCE(old.deleted_at, clock_timestamp()),
+    updated_at = clock_timestamp()
+WHERE old.user_id = $1
+  AND old.workos_user_id <> $2
+  AND old.deleted_at IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM organization_role_assignments AS neu
+      WHERE neu.organization_id = old.organization_id
+        AND neu.workos_user_id = $2
+        AND neu.role_urn = old.role_urn
+        AND neu.deleted_at IS NULL
+  )
+`
+
+type RetireCollidingOrganizationRoleAssignmentsParams struct {
+	UserID          pgtype.Text
+	NewWorkosUserID string
+}
+
+// Soft-delete leftover assignments that would unique-violate if remapped
+// onto a WorkOS id that already holds the same org+role.
+func (q *Queries) RetireCollidingOrganizationRoleAssignments(ctx context.Context, arg RetireCollidingOrganizationRoleAssignmentsParams) error {
+	_, err := q.db.Exec(ctx, retireCollidingOrganizationRoleAssignments, arg.UserID, arg.NewWorkosUserID)
 	return err
 }
 

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -1425,6 +1425,49 @@ func (q *Queries) MarkWorkOSMembershipDeleted(ctx context.Context, arg MarkWorkO
 	return items, nil
 }
 
+const reassignOrganizationRoleAssignmentWorkOSID = `-- name: ReassignOrganizationRoleAssignmentWorkOSID :exec
+UPDATE organization_role_assignments
+SET workos_user_id = $1,
+    updated_at = clock_timestamp()
+WHERE user_id = $2
+  AND workos_user_id = $3
+  AND deleted_at IS NULL
+`
+
+type ReassignOrganizationRoleAssignmentWorkOSIDParams struct {
+	NewWorkosUserID string
+	UserID          pgtype.Text
+	OldWorkosUserID string
+}
+
+// Role assignments are keyed by workos_user_id. Move them when a recreated
+// WorkOS user reuses the Gram identity so roster and sync joins still match.
+func (q *Queries) ReassignOrganizationRoleAssignmentWorkOSID(ctx context.Context, arg ReassignOrganizationRoleAssignmentWorkOSIDParams) error {
+	_, err := q.db.Exec(ctx, reassignOrganizationRoleAssignmentWorkOSID, arg.NewWorkosUserID, arg.UserID, arg.OldWorkosUserID)
+	return err
+}
+
+const reassignOrganizationUserWorkOSID = `-- name: ReassignOrganizationUserWorkOSID :exec
+UPDATE organization_user_relationships
+SET workos_user_id = $1,
+    updated_at = clock_timestamp()
+WHERE user_id = $2
+  AND workos_user_id = $3
+`
+
+type ReassignOrganizationUserWorkOSIDParams struct {
+	NewWorkosUserID pgtype.Text
+	UserID          pgtype.Text
+	OldWorkosUserID pgtype.Text
+}
+
+// Login reuses a Gram user after WorkOS delete-and-signup, so membership
+// rows must follow the new WorkOS user id.
+func (q *Queries) ReassignOrganizationUserWorkOSID(ctx context.Context, arg ReassignOrganizationUserWorkOSIDParams) error {
+	_, err := q.db.Exec(ctx, reassignOrganizationUserWorkOSID, arg.NewWorkosUserID, arg.UserID, arg.OldWorkosUserID)
+	return err
+}
+
 const revokeInvitation = `-- name: RevokeInvitation :exec
 UPDATE organization_invitations
 SET state = 'revoked',

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -1,4 +1,7 @@
 -- name: UpsertUser :one
+-- Login and other IDP upserts mean the user is authenticating now, so clear
+-- WorkOS soft-delete markers left by a prior user.deleted event. Without this,
+-- email reuse after WorkOS deletion leaves the Gram user RBAC-inactive.
 INSERT INTO users (id, email, display_name, photo_url, admin)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (id) DO UPDATE SET
@@ -7,7 +10,9 @@ ON CONFLICT (id) DO UPDATE SET
   photo_url = EXCLUDED.photo_url,
   admin = EXCLUDED.admin,
   last_login = clock_timestamp(),
-  updated_at = clock_timestamp()
+  updated_at = clock_timestamp(),
+  workos_deleted_at = NULL,
+  deleted_at = NULL
 RETURNING *, (xmax = 0) AS was_created;
 
 -- name: UpsertSyncedUser :execrows

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -546,7 +546,9 @@ ON CONFLICT (id) DO UPDATE SET
   photo_url = EXCLUDED.photo_url,
   admin = EXCLUDED.admin,
   last_login = clock_timestamp(),
-  updated_at = clock_timestamp()
+  updated_at = clock_timestamp(),
+  workos_deleted_at = NULL,
+  deleted_at = NULL
 RETURNING id, email, display_name, photo_url, admin, last_login, workos_id, workos_created_at, workos_updated_at, workos_deleted_at, deleted_at, created_at, updated_at, (xmax = 0) AS was_created
 `
 
@@ -575,6 +577,9 @@ type UpsertUserRow struct {
 	WasCreated      bool
 }
 
+// Login and other IDP upserts mean the user is authenticating now, so clear
+// WorkOS soft-delete markers left by a prior user.deleted event. Without this,
+// email reuse after WorkOS deletion leaves the Gram user RBAC-inactive.
 func (q *Queries) UpsertUser(ctx context.Context, arg UpsertUserParams) (UpsertUserRow, error) {
 	row := q.db.QueryRow(ctx, upsertUser,
 		arg.ID,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deleting a test user in WorkOS soft-deletes the corresponding Gram user. Signing up again with the same email reuses the existing Gram user row, but login-path `UpsertUser` did not clear `users.deleted_at`.

The user then appears authenticated and may still have organization/role rows, but RBAC treats them as inactive. `access.listGrants` returns no effective grants and dashboard pages render **Access restricted**.

## Root cause

1. WorkOS `user.deleted` → `DisableUser` sets `users.deleted_at` / `workos_deleted_at`.
2. Login resolves the Gram user by email (`GetUserByEmail` has no deleted filter).
3. Login-path `UpsertUser` updated profile fields but did not reactivate deleted users. Background `UpsertSyncedUser` already did.
4. RBAC (`HasActiveOrganizationUser` / `ResolveUserPrincipals`) requires `users.deleted_at IS NULL` → no grants.
5. Overwriting `users.workos_id` to the new WorkOS identity left membership and role-assignment rows pointing at the deleted WorkOS user id.

## Fix

* `UpsertUser` ON CONFLICT now clears `workos_deleted_at` and `deleted_at`, matching `UpsertSyncedUser`.
* `DisableUser` is unchanged. Genuinely deleted/deactivated users stay inactive until a successful IDP upsert (login or signup).
* When IDP upsert replaces `users.workos_id`, membership and role-assignment rows are remapped to the new WorkOS user id so roster and sync joins still match.
* Remap now links unlinked new-id role rows before retiring collisions, and retires extra leftover assignments that share org+role so remapping cannot unique-violate.
* Signup that reuses a Gram identity still lands on a usable organization (prefer an already-open membership; otherwise open the org about to become active). Ordinary login does not change that gate.

## Tests

* `TestUpsertUserFromIDP_ReactivatesDeletedUserOnSignup` — delete, then IDP upsert with a new WorkOS id / same email; asserts soft-delete cleared, role assignments move to the new WorkOS id, membership active, and RBAC principals include user + member role.
* `TestUpsertUserFromIDP_LinksUnlinkedSurvivorBeforeRetiringCollision` — surviving new-id assignment with `user_id` NULL is linked before the leftover is retired.
* `TestUpsertUserFromIDP_DedupesLeftoverRolesBeforeRemap` — two leftover WorkOS ids for the same org+role remap without a unique-index violation.
* Callback coverage for signup vs ordinary login after the same delete-and-reuse path.

Fixes AGE-3393.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3393](https://linear.app/speakeasy/issue/AGE-3393/reactivating-a-deleted-workos-user-leaves-gram-rbac-access-restricted)

<div><a href="https://cursor.com/agents/bc-63e93893-6ebf-4d9c-b659-ef0eae8f763f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e93893-6ebf-4d9c-b659-ef0eae8f763f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGE-3393: re-signing up with an email previously deleted in WorkOS left the Gram user RBAC-inactive and on a stale unwhitelisted org.

- Login-path `UpsertUser` now clears `deleted_at` and `workos_deleted_at`, matching `UpsertSyncedUser`.
- Membership and role-assignment rows are remapped to the new WorkOS id, linking unlinked assignments and retiring colliding or duplicate ones.
- Reactivated signups preserve restored memberships during sync; the background Speakeasy sync still replaces from the current WorkOS list.
- Only reactivated signups whitelist the active org (preferring an already-whitelisted one); ordinary login does not whitelist.
- WorkOS deletions still tombstone users until they sign in again.

<sup>Written for commit 01f6c2920d06b4f4e2325d7b14f8f318a69d8d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

