### PR TITLE
feat: clarify platform MCP inventory backends

### DIFF
--- a/.changeset/platform-mcp-inventory-fidelity.md
+++ b/.changeset/platform-mcp-inventory-fidelity.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Clarify Platform MCP inventory with explicit backend kinds and supported management operations.

--- a/server/internal/platformmcp/descriptor.go
+++ b/server/internal/platformmcp/descriptor.go
@@ -339,6 +339,16 @@ var wireTypeSchemas = map[reflect.Type]*jsonschema.Schema{
 		Type: "string",
 		Enum: setupCategoryEnumValues(),
 	},
+	reflect.TypeFor[MCPBackendKind](): {
+		Type: "string",
+		Enum: []any{
+			string(MCPBackendHosted),
+			string(MCPBackendRemote),
+			string(MCPBackendTunneled),
+			string(MCPBackendUnproxied),
+			string(MCPBackendLegacy),
+		},
+	},
 }
 
 // inferOutputSchema derives the schema the tool advertises for its result,

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -339,6 +339,18 @@ func TestAdvertisedSetupCategoryIsClosed(t *testing.T) {
 // Schema inference panics at process boot, so a tool input the nil-dependency
 // server never registers can crash-loop production while CI stays green. The
 // jsonschema tag is a description; a "word=" prefix is rejected outright.
+func TestAdvertisedInventoryBackendKindIsClosed(t *testing.T) {
+	t.Parallel()
+
+	schema := inferOutputSchema[FindMCPOutput]("find_mcp")
+	mcps := schema.Properties["mcps"]
+	require.NotNil(t, mcps)
+	require.NotNil(t, mcps.Items)
+	backendKind := mcps.Items.Properties["backend_kind"]
+	require.NotNil(t, backendKind)
+	require.Equal(t, []any{"hosted", "remote", "tunneled", "unproxied", "legacy"}, backendKind.Enum)
+}
+
 func TestClientAdmissionToolInputsInferSchemas(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/inventory.go
+++ b/server/internal/platformmcp/inventory.go
@@ -103,7 +103,7 @@ func inventoryDistributions(rows []platformrepo.ListPlatformMCPInventoryDistribu
 func mcpFromInventoryRow(row platformrepo.ListPlatformMCPInventoryRow, distributions map[uuid.UUID][]MCPDistribution) MCP {
 	return mcpFromInventory(
 		row.McpServerID, row.ProjectID, row.ProjectName, row.ProjectSlug, row.McpName.String, row.McpSlug.String, row.Visibility,
-		inventoryModel(row.RemoteMcpServerID, row.TunneledMcpServerID, row.UnproxiedMcpServerID), row.RegistrationID, row.SourceKind, row.CatalogProvider, row.CatalogReference, row.RegistrationStatus,
+		inventoryModel(row.RemoteMcpServerID, row.TunneledMcpServerID, row.UnproxiedMcpServerID), inventoryBackendKind(row.RemoteMcpServerID, row.TunneledMcpServerID, row.ToolsetID, row.UnproxiedMcpServerID), row.RegistrationID, row.SourceKind, row.CatalogProvider, row.CatalogReference, row.RegistrationStatus,
 		row.RegistrationRemoteMcpServerID, row.RegistrationUserSessionIssuerID, row.RegistrationMcpServerID, row.RegistrationMcpEndpointID,
 		row.ReadinessState, timestampString(row.ReadinessCheckedAt.Time, row.ReadinessCheckedAt.Valid), timestampString(row.ReadinessExpiresAt.Time, row.ReadinessExpiresAt.Valid), distributions,
 	)
@@ -112,13 +112,13 @@ func mcpFromInventoryRow(row platformrepo.ListPlatformMCPInventoryRow, distribut
 func mcpFromInventoryItem(row platformrepo.GetPlatformMCPInventoryItemRow, distributions map[uuid.UUID][]MCPDistribution) MCP {
 	return mcpFromInventory(
 		row.McpServerID, row.ProjectID, row.ProjectName, row.ProjectSlug, row.McpName.String, row.McpSlug.String, row.Visibility,
-		inventoryModel(row.RemoteMcpServerID, row.TunneledMcpServerID, row.UnproxiedMcpServerID), row.RegistrationID, row.SourceKind, row.CatalogProvider, row.CatalogReference, row.RegistrationStatus,
+		inventoryModel(row.RemoteMcpServerID, row.TunneledMcpServerID, row.UnproxiedMcpServerID), inventoryBackendKind(row.RemoteMcpServerID, row.TunneledMcpServerID, row.ToolsetID, row.UnproxiedMcpServerID), row.RegistrationID, row.SourceKind, row.CatalogProvider, row.CatalogReference, row.RegistrationStatus,
 		row.RegistrationRemoteMcpServerID, row.RegistrationUserSessionIssuerID, row.RegistrationMcpServerID, row.RegistrationMcpEndpointID,
 		row.ReadinessState, timestampString(row.ReadinessCheckedAt.Time, row.ReadinessCheckedAt.Valid), timestampString(row.ReadinessExpiresAt.Time, row.ReadinessExpiresAt.Valid), distributions,
 	)
 }
 
-func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, slug, visibility, model string, registrationID uuid.UUID, sourceKind, provider, reference, registrationStatus string, registrationRemoteID, registrationIssuerID, registrationMCPID, registrationEndpointID uuid.NullUUID, readinessState, checkedAt, expiresAt string, distributions map[uuid.UUID][]MCPDistribution) MCP {
+func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, slug, visibility, model string, backendKind MCPBackendKind, registrationID uuid.UUID, sourceKind, provider, reference, registrationStatus string, registrationRemoteID, registrationIssuerID, registrationMCPID, registrationEndpointID uuid.NullUUID, readinessState, checkedAt, expiresAt string, distributions map[uuid.UUID][]MCPDistribution) MCP {
 	mcp := MCP{
 		ID:               id.String(),
 		ProjectID:        projectID.String(),
@@ -130,6 +130,7 @@ func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, s
 		Visibility:       visibility,
 		EffectiveEnabled: visibility != "disabled",
 		Model:            "",
+		BackendKind:      backendKind,
 		Source:           MCPSource{Kind: "", Provider: "", Reference: ""},
 		Registration:     nil,
 		Readiness:        MCPReadiness{State: "", CheckedAt: "", ExpiresAt: ""},
@@ -171,6 +172,7 @@ func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, s
 		mcp.Model = model
 		mcp.Source = MCPSource{Kind: "dashboard_source", Provider: "", Reference: ""}
 		mcp.Readiness = MCPReadiness{State: "unsupported", CheckedAt: "", ExpiresAt: ""}
+		mcp.Operations = []string{"read", "dashboard_setup"}
 		mcp.DashboardPath = "dashboard_mcp_settings"
 	default:
 		mcp.Model = "legacy"
@@ -187,7 +189,25 @@ func inventoryModel(remote, tunneled, unproxied uuid.NullUUID) string {
 	if remote.Valid || tunneled.Valid || unproxied.Valid {
 		return "dashboard_managed"
 	}
+	// Toolset-backed hosted servers retain the existing legacy ownership model.
+	// BackendKind describes what serves the MCP; Model describes which lifecycle
+	// owns it, so a hosted/legacy pairing is intentional and compatible.
 	return "legacy"
+}
+
+func inventoryBackendKind(remote, tunneled, toolset, unproxied uuid.NullUUID) MCPBackendKind {
+	switch {
+	case remote.Valid && remote.UUID != uuid.Nil:
+		return MCPBackendRemote
+	case tunneled.Valid && tunneled.UUID != uuid.Nil:
+		return MCPBackendTunneled
+	case toolset.Valid && toolset.UUID != uuid.Nil:
+		return MCPBackendHosted
+	case unproxied.Valid && unproxied.UUID != uuid.Nil:
+		return MCPBackendUnproxied
+	default:
+		return MCPBackendLegacy
+	}
 }
 
 func inventorySourceKind(sourceKind string) string {

--- a/server/internal/platformmcp/inventory.go
+++ b/server/internal/platformmcp/inventory.go
@@ -186,7 +186,7 @@ func mcpFromInventory(id, projectID uuid.UUID, projectName, projectSlug, name, s
 }
 
 func inventoryModel(remote, tunneled, unproxied uuid.NullUUID) string {
-	if remote.Valid || tunneled.Valid || unproxied.Valid {
+	if validInventoryBackend(remote) || validInventoryBackend(tunneled) || validInventoryBackend(unproxied) {
 		return "dashboard_managed"
 	}
 	// Toolset-backed hosted servers retain the existing legacy ownership model.
@@ -195,15 +195,19 @@ func inventoryModel(remote, tunneled, unproxied uuid.NullUUID) string {
 	return "legacy"
 }
 
+func validInventoryBackend(backend uuid.NullUUID) bool {
+	return backend.Valid && backend.UUID != uuid.Nil
+}
+
 func inventoryBackendKind(remote, tunneled, toolset, unproxied uuid.NullUUID) MCPBackendKind {
 	switch {
-	case remote.Valid && remote.UUID != uuid.Nil:
+	case validInventoryBackend(remote):
 		return MCPBackendRemote
-	case tunneled.Valid && tunneled.UUID != uuid.Nil:
+	case validInventoryBackend(tunneled):
 		return MCPBackendTunneled
-	case toolset.Valid && toolset.UUID != uuid.Nil:
+	case validInventoryBackend(toolset):
 		return MCPBackendHosted
-	case unproxied.Valid && unproxied.UUID != uuid.Nil:
+	case validInventoryBackend(unproxied):
 		return MCPBackendUnproxied
 	default:
 		return MCPBackendLegacy

--- a/server/internal/platformmcp/inventory_test.go
+++ b/server/internal/platformmcp/inventory_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 )
 
 func TestInventoryCursorBindsProjectAndPrincipal(t *testing.T) {
@@ -39,32 +41,34 @@ func TestMCPFromInventoryLabelsOwnershipAndNeverProbesLegacy(t *testing.T) {
 	mcpID, projectID, registrationID := uuid.New(), uuid.New(), uuid.New()
 	complete := uuid.NullUUID{UUID: uuid.New(), Valid: true}
 
-	platform := mcpFromInventory(mcpID, projectID, "Project", "project", "Reviewed", "reviewed", "private", "dashboard_managed", registrationID, "catalog", "registry", "reviewed/server", "registered", complete, complete, complete, complete, "ready", "checked", "expires", map[uuid.UUID][]MCPDistribution{registrationID: {{PluginID: "plugin", State: "attached", PublicationState: "published"}}})
+	platform := mcpFromInventory(mcpID, projectID, "Project", "project", "Reviewed", "reviewed", "private", "dashboard_managed", MCPBackendRemote, registrationID, "catalog", "registry", "reviewed/server", "registered", complete, complete, complete, complete, "ready", "checked", "expires", map[uuid.UUID][]MCPDistribution{registrationID: {{PluginID: "plugin", State: "attached", PublicationState: "published"}}})
 	require.Equal(t, "platform_managed", platform.Model)
+	require.Equal(t, MCPBackendRemote, platform.BackendKind)
 	require.Equal(t, "reviewed_catalogue", platform.Source.Kind)
 	require.Equal(t, "ready", platform.Readiness.State)
 	require.Len(t, platform.Distributions, 1)
 	require.True(t, platform.Registration.ComponentsComplete)
 	require.Equal(t, []string{"read", "dashboard_setup", "update_mcp_metadata", "disable_mcp"}, platform.Operations)
 
-	disabled := mcpFromInventory(mcpID, projectID, "Project", "project", "Reviewed", "reviewed", "disabled", "dashboard_managed", registrationID, "catalog", "registry", "reviewed/server", "registered", complete, complete, complete, complete, "ready", "checked", "expires", nil)
+	disabled := mcpFromInventory(mcpID, projectID, "Project", "project", "Reviewed", "reviewed", "disabled", "dashboard_managed", MCPBackendRemote, registrationID, "catalog", "registry", "reviewed/server", "registered", complete, complete, complete, complete, "ready", "checked", "expires", nil)
 	require.False(t, disabled.EffectiveEnabled)
 	require.Equal(t, "unknown", disabled.Readiness.State, "disabled Platform-managed MCPs do not expose stale readiness as effective")
 	require.Empty(t, disabled.Readiness.CheckedAt)
 	require.Equal(t, []string{"read", "dashboard_setup", "update_mcp_metadata", "enable_mcp"}, disabled.Operations)
 
-	incomplete := mcpFromInventory(mcpID, projectID, "Project", "project", "Incomplete", "incomplete", "private", "dashboard_managed", registrationID, "catalog", "registry", "reviewed/incomplete", "pending", uuid.NullUUID{UUID: uuid.Nil, Valid: true}, complete, complete, complete, "", "", "", nil)
+	incomplete := mcpFromInventory(mcpID, projectID, "Project", "project", "Incomplete", "incomplete", "private", "dashboard_managed", MCPBackendRemote, registrationID, "catalog", "registry", "reviewed/incomplete", "pending", uuid.NullUUID{UUID: uuid.Nil, Valid: true}, complete, complete, complete, "", "", "", nil)
 	require.False(t, incomplete.Registration.ComponentsComplete, "zero UUID sentinels represent missing persisted components")
 	require.NotNil(t, incomplete.Distributions, "registered rows without distributions retain the stable empty array")
 	require.Empty(t, incomplete.Distributions)
 
-	dashboard := mcpFromInventory(mcpID, projectID, "Project", "project", "Dashboard", "dashboard", "private", "dashboard_managed", uuid.Nil, "", "", "", "", uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, "", "", "", nil)
+	dashboard := mcpFromInventory(mcpID, projectID, "Project", "project", "Dashboard", "dashboard", "private", "dashboard_managed", MCPBackendTunneled, uuid.Nil, "", "", "", "", uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, "", "", "", nil)
 	require.Equal(t, "dashboard_managed", dashboard.Model)
-	require.Equal(t, "dashboard_source", dashboard.Source.Kind)
+	require.Equal(t, MCPBackendTunneled, dashboard.BackendKind)
+	require.Equal(t, "dashboard_source", dashboard.Source.Kind, "the compatibility source kind remains unchanged")
 	require.Equal(t, "unsupported", dashboard.Readiness.State)
-	require.Equal(t, []string{"read"}, dashboard.Operations)
+	require.Equal(t, []string{"read", "dashboard_setup"}, dashboard.Operations)
 
-	legacy := mcpFromInventory(mcpID, projectID, "Project", "project", "Legacy", "legacy", "disabled", "legacy", uuid.Nil, "", "", "", "", uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, "ready", "checked", "expires", nil)
+	legacy := mcpFromInventory(mcpID, projectID, "Project", "project", "Legacy", "legacy", "disabled", "legacy", MCPBackendLegacy, uuid.Nil, "", "", "", "", uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}, "ready", "checked", "expires", nil)
 	require.Equal(t, "legacy", legacy.Model)
 	require.Equal(t, "unsupported", legacy.Readiness.State, "legacy rows never use readiness evidence or trigger egress")
 	require.False(t, legacy.EffectiveEnabled)
@@ -85,14 +89,75 @@ func TestLifecycleMetadataVersionChangesOnlyWithMutableInventoryState(t *testing
 func TestInventoryModelRecognizesEveryDashboardBackend(t *testing.T) {
 	t.Parallel()
 
-	for _, backend := range []uuid.NullUUID{
-		{UUID: uuid.New(), Valid: true},
-	} {
-		require.Equal(t, "dashboard_managed", inventoryModel(backend, uuid.NullUUID{}, uuid.NullUUID{}))
-		require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, backend, uuid.NullUUID{}))
-		require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, backend))
-	}
+	backend := uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	require.Equal(t, "dashboard_managed", inventoryModel(backend, uuid.NullUUID{}, uuid.NullUUID{}))
+	require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, backend, uuid.NullUUID{}))
+	require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, backend))
 	require.Equal(t, "legacy", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}))
+}
+
+func TestInventoryRowProjectsHostedBackendWithLegacyOwnership(t *testing.T) {
+	t.Parallel()
+
+	backendID := uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	mcp := mcpFromInventoryRow(platformrepo.ListPlatformMCPInventoryRow{
+		McpServerID: uuid.New(),
+		ProjectID:   uuid.New(),
+		Visibility:  "private",
+		ToolsetID:   backendID,
+	}, nil)
+
+	require.Equal(t, MCPBackendHosted, mcp.BackendKind)
+	require.Equal(t, "legacy", mcp.Model, "toolset-backed hosted servers retain their existing ownership model")
+	require.Equal(t, "legacy", mcp.Source.Kind)
+	require.Equal(t, []string{"read"}, mcp.Operations)
+}
+
+func TestInventoryBackendKindRecognizesEveryConfiguredBackend(t *testing.T) {
+	t.Parallel()
+
+	backend := uuid.NullUUID{UUID: uuid.New(), Valid: true}
+	empty := uuid.NullUUID{}
+	require.Equal(t, MCPBackendRemote, inventoryBackendKind(backend, empty, empty, empty))
+	require.Equal(t, MCPBackendTunneled, inventoryBackendKind(empty, backend, empty, empty))
+	require.Equal(t, MCPBackendHosted, inventoryBackendKind(empty, empty, backend, empty))
+	require.Equal(t, MCPBackendUnproxied, inventoryBackendKind(empty, empty, empty, backend))
+	require.Equal(t, MCPBackendLegacy, inventoryBackendKind(empty, empty, empty, empty))
+	require.Equal(t, MCPBackendLegacy, inventoryBackendKind(uuid.NullUUID{UUID: uuid.Nil, Valid: true}, empty, empty, empty))
+}
+
+func TestMCPInventoryOutputProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	output := FindMCPOutput{MCPs: []MCP{{
+		ID:               "mcp",
+		ProjectID:        "project",
+		ProjectName:      "Project",
+		ProjectSlug:      "project",
+		Name:             "Example",
+		Slug:             "example",
+		Version:          "version",
+		Visibility:       "private",
+		EffectiveEnabled: true,
+		Model:            "platform_managed",
+		BackendKind:      MCPBackendRemote,
+		Source:           MCPSource{Kind: "reviewed_catalogue", Provider: "provider", Reference: "reference"},
+		Registration:     &MCPRegistration{ID: "registration", Status: "registered", ComponentsComplete: true},
+		Readiness:        MCPReadiness{State: "ready", CheckedAt: "checked", ExpiresAt: "expires"},
+		Distributions:    []MCPDistribution{{PluginID: "plugin", State: "attached", PublicationState: "published"}},
+		Operations:       []string{"read"},
+		DashboardPath:    "dashboard_mcp_settings",
+	}}, NextCursor: "cursor"}
+
+	require.ElementsMatch(t, []string{
+		"mcps", "next_cursor",
+		"id", "project_id", "project_name", "project_slug", "name", "slug", "version", "visibility", "effective_enabled", "model", "backend_kind",
+		"source", "kind", "provider", "reference",
+		"registration", "id", "status", "components_complete",
+		"readiness", "state", "checked_at", "expires_at",
+		"distributions", "plugin_id", "state", "publication_state",
+		"operations", "dashboard_path",
+	}, decodeKeys(t, output))
 }
 
 func TestInventoryQueryResultReturnsUniqueExactOrBoundedCandidates(t *testing.T) {

--- a/server/internal/platformmcp/inventory_test.go
+++ b/server/internal/platformmcp/inventory_test.go
@@ -94,6 +94,10 @@ func TestInventoryModelRecognizesEveryDashboardBackend(t *testing.T) {
 	require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, backend, uuid.NullUUID{}))
 	require.Equal(t, "dashboard_managed", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, backend))
 	require.Equal(t, "legacy", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, uuid.NullUUID{}))
+	zero := uuid.NullUUID{UUID: uuid.Nil, Valid: true}
+	require.Equal(t, "legacy", inventoryModel(zero, uuid.NullUUID{}, uuid.NullUUID{}))
+	require.Equal(t, "legacy", inventoryModel(uuid.NullUUID{}, zero, uuid.NullUUID{}))
+	require.Equal(t, "legacy", inventoryModel(uuid.NullUUID{}, uuid.NullUUID{}, zero))
 }
 
 func TestInventoryRowProjectsHostedBackendWithLegacyOwnership(t *testing.T) {

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -14,6 +14,16 @@ import (
 
 const unavailableCode = "feature_unavailable"
 
+type MCPBackendKind string
+
+const (
+	MCPBackendHosted    MCPBackendKind = "hosted"
+	MCPBackendRemote    MCPBackendKind = "remote"
+	MCPBackendTunneled  MCPBackendKind = "tunneled"
+	MCPBackendUnproxied MCPBackendKind = "unproxied"
+	MCPBackendLegacy    MCPBackendKind = "legacy"
+)
+
 // bothAudiences admits a tool to the external endpoint and to a project's
 // managed assistant. Narrow this per tool when a capability is not fit for
 // both surfaces.
@@ -108,6 +118,7 @@ type MCP struct {
 	Visibility       string            `json:"visibility"`
 	EffectiveEnabled bool              `json:"effective_enabled"`
 	Model            string            `json:"model"`
+	BackendKind      MCPBackendKind    `json:"backend_kind"`
 	Source           MCPSource         `json:"source"`
 	Registration     *MCPRegistration  `json:"registration,omitempty"`
 	Readiness        MCPReadiness      `json:"readiness"`


### PR DESCRIPTION
## Linear

- [AIM-224](https://linear.app/speakeasy/issue/AIM-224)

## Summary

- Add a closed `backend_kind` field so configured MCP inventory distinguishes hosted, remote, tunneled, unproxied, and defensive legacy backends without exposing backend identifiers or URLs.
- Preserve the existing ownership model and `source.kind` values for compatibility, including `dashboard_source` for dashboard-managed servers.
- Report dashboard setup as the only non-read operation for dashboard-managed servers, while retaining existing Platform-managed lifecycle operations.
- Pin the serialized inventory allowlist, advertised output enum, backend wiring, and the intentional hosted-backend/legacy-ownership pairing in focused tests.

## Motivation

Platform MCP inventory currently collapses dashboard-managed MCP servers behind a generic source label. Administrators and agents cannot tell which backend serves a configured MCP or whether its lifecycle can be managed through Platform MCP. This additive projection makes the inventory truthful and actionable while keeping unsupported mutations and sensitive connection details out of the contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a closed `backend_kind` field to Platform MCP inventory so administrators and agents can tell which backend serves a configured MCP — hosted, remote, tunneled, unproxied, or legacy — without exposing backend identifiers or URLs. Dashboard-managed servers now also report `dashboard_setup` as a non-read operation.

**Behavior**
- New `backend_kind` enum on the inventory output distinguishes all configured backends, treating zero-UUID sentinels as unconfigured.
- Dashboard-managed servers report `dashboard_setup` in addition to `read`; existing Platform-managed lifecycle operations are unchanged.
- Existing `source.kind` values and the legacy ownership model are preserved, including the intentional hosted-backend/legacy-ownership pairing.

**Testing**
- Pins the serialized inventory allowlist, the advertised output enum, backend wiring, and the hosted/legacy pairing in focused tests.

<sup>Written for commit 27523f9b9961dffaebf65fe6f48a46cc3eab2fed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


