### PR TITLE
feat: gate agent management rollout

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1570,6 +1570,63 @@ jobs:
         # Do not retry: a nondeterministic race must fail CI even if a rerun passes.
         run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }} -race -tags=inv.debug ./...
 
+  # Standalone, non-retrying M1 gate. These packages jointly prove the agent
+  # identity, management, rollout, audit/event, and tenant-isolation contract.
+  m1-agent-gate:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    needs: changes
+    if: needs.changes.outputs.server == 'true'
+    env:
+      GOMAXPROCS: 8
+      TESTCONTAINERS_RYUK_DISABLED: true
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: true
+          cache_key_prefix: mise-blacksmith-v1
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache Go
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_GO_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_GO_KEY }}
+            ${{ env.GH_CACHE_GO_KEY_PARTIAL }}
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+
+      - name: Install Go deps
+        run: mise run install:go
+
+      - name: Test
+        run: >-
+          mise run test:server -count=1
+          ./internal/urn
+          ./internal/agents
+          ./internal/agentmanagement
+          ./internal/agentownership
+          ./internal/authz
+          ./internal/audit
+          ./internal/contextvalues
+          ./internal/feature
+          ./internal/thirdparty/posthog
+          ./internal/auth/chatsessions
+          ./internal/chat
+          ./internal/organizations
+          ./internal/background/activities
+          ./cmd/tools/migrations
+          ./cmd/tools/migrations/agentmanagementgrants
+
   # Standalone gate for the demo seed: TestDemoSeedSafety proves the seed
   # cannot touch other tenants' data, cleans up stray demo-org rows, and stays
   # idempotent across runs. The test is build-tagged (demoseed_safety) so the
@@ -2369,6 +2426,7 @@ jobs:
       - format-check
       - server-build-lint
       - server-test
+      - m1-agent-gate
       - demo-seed-safety
       - docker-build-server
       - docker-build-client

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1573,6 +1573,9 @@ jobs:
   # Standalone, non-retrying M1 gate. These packages jointly prove the agent
   # identity, management, rollout, audit/event, and tenant-isolation contract.
   m1-agent-gate:
+    permissions:
+      contents: read
+      id-token: none
     runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
     if: needs.changes.outputs.server == 'true'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1570,66 +1570,6 @@ jobs:
         # Do not retry: a nondeterministic race must fail CI even if a rerun passes.
         run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }} -race -tags=inv.debug ./...
 
-  # Standalone, non-retrying M1 gate. These packages jointly prove the agent
-  # identity, management, rollout, audit/event, and tenant-isolation contract.
-  m1-agent-gate:
-    permissions:
-      contents: read
-      id-token: none
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    needs: changes
-    if: needs.changes.outputs.server == 'true'
-    env:
-      GOMAXPROCS: 8
-      TESTCONTAINERS_RYUK_DISABLED: true
-    steps:
-      - name: Checkout
-        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
-
-      - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-        with:
-          install: true
-          cache: true
-          cache_key_prefix: mise-blacksmith-v1
-          env: false
-
-      - name: Prepare GitHub Actions environment
-        run: mise run github
-
-      - name: Cache Go
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: ${{ env.GH_CACHE_GO_KEY }}
-          restore-keys: |
-            ${{ env.GH_CACHE_GO_KEY }}
-            ${{ env.GH_CACHE_GO_KEY_PARTIAL }}
-          path: |
-            ${{ env.GOCACHE }}
-            ${{ env.GOMODCACHE }}
-
-      - name: Install Go deps
-        run: mise run install:go
-
-      - name: Test
-        run: >-
-          mise run test:server -count=1
-          ./internal/urn
-          ./internal/agents
-          ./internal/agentmanagement
-          ./internal/agentownership
-          ./internal/authz
-          ./internal/audit
-          ./internal/contextvalues
-          ./internal/feature
-          ./internal/thirdparty/posthog
-          ./internal/auth/chatsessions
-          ./internal/chat
-          ./internal/organizations
-          ./internal/background/activities
-          ./cmd/tools/migrations
-          ./cmd/tools/migrations/agentmanagementgrants
-
   # Standalone gate for the demo seed: TestDemoSeedSafety proves the seed
   # cannot touch other tenants' data, cleans up stray demo-org rows, and stays
   # idempotent across runs. The test is build-tagged (demoseed_safety) so the
@@ -2429,7 +2369,6 @@ jobs:
       - format-check
       - server-build-lint
       - server-test
-      - m1-agent-gate
       - demo-seed-safety
       - docker-build-server
       - docker-build-client

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1409,7 +1409,7 @@ func newStartCommand() *cli.Command {
 			roleManager := access.NewRoleManager(logger, db, roleClient, auditLogger)
 			access.Attach(mux, access.NewService(logger, tracerProvider, db, chDB, sessionManager, roleManager, authzEngine, auditLogger, emailService, siteURL, telemSvc))
 			agent.Attach(mux, agent.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, productFeatures, serverURL.String(), assetStorage, telemLogger, growthEmitter))
-			agentmanagement.Attach(mux, agentmanagement.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
+			agentmanagement.Attach(mux, agentmanagement.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, featureFlags))
 			assistants.Attach(mux, assistantsSvc)
 			assistantmemories.Attach(mux, assistantmemories.NewService(
 				logger,

--- a/server/internal/agentmanagement/gate_test.go
+++ b/server/internal/agentmanagement/gate_test.go
@@ -1,0 +1,140 @@
+package agentmanagement
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"goa.design/goa/v3/security"
+
+	gen "github.com/speakeasy-api/gram/server/gen/agents"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type staticSessionAuthorizer struct {
+	authCtx *contextvalues.AuthContext
+}
+
+func (a staticSessionAuthorizer) Authorize(ctx context.Context, _ string, _ *security.APIKeyScheme) (context.Context, error) {
+	return contextvalues.SetAuthContext(ctx, a.authCtx), nil
+}
+
+type recordingM1Features struct {
+	evaluation feature.Evaluation
+	err        error
+	flag       feature.Flag
+	distinctID string
+	groups     map[string]string
+}
+
+func (*recordingM1Features) IsFlagEnabled(context.Context, feature.Flag, string, map[string]string) (bool, error) {
+	return false, nil
+}
+
+func (*recordingM1Features) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+	return false, nil
+}
+
+func (*recordingM1Features) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *recordingM1Features) EvaluateFlag(_ context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Evaluation, error) {
+	f.flag = flag
+	f.distinctID = distinctID
+	f.groups = groups
+	return f.evaluation, f.err
+}
+
+func TestM1RolloutGateRequiresAuthoritativeEnablement(t *testing.T) {
+	t.Parallel()
+
+	backendFailure := errors.New("feature provider unavailable")
+	for _, test := range []struct {
+		name       string
+		features   feature.Provider
+		wantErr    bool
+		wantLookup bool
+	}{
+		{name: "enabled", features: &recordingM1Features{evaluation: feature.EvaluationEnabled}, wantLookup: true},
+		{name: "disabled", features: &recordingM1Features{evaluation: feature.EvaluationDisabled}, wantErr: true, wantLookup: true},
+		{name: "indeterminate", features: &recordingM1Features{evaluation: feature.EvaluationIndeterminate}, wantErr: true, wantLookup: true},
+		{name: "provider error", features: &recordingM1Features{err: backendFailure}, wantErr: true, wantLookup: true},
+		{name: "missing provider", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := &Service{logger: testenv.NewLogger(t), features: test.features}
+			ctx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+				ActiveOrganizationID: "organization",
+				OrganizationSlug:     "organization-slug",
+			})
+
+			err := service.requireM1Enabled(ctx)
+			if test.wantErr {
+				requireOopsCode(t, err, oops.CodeNotFound)
+			} else {
+				require.NoError(t, err)
+			}
+
+			flags, ok := test.features.(*recordingM1Features)
+			if !test.wantLookup {
+				require.False(t, ok)
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, feature.FlagAgentManagementM1, flags.flag)
+			require.Equal(t, "organization", flags.distinctID)
+			require.Equal(t, feature.OrgProjectGroups("organization-slug", ""), flags.groups)
+		})
+	}
+}
+
+func TestGeneratedM1EndpointsCannotBypassRolloutGate(t *testing.T) {
+	t.Parallel()
+
+	backendFailure := errors.New("feature provider unavailable")
+	for _, test := range []struct {
+		name     string
+		features feature.Provider
+	}{
+		{name: "disabled", features: &recordingM1Features{evaluation: feature.EvaluationDisabled}},
+		{name: "indeterminate", features: &recordingM1Features{evaluation: feature.EvaluationIndeterminate}},
+		{name: "provider error", features: &recordingM1Features{err: backendFailure}},
+		{name: "missing provider"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			authCtx := &contextvalues.AuthContext{
+				ActiveOrganizationID: "organization",
+				OrganizationSlug:     "organization-slug",
+			}
+			service := &Service{
+				logger:   testenv.NewLogger(t),
+				auth:     staticSessionAuthorizer{authCtx: authCtx},
+				features: test.features,
+			}
+			endpoint := gen.NewCreateEndpoint(service, service.APIKeyAuth)
+
+			_, err := endpoint(t.Context(), &gen.CreatePayload{Name: "must not be created"})
+			requireOopsCode(t, err, oops.CodeNotFound)
+		})
+	}
+}
+
+func TestM1RolloutGateRejectsMissingTenantContextBeforeEvaluation(t *testing.T) {
+	t.Parallel()
+
+	features := &recordingM1Features{evaluation: feature.EvaluationEnabled}
+	service := &Service{logger: testenv.NewLogger(t), features: features}
+
+	requireOopsCode(t, service.requireM1Enabled(t.Context()), oops.CodeNotFound)
+	requireOopsCode(t, service.requireM1Enabled(contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{})), oops.CodeNotFound)
+	require.Empty(t, features.flag)
+}

--- a/server/internal/agentmanagement/gate_test.go
+++ b/server/internal/agentmanagement/gate_test.go
@@ -29,7 +29,7 @@ func (a staticSessionAuthorizer) AuthorizeWithPostAuthenticationCheck(
 	return ctx, check(ctx)
 }
 
-type recordingM1Features struct {
+type recordingAgentManagementFeatures struct {
 	evaluation feature.Evaluation
 	err        error
 	flag       feature.Flag
@@ -37,19 +37,19 @@ type recordingM1Features struct {
 	groups     map[string]string
 }
 
-func (*recordingM1Features) IsFlagEnabled(context.Context, feature.Flag, string, map[string]string) (bool, error) {
+func (*recordingAgentManagementFeatures) IsFlagEnabled(context.Context, feature.Flag, string, map[string]string) (bool, error) {
 	return false, nil
 }
 
-func (*recordingM1Features) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
+func (*recordingAgentManagementFeatures) IsFlagEnabledLocal(context.Context, feature.Flag, string, map[string]string, map[string]string) (bool, error) {
 	return false, nil
 }
 
-func (*recordingM1Features) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
+func (*recordingAgentManagementFeatures) FlagPayload(context.Context, feature.Flag, string, map[string]string) ([]byte, error) {
 	return nil, nil
 }
 
-func (f *recordingM1Features) EvaluateFlag(_ context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Evaluation, error) {
+func (f *recordingAgentManagementFeatures) EvaluateFlag(_ context.Context, flag feature.Flag, distinctID string, groups map[string]string) (feature.Evaluation, error) {
 	f.flag = flag
 	f.distinctID = distinctID
 	f.groups = groups
@@ -66,10 +66,10 @@ func TestAgentManagementRolloutGateRequiresAuthoritativeEnablement(t *testing.T)
 		wantErr    bool
 		wantLookup bool
 	}{
-		{name: "enabled", features: &recordingM1Features{evaluation: feature.EvaluationEnabled}, wantLookup: true},
-		{name: "disabled", features: &recordingM1Features{evaluation: feature.EvaluationDisabled}, wantErr: true, wantLookup: true},
-		{name: "indeterminate", features: &recordingM1Features{evaluation: feature.EvaluationIndeterminate}, wantErr: true, wantLookup: true},
-		{name: "provider error", features: &recordingM1Features{err: backendFailure}, wantErr: true, wantLookup: true},
+		{name: "enabled", features: &recordingAgentManagementFeatures{evaluation: feature.EvaluationEnabled}, wantLookup: true},
+		{name: "disabled", features: &recordingAgentManagementFeatures{evaluation: feature.EvaluationDisabled}, wantErr: true, wantLookup: true},
+		{name: "indeterminate", features: &recordingAgentManagementFeatures{evaluation: feature.EvaluationIndeterminate}, wantErr: true, wantLookup: true},
+		{name: "provider error", features: &recordingAgentManagementFeatures{err: backendFailure}, wantErr: true, wantLookup: true},
 		{name: "missing provider", wantErr: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestAgentManagementRolloutGateRequiresAuthoritativeEnablement(t *testing.T)
 				require.NoError(t, err)
 			}
 
-			flags, ok := test.features.(*recordingM1Features)
+			flags, ok := test.features.(*recordingAgentManagementFeatures)
 			if !test.wantLookup {
 				require.False(t, ok)
 				return
@@ -109,9 +109,9 @@ func TestGeneratedAgentManagementEndpointsCannotBypassRolloutGate(t *testing.T) 
 		name     string
 		features feature.Provider
 	}{
-		{name: "disabled", features: &recordingM1Features{evaluation: feature.EvaluationDisabled}},
-		{name: "indeterminate", features: &recordingM1Features{evaluation: feature.EvaluationIndeterminate}},
-		{name: "provider error", features: &recordingM1Features{err: backendFailure}},
+		{name: "disabled", features: &recordingAgentManagementFeatures{evaluation: feature.EvaluationDisabled}},
+		{name: "indeterminate", features: &recordingAgentManagementFeatures{evaluation: feature.EvaluationIndeterminate}},
+		{name: "provider error", features: &recordingAgentManagementFeatures{err: backendFailure}},
 		{name: "missing provider"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestGeneratedAgentManagementEndpointsCannotBypassRolloutGate(t *testing.T) 
 func TestAgentManagementRolloutGateRejectsMissingTenantContextBeforeEvaluation(t *testing.T) {
 	t.Parallel()
 
-	features := &recordingM1Features{evaluation: feature.EvaluationEnabled}
+	features := &recordingAgentManagementFeatures{evaluation: feature.EvaluationEnabled}
 	service := &Service{logger: testenv.NewLogger(t), features: features}
 
 	requireOopsCode(t, service.requireAgentManagementEnabled(t.Context()), oops.CodeNotFound)

--- a/server/internal/agentmanagement/gate_test.go
+++ b/server/internal/agentmanagement/gate_test.go
@@ -19,8 +19,14 @@ type staticSessionAuthorizer struct {
 	authCtx *contextvalues.AuthContext
 }
 
-func (a staticSessionAuthorizer) Authorize(ctx context.Context, _ string, _ *security.APIKeyScheme) (context.Context, error) {
-	return contextvalues.SetAuthContext(ctx, a.authCtx), nil
+func (a staticSessionAuthorizer) AuthorizeWithPostAuthenticationCheck(
+	ctx context.Context,
+	_ string,
+	_ *security.APIKeyScheme,
+	check func(context.Context) error,
+) (context.Context, error) {
+	ctx = contextvalues.SetAuthContext(ctx, a.authCtx)
+	return ctx, check(ctx)
 }
 
 type recordingM1Features struct {

--- a/server/internal/agentmanagement/gate_test.go
+++ b/server/internal/agentmanagement/gate_test.go
@@ -56,7 +56,7 @@ func (f *recordingM1Features) EvaluateFlag(_ context.Context, flag feature.Flag,
 	return f.evaluation, f.err
 }
 
-func TestM1RolloutGateRequiresAuthoritativeEnablement(t *testing.T) {
+func TestAgentManagementRolloutGateRequiresAuthoritativeEnablement(t *testing.T) {
 	t.Parallel()
 
 	backendFailure := errors.New("feature provider unavailable")
@@ -81,7 +81,7 @@ func TestM1RolloutGateRequiresAuthoritativeEnablement(t *testing.T) {
 				OrganizationSlug:     "organization-slug",
 			})
 
-			err := service.requireM1Enabled(ctx)
+			err := service.requireAgentManagementEnabled(ctx)
 			if test.wantErr {
 				requireOopsCode(t, err, oops.CodeNotFound)
 			} else {
@@ -94,14 +94,14 @@ func TestM1RolloutGateRequiresAuthoritativeEnablement(t *testing.T) {
 				return
 			}
 			require.True(t, ok)
-			require.Equal(t, feature.FlagAgentManagementM1, flags.flag)
+			require.Equal(t, feature.FlagAgentManagement, flags.flag)
 			require.Equal(t, "organization", flags.distinctID)
 			require.Equal(t, feature.OrgProjectGroups("organization-slug", ""), flags.groups)
 		})
 	}
 }
 
-func TestGeneratedM1EndpointsCannotBypassRolloutGate(t *testing.T) {
+func TestGeneratedAgentManagementEndpointsCannotBypassRolloutGate(t *testing.T) {
 	t.Parallel()
 
 	backendFailure := errors.New("feature provider unavailable")
@@ -134,13 +134,13 @@ func TestGeneratedM1EndpointsCannotBypassRolloutGate(t *testing.T) {
 	}
 }
 
-func TestM1RolloutGateRejectsMissingTenantContextBeforeEvaluation(t *testing.T) {
+func TestAgentManagementRolloutGateRejectsMissingTenantContextBeforeEvaluation(t *testing.T) {
 	t.Parallel()
 
 	features := &recordingM1Features{evaluation: feature.EvaluationEnabled}
 	service := &Service{logger: testenv.NewLogger(t), features: features}
 
-	requireOopsCode(t, service.requireM1Enabled(t.Context()), oops.CodeNotFound)
-	requireOopsCode(t, service.requireM1Enabled(contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{})), oops.CodeNotFound)
+	requireOopsCode(t, service.requireAgentManagementEnabled(t.Context()), oops.CodeNotFound)
+	requireOopsCode(t, service.requireAgentManagementEnabled(contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{})), oops.CodeNotFound)
 	require.Empty(t, features.flag)
 }

--- a/server/internal/agentmanagement/ownership_test.go
+++ b/server/internal/agentmanagement/ownership_test.go
@@ -65,7 +65,7 @@ func TestTransferAtomicallyReplacesOwnerAndPreservesDirectPolicy(t *testing.T) {
 	require.Equal(t, "owner", actorID)
 	require.Equal(t, "owner", beforeOwner)
 	require.Equal(t, "replacement", afterOwner)
-	require.Equal(t, []string{"agent:create", "agent:transfer"}, m1OutboxActions(t, conn, "org-a"))
+	require.Equal(t, []string{"agent:create", "agent:transfer"}, agentWebhookOutboxActions(t, conn, "org-a"))
 }
 
 func TestExplicitReassignmentIsTheOnlyOwnershipOperationThatClearsLatch(t *testing.T) {
@@ -110,7 +110,7 @@ func TestExplicitReassignmentIsTheOnlyOwnershipOperationThatClearsLatch(t *testi
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"agent:owner_loss", "agent:reassign"}, actions)
-	require.Equal(t, actions, m1OutboxActions(t, conn, "org-a"))
+	require.Equal(t, actions, agentWebhookOutboxActions(t, conn, "org-a"))
 }
 
 func TestOwnerChangeRejectsIneligibleAndCrossTenantTargets(t *testing.T) {

--- a/server/internal/agentmanagement/ownership_test.go
+++ b/server/internal/agentmanagement/ownership_test.go
@@ -65,7 +65,7 @@ func TestTransferAtomicallyReplacesOwnerAndPreservesDirectPolicy(t *testing.T) {
 	require.Equal(t, "owner", actorID)
 	require.Equal(t, "owner", beforeOwner)
 	require.Equal(t, "replacement", afterOwner)
-	require.Equal(t, []string{"agent:create", "agent:transfer"}, agentWebhookOutboxActions(t, conn, "org-a"))
+	require.Equal(t, []string{"agent:create", "agent:policy_grant_create", "agent:transfer"}, agentWebhookOutboxActions(t, conn, "org-a"))
 }
 
 func TestExplicitReassignmentIsTheOnlyOwnershipOperationThatClearsLatch(t *testing.T) {

--- a/server/internal/agentmanagement/ownership_test.go
+++ b/server/internal/agentmanagement/ownership_test.go
@@ -65,6 +65,7 @@ func TestTransferAtomicallyReplacesOwnerAndPreservesDirectPolicy(t *testing.T) {
 	require.Equal(t, "owner", actorID)
 	require.Equal(t, "owner", beforeOwner)
 	require.Equal(t, "replacement", afterOwner)
+	require.Equal(t, []string{"agent:create", "agent:transfer"}, m1OutboxActions(t, conn, "org-a"))
 }
 
 func TestExplicitReassignmentIsTheOnlyOwnershipOperationThatClearsLatch(t *testing.T) {
@@ -109,6 +110,7 @@ func TestExplicitReassignmentIsTheOnlyOwnershipOperationThatClearsLatch(t *testi
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"agent:owner_loss", "agent:reassign"}, actions)
+	require.Equal(t, actions, m1OutboxActions(t, conn, "org-a"))
 }
 
 func TestOwnerChangeRejectsIneligibleAndCrossTenantTargets(t *testing.T) {

--- a/server/internal/agentmanagement/policy_test.go
+++ b/server/internal/agentmanagement/policy_test.go
@@ -70,7 +70,7 @@ func TestAgentPolicyCRUDIsExactAllowOnlyAndAudited(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"agent:policy_grant_create", "agent:policy_grant_update", "agent:policy_grant_delete"}, actions)
-	require.Equal(t, actions, m1OutboxActions(t, conn, "org-policy"))
+	require.Equal(t, actions, agentWebhookOutboxActions(t, conn, "org-policy"))
 }
 
 func TestAgentPolicyRejectsUnsafeDenyAndMalformedGrantsAtomically(t *testing.T) {

--- a/server/internal/agentmanagement/policy_test.go
+++ b/server/internal/agentmanagement/policy_test.go
@@ -70,6 +70,7 @@ func TestAgentPolicyCRUDIsExactAllowOnlyAndAudited(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"agent:policy_grant_create", "agent:policy_grant_update", "agent:policy_grant_delete"}, actions)
+	require.Equal(t, actions, m1OutboxActions(t, conn, "org-policy"))
 }
 
 func TestAgentPolicyRejectsUnsafeDenyAndMalformedGrantsAtomically(t *testing.T) {

--- a/server/internal/agentmanagement/service.go
+++ b/server/internal/agentmanagement/service.go
@@ -85,14 +85,14 @@ func Attach(mux goahttp.Muxer, service *Service) {
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
-	authorizedCtx, err := s.auth.AuthorizeWithPostAuthenticationCheck(ctx, key, schema, s.requireM1Enabled)
+	authorizedCtx, err := s.auth.AuthorizeWithPostAuthenticationCheck(ctx, key, schema, s.requireAgentManagementEnabled)
 	if err != nil {
 		return authorizedCtx, fmt.Errorf("authorize agent management session: %w", err)
 	}
 	return authorizedCtx, nil
 }
 
-func (s *Service) requireM1Enabled(ctx context.Context) error {
+func (s *Service) requireAgentManagementEnabled(ctx context.Context) error {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx.ActiveOrganizationID == "" {
 		return oops.C(oops.CodeNotFound)
@@ -101,7 +101,7 @@ func (s *Service) requireM1Enabled(ctx context.Context) error {
 	evaluation, err := feature.EvaluateFlag(
 		ctx,
 		s.features,
-		feature.FlagAgentManagementM1,
+		feature.FlagAgentManagement,
 		authCtx.ActiveOrganizationID,
 		feature.OrgProjectGroups(authCtx.OrganizationSlug, ""),
 	)

--- a/server/internal/agentmanagement/service.go
+++ b/server/internal/agentmanagement/service.go
@@ -28,18 +28,24 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+type sessionAuthorizer interface {
+	Authorize(context.Context, string, *security.APIKeyScheme) (context.Context, error)
+}
+
 type Service struct {
 	tracer     trace.Tracer
 	logger     *slog.Logger
 	db         *pgxpool.Pool
-	auth       *auth.Auth
+	auth       sessionAuthorizer
 	authorizer *Authorizer
 	audit      *audit.Logger
+	features   feature.Provider
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -52,6 +58,7 @@ func NewService(
 	sessionManager *sessions.Manager,
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
+	features feature.Provider,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("agents"))
 	return &Service{
@@ -61,6 +68,7 @@ func NewService(
 		auth:       auth.New(logger, db, sessionManager, authzEngine),
 		authorizer: NewAuthorizer(authzEngine),
 		audit:      auditLogger,
+		features:   features,
 	}
 }
 
@@ -72,7 +80,37 @@ func Attach(mux goahttp.Muxer, service *Service) {
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
-	return s.auth.Authorize(ctx, key, schema)
+	authorizedCtx, err := s.auth.Authorize(ctx, key, schema)
+	if err != nil {
+		return authorizedCtx, fmt.Errorf("authorize agent management session: %w", err)
+	}
+	if err := s.requireM1Enabled(authorizedCtx); err != nil {
+		return authorizedCtx, err
+	}
+	return authorizedCtx, nil
+}
+
+func (s *Service) requireM1Enabled(ctx context.Context) error {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx.ActiveOrganizationID == "" {
+		return oops.C(oops.CodeNotFound)
+	}
+
+	evaluation, err := feature.EvaluateFlag(
+		ctx,
+		s.features,
+		feature.FlagAgentManagementM1,
+		authCtx.ActiveOrganizationID,
+		feature.OrgProjectGroups(authCtx.OrganizationSlug, ""),
+	)
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to evaluate agent management rollout flag", attr.SlogError(err))
+	}
+	if evaluation != feature.EvaluationEnabled {
+		return oops.C(oops.CodeNotFound)
+	}
+
+	return nil
 }
 
 func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*gen.ManagedAgent, error) {

--- a/server/internal/agentmanagement/service.go
+++ b/server/internal/agentmanagement/service.go
@@ -85,7 +85,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
-	return s.auth.AuthorizeWithPostAuthenticationCheck(ctx, key, schema, s.requireM1Enabled)
+	authorizedCtx, err := s.auth.AuthorizeWithPostAuthenticationCheck(ctx, key, schema, s.requireM1Enabled)
+	if err != nil {
+		return authorizedCtx, fmt.Errorf("authorize agent management session: %w", err)
+	}
+	return authorizedCtx, nil
 }
 
 func (s *Service) requireM1Enabled(ctx context.Context) error {

--- a/server/internal/agentmanagement/service.go
+++ b/server/internal/agentmanagement/service.go
@@ -35,7 +35,12 @@ import (
 )
 
 type sessionAuthorizer interface {
-	Authorize(context.Context, string, *security.APIKeyScheme) (context.Context, error)
+	AuthorizeWithPostAuthenticationCheck(
+		context.Context,
+		string,
+		*security.APIKeyScheme,
+		func(context.Context) error,
+	) (context.Context, error)
 }
 
 type Service struct {
@@ -80,14 +85,7 @@ func Attach(mux goahttp.Muxer, service *Service) {
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {
-	authorizedCtx, err := s.auth.Authorize(ctx, key, schema)
-	if err != nil {
-		return authorizedCtx, fmt.Errorf("authorize agent management session: %w", err)
-	}
-	if err := s.requireM1Enabled(authorizedCtx); err != nil {
-		return authorizedCtx, err
-	}
-	return authorizedCtx, nil
+	return s.auth.AuthorizeWithPostAuthenticationCheck(ctx, key, schema, s.requireM1Enabled)
 }
 
 func (s *Service) requireM1Enabled(ctx context.Context) error {

--- a/server/internal/agentmanagement/service_test.go
+++ b/server/internal/agentmanagement/service_test.go
@@ -75,6 +75,7 @@ func TestServiceLifecycleMutationsAreAuditedAtomically(t *testing.T) {
 		"agent:revoke",
 		"agent:delete",
 	}, actions)
+	require.Equal(t, actions, m1OutboxActions(t, conn, "org-a"))
 }
 
 func TestAuditFailureRollsBackLifecycleMutation(t *testing.T) {

--- a/server/internal/agentmanagement/service_test.go
+++ b/server/internal/agentmanagement/service_test.go
@@ -75,7 +75,7 @@ func TestServiceLifecycleMutationsAreAuditedAtomically(t *testing.T) {
 		"agent:revoke",
 		"agent:delete",
 	}, actions)
-	require.Equal(t, actions, m1OutboxActions(t, conn, "org-a"))
+	require.Equal(t, actions, agentWebhookOutboxActions(t, conn, "org-a"))
 }
 
 func TestAuditFailureRollsBackLifecycleMutation(t *testing.T) {

--- a/server/internal/agentmanagement/setup_test.go
+++ b/server/internal/agentmanagement/setup_test.go
@@ -77,7 +77,7 @@ func createAgent(t *testing.T, conn *pgxpool.Pool, organizationID, ownerUserID, 
 	return agent
 }
 
-func m1OutboxActions(t *testing.T, conn *pgxpool.Pool, organizationID string) []string {
+func agentWebhookOutboxActions(t *testing.T, conn *pgxpool.Pool, organizationID string) []string {
 	t.Helper()
 
 	rows, err := testrepo.New(conn).ListPublishOutboxRows(t.Context())

--- a/server/internal/agentmanagement/setup_test.go
+++ b/server/internal/agentmanagement/setup_test.go
@@ -2,6 +2,7 @@ package agentmanagement
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"log/slog"
 	"os"
@@ -9,12 +10,17 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
 
 	"github.com/speakeasy-api/gram/server/internal/agents/repo"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
@@ -69,6 +75,35 @@ func createAgent(t *testing.T, conn *pgxpool.Pool, organizationID, ownerUserID, 
 	})
 	require.NoError(t, err)
 	return agent
+}
+
+func m1OutboxActions(t *testing.T, conn *pgxpool.Pool, organizationID string) []string {
+	t.Helper()
+
+	rows, err := testrepo.New(conn).ListPublishOutboxRows(t.Context())
+	require.NoError(t, err)
+
+	actions := make([]string, 0)
+	for _, row := range rows {
+		if row.OrganizationID != organizationID {
+			continue
+		}
+		var attributes map[string]string
+		require.NoError(t, json.Unmarshal(row.Attributes, &attributes))
+		if attributes["event_type"] != string(events.AgentV1.EventType()) {
+			continue
+		}
+
+		var event webhooksv1.Event
+		require.NoError(t, proto.Unmarshal(row.Message, &event))
+		var payload events.AuditLogCreatedPayloadV1
+		require.NoError(t, json.Unmarshal(event.GetPayload(), &payload))
+		require.Equal(t, organizationID, payload.OrganizationID)
+		require.Equal(t, "agent", payload.SubjectType)
+		actions = append(actions, payload.Action)
+	}
+
+	return actions
 }
 
 func newTestService(conn *pgxpool.Pool, engine authorizationEngine) *Service {

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -42,6 +42,24 @@ func New(logger *slog.Logger, db *pgxpool.Pool, sessions *sessions.Manager, auth
 }
 
 func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKeyScheme) (context.Context, error) {
+	return s.authorize(ctx, key, scheme, nil)
+}
+
+func (s *Auth) AuthorizeWithPostAuthenticationCheck(
+	ctx context.Context,
+	key string,
+	scheme *security.APIKeyScheme,
+	check func(context.Context) error,
+) (context.Context, error) {
+	return s.authorize(ctx, key, scheme, check)
+}
+
+func (s *Auth) authorize(
+	ctx context.Context,
+	key string,
+	scheme *security.APIKeyScheme,
+	postAuthenticationCheck func(context.Context) error,
+) (context.Context, error) {
 	if scheme == nil {
 		panic("Goa has not passed a schema") // TODO: figure something out here
 	}
@@ -64,6 +82,14 @@ func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKe
 	if err != nil {
 		return ctx, err
 	}
+
+	if postAuthenticationCheck != nil {
+		err = postAuthenticationCheck(ctx)
+		if err != nil {
+			return ctx, err
+		}
+	}
+
 	ctx, err = s.authz.PrepareContext(ctx)
 	if err != nil {
 		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").LogError(ctx, s.logger)

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -22,6 +22,11 @@ const (
 	// FlagRiskEnforcementPubsub routes realtime gitleaks and Presidio scans over Pub/Sub.
 	FlagRiskEnforcementPubsub Flag = "risk-enforcement-pubsub"
 
+	// FlagAgentManagementM1 gates the first-class agent management API while
+	// administrator grants are backfilled and the M1 safety suite is promoted.
+	// It is evaluated per organization and fails closed unless explicitly on.
+	FlagAgentManagementM1 Flag = "gram-agent-management-m1"
+
 	// FlagDeviceLevelCoverage switches device-agent coverage from matching a
 	// device's assigned-user email against user-keyed heartbeats to matching
 	// its hardware serial against device-keyed ones, falling back to email

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -25,7 +25,7 @@ const (
 	// FlagAgentManagement gates the first-class agent management API while
 	// administrator grants are backfilled. It is evaluated per organization
 	// and fails closed unless explicitly on.
-	FlagAgentManagement Flag = "gram-agent-management"
+	FlagAgentManagement Flag = "agent-management"
 
 	// FlagDeviceLevelCoverage switches device-agent coverage from matching a
 	// device's assigned-user email against user-keyed heartbeats to matching

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -22,10 +22,10 @@ const (
 	// FlagRiskEnforcementPubsub routes realtime gitleaks and Presidio scans over Pub/Sub.
 	FlagRiskEnforcementPubsub Flag = "risk-enforcement-pubsub"
 
-	// FlagAgentManagementM1 gates the first-class agent management API while
-	// administrator grants are backfilled and the M1 safety suite is promoted.
-	// It is evaluated per organization and fails closed unless explicitly on.
-	FlagAgentManagementM1 Flag = "gram-agent-management-m1"
+	// FlagAgentManagement gates the first-class agent management API while
+	// administrator grants are backfilled. It is evaluated per organization
+	// and fails closed unless explicitly on.
+	FlagAgentManagement Flag = "gram-agent-management"
 
 	// FlagDeviceLevelCoverage switches device-agent coverage from matching a
 	// device's assigned-user email against user-keyed heartbeats to matching

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -22,9 +22,8 @@ const (
 	// FlagRiskEnforcementPubsub routes realtime gitleaks and Presidio scans over Pub/Sub.
 	FlagRiskEnforcementPubsub Flag = "risk-enforcement-pubsub"
 
-	// FlagAgentManagement gates the first-class agent management API while
-	// administrator grants are backfilled. It is evaluated per organization
-	// and fails closed unless explicitly on.
+	// FlagAgentManagement gates the first-class agent management API. It is
+	// evaluated per organization and fails closed unless explicitly on.
 	FlagAgentManagement Flag = "agent-management"
 
 	// FlagDeviceLevelCoverage switches device-agent coverage from matching a

--- a/server/internal/mcpservers/listmcpserversfororg_test.go
+++ b/server/internal/mcpservers/listmcpserversfororg_test.go
@@ -146,10 +146,11 @@ func TestListMcpServersForOrg_WithoutProjectID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Remove project from auth context — simulates the RBAC page which has no
-	// project slug in the URL.
-	authCtx.ProjectID = nil
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	// Copy before removing project scope: background icon discovery still uses
+	// the original auth context. This simulates the org-wide RBAC page.
+	orgAuthCtx := *authCtx
+	orgAuthCtx.ProjectID = nil
+	ctx = contextvalues.SetAuthContext(ctx, &orgAuthCtx)
 
 	result, err := ti.service.ListMcpServersForOrg(ctx, &gen.ListMcpServersForOrgPayload{
 		SessionToken: nil,
@@ -191,9 +192,11 @@ func TestListMcpServersForOrg_CrossProject(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	authCtx.ProjectID = &p2.ID
-	authCtx.ProjectSlug = &p2.Slug
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	// Each request needs its own auth context while icon discovery runs.
+	projectAuthCtx := *authCtx
+	projectAuthCtx.ProjectID = &p2.ID
+	projectAuthCtx.ProjectSlug = &p2.Slug
+	ctx = contextvalues.SetAuthContext(ctx, &projectAuthCtx)
 
 	remoteB := seedRemoteMcpServer(t, ctx, ti.conn, p2.ID).String()
 	serverB, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
@@ -210,9 +213,10 @@ func TestListMcpServersForOrg_CrossProject(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Clear project scope to simulate the org-wide query.
-	authCtx.ProjectID = nil
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	// Clear project scope on another copy to simulate the org-wide query.
+	orgAuthCtx := projectAuthCtx
+	orgAuthCtx.ProjectID = nil
+	ctx = contextvalues.SetAuthContext(ctx, &orgAuthCtx)
 
 	result, err := ti.service.ListMcpServersForOrg(ctx, &gen.ListMcpServersForOrgPayload{
 		SessionToken: nil,

--- a/server/internal/mcpservers/setup_test.go
+++ b/server/internal/mcpservers/setup_test.go
@@ -111,8 +111,10 @@ func withExactAuthzGrants(t *testing.T, ctx context.Context, conn *pgxpool.Pool,
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx)
-	authCtx.AccountType = "enterprise"
-	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+	// Existing requests may still be using authCtx in background icon discovery.
+	updatedAuthCtx := *authCtx
+	updatedAuthCtx.AccountType = "enterprise"
+	ctx = contextvalues.SetAuthContext(ctx, &updatedAuthCtx)
 
 	principal := urn.NewPrincipal(urn.PrincipalTypeRole, "mcpservers-rbac-grants-"+uuid.NewString())
 	for _, grant := range grants {
@@ -202,9 +204,10 @@ func withStaffEmail(t *testing.T, ctx context.Context) context.Context {
 	require.NotNil(t, authCtx)
 
 	email := "staffer@speakeasyapi.dev"
-	authCtx.Email = &email
+	updatedAuthCtx := *authCtx
+	updatedAuthCtx.Email = &email
 
-	return contextvalues.SetAuthContext(ctx, authCtx)
+	return contextvalues.SetAuthContext(ctx, &updatedAuthCtx)
 }
 
 func enableTunneledPublicConsent(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, tunneledServerID uuid.UUID) {


### PR DESCRIPTION
## Summary

Gates agent-management endpoints behind an organization-targeted `agent-management` feature flag and extends authorization and audit coverage for agent identity and setup. Endpoints fail closed unless the flag is explicitly enabled, and rollout requires administrator-grant verification before the feature flag is enabled.

## Motivation

Agent-management surfaces must not become reachable until administrator grants are fully backfilled and verified.

## Technical details

### Rollout control

The feature flag is evaluated after session authentication using the authenticated organization ID and organization cohort. Disabled, missing, indeterminate, and provider-error results return a uniform not-found response before an endpoint can read or mutate agent state.

### Grant verification

The operator runbook requires complete-database grant verification before enabling the feature for an environment or cohort. Verification fails when required grants are missing, unexpected agent grants exist, or administrator roles remain unresolved.

### Rollout prerequisite

This PR targets `main`. The backfill command and runbook remain in #6044; they are an operational rollout prerequisite, not a runtime code or merge dependency of this PR.

Run the administrator-grant backfill and verify the complete target database before enabling the `agent-management` feature flag for an environment or cohort. Keep the flag disabled until verification exits zero and reports `summary.verification.ready_for_enforcement=true`.

Linear: AIM-190
