### PR TITLE
feat: classify platform MCP setup failures

### DIFF
--- a/.changeset/platform-mcp-setup-diagnostics.md
+++ b/.changeset/platform-mcp-setup-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Classify Platform MCP setup failures with privacy-safe categories and actionable next steps.

--- a/server/internal/platformmcp/catalog_readiness.go
+++ b/server/internal/platformmcp/catalog_readiness.go
@@ -183,7 +183,7 @@ func catalogProbeFailure(err error, roundTripper *catalogAuthorizationRoundTripp
 	if roundTripper.tooLarge.Load() || errors.Is(err, errCatalogProbeResponseTooLarge) {
 		return ReadinessUnsupported, "response_too_large"
 	}
-	return ReadinessUnreachable, "probe_failed"
+	return ClassifyReadinessProbeFailure(err)
 }
 
 type catalogAuthorizationRoundTripper struct {

--- a/server/internal/platformmcp/catalog_readiness.go
+++ b/server/internal/platformmcp/catalog_readiness.go
@@ -161,29 +161,57 @@ func (p *RemoteMCPReadinessProber) probe(ctx context.Context, remoteURL string, 
 		headers:      headers,
 		unauthorized: atomic.Bool{},
 		tooLarge:     atomic.Bool{},
+		responded:    atomic.Bool{},
+		transient:    atomic.Bool{},
 	}
 	httpClient.Transport = roundTripper
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "platform-mcp-readiness", Version: "1.0.0"}, nil)
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: remoteURL, HTTPClient: httpClient, MaxRetries: 0, DisableStandaloneSSE: true}, nil)
 	if err != nil {
-		return catalogProbeFailure(err, roundTripper)
+		return catalogProbeFailure(err, roundTripper, catalogProbeStageInitialize)
 	}
 	defer func() { _ = session.Close() }()
 	if _, err := session.ListTools(ctx, nil); err != nil {
-		return catalogProbeFailure(err, roundTripper)
+		return catalogProbeFailure(err, roundTripper, catalogProbeStageToolsList)
 	}
 	return ReadinessReady, "tools_list_ok"
 }
 
-func catalogProbeFailure(err error, roundTripper *catalogAuthorizationRoundTripper) (ReadinessState, string) {
+type catalogProbeStage string
+
+const (
+	catalogProbeStageInitialize catalogProbeStage = "initialize"
+	catalogProbeStageToolsList  catalogProbeStage = "tools_list"
+)
+
+func catalogProbeFailure(err error, roundTripper *catalogAuthorizationRoundTripper, stage catalogProbeStage) (ReadinessState, string) {
+	if roundTripper == nil {
+		return ReadinessUnsupported, "invalid_mcp_response"
+	}
 	if roundTripper.unauthorized.Load() {
 		return ReadinessUnauthorized, "upstream_authorization_rejected"
 	}
 	if roundTripper.tooLarge.Load() || errors.Is(err, errCatalogProbeResponseTooLarge) {
-		return ReadinessUnsupported, "response_too_large"
+		if stage == catalogProbeStageToolsList {
+			return ReadinessDegraded, "tools_list_response_too_large"
+		}
+		return ReadinessUnsupported, "initialize_response_too_large"
 	}
-	return ClassifyReadinessProbeFailure(err)
+	if roundTripper.redirected.Load() {
+		return ReadinessUnsupported, "redirect_rejected"
+	}
+	state, evidence := ClassifyReadinessProbeFailure(err)
+	if evidence == "probe_timeout" || evidence == "probe_unreachable" {
+		return state, evidence
+	}
+	if roundTripper.transient.Load() {
+		return ReadinessDegraded, "probe_temporarily_unavailable"
+	}
+	if evidence == "probe_failed" && roundTripper.responded.Load() && !IsReadinessMCPErrorResponse(err) {
+		return ReadinessUnsupported, "invalid_mcp_response"
+	}
+	return state, evidence
 }
 
 type catalogAuthorizationRoundTripper struct {
@@ -192,6 +220,9 @@ type catalogAuthorizationRoundTripper struct {
 	headers      []remotemcprepo.RemoteMcpServerHeader
 	unauthorized atomic.Bool
 	tooLarge     atomic.Bool
+	responded    atomic.Bool
+	transient    atomic.Bool
+	redirected   atomic.Bool
 }
 
 func (rt *catalogAuthorizationRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -208,8 +239,15 @@ func (rt *catalogAuthorizationRoundTripper) RoundTrip(request *http.Request) (*h
 	if err != nil {
 		return nil, fmt.Errorf("send registered Remote MCP readiness request: %w", err)
 	}
+	rt.responded.Store(true)
 	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
 		rt.unauthorized.Store(true)
+	}
+	if response.StatusCode >= http.StatusMultipleChoices && response.StatusCode < http.StatusBadRequest {
+		rt.redirected.Store(true)
+	}
+	if transientCatalogProbeStatus(response.StatusCode) {
+		rt.transient.Store(true)
 	}
 	if response.ContentLength > catalogProbeMaxResponse {
 		rt.tooLarge.Store(true)
@@ -218,6 +256,10 @@ func (rt *catalogAuthorizationRoundTripper) RoundTrip(request *http.Request) (*h
 	}
 	response.Body = &catalogBoundedReadCloser{ReadCloser: response.Body, remaining: catalogProbeMaxResponse, exceeded: &rt.tooLarge}
 	return response, nil
+}
+
+func transientCatalogProbeStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
 }
 
 type catalogBoundedReadCloser struct {

--- a/server/internal/platformmcp/catalog_readiness.go
+++ b/server/internal/platformmcp/catalog_readiness.go
@@ -192,6 +192,9 @@ func catalogProbeFailure(err error, roundTripper *catalogAuthorizationRoundTripp
 	if roundTripper.unauthorized.Load() {
 		return ReadinessUnauthorized, "upstream_authorization_rejected"
 	}
+	if roundTripper.transient.Load() {
+		return ReadinessDegraded, "probe_temporarily_unavailable"
+	}
 	if roundTripper.tooLarge.Load() || errors.Is(err, errCatalogProbeResponseTooLarge) {
 		if stage == catalogProbeStageToolsList {
 			return ReadinessDegraded, "tools_list_response_too_large"
@@ -204,9 +207,6 @@ func catalogProbeFailure(err error, roundTripper *catalogAuthorizationRoundTripp
 	state, evidence := ClassifyReadinessProbeFailure(err)
 	if evidence == "probe_timeout" || evidence == "probe_unreachable" {
 		return state, evidence
-	}
-	if roundTripper.transient.Load() {
-		return ReadinessDegraded, "probe_temporarily_unavailable"
 	}
 	if evidence == "probe_failed" && roundTripper.responded.Load() && !IsReadinessMCPErrorResponse(err) {
 		return ReadinessUnsupported, "invalid_mcp_response"
@@ -259,7 +259,7 @@ func (rt *catalogAuthorizationRoundTripper) RoundTrip(request *http.Request) (*h
 }
 
 func transientCatalogProbeStatus(status int) bool {
-	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
 }
 
 type catalogBoundedReadCloser struct {

--- a/server/internal/platformmcp/catalog_readiness_unit_test.go
+++ b/server/internal/platformmcp/catalog_readiness_unit_test.go
@@ -2,6 +2,7 @@ package platformmcp
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,24 @@ func TestCatalogProbeFailureDistinguishesResponseSizeByStage(t *testing.T) {
 			require.Equal(t, test.wantEvidence, evidence)
 		})
 	}
+}
+
+func TestCatalogProbeFailureKeepsTransientPrecedenceOverResponseSize(t *testing.T) {
+	t.Parallel()
+
+	roundTripper := &catalogAuthorizationRoundTripper{}
+	roundTripper.transient.Store(true)
+	roundTripper.tooLarge.Store(true)
+	state, evidence := catalogProbeFailure(errCatalogProbeResponseTooLarge, roundTripper, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessDegraded, state)
+	require.Equal(t, "probe_temporarily_unavailable", evidence)
+}
+
+func TestTransientCatalogProbeStatusIncludesRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, transientCatalogProbeStatus(http.StatusRequestTimeout))
+	require.False(t, transientCatalogProbeStatus(http.StatusBadRequest))
 }
 
 func TestCatalogProbeFailurePrecedenceAndRedirect(t *testing.T) {

--- a/server/internal/platformmcp/catalog_readiness_unit_test.go
+++ b/server/internal/platformmcp/catalog_readiness_unit_test.go
@@ -1,0 +1,70 @@
+package platformmcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogProbeFailureDistinguishesResponseSizeByStage(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		stage        catalogProbeStage
+		wantState    ReadinessState
+		wantEvidence string
+	}{
+		{name: "initialize", stage: catalogProbeStageInitialize, wantState: ReadinessUnsupported, wantEvidence: "initialize_response_too_large"},
+		{name: "tools list", stage: catalogProbeStageToolsList, wantState: ReadinessDegraded, wantEvidence: "tools_list_response_too_large"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			roundTripper := &catalogAuthorizationRoundTripper{}
+			roundTripper.tooLarge.Store(true)
+			state, evidence := catalogProbeFailure(errCatalogProbeResponseTooLarge, roundTripper, test.stage)
+			require.Equal(t, test.wantState, state)
+			require.Equal(t, test.wantEvidence, evidence)
+		})
+	}
+}
+
+func TestCatalogProbeFailurePrecedenceAndRedirect(t *testing.T) {
+	t.Parallel()
+
+	unauthorized := &catalogAuthorizationRoundTripper{}
+	unauthorized.unauthorized.Store(true)
+	unauthorized.transient.Store(true)
+	state, evidence := catalogProbeFailure(errors.New("private HTTP detail"), unauthorized, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessUnauthorized, state)
+	require.Equal(t, "upstream_authorization_rejected", evidence)
+
+	redirected := &catalogAuthorizationRoundTripper{}
+	redirected.responded.Store(true)
+	redirected.redirected.Store(true)
+	state, evidence = catalogProbeFailure(errors.New("private HTTP detail"), redirected, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessUnsupported, state)
+	require.Equal(t, "redirect_rejected", evidence)
+}
+
+func TestCatalogProbeFailureClassifiesHTTPProtocolAndTransportFailures(t *testing.T) {
+	t.Parallel()
+
+	response := &catalogAuthorizationRoundTripper{}
+	response.responded.Store(true)
+	state, evidence := catalogProbeFailure(errors.New("private SDK detail"), response, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessUnsupported, state)
+	require.Equal(t, "invalid_mcp_response", evidence)
+
+	state, evidence = catalogProbeFailure(errors.New("private transport detail"), &catalogAuthorizationRoundTripper{}, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessUnreachable, state)
+	require.Equal(t, "probe_failed", evidence)
+
+	transient := &catalogAuthorizationRoundTripper{}
+	transient.responded.Store(true)
+	transient.transient.Store(true)
+	state, evidence = catalogProbeFailure(errors.New("private HTTP detail"), transient, catalogProbeStageInitialize)
+	require.Equal(t, ReadinessDegraded, state)
+	require.Equal(t, "probe_temporarily_unavailable", evidence)
+}

--- a/server/internal/platformmcp/descriptor.go
+++ b/server/internal/platformmcp/descriptor.go
@@ -329,12 +329,16 @@ func prepareInputSchema[In any](tool *mcp.Tool) ([]byte, *jsonschema.Resolved) {
 	return encoded, resolved
 }
 
-// wireTypeSchemas overrides schema inference for types whose JSON form does not
-// match their Go shape. Inference reflects on the Go type and cannot see a
-// custom MarshalJSON, so a type that serializes as something other than its
-// struct has to say so here.
+// wireTypeSchemas overrides schema inference for types whose JSON contract is
+// narrower than their Go shape. Inference cannot see a custom MarshalJSON or a
+// named string's closed vocabulary, so those types declare their wire schema
+// here.
 var wireTypeSchemas = map[reflect.Type]*jsonschema.Schema{
 	reflect.TypeFor[SubjectCount](): subjectCountSchema,
+	reflect.TypeFor[SetupCategory](): {
+		Type: "string",
+		Enum: setupCategoryEnumValues(),
+	},
 }
 
 // inferOutputSchema derives the schema the tool advertises for its result,

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -322,6 +322,15 @@ func TestAdvertisedOutputSchemaMatchesTheSubjectCountWireForm(t *testing.T) {
 	}
 }
 
+func TestAdvertisedSetupCategoryIsClosed(t *testing.T) {
+	t.Parallel()
+
+	schema := inferOutputSchema[GetMCPReadinessToolOutput]("get_mcp_readiness")
+	category := schema.Properties["setup_category"]
+	require.NotNil(t, category)
+	require.Equal(t, setupCategoryEnumValues(), category.Enum)
+}
+
 // Schema inference panics at process boot, so a tool input the nil-dependency
 // server never registers can crash-loop production while CI stays green. The
 // jsonschema tag is a description; a "word=" prefix is rejected outright.

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -306,6 +306,7 @@ type MCPClientEvidence struct {
 // freshness that decides whether it can exonerate anything.
 type MCPDiagnosticsReadiness struct {
 	State         string         `json:"state"`
+	EvidenceCode  string         `json:"evidence_code,omitempty"`
 	SetupCategory SetupCategory  `json:"setup_category,omitempty"`
 	Freshness     string         `json:"freshness"`
 	CheckedAt     string         `json:"checked_at,omitempty"`
@@ -390,7 +391,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	serverTotals := totalsFromRows(serverRows)
 	organizationTotals := totalsFromRows(organizationRows)
 	readiness, readinessFound := s.currentReadiness(ctx, principal, mcp)
-	normalized := normalizedReadiness(readiness, readinessFound)
+	normalized := diagnosticsReadiness(mcp, readiness, readinessFound)
 	setupCategory := setupCategoryFromReadiness(normalized)
 	clients, truncated := clientEvidence(serverRows)
 
@@ -407,6 +408,7 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 		Envelope:  newDataEnvelope(now, watermarkTime(watermark), window, serverTotals.Total > 0),
 		Readiness: MCPDiagnosticsReadiness{
 			State:         string(normalized.State),
+			EvidenceCode:  normalized.EvidenceCode,
 			SetupCategory: setupCategory,
 			Freshness:     readinessFreshness(readiness, readinessFound),
 			CheckedAt:     readinessTimestamp(readiness.CheckedAt),
@@ -477,6 +479,16 @@ func (s *DiagnosticsService) currentReadiness(ctx context.Context, principal Pri
 		return Readiness{}, false
 	}
 	return readiness, found
+}
+
+// diagnosticsReadiness preserves the inventory's unsupported state for MCPs
+// that are not managed by a Platform registration while normalizing missing
+// evidence for registered MCPs as a retryable gap.
+func diagnosticsReadiness(mcp MCP, readiness Readiness, found bool) Readiness {
+	if mcp.Registration == nil || mcp.Registration.ID == "" {
+		return Readiness{State: ReadinessUnsupported, EvidenceCode: "readiness_not_managed"}
+	}
+	return normalizedReadiness(readiness, found)
 }
 
 func totalsFromRows(rows []telemetryrepo.MCPOutcomeBreakdownRow) outcomeTotals {

--- a/server/internal/platformmcp/diagnostics.go
+++ b/server/internal/platformmcp/diagnostics.go
@@ -305,9 +305,11 @@ type MCPClientEvidence struct {
 // MCPDiagnosticsReadiness is the latest server-side readiness result, with the
 // freshness that decides whether it can exonerate anything.
 type MCPDiagnosticsReadiness struct {
-	State     string `json:"state"`
-	Freshness string `json:"freshness"`
-	CheckedAt string `json:"checked_at,omitempty"`
+	State         string         `json:"state"`
+	SetupCategory SetupCategory  `json:"setup_category,omitempty"`
+	Freshness     string         `json:"freshness"`
+	CheckedAt     string         `json:"checked_at,omitempty"`
+	Actions       []RepairAction `json:"actions"`
 }
 
 type GetMCPDiagnosticsOutput struct {
@@ -388,6 +390,8 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 	serverTotals := totalsFromRows(serverRows)
 	organizationTotals := totalsFromRows(organizationRows)
 	readiness, readinessFound := s.currentReadiness(ctx, principal, mcp)
+	normalized := normalizedReadiness(readiness, readinessFound)
+	setupCategory := setupCategoryFromReadiness(normalized)
 	clients, truncated := clientEvidence(serverRows)
 
 	attribution := attributeFault(readiness, readinessFound, serverTotals, organizationTotals)
@@ -402,9 +406,11 @@ func (s *DiagnosticsService) GetMCPDiagnostics(ctx context.Context, principal Pr
 		MCPID:     input.MCPID,
 		Envelope:  newDataEnvelope(now, watermarkTime(watermark), window, serverTotals.Total > 0),
 		Readiness: MCPDiagnosticsReadiness{
-			State:     string(normalizedReadiness(readiness, readinessFound).State),
-			Freshness: readinessFreshness(readiness, readinessFound),
-			CheckedAt: readinessTimestamp(readiness.CheckedAt),
+			State:         string(normalized.State),
+			SetupCategory: setupCategory,
+			Freshness:     readinessFreshness(readiness, readinessFound),
+			CheckedAt:     readinessTimestamp(readiness.CheckedAt),
+			Actions:       setupRepairActions(setupCategory, normalized.State),
 		},
 		Outcomes:                    summaryFromTotals(serverTotals),
 		OrganizationOutcomes:        summaryFromTotals(organizationTotals),

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -87,6 +87,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window, true),
 		Readiness: MCPDiagnosticsReadiness{
 			State:         string(ReadinessUnauthorized),
+			EvidenceCode:  "provider_authorization_rejected",
 			SetupCategory: SetupCategoryProviderAuthorizationRejected,
 			Freshness:     "fresh",
 			CheckedAt:     now.Format(time.RFC3339),
@@ -108,7 +109,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
 		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
-		"readiness", "state", "setup_category", "freshness", "checked_at", "actions", "kind", "label",
+		"readiness", "state", "evidence_code", "setup_category", "freshness", "checked_at", "actions", "kind", "label",
 		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes_partial",
@@ -116,6 +117,29 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		"clients_truncated",
 		"attribution", "fault", "reason", "readiness_exonerates", "scope",
 	}, decodeKeys(t, output))
+}
+
+func TestDiagnosticsReadinessKeepsUnmanagedMCPUnsupportedWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	readiness := diagnosticsReadiness(MCP{Registration: nil}, Readiness{}, false)
+	category := setupCategoryFromReadiness(readiness)
+
+	require.Equal(t, ReadinessUnsupported, readiness.State)
+	require.Equal(t, "readiness_not_managed", readiness.EvidenceCode)
+	require.Empty(t, category)
+	require.Empty(t, setupRepairActions(category, readiness.State))
+}
+
+func TestDiagnosticsReadinessKeepsMissingRegisteredEvidenceRetryable(t *testing.T) {
+	t.Parallel()
+
+	readiness := diagnosticsReadiness(MCP{Registration: &MCPRegistration{ID: "registration"}}, Readiness{}, false)
+	category := setupCategoryFromReadiness(readiness)
+
+	require.Equal(t, ReadinessDegraded, readiness.State)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, category)
+	require.Equal(t, []RepairAction{{Kind: "retry_readiness", Label: "Check again whether this MCP server is working"}}, setupRepairActions(category, readiness.State))
 }
 
 func TestMetricsMode_NamesWhatTheCountsMeasure(t *testing.T) {

--- a/server/internal/platformmcp/diagnostics_test.go
+++ b/server/internal/platformmcp/diagnostics_test.go
@@ -82,10 +82,16 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	require.NoError(t, err)
 
 	output := GetMCPDiagnosticsOutput{
-		ProjectID:                   "00000000-0000-0000-0000-000000000001",
-		MCPID:                       "00000000-0000-0000-0000-000000000002",
-		Envelope:                    newDataEnvelope(now, now.Add(-time.Minute), window, true),
-		Readiness:                   MCPDiagnosticsReadiness{State: string(ReadinessReady), Freshness: "fresh", CheckedAt: now.Format(time.RFC3339)},
+		ProjectID: "00000000-0000-0000-0000-000000000001",
+		MCPID:     "00000000-0000-0000-0000-000000000002",
+		Envelope:  newDataEnvelope(now, now.Add(-time.Minute), window, true),
+		Readiness: MCPDiagnosticsReadiness{
+			State:         string(ReadinessUnauthorized),
+			SetupCategory: SetupCategoryProviderAuthorizationRejected,
+			Freshness:     "fresh",
+			CheckedAt:     now.Format(time.RFC3339),
+			Actions:       []RepairAction{{Kind: "continue_dashboard_setup", Label: "Finish this MCP server's source and sign-in setup in the dashboard"}},
+		},
 		Outcomes:                    MCPOutcomeSummary{Total: 10, Success: 4, Unauthorized: 6},
 		OrganizationOutcomes:        MCPOutcomeSummary{Total: 100, Success: 98, ServerError: 2},
 		OrganizationOutcomesPartial: false,
@@ -102,7 +108,7 @@ func TestGetMCPDiagnosticsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp_id",
 		"data", "queried_at", "data_through", "freshness", "no_observations", "resolved_window", "window", "from", "to",
-		"readiness", "state", "freshness", "checked_at",
+		"readiness", "state", "setup_category", "freshness", "checked_at", "actions", "kind", "label",
 		"outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes", "total", "success", "unauthorized", "client_error", "server_error", "failed", "unknown",
 		"organization_outcomes_partial",

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -100,7 +100,11 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 		return DirectRemoteInspection{}, sanitizedSetupFailure(err)
 	}
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
-		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
+		oauthDiscovery, err := directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget)
+		if err != nil {
+			return DirectRemoteInspection{}, sanitizedSetupFailure(err)
+		}
+		return directRemoteInspection(finalURL, nil, "authentication_required", oauthDiscovery, true), nil
 	}
 	if status < http.StatusOK || status >= http.StatusMultipleChoices || initialize.Result == nil {
 		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
@@ -120,7 +124,11 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 		return DirectRemoteInspection{}, sanitizedSetupFailure(err)
 	}
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
-		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
+		oauthDiscovery, err := directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget)
+		if err != nil {
+			return DirectRemoteInspection{}, sanitizedSetupFailure(err)
+		}
+		return directRemoteInspection(finalURL, nil, "authentication_required", oauthDiscovery, true), nil
 	}
 	if status < http.StatusOK || status >= http.StatusMultipleChoices || tools.Result == nil {
 		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
@@ -303,13 +311,23 @@ func directRemoteNotification(ctx context.Context, client directRemoteHTTPClient
 	return finalURL, resp.StatusCode, nil
 }
 
-// directRemoteOAuthDiscovery returns only the safe discovery category. Metadata
-// URLs are derived from the canonical resource or a discovered issuer, rechecked
-// with Guardian before egress, and charged to the inspection response budget.
-func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client directRemoteHTTPClient, resourceURL string, budget *directRemoteResponseBudget) string {
+// directRemoteOAuthDiscovery returns a safe discovery category or a sanitized
+// temporary failure. Metadata URLs are derived from the canonical resource or a
+// discovered issuer, rechecked with Guardian before egress, and charged to the
+// inspection response budget.
+func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, client directRemoteHTTPClient, resourceURL string, budget *directRemoteResponseBudget) (string, error) {
 	available := false
 	for _, metadataURL := range directRemoteProtectedResourceMetadataURLs(resourceURL) {
 		metadata, status, err := directRemoteGetJSON(ctx, policy, client, metadataURL, budget)
+		if transientDirectRemoteMetadataStatus(status) {
+			err = setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
+		}
+		if setupCategoryFromError(err) == SetupCategoryTemporarilyUnavailable {
+			if available {
+				return "available", nil
+			}
+			return "", err
+		}
 		if err != nil || status != http.StatusOK {
 			continue
 		}
@@ -327,20 +345,33 @@ func directRemoteOAuthDiscovery(ctx context.Context, policy *guardian.Policy, cl
 			}
 			for _, authorizationMetadataURL := range directRemoteAuthorizationServerMetadataURLs(issuer) {
 				authorizationMetadata, status, err := directRemoteGetJSON(ctx, policy, client, authorizationMetadataURL, budget)
+				if transientDirectRemoteMetadataStatus(status) {
+					err = setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
+				}
+				if setupCategoryFromError(err) == SetupCategoryTemporarilyUnavailable {
+					if available {
+						return "available", nil
+					}
+					return "", err
+				}
 				if err != nil || status != http.StatusOK {
 					continue
 				}
 				if endpoint, _ := authorizationMetadata["registration_endpoint"].(string); endpoint != "" {
-					return "available_dcr"
+					return "available_dcr", nil
 				}
 				available = true
 			}
 		}
 	}
 	if available {
-		return "available"
+		return "available", nil
 	}
-	return "incomplete"
+	return "incomplete", nil
+}
+
+func transientDirectRemoteMetadataStatus(status int) bool {
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
 }
 
 func directRemoteProtectedResourceMetadataURLs(resourceURL string) []string {
@@ -374,8 +405,11 @@ func directRemoteAuthorizationServerMetadataURLs(issuer string) []string {
 }
 
 func directRemoteGetJSON(ctx context.Context, policy *guardian.Policy, client directRemoteHTTPClient, rawURL string, budget *directRemoteResponseBudget) (map[string]any, int, error) {
-	if policy == nil || client == nil || budget == nil || budget.remaining <= 0 {
+	if policy == nil || client == nil || budget == nil {
 		return nil, 0, ErrDirectRemoteUnavailable
+	}
+	if budget.remaining <= 0 {
+		return nil, 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	canonicalURL, err := canonicalDirectRemoteURL(rawURL)
 	if err != nil {

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -88,22 +88,7 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 	budget := &directRemoteResponseBudget{remaining: directRemoteProbeMaxBytes, requestsRemaining: directRemoteProbeMaxRequests}
 	client := s.policy.Client()
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) > directRemoteProbeMaxRedirects || budget.consumeRequest() != nil {
-			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: too many redirects", ErrDirectRemoteRejected))
-		}
-		next, err := canonicalDirectRemoteURL(req.URL.String())
-		if err != nil {
-			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, err)
-		}
-		validated, err := s.policy.ValidateHTTPSURL(req.Context(), next)
-		if err != nil {
-			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: unsafe redirect", ErrDirectRemoteRejected))
-		}
-		req.URL = validated
-		// This probe never sends credentials. Explicitly clearing Authorization
-		// keeps that invariant if a client implementation changes later.
-		req.Header.Del("Authorization")
-		return nil
+		return directRemoteRedirectCheck(s.policy, budget, req, via)
 	}
 
 	initialize, finalURL, sessionID, status, err := directRemoteRequest(probeCtx, client, canonicalURL, "initialize", map[string]any{
@@ -159,6 +144,28 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 		}
 	}
 	return directRemoteInspection(finalURL, names, "anonymous", "not_advertised", false), nil
+}
+
+func directRemoteRedirectCheck(policy *guardian.Policy, budget *directRemoteResponseBudget, req *http.Request, via []*http.Request) error {
+	if len(via) > directRemoteProbeMaxRedirects {
+		return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: too many redirects", ErrDirectRemoteRejected))
+	}
+	if budget.consumeRequest() != nil {
+		return setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
+	}
+	next, err := canonicalDirectRemoteURL(req.URL.String())
+	if err != nil {
+		return setupFailure(SetupCategoryUnsafeTargetOrRedirect, err)
+	}
+	validated, err := policy.ValidateHTTPSURL(req.Context(), next)
+	if err != nil {
+		return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: unsafe redirect", ErrDirectRemoteRejected))
+	}
+	req.URL = validated
+	// This probe never sends credentials. Explicitly clearing Authorization
+	// keeps that invariant if a client implementation changes later.
+	req.Header.Del("Authorization")
+	return nil
 }
 
 type directRemoteResponseBudget struct {
@@ -378,7 +385,7 @@ func directRemoteGetJSON(ctx context.Context, policy *guardian.Policy, client di
 		return nil, 0, ErrDirectRemoteRejected
 	}
 	if err := budget.consumeRequest(); err != nil {
-		return nil, 0, err
+		return nil, 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, canonicalURL, nil)
 	if err != nil {

--- a/server/internal/platformmcp/direct_remote.go
+++ b/server/internal/platformmcp/direct_remote.go
@@ -73,14 +73,14 @@ func NewGuardianDirectRemoteInspector(policy *guardian.Policy) *GuardianDirectRe
 
 func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL string) (DirectRemoteInspection, error) {
 	if s == nil || s.policy == nil {
-		return DirectRemoteInspection{}, ErrDirectRemoteUnavailable
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	canonicalURL, err := canonicalDirectRemoteURL(rawURL)
 	if err != nil {
-		return DirectRemoteInspection{}, err
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidURL, err)
 	}
 	if _, err := s.policy.ValidateHTTPSURL(ctx, canonicalURL); err != nil {
-		return DirectRemoteInspection{}, fmt.Errorf("validate direct remote URL: %w", ErrDirectRemoteRejected)
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("validate direct remote URL: %w", ErrDirectRemoteRejected))
 	}
 
 	probeCtx, cancel := context.WithTimeout(ctx, directRemoteProbeDeadline)
@@ -89,15 +89,15 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 	client := s.policy.Client()
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) > directRemoteProbeMaxRedirects || budget.consumeRequest() != nil {
-			return fmt.Errorf("%w: too many redirects", ErrDirectRemoteRejected)
+			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: too many redirects", ErrDirectRemoteRejected))
 		}
 		next, err := canonicalDirectRemoteURL(req.URL.String())
 		if err != nil {
-			return err
+			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, err)
 		}
 		validated, err := s.policy.ValidateHTTPSURL(req.Context(), next)
 		if err != nil {
-			return fmt.Errorf("%w: unsafe redirect", ErrDirectRemoteRejected)
+			return setupFailure(SetupCategoryUnsafeTargetOrRedirect, fmt.Errorf("%w: unsafe redirect", ErrDirectRemoteRejected))
 		}
 		req.URL = validated
 		// This probe never sends credentials. Explicitly clearing Authorization
@@ -112,30 +112,33 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 		"clientInfo":      map[string]string{"name": "gram-platform-mcp", "version": "1"},
 	}, "", budget)
 	if err != nil {
-		return DirectRemoteInspection{}, err
+		return DirectRemoteInspection{}, sanitizedSetupFailure(err)
 	}
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
 		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
 	}
 	if status < http.StatusOK || status >= http.StatusMultipleChoices || initialize.Result == nil {
-		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	if sessionID != "" {
 		finalURL, status, err = directRemoteNotification(probeCtx, client, finalURL, "notifications/initialized", map[string]any{}, sessionID, budget)
-		if err != nil || status < http.StatusOK || status >= http.StatusMultipleChoices {
-			return DirectRemoteInspection{}, ErrDirectRemoteRejected
+		if err != nil {
+			return DirectRemoteInspection{}, sanitizedSetupFailure(err)
+		}
+		if status < http.StatusOK || status >= http.StatusMultipleChoices {
+			return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 		}
 	}
 
 	tools, finalURL, _, status, err := directRemoteRequest(probeCtx, client, finalURL, "tools/list", map[string]any{}, sessionID, budget)
 	if err != nil {
-		return DirectRemoteInspection{}, err
+		return DirectRemoteInspection{}, sanitizedSetupFailure(err)
 	}
 	if status == http.StatusUnauthorized || status == http.StatusForbidden {
 		return directRemoteInspection(finalURL, nil, "authentication_required", directRemoteOAuthDiscovery(probeCtx, s.policy, client, finalURL, budget), true), nil
 	}
 	if status < http.StatusOK || status >= http.StatusMultipleChoices || tools.Result == nil {
-		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 
 	var toolList struct {
@@ -144,7 +147,7 @@ func (s *GuardianDirectRemoteInspector) Inspect(ctx context.Context, rawURL stri
 		} `json:"tools"`
 	}
 	if err := json.Unmarshal(tools.Result, &toolList); err != nil {
-		return DirectRemoteInspection{}, ErrDirectRemoteRejected
+		return DirectRemoteInspection{}, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	names := make([]string, 0, min(len(toolList.Tools), directRemoteToolNameLimit))
 	for _, tool := range toolList.Tools {
@@ -185,100 +188,109 @@ func emptyDirectRemoteRPCResponse() directRemoteRPCResponse {
 
 func directRemoteRequest(ctx context.Context, client directRemoteHTTPClient, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (directRemoteRPCResponse, string, string, int, error) {
 	if err := budget.consumeRequest(); err != nil {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, err
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
 	if err != nil {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, fmt.Errorf("marshal MCP probe: %w", err)
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
 	if err != nil {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, fmt.Errorf("build direct MCP probe: %w", err)
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
 		if len(sessionID) > directRemoteSessionIDMaxBytes {
-			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+			return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 		}
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
+		if category := setupCategoryFromError(err); category != "" {
+			return emptyDirectRemoteRPCResponse(), "", "", 0, sanitizedSetupFailure(err)
+		}
 		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
-			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+			return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected)
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
-			return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteUnavailable
+			return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTimeout, ErrDirectRemoteUnavailable)
 		}
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteUnavailable
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryUnreachable, ErrDirectRemoteUnavailable)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	finalURL, err := canonicalDirectRemoteURL(resp.Request.URL.String())
 	if err != nil {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, err
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected)
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return emptyDirectRemoteRPCResponse(), finalURL, "", resp.StatusCode, nil
 	}
 	if mediaType := strings.ToLower(strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])); mediaType != "application/json" && resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	if budget == nil || budget.remaining <= 0 {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
 	if err != nil || len(payload) > budget.remaining {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	budget.remaining -= len(payload)
 	var result directRemoteRPCResponse
 	if err := json.Unmarshal(payload, &result); err != nil {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	sessionID = resp.Header.Get("Mcp-Session-Id")
 	if len(sessionID) > directRemoteSessionIDMaxBytes {
-		return emptyDirectRemoteRPCResponse(), "", "", 0, ErrDirectRemoteRejected
+		return emptyDirectRemoteRPCResponse(), "", "", 0, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	return result, finalURL, sessionID, resp.StatusCode, nil
 }
 
 func directRemoteNotification(ctx context.Context, client directRemoteHTTPClient, rawURL, method string, params any, sessionID string, budget *directRemoteResponseBudget) (string, int, error) {
 	if err := budget.consumeRequest(); err != nil {
-		return "", 0, err
+		return "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
 	if err != nil {
-		return "", 0, fmt.Errorf("marshal MCP probe notification: %w", err)
+		return "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
 	if err != nil {
-		return "", 0, fmt.Errorf("build direct MCP probe notification: %w", err)
+		return "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	if len(sessionID) > directRemoteSessionIDMaxBytes {
-		return "", 0, ErrDirectRemoteRejected
+		return "", 0, setupFailure(SetupCategoryInvalidMCPResponse, ErrDirectRemoteRejected)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set("Mcp-Session-Id", sessionID)
 	resp, err := client.Do(req)
 	if err != nil {
-		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
-			return "", 0, ErrDirectRemoteRejected
+		if category := setupCategoryFromError(err); category != "" {
+			return "", 0, sanitizedSetupFailure(err)
 		}
-		return "", 0, ErrDirectRemoteUnavailable
+		if errors.Is(err, ErrDirectRemoteRejected) || errors.Is(err, guardian.ErrBlockedIP) || errors.Is(err, guardian.ErrBadHost) {
+			return "", 0, setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected)
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+			return "", 0, setupFailure(SetupCategoryTimeout, ErrDirectRemoteUnavailable)
+		}
+		return "", 0, setupFailure(SetupCategoryUnreachable, ErrDirectRemoteUnavailable)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	finalURL, err := canonicalDirectRemoteURL(resp.Request.URL.String())
 	if err != nil {
-		return "", 0, err
+		return "", 0, setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected)
 	}
 	if budget == nil || budget.remaining <= 0 {
-		return "", 0, ErrDirectRemoteRejected
+		return "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	payload, err := io.ReadAll(io.LimitReader(resp.Body, int64(budget.remaining+1)))
 	if err != nil || len(payload) > budget.remaining {
-		return "", 0, ErrDirectRemoteRejected
+		return "", 0, setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable)
 	}
 	budget.remaining -= len(payload)
 	return finalURL, resp.StatusCode, nil

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -199,8 +199,9 @@ func TestDirectRemoteOAuthDiscoveryScansForDCR(t *testing.T) {
 			return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
 		}
 	})
-	result := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
 
+	require.NoError(t, err)
 	require.Equal(t, "available_dcr", result)
 	require.Equal(t, []string{
 		"https://remote.example.test/.well-known/oauth-protected-resource/mcp",
@@ -226,7 +227,9 @@ func TestDirectRemoteOAuthDiscoveryUsesOIDCCompatibleCandidate(t *testing.T) {
 		}
 	})
 
-	require.Equal(t, "available_dcr", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+	require.NoError(t, err)
+	require.Equal(t, "available_dcr", result)
 }
 
 func TestDirectRemoteOAuthDiscoveryReportsAvailableWithoutDCR(t *testing.T) {
@@ -243,7 +246,9 @@ func TestDirectRemoteOAuthDiscoveryReportsAvailableWithoutDCR(t *testing.T) {
 		}
 	})
 
-	require.Equal(t, "available", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+	require.NoError(t, err)
+	require.Equal(t, "available", result)
 }
 
 func TestDirectRemoteOAuthDiscoveryReportsIncompleteWithoutAuthorizationMetadata(t *testing.T) {
@@ -253,7 +258,82 @@ func TestDirectRemoteOAuthDiscoveryReportsIncompleteWithoutAuthorizationMetadata
 		return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
 	})
 
-	require.Equal(t, "incomplete", directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8}))
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+	require.NoError(t, err)
+	require.Equal(t, "incomplete", result)
+}
+
+func TestDirectRemoteOAuthDiscoveryPreservesAvailableResultWhenLaterProbeExhaustsBudget(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		requests++
+		switch requests {
+		case 1:
+			return directRemoteTestResponse(request, http.StatusOK, `{"authorization_servers":["https://issuer.example.test"]}`)
+		case 2:
+			return directRemoteTestResponse(request, http.StatusOK, `{}`)
+		default:
+			t.Fatalf("request must not run after the budget is exhausted: %s", request.URL)
+			return nil
+		}
+	})
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 2})
+	require.NoError(t, err)
+	require.Equal(t, "available", result)
+	require.Equal(t, 2, requests)
+}
+
+func TestDirectRemoteOAuthDiscoveryPropagatesRequestBudgetExhaustion(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		t.Fatalf("request must not run after the budget is exhausted: %s", request.URL)
+		return nil
+	})
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 0})
+	require.Empty(t, result)
+	require.ErrorIs(t, err, ErrDirectRemoteUnavailable)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, setupCategoryFromError(err))
+}
+
+func TestDirectRemoteOAuthDiscoveryPropagatesTransientMetadataStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout} {
+		client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+			return directRemoteTestResponse(request, status, `{}`)
+		})
+		result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+		require.Empty(t, result)
+		require.ErrorIs(t, err, ErrDirectRemoteUnavailable)
+		require.Equal(t, SetupCategoryTemporarilyUnavailable, setupCategoryFromError(err))
+	}
+}
+
+func TestDirectRemoteOAuthDiscoveryKeepsNonTransientMissingMetadataIncomplete(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		return directRemoteTestResponse(request, http.StatusNotFound, `{}`)
+	})
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 4096, requestsRemaining: 8})
+	require.NoError(t, err)
+	require.Equal(t, "incomplete", result)
+}
+
+func TestDirectRemoteOAuthDiscoveryPropagatesByteBudgetExhaustion(t *testing.T) {
+	t.Parallel()
+
+	client := directRemoteTestClient(t, func(request *http.Request) *http.Response {
+		t.Fatalf("request must not run after the byte budget is exhausted: %s", request.URL)
+		return nil
+	})
+	result, err := directRemoteOAuthDiscovery(t.Context(), directRemoteTestPolicy(t), client, "https://remote.example.test/mcp", &directRemoteResponseBudget{remaining: 0, requestsRemaining: 1})
+	require.Empty(t, result)
+	require.ErrorIs(t, err, ErrDirectRemoteUnavailable)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, setupCategoryFromError(err))
 }
 
 func directRemoteTestPolicy(t *testing.T) *guardian.Policy {

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -135,6 +135,22 @@ func TestDirectRemoteNotificationAcceptsJSONAndSSE(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, status)
 }
 
+func TestDirectRemoteRedirectCheckDistinguishesUnsafeRedirectFromBudgetExhaustion(t *testing.T) {
+	t.Parallel()
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://remote.example.test/redirect", nil)
+	require.NoError(t, err)
+
+	budgetErr := directRemoteRedirectCheck(directRemoteTestPolicy(t), &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 0}, request, nil)
+	require.ErrorIs(t, budgetErr, ErrDirectRemoteUnavailable)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, setupCategoryFromError(budgetErr))
+
+	via := make([]*http.Request, directRemoteProbeMaxRedirects+1)
+	redirectErr := directRemoteRedirectCheck(directRemoteTestPolicy(t), &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1}, request, via)
+	require.ErrorIs(t, redirectErr, ErrDirectRemoteRejected)
+	require.Equal(t, SetupCategoryUnsafeTargetOrRedirect, setupCategoryFromError(redirectErr))
+}
+
 func TestDirectRemoteRequestClassifiesBudgetExhaustionAsTemporarilyUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/direct_remote_test.go
+++ b/server/internal/platformmcp/direct_remote_test.go
@@ -65,6 +65,61 @@ func TestDirectRemoteRequestAcceptsJSONAndSSE(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 }
 
+func TestDirectRemoteRequestClassifiesSafeFailureCategories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response func(*http.Request) (*http.Response, error)
+		want     SetupCategory
+		broad    error
+	}{
+		{
+			name: "unreachable",
+			response: func(*http.Request) (*http.Response, error) {
+				return nil, &net.DNSError{IsTemporary: true}
+			},
+			want:  SetupCategoryUnreachable,
+			broad: ErrDirectRemoteUnavailable,
+		},
+		{
+			name: "timeout",
+			response: func(*http.Request) (*http.Response, error) {
+				return nil, context.DeadlineExceeded
+			},
+			want:  SetupCategoryTimeout,
+			broad: ErrDirectRemoteUnavailable,
+		},
+		{
+			name: "invalid MCP response",
+			response: func(request *http.Request) (*http.Response, error) {
+				response := directRemoteTestResponse(request, http.StatusOK, `not-json`)
+				return response, nil
+			},
+			want:  SetupCategoryInvalidMCPResponse,
+			broad: ErrDirectRemoteRejected,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			client := &http.Client{Transport: directRemoteTestRoundTripper(test.response)}
+			_, _, _, _, err := directRemoteRequest(t.Context(), client, "https://remote.example.test/mcp", "initialize", map[string]any{}, "", &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 1})
+			require.ErrorIs(t, err, test.broad)
+			require.Equal(t, test.want, setupCategoryFromError(err))
+		})
+	}
+}
+
+func TestGuardianDirectRemoteInspectorClassifiesInvalidURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewGuardianDirectRemoteInspector(directRemoteTestPolicy(t)).Inspect(t.Context(), "http://remote.example.test/mcp")
+	require.ErrorIs(t, err, ErrDirectRemoteRejected)
+	require.Equal(t, SetupCategoryInvalidURL, setupCategoryFromError(err))
+}
+
 func TestDirectRemoteNotificationAcceptsJSONAndSSE(t *testing.T) {
 	t.Parallel()
 
@@ -78,6 +133,15 @@ func TestDirectRemoteNotificationAcceptsJSONAndSSE(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusAccepted, status)
+}
+
+func TestDirectRemoteRequestClassifiesBudgetExhaustionAsTemporarilyUnavailable(t *testing.T) {
+	t.Parallel()
+
+	_, _, _, _, err := directRemoteRequest(t.Context(), http.DefaultClient, "https://remote.example.test/mcp", "initialize", map[string]any{}, "", &directRemoteResponseBudget{remaining: 1024, requestsRemaining: 0})
+
+	require.ErrorIs(t, err, ErrDirectRemoteUnavailable)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, setupCategoryFromError(err))
 }
 
 func TestDirectRemoteRequestRejectsOversizedSessionID(t *testing.T) {

--- a/server/internal/platformmcp/management.go
+++ b/server/internal/platformmcp/management.go
@@ -415,7 +415,7 @@ func (s *ManagementService) state(ctx context.Context, authCtx *contextvalues.Au
 			repairAction = "contact_support"
 		}
 	case registrationComplete && readiness != nil:
-		actions := repairActions(readiness.State)
+		actions := setupRepairActions(setupCategoryFromReadiness(*readiness), readiness.State)
 		if len(actions) > 0 {
 			repairAction = actions[0].Kind
 		}

--- a/server/internal/platformmcp/readiness_service_test.go
+++ b/server/internal/platformmcp/readiness_service_test.go
@@ -95,6 +95,18 @@ func TestReadinessToolOutputDoesNotExposeProviderAuthorizationIdentity(t *testin
 	require.NotContains(t, string(encoded), "connection_generation")
 }
 
+func TestReadinessToolOutputUsesCategorySpecificActions(t *testing.T) {
+	t.Parallel()
+
+	output := readinessToolOutput("project", "registration", Readiness{
+		State:        ReadinessUnsupported,
+		EvidenceCode: "redirect_rejected",
+	}, true)
+
+	require.Equal(t, SetupCategoryUnsafeTargetOrRedirect, output.SetupCategory)
+	require.Equal(t, []RepairAction{{Kind: "review_remote_url", Label: "Review this MCP server's HTTPS URL in the dashboard"}}, output.Actions)
+}
+
 func TestReadyStateSuppressesStaleFailureEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/readiness_service_test.go
+++ b/server/internal/platformmcp/readiness_service_test.go
@@ -63,6 +63,7 @@ func TestMissingReadinessNormalizesToAStableRepairProjection(t *testing.T) {
 
 	require.Equal(t, ReadinessDegraded, readiness.State)
 	require.Equal(t, "readiness_unavailable", readiness.EvidenceCode)
+	require.Equal(t, SetupCategoryTemporarilyUnavailable, output.SetupCategory)
 	require.Equal(t, "unavailable", output.Freshness)
 	require.Equal(t, []RepairAction{{Kind: "retry_readiness", Label: "Check again whether this MCP server is working"}}, output.Actions)
 }
@@ -84,6 +85,7 @@ func TestReadinessToolOutputDoesNotExposeProviderAuthorizationIdentity(t *testin
 	require.Equal(t, "fresh", output.Freshness)
 	require.NotEmpty(t, output.Actions)
 	require.Equal(t, "provider_authorization_rejected", output.EvidenceCode)
+	require.Equal(t, SetupCategoryProviderAuthorizationRejected, output.SetupCategory)
 
 	encoded, err := json.Marshal(output)
 	require.NoError(t, err)
@@ -91,4 +93,28 @@ func TestReadinessToolOutputDoesNotExposeProviderAuthorizationIdentity(t *testin
 	require.NotContains(t, string(encoded), "token")
 	require.NotContains(t, string(encoded), "connection_id")
 	require.NotContains(t, string(encoded), "connection_generation")
+}
+
+func TestReadyStateSuppressesStaleFailureEvidence(t *testing.T) {
+	t.Parallel()
+
+	output := readinessToolOutput("project", "registration", Readiness{
+		State:        ReadinessReady,
+		EvidenceCode: "provider_authorization_rejected",
+	}, true)
+
+	require.Empty(t, output.SetupCategory)
+	require.Empty(t, output.Actions)
+}
+
+func TestGuideUnavailableKeepsContactSupportRepairAction(t *testing.T) {
+	t.Parallel()
+
+	output := readinessToolOutput("project", "registration", Readiness{
+		State:        ReadinessGuideUnavailable,
+		EvidenceCode: "guide_missing",
+	}, true)
+
+	require.Empty(t, output.SetupCategory)
+	require.Equal(t, []RepairAction{{Kind: "contact_support", Label: "Ask an administrator to restore the setup guide for this MCP server"}}, output.Actions)
 }

--- a/server/internal/platformmcp/remotesessionprovider/adapter.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter.go
@@ -296,6 +296,9 @@ func normalizedProbeFailure(err error, authRT *authorizationRoundTripper, stage 
 	if authRT.authorizationRejected.Load() {
 		return platformmcp.ReadinessUnauthorized, "provider_authorization_rejected"
 	}
+	if authRT.transientResponse.Load() {
+		return platformmcp.ReadinessDegraded, "probe_temporarily_unavailable"
+	}
 	if authRT.responseTooLarge.Load() || errors.Is(err, errResponseTooLarge) {
 		if stage == probeStageToolsList {
 			return platformmcp.ReadinessDegraded, "tools_list_response_too_large"
@@ -308,9 +311,6 @@ func normalizedProbeFailure(err error, authRT *authorizationRoundTripper, stage 
 	state, evidence := platformmcp.ClassifyReadinessProbeFailure(err)
 	if evidence == "probe_timeout" || evidence == "probe_unreachable" {
 		return state, evidence
-	}
-	if authRT.transientResponse.Load() {
-		return platformmcp.ReadinessDegraded, "probe_temporarily_unavailable"
 	}
 	if evidence == "probe_failed" && authRT.responseReceived.Load() && !platformmcp.IsReadinessMCPErrorResponse(err) {
 		return platformmcp.ReadinessUnsupported, "invalid_mcp_response"
@@ -382,7 +382,7 @@ func (rt *authorizationRoundTripper) RoundTrip(request *http.Request) (*http.Res
 }
 
 func transientProbeStatus(status int) bool {
-	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
 }
 
 type boundedReadCloser struct {

--- a/server/internal/platformmcp/remotesessionprovider/adapter.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter.go
@@ -228,6 +228,8 @@ func (a *Adapter) probe(ctx context.Context, descriptor Descriptor, token string
 		authorization:         "Bearer " + token,
 		authorizationRejected: atomic.Bool{},
 		responseTooLarge:      atomic.Bool{},
+		responseReceived:      atomic.Bool{},
+		transientResponse:     atomic.Bool{},
 	}
 	httpClient.Transport = authRT
 
@@ -247,11 +249,11 @@ func (a *Adapter) probe(ctx context.Context, descriptor Descriptor, token string
 		DisableStandaloneSSE: true,
 	}, nil)
 	if err != nil {
-		return normalizedProbeFailure(err, authRT)
+		return normalizedProbeFailure(err, authRT, probeStageInitialize)
 	}
 	defer func() { _ = session.Close() }()
 	if _, err := session.ListTools(ctx, nil); err != nil {
-		return normalizedProbeFailure(err, authRT)
+		return normalizedProbeFailure(err, authRT, probeStageToolsList)
 	}
 	return platformmcp.ReadinessReady, "tools_list_ok"
 }
@@ -280,17 +282,40 @@ func (a *Adapter) readinessResult(state platformmcp.ReadinessState, evidence str
 	}
 }
 
-func normalizedProbeFailure(err error, authRT *authorizationRoundTripper) (platformmcp.ReadinessState, string) {
+type probeStage string
+
+const (
+	probeStageInitialize probeStage = "initialize"
+	probeStageToolsList  probeStage = "tools_list"
+)
+
+func normalizedProbeFailure(err error, authRT *authorizationRoundTripper, stage probeStage) (platformmcp.ReadinessState, string) {
+	if authRT == nil {
+		return platformmcp.ReadinessUnsupported, "invalid_mcp_response"
+	}
 	if authRT.authorizationRejected.Load() {
 		return platformmcp.ReadinessUnauthorized, "provider_authorization_rejected"
 	}
 	if authRT.responseTooLarge.Load() || errors.Is(err, errResponseTooLarge) {
-		return platformmcp.ReadinessUnsupported, "response_too_large"
+		if stage == probeStageToolsList {
+			return platformmcp.ReadinessDegraded, "tools_list_response_too_large"
+		}
+		return platformmcp.ReadinessUnsupported, "initialize_response_too_large"
 	}
 	if errors.Is(err, errRedirectRejected) {
 		return platformmcp.ReadinessUnsupported, "redirect_rejected"
 	}
-	return platformmcp.ClassifyReadinessProbeFailure(err)
+	state, evidence := platformmcp.ClassifyReadinessProbeFailure(err)
+	if evidence == "probe_timeout" || evidence == "probe_unreachable" {
+		return state, evidence
+	}
+	if authRT.transientResponse.Load() {
+		return platformmcp.ReadinessDegraded, "probe_temporarily_unavailable"
+	}
+	if evidence == "probe_failed" && authRT.responseReceived.Load() && !platformmcp.IsReadinessMCPErrorResponse(err) {
+		return platformmcp.ReadinessUnsupported, "invalid_mcp_response"
+	}
+	return state, evidence
 }
 
 func validateSetupRequest(request platformmcp.ProviderSetupRequest) error {
@@ -329,6 +354,8 @@ type authorizationRoundTripper struct {
 	authorization         string
 	authorizationRejected atomic.Bool
 	responseTooLarge      atomic.Bool
+	responseReceived      atomic.Bool
+	transientResponse     atomic.Bool
 }
 
 func (rt *authorizationRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -338,8 +365,12 @@ func (rt *authorizationRoundTripper) RoundTrip(request *http.Request) (*http.Res
 	if err != nil {
 		return nil, fmt.Errorf("send reviewed provider request: %w", err)
 	}
+	rt.responseReceived.Store(true)
 	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
 		rt.authorizationRejected.Store(true)
+	}
+	if transientProbeStatus(response.StatusCode) {
+		rt.transientResponse.Store(true)
 	}
 	if response.ContentLength > maxResponseBytes {
 		rt.responseTooLarge.Store(true)
@@ -348,6 +379,10 @@ func (rt *authorizationRoundTripper) RoundTrip(request *http.Request) (*http.Res
 	}
 	response.Body = &boundedReadCloser{ReadCloser: response.Body, remaining: maxResponseBytes, exceeded: &rt.responseTooLarge}
 	return response, nil
+}
+
+func transientProbeStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError || status == http.StatusBadGateway || status == http.StatusServiceUnavailable || status == http.StatusGatewayTimeout
 }
 
 type boundedReadCloser struct {

--- a/server/internal/platformmcp/remotesessionprovider/adapter.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter.go
@@ -290,7 +290,7 @@ func normalizedProbeFailure(err error, authRT *authorizationRoundTripper) (platf
 	if errors.Is(err, errRedirectRejected) {
 		return platformmcp.ReadinessUnsupported, "redirect_rejected"
 	}
-	return platformmcp.ReadinessUnreachable, "probe_failed"
+	return platformmcp.ClassifyReadinessProbeFailure(err)
 }
 
 func validateSetupRequest(request platformmcp.ProviderSetupRequest) error {

--- a/server/internal/platformmcp/remotesessionprovider/adapter_test.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter_test.go
@@ -122,6 +122,24 @@ func TestNormalizedProbeFailureDistinguishesResponseSizeByStage(t *testing.T) {
 	}
 }
 
+func TestNormalizedProbeFailureKeepsTransientPrecedenceOverResponseSize(t *testing.T) {
+	t.Parallel()
+
+	roundTripper := &authorizationRoundTripper{}
+	roundTripper.transientResponse.Store(true)
+	roundTripper.responseTooLarge.Store(true)
+	state, evidence := normalizedProbeFailure(errResponseTooLarge, roundTripper, probeStageInitialize)
+	require.Equal(t, platformmcp.ReadinessDegraded, state)
+	require.Equal(t, "probe_temporarily_unavailable", evidence)
+}
+
+func TestTransientProbeStatusIncludesRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, transientProbeStatus(http.StatusRequestTimeout))
+	require.False(t, transientProbeStatus(http.StatusBadRequest))
+}
+
 func TestNormalizedProbeFailureKeepsAuthorizationRejectionPrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/remotesessionprovider/adapter_test.go
+++ b/server/internal/platformmcp/remotesessionprovider/adapter_test.go
@@ -99,6 +99,61 @@ func TestBoundedReadCloserRejectsOverflow(t *testing.T) {
 	require.ErrorIs(t, err, errResponseTooLarge)
 }
 
+func TestNormalizedProbeFailureDistinguishesResponseSizeByStage(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		stage        probeStage
+		wantState    platformmcp.ReadinessState
+		wantEvidence string
+	}{
+		{name: "initialize", stage: probeStageInitialize, wantState: platformmcp.ReadinessUnsupported, wantEvidence: "initialize_response_too_large"},
+		{name: "tools list", stage: probeStageToolsList, wantState: platformmcp.ReadinessDegraded, wantEvidence: "tools_list_response_too_large"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			roundTripper := &authorizationRoundTripper{}
+			roundTripper.responseTooLarge.Store(true)
+			state, evidence := normalizedProbeFailure(errResponseTooLarge, roundTripper, test.stage)
+			require.Equal(t, test.wantState, state)
+			require.Equal(t, test.wantEvidence, evidence)
+		})
+	}
+}
+
+func TestNormalizedProbeFailureKeepsAuthorizationRejectionPrecedence(t *testing.T) {
+	t.Parallel()
+
+	roundTripper := &authorizationRoundTripper{}
+	roundTripper.authorizationRejected.Store(true)
+	roundTripper.transientResponse.Store(true)
+	state, evidence := normalizedProbeFailure(errors.New("private HTTP detail"), roundTripper, probeStageInitialize)
+	require.Equal(t, platformmcp.ReadinessUnauthorized, state)
+	require.Equal(t, "provider_authorization_rejected", evidence)
+}
+
+func TestNormalizedProbeFailureClassifiesHTTPProtocolAndTransportFailures(t *testing.T) {
+	t.Parallel()
+
+	response := &authorizationRoundTripper{}
+	response.responseReceived.Store(true)
+	state, evidence := normalizedProbeFailure(errors.New("private SDK detail"), response, probeStageInitialize)
+	require.Equal(t, platformmcp.ReadinessUnsupported, state)
+	require.Equal(t, "invalid_mcp_response", evidence)
+
+	state, evidence = normalizedProbeFailure(errors.New("private transport detail"), &authorizationRoundTripper{}, probeStageInitialize)
+	require.Equal(t, platformmcp.ReadinessUnreachable, state)
+	require.Equal(t, "probe_failed", evidence)
+
+	transient := &authorizationRoundTripper{}
+	transient.responseReceived.Store(true)
+	transient.transientResponse.Store(true)
+	state, evidence = normalizedProbeFailure(errors.New("private HTTP detail"), transient, probeStageInitialize)
+	require.Equal(t, platformmcp.ReadinessDegraded, state)
+	require.Equal(t, "probe_temporarily_unavailable", evidence)
+}
+
 func TestAuthorizationRoundTripperRejectsChunkedOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/remotesessionprovider/vertical_integration_test.go
+++ b/server/internal/platformmcp/remotesessionprovider/vertical_integration_test.go
@@ -160,7 +160,7 @@ func TestReviewedRemoteSessionProviderVerticalSlice(t *testing.T) {
 	overflow, err := adapter.ProbeReadiness(ctx, providerProbeRequest(principal, project.ID, registration))
 	require.NoError(t, err)
 	require.Equal(t, platformmcp.ReadinessUnsupported, overflow.State)
-	require.Equal(t, "response_too_large", overflow.EvidenceCode)
+	require.Equal(t, "initialize_response_too_large", overflow.EvidenceCode)
 	upstream.mode.Store(upstreamModeNormal)
 
 	_, err = remotesessionsrepo.New(conn).RevokeRemoteSession(ctx, remotesessionsrepo.RevokeRemoteSessionParams{ID: remoteSession.ID, ProjectID: project.ID})

--- a/server/internal/platformmcp/setup_diagnostics.go
+++ b/server/internal/platformmcp/setup_diagnostics.go
@@ -1,0 +1,218 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"net"
+)
+
+// SetupCategory is the privacy-safe reason an MCP setup needs attention. Values
+// are server-authored from typed errors or closed evidence codes; raw provider,
+// network, or protocol text must never be used as a category.
+type SetupCategory string
+
+const (
+	SetupCategoryInvalidURL                     SetupCategory = "invalid_url"
+	SetupCategoryUnsafeTargetOrRedirect         SetupCategory = "unsafe_target_or_redirect"
+	SetupCategoryUnreachable                    SetupCategory = "unreachable"
+	SetupCategoryTimeout                        SetupCategory = "timeout"
+	SetupCategoryInvalidMCPResponse             SetupCategory = "invalid_mcp_response"
+	SetupCategoryAuthenticationRequired         SetupCategory = "authentication_required"
+	SetupCategoryConfigurationRequired          SetupCategory = "configuration_required"
+	SetupCategoryOAuthMetadataIncomplete        SetupCategory = "oauth_metadata_incomplete"
+	SetupCategoryDynamicRegistrationUnsupported SetupCategory = "dynamic_registration_unsupported"
+	SetupCategoryProviderAuthorizationRejected  SetupCategory = "provider_authorization_rejected"
+	SetupCategoryTemporarilyUnavailable         SetupCategory = "temporarily_unavailable"
+)
+
+var allSetupCategories = []SetupCategory{
+	SetupCategoryInvalidURL,
+	SetupCategoryUnsafeTargetOrRedirect,
+	SetupCategoryUnreachable,
+	SetupCategoryTimeout,
+	SetupCategoryInvalidMCPResponse,
+	SetupCategoryAuthenticationRequired,
+	SetupCategoryConfigurationRequired,
+	SetupCategoryOAuthMetadataIncomplete,
+	SetupCategoryDynamicRegistrationUnsupported,
+	SetupCategoryProviderAuthorizationRejected,
+	SetupCategoryTemporarilyUnavailable,
+}
+
+func setupCategoryEnumValues() []any {
+	values := make([]any, 0, len(allSetupCategories))
+	for _, category := range allSetupCategories {
+		values = append(values, string(category))
+	}
+	return values
+}
+
+type setupDiagnosticError struct {
+	category SetupCategory
+	cause    error
+}
+
+func (e *setupDiagnosticError) Error() string {
+	if e == nil || e.cause == nil {
+		return "platform mcp setup diagnostic unavailable"
+	}
+	return e.cause.Error()
+}
+
+func (e *setupDiagnosticError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func setupFailure(category SetupCategory, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return &setupDiagnosticError{category: category, cause: cause}
+}
+
+func setupCategoryFromError(err error) SetupCategory {
+	if diagnostic, ok := errors.AsType[*setupDiagnosticError](err); ok && diagnostic != nil {
+		return diagnostic.category
+	}
+	return ""
+}
+
+// sanitizedSetupFailure keeps only a category and the established broad
+// sentinel when an HTTP client wraps a redirect or transport failure. This
+// prevents target URLs and provider-specific text from crossing the boundary.
+func sanitizedSetupFailure(err error) error {
+	category := setupCategoryFromError(err)
+	if errors.Is(err, ErrDirectRemoteRejected) {
+		return setupFailure(category, ErrDirectRemoteRejected)
+	}
+	return setupFailure(category, ErrDirectRemoteUnavailable)
+}
+
+func setupCategoryFromInspection(inspection DirectRemoteInspection) SetupCategory {
+	if inspection.Authentication != "authentication_required" {
+		return ""
+	}
+	switch inspection.OAuthDiscovery {
+	case "available_dcr":
+		return SetupCategoryAuthenticationRequired
+	case "available":
+		return SetupCategoryDynamicRegistrationUnsupported
+	default:
+		return SetupCategoryOAuthMetadataIncomplete
+	}
+}
+
+// ClassifyReadinessProbeFailure separates transport failures from invalid MCP
+// responses without exposing the underlying network or protocol error. It is
+// exported for provider adapters in child packages; callers receive only the
+// closed state and evidence code, never the original error.
+func ClassifyReadinessProbeFailure(err error) (ReadinessState, string) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ReadinessUnreachable, "probe_timeout"
+	}
+	if networkError, ok := errors.AsType[net.Error](err); ok {
+		if networkError.Timeout() {
+			return ReadinessUnreachable, "probe_timeout"
+		}
+		return ReadinessUnreachable, "probe_unreachable"
+	}
+	// Preserve the established readiness state and evidence for MCP negotiation
+	// failures that do not expose a typed network cause. More specific producers
+	// such as response-size and redirect guards retain their existing evidence.
+	return ReadinessUnreachable, "probe_failed"
+}
+
+func setupCategoryFromReadiness(readiness Readiness) SetupCategory {
+	if readiness.State == ReadinessReady {
+		return ""
+	}
+	switch readiness.EvidenceCode {
+	case "invalid_url":
+		return SetupCategoryInvalidURL
+	case "redirect_rejected", "unsafe_target_or_redirect":
+		return SetupCategoryUnsafeTargetOrRedirect
+	case "probe_timeout":
+		return SetupCategoryTimeout
+	case "probe_failed", "probe_unreachable":
+		return SetupCategoryUnreachable
+	case "invalid_mcp_response", "response_too_large":
+		return SetupCategoryInvalidMCPResponse
+	case "upstream_authorization_required", "no_valid_authorization":
+		return SetupCategoryAuthenticationRequired
+	case "required_header_missing", "request_header_not_supported", "multiple_upstream_identity_providers", "upstream_identity_provider_not_configured", "no_reviewed_client":
+		return SetupCategoryConfigurationRequired
+	case "oauth_metadata_incomplete":
+		return SetupCategoryOAuthMetadataIncomplete
+	case "dynamic_registration_unsupported":
+		return SetupCategoryDynamicRegistrationUnsupported
+	case "upstream_authorization_rejected", "provider_authorization_rejected":
+		return SetupCategoryProviderAuthorizationRejected
+	case "readiness_unavailable":
+		return SetupCategoryTemporarilyUnavailable
+	}
+
+	switch readiness.State {
+	case ReadinessReady:
+		return ""
+	case ReadinessNeedsProviderSetup:
+		return SetupCategoryOAuthMetadataIncomplete
+	case ReadinessNeedsGramAuthorization:
+		return SetupCategoryAuthenticationRequired
+	case ReadinessAuthFailed, ReadinessUnauthorized:
+		return SetupCategoryProviderAuthorizationRejected
+	case ReadinessNeedsConfiguration:
+		return SetupCategoryConfigurationRequired
+	case ReadinessUnreachable:
+		return SetupCategoryUnreachable
+	case ReadinessUnsupported:
+		return SetupCategoryInvalidMCPResponse
+	case ReadinessGuideUnavailable:
+		return ""
+	default:
+		return SetupCategoryTemporarilyUnavailable
+	}
+}
+
+func inspectionFailureActions(category SetupCategory) []RepairAction {
+	switch category {
+	case SetupCategoryInvalidURL, SetupCategoryUnsafeTargetOrRedirect:
+		return []RepairAction{{Kind: "review_remote_url", Label: "Use a public HTTPS MCP endpoint without credentials in the URL"}}
+	case SetupCategoryInvalidMCPResponse:
+		return []RepairAction{{Kind: "review_remote_endpoint", Label: "Check that the URL serves MCP over Streamable HTTP"}}
+	case SetupCategoryUnreachable, SetupCategoryTimeout, SetupCategoryTemporarilyUnavailable:
+		return []RepairAction{{Kind: "retry_inspection", Label: "Check this MCP server again shortly"}}
+	default:
+		return nil
+	}
+}
+
+func inspectionResultActions(category SetupCategory) []RepairAction {
+	switch category {
+	case SetupCategoryAuthenticationRequired, SetupCategoryConfigurationRequired, SetupCategoryOAuthMetadataIncomplete, SetupCategoryDynamicRegistrationUnsupported, SetupCategoryProviderAuthorizationRejected:
+		return []RepairAction{{Kind: "continue_registration", Label: "Choose a project and add this MCP server before finishing its sign-in setup"}}
+	default:
+		return nil
+	}
+}
+
+func setupRepairActions(category SetupCategory, state ReadinessState) []RepairAction {
+	if state == ReadinessReady && category == "" {
+		return []RepairAction{}
+	}
+
+	switch category {
+	case SetupCategoryInvalidURL, SetupCategoryUnsafeTargetOrRedirect:
+		return []RepairAction{{Kind: "review_remote_url", Label: "Review this MCP server's HTTPS URL in the dashboard"}}
+	case SetupCategoryInvalidMCPResponse:
+		return []RepairAction{{Kind: "retry_readiness", Label: "Check the MCP server endpoint, then check again"}}
+	case SetupCategoryAuthenticationRequired, SetupCategoryConfigurationRequired, SetupCategoryOAuthMetadataIncomplete, SetupCategoryDynamicRegistrationUnsupported, SetupCategoryProviderAuthorizationRejected:
+		return []RepairAction{{Kind: "continue_dashboard_setup", Label: "Finish this MCP server's source and sign-in setup in the dashboard"}}
+	case SetupCategoryUnreachable, SetupCategoryTimeout, SetupCategoryTemporarilyUnavailable:
+		return []RepairAction{{Kind: "retry_readiness", Label: "Check again whether this MCP server is working"}}
+	}
+
+	return repairActions(state)
+}

--- a/server/internal/platformmcp/setup_diagnostics.go
+++ b/server/internal/platformmcp/setup_diagnostics.go
@@ -2,8 +2,11 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 // SetupCategory is the privacy-safe reason an MCP setup needs attention. Values
@@ -119,10 +122,30 @@ func ClassifyReadinessProbeFailure(err error) (ReadinessState, string) {
 		}
 		return ReadinessUnreachable, "probe_unreachable"
 	}
-	// Preserve the established readiness state and evidence for MCP negotiation
-	// failures that do not expose a typed network cause. More specific producers
-	// such as response-size and redirect guards retain their existing evidence.
+	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
+		return ReadinessUnsupported, "invalid_mcp_response"
+	}
+	if _, ok := errors.AsType[*json.UnmarshalTypeError](err); ok {
+		return ReadinessUnsupported, "invalid_mcp_response"
+	}
+	if protocolError, ok := errors.AsType[*jsonrpc.Error](err); ok {
+		switch protocolError.Code {
+		case jsonrpc.CodeParseError, jsonrpc.CodeInvalidRequest, jsonrpc.CodeInvalidParams:
+			return ReadinessUnsupported, "invalid_mcp_response"
+		}
+	}
+	// Unknown failures remain transport failures here. Producers that know an
+	// error crossed a valid HTTP response boundary classify that stage before
+	// delegating to this fallback.
 	return ReadinessUnreachable, "probe_failed"
+}
+
+// IsReadinessMCPErrorResponse reports whether an SDK error preserves a
+// well-formed server-authored JSON-RPC error. Provider adapters use it to avoid
+// treating a valid error response as malformed protocol data.
+func IsReadinessMCPErrorResponse(err error) bool {
+	_, ok := errors.AsType[*jsonrpc.Error](err)
+	return ok
 }
 
 func setupCategoryFromReadiness(readiness Readiness) SetupCategory {
@@ -138,8 +161,12 @@ func setupCategoryFromReadiness(readiness Readiness) SetupCategory {
 		return SetupCategoryTimeout
 	case "probe_failed", "probe_unreachable":
 		return SetupCategoryUnreachable
-	case "invalid_mcp_response", "response_too_large":
+	case "invalid_mcp_response", "initialize_response_too_large":
 		return SetupCategoryInvalidMCPResponse
+	case "tools_list_response_too_large", "probe_temporarily_unavailable":
+		return SetupCategoryTemporarilyUnavailable
+	case "readiness_not_managed":
+		return ""
 	case "upstream_authorization_required", "no_valid_authorization":
 		return SetupCategoryAuthenticationRequired
 	case "required_header_missing", "request_header_not_supported", "multiple_upstream_identity_providers", "upstream_identity_provider_not_configured", "no_reviewed_client":
@@ -199,7 +226,7 @@ func inspectionResultActions(category SetupCategory) []RepairAction {
 }
 
 func setupRepairActions(category SetupCategory, state ReadinessState) []RepairAction {
-	if state == ReadinessReady && category == "" {
+	if category == "" && (state == ReadinessReady || state == ReadinessUnsupported) {
 		return []RepairAction{}
 	}
 

--- a/server/internal/platformmcp/setup_diagnostics_test.go
+++ b/server/internal/platformmcp/setup_diagnostics_test.go
@@ -1,0 +1,147 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupCategoryFromInspection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		inspection DirectRemoteInspection
+		want       SetupCategory
+	}{
+		{name: "anonymous", inspection: DirectRemoteInspection{Authentication: "anonymous"}},
+		{name: "dynamic registration", inspection: DirectRemoteInspection{Authentication: "authentication_required", OAuthDiscovery: "available_dcr"}, want: SetupCategoryAuthenticationRequired},
+		{name: "registration unsupported", inspection: DirectRemoteInspection{Authentication: "authentication_required", OAuthDiscovery: "available"}, want: SetupCategoryDynamicRegistrationUnsupported},
+		{name: "metadata incomplete", inspection: DirectRemoteInspection{Authentication: "authentication_required", OAuthDiscovery: "incomplete"}, want: SetupCategoryOAuthMetadataIncomplete},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, setupCategoryFromInspection(test.inspection))
+		})
+	}
+}
+
+func TestSetupCategoryFromReadinessEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		evidence string
+		state    ReadinessState
+		want     SetupCategory
+	}{
+		{evidence: "invalid_url", state: ReadinessUnsupported, want: SetupCategoryInvalidURL},
+		{evidence: "redirect_rejected", state: ReadinessUnsupported, want: SetupCategoryUnsafeTargetOrRedirect},
+		{evidence: "probe_unreachable", state: ReadinessUnreachable, want: SetupCategoryUnreachable},
+		{evidence: "probe_timeout", state: ReadinessUnreachable, want: SetupCategoryTimeout},
+		{evidence: "invalid_mcp_response", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
+		{evidence: "response_too_large", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
+		{evidence: "upstream_authorization_required", state: ReadinessNeedsGramAuthorization, want: SetupCategoryAuthenticationRequired},
+		{evidence: "required_header_missing", state: ReadinessNeedsConfiguration, want: SetupCategoryConfigurationRequired},
+		{evidence: "oauth_metadata_incomplete", state: ReadinessNeedsProviderSetup, want: SetupCategoryOAuthMetadataIncomplete},
+		{evidence: "dynamic_registration_unsupported", state: ReadinessNeedsProviderSetup, want: SetupCategoryDynamicRegistrationUnsupported},
+		{evidence: "provider_authorization_rejected", state: ReadinessUnauthorized, want: SetupCategoryProviderAuthorizationRejected},
+		{evidence: "readiness_unavailable", state: ReadinessDegraded, want: SetupCategoryTemporarilyUnavailable},
+		{evidence: "tools_list_ok", state: ReadinessReady},
+		{evidence: "provider_authorization_rejected", state: ReadinessReady},
+	}
+	for _, test := range tests {
+		t.Run(test.evidence, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, setupCategoryFromReadiness(Readiness{State: test.state, EvidenceCode: test.evidence}))
+		})
+	}
+}
+
+func TestClassifyReadinessProbeFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		err          error
+		wantState    ReadinessState
+		wantEvidence string
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, wantState: ReadinessUnreachable, wantEvidence: "probe_timeout"},
+		{name: "network timeout", err: &net.DNSError{IsTimeout: true}, wantState: ReadinessUnreachable, wantEvidence: "probe_timeout"},
+		{name: "network unreachable", err: &net.DNSError{IsTemporary: true}, wantState: ReadinessUnreachable, wantEvidence: "probe_unreachable"},
+		{name: "unclassified probe failure", err: errors.New("private upstream response detail"), wantState: ReadinessUnreachable, wantEvidence: "probe_failed"},
+		{name: "nil failure", err: nil, wantState: ReadinessUnreachable, wantEvidence: "probe_failed"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			state, evidence := ClassifyReadinessProbeFailure(test.err)
+			require.Equal(t, test.wantState, state)
+			require.Equal(t, test.wantEvidence, evidence)
+		})
+	}
+}
+
+func TestSetupFailurePreservesBroadErrorIdentity(t *testing.T) {
+	t.Parallel()
+
+	err := setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected)
+	require.ErrorIs(t, err, ErrDirectRemoteRejected)
+	require.Equal(t, SetupCategoryUnsafeTargetOrRedirect, setupCategoryFromError(err))
+}
+
+func TestSanitizedSetupFailureDropsWrappedTargetDetails(t *testing.T) {
+	t.Parallel()
+
+	wrapped := &url.Error{
+		Op:  "Get",
+		URL: "https://private.example.test/mcp?tenant=sensitive",
+		Err: setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected),
+	}
+	sanitized := sanitizedSetupFailure(wrapped)
+
+	require.ErrorIs(t, sanitized, ErrDirectRemoteRejected)
+	require.Equal(t, SetupCategoryUnsafeTargetOrRedirect, setupCategoryFromError(sanitized))
+	require.NotContains(t, sanitized.Error(), "private.example.test")
+	require.NotContains(t, sanitized.Error(), "sensitive")
+}
+
+func TestZeroValueSetupDiagnosticErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	err := &setupDiagnosticError{}
+	require.Equal(t, "platform mcp setup diagnostic unavailable", err.Error())
+	require.NoError(t, err.Unwrap())
+}
+
+func TestSetupRepairActionsAreBoundedAndContainNoSensitiveDetail(t *testing.T) {
+	t.Parallel()
+
+	for _, category := range []SetupCategory{
+		SetupCategoryInvalidURL,
+		SetupCategoryUnsafeTargetOrRedirect,
+		SetupCategoryUnreachable,
+		SetupCategoryTimeout,
+		SetupCategoryInvalidMCPResponse,
+		SetupCategoryAuthenticationRequired,
+		SetupCategoryConfigurationRequired,
+		SetupCategoryOAuthMetadataIncomplete,
+		SetupCategoryDynamicRegistrationUnsupported,
+		SetupCategoryProviderAuthorizationRejected,
+		SetupCategoryTemporarilyUnavailable,
+	} {
+		actions := setupRepairActions(category, ReadinessDegraded)
+		require.NotEmpty(t, actions, category)
+		require.LessOrEqual(t, len(actions), 3, category)
+		for _, action := range actions {
+			require.NotContains(t, action.Label, "private upstream response detail")
+			require.NotContains(t, action.Label, "token")
+			require.NotContains(t, action.Label, "header")
+		}
+	}
+}

--- a/server/internal/platformmcp/setup_diagnostics_test.go
+++ b/server/internal/platformmcp/setup_diagnostics_test.go
@@ -2,11 +2,13 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/url"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,27 +37,31 @@ func TestSetupCategoryFromReadinessEvidence(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name     string
 		evidence string
 		state    ReadinessState
 		want     SetupCategory
 	}{
-		{evidence: "invalid_url", state: ReadinessUnsupported, want: SetupCategoryInvalidURL},
-		{evidence: "redirect_rejected", state: ReadinessUnsupported, want: SetupCategoryUnsafeTargetOrRedirect},
-		{evidence: "probe_unreachable", state: ReadinessUnreachable, want: SetupCategoryUnreachable},
-		{evidence: "probe_timeout", state: ReadinessUnreachable, want: SetupCategoryTimeout},
-		{evidence: "invalid_mcp_response", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
-		{evidence: "response_too_large", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
-		{evidence: "upstream_authorization_required", state: ReadinessNeedsGramAuthorization, want: SetupCategoryAuthenticationRequired},
-		{evidence: "required_header_missing", state: ReadinessNeedsConfiguration, want: SetupCategoryConfigurationRequired},
-		{evidence: "oauth_metadata_incomplete", state: ReadinessNeedsProviderSetup, want: SetupCategoryOAuthMetadataIncomplete},
-		{evidence: "dynamic_registration_unsupported", state: ReadinessNeedsProviderSetup, want: SetupCategoryDynamicRegistrationUnsupported},
-		{evidence: "provider_authorization_rejected", state: ReadinessUnauthorized, want: SetupCategoryProviderAuthorizationRejected},
-		{evidence: "readiness_unavailable", state: ReadinessDegraded, want: SetupCategoryTemporarilyUnavailable},
-		{evidence: "tools_list_ok", state: ReadinessReady},
-		{evidence: "provider_authorization_rejected", state: ReadinessReady},
+		{name: "invalid URL", evidence: "invalid_url", state: ReadinessUnsupported, want: SetupCategoryInvalidURL},
+		{name: "redirect rejected", evidence: "redirect_rejected", state: ReadinessUnsupported, want: SetupCategoryUnsafeTargetOrRedirect},
+		{name: "unreachable", evidence: "probe_unreachable", state: ReadinessUnreachable, want: SetupCategoryUnreachable},
+		{name: "timeout", evidence: "probe_timeout", state: ReadinessUnreachable, want: SetupCategoryTimeout},
+		{name: "invalid MCP response", evidence: "invalid_mcp_response", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
+		{name: "oversized initialize response", evidence: "initialize_response_too_large", state: ReadinessUnsupported, want: SetupCategoryInvalidMCPResponse},
+		{name: "oversized tools list response", evidence: "tools_list_response_too_large", state: ReadinessDegraded, want: SetupCategoryTemporarilyUnavailable},
+		{name: "transient HTTP response", evidence: "probe_temporarily_unavailable", state: ReadinessDegraded, want: SetupCategoryTemporarilyUnavailable},
+		{name: "authentication required", evidence: "upstream_authorization_required", state: ReadinessNeedsGramAuthorization, want: SetupCategoryAuthenticationRequired},
+		{name: "configuration required", evidence: "required_header_missing", state: ReadinessNeedsConfiguration, want: SetupCategoryConfigurationRequired},
+		{name: "OAuth metadata incomplete", evidence: "oauth_metadata_incomplete", state: ReadinessNeedsProviderSetup, want: SetupCategoryOAuthMetadataIncomplete},
+		{name: "dynamic registration unsupported", evidence: "dynamic_registration_unsupported", state: ReadinessNeedsProviderSetup, want: SetupCategoryDynamicRegistrationUnsupported},
+		{name: "provider authorization rejected", evidence: "provider_authorization_rejected", state: ReadinessUnauthorized, want: SetupCategoryProviderAuthorizationRejected},
+		{name: "readiness unavailable", evidence: "readiness_unavailable", state: ReadinessDegraded, want: SetupCategoryTemporarilyUnavailable},
+		{name: "unmanaged readiness", evidence: "readiness_not_managed", state: ReadinessUnsupported},
+		{name: "ready", evidence: "tools_list_ok", state: ReadinessReady},
+		{name: "ready suppresses stale evidence", evidence: "provider_authorization_rejected", state: ReadinessReady},
 	}
 	for _, test := range tests {
-		t.Run(test.evidence, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, test.want, setupCategoryFromReadiness(Readiness{State: test.state, EvidenceCode: test.evidence}))
 		})
@@ -74,6 +80,10 @@ func TestClassifyReadinessProbeFailure(t *testing.T) {
 		{name: "deadline", err: context.DeadlineExceeded, wantState: ReadinessUnreachable, wantEvidence: "probe_timeout"},
 		{name: "network timeout", err: &net.DNSError{IsTimeout: true}, wantState: ReadinessUnreachable, wantEvidence: "probe_timeout"},
 		{name: "network unreachable", err: &net.DNSError{IsTemporary: true}, wantState: ReadinessUnreachable, wantEvidence: "probe_unreachable"},
+		{name: "malformed JSON", err: &json.SyntaxError{}, wantState: ReadinessUnsupported, wantEvidence: "invalid_mcp_response"},
+		{name: "invalid JSON shape", err: &json.UnmarshalTypeError{}, wantState: ReadinessUnsupported, wantEvidence: "invalid_mcp_response"},
+		{name: "invalid JSON-RPC request", err: &jsonrpc.Error{Code: jsonrpc.CodeInvalidRequest}, wantState: ReadinessUnsupported, wantEvidence: "invalid_mcp_response"},
+		{name: "valid JSON-RPC application error", err: &jsonrpc.Error{Code: jsonrpc.CodeMethodNotFound}, wantState: ReadinessUnreachable, wantEvidence: "probe_failed"},
 		{name: "unclassified probe failure", err: errors.New("private upstream response detail"), wantState: ReadinessUnreachable, wantEvidence: "probe_failed"},
 		{name: "nil failure", err: nil, wantState: ReadinessUnreachable, wantEvidence: "probe_failed"},
 	}
@@ -117,6 +127,13 @@ func TestZeroValueSetupDiagnosticErrorDoesNotPanic(t *testing.T) {
 	err := &setupDiagnosticError{}
 	require.Equal(t, "platform mcp setup diagnostic unavailable", err.Error())
 	require.NoError(t, err.Unwrap())
+}
+
+func TestSetupRepairActionsUseCategorySpecificGuidance(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []RepairAction{{Kind: "review_remote_url", Label: "Review this MCP server's HTTPS URL in the dashboard"}}, setupRepairActions(SetupCategoryUnsafeTargetOrRedirect, ReadinessUnsupported))
+	require.Empty(t, setupRepairActions("", ReadinessUnsupported))
 }
 
 func TestSetupRepairActionsAreBoundedAndContainNoSensitiveDetail(t *testing.T) {

--- a/server/internal/platformmcp/tool_catalog.go
+++ b/server/internal/platformmcp/tool_catalog.go
@@ -46,6 +46,8 @@ type CandidateInspection struct {
 	Authentication         string                      `json:"authentication,omitempty"`
 	OAuthDiscovery         string                      `json:"oauth_discovery,omitempty"`
 	SetupIntent            string                      `json:"setup_intent,omitempty"`
+	SetupCategory          SetupCategory               `json:"setup_category,omitempty"`
+	Actions                []RepairAction              `json:"actions,omitempty"`
 }
 
 func registerCatalogTools(reg *Registrar, catalog Catalog, budget OperationBudget, cursorCodec *catalogCursorCodec, onboarding *OnboardingService) {
@@ -133,20 +135,21 @@ func registerCandidateInspectionTool(reg *Registrar, catalog Catalog, directRemo
 		}
 		if remoteURL != "" {
 			if directRemote == nil || gate == nil {
-				return directRemoteInspectionUnavailableToolResult()
+				return directRemoteInspectionUnavailableToolResult(setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable))
 			}
 			enabled, err := gate.EnabledOrganization(ctx, principal.OrganizationID)
 			if err != nil || !enabled {
-				return directRemoteInspectionUnavailableToolResult()
+				return directRemoteInspectionUnavailableToolResult(setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable))
 			}
 			inspection, err := directRemote.Inspect(ctx, remoteURL)
 			if err != nil {
 				if result, ok := operationBudgetToolResult(err); ok {
 					return result, CandidateInspection{}, nil
 				}
-				return directRemoteInspectionUnavailableToolResult()
+				return directRemoteInspectionUnavailableToolResult(setupFailure(SetupCategoryTemporarilyUnavailable, ErrDirectRemoteUnavailable))
 			}
-			return nil, CandidateInspection{CanonicalURL: inspection.CanonicalURL, Transport: inspection.Transport, ToolNames: inspection.ToolNames, ToolCount: inspection.ToolCount, RequiresDashboardSetup: inspection.RequiresDashboardSetup, Trust: inspection.Trust, Authentication: inspection.Authentication, OAuthDiscovery: inspection.OAuthDiscovery}, nil
+			category := setupCategoryFromInspection(inspection)
+			return nil, CandidateInspection{CanonicalURL: inspection.CanonicalURL, Transport: inspection.Transport, ToolNames: inspection.ToolNames, ToolCount: inspection.ToolCount, RequiresDashboardSetup: inspection.RequiresDashboardSetup, Trust: inspection.Trust, Authentication: inspection.Authentication, OAuthDiscovery: inspection.OAuthDiscovery, SetupCategory: category, Actions: inspectionResultActions(category)}, nil
 		}
 		if catalog == nil {
 			return nil, CandidateInspection{}, ErrCatalogUnavailable
@@ -165,8 +168,8 @@ func registerCandidateInspectionTool(reg *Registrar, catalog Catalog, directRemo
 	})
 }
 
-func directRemoteInspectionUnavailableToolResult() (*mcp.CallToolResult, CandidateInspection, error) {
-	if result, ok := operationBudgetToolResult(ErrDirectRemoteUnavailable); ok {
+func directRemoteInspectionUnavailableToolResult(err error) (*mcp.CallToolResult, CandidateInspection, error) {
+	if result, ok := operationBudgetToolResult(err); ok {
 		return result, CandidateInspection{}, nil
 	}
 	return nil, CandidateInspection{}, ErrDirectRemoteUnavailable

--- a/server/internal/platformmcp/tool_catalog_test.go
+++ b/server/internal/platformmcp/tool_catalog_test.go
@@ -54,7 +54,40 @@ func TestCandidateInspectionReturnsSafeDirectRemoteErrors(t *testing.T) {
 
 	var refusal *ToolRefusalError
 	require.ErrorAs(t, err, &refusal)
-	require.JSONEq(t, `{"code":"feature_unavailable","reason":"remote_inspection_unavailable","message":"That MCP server could not be checked safely right now. Try again shortly."}`, refusal.Payload)
+	require.JSONEq(t, `{"code":"feature_unavailable","reason":"remote_inspection_unavailable","setup_category":"temporarily_unavailable","actions":[{"kind":"retry_inspection","label":"Check this MCP server again shortly"}],"message":"That MCP server could not be checked safely right now. Try again shortly."}`, refusal.Payload)
+	require.NotContains(t, refusal.Payload, "unsafe network detail")
+}
+
+func TestCandidateInspectionReturnsOAuthSetupCategoryAndActions(t *testing.T) {
+	t.Parallel()
+
+	server := newTestMCPServer()
+	registrar := newRegistrar(server)
+	registerCandidateInspectionTool(
+		registrar,
+		nil,
+		&testDirectRemoteInspector{inspection: DirectRemoteInspection{
+			CanonicalURL:           "https://remote.example.test/mcp",
+			Transport:              "streamable-http",
+			Authentication:         "authentication_required",
+			OAuthDiscovery:         "available",
+			Trust:                  "user_supplied_unreviewed",
+			RequiresDashboardSetup: true,
+		}},
+		&testRegistrationGate{enabled: true},
+		allowBudget(),
+	)
+
+	result, err := catalogInspectionDescriptor(t, registrar).Invoke(
+		ContextWithPrincipal(t.Context(), registrationServicePrincipal()),
+		json.RawMessage(`{"remote_url":"https://remote.example.test/mcp"}`),
+	)
+
+	require.NoError(t, err)
+	inspection, ok := result.(CandidateInspection)
+	require.True(t, ok)
+	require.Equal(t, SetupCategoryDynamicRegistrationUnsupported, inspection.SetupCategory)
+	require.Equal(t, []RepairAction{{Kind: "continue_registration", Label: "Choose a project and add this MCP server before finishing its sign-in setup"}}, inspection.Actions)
 }
 
 func fmtDirectRemoteInspectionError() error {

--- a/server/internal/platformmcp/tool_readiness.go
+++ b/server/internal/platformmcp/tool_readiness.go
@@ -18,6 +18,7 @@ type GetMCPReadinessToolOutput struct {
 	RegistrationID string         `json:"registration_id"`
 	State          ReadinessState `json:"state"`
 	EvidenceCode   string         `json:"evidence_code,omitempty"`
+	SetupCategory  SetupCategory  `json:"setup_category,omitempty"`
 	Freshness      string         `json:"freshness"`
 	CheckedAt      string         `json:"checked_at,omitempty"`
 	ExpiresAt      string         `json:"expires_at,omitempty"`
@@ -33,6 +34,7 @@ type GetMCPRepairPlanToolOutput struct {
 	ProjectSlug    string         `json:"project_slug"`
 	RegistrationID string         `json:"registration_id"`
 	State          ReadinessState `json:"state"`
+	SetupCategory  SetupCategory  `json:"setup_category,omitempty"`
 	Freshness      string         `json:"freshness"`
 	Actions        []RepairAction `json:"actions"`
 }
@@ -104,6 +106,7 @@ func registerReadinessTools(reg *Registrar, readiness *ReadinessService) {
 			ProjectSlug:    project.Slug,
 			RegistrationID: input.RegistrationID,
 			State:          result.State,
+			SetupCategory:  setupCategoryFromReadiness(result),
 			Freshness:      readinessFreshness(result, found),
 			Actions:        repairActions(result.State),
 		}, nil
@@ -111,11 +114,13 @@ func registerReadinessTools(reg *Registrar, readiness *ReadinessService) {
 }
 
 func readinessToolOutput(projectSlug, registrationID string, readiness Readiness, found bool) GetMCPReadinessToolOutput {
+	category := setupCategoryFromReadiness(readiness)
 	return GetMCPReadinessToolOutput{
 		ProjectSlug:    projectSlug,
 		RegistrationID: registrationID,
 		State:          readiness.State,
 		EvidenceCode:   readiness.EvidenceCode,
+		SetupCategory:  category,
 		Freshness:      readinessFreshness(readiness, found),
 		CheckedAt:      readinessTimestamp(readiness.CheckedAt),
 		ExpiresAt:      readinessTimestamp(readiness.ExpiresAt),

--- a/server/internal/platformmcp/tool_readiness.go
+++ b/server/internal/platformmcp/tool_readiness.go
@@ -102,13 +102,14 @@ func registerReadinessTools(reg *Registrar, readiness *ReadinessService) {
 			return nil, GetMCPRepairPlanToolOutput{}, err
 		}
 		result = normalizedReadiness(result, found)
+		category := setupCategoryFromReadiness(result)
 		return nil, GetMCPRepairPlanToolOutput{
 			ProjectSlug:    project.Slug,
 			RegistrationID: input.RegistrationID,
 			State:          result.State,
-			SetupCategory:  setupCategoryFromReadiness(result),
+			SetupCategory:  category,
 			Freshness:      readinessFreshness(result, found),
-			Actions:        repairActions(result.State),
+			Actions:        setupRepairActions(category, result.State),
 		}, nil
 	})
 }
@@ -124,6 +125,6 @@ func readinessToolOutput(projectSlug, registrationID string, readiness Readiness
 		Freshness:      readinessFreshness(readiness, found),
 		CheckedAt:      readinessTimestamp(readiness.CheckedAt),
 		ExpiresAt:      readinessTimestamp(readiness.ExpiresAt),
-		Actions:        repairActions(readiness.State),
+		Actions:        setupRepairActions(category, readiness.State),
 	}
 }

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -139,9 +139,11 @@ type featureUnavailableResult struct {
 }
 
 type operationBudgetResult struct {
-	Code    string `json:"code"`
-	Reason  string `json:"reason,omitempty"`
-	Message string `json:"message"`
+	Code          string         `json:"code"`
+	Reason        string         `json:"reason,omitempty"`
+	SetupCategory SetupCategory  `json:"setup_category,omitempty"`
+	Actions       []RepairAction `json:"actions,omitempty"`
+	Message       string         `json:"message"`
 }
 
 // newServer composes the Platform MCP tools for one deployment. It returns the
@@ -409,9 +411,11 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 	case errors.Is(err, ErrCatalogUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Reason: "catalog_unavailable", Message: "The reviewed catalogue of MCP servers is temporarily unavailable. Try searching it again shortly; everything else still works."}
 	case errors.Is(err, ErrDirectRemoteRejected):
-		result = operationBudgetResult{Code: "invalid_request", Reason: "remote_url_rejected", Message: "That MCP server URL is unsafe, unsupported, or did not answer a Streamable HTTP check. Use an HTTPS URL with no credentials, query parameters, or fragments."}
+		category := setupCategoryFromError(err)
+		result = operationBudgetResult{Code: "invalid_request", Reason: "remote_url_rejected", SetupCategory: category, Actions: inspectionFailureActions(category), Message: "That MCP server URL is unsafe, unsupported, or did not answer a Streamable HTTP check. Use an HTTPS URL with no credentials, credential-like query parameters, or fragments."}
 	case errors.Is(err, ErrDirectRemoteUnavailable):
-		result = operationBudgetResult{Code: unavailableCode, Reason: "remote_inspection_unavailable", Message: "That MCP server could not be checked safely right now. Try again shortly."}
+		category := setupCategoryFromError(err)
+		result = operationBudgetResult{Code: unavailableCode, Reason: "remote_inspection_unavailable", SetupCategory: category, Actions: inspectionFailureActions(category), Message: "That MCP server could not be checked safely right now. Try again shortly."}
 	case errors.Is(err, ErrLifecycleVisibilityUnavailable):
 		result = operationBudgetResult{Code: unavailableCode, Reason: "unsupported_lifecycle_target", Message: "This MCP server was not set up through this platform, so it cannot be turned on or off from here. Manage it in the dashboard instead."}
 	case errors.Is(err, ErrOperationBudgetUnavailable), errors.Is(err, ErrRegistrationUnavailable):

--- a/server/internal/platformmcp/tools_test.go
+++ b/server/internal/platformmcp/tools_test.go
@@ -10,6 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOperationBudgetToolResultAddsOnlyTypedSetupDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	categorized, ok := operationBudgetToolResult(setupFailure(SetupCategoryUnsafeTargetOrRedirect, ErrDirectRemoteRejected))
+	require.True(t, ok)
+	categorizedText, ok := categorized.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var categorizedBody operationBudgetResult
+	require.NoError(t, json.Unmarshal([]byte(categorizedText.Text), &categorizedBody))
+	require.Equal(t, SetupCategoryUnsafeTargetOrRedirect, categorizedBody.SetupCategory)
+	require.Equal(t, []RepairAction{{Kind: "review_remote_url", Label: "Use a public HTTPS MCP endpoint without credentials in the URL"}}, categorizedBody.Actions)
+	require.NotContains(t, categorizedText.Text, "blocked IP")
+
+	legacy, ok := operationBudgetToolResult(ErrDirectRemoteUnavailable)
+	require.True(t, ok)
+	legacyText, ok := legacy.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"code":"feature_unavailable","reason":"remote_inspection_unavailable","message":"That MCP server could not be checked safely right now. Try again shortly."}`, legacyText.Text)
+}
+
 func TestOperationBudgetToolResultMapsRegistrationInputErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Linear

- [AIM-225](https://linear.app/speakeasy/issue/AIM-225)

## Summary

- Add a closed `setup_category` taxonomy for candidate inspection, readiness, repair plans, and MCP diagnostics.
- Distinguish invalid URLs, unsafe targets or redirects, transport failures, invalid MCP responses, OAuth setup gaps, rejected authorization, and transient failures without exposing raw network or provider details.
- Return stage-appropriate next actions while preserving existing readiness states, evidence codes, broad error identities, and uncategorized legacy refusal payloads.
- Share the category enum across output schemas and cover classification, privacy, compatibility, and healthy-state precedence in focused tests.

## Motivation

Platform MCP previously collapsed several setup and trust failures into broad unavailable or probe-failed results. Administrators could not reliably tell whether to correct an endpoint, retry inspection, complete registration, or finish sign-in setup. This change makes those failures actionable while keeping URLs, response bodies, headers, credentials, and provider-specific error text out of the public diagnostic contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies platform MCP setup failures so administrators can tell whether to correct an endpoint, retry inspection, finish registration, or complete sign-in setup, and can separate transient outages from endpoint misconfiguration.

**Behavior**
- Adds a closed `SetupCategory` enum surfaced on diagnostics, readiness, repair-plan, candidate-inspection, and refusal outputs.
- Evidence now distinguishes probe stage, transient HTTP statuses (408/429/5xx become degraded), and transport failures from invalid MCP responses.
- Returns stage-appropriate repair actions for each category; ready and unmanaged states get none, and guide-unavailable keeps its existing contact-support action.
- Existing readiness states, broad error sentinels, and uncategorized legacy refusal payloads pass through unchanged.

**Privacy**
- Raw URLs, response bodies, headers, credentials, and provider-specific error text never enter the public diagnostic contract.
- `sanitizedSetupFailure` keeps only a category and broad sentinel when HTTP clients wrap redirect or transport failures.
- `setup_category` is advertised as a closed enum in tool schemas.

<sup>Written for commit 68e2dece2091b6ae37afa431438426779aeaf1b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


