### PR TITLE
feat: forward audited mutations to PostHog

### DIFF
--- a/.changeset/growth-signals-stream-handler.md
+++ b/.changeset/growth-signals-stream-handler.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Forward audited mutations to PostHog as `gram_activity` events. The `gram streams` process now runs a growth-signals handler alongside its existing webhook consumers, so every audited mutation — projects and MCP servers created, security policies written, members invited — reaches PostHog without any service emitting analytics of its own. Uncurated actions pass through under a normalized name so coverage is automatic, and a small exclusion list keeps high-volume noise out.

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -6,6 +6,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"io/fs"
 	"log/slog"
 	"net/url"
@@ -1406,4 +1407,16 @@ func newKMSSigningClients(ctx context.Context, logger *slog.Logger, c *cli.Conte
 		}
 		return client, nil
 	}, nil
+}
+
+// newGrowthSignalsEmitter builds the emitter that reports notable moments to
+// PostHog.
+//
+// It enriches against the read replica. The lookups are display names for an
+// ops notification, not authority for anything, and a miss degrades the event
+// by omitting a property rather than dropping it — so replication lag costs at
+// most a missing slug on a very fresh row, which is not worth the primary's
+// capacity.
+func newGrowthSignalsEmitter(logger *slog.Logger, posthogClient *posthog.Posthog, replicaDB *pgxpool.Pool, siteURL *url.URL) *growthsignals.Emitter {
+	return growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(replicaDB), siteURL)
 }

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -510,6 +510,13 @@ func newStreamsCommand() *cli.Command {
 				if err != nil {
 					return fmt.Errorf("parse site url: %w", err)
 				}
+				// url.Parse accepts a bare path or a custom scheme, and either
+				// would produce a link Slack rejects. A site URL that cannot
+				// address the dashboard is a misconfiguration worth failing on
+				// rather than discovering one dead button at a time.
+				if (siteURL.Scheme != "http" && siteURL.Scheme != "https") || siteURL.Host == "" {
+					return fmt.Errorf("site url must be an absolute http(s) URL, got %q", raw)
+				}
 			}
 			growthSignalHandler := growthsignals.NewEventHandler(logger, growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(db), siteURL))
 

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/signal"
 	"runtime/debug"
@@ -44,6 +45,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/control"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/metering"
 	meteringchrepo "github.com/speakeasy-api/gram/server/internal/metering/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/modelkeys"
@@ -229,6 +231,11 @@ func newStreamsCommand() *cli.Command {
 			Usage:    "List of CIDR blocks to block for SSRF protection",
 			EnvVars:  []string{"GRAM_DISALLOWED_CIDR_BLOCKS"},
 			Required: false,
+		},
+		&cli.StringFlag{
+			Name:    "site-url",
+			Usage:   "The URL of the dashboard site, used to deep link from growth activity events",
+			EnvVars: []string{"GRAM_SITE_URL"},
 		},
 		&cli.PathFlag{
 			Name:     "config-file",
@@ -492,6 +499,20 @@ func newStreamsCommand() *cli.Command {
 			paygKeyRefreshHandler := usage.NewPaygKeyRefreshHandler(logger, openRouterKeyRefresher)
 			trialConversionKeyReconcileHandler := usage.NewEnterpriseTrialConversionKeyReconcileHandler(logger, openRouterKeyRefresher)
 			billingNotificationHandler := billingnotifications.NewEventHandler(logger, &background.TemporalBillingEmailScheduler{TemporalEnv: temporalEnv})
+
+			// Growth activities enrich against the primary rather than the read
+			// replica: an audit event arrives within milliseconds of the write it
+			// describes, so replica lag would leave a just-created project or
+			// organization unresolvable exactly when it is most interesting.
+			var siteURL *url.URL
+			if raw := c.String("site-url"); raw != "" {
+				siteURL, err = url.Parse(raw)
+				if err != nil {
+					return fmt.Errorf("parse site url: %w", err)
+				}
+			}
+			growthSignalHandler := growthsignals.NewEventHandler(logger, growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(db), siteURL))
+
 			webhookEventHandler := streams.HandlerFunc[*webhooksv1.Event](func(ctx context.Context, event *webhooksv1.Event, metadata gcp.MessageMetadata) error {
 				var handlerErrors []error
 				if err := svixRelayHandler.Handle(ctx, event, metadata); err != nil {
@@ -505,6 +526,9 @@ func newStreamsCommand() *cli.Command {
 				}
 				if err := billingNotificationHandler.Handle(ctx, event, metadata); err != nil {
 					handlerErrors = append(handlerErrors, fmt.Errorf("schedule billing notification: %w", err))
+				}
+				if err := growthSignalHandler.Handle(ctx, event, metadata); err != nil {
+					handlerErrors = append(handlerErrors, fmt.Errorf("report growth activity: %w", err))
 				}
 				return errors.Join(handlerErrors...)
 			})

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -500,10 +500,6 @@ func newStreamsCommand() *cli.Command {
 			trialConversionKeyReconcileHandler := usage.NewEnterpriseTrialConversionKeyReconcileHandler(logger, openRouterKeyRefresher)
 			billingNotificationHandler := billingnotifications.NewEventHandler(logger, &background.TemporalBillingEmailScheduler{TemporalEnv: temporalEnv})
 
-			// Growth activities enrich against the primary rather than the read
-			// replica: an audit event arrives within milliseconds of the write it
-			// describes, so replica lag would leave a just-created project or
-			// organization unresolvable exactly when it is most interesting.
 			var siteURL *url.URL
 			if raw := c.String("site-url"); raw != "" {
 				siteURL, err = url.Parse(raw)
@@ -518,7 +514,7 @@ func newStreamsCommand() *cli.Command {
 					return fmt.Errorf("site url must be an absolute http(s) URL, got %q", raw)
 				}
 			}
-			growthSignalHandler := growthsignals.NewEventHandler(logger, growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(db), siteURL))
+			growthSignalHandler := growthsignals.NewEventHandler(logger, newGrowthSignalsEmitter(logger, posthogClient, replicaDB, siteURL))
 
 			webhookEventHandler := streams.HandlerFunc[*webhooksv1.Event](func(ctx context.Context, event *webhooksv1.Event, metadata gcp.MessageMetadata) error {
 				var handlerErrors []error

--- a/server/internal/growthsignals/handler.go
+++ b/server/internal/growthsignals/handler.go
@@ -22,6 +22,11 @@ import (
 // services add later, without a list here to extend.
 const auditEventTypePrefix = "audit_log."
 
+// propertyInsertID is PostHog's deduplication key. Two captures carrying the
+// same value describe one occurrence, which is what makes an at-least-once
+// topic safe to report from.
+const propertyInsertID = "$insert_id"
+
 // EventHandler turns audited mutations into growth activities.
 //
 // It reads the webhook stream the audit logger already publishes, so every
@@ -86,6 +91,10 @@ func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gc
 	action := audit.Action(payload.Action)
 	mapping := ActivityForAction(action)
 	if mapping.Activity == ActivitySkip {
+		h.logger.DebugContext(ctx, "growth signal excluded by action",
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogEvent(event.GetEventType()),
+		)
 		return nil
 	}
 
@@ -110,8 +119,25 @@ func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gc
 		// Audit records address subjects by id and type rather than by page, so
 		// the event takes the emitter's organization-level fallback link.
 		DashboardURL: "",
-		Extra:        mapping.Extra,
+		Extra:        withInsertID(mapping.Extra, eventID),
 	})
 
 	return nil
+}
+
+// withInsertID stamps the outbox event id as PostHog's deduplication key.
+//
+// The topic is at-least-once and this handler shares a message with its
+// siblings: when any of them fails, the whole message nacks and every handler
+// sees the event again. Without a stable key that is a duplicate Slack line for
+// something that happened once. The outbox id is stable across redeliveries,
+// which is exactly what the key needs to be.
+func withInsertID(extra map[string]string, eventID string) map[string]string {
+	stamped := make(map[string]string, len(extra)+1)
+	for key, value := range extra {
+		stamped[key] = value
+	}
+	stamped[propertyInsertID] = eventID
+
+	return stamped
 }

--- a/server/internal/growthsignals/handler.go
+++ b/server/internal/growthsignals/handler.go
@@ -1,0 +1,117 @@
+package growthsignals
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// auditEventTypePrefix selects the audit-derived events out of the webhook
+// topic. Every audited subject publishes under its own `audit_log.*_event_v1`
+// type, so matching the prefix covers all of them and keeps covering the ones
+// services add later, without a list here to extend.
+const auditEventTypePrefix = "audit_log."
+
+// EventHandler turns audited mutations into growth activities.
+//
+// It reads the webhook stream the audit logger already publishes, so every
+// mutation Gram records reaches PostHog without any service having to emit
+// analytics of its own.
+type EventHandler struct {
+	logger  *slog.Logger
+	emitter *Emitter
+}
+
+func NewEventHandler(logger *slog.Logger, emitter *Emitter) *EventHandler {
+	return &EventHandler{
+		logger:  logger.With(attr.SlogComponent("growth-signal-events")),
+		emitter: emitter,
+	}
+}
+
+// Handle emits one activity for an audited mutation.
+//
+// It returns an error only for a failure worth redelivering. Every other
+// outcome — an envelope that makes no sense, a payload that will not decode, an
+// action with no ops value — acks the message, because a message this handler
+// can never make sense of would otherwise redeliver until the subscription's
+// retention runs out. Emission itself cannot fail the message: an activity that
+// could not be captured is logged by the emitter and dropped, since analytics
+// must never hold up the stream.
+func (h *EventHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gcp.MessageMetadata) error {
+	if event == nil {
+		h.logger.ErrorContext(ctx, "dropping nil growth signal event")
+		return nil
+	}
+
+	eventID := event.GetEventId()
+	organizationID := event.GetOrganizationId()
+	if eventID == "" || organizationID == "" {
+		h.logger.ErrorContext(ctx, "dropping invalid growth signal event",
+			attr.SlogOrganizationID(organizationID),
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogEvent(event.GetEventType()),
+		)
+		return nil
+	}
+
+	// Every webhook event on the topic reaches this handler, so anything that
+	// is not an audit record must leave before the payload is decoded.
+	if !strings.HasPrefix(event.GetEventType(), auditEventTypePrefix) {
+		return nil
+	}
+
+	var payload events.AuditLogCreatedPayloadV1
+	if err := json.Unmarshal(event.GetPayload(), &payload); err != nil {
+		h.logger.ErrorContext(ctx, "dropping unreadable growth signal event",
+			attr.SlogOutboxPublicID(eventID),
+			attr.SlogEvent(event.GetEventType()),
+			attr.SlogError(err),
+		)
+		return nil
+	}
+
+	// The event type is a coarse bucket — an MCP server creation and a metadata
+	// edit share one — so the action is what says which activity this is.
+	action := audit.Action(payload.Action)
+	mapping := ActivityForAction(action)
+	if mapping.Activity == ActivitySkip {
+		return nil
+	}
+
+	projectID := uuid.Nil
+	if payload.ProjectID.Valid {
+		projectID = payload.ProjectID.UUID
+	}
+
+	h.emitter.Emit(ctx, ActivityEvent{
+		Activity:       mapping.Activity,
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		ActorID:        payload.ActorID,
+		ActorType:      urn.PrincipalType(payload.ActorType),
+		// The audit record carries the actor's id, not their address, so the
+		// emitter resolves the email itself behind its cache.
+		ActorEmail:    "",
+		ActorName:     payload.ActorDisplayName,
+		SubjectName:   payload.SubjectDisplayName,
+		ActingSurface: payload.ActingSurface,
+		AuditAction:   action,
+		// Audit records address subjects by id and type rather than by page, so
+		// the event takes the emitter's organization-level fallback link.
+		DashboardURL: "",
+		Extra:        mapping.Extra,
+	})
+
+	return nil
+}

--- a/server/internal/growthsignals/handler_test.go
+++ b/server/internal/growthsignals/handler_test.go
@@ -176,3 +176,22 @@ func TestEventHandlerAcksMalformedEnvelope(t *testing.T) {
 
 	require.Empty(t, client.Captured())
 }
+
+// The topic is at-least-once and this handler shares a message with its
+// siblings, so a sibling failure redelivers the event to everyone. The stable
+// outbox id is what lets PostHog collapse the redelivery into one occurrence.
+func TestEventHandlerStampsDeduplicationKey(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, string(events.RemoteMcpServerV1.EventType()), audit.ActionRemoteMcpServerCreate)
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+
+	captured := client.Captured()
+	require.Len(t, captured, 2, "the handler itself does not dedupe; PostHog does")
+	require.Equal(t, handlerEventID, captured[0].Properties["$insert_id"])
+	require.Equal(t, captured[0].Properties["$insert_id"], captured[1].Properties["$insert_id"],
+		"a redelivery of one event must carry one key")
+}

--- a/server/internal/growthsignals/handler_test.go
+++ b/server/internal/growthsignals/handler_test.go
@@ -1,0 +1,178 @@
+package growthsignals_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	webhooksv1 "github.com/speakeasy-api/gram/infra/gen/gram/webhooks/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
+	"github.com/speakeasy-api/gram/server/internal/outbox/events"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	handlerOrganizationID = "<ORGANIZATION_ID>"
+	handlerEventID        = "<EVENT_ID>"
+	handlerUserID         = "<USER_ID>"
+	handlerUserEmail      = "person@example.test"
+)
+
+// handlerProjectID is the project a test audit record is scoped to.
+var handlerProjectID = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+
+func auditWebhookEvent(t *testing.T, eventType string, action audit.Action) *webhooksv1.Event {
+	t.Helper()
+
+	payload, err := json.Marshal(events.AuditLogCreatedPayloadV1{
+		ID:                 uuid.MustParse("99999999-8888-7777-6666-555555555555"),
+		OrganizationID:     handlerOrganizationID,
+		ProjectID:          uuid.NullUUID{UUID: handlerProjectID, Valid: true},
+		ActorID:            handlerUserID,
+		ActorType:          string(urn.PrincipalTypeUser),
+		ActorDisplayName:   "Placeholder Person",
+		ActorSlug:          "placeholder-person",
+		Action:             string(action),
+		SubjectID:          "<SUBJECT_ID>",
+		SubjectType:        "mcp_server",
+		SubjectDisplayName: "Widgets Server",
+		SubjectSlug:        "widgets-server",
+		ActingSurface:      string(audit.SurfaceDashboard),
+		BeforeSnapshot:     nil,
+		AfterSnapshot:      nil,
+		Metadata:           nil,
+		ActingClientID:     "",
+	})
+	require.NoError(t, err)
+
+	eventID := handlerEventID
+	organizationID := handlerOrganizationID
+	createdAt := "2026-09-03T12:00:00Z"
+
+	return webhooksv1.Event_builder{
+		EventId:        &eventID,
+		OrganizationId: &organizationID,
+		EventType:      &eventType,
+		Payload:        payload,
+		CreatedAt:      &createdAt,
+	}.Build()
+}
+
+func newTestEventHandler(t *testing.T) (*growthsignals.EventHandler, *capturePostHog) {
+	t.Helper()
+
+	client := &capturePostHog{}
+	enricher := &fakeEnricher{
+		organization: growthsignals.OrganizationDetails{Slug: "acme", Name: "Acme Incorporated"},
+		project:      growthsignals.ProjectDetails{Slug: "widgets", Name: "Widgets"},
+		userEmails:   map[string]string{handlerUserID: handlerUserEmail},
+	}
+	emitter := growthsignals.NewEmitter(testenv.NewLogger(t), client, enricher, emitterSiteURL())
+
+	return growthsignals.NewEventHandler(testenv.NewLogger(t), emitter), client
+}
+
+func testMessageMetadata() gcp.MessageMetadata {
+	return gcp.MessageMetadata{ID: "<MESSAGE_ID>", Attributes: nil, DeliveryAttempt: nil}
+}
+
+func TestEventHandlerEmitsCuratedActivity(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, string(events.RemoteMcpServerV1.EventType()), audit.ActionRemoteMcpServerCreate)
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+
+	captured := client.Captured()
+	require.Len(t, captured, 1)
+	require.Equal(t, growthsignals.EventName, captured[0].Name)
+	require.Equal(t, handlerUserEmail, captured[0].DistinctID)
+
+	properties := captured[0].Properties
+	require.Equal(t, "mcp_server_created", properties["activity"])
+	require.Equal(t, "remote", properties["mcp_kind"])
+	require.Equal(t, handlerOrganizationID, properties["organization_id"])
+	require.Equal(t, "acme", properties["organization_slug"])
+	require.Equal(t, handlerProjectID.String(), properties["project_id"])
+	require.Equal(t, "widgets", properties["project_slug"])
+	require.Equal(t, handlerUserEmail, properties["actor_email"])
+	require.Equal(t, "Placeholder Person", properties["actor_name"])
+	require.Equal(t, "Widgets Server", properties["subject_name"])
+	require.Equal(t, string(audit.SurfaceDashboard), properties["acting_surface"])
+	require.Equal(t, string(audit.ActionRemoteMcpServerCreate), properties["audit_action"])
+	require.Equal(t, "https://app.example.test/acme", properties["dashboard_url"])
+}
+
+// An excluded action is the high-volume kind the firehose exists in spite of,
+// so it must not reach PostHog at all.
+func TestEventHandlerSkipsExcludedAction(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, string(events.AssistantToolCallV1.EventType()), audit.ActionAssistantToolCall)
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+	require.Empty(t, client.Captured())
+}
+
+// An action nobody curated still ships, so the firehose covers new audit
+// coverage the day it lands rather than when someone remembers to list it.
+func TestEventHandlerPassesThroughUncuratedAction(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, string(events.ToolsetV1.EventType()), audit.ActionToolsetCreate)
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+
+	captured := client.Captured()
+	require.Len(t, captured, 1)
+	require.Equal(t, "toolset_create", captured[0].Properties["activity"])
+	require.NotContains(t, captured[0].Properties, "mcp_kind")
+}
+
+func TestEventHandlerIgnoresNonAuditEventType(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, "organization.usage_v1", audit.ActionProjectCreate)
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+	require.Empty(t, client.Captured())
+}
+
+func TestEventHandlerAcksUnreadablePayload(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	event := auditWebhookEvent(t, string(events.ProjectV1.EventType()), audit.ActionProjectCreate)
+	event.SetPayload([]byte("{not json"))
+
+	require.NoError(t, handler.Handle(t.Context(), event, testMessageMetadata()))
+	require.Empty(t, client.Captured())
+}
+
+func TestEventHandlerAcksMalformedEnvelope(t *testing.T) {
+	t.Parallel()
+
+	handler, client := newTestEventHandler(t)
+	metadata := testMessageMetadata()
+
+	require.NoError(t, handler.Handle(t.Context(), nil, metadata))
+
+	blankEventID := auditWebhookEvent(t, string(events.ProjectV1.EventType()), audit.ActionProjectCreate)
+	blankEventID.SetEventId("")
+	require.NoError(t, handler.Handle(t.Context(), blankEventID, metadata))
+
+	blankOrganizationID := auditWebhookEvent(t, string(events.ProjectV1.EventType()), audit.ActionProjectCreate)
+	blankOrganizationID.SetOrganizationId("")
+	require.NoError(t, handler.Handle(t.Context(), blankOrganizationID, metadata))
+
+	require.Empty(t, client.Captured())
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — merge bottom-up.** Each PR targets the one above it, so its Files tab shows only its own diff.
>
> 1. #6057 — core taxonomy and emitter
> 2. #6058 — audit stream to PostHog 👈 **this PR**
> 3. #6059 — direct emits: signup source, org created, member joined
> 4. #6060 — devices
> 5. #6061 — agents
>
> Merging #6057 retargets #6058 to `main` automatically, and so on down the stack.

[GRW-66](https://linear.app/speakeasy/issue/GRW-66/feat-revamp-posthog-slack-notifications)

Second of a five-PR stack. **Targets #6057**, review that first.

## Summary

Turns audit-log outbox events into `gram_activity` and joins the handler to the existing webhook fan-out in the `gram streams` process. No new subscription and no new infrastructure.

Three behaviours worth a reviewer's attention:

- **Filters on the `audit_log.` event-type prefix before decoding.** The whole webhook firehose reaches this handler, so decoding every event would be wasted work. The prefix also means new audited subjects are covered as services add them, with no list here to extend.
- **Switches on the audit action, not the event type.** The type is a coarse bucket: an MCP server creation and a tool-metadata edit publish under the same one. Only the action says which activity a record is.
- **Every ignore path acks.** A returned error nacks the Pub/Sub message and redelivers it forever, so a nonsensical envelope, an undecodable payload, and an excluded action are all logged and acked instead. Emission cannot fail the message either.

Two wiring choices:

- The existing PostHog client is reused rather than a second being constructed.
- Enrichment reads the primary, not a replica. These events describe a write that happened milliseconds earlier, so replica lag would leave a just-created row unresolvable exactly when it is most interesting. The lookups are TTL-cached, so the cost is per active organization rather than per event.

The `streams` command previously had no site URL source, so an optional `site-url` flag is added, matching `worker.go`'s optional form rather than `start.go`'s required one, so an unset variable cannot fail startup.

## Motivation

This is the step that makes the audit log's existing signal visible. Without it the taxonomy from #6057 has no producer.

Temporal actions/month: 0, scales with fixed. Rides the existing subscription; no workflows, schedules or activities are added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns audit-log outbox events into `gram_activity` events in PostHog by joining a new growth-signals handler to the existing webhook fan-out in `gram streams`. This is the second step of the [GRW-66](https://linear.app/speakeasy/issue/GRW-66/feat-revamp-posthog-slack-notifications) PostHog/Slack notifications revamp; no new subscription or infrastructure is added.

**Handler behavior**
- Filters on the `audit_log.` event-type prefix before decoding, so the rest of the webhook firehose costs nothing.
- Switches on the audit action, not the event type, since an MCP server creation and a metadata edit share one type bucket.
- Acks every ignore path — malformed envelope, undecodable payload, excluded action — because a returned error nacks the message and redelivers it forever.
- Logs excluded actions at debug with the event id, so intentional filtering is distinguishable from a missing signal.
- Stamps the outbox event id as PostHog's deduplication key, so a sibling handler's failure redelivering the message doesn't create a duplicate Slack line.
- Logs and drops emission failures so analytics never hold up the stream.

**Wiring**
- Reuses the existing PostHog client rather than constructing a second one.
- Enriches against the read replica with TTL-cached lookups; a lagging miss omits a slug property rather than dropping the event.
- Adds an optional `site-url` flag to `gram streams` for dashboard deep links; when set, startup fails unless it is an absolute http(s) URL.

<sup>Written for commit 5e8e0c20e105216e27e808f4e178ce94ab5ab217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

