### PR TITLE
feat: report signups as invited or organic

### DIFF
--- a/.changeset/growth-signals-signup-source.md
+++ b/.changeset/growth-signals-signup-source.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Report first-time signups as `gram_activity`, distinguishing an invited arrival from an organic one. The classification is made at user creation, the only moment it is knowable: a live invitation addressed to the new user means somebody asked them to join, and a moment later that invitation is accepted and the evidence is gone.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1456,6 +1456,7 @@ func newStartCommand() *cli.Command {
 				billingRepo,
 				&background.TemporalAssistantsSubscriptionCancelScheduler{TemporalEnv: temporalEnv},
 				posthogClient,
+				growthEmitter,
 				cache.NewRedisCacheAdapter(redisClient),
 				authzProvisioner,
 				productfeatures.SeedOrganizationDefaultsTx,
@@ -1463,7 +1464,7 @@ func newStartCommand() *cli.Command {
 				auditLogger,
 				trialEmailNotifier,
 			))
-			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailNotifier, productfeatures.SeedEnterpriseTrialBundleTx, posthogClient, serverURL.String(), siteURL.String(), auditLogger, svixClient)
+			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailNotifier, productfeatures.SeedEnterpriseTrialBundleTx, posthogClient, growthEmitter, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
 				Client:         ghClient,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -68,6 +68,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
 	"github.com/speakeasy-api/gram/server/internal/identityapi"
 	"github.com/speakeasy-api/gram/server/internal/instances"
@@ -716,6 +717,18 @@ func newStartCommand() *cli.Command {
 			productFeatures := productfeatures.NewClient(logger, tracerProvider, db, redisClient)
 			authzProvisioner := authz.NewProvisioner(db)
 
+			siteURL, err := url.Parse(c.String("site-url"))
+			if err != nil {
+				return fmt.Errorf("failed to parse site url: %w", err)
+			}
+
+			// Growth activities enrich against the primary rather than a read
+			// replica: these events describe a write that just happened, so
+			// replica lag would leave the new row unresolvable exactly when it
+			// is most interesting. The lookups are TTL-cached, so the cost is
+			// per active organization rather than per event.
+			growthEmitter := growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(db), siteURL)
+
 			identityResolver := identity.NewResolver(
 				logger,
 				tracerProvider,
@@ -728,6 +741,7 @@ func newStartCommand() *cli.Command {
 				userRepo.New(db),
 				pylonClient,
 				posthogClient,
+				growthEmitter,
 				cache.SuffixNone,
 			)
 
@@ -807,10 +821,6 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to parse server url: %w", err)
 			}
 
-			siteURL, err := url.Parse(c.String("site-url"))
-			if err != nil {
-				return fmt.Errorf("failed to parse site url: %w", err)
-			}
 			trialEmailNotifier := &background.TemporalTrialEmailNotifier{TemporalEnv: temporalEnv}
 			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
 			trialEmailsService := trialemails.NewService(db, loopsWorkflowClient, logger, siteURL.String())

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -679,6 +679,7 @@ func newWorkerCommand() *cli.Command {
 				userRepo.New(db),
 				pylonClient,
 				posthogClient,
+				nil,
 				cache.SuffixNone,
 			)
 

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -192,7 +192,7 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	trialNotifier := &fakeTrialNotifier{}
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nil, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 
 	ti := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	ti.trialNotifier = trialNotifier

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -176,7 +176,7 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 
 	authzProvisioner := authz.NewProvisioner(conn)
 	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, wf, orgRepo.New(conn), usersRepo.New(conn), pylonClient, posthogClient, cacheSuffix)
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, wf, orgRepo.New(conn), usersRepo.New(conn), pylonClient, posthogClient, nil, cacheSuffix)
 	sessionManager := sessions.NewManager(
 		logger, tracerProvider, conn, redisClient, cacheSuffix,
 		idpClient, billingClient, resolver,

--- a/server/internal/auth/identity/authorization_url_test.go
+++ b/server/internal/auth/identity/authorization_url_test.go
@@ -28,6 +28,7 @@ func newURLResolver(t *testing.T, idpBaseURL, idpClientID string) *identity.Reso
 		nil, // userRepo
 		nil, // pylon
 		nil, // posthog
+		nil, // growth signals
 		"",  // cache suffix
 	)
 }

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -22,12 +22,14 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	orgid "github.com/speakeasy-api/gram/server/internal/organizations/id"
 	"github.com/speakeasy-api/gram/server/internal/organizations/orgprovision"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/users"
 	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
@@ -133,6 +135,7 @@ type Resolver struct {
 	userRepo      *userRepo.Queries
 	pylon         *pylon.Pylon
 	posthog       *posthog.Posthog
+	growth        *growthsignals.Emitter
 }
 
 func NewResolver(
@@ -147,6 +150,7 @@ func NewResolver(
 	userRepo *userRepo.Queries,
 	pylon *pylon.Pylon,
 	posthog *posthog.Posthog,
+	growth *growthsignals.Emitter,
 	suffix cache.Suffix,
 ) *Resolver {
 	logger = logger.With(attr.SlogComponent("identity"))
@@ -162,6 +166,7 @@ func NewResolver(
 		userRepo:      userRepo,
 		pylon:         pylon,
 		posthog:       posthog,
+		growth:        growth,
 	}
 }
 
@@ -310,6 +315,8 @@ func (r *Resolver) UpsertUserFromIDP(ctx context.Context, idpUser *IDPUserInfo) 
 		}); err != nil {
 			r.logger.ErrorContext(ctx, "failed to capture is_first_time_user_signup event", attr.SlogError(err))
 		}
+
+		r.emitSignup(ctx, user.Email, user.DisplayName)
 	}
 
 	return user.ID, nil
@@ -689,4 +696,41 @@ func (r *Resolver) ProvisionOrgInWorkOS(ctx context.Context, orgName, gramUserID
 		WorkOSUserID:         user.WorkosID.String,
 		WorkOSMembershipID:   membershipID,
 	}, nil
+}
+
+// emitSignup reports a first-time signup and says whether it was invited or
+// organic. The distinction is asked for at exactly this moment because it is
+// only knowable here: the user row has just been created, so a live invitation
+// addressed to them means somebody asked them to join, and its absence means
+// they arrived on their own. A moment later the invitation is accepted and the
+// evidence is gone.
+//
+// A failed lookup reports neither, rather than guessing "organic" and
+// overstating self-serve growth.
+func (r *Resolver) emitSignup(ctx context.Context, email, displayName string) {
+	extra := map[string]string{}
+	invited, err := r.orgRepo.HasPendingInvitationForEmail(ctx, email)
+	switch {
+	case err != nil:
+		r.logger.ErrorContext(ctx, "failed to classify signup source", attr.SlogError(err))
+	case invited:
+		extra[growthsignals.PropertySignupSource] = growthsignals.SignupSourceInvited
+	default:
+		extra[growthsignals.PropertySignupSource] = growthsignals.SignupSourceOrganic
+	}
+
+	r.growth.Emit(ctx, growthsignals.ActivityEvent{
+		Activity:       growthsignals.ActivityUserSignedUp,
+		OrganizationID: "",
+		ProjectID:      uuid.Nil,
+		ActorID:        email,
+		ActorType:      urn.PrincipalTypeEmail,
+		ActorEmail:     email,
+		ActorName:      displayName,
+		SubjectName:    displayName,
+		ActingSurface:  "",
+		AuditAction:    "",
+		DashboardURL:   "",
+		Extra:          extra,
+	})
 }

--- a/server/internal/auth/identity/identity.go
+++ b/server/internal/auth/identity/identity.go
@@ -709,7 +709,10 @@ func (r *Resolver) ProvisionOrgInWorkOS(ctx context.Context, orgName, gramUserID
 // overstating self-serve growth.
 func (r *Resolver) emitSignup(ctx context.Context, email, displayName string) {
 	extra := map[string]string{}
-	invited, err := r.orgRepo.HasPendingInvitationForEmail(ctx, email)
+	// Invitations are stored normalized, and the address arriving from the IDP
+	// is not. Comparing them raw classified an invited user with a mixed-case
+	// address as organic, which is the exact distinction this event exists for.
+	invited, err := r.orgRepo.HasPendingInvitationForEmail(ctx, conv.NormalizeEmail(email))
 	switch {
 	case err != nil:
 		r.logger.ErrorContext(ctx, "failed to classify signup source", attr.SlogError(err))

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -25,6 +25,7 @@ import (
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
 
+	"github.com/google/uuid"
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
 	srv "github.com/speakeasy-api/gram/server/gen/http/auth/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
@@ -40,6 +41,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	envRepo "github.com/speakeasy-api/gram/server/internal/environments/repo"
+
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -50,6 +53,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const dispositionAssistants = "assistants"
@@ -121,6 +125,7 @@ type Service struct {
 	billing              billing.Repository
 	cancelSubsScheduler  AssistantsSubscriptionCancelScheduler
 	posthog              *posthog.Posthog
+	growth               *growthsignals.Emitter
 	nonceStore           cache.Cache
 	supportHandoffs      *supporthandoff.Store
 	supportHandoffIssuer *supporthandoff.Issuer
@@ -152,6 +157,7 @@ func NewService(
 	billingRepo billing.Repository,
 	cancelSubsScheduler AssistantsSubscriptionCancelScheduler,
 	posthogClient *posthog.Posthog,
+	growthEmitter *growthsignals.Emitter,
 	nonceStore cache.Cache,
 	authzProvisioner *authz.Provisioner,
 	organizationSeeder OrganizationFeatureSeeder,
@@ -177,6 +183,7 @@ func NewService(
 		billing:              billingRepo,
 		cancelSubsScheduler:  cancelSubsScheduler,
 		posthog:              posthogClient,
+		growth:               growthEmitter,
 		nonceStore:           nonceStore,
 		supportHandoffs:      supportHandoffs,
 		supportHandoffIssuer: supporthandoff.NewIssuer(supportHandoffs),
@@ -580,6 +587,25 @@ func (s *Service) acceptPendingInvitationForMember(ctx context.Context, organiza
 	if err := s.sessions.InvalidateUserInfoCache(ctx, gramUserID); err != nil {
 		return fmt.Errorf("invalidate user info cache: %w", err)
 	}
+
+	// Reported only once the membership is durable. An invitation that was
+	// accepted but whose role sync failed has not produced a member yet, and
+	// the early returns above leave before this point.
+	s.growth.Emit(ctx, growthsignals.ActivityEvent{
+		Activity:       growthsignals.ActivityMemberJoinedOrganization,
+		OrganizationID: invite.OrganizationID,
+		ProjectID:      uuid.Nil,
+		ActorID:        gramUserID,
+		ActorType:      urn.PrincipalTypeUser,
+		ActorEmail:     inviteeEmail,
+		ActorName:      "",
+		SubjectName:    inviteeEmail,
+		ActingSurface:  "",
+		AuditAction:    "",
+		DashboardURL:   "",
+		Extra:          map[string]string{growthsignals.PropertyRole: conv.FromPGTextOrEmpty[string](invite.RoleSlug)},
+	})
+
 	return nil
 }
 
@@ -1382,7 +1408,31 @@ func (s *Service) captureSignupTelemetry(ctx context.Context, email, orgName str
 	}); err != nil {
 		s.logger.ErrorContext(ctx, "failed to set signup created_via person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
 	}
+
+	s.growth.Emit(ctx, growthsignals.ActivityEvent{
+		Activity:       growthsignals.ActivityOrganizationCreated,
+		OrganizationID: org.ID,
+		ProjectID:      uuid.Nil,
+		ActorID:        email,
+		ActorType:      urn.PrincipalTypeEmail,
+		ActorEmail:     email,
+		ActorName:      "",
+		SubjectName:    orgName,
+		ActingSurface:  "",
+		AuditAction:    "",
+		DashboardURL:   "",
+		Extra:          map[string]string{createdViaProperty: createdViaSignup},
+	})
 }
+
+// createdViaProperty says which flow produced an organization. It is the same
+// tag the onboarding funnel already carries, repeated on the activity so a
+// Slack reader can tell a self-serve signup from a platform-admin invite
+// without opening PostHog.
+const (
+	createdViaProperty = "created_via"
+	createdViaSignup   = "signup"
+)
 
 func (s *Service) dispositionFromState(payload *gen.CallbackPayload) string {
 	parsed, err := url.Parse(s.destinationFromState(payload))

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -194,7 +194,7 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 
 	authzProvisioner := authz.NewProvisioner(conn)
 	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, workosClient, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, workosClient, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, nil, cacheSuffix)
 	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 
 	authConfigs := auth.AuthConfigurations{
@@ -261,7 +261,7 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 
 	authzProvisioner := authz.NewProvisioner(conn)
 	cacheSuffix := testenv.NewCacheSuffix(t, cache.Suffix("auth"))
-	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, nil, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, cacheSuffix)
+	resolver := identity.NewResolver(logger, tracerProvider, cache.NewRedisCacheAdapter(redisClient), mockServer.URL, "test-client-id", idpClient, nil, orgRepo.New(conn), userRepo.New(conn), pylon, posthog, nil, cacheSuffix)
 	sessionManager := sessions.NewManager(logger, testenv.NewTracerProvider(t), conn, redisClient, cacheSuffix, idpClient, billingClient, resolver)
 
 	authConfigs := auth.AuthConfigurations{

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -207,7 +207,7 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	trialNotifier := &fakeTrialNotifier{}
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nil, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
 	result.trialNotifier = trialNotifier
@@ -274,7 +274,7 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	trialNotifier := &fakeTrialNotifier{}
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nil, nonceStore, authzProvisioner, productfeatures.SeedOrganizationDefaultsTx, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
 	result.trialNotifier = trialNotifier

--- a/server/internal/growthsignals/emitter.go
+++ b/server/internal/growthsignals/emitter.go
@@ -52,6 +52,14 @@ func NewEmitter(logger *slog.Logger, client PostHogClient, enricher Enricher, si
 // analytics event must never be able to fail that work. Everything that goes
 // wrong is logged here instead.
 func (e *Emitter) Emit(ctx context.Context, event ActivityEvent) {
+	// A nil emitter reports nothing and says so quietly. Callers that have no
+	// PostHog wiring — tests, and commands that construct a service without the
+	// analytics stack — should not each have to guard the call, and analytics
+	// must never be the reason a request path panics.
+	if e == nil {
+		return
+	}
+
 	if event.Activity == "" || event.Activity == ActivitySkip {
 		return
 	}

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -217,7 +217,7 @@ func newTestMCPServiceWithDevIDP(t *testing.T) (context.Context, *testInstance, 
 		idp.OAuth21URL,
 		"devidp-test-client", // non-"client_" prefix routes through idpBaseURL
 		nil,                  // idpClient — BuildAuthorizationURL doesn't touch it
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
 		cache.SuffixNone,
 	)
 	ctx, ti := newTestMCPServiceWithIdentityResolver(t, resolver)

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -42,6 +42,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/email"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -125,6 +126,7 @@ type Service struct {
 	trial             trialemails.Notifier
 	trialBundleSeeder auth.EnterpriseTrialBundleSeeder
 	posthog           onboardingTelemetry
+	growth            *growthsignals.Emitter
 	serverURL         string // API server URL; used to build invite links
 	siteURL           string // frontend URL; used for post-callback browser redirects
 	audit             *audit.Logger
@@ -135,7 +137,7 @@ var _ gen.Service = (*Service)(nil)
 
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService EmailSender, trialNotifier trialemails.Notifier, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, posthog onboardingTelemetry, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService EmailSender, trialNotifier trialemails.Notifier, trialBundleSeeder auth.EnterpriseTrialBundleSeeder, posthog onboardingTelemetry, growthEmitter *growthsignals.Emitter, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
 	logger = logger.With(attr.SlogComponent("organizations"))
 	if trialNotifier == nil {
 		trialNotifier = trialemails.NoopNotifier{}
@@ -156,6 +158,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		trial:             trialNotifier,
 		trialBundleSeeder: trialBundleSeeder,
 		posthog:           posthog,
+		growth:            growthEmitter,
 		serverURL:         serverURL,
 		siteURL:           siteURL,
 		audit:             auditLogger,
@@ -1503,6 +1506,21 @@ func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email
 	if err := s.posthog.IdentifyUser(ctx, email, map[string]any{"created_via": "platform_admin_invite"}); err != nil {
 		s.logger.ErrorContext(ctx, "failed to set platform admin invite created_via person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
 	}
+
+	s.growth.Emit(ctx, growthsignals.ActivityEvent{
+		Activity:       growthsignals.ActivityOrganizationCreated,
+		OrganizationID: org.ID,
+		ProjectID:      uuid.Nil,
+		ActorID:        email,
+		ActorType:      urn.PrincipalTypeEmail,
+		ActorEmail:     email,
+		ActorName:      "",
+		SubjectName:    org.Name,
+		ActingSurface:  string(audit.SurfaceAdmin),
+		AuditAction:    "",
+		DashboardURL:   "",
+		Extra:          map[string]string{"created_via": "platform_admin_invite"},
+	})
 }
 
 func (s *Service) reconcileInvitationWorkOSMembership(ctx context.Context, invite orgrepo.OrganizationInvitation, org orgrepo.OrganizationMetadatum, gramUserID, workosUserID string) {

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -1490,6 +1490,12 @@ func (s *Service) acceptInvitationTx(ctx context.Context, inviteID uuid.UUID, or
 }
 
 func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email string, org orgrepo.OrganizationMetadatum) {
+	// Emitted before the PostHog guard below, because the two are configured
+	// independently: a service with an emitter but no PostHog client would
+	// otherwise drop every platform-admin organization from growth reporting.
+	// Emit is nil-safe, so this is unconditional.
+	s.emitOrganizationCreated(ctx, email, org)
+
 	if s.posthog == nil {
 		return
 	}
@@ -1507,20 +1513,6 @@ func (s *Service) capturePlatformAdminInviteTelemetry(ctx context.Context, email
 		s.logger.ErrorContext(ctx, "failed to set platform admin invite created_via person property", attr.SlogError(err), attr.SlogOrganizationID(org.ID))
 	}
 
-	s.growth.Emit(ctx, growthsignals.ActivityEvent{
-		Activity:       growthsignals.ActivityOrganizationCreated,
-		OrganizationID: org.ID,
-		ProjectID:      uuid.Nil,
-		ActorID:        email,
-		ActorType:      urn.PrincipalTypeEmail,
-		ActorEmail:     email,
-		ActorName:      "",
-		SubjectName:    org.Name,
-		ActingSurface:  string(audit.SurfaceAdmin),
-		AuditAction:    "",
-		DashboardURL:   "",
-		Extra:          map[string]string{"created_via": "platform_admin_invite"},
-	})
 }
 
 func (s *Service) reconcileInvitationWorkOSMembership(ctx context.Context, invite orgrepo.OrganizationInvitation, org orgrepo.OrganizationMetadatum, gramUserID, workosUserID string) {
@@ -1835,4 +1827,22 @@ func fullSvixAppPortalCapabilities() []models.AppPortalCapability {
 }
 func minimumSvixAppPortalCapabilities() []models.AppPortalCapability {
 	return []models.AppPortalCapability{models.APPPORTALCAPABILITY_VIEW_BASE}
+}
+
+// emitOrganizationCreated reports a platform-admin provisioned organization.
+func (s *Service) emitOrganizationCreated(ctx context.Context, email string, org orgrepo.OrganizationMetadatum) {
+	s.growth.Emit(ctx, growthsignals.ActivityEvent{
+		Activity:       growthsignals.ActivityOrganizationCreated,
+		OrganizationID: org.ID,
+		ProjectID:      uuid.Nil,
+		ActorID:        email,
+		ActorType:      urn.PrincipalTypeEmail,
+		ActorEmail:     email,
+		ActorName:      "",
+		SubjectName:    org.Name,
+		ActingSurface:  string(audit.SurfaceAdmin),
+		AuditAction:    "",
+		DashboardURL:   "",
+		Extra:          map[string]string{"created_via": "platform_admin_invite"},
+	})
 }

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -344,6 +344,19 @@ WHERE organization_id = @organization_id
   AND expires_at > clock_timestamp()
 RETURNING *;
 
+-- name: HasPendingInvitationForEmail :one
+-- Reports whether any organization has a live invitation outstanding for this
+-- address. It is asked at first-time user creation to tell an invited signup
+-- from an organic one, so it deliberately spans every organization rather than
+-- one: the user does not exist yet and belongs to none.
+SELECT EXISTS (
+  SELECT 1
+  FROM organization_invitations
+  WHERE email = @email
+    AND state = 'pending'
+    AND expires_at > clock_timestamp()
+);
+
 -- name: ExpireInvitationForTest :exec
 UPDATE organization_invitations
 SET expires_at = clock_timestamp() - interval '1 hour'

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -790,6 +790,27 @@ func (q *Queries) HasOtherActiveOrganizationUsers(ctx context.Context, arg HasOt
 	return exists, err
 }
 
+const hasPendingInvitationForEmail = `-- name: HasPendingInvitationForEmail :one
+SELECT EXISTS (
+  SELECT 1
+  FROM organization_invitations
+  WHERE email = $1
+    AND state = 'pending'
+    AND expires_at > clock_timestamp()
+)
+`
+
+// Reports whether any organization has a live invitation outstanding for this
+// address. It is asked at first-time user creation to tell an invited signup
+// from an organic one, so it deliberately spans every organization rather than
+// one: the user does not exist yet and belongs to none.
+func (q *Queries) HasPendingInvitationForEmail(ctx context.Context, email string) (bool, error) {
+	row := q.db.QueryRow(ctx, hasPendingInvitationForEmail, email)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const linkRelationshipsToUser = `-- name: LinkRelationshipsToUser :exec
 WITH pending_relationships AS (
     SELECT

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -291,7 +291,7 @@ func newTestOrganizationsServiceWithOptions(t *testing.T, featureStub orgFeature
 	if useRealFeatures {
 		featureChecker = features
 	}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, invite, featureChecker, nil, authzEngine, nil, trialNotifier, trialBundleSeeder, posthog, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, invite, featureChecker, nil, authzEngine, nil, trialNotifier, trialBundleSeeder, posthog, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service:  svc,
@@ -355,7 +355,7 @@ func newTestOrganizationsServiceWithEmailEnabled(t *testing.T, emailEnabled bool
 		"setup_task_assignment": "setup-task-assignment-test-id",
 	}), emailEnabled)
 	trialNotifier := &fakeTrialNotifier{}
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, enabledFeatures(), nil, authzEngine, emailService, trialNotifier, productfeatures.SeedEnterpriseTrialBundleTx, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, enabledFeatures(), nil, authzEngine, emailService, trialNotifier, productfeatures.SeedEnterpriseTrialBundleTx, nil, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,

--- a/server/internal/testenv/auth.go
+++ b/server/internal/testenv/auth.go
@@ -64,6 +64,7 @@ func NewTestManager(t *testing.T, logger *slog.Logger, tracerProvider trace.Trac
 		userRepo.New(db),
 		fakePylon,
 		fakePosthog,
+		nil,
 		suffix,
 	)
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — merge bottom-up.** Each PR targets the one above it, so its Files tab shows only its own diff.
>
> 1. #6057 — core taxonomy and emitter
> 2. #6058 — audit stream to PostHog
> 3. #6059 — direct emits: signup source, org created, member joined 👈 **this PR**
> 4. #6060 — devices
> 5. #6061 — agents
>
> Merging #6057 retargets #6058 to `main` automatically, and so on down the stack.

[GRW-66](https://linear.app/speakeasy/issue/GRW-66/feat-revamp-posthog-slack-notifications)

Third of a five-PR stack. **Targets #6058**, review that first.

## Summary

Emits `user_signed_up` when a user row is first created, carrying `signup_source` so self-serve growth can be told apart from growth that came from somebody sending an invitation.

- Adds `HasPendingInvitationForEmail`, which deliberately spans every organization rather than one: the user does not exist yet and belongs to none.
- Classifies at user creation, the only moment it is knowable. A live invitation addressed to the new user means somebody asked them to join. A moment later that invitation is accepted and the evidence is gone.
- A failed lookup reports neither value rather than guessing "organic" and overstating self-serve growth.
- Wires the emitter into the identity resolver, and constructs it in `start.go`. That wiring is the shared edit the remaining two PRs extend rather than rewrite.

`Emit` becomes nil-safe, so callers with no analytics wiring do not each have to guard the call, and analytics can never be the reason a request path panics. This matches the existing `if s.posthog == nil` guard used elsewhere in the auth and organizations services.

## Motivation

Distinguishing invited from organic signups was the specific gap raised on the ticket: the existing `is_first_time_user_signup` event fires before we know which kind of arrival it was, so the funnel cannot separate the two.

Remaining in the stack, not in this PR: the other two direct emits (organization created, member joined), then devices and agents.

Temporal actions/month: 0, scales with fixed. No background work is added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports first-time signups as `gram_activity` with a `signup_source` of invited or organic, and emits the two remaining direct activities the audit log doesn't record — `organization_created` and `member_joined_organization` — closing the GRW-66 gap where the signup funnel couldn't tell invited from organic growth.

- Classifies at user creation, the only moment it's knowable: a live invitation addressed to the new user means someone asked them to join, and a moment later that evidence is gone.
- Invitation lookups normalize the email first; invitations are stored normalized and IDP addresses aren't, so raw comparison misclassified mixed-case invited users as organic.
- A failed lookup reports neither value rather than guessing "organic" and overstating self-serve growth.
- `HasPendingInvitationForEmail` spans every organization because the user belongs to none yet.
- `Emit` is now nil-safe, so callers without analytics wiring don't guard the call and analytics can't panic a request path.
- `organization_created` fires from both provisioning paths, each tagged with the flow that produced it, and before the PostHog nil guard because the emitter and client are configured independently.
- `member_joined_organization` fires only once the membership is durable; an invitation whose role sync failed returns before the emit.

<sup>Written for commit 12e4a7657e7b41cfa1120fc7bf6d9b00ccf5c301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

