### PR TITLE
feat: report devices appearing in a fleet

### DIFF
--- a/.changeset/growth-signals-devices.md
+++ b/.changeset/growth-signals-devices.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Report devices appearing in an organization's fleet as `gram_activity`. The MDM upsert now reports whether it inserted, which is the only way to tell a first sighting from a re-sighting, and a config's first successful sync is treated as a backfill rather than a stream of new devices.

--- a/docs/superpowers/specs/2026-09-03-posthog-slack-notifications-design.md
+++ b/docs/superpowers/specs/2026-09-03-posthog-slack-notifications-design.md
@@ -323,7 +323,7 @@ button linking to the subject in the Gram dashboard.
 1. Ship the Go change. Events begin flowing to PostHog with no destinations
    consuming them yet, so Slack stays quiet.
 2. Confirm `gram_activity` volume and shape in PostHog over a day.
-3. Create the six new destinations disabled, test-invoke each, enable them.
+3. Create the five new destinations disabled, test-invoke each, enable them.
 4. Disable the eleven old destinations in the same sitting, so there is no
    window of doubled notifications.
 5. After a week of clean signal, delete the eleven disabled destinations.
@@ -341,7 +341,7 @@ button linking to the subject in the Gram dashboard.
 
 ## Appendix: the shared Slack message template
 
-All six destinations use one template, so every Gram notification reads the same
+All five destinations use one template, so every Gram notification reads the same
 way regardless of channel. PostHog's Slack destination templates support hog
 expressions, including `??` and ternaries, which today's destinations already use.
 

--- a/docs/superpowers/specs/2026-09-03-posthog-slack-notifications-design.md
+++ b/docs/superpowers/specs/2026-09-03-posthog-slack-notifications-design.md
@@ -277,7 +277,7 @@ points at a different channel.
 
 ### New destinations
 
-All six are created on Slack workspace integration 57009, which already posts
+All five are created on Slack workspace integration 57009, which already posts
 successfully to all three channels. Each is created disabled, tested with a
 sample invocation, then enabled.
 
@@ -285,20 +285,21 @@ sample invocation, then enabled.
 | ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Gram significant          | `#ops-significant-events` | `gram_activity` where `activity` is one of `organization_created`, `user_signed_up`, `member_joined_organization`, `project_created`, `mcp_server_created`, `security_policy_created` |
 | Gram firehose             | `#ops-aicp-events`        | every `gram_activity`                                                                                                                                                                 |
-| Gram MCP settings         | `#ops-all-events`         | `gram_activity` where `activity` is `mcp_server_updated`                                                                                                                              |
 | Gram subscription changes | `#ops-significant-events` | `gram_subscription_changed`                                                                                                                                                           |
 | Gram feature requests     | `#ops-significant-events` | `feature_requested`                                                                                                                                                                   |
 | Gram enterprise gate      | `#ops-significant-events` | `enterprise_gate_viewed`                                                                                                                                                              |
 
 Every MCP server creation reaches the significant channel, not only the first per
-project. MCP settings changes reach both `#ops-aicp-events` (via the firehose)
-and `#ops-all-events` (via its own destination).
+project. MCP settings changes ride the firehose into `#ops-aicp-events` and get
+no destination of their own: the firehose already carries every activity, so a
+second destination would only duplicate them into a channel nobody watches for
+this. `#ops-all-events` therefore receives nothing from this design.
 
 The last three carry over today's behaviour on their own events; they are
 recreated cleanly rather than folded into `gram_activity` because they are
 genuinely different events with different properties.
 
-All six share one message template: actor, activity, org and project, and a
+All five share one message template: actor, activity, org and project, and a
 button linking to the subject in the Gram dashboard.
 
 ## Testing

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -47,6 +47,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
@@ -375,6 +376,11 @@ func NewActivities(
 
 	conversionPolicyReconciler, _ := openrouterProvisioner.(activities.ConversionPolicyReconciler)
 
+	// Built here rather than threaded in: this constructor already holds every
+	// dependency the emitter needs, and only the device sync reports growth
+	// activity from the worker.
+	growthEmitter := growthsignals.NewEmitter(logger, posthogClient, growthsignals.NewDatabaseEnricher(db), siteURL)
+
 	return &Activities{
 		db:                              db,
 		temporalEnv:                     temporalEnv,
@@ -384,8 +390,8 @@ func NewActivities(
 		collectPlatformUsageMetrics:     activities.NewCollectPlatformUsageMetrics(logger, db),
 		getAIIntegrationsCandidates:     activities.NewGetAIIntegrationsCandidates(logger, db, encryption),
 		pollAIData:                      activities.NewPollAIData(logger, db, encryption, telemetryLogger, guardianPolicy, chatWriter),
-		getDeviceIntegrationCandidates:  activities.NewGetDeviceIntegrationSyncCandidates(logger, meterProvider, db, encryption, guardianPolicy, features),
-		runDeviceIntegrationSync:        activities.NewRunDeviceIntegrationSync(logger, meterProvider, db, encryption, guardianPolicy, features),
+		getDeviceIntegrationCandidates:  activities.NewGetDeviceIntegrationSyncCandidates(logger, meterProvider, db, encryption, guardianPolicy, features, growthEmitter),
+		runDeviceIntegrationSync:        activities.NewRunDeviceIntegrationSync(logger, meterProvider, db, encryption, guardianPolicy, features, growthEmitter),
 		customDomainIngress:             activities.NewCustomDomainIngress(logger, db, k8sClient),
 		customDomainHealth:              activities.NewCustomDomainHealth(logger, db, k8sClient, expectedTargetCNAME, expectedARecords, emailService, siteURL, guardianPolicy),
 		fireOpenRouterCreditsMetrics:    activities.NewFireOpenRouterCreditsMetrics(logger, meterProvider),

--- a/server/internal/background/activities/device_integration_sync.go
+++ b/server/internal/background/activities/device_integration_sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deviceintegrations"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 )
 
@@ -21,9 +22,9 @@ type GetDeviceIntegrationSyncCandidates struct {
 	syncer *deviceintegrations.Syncer
 }
 
-func NewGetDeviceIntegrationSyncCandidates(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, encryptionClient *encryption.Client, guardianPolicy *guardian.Policy, features feature.Provider) *GetDeviceIntegrationSyncCandidates {
+func NewGetDeviceIntegrationSyncCandidates(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, encryptionClient *encryption.Client, guardianPolicy *guardian.Policy, features feature.Provider, growthEmitter *growthsignals.Emitter) *GetDeviceIntegrationSyncCandidates {
 	return &GetDeviceIntegrationSyncCandidates{
-		syncer: deviceintegrations.NewSyncer(logger, meterProvider, db, encryptionClient, guardianPolicy, features),
+		syncer: deviceintegrations.NewSyncer(logger, meterProvider, db, encryptionClient, guardianPolicy, features, growthEmitter),
 	}
 }
 
@@ -52,9 +53,9 @@ type RunDeviceIntegrationSync struct {
 	syncer *deviceintegrations.Syncer
 }
 
-func NewRunDeviceIntegrationSync(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, encryptionClient *encryption.Client, guardianPolicy *guardian.Policy, features feature.Provider) *RunDeviceIntegrationSync {
+func NewRunDeviceIntegrationSync(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, encryptionClient *encryption.Client, guardianPolicy *guardian.Policy, features feature.Provider, growthEmitter *growthsignals.Emitter) *RunDeviceIntegrationSync {
 	return &RunDeviceIntegrationSync{
-		syncer: deviceintegrations.NewSyncer(logger, meterProvider, db, encryptionClient, guardianPolicy, features),
+		syncer: deviceintegrations.NewSyncer(logger, meterProvider, db, encryptionClient, guardianPolicy, features, growthEmitter),
 	}
 }
 

--- a/server/internal/deviceintegrations/queries.sql
+++ b/server/internal/deviceintegrations/queries.sql
@@ -520,6 +520,7 @@ SELECT
   , s.consecutive_failures
   , s.auto_paused_at
   , s.last_push_digest
+  , s.last_poll_success_at
 FROM device_integration_syncs s
 JOIN device_integration_schedules sch
   ON sch.id = s.device_integration_schedule_id
@@ -599,7 +600,7 @@ RETURNING (s.auto_paused_at IS NOT NULL)::boolean AS auto_paused;
 -- the insert a zero-row no-op, so stale-credential inventory never merges
 -- into the newly saved config.
 
--- name: UpsertMdmDevice :execrows
+-- name: UpsertMdmDevice :one
 INSERT INTO mdm_devices (
     device_integration_config_id
   , organization_id
@@ -642,7 +643,11 @@ ON CONFLICT (device_integration_config_id, external_id) DO UPDATE SET
     raw = EXCLUDED.raw,
     last_seen_at = clock_timestamp(),
     missing_since = NULL,
-    updated_at = clock_timestamp();
+    updated_at = clock_timestamp()
+-- xmax is zero on a freshly inserted row and non-zero on one this statement
+-- updated, which is the only way to tell a first sighting from a re-sighting:
+-- the row count is 1 for both. A guard failure returns no row at all.
+RETURNING (xmax = 0) AS inserted;
 
 -- MarkDevicesMissing stamps devices absent from the snapshot that started at
 -- @sync_started_at. INVARIANT: only ever called in the same transaction that

--- a/server/internal/deviceintegrations/repo/queries.sql.go
+++ b/server/internal/deviceintegrations/repo/queries.sql.go
@@ -494,6 +494,7 @@ SELECT
   , s.consecutive_failures
   , s.auto_paused_at
   , s.last_push_digest
+  , s.last_poll_success_at
 FROM device_integration_syncs s
 JOIN device_integration_schedules sch
   ON sch.id = s.device_integration_schedule_id
@@ -518,6 +519,7 @@ type GetSyncTargetRow struct {
 	ConsecutiveFailures  int32
 	AutoPausedAt         pgtype.Timestamptz
 	LastPushDigest       pgtype.Text
+	LastPollSuccessAt    pgtype.Timestamptz
 }
 
 func (q *Queries) GetSyncTarget(ctx context.Context, syncID uuid.UUID) (GetSyncTargetRow, error) {
@@ -539,6 +541,7 @@ func (q *Queries) GetSyncTarget(ctx context.Context, syncID uuid.UUID) (GetSyncT
 		&i.ConsecutiveFailures,
 		&i.AutoPausedAt,
 		&i.LastPushDigest,
+		&i.LastPollSuccessAt,
 	)
 	return i, err
 }
@@ -1365,7 +1368,7 @@ func (q *Queries) UpdateConfigSettings(ctx context.Context, arg UpdateConfigSett
 	return i, err
 }
 
-const upsertMdmDevice = `-- name: UpsertMdmDevice :execrows
+const upsertMdmDevice = `-- name: UpsertMdmDevice :one
 
 INSERT INTO mdm_devices (
     device_integration_config_id
@@ -1410,6 +1413,7 @@ ON CONFLICT (device_integration_config_id, external_id) DO UPDATE SET
     last_seen_at = clock_timestamp(),
     missing_since = NULL,
     updated_at = clock_timestamp()
+RETURNING (xmax = 0) AS inserted
 `
 
 type UpsertMdmDeviceParams struct {
@@ -1433,8 +1437,11 @@ type UpsertMdmDeviceParams struct {
 // the sync started: a config save (rotation, endpoint change) mid-pull makes
 // the insert a zero-row no-op, so stale-credential inventory never merges
 // into the newly saved config.
-func (q *Queries) UpsertMdmDevice(ctx context.Context, arg UpsertMdmDeviceParams) (int64, error) {
-	result, err := q.db.Exec(ctx, upsertMdmDevice,
+// xmax is zero on a freshly inserted row and non-zero on one this statement
+// updated, which is the only way to tell a first sighting from a re-sighting:
+// the row count is 1 for both. A guard failure returns no row at all.
+func (q *Queries) UpsertMdmDevice(ctx context.Context, arg UpsertMdmDeviceParams) (bool, error) {
+	row := q.db.QueryRow(ctx, upsertMdmDevice,
 		arg.DeviceIntegrationConfigID,
 		arg.OrganizationID,
 		arg.ExternalID,
@@ -1448,8 +1455,7 @@ func (q *Queries) UpsertMdmDevice(ctx context.Context, arg UpsertMdmDeviceParams
 		arg.Raw,
 		arg.ConfigUpdatedAt,
 	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
 }

--- a/server/internal/deviceintegrations/sync.go
+++ b/server/internal/deviceintegrations/sync.go
@@ -24,6 +24,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/deviceintegrations/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -108,6 +109,7 @@ type Syncer struct {
 	guardian *guardian.Policy
 	features feature.Provider
 	metrics  *syncMetrics
+	growth   *growthsignals.Emitter
 }
 
 func NewSyncer(
@@ -117,6 +119,7 @@ func NewSyncer(
 	enc *encryption.Client,
 	guardianPolicy *guardian.Policy,
 	features feature.Provider,
+	growthEmitter *growthsignals.Emitter,
 ) *Syncer {
 	componentLogger := logger.With(attr.SlogComponent("deviceintegrations.syncer"))
 	return &Syncer{
@@ -127,6 +130,7 @@ func NewSyncer(
 		guardian: guardianPolicy,
 		features: features,
 		metrics:  newSyncMetrics(componentLogger, meterProvider),
+		growth:   growthEmitter,
 	}
 }
 
@@ -278,6 +282,13 @@ var errStaleSync = errors.New("sync outcome superseded by a config save")
 func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTargetRow, source providers.InventorySource, creds providers.Credentials, settings providers.Settings, started time.Time) error {
 	cursor := ""
 	memberCache := map[string]pgtype.Text{}
+
+	// A config that has never completed a sync is being backfilled, not
+	// observed: its first snapshot inserts the whole existing fleet at once,
+	// and reporting each row would announce hundreds of devices that were
+	// already there. Only later syncs describe devices genuinely appearing.
+	backfill := !target.LastPollSuccessAt.Valid
+	var firstSeen []deviceSighting
 	for page := 0; ; page++ {
 		if page >= syncMaxPages {
 			return fmt.Errorf("inventory listing exceeded %d pages without completing", syncMaxPages)
@@ -307,7 +318,7 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 			if !device.LastCheckInAt.IsZero() {
 				checkIn = conv.ToPGTimestamptz(device.LastCheckInAt)
 			}
-			rows, err := s.repo.UpsertMdmDevice(ctx, repo.UpsertMdmDeviceParams{
+			inserted, err := s.repo.UpsertMdmDevice(ctx, repo.UpsertMdmDeviceParams{
 				DeviceIntegrationConfigID: target.ConfigID,
 				OrganizationID:            target.OrganizationID,
 				ExternalID:                device.ExternalID,
@@ -322,17 +333,24 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 				ConfigUpdatedAt:           target.ConfigUpdatedAt,
 			})
 			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					// The config was saved mid-pull: this run's inventory came
+					// from the pre-save credentials/settings and must not merge
+					// into the new config. Abort; the reset schedule re-runs
+					// promptly with the new configuration.
+					return errStaleSync
+				}
 				if isVendorDataError(err) {
 					return fmt.Errorf("upsert mdm device %s: %w", device.ExternalID, err)
 				}
 				return asInfra(oops.E(oops.CodeUnexpected, err, "upsert mdm device"))
 			}
-			if rows == 0 {
-				// The config was saved mid-pull: this run's inventory came
-				// from the pre-save credentials/settings and must not merge
-				// into the new config. Abort; the reset schedule re-runs
-				// promptly with the new configuration.
-				return errStaleSync
+			if inserted && !backfill && len(firstSeen) < maxDeviceActivitiesPerSync {
+				firstSeen = append(firstSeen, deviceSighting{
+					externalID: device.ExternalID,
+					hostname:   device.Hostname,
+					userEmail:  device.UserEmail,
+				})
 			}
 		}
 		cursor = devicePage.NextCursor
@@ -375,7 +393,54 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 		}
 		return asInfra(oops.E(oops.CodeUnexpected, err, "finalize inventory snapshot"))
 	}
+
+	// Reported only once the snapshot is durable. Emitting inside the loop
+	// would announce devices for a run that later aborts as stale, and the
+	// abort paths above all return before this point.
+	s.reportFirstSeen(ctx, target.OrganizationID, firstSeen)
+
 	return nil
+}
+
+// maxDeviceActivitiesPerSync bounds how many first sightings one snapshot
+// reports. A fleet that doubles overnight is worth one glance at the
+// dashboard, not hundreds of notifications, and the devices themselves are
+// all in the inventory either way.
+const maxDeviceActivitiesPerSync = 10
+
+// deviceSighting is a device this sync inserted for the first time. It holds
+// only what the activity reports, so the vendor payload does not travel.
+type deviceSighting struct {
+	externalID string
+	hostname   string
+	userEmail  string
+}
+
+// reportFirstSeen announces devices that appeared in this snapshot. Devices
+// are organization-scoped: no MDM table carries a project, so these activities
+// never claim one.
+func (s *Syncer) reportFirstSeen(ctx context.Context, organizationID string, sightings []deviceSighting) {
+	for _, sighting := range sightings {
+		name := sighting.hostname
+		if name == "" {
+			name = sighting.externalID
+		}
+
+		s.growth.Emit(ctx, growthsignals.ActivityEvent{
+			Activity:       growthsignals.ActivityDeviceFirstSeen,
+			OrganizationID: organizationID,
+			ProjectID:      uuid.Nil,
+			ActorID:        "",
+			ActorType:      "",
+			ActorEmail:     sighting.userEmail,
+			ActorName:      "",
+			SubjectName:    name,
+			ActingSurface:  "",
+			AuditAction:    "",
+			DashboardURL:   "",
+			Extra:          map[string]string{},
+		})
+	}
 }
 
 // runEvidencePush builds the org's coverage snapshot and delivers it to the

--- a/server/internal/deviceintegrations/sync.go
+++ b/server/internal/deviceintegrations/sync.go
@@ -408,6 +408,11 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 // all in the inventory either way.
 const maxDeviceActivitiesPerSync = 10
 
+// propertyDeviceOwnerEmail carries the MDM-assigned user of a device. It is a
+// property rather than the actor because the owner did not do anything: a
+// scheduled sync observed their device.
+const propertyDeviceOwnerEmail = "device_owner_email"
+
 // deviceSighting is a device this sync inserted for the first time. It holds
 // only what the activity reports, so the vendor payload does not travel.
 type deviceSighting struct {
@@ -419,11 +424,27 @@ type deviceSighting struct {
 // reportFirstSeen announces devices that appeared in this snapshot. Devices
 // are organization-scoped: no MDM table carries a project, so these activities
 // never claim one.
+//
+// Reporting is at-most-once by design. A sync that inserts rows and then fails
+// on a later page has already committed those rows, so the retry sees them as
+// existing and reports nothing. The alternative — persisting pending sightings
+// so a retry could finish announcing them — buys durability for an ops
+// notification at the cost of a table and its own failure modes. The devices
+// are in the inventory either way; only the Slack line is lost.
 func (s *Syncer) reportFirstSeen(ctx context.Context, organizationID string, sightings []deviceSighting) {
 	for _, sighting := range sightings {
 		name := sighting.hostname
 		if name == "" {
 			name = sighting.externalID
+		}
+
+		// The device's assigned user is its owner, not the actor: nobody
+		// performed this, a scheduled inventory sync observed it. Reporting
+		// them as the actor would attribute the event to them and attach it to
+		// their PostHog person, so the owner travels as a plain property.
+		extra := map[string]string{}
+		if sighting.userEmail != "" {
+			extra[propertyDeviceOwnerEmail] = sighting.userEmail
 		}
 
 		s.growth.Emit(ctx, growthsignals.ActivityEvent{
@@ -432,13 +453,13 @@ func (s *Syncer) reportFirstSeen(ctx context.Context, organizationID string, sig
 			ProjectID:      uuid.Nil,
 			ActorID:        "",
 			ActorType:      "",
-			ActorEmail:     sighting.userEmail,
+			ActorEmail:     "",
 			ActorName:      "",
 			SubjectName:    name,
 			ActingSurface:  "",
 			AuditAction:    "",
 			DashboardURL:   "",
-			Extra:          map[string]string{},
+			Extra:          extra,
 		})
 	}
 }

--- a/server/internal/deviceintegrations/sync_test.go
+++ b/server/internal/deviceintegrations/sync_test.go
@@ -26,7 +26,7 @@ import (
 func newSyncTestEnv(t *testing.T) (context.Context, *pgxpool.Pool, *Store, *Syncer, string) {
 	t.Helper()
 	ctx, conn, store, orgID := newStoreTestDB(t)
-	syncer := NewSyncer(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, testenv.NewEncryptionClient(t), guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), nil)
+	syncer := NewSyncer(testenv.NewLogger(t), testenv.NewMeterProvider(t), conn, testenv.NewEncryptionClient(t), guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), nil, nil)
 	return ctx, conn, store, syncer, orgID
 }
 
@@ -37,7 +37,7 @@ func newSyncMetricTestEnv(t *testing.T) (context.Context, *pgxpool.Pool, *Store,
 	ctx, conn, store, orgID := newStoreTestDB(t)
 	reader := sdkmetric.NewManualReader()
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	syncer := NewSyncer(testenv.NewLogger(t), meterProvider, conn, testenv.NewEncryptionClient(t), guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), nil)
+	syncer := NewSyncer(testenv.NewLogger(t), meterProvider, conn, testenv.NewEncryptionClient(t), guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), nil, nil)
 	return ctx, conn, store, syncer, orgID, reader
 }
 

--- a/server/internal/deviceintegrations/sync_test.go
+++ b/server/internal/deviceintegrations/sync_test.go
@@ -453,7 +453,7 @@ func TestMidPullConfigSaveAbortsInventoryMerge(t *testing.T) {
 	require.NoError(t, err)
 	mustUpsert(t, ctx, conn, store, orgID, nil, providers.Settings{"note": "changed"}, true)
 
-	rows, err := store.repo.UpsertMdmDevice(ctx, repo.UpsertMdmDeviceParams{
+	_, err = store.repo.UpsertMdmDevice(ctx, repo.UpsertMdmDeviceParams{
 		DeviceIntegrationConfigID: target.ConfigID,
 		OrganizationID:            target.OrganizationID,
 		ExternalID:                "stale-device",
@@ -467,8 +467,9 @@ func TestMidPullConfigSaveAbortsInventoryMerge(t *testing.T) {
 		Raw:                       []byte("{}"),
 		ConfigUpdatedAt:           target.ConfigUpdatedAt,
 	})
-	require.NoError(t, err)
-	require.Zero(t, rows, "stale-generation device writes are refused")
+	// The write is refused by the config-generation guard, which returns no row
+	// at all rather than a zero row count.
+	require.ErrorIs(t, err, pgx.ErrNoRows, "stale-generation device writes are refused")
 
 	// A fresh run (which re-reads the target) still works end to end.
 	require.NoError(t, syncer.RunSync(ctx, syncID))


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — merge bottom-up.** Each PR targets the one above it, so its Files tab shows only its own diff.
>
> 1. #6057 — core taxonomy and emitter
> 2. #6058 — audit stream to PostHog
> 3. #6059 — direct emits: signup source, org created, member joined
> 4. #6060 — devices 👈 **this PR**
> 5. #6061 — agents
>
> Merging #6057 retargets #6058 to `main` automatically, and so on down the stack.

[GRW-66](https://linear.app/speakeasy/issue/GRW-66/feat-revamp-posthog-slack-notifications)

Fourth of a five-PR stack. **Targets #6059**, review that first.

## Summary

Emits `device_first_seen` when an MDM snapshot inserts a device the inventory has not held before.

Detecting that at all required a query change. `UpsertMdmDevice` returned the same row count on insert and on update, so a first sighting and a re-sighting were indistinguishable. It now returns `(xmax = 0)`, which is true only on a freshly inserted row. The config-guard case, which previously surfaced as a zero row count, is now no row at all and maps to the same stale-sync outcome as before, so that behaviour is unchanged.

Two guards keep this from flooding the channel:

- **A config's first successful sync is a backfill, not news.** It inserts the whole existing fleet at once, so it reports nothing. `last_poll_success_at` is the signal, newly exposed on `GetSyncTarget`.
- **Later syncs report at most ten devices.** A fleet that doubles overnight is worth one glance at the dashboard, not hundreds of notifications. The devices are all in the inventory either way.

Reporting happens only after the snapshot is durable. Emitting inside the loop would announce devices for a run that later aborts as stale, and every abort path returns before the emit.

These activities are organization-scoped, because no MDM table carries a project id.

## Motivation

Devices were the riskiest item on the ticket precisely because none of the three device ingest paths could tell that a row was new, and the bulk-sync shape meant a naive implementation would announce an entire fleet the first time an integration was connected.

Temporal actions/month: 0, scales with fixed. No schedules, workflows or activities are added; this rides the existing device-integration sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `device_first_seen` when an MDM snapshot inserts a device the inventory hasn't held before, covering the devices scope of GRW-66. The upsert previously returned the same row count on insert and update, so a first sighting and a re-sighting were indistinguishable.

- `UpsertMdmDevice` now returns `(xmax = 0)`, true only on a freshly inserted row; the config-guard case is now no row at all and maps to the same stale-sync outcome as before.
- Two guards prevent flooding: a config's first successful sync is a backfill and reports nothing (via `last_poll_success_at`, newly exposed on `GetSyncTarget`), and later syncs report at most ten devices.
- The device's assigned user travels as a `device_owner_email` property rather than the actor, so the sighting isn't attached to the owner's PostHog person.
- Reporting is at-most-once: rows committed before a later-page failure read as existing on retry, so the retry reports nothing.
- Reporting happens only after the snapshot is durable, so runs that later abort as stale announce nothing.
- These activities are organization-scoped because no MDM table carries a project id.
- No Temporal schedules, workflows, or activities are added; this rides the existing device-integration sync.
- The design spec drops the MCP settings destination; those events ride the firehose instead.

<sup>Written for commit a6b662d2f04402dd4ea59454ea1f3d334411f019. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

