### PR TITLE
feat: report agents new to an organization

### DIFF
--- a/.changeset/growth-signals-agents.md
+++ b/.changeset/growth-signals-agents.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Report AI agents appearing in an organization for the first time as `gram_activity`. Detections are stored per device and user, so a harness already known on one laptop looked brand new on the next one; an organization-wide check now distinguishes a genuinely new agent from a known one spreading.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1380,7 +1380,7 @@ func newStartCommand() *cli.Command {
 			external.AttachWebhookHandler(mux, external.NewWebhookHandler(logger, tracerProvider, newWorkOSWebhooksClient(c), temporalEnv))
 			roleManager := access.NewRoleManager(logger, db, roleClient, auditLogger)
 			access.Attach(mux, access.NewService(logger, tracerProvider, db, chDB, sessionManager, roleManager, authzEngine, auditLogger, emailService, siteURL, telemSvc))
-			agent.Attach(mux, agent.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, productFeatures, serverURL.String(), assetStorage, telemLogger))
+			agent.Attach(mux, agent.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, productFeatures, serverURL.String(), assetStorage, telemLogger, growthEmitter))
 			assistants.Attach(mux, assistantsSvc)
 			assistantmemories.Attach(mux, assistantmemories.NewService(
 				logger,

--- a/server/internal/access/ai_detections_test.go
+++ b/server/internal/access/ai_detections_test.go
@@ -57,7 +57,7 @@ func withUniqueDetectionOrg(t *testing.T, ctx context.Context, ti *testInstance)
 
 func seedAIDetection(t *testing.T, ctx context.Context, ti *testInstance, orgID, targetID, serial, email, signal, category, version string, seenAt time.Time) {
 	t.Helper()
-	require.NoError(t, telemetryrepo.New(ti.chConn).UpsertAIDetections(ctx, []telemetryrepo.UpsertAIDetectionParams{{
+	_, err := telemetryrepo.New(ti.chConn).UpsertAIDetections(ctx, []telemetryrepo.UpsertAIDetectionParams{{
 		OrganizationID: orgID,
 		TargetID:       targetID,
 		DeviceSerial:   serial,
@@ -67,7 +67,8 @@ func seedAIDetection(t *testing.T, ctx context.Context, ti *testInstance, orgID,
 		Version:        version,
 		SeenAt:         seenAt,
 		UpdatedAt:      time.Now().UTC(),
-	}}))
+	}})
+	require.NoError(t, err)
 }
 
 func seedAIDetectionIdentity(t *testing.T, ctx context.Context, ti *testInstance, orgID, emailLower, userID, canonicalEmail string) {

--- a/server/internal/agent/aiscan.go
+++ b/server/internal/agent/aiscan.go
@@ -165,7 +165,17 @@ func (s *Service) reportFirstDetected(ctx context.Context, organizationID string
 			ActingSurface:  "",
 			AuditAction:    "",
 			DashboardURL:   "",
-			Extra:          map[string]string{propertyAgentTargetID: targetID},
+			Extra: map[string]string{
+				propertyAgentTargetID: targetID,
+				// Two scans for the same organization and target can overlap:
+				// both pass the pre-insert lookup, both see it as unseen, and
+				// both report. The claim is not atomic and making it so would
+				// cost a lock on a scan path that is otherwise append-only, so
+				// the report carries a key derived from what it asserts —
+				// this target was first seen in this organization — and PostHog
+				// collapses the duplicates.
+				propertyInsertID: "agent_first_detected:" + organizationID + ":" + targetID,
+			},
 		})
 	}
 }
@@ -173,3 +183,6 @@ func (s *Service) reportFirstDetected(ctx context.Context, organizationID string
 // propertyAgentTargetID is the catalog id behind a detected agent, kept
 // alongside the display name so a renamed catalog entry stays traceable.
 const propertyAgentTargetID = "agent_target_id"
+
+// propertyInsertID is PostHog's deduplication key.
+const propertyInsertID = "$insert_id"

--- a/server/internal/agent/aiscan.go
+++ b/server/internal/agent/aiscan.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"math"
 	"slices"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -117,9 +119,11 @@ func (s *Service) ReportAIScan(ctx context.Context, payload *gen.ReportAIScanPay
 		)
 	}
 
-	if err := s.telemetry.UpsertAIDetections(ctx, detections); err != nil {
+	firstInOrganization, err := s.telemetry.UpsertAIDetections(ctx, detections)
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error recording ai scan detections").LogError(ctx, s.logger)
 	}
+	s.reportFirstDetected(ctx, authCtx.ActiveOrganizationID, firstInOrganization)
 
 	if err := s.telemetry.InsertAIScanReceipt(ctx, telemetry.AIScanReceipt{
 		OrganizationID:    authCtx.ActiveOrganizationID,
@@ -136,3 +140,36 @@ func (s *Service) ReportAIScan(ctx context.Context, payload *gen.ReportAIScanPay
 
 	return nil
 }
+
+// reportFirstDetected announces AI agents this organization had never seen.
+//
+// Nobody performed this: a device agent scanned and reported what it found, so
+// the activity carries no actor. Detections are organization-scoped — the
+// inventory has no project dimension — so these never claim a project.
+func (s *Service) reportFirstDetected(ctx context.Context, organizationID string, targetIDs []string) {
+	for _, targetID := range targetIDs {
+		name := targetID
+		if target, known := aitargets.ByID(targetID); known {
+			name = target.DisplayName
+		}
+
+		s.growth.Emit(ctx, growthsignals.ActivityEvent{
+			Activity:       growthsignals.ActivityAgentFirstDetected,
+			OrganizationID: organizationID,
+			ProjectID:      uuid.Nil,
+			ActorID:        "",
+			ActorType:      "",
+			ActorEmail:     "",
+			ActorName:      "",
+			SubjectName:    name,
+			ActingSurface:  "",
+			AuditAction:    "",
+			DashboardURL:   "",
+			Extra:          map[string]string{propertyAgentTargetID: targetID},
+		})
+	}
+}
+
+// propertyAgentTargetID is the catalog id behind a detected agent, kept
+// alongside the display name so a renamed catalog entry stays traceable.
+const propertyAgentTargetID = "agent_target_id"

--- a/server/internal/agent/impl.go
+++ b/server/internal/agent/impl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/growthsignals"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -59,6 +60,7 @@ type Service struct {
 	serverURL       string
 	blobStore       assets.BlobStore
 	telemetry       *telemetry.Logger
+	growth          *growthsignals.Emitter
 }
 
 var (
@@ -78,6 +80,7 @@ func NewService(
 	serverURL string,
 	blobStore assets.BlobStore,
 	telemetryLogger *telemetry.Logger,
+	growthEmitter *growthsignals.Emitter,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("agent"))
 	return &Service{
@@ -92,6 +95,7 @@ func NewService(
 		serverURL:       serverURL,
 		blobStore:       blobStore,
 		telemetry:       telemetryLogger,
+		growth:          growthEmitter,
 	}
 }
 

--- a/server/internal/agent/setup_test.go
+++ b/server/internal/agent/setup_test.go
@@ -120,7 +120,7 @@ func newTestAgentService(t *testing.T) (context.Context, *testInstance) {
 	enabled := func(context.Context, string) (bool, error) { return true, nil }
 	telemetryLogger := telemetry.NewLogger(ctx, logger, tracerProvider, testenv.NewMeterProvider(t), chConn, enabled, enabled, nil, telemetry.NewNoopLogPublisher(logger))
 
-	svc := agent.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, audit.NewLogger(), features, testServerURL, blobs, telemetryLogger)
+	svc := agent.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, audit.NewLogger(), features, testServerURL, blobs, telemetryLogger, nil)
 
 	return ctx, &testInstance{
 		service:   svc,

--- a/server/internal/telemetry/ai_detections.go
+++ b/server/internal/telemetry/ai_detections.go
@@ -34,31 +34,33 @@ type AIScanReceipt struct {
 
 // UpsertAIDetections merges AI-scan detections into the ai_detections
 // inventory, preserving first_seen via the repo's read-merge-write.
-func (l *Logger) UpsertAIDetections(ctx context.Context, detections []AIDetection) error {
+// It returns the target ids that were new to the organization, so a caller can
+// report a genuinely new agent without re-deriving that from the inventory.
+func (l *Logger) UpsertAIDetections(ctx context.Context, detections []AIDetection) ([]string, error) {
 	if len(detections) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	now := time.Now().UTC()
 	params := make([]repo.UpsertAIDetectionParams, 0, len(detections))
 	for _, detection := range detections {
 		if detection.OrganizationID == "" {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection missing organization id")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection missing organization id")
 		}
 		if detection.TargetID == "" {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection missing target id")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection missing target id")
 		}
 		if detection.UserEmail == "" {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection missing user email")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection missing user email")
 		}
 		if detection.Signal != "installed" && detection.Signal != "running" {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection has invalid signal")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection has invalid signal")
 		}
 		if detection.Category != "harness" && detection.Category != "local_model" {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection has invalid category")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection has invalid category")
 		}
 		if detection.SeenAt.IsZero() {
-			return oops.E(oops.CodeUnexpected, nil, "ai detection missing seen_at")
+			return nil, oops.E(oops.CodeUnexpected, nil, "ai detection missing seen_at")
 		}
 		params = append(params, repo.UpsertAIDetectionParams{
 			OrganizationID: detection.OrganizationID,
@@ -74,14 +76,15 @@ func (l *Logger) UpsertAIDetections(ctx context.Context, detections []AIDetectio
 	}
 
 	if l.chConn == nil {
-		return nil
+		return nil, nil
 	}
 
-	if err := repo.New(l.chConn).UpsertAIDetections(l.detachedWriteContext(ctx), params); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "upsert ai detections")
+	firstInOrganization, err := repo.New(l.chConn).UpsertAIDetections(l.detachedWriteContext(ctx), params)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "upsert ai detections")
 	}
 
-	return nil
+	return firstInOrganization, nil
 }
 
 // InsertAIScanReceipt appends one scan receipt to ai_scan_receipts.

--- a/server/internal/telemetry/ai_detections_test.go
+++ b/server/internal/telemetry/ai_detections_test.go
@@ -24,8 +24,8 @@ func TestUpsertAIDetectionsRejectsZeroSeenAtDeterministically(t *testing.T) {
 		SeenAt:         time.Time{},
 	}
 
-	firstErr := logger.UpsertAIDetections(t.Context(), []AIDetection{detection})
-	secondErr := logger.UpsertAIDetections(t.Context(), []AIDetection{detection})
+	_, firstErr := logger.UpsertAIDetections(t.Context(), []AIDetection{detection})
+	_, secondErr := logger.UpsertAIDetections(t.Context(), []AIDetection{detection})
 	require.Error(t, firstErr)
 	require.Error(t, secondErr)
 	require.EqualError(t, firstErr, secondErr.Error())
@@ -51,9 +51,11 @@ func TestUpsertAIDetectionsRejectsInvalidSignalAndCategory(t *testing.T) {
 
 	invalidSignal := valid
 	invalidSignal.Signal = "stopped"
-	require.Error(t, logger.UpsertAIDetections(t.Context(), []AIDetection{invalidSignal}))
+	_, signalErr := logger.UpsertAIDetections(t.Context(), []AIDetection{invalidSignal})
+	require.Error(t, signalErr)
 
 	invalidCategory := valid
 	invalidCategory.Category = "other"
-	require.Error(t, logger.UpsertAIDetections(t.Context(), []AIDetection{invalidCategory}))
+	_, categoryErr := logger.UpsertAIDetections(t.Context(), []AIDetection{invalidCategory})
+	require.Error(t, categoryErr)
 }

--- a/server/internal/telemetry/repo/ai_detections.go
+++ b/server/internal/telemetry/repo/ai_detections.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -75,30 +76,34 @@ type aiDetectionScope struct {
 // acknowledged async insert. ClickHouse buffers the tiny batch, while
 // wait_for_async_insert=1 preserves the immediate visibility required by the
 // read-merge-write cycle.
-func (q *Queries) UpsertAIDetections(ctx context.Context, args []UpsertAIDetectionParams) error {
+// It also reports which target ids were new to the organization: rows are
+// merged per reporting device and user, so "new here" is not "new anywhere",
+// and only an organization-wide check can tell a genuinely new agent from a
+// known one appearing on a second laptop.
+func (q *Queries) UpsertAIDetections(ctx context.Context, args []UpsertAIDetectionParams) ([]string, error) {
 	if len(args) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	upserts := make(map[aiDetectionKey]*aiDetectionUpsert, len(args))
 	for _, arg := range args {
 		if arg.OrganizationID == "" {
-			return fmt.Errorf("validating ai detection: organization id is required")
+			return nil, fmt.Errorf("validating ai detection: organization id is required")
 		}
 		if arg.TargetID == "" {
-			return fmt.Errorf("validating ai detection: target id is required")
+			return nil, fmt.Errorf("validating ai detection: target id is required")
 		}
 		if arg.UserEmail == "" {
-			return fmt.Errorf("validating ai detection: user email is required")
+			return nil, fmt.Errorf("validating ai detection: user email is required")
 		}
 		if arg.Signal != "installed" && arg.Signal != "running" {
-			return fmt.Errorf("validating ai detection: invalid signal %q", arg.Signal)
+			return nil, fmt.Errorf("validating ai detection: invalid signal %q", arg.Signal)
 		}
 		if arg.Category != "harness" && arg.Category != "local_model" {
-			return fmt.Errorf("validating ai detection: invalid category %q", arg.Category)
+			return nil, fmt.Errorf("validating ai detection: invalid category %q", arg.Category)
 		}
 		if arg.SeenAt.IsZero() {
-			return fmt.Errorf("validating ai detection: seen at is required")
+			return nil, fmt.Errorf("validating ai detection: seen at is required")
 		}
 		seenAt := arg.SeenAt
 		updatedAt := arg.UpdatedAt
@@ -161,7 +166,7 @@ func (q *Queries) UpsertAIDetections(ctx context.Context, args []UpsertAIDetecti
 	for scope, targetIDs := range targetsByScope {
 		existingRows, err := q.listAIDetectionRowsByScope(ctx, scope, targetIDs)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, existing := range existingRows {
 			key := aiDetectionKey{
@@ -192,15 +197,95 @@ func (q *Queries) UpsertAIDetections(ctx context.Context, args []UpsertAIDetecti
 		}
 	}
 
+	// Asked before the insert, so the answer describes the organization as it
+	// was: which of these targets it had never seen on any device, by any user.
+	firstInOrganization, err := q.listUnseenOrganizationTargets(ctx, upserts)
+	if err != nil {
+		return nil, err
+	}
+
 	rows := make([]*aiDetectionUpsert, 0, len(upserts))
 	for _, upsert := range upserts {
 		rows = append(rows, upsert)
 	}
 	if err := q.insertAIDetectionRows(ctx, rows); err != nil {
-		return fmt.Errorf("upserting ai detections: %w", err)
+		return nil, fmt.Errorf("upserting ai detections: %w", err)
 	}
 
-	return nil
+	return firstInOrganization, nil
+}
+
+// listUnseenOrganizationTargets returns the target ids in this batch that the
+// organization has no detection for yet.
+//
+// The read-merge-write above is keyed by device serial and user email, because
+// that is the storage key. That makes its notion of "existing" per-device: a
+// harness already known on one laptop looks brand new on the next one. An
+// organization-wide question needs its own lookup, keyed on nothing but the
+// organization and the target.
+//
+// ReplacingMergeTree may hold unmerged duplicates, which does not matter here:
+// the question is existence, and any surviving row answers it.
+func (q *Queries) listUnseenOrganizationTargets(ctx context.Context, upserts map[aiDetectionKey]*aiDetectionUpsert) ([]string, error) {
+	byOrganization := map[string]map[string]struct{}{}
+	for key := range upserts {
+		targets, ok := byOrganization[key.OrganizationID]
+		if !ok {
+			targets = map[string]struct{}{}
+			byOrganization[key.OrganizationID] = targets
+		}
+		targets[key.TargetID] = struct{}{}
+	}
+
+	var unseen []string
+	for organizationID, targets := range byOrganization {
+		targetIDs := make([]string, 0, len(targets))
+		for targetID := range targets {
+			targetIDs = append(targetIDs, targetID)
+		}
+		sort.Strings(targetIDs)
+
+		query, queryArgs, err := sq.Select("DISTINCT target_id").
+			From("ai_detections").
+			Where("organization_id = ?", organizationID).
+			Where(squirrel.Eq{"target_id": targetIDs}).
+			ToSql()
+		if err != nil {
+			return nil, fmt.Errorf("building organization target lookup query: %w", err)
+		}
+
+		seen := map[string]struct{}{}
+		err = func() error {
+			rows, err := q.conn.Query(ctx, query, queryArgs...)
+			if err != nil {
+				return fmt.Errorf("querying organization targets: %w", err)
+			}
+			defer o11y.NoLogDefer(func() error { return rows.Close() })
+
+			for rows.Next() {
+				var targetID string
+				if err := rows.Scan(&targetID); err != nil {
+					return fmt.Errorf("scanning organization target: %w", err)
+				}
+				seen[targetID] = struct{}{}
+			}
+
+			return rows.Err()
+		}()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, targetID := range targetIDs {
+			if _, ok := seen[targetID]; !ok {
+				unseen = append(unseen, targetID)
+			}
+		}
+	}
+
+	sort.Strings(unseen)
+
+	return unseen, nil
 }
 
 // insertAIDetectionRows buffers tiny batches with async_insert=1 and waits for

--- a/server/internal/telemetry/repo/ai_detections_test.go
+++ b/server/internal/telemetry/repo/ai_detections_test.go
@@ -21,7 +21,7 @@ func TestUpsertAIDetectionsRejectsZeroSeenAt(t *testing.T) {
 		UpdatedAt:      time.Now().UTC(),
 	}
 
-	err := New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{arg})
+	_, err := New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{arg})
 	require.ErrorContains(t, err, "seen at is required")
 }
 
@@ -41,9 +41,11 @@ func TestUpsertAIDetectionsRejectsInvalidFiniteValues(t *testing.T) {
 
 	invalidSignal := valid
 	invalidSignal.Signal = "stopped"
-	require.ErrorContains(t, New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{invalidSignal}), "invalid signal")
+	_, signalErr := New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{invalidSignal})
+	require.ErrorContains(t, signalErr, "invalid signal")
 
 	invalidCategory := valid
 	invalidCategory.Category = "other"
-	require.ErrorContains(t, New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{invalidCategory}), "invalid category")
+	_, categoryErr := New(nil).UpsertAIDetections(t.Context(), []UpsertAIDetectionParams{invalidCategory})
+	require.ErrorContains(t, categoryErr, "invalid category")
 }


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR — merge bottom-up.** Each PR targets the one above it, so its Files tab shows only its own diff.
>
> 1. #6057 — core taxonomy and emitter
> 2. #6058 — audit stream to PostHog
> 3. #6059 — direct emits: signup source, org created, member joined
> 4. #6060 — devices
> 5. #6061 — agents 👈 **this PR**
>
> Merging #6057 retargets #6058 to `main` automatically, and so on down the stack.

[GRW-66](https://linear.app/speakeasy/issue/GRW-66/feat-revamp-posthog-slack-notifications)

Last of a five-PR stack. **Targets #6060**, review that first.

## Summary

Emits `agent_first_detected` when a device-agent scan reports a target the organization has no detection for yet.

The interesting part is what "first" means. The existing read-merge-write in `ai_detections` is keyed by device serial and user email, because that is the ClickHouse storage key. That makes its notion of "existing" per-device: a harness already known on one laptop looks brand new on the next one, so firing on that signal would announce the same agent once per machine as it spreads through a company.

A separate lookup keyed on nothing but the organization and the target answers the question actually being asked. It runs before the insert, so it describes the organization as it was, and needs no schema change. ReplacingMergeTree may hold unmerged duplicates, which does not matter here: the question is existence, and any surviving row answers it.

Two shape decisions:

- **No actor.** Nobody performed this; a device agent scanned and reported what it found. Reporting a user would attribute it to them and attach it to their PostHog person.
- **No project.** The detection inventory has no project dimension, so these activities never claim one.

The catalog supplies the display name, with the raw target id kept alongside it so a renamed catalog entry stays traceable.

## Motivation

Agents were in scope on the ticket but had no natural signal: they are derived from telemetry rather than stored as detection events, so there was no insert to hook. This uses the read-merge-write the write path already performs, which is what makes it a query rather than a migration.

Temporal actions/month: 0, scales with fixed. No background work is added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits `agent_first_detected` when a device-agent scan reports a target the organization has no detection for yet, completing the agent piece of the GRW-66 PostHog Slack notifications revamp.

- The existing read-merge-write is keyed by device serial and user email, so a known agent on a new laptop would look brand new; a separate organization-wide lookup now distinguishes genuinely new agents from known ones spreading.
- The activity carries no actor (a device agent performed the scan) and no project (detections have no project dimension).
- The catalog supplies the display name, with the raw target id kept alongside so renames stay traceable.
- Overlapping scans can both pass the pre-insert lookup and both report; the report carries a PostHog `$insert_id` derived from the organization and target so PostHog collapses the duplicates.

<sup>Written for commit 19cbe995473ed3d2b9a4e97a27235ba1c2a248dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

