### PR TITLE
feat(platform-mcp): inspect plugin assignments

### DIFF
--- a/.changeset/platform-mcp-plugin-audiences.md
+++ b/.changeset/platform-mcp-plugin-audiences.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add privacy-safe Platform MCP reads for plugin audiences and assignment versions.

--- a/.changeset/platform-mcp-plugin-audiences.md
+++ b/.changeset/platform-mcp-plugin-audiences.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Add privacy-safe Platform MCP reads for plugin audiences and assignment versions.
+Add privacy-safe Platform MCP reads for plugin assignments and assignment versions.

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -184,7 +184,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	for _, name := range []string{
 		"distribute_mcp_to_plugin",
 		"remove_mcp_from_plugin",
-		"list_plugin_audiences",
+		"list_plugin_assignments",
 		"list_plugins",
 		"get_plugin",
 		"list_my_sessions",

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -184,6 +184,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	for _, name := range []string{
 		"distribute_mcp_to_plugin",
 		"remove_mcp_from_plugin",
+		"list_plugin_audiences",
 		"list_plugins",
 		"get_plugin",
 		"list_my_sessions",

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -402,6 +402,7 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"update_mcp_metadata":                   {},
 	"disable_mcp":                           {},
 	"enable_mcp":                            {},
+	"list_plugin_audiences":                 {},
 	"list_plugins":                          {},
 	"get_plugin":                            {},
 	"get_mcp_client_admission":              {},

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -402,7 +402,7 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"update_mcp_metadata":                   {},
 	"disable_mcp":                           {},
 	"enable_mcp":                            {},
-	"list_plugin_audiences":                 {},
+	"list_plugin_assignments":               {},
 	"list_plugins":                          {},
 	"get_plugin":                            {},
 	"get_mcp_client_admission":              {},

--- a/server/internal/platformmcp/feedback_test.go
+++ b/server/internal/platformmcp/feedback_test.go
@@ -43,7 +43,7 @@ func TestValidateFeedbackInputRejectsSensitiveOrOutOfBoundsValues(t *testing.T) 
 func TestValidateFeedbackInputAcceptsRegisteredTools(t *testing.T) {
 	t.Parallel()
 
-	for _, toolName := range []string{"attach_platform_mcp_identity_provider", "list_plugin_audiences"} {
+	for _, toolName := range []string{"attach_platform_mcp_identity_provider", "list_plugin_assignments"} {
 		err := validateFeedbackInput(testPrincipal(), FeedbackInput{
 			Category:       "success",
 			ToolName:       toolName,

--- a/server/internal/platformmcp/feedback_test.go
+++ b/server/internal/platformmcp/feedback_test.go
@@ -40,15 +40,17 @@ func TestValidateFeedbackInputRejectsSensitiveOrOutOfBoundsValues(t *testing.T) 
 	}
 }
 
-func TestValidateFeedbackInputAcceptsRegisteredIdentityProviderTool(t *testing.T) {
+func TestValidateFeedbackInputAcceptsRegisteredTools(t *testing.T) {
 	t.Parallel()
 
-	err := validateFeedbackInput(testPrincipal(), FeedbackInput{
-		Category:       "success",
-		ToolName:       "attach_platform_mcp_identity_provider",
-		IdempotencyKey: "feedback-identity-provider",
-	})
-	require.NoError(t, err)
+	for _, toolName := range []string{"attach_platform_mcp_identity_provider", "list_plugin_audiences"} {
+		err := validateFeedbackInput(testPrincipal(), FeedbackInput{
+			Category:       "success",
+			ToolName:       toolName,
+			IdempotencyKey: "feedback-registered-tool",
+		})
+		require.NoError(t, err, toolName)
+	}
 }
 
 func TestFeedbackNoteSafeTextAllowsOrdinaryPunctuationAndRejectsIdentifiers(t *testing.T) {

--- a/server/internal/platformmcp/plugins.go
+++ b/server/internal/platformmcp/plugins.go
@@ -3,15 +3,24 @@ package platformmcp
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/speakeasy-api/gram/server/internal/directory"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	pluginaudience "github.com/speakeasy-api/gram/server/internal/plugins/audience"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 const (
@@ -32,11 +41,18 @@ const (
 // maxPluginPageSize bounds one page of plugin inventory.
 const maxPluginPageSize = 50
 
-// maxPluginMembers bounds the membership lists on one plugin. A plugin is a
-// curated bundle an administrator assembled; a bundle larger than this is
-// reported truncated rather than paged, because the question the tool answers
-// ("what is in this plugin") is already answered by the first hundred entries.
+// maxPluginMembers bounds every membership list returned by plugin reads. A
+// plugin or organization larger than this is reported truncated rather than
+// allowing an unbounded MCP result.
 const maxPluginMembers = 100
+
+var platformVisibleDirectoryAttributes = map[string]struct{}{
+	"cost_center_name": {},
+	"department_name":  {},
+	"division_name":    {},
+	"employee_type":    {},
+	"job_title":        {},
+}
 
 var (
 	// ErrPluginProjectNotFound is a project this principal may not read, or one
@@ -66,6 +82,17 @@ type PluginAudience struct {
 
 	// Users is how many individual principals the plugin is assigned to.
 	Users int64 `json:"users"`
+}
+
+// PluginAudienceOption is one current organization audience that can receive a
+// plugin. Reference is encrypted and short-lived; the underlying principal URN
+// never leaves the server. MemberCount is omitted for Everyone because the
+// shared dashboard audience authority does not currently calculate it.
+type PluginAudienceOption struct {
+	Kind        string        `json:"kind"`
+	DisplayName string        `json:"display_name"`
+	MemberCount *SubjectCount `json:"member_count,omitempty"`
+	Reference   string        `json:"reference"`
 }
 
 // Plugin publication states.
@@ -154,6 +181,17 @@ type ListPluginsInput struct {
 	Cursor    string `json:"cursor,omitempty" jsonschema:"opaque cursor from a previous list_plugins result"`
 }
 
+type ListPluginAudiencesInput struct {
+	ProjectID string `json:"project_id" jsonschema:"explicit project ID whose plugin audiences to list"`
+}
+
+type ListPluginAudiencesOutput struct {
+	ProjectID          string                 `json:"project_id"`
+	Audiences          []PluginAudienceOption `json:"audiences"`
+	ReferencesExpireAt string                 `json:"references_expire_at,omitempty"`
+	Truncated          bool                   `json:"truncated"`
+}
+
 type ListPluginsOutput struct {
 	// ProjectID echoes the project the plugins belong to.
 	ProjectID string `json:"project_id"`
@@ -184,6 +222,27 @@ type GetPluginOutput struct {
 	// Skills is the skills the plugin carries.
 	Skills []PluginSkill `json:"skills"`
 
+	// AssignmentVersion is an opaque optimistic-concurrency token over the
+	// plugin identity and its complete canonical assignment set. It remains
+	// valid until that state changes; a future write must also use unexpired
+	// audience references from the same or a fresher read.
+	AssignmentVersion string `json:"assignment_version"`
+
+	// Audiences are the current assignments that can be named without exposing
+	// an individual identity or stale internal principal.
+	Audiences []PluginAudienceOption `json:"audiences"`
+
+	// AudienceDetailsComplete is false when at least one current assignment
+	// cannot be safely represented as a reviewed role or directory audience.
+	AudienceDetailsComplete bool `json:"audience_details_complete"`
+
+	// AudiencesTruncated is true when more than 100 current audience assignments
+	// can be represented and the returned list is only a prefix.
+	AudiencesTruncated bool `json:"audiences_truncated"`
+
+	// ReferencesExpireAt applies to every audience reference in this result.
+	ReferencesExpireAt string `json:"references_expire_at,omitempty"`
+
 	// Truncated is true when the plugin carries more members than one result
 	// projects, so the lists above are a prefix rather than the whole bundle.
 	Truncated bool `json:"truncated"`
@@ -192,21 +251,40 @@ type GetPluginOutput struct {
 // PluginsService answers what plugins a project has and what is inside one,
 // and resolves the exact plugin a distribution names.
 type PluginsService struct {
-	db      *pgxpool.Pool
-	budget  OperationBudget
-	cursors *pluginCursorCodec
+	db                   *pgxpool.Pool
+	budget               OperationBudget
+	cursors              *pluginCursorCodec
+	audienceReferences   *subjectReferenceCodec
+	assignmentVersionKey []byte
+	now                  func() time.Time
 }
 
 func NewPluginsService(db *pgxpool.Pool, budget OperationBudget, cursorKeyMaterial string) *PluginsService {
-	codec, err := newPluginCursorCodec(cursorKeyMaterial)
-	if err != nil {
-		codec = nil
+	cursor, cursorErr := newPluginCursorCodec(cursorKeyMaterial)
+	references, referenceErr := newSubjectReferenceCodec(cursorKeyMaterial)
+	var versionKey []byte
+	if cursorKeyMaterial != "" {
+		digest := sha256.Sum256([]byte("platform-mcp-plugin-assignment-version:" + cursorKeyMaterial))
+		versionKey = digest[:]
 	}
-	return &PluginsService{db: db, budget: budget, cursors: codec}
+	if cursorErr != nil {
+		cursor = nil
+	}
+	if referenceErr != nil {
+		references = nil
+	}
+	return &PluginsService{
+		db:                   db,
+		budget:               budget,
+		cursors:              cursor,
+		audienceReferences:   references,
+		assignmentVersionKey: versionKey,
+		now:                  time.Now,
+	}
 }
 
 func (s *PluginsService) valid() bool {
-	return s != nil && s.db != nil && s.budget.valid() && s.cursors != nil
+	return s != nil && s.db != nil && s.budget.valid() && s.cursors != nil && s.audienceReferences != nil && len(s.assignmentVersionKey) > 0 && s.now != nil
 }
 
 func (s *PluginsService) ListPlugins(ctx context.Context, principal Principal, input ListPluginsInput) (ListPluginsOutput, error) {
@@ -264,6 +342,29 @@ func (s *PluginsService) ListPlugins(ctx context.Context, principal Principal, i
 	return output, nil
 }
 
+func (s *PluginsService) ListPluginAudiences(ctx context.Context, principal Principal, input ListPluginAudiencesInput) (ListPluginAudiencesOutput, error) {
+	if !s.valid() {
+		return ListPluginAudiencesOutput{}, ErrUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ListPluginAudiencesOutput{}, err
+	}
+	project, err := s.resolveProject(ctx, platformrepo.New(s.db), principal, input.ProjectID)
+	if err != nil {
+		return ListPluginAudiencesOutput{}, err
+	}
+	audiences, expiresAt, truncated, err := s.resolveAudienceOptions(ctx, principal, project, nil)
+	if err != nil {
+		return ListPluginAudiencesOutput{}, err
+	}
+	return ListPluginAudiencesOutput{
+		ProjectID:          project.ID.String(),
+		Audiences:          publicAudienceOptions(audiences),
+		ReferencesExpireAt: expiresAt.Format(time.RFC3339),
+		Truncated:          truncated,
+	}, nil
+}
+
 func (s *PluginsService) GetPlugin(ctx context.Context, principal Principal, input GetPluginInput) (GetPluginOutput, error) {
 	if !s.valid() {
 		return GetPluginOutput{}, ErrUnavailable
@@ -314,15 +415,46 @@ func (s *PluginsService) GetPlugin(ctx context.Context, principal Principal, inp
 	}
 	servers, serversTruncated := boundedRows(servers, maxPluginMembers)
 	skills, skillsTruncated := boundedRows(skills, maxPluginMembers)
+	assignmentRows, err := pluginsrepo.New(s.db).ListPluginAssignments(ctx, target.ID)
+	if err != nil {
+		return GetPluginOutput{}, fmt.Errorf("list platform mcp plugin assignments: %w", err)
+	}
+	assignments := make([]string, 0, len(assignmentRows))
+	for _, assignment := range assignmentRows {
+		// The target was resolved through organization- and project-qualified
+		// plugin reads above. Refuse an internally inconsistent assignment rather
+		// than including another organization's principal in the version.
+		if assignment.OrganizationID != principal.OrganizationID {
+			return GetPluginOutput{}, ErrPluginNotFound
+		}
+		assignments = append(assignments, assignment.PrincipalUrn)
+	}
+	availableAudiences := []resolvedPluginAudience{}
+	expiresAt := time.Time{}
+	audiencesTruncated := false
+	if len(assignments) > 0 {
+		availableAudiences, expiresAt, audiencesTruncated, err = s.resolveAudienceOptions(ctx, principal, project, assignments)
+		if err != nil {
+			return GetPluginOutput{}, err
+		}
+	}
+	currentAudiences, detailsComplete := currentPluginAudiences(availableAudiences, assignments)
 
 	output := GetPluginOutput{
 		ProjectID: project.ID.String(),
 		// The two inventory rows are the same projection selected two ways, so the
 		// conversion keeps one mapping rather than a second copy of it.
-		Plugin:    pluginFromInventoryRow(platformrepo.ListPlatformMCPPluginInventoryRow(row)),
-		Servers:   make([]PluginServer, 0, len(servers)),
-		Skills:    make([]PluginSkill, 0, len(skills)),
-		Truncated: serversTruncated || skillsTruncated,
+		Plugin:                  pluginFromInventoryRow(platformrepo.ListPlatformMCPPluginInventoryRow(row)),
+		Servers:                 make([]PluginServer, 0, len(servers)),
+		Skills:                  make([]PluginSkill, 0, len(skills)),
+		AssignmentVersion:       pluginAssignmentVersion(s.assignmentVersionKey, project.ID, target.ID, assignments),
+		Audiences:               publicAudienceOptions(currentAudiences),
+		AudienceDetailsComplete: detailsComplete,
+		AudiencesTruncated:      audiencesTruncated,
+		Truncated:               serversTruncated || skillsTruncated,
+	}
+	if !expiresAt.IsZero() {
+		output.ReferencesExpireAt = expiresAt.Format(time.RFC3339)
 	}
 	for _, server := range servers {
 		backend := "mcp_server"
@@ -428,6 +560,143 @@ func (s *PluginsService) resolveProject(ctx context.Context, q *platformrepo.Que
 		return ResolvedProject{}, fmt.Errorf("resolve platform mcp plugin project: %w", err)
 	}
 	return ResolvedProject{ID: row.ID, Name: row.Name, Slug: row.Slug}, nil
+}
+
+type resolvedPluginAudience struct {
+	option       PluginAudienceOption
+	principalURN string
+}
+
+func (s *PluginsService) resolveAudienceOptions(ctx context.Context, principal Principal, project ResolvedProject, selectedURNs []string) ([]resolvedPluginAudience, time.Time, bool, error) {
+	audiences, err := pluginaudience.Resolve(ctx, s.db, principal.OrganizationID)
+	if err != nil {
+		return nil, time.Time{}, false, fmt.Errorf("resolve platform mcp plugin audiences: %w", err)
+	}
+	now := s.now().UTC()
+	expiresAt := now.Add(SubjectReferenceTTL)
+	resolved, truncated, err := projectPluginAudiences(audiences, selectedURNs, func(principalURN string) (string, error) {
+		return s.audienceReferences.EncodeScoped(principal, subjectKindPluginAudience, project.ID.String(), principalURN, now)
+	})
+	if err != nil {
+		return nil, time.Time{}, false, err
+	}
+	return resolved, expiresAt, truncated, nil
+}
+
+func projectPluginAudiences(audiences []pluginaudience.Audience, selectedURNs []string, referenceFor func(string) (string, error)) ([]resolvedPluginAudience, bool, error) {
+	selected := make(map[string]struct{}, len(selectedURNs))
+	for _, principalURN := range selectedURNs {
+		selected[canonicalPluginAudienceURN(principalURN)] = struct{}{}
+	}
+	resolved := make([]resolvedPluginAudience, 0, min(len(audiences), maxPluginMembers))
+	truncated := false
+	for _, audience := range audiences {
+		displayName, visible := platformAudienceDisplayName(audience)
+		if !visible {
+			continue
+		}
+		canonicalURN := canonicalPluginAudienceURN(audience.PrincipalURN)
+		if selectedURNs != nil {
+			if _, ok := selected[canonicalURN]; !ok {
+				continue
+			}
+		}
+		if len(resolved) == maxPluginMembers {
+			truncated = true
+			break
+		}
+		reference, err := referenceFor(canonicalURN)
+		if err != nil {
+			return nil, false, err
+		}
+		var memberCount *SubjectCount
+		if audience.MemberCount != nil {
+			count := NewSubjectCount(*audience.MemberCount)
+			memberCount = &count
+		}
+		resolved = append(resolved, resolvedPluginAudience{
+			option: PluginAudienceOption{
+				Kind:        audience.Kind,
+				DisplayName: displayName,
+				MemberCount: memberCount,
+				Reference:   reference,
+			},
+			principalURN: canonicalURN,
+		})
+	}
+	return resolved, truncated, nil
+}
+
+func publicAudienceOptions(audiences []resolvedPluginAudience) []PluginAudienceOption {
+	result := make([]PluginAudienceOption, 0, len(audiences))
+	for _, audience := range audiences {
+		result = append(result, audience.option)
+	}
+	return result
+}
+
+func currentPluginAudiences(available []resolvedPluginAudience, assignments []string) ([]resolvedPluginAudience, bool) {
+	assigned := make(map[string]struct{}, len(assignments))
+	for _, principalURN := range assignments {
+		assigned[canonicalPluginAudienceURN(principalURN)] = struct{}{}
+	}
+	current := make([]resolvedPluginAudience, 0, len(assignments))
+	for _, audience := range available {
+		if _, ok := assigned[audience.principalURN]; !ok {
+			continue
+		}
+		current = append(current, audience)
+		delete(assigned, audience.principalURN)
+	}
+	return current, len(assigned) == 0
+}
+
+func pluginAssignmentVersion(key []byte, projectID, pluginID uuid.UUID, assignments []string) string {
+	canonical := slices.Clone(assignments)
+	for index := range canonical {
+		canonical[index] = canonicalPluginAudienceURN(canonical[index])
+	}
+	slices.Sort(canonical)
+	canonical = slices.Compact(canonical)
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(projectID.String()))
+	_, _ = mac.Write([]byte{0})
+	_, _ = mac.Write([]byte(pluginID.String()))
+	for _, principalURN := range canonical {
+		_, _ = mac.Write([]byte{0})
+		_, _ = mac.Write([]byte(principalURN))
+	}
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func platformAudienceDisplayName(audience pluginaudience.Audience) (string, bool) {
+	if audience.Kind != "directory_attribute" {
+		return audience.DisplayName, true
+	}
+	attribute, err := directory.ParseAttributePrincipal(audience.PrincipalURN)
+	if err != nil {
+		return "", false
+	}
+	if _, ok := platformVisibleDirectoryAttributes[attribute.Key]; !ok {
+		return "", false
+	}
+	return fmt.Sprintf("%s: %s", attribute.Key, attribute.Value), true
+}
+
+func canonicalPluginAudienceURN(value string) string {
+	if value == urn.PrincipalWildcard {
+		return value
+	}
+	if groupID, err := directory.ParseGroupPrincipal(value); err == nil {
+		return directory.GroupPrincipal(groupID)
+	}
+	if attribute, err := directory.ParseAttributePrincipal(value); err == nil {
+		return directory.AttributePrincipal(attribute.Key, attribute.Value)
+	}
+	if principal, err := urn.ParsePrincipal(value); err == nil {
+		return principal.String()
+	}
+	return value
 }
 
 func pluginFromInventoryRow(row platformrepo.ListPlatformMCPPluginInventoryRow) Plugin {

--- a/server/internal/platformmcp/plugins.go
+++ b/server/internal/platformmcp/plugins.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/directory"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
-	pluginaudience "github.com/speakeasy-api/gram/server/internal/plugins/audience"
-	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -46,14 +44,6 @@ const maxPluginPageSize = 50
 // allowing an unbounded MCP result.
 const maxPluginMembers = 100
 
-var platformVisibleDirectoryAttributes = map[string]struct{}{
-	"cost_center_name": {},
-	"department_name":  {},
-	"division_name":    {},
-	"employee_type":    {},
-	"job_title":        {},
-}
-
 var (
 	// ErrPluginProjectNotFound is a project this principal may not read, or one
 	// that does not exist. The two are deliberately one answer: distinguishing
@@ -69,10 +59,10 @@ var (
 	ErrPluginCursorInvalid = errors.New("invalid platform MCP plugin cursor")
 )
 
-// PluginAudience is who receives a plugin, projected as a shape rather than as
-// principals. A plugin assignment holds a principal URN that embeds a user id,
-// which this surface must not carry.
-type PluginAudience struct {
+// PluginAssignmentSummary is who receives a plugin, projected as counts rather
+// than principals. A plugin assignment holds a principal URN that embeds a user
+// id, which this surface must not carry.
+type PluginAssignmentSummary struct {
 	// AllMembers is true when the plugin is assigned to every organization
 	// member through the wildcard principal.
 	AllMembers bool `json:"all_members"`
@@ -84,11 +74,10 @@ type PluginAudience struct {
 	Users int64 `json:"users"`
 }
 
-// PluginAudienceOption is one current organization audience that can receive a
-// plugin. Reference is encrypted and short-lived; the underlying principal URN
-// never leaves the server. MemberCount is omitted for Everyone because the
-// shared dashboard audience authority does not currently calculate it.
-type PluginAudienceOption struct {
+// PluginAssignmentOption is one current organization assignment target that can
+// receive a plugin. Reference is encrypted and short-lived; the underlying
+// principal URN never leaves the server. MemberCount is omitted for Everyone.
+type PluginAssignmentOption struct {
 	Kind        string        `json:"kind"`
 	DisplayName string        `json:"display_name"`
 	MemberCount *SubjectCount `json:"member_count,omitempty"`
@@ -133,8 +122,8 @@ type Plugin struct {
 	// SkillCount is how many skills the plugin carries.
 	SkillCount int64 `json:"skill_count"`
 
-	// Audience is who receives the plugin.
-	Audience PluginAudience `json:"audience"`
+	// Assignments summarizes who receives the plugin.
+	Assignments PluginAssignmentSummary `json:"assignments"`
 
 	// Publication is the plugin's package publication state.
 	Publication string `json:"publication"`
@@ -181,15 +170,15 @@ type ListPluginsInput struct {
 	Cursor    string `json:"cursor,omitempty" jsonschema:"opaque cursor from a previous list_plugins result"`
 }
 
-type ListPluginAudiencesInput struct {
-	ProjectID string `json:"project_id" jsonschema:"explicit project ID whose plugin audiences to list"`
+type ListPluginAssignmentsInput struct {
+	ProjectID string `json:"project_id" jsonschema:"explicit project ID whose plugin assignment targets to list"`
 }
 
-type ListPluginAudiencesOutput struct {
-	ProjectID          string                 `json:"project_id"`
-	Audiences          []PluginAudienceOption `json:"audiences"`
-	ReferencesExpireAt string                 `json:"references_expire_at,omitempty"`
-	Truncated          bool                   `json:"truncated"`
+type ListPluginAssignmentsOutput struct {
+	ProjectID          string                   `json:"project_id"`
+	Assignments        []PluginAssignmentOption `json:"assignments"`
+	ReferencesExpireAt string                   `json:"references_expire_at,omitempty"`
+	Truncated          bool                     `json:"truncated"`
 }
 
 type ListPluginsOutput struct {
@@ -225,22 +214,22 @@ type GetPluginOutput struct {
 	// AssignmentVersion is an opaque optimistic-concurrency token over the
 	// plugin identity and its complete canonical assignment set. It remains
 	// valid until that state changes; a future write must also use unexpired
-	// audience references from the same or a fresher read.
+	// assignment references from the same or a fresher read.
 	AssignmentVersion string `json:"assignment_version"`
 
-	// Audiences are the current assignments that can be named without exposing
-	// an individual identity or stale internal principal.
-	Audiences []PluginAudienceOption `json:"audiences"`
+	// Assignments are the current assignment targets that can be named without
+	// exposing an individual identity or stale internal principal.
+	Assignments []PluginAssignmentOption `json:"assignments"`
 
-	// AudienceDetailsComplete is false when at least one current assignment
-	// cannot be safely represented as a reviewed role or directory audience.
-	AudienceDetailsComplete bool `json:"audience_details_complete"`
+	// AssignmentDetailsComplete is false when at least one current assignment
+	// cannot be safely represented as a reviewed role or directory target.
+	AssignmentDetailsComplete bool `json:"assignment_details_complete"`
 
-	// AudiencesTruncated is true when more than 100 current audience assignments
-	// can be represented and the returned list is only a prefix.
-	AudiencesTruncated bool `json:"audiences_truncated"`
+	// AssignmentsTruncated is true when more than 100 current assignments can be
+	// represented and the returned list is only a prefix.
+	AssignmentsTruncated bool `json:"assignments_truncated"`
 
-	// ReferencesExpireAt applies to every audience reference in this result.
+	// ReferencesExpireAt applies to every assignment reference in this result.
 	ReferencesExpireAt string `json:"references_expire_at,omitempty"`
 
 	// Truncated is true when the plugin carries more members than one result
@@ -254,7 +243,7 @@ type PluginsService struct {
 	db                   *pgxpool.Pool
 	budget               OperationBudget
 	cursors              *pluginCursorCodec
-	audienceReferences   *subjectReferenceCodec
+	assignmentReferences *subjectReferenceCodec
 	assignmentVersionKey []byte
 	now                  func() time.Time
 }
@@ -277,14 +266,14 @@ func NewPluginsService(db *pgxpool.Pool, budget OperationBudget, cursorKeyMateri
 		db:                   db,
 		budget:               budget,
 		cursors:              cursor,
-		audienceReferences:   references,
+		assignmentReferences: references,
 		assignmentVersionKey: versionKey,
 		now:                  time.Now,
 	}
 }
 
 func (s *PluginsService) valid() bool {
-	return s != nil && s.db != nil && s.budget.valid() && s.cursors != nil && s.audienceReferences != nil && len(s.assignmentVersionKey) > 0 && s.now != nil
+	return s != nil && s.db != nil && s.budget.valid() && s.cursors != nil && s.assignmentReferences != nil && len(s.assignmentVersionKey) > 0 && s.now != nil
 }
 
 func (s *PluginsService) ListPlugins(ctx context.Context, principal Principal, input ListPluginsInput) (ListPluginsOutput, error) {
@@ -342,24 +331,24 @@ func (s *PluginsService) ListPlugins(ctx context.Context, principal Principal, i
 	return output, nil
 }
 
-func (s *PluginsService) ListPluginAudiences(ctx context.Context, principal Principal, input ListPluginAudiencesInput) (ListPluginAudiencesOutput, error) {
+func (s *PluginsService) ListPluginAssignments(ctx context.Context, principal Principal, input ListPluginAssignmentsInput) (ListPluginAssignmentsOutput, error) {
 	if !s.valid() {
-		return ListPluginAudiencesOutput{}, ErrUnavailable
+		return ListPluginAssignmentsOutput{}, ErrUnavailable
 	}
 	if err := s.budget.Allow(ctx, principal); err != nil {
-		return ListPluginAudiencesOutput{}, err
+		return ListPluginAssignmentsOutput{}, err
 	}
 	project, err := s.resolveProject(ctx, platformrepo.New(s.db), principal, input.ProjectID)
 	if err != nil {
-		return ListPluginAudiencesOutput{}, err
+		return ListPluginAssignmentsOutput{}, err
 	}
-	audiences, expiresAt, truncated, err := s.resolveAudienceOptions(ctx, principal, project, nil)
+	assignments, expiresAt, truncated, err := s.resolveAssignmentOptions(ctx, principal, project, nil)
 	if err != nil {
-		return ListPluginAudiencesOutput{}, err
+		return ListPluginAssignmentsOutput{}, err
 	}
-	return ListPluginAudiencesOutput{
+	return ListPluginAssignmentsOutput{
 		ProjectID:          project.ID.String(),
-		Audiences:          publicAudienceOptions(audiences),
+		Assignments:        publicAssignmentOptions(assignments),
 		ReferencesExpireAt: expiresAt.Format(time.RFC3339),
 		Truncated:          truncated,
 	}, nil
@@ -415,43 +404,37 @@ func (s *PluginsService) GetPlugin(ctx context.Context, principal Principal, inp
 	}
 	servers, serversTruncated := boundedRows(servers, maxPluginMembers)
 	skills, skillsTruncated := boundedRows(skills, maxPluginMembers)
-	assignmentRows, err := pluginsrepo.New(s.db).ListPluginAssignments(ctx, target.ID)
+	assignments, err := q.ListPlatformMCPPluginAssignments(ctx, platformrepo.ListPlatformMCPPluginAssignmentsParams{
+		PluginID:       target.ID,
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
 	if err != nil {
 		return GetPluginOutput{}, fmt.Errorf("list platform mcp plugin assignments: %w", err)
 	}
-	assignments := make([]string, 0, len(assignmentRows))
-	for _, assignment := range assignmentRows {
-		// The target was resolved through organization- and project-qualified
-		// plugin reads above. Refuse an internally inconsistent assignment rather
-		// than including another organization's principal in the version.
-		if assignment.OrganizationID != principal.OrganizationID {
-			return GetPluginOutput{}, ErrPluginNotFound
-		}
-		assignments = append(assignments, assignment.PrincipalUrn)
-	}
-	availableAudiences := []resolvedPluginAudience{}
+	availableAssignments := []resolvedPluginAssignment{}
 	expiresAt := time.Time{}
-	audiencesTruncated := false
+	assignmentsTruncated := false
 	if len(assignments) > 0 {
-		availableAudiences, expiresAt, audiencesTruncated, err = s.resolveAudienceOptions(ctx, principal, project, assignments)
+		availableAssignments, expiresAt, assignmentsTruncated, err = s.resolveAssignmentOptions(ctx, principal, project, assignments)
 		if err != nil {
 			return GetPluginOutput{}, err
 		}
 	}
-	currentAudiences, detailsComplete := currentPluginAudiences(availableAudiences, assignments)
+	currentAssignments, detailsComplete := currentPluginAssignments(availableAssignments, assignments)
 
 	output := GetPluginOutput{
 		ProjectID: project.ID.String(),
 		// The two inventory rows are the same projection selected two ways, so the
 		// conversion keeps one mapping rather than a second copy of it.
-		Plugin:                  pluginFromInventoryRow(platformrepo.ListPlatformMCPPluginInventoryRow(row)),
-		Servers:                 make([]PluginServer, 0, len(servers)),
-		Skills:                  make([]PluginSkill, 0, len(skills)),
-		AssignmentVersion:       pluginAssignmentVersion(s.assignmentVersionKey, project.ID, target.ID, assignments),
-		Audiences:               publicAudienceOptions(currentAudiences),
-		AudienceDetailsComplete: detailsComplete,
-		AudiencesTruncated:      audiencesTruncated,
-		Truncated:               serversTruncated || skillsTruncated,
+		Plugin:                    pluginFromInventoryRow(platformrepo.ListPlatformMCPPluginInventoryRow(row)),
+		Servers:                   make([]PluginServer, 0, len(servers)),
+		Skills:                    make([]PluginSkill, 0, len(skills)),
+		AssignmentVersion:         pluginAssignmentVersion(s.assignmentVersionKey, project.ID, target.ID, assignments),
+		Assignments:               publicAssignmentOptions(currentAssignments),
+		AssignmentDetailsComplete: detailsComplete,
+		AssignmentsTruncated:      assignmentsTruncated,
+		Truncated:                 serversTruncated || skillsTruncated,
 	}
 	if !expiresAt.IsZero() {
 		output.ReferencesExpireAt = expiresAt.Format(time.RFC3339)
@@ -562,91 +545,72 @@ func (s *PluginsService) resolveProject(ctx context.Context, q *platformrepo.Que
 	return ResolvedProject{ID: row.ID, Name: row.Name, Slug: row.Slug}, nil
 }
 
-type resolvedPluginAudience struct {
-	option       PluginAudienceOption
+type resolvedPluginAssignment struct {
+	option       PluginAssignmentOption
 	principalURN string
 }
 
-func (s *PluginsService) resolveAudienceOptions(ctx context.Context, principal Principal, project ResolvedProject, selectedURNs []string) ([]resolvedPluginAudience, time.Time, bool, error) {
-	audiences, err := pluginaudience.Resolve(ctx, s.db, principal.OrganizationID)
+func (s *PluginsService) resolveAssignmentOptions(ctx context.Context, principal Principal, project ResolvedProject, selectedURNs []string) ([]resolvedPluginAssignment, time.Time, bool, error) {
+	canonicalSelectedURNs := make([]string, len(selectedURNs))
+	for index, principalURN := range selectedURNs {
+		canonicalSelectedURNs[index] = canonicalPluginAssignmentURN(principalURN)
+	}
+	rows, err := platformrepo.New(s.db).ListPlatformMCPPluginAssignmentOptions(ctx, platformrepo.ListPlatformMCPPluginAssignmentOptionsParams{
+		SelectedPrincipalUrns: canonicalSelectedURNs,
+		ResultLimit:           maxPluginMembers + 1,
+		OrganizationID:        principal.OrganizationID,
+	})
 	if err != nil {
-		return nil, time.Time{}, false, fmt.Errorf("resolve platform mcp plugin audiences: %w", err)
+		return nil, time.Time{}, false, fmt.Errorf("resolve platform mcp plugin assignments: %w", err)
 	}
 	now := s.now().UTC()
 	expiresAt := now.Add(SubjectReferenceTTL)
-	resolved, truncated, err := projectPluginAudiences(audiences, selectedURNs, func(principalURN string) (string, error) {
-		return s.audienceReferences.EncodeScoped(principal, subjectKindPluginAudience, project.ID.String(), principalURN, now)
-	})
-	if err != nil {
-		return nil, time.Time{}, false, err
-	}
-	return resolved, expiresAt, truncated, nil
-}
-
-func projectPluginAudiences(audiences []pluginaudience.Audience, selectedURNs []string, referenceFor func(string) (string, error)) ([]resolvedPluginAudience, bool, error) {
-	selected := make(map[string]struct{}, len(selectedURNs))
-	for _, principalURN := range selectedURNs {
-		selected[canonicalPluginAudienceURN(principalURN)] = struct{}{}
-	}
-	resolved := make([]resolvedPluginAudience, 0, min(len(audiences), maxPluginMembers))
-	truncated := false
-	for _, audience := range audiences {
-		displayName, visible := platformAudienceDisplayName(audience)
-		if !visible {
-			continue
-		}
-		canonicalURN := canonicalPluginAudienceURN(audience.PrincipalURN)
-		if selectedURNs != nil {
-			if _, ok := selected[canonicalURN]; !ok {
-				continue
-			}
-		}
-		if len(resolved) == maxPluginMembers {
-			truncated = true
-			break
-		}
-		reference, err := referenceFor(canonicalURN)
+	rows, truncated := boundedRows(rows, maxPluginMembers)
+	resolved := make([]resolvedPluginAssignment, 0, len(rows))
+	for _, row := range rows {
+		canonicalURN := canonicalPluginAssignmentURN(row.PrincipalUrn)
+		reference, err := s.assignmentReferences.EncodeScoped(principal, subjectKindPluginAssignment, project.ID.String(), canonicalURN, now)
 		if err != nil {
-			return nil, false, err
+			return nil, time.Time{}, false, err
 		}
 		var memberCount *SubjectCount
-		if audience.MemberCount != nil {
-			count := NewSubjectCount(*audience.MemberCount)
+		if row.MemberCount.Valid {
+			count := NewSubjectCount(row.MemberCount.Int64)
 			memberCount = &count
 		}
-		resolved = append(resolved, resolvedPluginAudience{
-			option: PluginAudienceOption{
-				Kind:        audience.Kind,
-				DisplayName: displayName,
+		resolved = append(resolved, resolvedPluginAssignment{
+			option: PluginAssignmentOption{
+				Kind:        row.Kind,
+				DisplayName: row.DisplayName,
 				MemberCount: memberCount,
 				Reference:   reference,
 			},
 			principalURN: canonicalURN,
 		})
 	}
-	return resolved, truncated, nil
+	return resolved, expiresAt, truncated, nil
 }
 
-func publicAudienceOptions(audiences []resolvedPluginAudience) []PluginAudienceOption {
-	result := make([]PluginAudienceOption, 0, len(audiences))
-	for _, audience := range audiences {
-		result = append(result, audience.option)
+func publicAssignmentOptions(assignments []resolvedPluginAssignment) []PluginAssignmentOption {
+	result := make([]PluginAssignmentOption, 0, len(assignments))
+	for _, assignment := range assignments {
+		result = append(result, assignment.option)
 	}
 	return result
 }
 
-func currentPluginAudiences(available []resolvedPluginAudience, assignments []string) ([]resolvedPluginAudience, bool) {
+func currentPluginAssignments(available []resolvedPluginAssignment, assignments []string) ([]resolvedPluginAssignment, bool) {
 	assigned := make(map[string]struct{}, len(assignments))
 	for _, principalURN := range assignments {
-		assigned[canonicalPluginAudienceURN(principalURN)] = struct{}{}
+		assigned[canonicalPluginAssignmentURN(principalURN)] = struct{}{}
 	}
-	current := make([]resolvedPluginAudience, 0, len(assignments))
-	for _, audience := range available {
-		if _, ok := assigned[audience.principalURN]; !ok {
+	current := make([]resolvedPluginAssignment, 0, len(assignments))
+	for _, assignment := range available {
+		if _, ok := assigned[assignment.principalURN]; !ok {
 			continue
 		}
-		current = append(current, audience)
-		delete(assigned, audience.principalURN)
+		current = append(current, assignment)
+		delete(assigned, assignment.principalURN)
 	}
 	return current, len(assigned) == 0
 }
@@ -654,7 +618,7 @@ func currentPluginAudiences(available []resolvedPluginAudience, assignments []st
 func pluginAssignmentVersion(key []byte, projectID, pluginID uuid.UUID, assignments []string) string {
 	canonical := slices.Clone(assignments)
 	for index := range canonical {
-		canonical[index] = canonicalPluginAudienceURN(canonical[index])
+		canonical[index] = canonicalPluginAssignmentURN(canonical[index])
 	}
 	slices.Sort(canonical)
 	canonical = slices.Compact(canonical)
@@ -669,21 +633,7 @@ func pluginAssignmentVersion(key []byte, projectID, pluginID uuid.UUID, assignme
 	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 }
 
-func platformAudienceDisplayName(audience pluginaudience.Audience) (string, bool) {
-	if audience.Kind != "directory_attribute" {
-		return audience.DisplayName, true
-	}
-	attribute, err := directory.ParseAttributePrincipal(audience.PrincipalURN)
-	if err != nil {
-		return "", false
-	}
-	if _, ok := platformVisibleDirectoryAttributes[attribute.Key]; !ok {
-		return "", false
-	}
-	return fmt.Sprintf("%s: %s", attribute.Key, attribute.Value), true
-}
-
-func canonicalPluginAudienceURN(value string) string {
+func canonicalPluginAssignmentURN(value string) string {
 	if value == urn.PrincipalWildcard {
 		return value
 	}
@@ -715,7 +665,7 @@ func pluginFromInventoryRow(row platformrepo.ListPlatformMCPPluginInventoryRow) 
 		IsDefault:   row.IsDefault,
 		ServerCount: row.ServerCount,
 		SkillCount:  row.SkillCount,
-		Audience: PluginAudience{
+		Assignments: PluginAssignmentSummary{
 			AllMembers: row.WildcardAssignmentCount > 0,
 			Roles:      row.RoleAssignmentCount,
 			Users:      row.UserAssignmentCount,

--- a/server/internal/platformmcp/plugins_integration_test.go
+++ b/server/internal/platformmcp/plugins_integration_test.go
@@ -3,6 +3,7 @@ package platformmcp
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -73,6 +74,68 @@ func TestListPluginsPagesAProjectsPluginsWithMembershipCounts(t *testing.T) {
 	require.Len(t, seen, 2)
 }
 
+func TestListPluginAudiencesReturnsOpaqueProjectBoundReferences(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_audiences")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	service := testPluginTargets(conn)
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return now }
+
+	result, err := service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	require.Equal(t, project.ID.String(), result.ProjectID)
+	require.Equal(t, now.Add(SubjectReferenceTTL).Format(time.RFC3339), result.ReferencesExpireAt)
+	require.NotEmpty(t, result.Audiences)
+	require.Equal(t, PluginAudienceOption{Kind: "everyone", DisplayName: "Everyone", Reference: result.Audiences[0].Reference}, result.Audiences[0])
+
+	resolved, err := service.audienceReferences.DecodeScoped(result.Audiences[0].Reference, principal, subjectKindPluginAudience, project.ID.String(), now)
+	require.NoError(t, err)
+	require.Equal(t, urn.PrincipalWildcard, resolved)
+
+	_, otherProject := seedRegistrationLifecycle(t, ctx, conn)
+	_, err = service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: otherProject.ID.String()})
+	require.ErrorIs(t, err, ErrPluginProjectNotFound)
+	_, err = service.audienceReferences.DecodeScoped(result.Audiences[0].Reference, principal, subjectKindPluginAudience, otherProject.ID.String(), now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}
+
+func TestGetPluginAssignmentVersionChangesAfterDashboardStyleEdit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_assignment_version")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	service := testPluginTargets(conn)
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Shared Tools", "shared")
+
+	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.NotEmpty(t, before.AssignmentVersion)
+	require.Empty(t, before.Audiences)
+	require.True(t, before.AudienceDetailsComplete)
+
+	_, err = pluginsrepo.New(conn).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{
+		PluginID:       plugin.ID,
+		OrganizationID: principal.OrganizationID,
+		PrincipalUrn:   urn.PrincipalWildcard,
+	})
+	require.NoError(t, err)
+
+	after, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.NotEqual(t, before.AssignmentVersion, after.AssignmentVersion)
+	require.Len(t, after.Audiences, 1)
+	require.Equal(t, "everyone", after.Audiences[0].Kind)
+	require.True(t, after.AudienceDetailsComplete)
+}
+
 func TestGetPluginResolvesAnExactTargetAndReportsMembership(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +199,9 @@ func TestPluginInventoryRefusesAnotherOrganizationsProject(t *testing.T) {
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
 
 	_, err = service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: otherProject.ID.String(), Plugin: "foreign"})
+	require.ErrorIs(t, err, ErrPluginProjectNotFound)
+
+	_, err = service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: otherProject.ID.String()})
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
 }
 

--- a/server/internal/platformmcp/plugins_integration_test.go
+++ b/server/internal/platformmcp/plugins_integration_test.go
@@ -2,6 +2,8 @@ package platformmcp
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,7 +12,12 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/directory"
+	directoryrepo "github.com/speakeasy-api/gram/server/internal/directory/repo"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -50,8 +57,8 @@ func TestListPluginsPagesAProjectsPluginsWithMembershipCounts(t *testing.T) {
 	}
 	require.True(t, byID[defaultPlugin.ID.String()].IsDefault)
 	require.False(t, byID[marketing.ID.String()].IsDefault)
-	require.True(t, byID[marketing.ID.String()].Audience.AllMembers)
-	require.Zero(t, byID[marketing.ID.String()].Audience.Users)
+	require.True(t, byID[marketing.ID.String()].Assignments.AllMembers)
+	require.Zero(t, byID[marketing.ID.String()].Assignments.Users)
 	// The project has no package repository connected, so nothing in it can be
 	// published — reported as its own state rather than as "unpublished".
 	require.Equal(t, PluginPublicationNoRepository, byID[marketing.ID.String()].Publication)
@@ -74,11 +81,11 @@ func TestListPluginsPagesAProjectsPluginsWithMembershipCounts(t *testing.T) {
 	require.Len(t, seen, 2)
 }
 
-func TestListPluginAudiencesReturnsOpaqueProjectBoundReferences(t *testing.T) {
+func TestListPluginAssignmentsReturnsOpaqueProjectBoundReferences(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_audiences")
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_assignments")
 	require.NoError(t, err)
 
 	principal, project := seedRegistrationLifecycle(t, ctx, conn)
@@ -86,22 +93,122 @@ func TestListPluginAudiencesReturnsOpaqueProjectBoundReferences(t *testing.T) {
 	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
 	service.now = func() time.Time { return now }
 
-	result, err := service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: project.ID.String()})
+	result, err := service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
 	require.NoError(t, err)
 	require.Equal(t, project.ID.String(), result.ProjectID)
 	require.Equal(t, now.Add(SubjectReferenceTTL).Format(time.RFC3339), result.ReferencesExpireAt)
-	require.NotEmpty(t, result.Audiences)
-	require.Equal(t, PluginAudienceOption{Kind: "everyone", DisplayName: "Everyone", Reference: result.Audiences[0].Reference}, result.Audiences[0])
+	require.NotEmpty(t, result.Assignments)
+	require.Equal(t, PluginAssignmentOption{Kind: "everyone", DisplayName: "Everyone", Reference: result.Assignments[0].Reference}, result.Assignments[0])
 
-	resolved, err := service.audienceReferences.DecodeScoped(result.Audiences[0].Reference, principal, subjectKindPluginAudience, project.ID.String(), now)
+	resolved, err := service.assignmentReferences.DecodeScoped(result.Assignments[0].Reference, principal, subjectKindPluginAssignment, project.ID.String(), now)
 	require.NoError(t, err)
 	require.Equal(t, urn.PrincipalWildcard, resolved)
 
 	_, otherProject := seedRegistrationLifecycle(t, ctx, conn)
-	_, err = service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: otherProject.ID.String()})
+	_, err = service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: otherProject.ID.String()})
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
-	_, err = service.audienceReferences.DecodeScoped(result.Audiences[0].Reference, principal, subjectKindPluginAudience, otherProject.ID.String(), now)
+	_, err = service.assignmentReferences.DecodeScoped(result.Assignments[0].Reference, principal, subjectKindPluginAssignment, otherProject.ID.String(), now)
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}
+
+func TestPluginReadsIgnoreCrossTenantAssignmentRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_assignment_tenancy")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	service := testPluginTargets(conn)
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Shared Tools", "shared")
+
+	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.Zero(t, before.Plugin.Assignments.Roles)
+
+	foreignPrincipal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	require.NoError(t, testrepo.New(conn).InsertPluginAssignmentFixture(ctx, testrepo.InsertPluginAssignmentFixtureParams{
+		PluginID:       plugin.ID,
+		OrganizationID: foreignPrincipal.OrganizationID,
+		PrincipalUrn:   "role:organization:" + uuid.NewString(),
+	}))
+
+	after, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.Equal(t, before.AssignmentVersion, after.AssignmentVersion)
+	require.Zero(t, after.Plugin.Assignments.Roles)
+	require.Empty(t, after.Assignments)
+	require.True(t, after.AssignmentDetailsComplete)
+}
+
+func TestListPluginAssignmentsBoundsResolverWorkInSQL(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_assignment_bound")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	now := time.Now().UTC()
+	for index := range maxPluginMembers + 1 {
+		_, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+			OrganizationID:    principal.OrganizationID,
+			WorkosSlug:        fmt.Sprintf("role-%03d", index),
+			WorkosName:        fmt.Sprintf("Role %03d", index),
+			WorkosDescription: pgtype.Text{},
+			WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+			WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+			WorkosLastEventID: pgtype.Text{},
+		})
+		require.NoError(t, err)
+	}
+
+	result, err := testPluginTargets(conn).ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	require.True(t, result.Truncated)
+	require.Len(t, result.Assignments, maxPluginMembers)
+	require.Equal(t, "everyone", result.Assignments[0].Kind)
+}
+
+func TestPluginAssignmentOptionsUseCanonicalRoleAndLongAttributePrincipals(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_assignment_principals")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	now := time.Now().UTC()
+	role, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID: principal.OrganizationID, WorkosSlug: "custom-role", WorkosName: "Custom Role",
+		WorkosDescription: pgtype.Text{}, WorkosCreatedAt: conv.ToPGTimestamptz(now), WorkosUpdatedAt: conv.ToPGTimestamptz(now), WorkosLastEventID: pgtype.Text{},
+	})
+	require.NoError(t, err)
+	longValue := strings.Repeat("long-attribute-value-", 8)
+	_, err = directoryrepo.New(conn).UpsertDirectoryUser(ctx, directoryrepo.UpsertDirectoryUserParams{
+		OrganizationID: principal.OrganizationID, UserID: pgtype.Text{}, WorkosDirectoryUserID: "directory-user-" + uuid.NewString(),
+		Email: conv.ToPGText("member@example.test"), Attributes: []byte(`{"department_name":"` + longValue + `"}`),
+		WorkosCreatedAt: conv.ToPGTimestamptz(now), WorkosUpdatedAt: conv.ToPGTimestamptz(now), WorkosLastEventID: pgtype.Text{}, RestoreDeleted: true,
+	})
+	require.NoError(t, err)
+
+	service := testPluginTargets(conn)
+	result, err := service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	byName := map[string]PluginAssignmentOption{}
+	for _, assignment := range result.Assignments {
+		byName[assignment.DisplayName] = assignment
+	}
+	for displayName, expectedURN := range map[string]string{
+		"Custom Role":                   role.RoleUrn,
+		"department_name: " + longValue: directory.AttributePrincipal("department_name", longValue),
+	} {
+		assignment, ok := byName[displayName]
+		require.True(t, ok, displayName)
+		resolved, err := service.assignmentReferences.DecodeScoped(assignment.Reference, principal, subjectKindPluginAssignment, project.ID.String(), service.now().UTC())
+		require.NoError(t, err)
+		require.Equal(t, expectedURN, resolved)
+	}
 }
 
 func TestGetPluginAssignmentVersionChangesAfterDashboardStyleEdit(t *testing.T) {
@@ -118,8 +225,8 @@ func TestGetPluginAssignmentVersionChangesAfterDashboardStyleEdit(t *testing.T) 
 	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
 	require.NoError(t, err)
 	require.NotEmpty(t, before.AssignmentVersion)
-	require.Empty(t, before.Audiences)
-	require.True(t, before.AudienceDetailsComplete)
+	require.Empty(t, before.Assignments)
+	require.True(t, before.AssignmentDetailsComplete)
 
 	_, err = pluginsrepo.New(conn).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{
 		PluginID:       plugin.ID,
@@ -131,9 +238,9 @@ func TestGetPluginAssignmentVersionChangesAfterDashboardStyleEdit(t *testing.T) 
 	after, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
 	require.NoError(t, err)
 	require.NotEqual(t, before.AssignmentVersion, after.AssignmentVersion)
-	require.Len(t, after.Audiences, 1)
-	require.Equal(t, "everyone", after.Audiences[0].Kind)
-	require.True(t, after.AudienceDetailsComplete)
+	require.Len(t, after.Assignments, 1)
+	require.Equal(t, "everyone", after.Assignments[0].Kind)
+	require.True(t, after.AssignmentDetailsComplete)
 }
 
 func TestGetPluginResolvesAnExactTargetAndReportsMembership(t *testing.T) {
@@ -201,7 +308,7 @@ func TestPluginInventoryRefusesAnotherOrganizationsProject(t *testing.T) {
 	_, err = service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: otherProject.ID.String(), Plugin: "foreign"})
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
 
-	_, err = service.ListPluginAudiences(ctx, principal, ListPluginAudiencesInput{ProjectID: otherProject.ID.String()})
+	_, err = service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: otherProject.ID.String()})
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
 }
 

--- a/server/internal/platformmcp/plugins_integration_test.go
+++ b/server/internal/platformmcp/plugins_integration_test.go
@@ -150,8 +150,9 @@ func TestListPluginAssignmentsBoundsResolverWorkInSQL(t *testing.T) {
 
 	principal, project := seedRegistrationLifecycle(t, ctx, conn)
 	now := time.Now().UTC()
+	var beyondBoundRole string
 	for index := range maxPluginMembers + 1 {
-		_, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		role, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
 			OrganizationID:    principal.OrganizationID,
 			WorkosSlug:        fmt.Sprintf("role-%03d", index),
 			WorkosName:        fmt.Sprintf("Role %03d", index),
@@ -161,13 +162,27 @@ func TestListPluginAssignmentsBoundsResolverWorkInSQL(t *testing.T) {
 			WorkosLastEventID: pgtype.Text{},
 		})
 		require.NoError(t, err)
+		if index == maxPluginMembers {
+			beyondBoundRole = role.RoleUrn
+		}
 	}
 
-	result, err := testPluginTargets(conn).ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
+	service := testPluginTargets(conn)
+	result, err := service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
 	require.NoError(t, err)
 	require.True(t, result.Truncated)
 	require.Len(t, result.Assignments, maxPluginMembers)
 	require.Equal(t, "everyone", result.Assignments[0].Kind)
+
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Beyond Bound", "beyond-bound")
+	_, err = pluginsrepo.New(conn).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, PrincipalUrn: beyondBoundRole})
+	require.NoError(t, err)
+	detail, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.True(t, detail.AssignmentDetailsComplete)
+	require.False(t, detail.AssignmentsTruncated)
+	require.Len(t, detail.Assignments, 1)
+	require.Equal(t, "Role 100", detail.Assignments[0].DisplayName)
 }
 
 func TestPluginAssignmentOptionsUseCanonicalRoleAndLongAttributePrincipals(t *testing.T) {
@@ -187,7 +202,7 @@ func TestPluginAssignmentOptionsUseCanonicalRoleAndLongAttributePrincipals(t *te
 	longValue := strings.Repeat("long-attribute-value-", 8)
 	_, err = directoryrepo.New(conn).UpsertDirectoryUser(ctx, directoryrepo.UpsertDirectoryUserParams{
 		OrganizationID: principal.OrganizationID, UserID: pgtype.Text{}, WorkosDirectoryUserID: "directory-user-" + uuid.NewString(),
-		Email: conv.ToPGText("member@example.test"), Attributes: []byte(`{"department_name":"` + longValue + `"}`),
+		Email: conv.ToPGText("member@example.test"), Attributes: []byte(`{"department_name":"` + longValue + `","manager_email":"private@example.test"}`),
 		WorkosCreatedAt: conv.ToPGTimestamptz(now), WorkosUpdatedAt: conv.ToPGTimestamptz(now), WorkosLastEventID: pgtype.Text{}, RestoreDeleted: true,
 	})
 	require.NoError(t, err)
@@ -199,6 +214,7 @@ func TestPluginAssignmentOptionsUseCanonicalRoleAndLongAttributePrincipals(t *te
 	for _, assignment := range result.Assignments {
 		byName[assignment.DisplayName] = assignment
 	}
+	require.NotContains(t, byName, "manager_email: private@example.test")
 	for displayName, expectedURN := range map[string]string{
 		"Custom Role":                   role.RoleUrn,
 		"department_name: " + longValue: directory.AttributePrincipal("department_name", longValue),
@@ -209,6 +225,15 @@ func TestPluginAssignmentOptionsUseCanonicalRoleAndLongAttributePrincipals(t *te
 		require.NoError(t, err)
 		require.Equal(t, expectedURN, resolved)
 	}
+
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Sensitive Attribute", "sensitive-attribute")
+	sensitiveURN := directory.AttributePrincipal("manager_email", "private@example.test")
+	_, err = pluginsrepo.New(conn).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, PrincipalUrn: sensitiveURN})
+	require.NoError(t, err)
+	detail, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.False(t, detail.AssignmentDetailsComplete)
+	require.Empty(t, detail.Assignments)
 }
 
 func TestGetPluginAssignmentVersionChangesAfterDashboardStyleEdit(t *testing.T) {

--- a/server/internal/platformmcp/plugins_test.go
+++ b/server/internal/platformmcp/plugins_test.go
@@ -1,10 +1,17 @@
 package platformmcp
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/directory"
+	pluginaudience "github.com/speakeasy-api/gram/server/internal/plugins/audience"
 )
 
 // TestListPluginsOutput_ProjectsOnlyAllowlistedFields pins the inventory's
@@ -41,6 +48,27 @@ func TestListPluginsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	}, decodeKeys(t, output))
 }
 
+func TestListPluginAudiencesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	count := NewSubjectCount(8)
+	output := ListPluginAudiencesOutput{
+		ProjectID: "00000000-0000-0000-0000-000000000001",
+		Audiences: []PluginAudienceOption{{
+			Kind:        "role",
+			DisplayName: "Engineering",
+			MemberCount: &count,
+			Reference:   "opaque",
+		}},
+		ReferencesExpireAt: "2026-09-04T12:10:00Z",
+		Truncated:          false,
+	}
+
+	require.ElementsMatch(t, []string{
+		"project_id", "audiences", "kind", "display_name", "member_count", "reference", "references_expire_at", "truncated",
+	}, decodeKeys(t, output))
+}
+
 // TestGetPluginOutput_ProjectsOnlyAllowlistedFields does the same for one
 // plugin's membership.
 func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
@@ -69,7 +97,16 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 			Name:          "triage",
 			FollowsLatest: true,
 		}},
-		Truncated: false,
+		AssignmentVersion: "opaque-version",
+		Audiences: []PluginAudienceOption{{
+			Kind:        "everyone",
+			DisplayName: "Everyone",
+			Reference:   "opaque-reference",
+		}},
+		AudienceDetailsComplete: true,
+		AudiencesTruncated:      false,
+		ReferencesExpireAt:      "2026-09-04T12:10:00Z",
+		Truncated:               false,
 	}
 
 	require.ElementsMatch(t, []string{
@@ -80,6 +117,9 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		"publication",
 		"servers", "display_name", "backend", "mcp_slug", "policy", "enabled",
 		"skills", "name", "follows_latest",
+		"assignment_version",
+		"audiences", "kind", "display_name", "reference",
+		"audience_details_complete", "audiences_truncated", "references_expire_at",
 		"truncated",
 	}, decodeKeys(t, output))
 }
@@ -87,6 +127,153 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 // TestMatchesTargetNameRefusesPartialMatches pins what an exact target means.
 // A prefix or substring match is what turns "the marketing plugin" into
 // someone else's plugin, so only an id, a slug, or a whole name matches.
+func TestPluginAudienceReferenceIsEncryptedAndBound(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("key-material")
+	require.NoError(t, err)
+	principal := testReferencePrincipal()
+	projectID := "00000000-0000-0000-0000-000000000001"
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	principalURN := "role:organization:00000000-0000-0000-0000-0000000000a1"
+
+	reference, err := codec.EncodeScoped(principal, subjectKindPluginAudience, projectID, principalURN, now)
+	require.NoError(t, err)
+	raw, err := base64.RawURLEncoding.DecodeString(reference)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), principalURN)
+	require.NotContains(t, string(raw), principal.OrganizationID)
+
+	resolved, err := codec.DecodeScoped(reference, principal, subjectKindPluginAudience, projectID, now)
+	require.NoError(t, err)
+	require.Equal(t, principalURN, resolved)
+
+	otherOrganization := principal
+	otherOrganization.OrganizationID = "org-2"
+	_, err = codec.DecodeScoped(reference, otherOrganization, subjectKindPluginAudience, projectID, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAudience, "00000000-0000-0000-0000-000000000002", now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAudience, projectID, now.Add(SubjectReferenceTTL))
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}
+
+func TestPluginAssignmentVersionCoversPluginAndCanonicalAssignmentSet(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("version-key")
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	pluginID := uuid.MustParse("00000000-0000-0000-0000-0000000000a1")
+	assignments := []string{"role:global:00000000-0000-0000-0000-0000000000b2", "*"}
+	version := pluginAssignmentVersion(key, projectID, pluginID, assignments)
+
+	require.Equal(t, version, pluginAssignmentVersion(key, projectID, pluginID, []string{"*", assignments[0], "*"}))
+	require.NotEqual(t, version, pluginAssignmentVersion(key, projectID, pluginID, []string{"*"}))
+	require.NotEqual(t, version, pluginAssignmentVersion(key, projectID, uuid.New(), assignments))
+	require.NotEqual(t, version, pluginAssignmentVersion(key, uuid.New(), pluginID, assignments))
+}
+
+func TestPlatformAudienceDisplayNameRejectsSensitiveDirectoryAttributes(t *testing.T) {
+	t.Parallel()
+
+	visibleURN := directory.AttributePrincipal("department_name", "Engineering")
+	visible, ok := platformAudienceDisplayName(pluginaudience.Audience{
+		Kind:         "directory_attribute",
+		DisplayName:  "department_name: Engineering",
+		MemberCount:  nil,
+		PrincipalURN: visibleURN,
+	})
+	require.True(t, ok)
+	require.Equal(t, "department_name: Engineering", visible)
+
+	sensitiveValue := "manager@example.com"
+	hidden, ok := platformAudienceDisplayName(pluginaudience.Audience{
+		Kind:         "directory_attribute",
+		DisplayName:  "manager_email: " + sensitiveValue,
+		MemberCount:  nil,
+		PrincipalURN: directory.AttributePrincipal("manager_email", sensitiveValue),
+	})
+	require.False(t, ok)
+	require.Empty(t, hidden)
+}
+
+func TestCurrentPluginAudiencesCanonicalizesAndHidesUnreviewedAssignments(t *testing.T) {
+	t.Parallel()
+
+	groupID := uuid.MustParse("00000000-0000-0000-0000-0000000000b2")
+	available := []resolvedPluginAudience{
+		{option: PluginAudienceOption{Kind: "everyone", DisplayName: "Everyone", Reference: "everyone-ref"}, principalURN: "*"},
+		{option: PluginAudienceOption{Kind: "directory_group", DisplayName: "Engineering", Reference: "group-ref"}, principalURN: directory.GroupPrincipal(groupID)},
+	}
+	current, complete := currentPluginAudiences(available, []string{"user:private-user-id", "*", "directory_group:00000000-0000-0000-0000-0000000000B2"})
+
+	require.False(t, complete)
+	require.Equal(t, []PluginAudienceOption{
+		{Kind: "everyone", DisplayName: "Everyone", Reference: "everyone-ref"},
+		{Kind: "directory_group", DisplayName: "Engineering", Reference: "group-ref"},
+	}, publicAudienceOptions(current))
+	encoded, err := json.Marshal(publicAudienceOptions(current))
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "private-user-id")
+	require.NotContains(t, string(encoded), "principal")
+}
+
+func TestProjectPluginAudiencesBoundsResultsAfterFiltering(t *testing.T) {
+	t.Parallel()
+
+	audiences := make([]pluginaudience.Audience, 0, maxPluginMembers+2)
+	for index := range maxPluginMembers + 1 {
+		principalURN := fmt.Sprintf("role:organization:%03d", index)
+		audiences = append(audiences, pluginaudience.Audience{
+			Kind:         "role",
+			DisplayName:  fmt.Sprintf("Role %03d", index),
+			MemberCount:  nil,
+			PrincipalURN: principalURN,
+		})
+	}
+	// A sensitive attribute does not consume an output slot or leak its value.
+	audiences = append(audiences, pluginaudience.Audience{
+		Kind:         "directory_attribute",
+		DisplayName:  "manager_email: private@example.com",
+		MemberCount:  nil,
+		PrincipalURN: directory.AttributePrincipal("manager_email", "private@example.com"),
+	})
+
+	projected, truncated, err := projectPluginAudiences(audiences, nil, func(principalURN string) (string, error) {
+		return "ref:" + principalURN, nil
+	})
+	require.NoError(t, err)
+	require.True(t, truncated)
+	require.Len(t, projected, maxPluginMembers)
+	encoded, err := json.Marshal(publicAudienceOptions(projected))
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "private@example.com")
+
+	selectedURN := audiences[maxPluginMembers].PrincipalURN
+	selected, selectedTruncated, err := projectPluginAudiences(audiences, []string{selectedURN}, func(principalURN string) (string, error) {
+		return "ref:" + principalURN, nil
+	})
+	require.NoError(t, err)
+	require.False(t, selectedTruncated)
+	require.Len(t, selected, 1)
+	require.Equal(t, selectedURN, selected[0].principalURN)
+}
+
+func TestPluginAssignmentVersionCanonicalizesDirectoryPrincipals(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("version-key")
+	projectID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	pluginID := uuid.MustParse("00000000-0000-0000-0000-0000000000a1")
+	canonical := directory.GroupPrincipal(uuid.MustParse("00000000-0000-0000-0000-0000000000b2"))
+	legacyCase := "directory_group:00000000-0000-0000-0000-0000000000B2"
+
+	require.Equal(t,
+		pluginAssignmentVersion(key, projectID, pluginID, []string{canonical}),
+		pluginAssignmentVersion(key, projectID, pluginID, []string{legacyCase}),
+	)
+}
+
 func TestMatchesTargetNameRefusesPartialMatches(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/plugins_test.go
+++ b/server/internal/platformmcp/plugins_test.go
@@ -3,7 +3,6 @@ package platformmcp
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/directory"
-	pluginaudience "github.com/speakeasy-api/gram/server/internal/plugins/audience"
 )
 
 // TestListPluginsOutput_ProjectsOnlyAllowlistedFields pins the inventory's
@@ -32,7 +30,7 @@ func TestListPluginsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 			IsDefault:   false,
 			ServerCount: 3,
 			SkillCount:  1,
-			Audience:    PluginAudience{AllMembers: false, Roles: 2, Users: 4},
+			Assignments: PluginAssignmentSummary{AllMembers: false, Roles: 2, Users: 4},
 			Publication: PluginPublicationPublished,
 		}},
 		NextCursor: "opaque",
@@ -42,19 +40,19 @@ func TestListPluginsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 		"project_id",
 		"plugins", "id", "name", "slug", "description", "is_default",
 		"server_count", "skill_count",
-		"audience", "all_members", "roles", "users",
+		"assignments", "all_members", "roles", "users",
 		"publication",
 		"next_cursor",
 	}, decodeKeys(t, output))
 }
 
-func TestListPluginAudiencesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
+func TestListPluginAssignmentsOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	t.Parallel()
 
 	count := NewSubjectCount(8)
-	output := ListPluginAudiencesOutput{
+	output := ListPluginAssignmentsOutput{
 		ProjectID: "00000000-0000-0000-0000-000000000001",
-		Audiences: []PluginAudienceOption{{
+		Assignments: []PluginAssignmentOption{{
 			Kind:        "role",
 			DisplayName: "Engineering",
 			MemberCount: &count,
@@ -65,7 +63,7 @@ func TestListPluginAudiencesOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 	}
 
 	require.ElementsMatch(t, []string{
-		"project_id", "audiences", "kind", "display_name", "member_count", "reference", "references_expire_at", "truncated",
+		"project_id", "assignments", "kind", "display_name", "member_count", "reference", "references_expire_at", "truncated",
 	}, decodeKeys(t, output))
 }
 
@@ -83,7 +81,7 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 			IsDefault:   true,
 			ServerCount: 1,
 			SkillCount:  1,
-			Audience:    PluginAudience{AllMembers: true},
+			Assignments: PluginAssignmentSummary{AllMembers: true},
 			Publication: PluginPublicationUnpublished,
 		},
 		Servers: []PluginServer{{
@@ -98,28 +96,28 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 			FollowsLatest: true,
 		}},
 		AssignmentVersion: "opaque-version",
-		Audiences: []PluginAudienceOption{{
+		Assignments: []PluginAssignmentOption{{
 			Kind:        "everyone",
 			DisplayName: "Everyone",
 			Reference:   "opaque-reference",
 		}},
-		AudienceDetailsComplete: true,
-		AudiencesTruncated:      false,
-		ReferencesExpireAt:      "2026-09-04T12:10:00Z",
-		Truncated:               false,
+		AssignmentDetailsComplete: true,
+		AssignmentsTruncated:      false,
+		ReferencesExpireAt:        "2026-09-04T12:10:00Z",
+		Truncated:                 false,
 	}
 
 	require.ElementsMatch(t, []string{
 		"project_id",
 		"plugin", "id", "name", "slug", "is_default",
 		"server_count", "skill_count",
-		"audience", "all_members", "roles", "users",
+		"assignments", "all_members", "roles", "users",
 		"publication",
 		"servers", "display_name", "backend", "mcp_slug", "policy", "enabled",
 		"skills", "name", "follows_latest",
 		"assignment_version",
-		"audiences", "kind", "display_name", "reference",
-		"audience_details_complete", "audiences_truncated", "references_expire_at",
+		"assignments", "kind", "display_name", "reference",
+		"assignment_details_complete", "assignments_truncated", "references_expire_at",
 		"truncated",
 	}, decodeKeys(t, output))
 }
@@ -127,7 +125,7 @@ func TestGetPluginOutput_ProjectsOnlyAllowlistedFields(t *testing.T) {
 // TestMatchesTargetNameRefusesPartialMatches pins what an exact target means.
 // A prefix or substring match is what turns "the marketing plugin" into
 // someone else's plugin, so only an id, a slug, or a whole name matches.
-func TestPluginAudienceReferenceIsEncryptedAndBound(t *testing.T) {
+func TestPluginAssignmentReferenceIsEncryptedAndBound(t *testing.T) {
 	t.Parallel()
 
 	codec, err := newSubjectReferenceCodec("key-material")
@@ -137,24 +135,24 @@ func TestPluginAudienceReferenceIsEncryptedAndBound(t *testing.T) {
 	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
 	principalURN := "role:organization:00000000-0000-0000-0000-0000000000a1"
 
-	reference, err := codec.EncodeScoped(principal, subjectKindPluginAudience, projectID, principalURN, now)
+	reference, err := codec.EncodeScoped(principal, subjectKindPluginAssignment, projectID, principalURN, now)
 	require.NoError(t, err)
 	raw, err := base64.RawURLEncoding.DecodeString(reference)
 	require.NoError(t, err)
 	require.NotContains(t, string(raw), principalURN)
 	require.NotContains(t, string(raw), principal.OrganizationID)
 
-	resolved, err := codec.DecodeScoped(reference, principal, subjectKindPluginAudience, projectID, now)
+	resolved, err := codec.DecodeScoped(reference, principal, subjectKindPluginAssignment, projectID, now)
 	require.NoError(t, err)
 	require.Equal(t, principalURN, resolved)
 
 	otherOrganization := principal
 	otherOrganization.OrganizationID = "org-2"
-	_, err = codec.DecodeScoped(reference, otherOrganization, subjectKindPluginAudience, projectID, now)
+	_, err = codec.DecodeScoped(reference, otherOrganization, subjectKindPluginAssignment, projectID, now)
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
-	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAudience, "00000000-0000-0000-0000-000000000002", now)
+	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAssignment, "00000000-0000-0000-0000-000000000002", now)
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
-	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAudience, projectID, now.Add(SubjectReferenceTTL))
+	_, err = codec.DecodeScoped(reference, principal, subjectKindPluginAssignment, projectID, now.Add(SubjectReferenceTTL))
 	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
 }
 
@@ -173,90 +171,25 @@ func TestPluginAssignmentVersionCoversPluginAndCanonicalAssignmentSet(t *testing
 	require.NotEqual(t, version, pluginAssignmentVersion(key, uuid.New(), pluginID, assignments))
 }
 
-func TestPlatformAudienceDisplayNameRejectsSensitiveDirectoryAttributes(t *testing.T) {
-	t.Parallel()
-
-	visibleURN := directory.AttributePrincipal("department_name", "Engineering")
-	visible, ok := platformAudienceDisplayName(pluginaudience.Audience{
-		Kind:         "directory_attribute",
-		DisplayName:  "department_name: Engineering",
-		MemberCount:  nil,
-		PrincipalURN: visibleURN,
-	})
-	require.True(t, ok)
-	require.Equal(t, "department_name: Engineering", visible)
-
-	sensitiveValue := "manager@example.com"
-	hidden, ok := platformAudienceDisplayName(pluginaudience.Audience{
-		Kind:         "directory_attribute",
-		DisplayName:  "manager_email: " + sensitiveValue,
-		MemberCount:  nil,
-		PrincipalURN: directory.AttributePrincipal("manager_email", sensitiveValue),
-	})
-	require.False(t, ok)
-	require.Empty(t, hidden)
-}
-
-func TestCurrentPluginAudiencesCanonicalizesAndHidesUnreviewedAssignments(t *testing.T) {
+func TestCurrentPluginAssignmentsCanonicalizesAndHidesUnreviewedAssignments(t *testing.T) {
 	t.Parallel()
 
 	groupID := uuid.MustParse("00000000-0000-0000-0000-0000000000b2")
-	available := []resolvedPluginAudience{
-		{option: PluginAudienceOption{Kind: "everyone", DisplayName: "Everyone", Reference: "everyone-ref"}, principalURN: "*"},
-		{option: PluginAudienceOption{Kind: "directory_group", DisplayName: "Engineering", Reference: "group-ref"}, principalURN: directory.GroupPrincipal(groupID)},
+	available := []resolvedPluginAssignment{
+		{option: PluginAssignmentOption{Kind: "everyone", DisplayName: "Everyone", Reference: "everyone-ref"}, principalURN: "*"},
+		{option: PluginAssignmentOption{Kind: "directory_group", DisplayName: "Engineering", Reference: "group-ref"}, principalURN: directory.GroupPrincipal(groupID)},
 	}
-	current, complete := currentPluginAudiences(available, []string{"user:private-user-id", "*", "directory_group:00000000-0000-0000-0000-0000000000B2"})
+	current, complete := currentPluginAssignments(available, []string{"user:private-user-id", "*", "directory_group:00000000-0000-0000-0000-0000000000B2"})
 
 	require.False(t, complete)
-	require.Equal(t, []PluginAudienceOption{
+	require.Equal(t, []PluginAssignmentOption{
 		{Kind: "everyone", DisplayName: "Everyone", Reference: "everyone-ref"},
 		{Kind: "directory_group", DisplayName: "Engineering", Reference: "group-ref"},
-	}, publicAudienceOptions(current))
-	encoded, err := json.Marshal(publicAudienceOptions(current))
+	}, publicAssignmentOptions(current))
+	encoded, err := json.Marshal(publicAssignmentOptions(current))
 	require.NoError(t, err)
 	require.NotContains(t, string(encoded), "private-user-id")
 	require.NotContains(t, string(encoded), "principal")
-}
-
-func TestProjectPluginAudiencesBoundsResultsAfterFiltering(t *testing.T) {
-	t.Parallel()
-
-	audiences := make([]pluginaudience.Audience, 0, maxPluginMembers+2)
-	for index := range maxPluginMembers + 1 {
-		principalURN := fmt.Sprintf("role:organization:%03d", index)
-		audiences = append(audiences, pluginaudience.Audience{
-			Kind:         "role",
-			DisplayName:  fmt.Sprintf("Role %03d", index),
-			MemberCount:  nil,
-			PrincipalURN: principalURN,
-		})
-	}
-	// A sensitive attribute does not consume an output slot or leak its value.
-	audiences = append(audiences, pluginaudience.Audience{
-		Kind:         "directory_attribute",
-		DisplayName:  "manager_email: private@example.com",
-		MemberCount:  nil,
-		PrincipalURN: directory.AttributePrincipal("manager_email", "private@example.com"),
-	})
-
-	projected, truncated, err := projectPluginAudiences(audiences, nil, func(principalURN string) (string, error) {
-		return "ref:" + principalURN, nil
-	})
-	require.NoError(t, err)
-	require.True(t, truncated)
-	require.Len(t, projected, maxPluginMembers)
-	encoded, err := json.Marshal(publicAudienceOptions(projected))
-	require.NoError(t, err)
-	require.NotContains(t, string(encoded), "private@example.com")
-
-	selectedURN := audiences[maxPluginMembers].PrincipalURN
-	selected, selectedTruncated, err := projectPluginAudiences(audiences, []string{selectedURN}, func(principalURN string) (string, error) {
-		return "ref:" + principalURN, nil
-	})
-	require.NoError(t, err)
-	require.False(t, selectedTruncated)
-	require.Len(t, selected, 1)
-	require.Equal(t, selectedURN, selected[0].principalURN)
 }
 
 func TestPluginAssignmentVersionCanonicalizesDirectoryPrincipals(t *testing.T) {

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2583,9 +2583,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn = '*') AS wildcard_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2623,9 +2623,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn = '*') AS wildcard_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2705,6 +2705,116 @@ WHERE sd.plugin_id = @plugin_id
   AND sd.assistant_id IS NULL
   AND sd.revoked_at IS NULL
 ORDER BY sk.name ASC
+LIMIT @result_limit;
+
+-- name: ListPlatformMCPPluginAssignments :many
+-- Reads the exact plugin's complete assignment set only after proving the
+-- plugin belongs to the caller's organization and project. The complete set is
+-- required for the optimistic-concurrency version; no principal leaves this
+-- internal query boundary.
+SELECT pa.principal_urn
+FROM plugin_assignments pa
+JOIN plugins p
+  ON p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND p.deleted IS FALSE
+JOIN projects
+  ON projects.id = p.project_id
+  AND projects.organization_id = p.organization_id
+  AND projects.deleted IS FALSE
+WHERE pa.plugin_id = @plugin_id
+  AND pa.organization_id = @organization_id
+  AND p.project_id = @project_id
+ORDER BY pa.principal_urn;
+
+-- name: ListPlatformMCPPluginAssignmentOptions :many
+-- Resolves only the bounded assignment options this Platform response can use.
+-- selected_principal_urns is empty for the organization-wide chooser and set to
+-- one plugin's current assignments for the detail view.
+WITH active_roles AS (
+  SELECT id, workos_slug, workos_name, 'global'::text AS role_kind
+  FROM global_roles
+  WHERE deleted IS FALSE
+    AND workos_deleted IS FALSE
+  UNION ALL
+  SELECT id, workos_slug, workos_name, 'organization'::text AS role_kind
+  FROM organization_roles
+  WHERE organization_roles.organization_id = @organization_id
+    AND organization_roles.deleted IS FALSE
+    AND organization_roles.workos_deleted IS FALSE
+), assignment_options AS (
+  SELECT
+    0::int AS kind_order,
+    ''::text AS sort_key,
+    'everyone'::text AS kind,
+    'Everyone'::text AS display_name,
+    NULL::bigint AS member_count,
+    '*'::text AS principal_urn
+  UNION ALL
+  SELECT
+    1::int,
+    active_roles.workos_slug,
+    'role'::text,
+    active_roles.workos_name,
+    COUNT(DISTINCT ora.user_id)::bigint,
+    ('role:' || active_roles.role_kind || ':' || active_roles.id::text)::text
+  FROM active_roles
+  LEFT JOIN organization_role_assignments ora
+    ON ora.organization_id = @organization_id
+    AND ora.role_urn = 'role:' || active_roles.role_kind || ':' || active_roles.id::text
+    AND ora.user_id IS NOT NULL
+    AND ora.deleted_at IS NULL
+  GROUP BY active_roles.id, active_roles.role_kind, active_roles.workos_slug, active_roles.workos_name
+  UNION ALL
+  SELECT
+    2::int,
+    dg.name,
+    'directory_group'::text,
+    dg.name,
+    COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint,
+    ('directory_group:' || dg.id::text)::text
+  FROM directory_groups dg
+  LEFT JOIN directory_user_group_memberships m
+    ON m.directory_group_id = dg.id
+    AND m.deleted IS FALSE
+  LEFT JOIN directory_users du
+    ON du.id = m.directory_user_id
+    AND du.organization_id = dg.organization_id
+    AND du.deleted IS FALSE
+    AND du.workos_deleted IS FALSE
+  WHERE dg.organization_id = @organization_id
+    AND dg.deleted IS FALSE
+    AND dg.workos_deleted IS FALSE
+  GROUP BY dg.id, dg.name
+  UNION ALL
+  SELECT
+    3::int,
+    attribute.key || ':' || attribute.value,
+    'directory_attribute'::text,
+    attribute.key || ': ' || attribute.value,
+    COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint,
+    ('directory_attribute:' ||
+      translate(rtrim(replace(encode(convert_to(attribute.key, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_') || ':' ||
+      translate(rtrim(replace(encode(convert_to(attribute.value, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_'))::text
+  FROM directory_users du
+  CROSS JOIN LATERAL jsonb_each_text(
+    CASE jsonb_typeof(du.attributes)
+      WHEN 'object' THEN du.attributes
+      ELSE '{}'::jsonb
+    END
+  ) attribute(key, value)
+  WHERE du.organization_id = @organization_id
+    AND du.deleted IS FALSE
+    AND du.workos_deleted IS FALSE
+    AND attribute.key IN ('cost_center_name', 'department_name', 'division_name', 'employee_type', 'job_title')
+    AND attribute.value IS NOT NULL
+  GROUP BY attribute.key, attribute.value
+)
+SELECT kind, display_name, member_count, principal_urn
+FROM assignment_options
+WHERE COALESCE(cardinality(@selected_principal_urns::text[]), 0) = 0
+   OR principal_urn = ANY(@selected_principal_urns::text[])
+ORDER BY kind_order, sort_key, principal_urn
 LIMIT @result_limit;
 
 -- name: ResolvePlatformMCPPluginTarget :many

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2583,9 +2583,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    COALESCE(assignment_counts.wildcard_count, 0)::bigint AS wildcard_assignment_count,
+    COALESCE(assignment_counts.role_count, 0)::bigint AS role_assignment_count,
+    COALESCE(assignment_counts.user_count, 0)::bigint AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2593,6 +2593,24 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(*) FILTER (WHERE pa.principal_urn = '*') AS wildcard_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'role:%') AS role_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'user:%') AS user_count
+  FROM plugin_assignments pa
+  JOIN plugins assignment_plugin
+    ON assignment_plugin.id = pa.plugin_id
+    AND assignment_plugin.organization_id = pa.organization_id
+    AND assignment_plugin.project_id = @project_id
+    AND assignment_plugin.deleted IS FALSE
+  JOIN projects assignment_project
+    ON assignment_project.id = assignment_plugin.project_id
+    AND assignment_project.organization_id = assignment_plugin.organization_id
+    AND assignment_project.deleted IS FALSE
+  WHERE pa.plugin_id = p.id
+    AND pa.organization_id = @organization_id
+) assignment_counts ON TRUE
 WHERE p.project_id = @project_id
   AND p.organization_id = @organization_id
   AND projects.organization_id = @organization_id
@@ -2623,9 +2641,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = @organization_id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    COALESCE(assignment_counts.wildcard_count, 0)::bigint AS wildcard_assignment_count,
+    COALESCE(assignment_counts.role_count, 0)::bigint AS role_assignment_count,
+    COALESCE(assignment_counts.user_count, 0)::bigint AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2633,6 +2651,24 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(*) FILTER (WHERE pa.principal_urn = '*') AS wildcard_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'role:%') AS role_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'user:%') AS user_count
+  FROM plugin_assignments pa
+  JOIN plugins assignment_plugin
+    ON assignment_plugin.id = pa.plugin_id
+    AND assignment_plugin.organization_id = pa.organization_id
+    AND assignment_plugin.project_id = @project_id
+    AND assignment_plugin.deleted IS FALSE
+  JOIN projects assignment_project
+    ON assignment_project.id = assignment_plugin.project_id
+    AND assignment_project.organization_id = assignment_plugin.organization_id
+    AND assignment_project.deleted IS FALSE
+  WHERE pa.plugin_id = p.id
+    AND pa.organization_id = @organization_id
+) assignment_counts ON TRUE
 WHERE p.id = @plugin_id
   AND p.project_id = @project_id
   AND p.organization_id = @organization_id
@@ -2750,6 +2786,8 @@ WITH active_roles AS (
     'Everyone'::text AS display_name,
     NULL::bigint AS member_count,
     '*'::text AS principal_urn
+  WHERE COALESCE(cardinality(@selected_principal_urns::text[]), 0) = 0
+     OR '*' = ANY(@selected_principal_urns::text[])
   UNION ALL
   SELECT
     1::int,
@@ -2764,6 +2802,8 @@ WITH active_roles AS (
     AND ora.role_urn = 'role:' || active_roles.role_kind || ':' || active_roles.id::text
     AND ora.user_id IS NOT NULL
     AND ora.deleted_at IS NULL
+  WHERE COALESCE(cardinality(@selected_principal_urns::text[]), 0) = 0
+     OR ('role:' || active_roles.role_kind || ':' || active_roles.id::text) = ANY(@selected_principal_urns::text[])
   GROUP BY active_roles.id, active_roles.role_kind, active_roles.workos_slug, active_roles.workos_name
   UNION ALL
   SELECT
@@ -2785,6 +2825,10 @@ WITH active_roles AS (
   WHERE dg.organization_id = @organization_id
     AND dg.deleted IS FALSE
     AND dg.workos_deleted IS FALSE
+    AND (
+      COALESCE(cardinality(@selected_principal_urns::text[]), 0) = 0
+      OR ('directory_group:' || dg.id::text) = ANY(@selected_principal_urns::text[])
+    )
   GROUP BY dg.id, dg.name
   UNION ALL
   SELECT
@@ -2808,6 +2852,12 @@ WITH active_roles AS (
     AND du.workos_deleted IS FALSE
     AND attribute.key IN ('cost_center_name', 'department_name', 'division_name', 'employee_type', 'job_title')
     AND attribute.value IS NOT NULL
+    AND (
+      COALESCE(cardinality(@selected_principal_urns::text[]), 0) = 0
+      OR ('directory_attribute:' ||
+        translate(rtrim(replace(encode(convert_to(attribute.key, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_') || ':' ||
+        translate(rtrim(replace(encode(convert_to(attribute.value, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_')) = ANY(@selected_principal_urns::text[])
+    )
   GROUP BY attribute.key, attribute.value
 )
 SELECT kind, display_name, member_count, principal_urn

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2775,9 +2775,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn = '*') AS wildcard_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2785,18 +2785,18 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
-WHERE p.id = $1
-  AND p.project_id = $2
-  AND p.organization_id = $3
-  AND projects.organization_id = $3
+WHERE p.id = $2
+  AND p.project_id = $3
+  AND p.organization_id = $1
+  AND projects.organization_id = $1
   AND projects.deleted IS FALSE
   AND p.deleted IS FALSE
 `
 
 type GetPlatformMCPPluginInventoryItemParams struct {
+	OrganizationID string
 	PluginID       uuid.UUID
 	ProjectID      uuid.UUID
-	OrganizationID string
 }
 
 type GetPlatformMCPPluginInventoryItemRow struct {
@@ -2815,7 +2815,7 @@ type GetPlatformMCPPluginInventoryItemRow struct {
 }
 
 func (q *Queries) GetPlatformMCPPluginInventoryItem(ctx context.Context, arg GetPlatformMCPPluginInventoryItemParams) (GetPlatformMCPPluginInventoryItemRow, error) {
-	row := q.db.QueryRow(ctx, getPlatformMCPPluginInventoryItem, arg.PluginID, arg.ProjectID, arg.OrganizationID)
+	row := q.db.QueryRow(ctx, getPlatformMCPPluginInventoryItem, arg.OrganizationID, arg.PluginID, arg.ProjectID)
 	var i GetPlatformMCPPluginInventoryItemRow
 	err := row.Scan(
 		&i.ID,
@@ -4395,6 +4395,182 @@ func (q *Queries) ListPlatformMCPInventoryDistributions(ctx context.Context, arg
 	return items, nil
 }
 
+const listPlatformMCPPluginAssignmentOptions = `-- name: ListPlatformMCPPluginAssignmentOptions :many
+WITH active_roles AS (
+  SELECT id, workos_slug, workos_name, 'global'::text AS role_kind
+  FROM global_roles
+  WHERE deleted IS FALSE
+    AND workos_deleted IS FALSE
+  UNION ALL
+  SELECT id, workos_slug, workos_name, 'organization'::text AS role_kind
+  FROM organization_roles
+  WHERE organization_roles.organization_id = $3
+    AND organization_roles.deleted IS FALSE
+    AND organization_roles.workos_deleted IS FALSE
+), assignment_options AS (
+  SELECT
+    0::int AS kind_order,
+    ''::text AS sort_key,
+    'everyone'::text AS kind,
+    'Everyone'::text AS display_name,
+    NULL::bigint AS member_count,
+    '*'::text AS principal_urn
+  UNION ALL
+  SELECT
+    1::int,
+    active_roles.workos_slug,
+    'role'::text,
+    active_roles.workos_name,
+    COUNT(DISTINCT ora.user_id)::bigint,
+    ('role:' || active_roles.role_kind || ':' || active_roles.id::text)::text
+  FROM active_roles
+  LEFT JOIN organization_role_assignments ora
+    ON ora.organization_id = $3
+    AND ora.role_urn = 'role:' || active_roles.role_kind || ':' || active_roles.id::text
+    AND ora.user_id IS NOT NULL
+    AND ora.deleted_at IS NULL
+  GROUP BY active_roles.id, active_roles.role_kind, active_roles.workos_slug, active_roles.workos_name
+  UNION ALL
+  SELECT
+    2::int,
+    dg.name,
+    'directory_group'::text,
+    dg.name,
+    COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint,
+    ('directory_group:' || dg.id::text)::text
+  FROM directory_groups dg
+  LEFT JOIN directory_user_group_memberships m
+    ON m.directory_group_id = dg.id
+    AND m.deleted IS FALSE
+  LEFT JOIN directory_users du
+    ON du.id = m.directory_user_id
+    AND du.organization_id = dg.organization_id
+    AND du.deleted IS FALSE
+    AND du.workos_deleted IS FALSE
+  WHERE dg.organization_id = $3
+    AND dg.deleted IS FALSE
+    AND dg.workos_deleted IS FALSE
+  GROUP BY dg.id, dg.name
+  UNION ALL
+  SELECT
+    3::int,
+    attribute.key || ':' || attribute.value,
+    'directory_attribute'::text,
+    attribute.key || ': ' || attribute.value,
+    COUNT(DISTINCT NULLIF(LOWER(TRIM(du.email)), ''))::bigint,
+    ('directory_attribute:' ||
+      translate(rtrim(replace(encode(convert_to(attribute.key, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_') || ':' ||
+      translate(rtrim(replace(encode(convert_to(attribute.value, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_'))::text
+  FROM directory_users du
+  CROSS JOIN LATERAL jsonb_each_text(
+    CASE jsonb_typeof(du.attributes)
+      WHEN 'object' THEN du.attributes
+      ELSE '{}'::jsonb
+    END
+  ) attribute(key, value)
+  WHERE du.organization_id = $3
+    AND du.deleted IS FALSE
+    AND du.workos_deleted IS FALSE
+    AND attribute.key IN ('cost_center_name', 'department_name', 'division_name', 'employee_type', 'job_title')
+    AND attribute.value IS NOT NULL
+  GROUP BY attribute.key, attribute.value
+)
+SELECT kind, display_name, member_count, principal_urn
+FROM assignment_options
+WHERE COALESCE(cardinality($1::text[]), 0) = 0
+   OR principal_urn = ANY($1::text[])
+ORDER BY kind_order, sort_key, principal_urn
+LIMIT $2
+`
+
+type ListPlatformMCPPluginAssignmentOptionsParams struct {
+	SelectedPrincipalUrns []string
+	ResultLimit           int32
+	OrganizationID        string
+}
+
+type ListPlatformMCPPluginAssignmentOptionsRow struct {
+	Kind         string
+	DisplayName  string
+	MemberCount  pgtype.Int8
+	PrincipalUrn string
+}
+
+// Resolves only the bounded assignment options this Platform response can use.
+// selected_principal_urns is empty for the organization-wide chooser and set to
+// one plugin's current assignments for the detail view.
+func (q *Queries) ListPlatformMCPPluginAssignmentOptions(ctx context.Context, arg ListPlatformMCPPluginAssignmentOptionsParams) ([]ListPlatformMCPPluginAssignmentOptionsRow, error) {
+	rows, err := q.db.Query(ctx, listPlatformMCPPluginAssignmentOptions, arg.SelectedPrincipalUrns, arg.ResultLimit, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPlatformMCPPluginAssignmentOptionsRow
+	for rows.Next() {
+		var i ListPlatformMCPPluginAssignmentOptionsRow
+		if err := rows.Scan(
+			&i.Kind,
+			&i.DisplayName,
+			&i.MemberCount,
+			&i.PrincipalUrn,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPlatformMCPPluginAssignments = `-- name: ListPlatformMCPPluginAssignments :many
+SELECT pa.principal_urn
+FROM plugin_assignments pa
+JOIN plugins p
+  ON p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND p.deleted IS FALSE
+JOIN projects
+  ON projects.id = p.project_id
+  AND projects.organization_id = p.organization_id
+  AND projects.deleted IS FALSE
+WHERE pa.plugin_id = $1
+  AND pa.organization_id = $2
+  AND p.project_id = $3
+ORDER BY pa.principal_urn
+`
+
+type ListPlatformMCPPluginAssignmentsParams struct {
+	PluginID       uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+// Reads the exact plugin's complete assignment set only after proving the
+// plugin belongs to the caller's organization and project. The complete set is
+// required for the optimistic-concurrency version; no principal leaves this
+// internal query boundary.
+func (q *Queries) ListPlatformMCPPluginAssignments(ctx context.Context, arg ListPlatformMCPPluginAssignmentsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, listPlatformMCPPluginAssignments, arg.PluginID, arg.OrganizationID, arg.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var principal_urn string
+		if err := rows.Scan(&principal_urn); err != nil {
+			return nil, err
+		}
+		items = append(items, principal_urn)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPlatformMCPPluginInventory = `-- name: ListPlatformMCPPluginInventory :many
 
 SELECT
@@ -4417,9 +4593,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn = '*') AS wildcard_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
+    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -4427,9 +4603,9 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
-WHERE p.project_id = $1
-  AND p.organization_id = $2
-  AND projects.organization_id = $2
+WHERE p.project_id = $2
+  AND p.organization_id = $1
+  AND projects.organization_id = $1
   AND projects.deleted IS FALSE
   AND p.deleted IS FALSE
   AND (NOT $3::boolean OR p.id > $4)
@@ -4438,8 +4614,8 @@ LIMIT $5
 `
 
 type ListPlatformMCPPluginInventoryParams struct {
-	ProjectID      uuid.UUID
 	OrganizationID string
+	ProjectID      uuid.UUID
 	UseAfter       bool
 	AfterID        uuid.UUID
 	ResultLimit    int32
@@ -4470,8 +4646,8 @@ type ListPlatformMCPPluginInventoryRow struct {
 // surface must not carry.
 func (q *Queries) ListPlatformMCPPluginInventory(ctx context.Context, arg ListPlatformMCPPluginInventoryParams) ([]ListPlatformMCPPluginInventoryRow, error) {
 	rows, err := q.db.Query(ctx, listPlatformMCPPluginInventory,
-		arg.ProjectID,
 		arg.OrganizationID,
+		arg.ProjectID,
 		arg.UseAfter,
 		arg.AfterID,
 		arg.ResultLimit,

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -2775,9 +2775,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    COALESCE(assignment_counts.wildcard_count, 0)::bigint AS wildcard_assignment_count,
+    COALESCE(assignment_counts.role_count, 0)::bigint AS role_assignment_count,
+    COALESCE(assignment_counts.user_count, 0)::bigint AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -2785,18 +2785,36 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
-WHERE p.id = $2
-  AND p.project_id = $3
-  AND p.organization_id = $1
-  AND projects.organization_id = $1
+LEFT JOIN LATERAL (
+  SELECT
+    count(*) FILTER (WHERE pa.principal_urn = '*') AS wildcard_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'role:%') AS role_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'user:%') AS user_count
+  FROM plugin_assignments pa
+  JOIN plugins assignment_plugin
+    ON assignment_plugin.id = pa.plugin_id
+    AND assignment_plugin.organization_id = pa.organization_id
+    AND assignment_plugin.project_id = $1
+    AND assignment_plugin.deleted IS FALSE
+  JOIN projects assignment_project
+    ON assignment_project.id = assignment_plugin.project_id
+    AND assignment_project.organization_id = assignment_plugin.organization_id
+    AND assignment_project.deleted IS FALSE
+  WHERE pa.plugin_id = p.id
+    AND pa.organization_id = $2
+) assignment_counts ON TRUE
+WHERE p.id = $3
+  AND p.project_id = $1
+  AND p.organization_id = $2
+  AND projects.organization_id = $2
   AND projects.deleted IS FALSE
   AND p.deleted IS FALSE
 `
 
 type GetPlatformMCPPluginInventoryItemParams struct {
+	ProjectID      uuid.UUID
 	OrganizationID string
 	PluginID       uuid.UUID
-	ProjectID      uuid.UUID
 }
 
 type GetPlatformMCPPluginInventoryItemRow struct {
@@ -2815,7 +2833,7 @@ type GetPlatformMCPPluginInventoryItemRow struct {
 }
 
 func (q *Queries) GetPlatformMCPPluginInventoryItem(ctx context.Context, arg GetPlatformMCPPluginInventoryItemParams) (GetPlatformMCPPluginInventoryItemRow, error) {
-	row := q.db.QueryRow(ctx, getPlatformMCPPluginInventoryItem, arg.OrganizationID, arg.PluginID, arg.ProjectID)
+	row := q.db.QueryRow(ctx, getPlatformMCPPluginInventoryItem, arg.ProjectID, arg.OrganizationID, arg.PluginID)
 	var i GetPlatformMCPPluginInventoryItemRow
 	err := row.Scan(
 		&i.ID,
@@ -4415,6 +4433,8 @@ WITH active_roles AS (
     'Everyone'::text AS display_name,
     NULL::bigint AS member_count,
     '*'::text AS principal_urn
+  WHERE COALESCE(cardinality($1::text[]), 0) = 0
+     OR '*' = ANY($1::text[])
   UNION ALL
   SELECT
     1::int,
@@ -4429,6 +4449,8 @@ WITH active_roles AS (
     AND ora.role_urn = 'role:' || active_roles.role_kind || ':' || active_roles.id::text
     AND ora.user_id IS NOT NULL
     AND ora.deleted_at IS NULL
+  WHERE COALESCE(cardinality($1::text[]), 0) = 0
+     OR ('role:' || active_roles.role_kind || ':' || active_roles.id::text) = ANY($1::text[])
   GROUP BY active_roles.id, active_roles.role_kind, active_roles.workos_slug, active_roles.workos_name
   UNION ALL
   SELECT
@@ -4450,6 +4472,10 @@ WITH active_roles AS (
   WHERE dg.organization_id = $3
     AND dg.deleted IS FALSE
     AND dg.workos_deleted IS FALSE
+    AND (
+      COALESCE(cardinality($1::text[]), 0) = 0
+      OR ('directory_group:' || dg.id::text) = ANY($1::text[])
+    )
   GROUP BY dg.id, dg.name
   UNION ALL
   SELECT
@@ -4473,6 +4499,12 @@ WITH active_roles AS (
     AND du.workos_deleted IS FALSE
     AND attribute.key IN ('cost_center_name', 'department_name', 'division_name', 'employee_type', 'job_title')
     AND attribute.value IS NOT NULL
+    AND (
+      COALESCE(cardinality($1::text[]), 0) = 0
+      OR ('directory_attribute:' ||
+        translate(rtrim(replace(encode(convert_to(attribute.key, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_') || ':' ||
+        translate(rtrim(replace(encode(convert_to(attribute.value, 'UTF8'), 'base64'), E'\n', ''), '='), '+/', '-_')) = ANY($1::text[])
+    )
   GROUP BY attribute.key, attribute.value
 )
 SELECT kind, display_name, member_count, principal_urn
@@ -4593,9 +4625,9 @@ SELECT
         AND sd.assistant_id IS NULL
         AND sd.revoked_at IS NULL
     ) AS skill_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn = '*') AS wildcard_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'role:%') AS role_assignment_count,
-    (SELECT count(*) FROM plugin_assignments pa WHERE pa.plugin_id = p.id AND pa.organization_id = $1 AND pa.principal_urn LIKE 'user:%') AS user_assignment_count,
+    COALESCE(assignment_counts.wildcard_count, 0)::bigint AS wildcard_assignment_count,
+    COALESCE(assignment_counts.role_count, 0)::bigint AS role_assignment_count,
+    COALESCE(assignment_counts.user_count, 0)::bigint AS user_assignment_count,
     (gc.id IS NOT NULL)::boolean AS repository_connected,
     (COALESCE(gc.published_mcp_fingerprints ->> p.slug, '') <> '')::boolean AS published
 FROM plugins p
@@ -4603,9 +4635,27 @@ JOIN projects
   ON projects.id = p.project_id
 LEFT JOIN plugin_github_connections gc
   ON gc.project_id = p.project_id
-WHERE p.project_id = $2
-  AND p.organization_id = $1
-  AND projects.organization_id = $1
+LEFT JOIN LATERAL (
+  SELECT
+    count(*) FILTER (WHERE pa.principal_urn = '*') AS wildcard_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'role:%') AS role_count,
+    count(*) FILTER (WHERE pa.principal_urn LIKE 'user:%') AS user_count
+  FROM plugin_assignments pa
+  JOIN plugins assignment_plugin
+    ON assignment_plugin.id = pa.plugin_id
+    AND assignment_plugin.organization_id = pa.organization_id
+    AND assignment_plugin.project_id = $1
+    AND assignment_plugin.deleted IS FALSE
+  JOIN projects assignment_project
+    ON assignment_project.id = assignment_plugin.project_id
+    AND assignment_project.organization_id = assignment_plugin.organization_id
+    AND assignment_project.deleted IS FALSE
+  WHERE pa.plugin_id = p.id
+    AND pa.organization_id = $2
+) assignment_counts ON TRUE
+WHERE p.project_id = $1
+  AND p.organization_id = $2
+  AND projects.organization_id = $2
   AND projects.deleted IS FALSE
   AND p.deleted IS FALSE
   AND (NOT $3::boolean OR p.id > $4)
@@ -4614,8 +4664,8 @@ LIMIT $5
 `
 
 type ListPlatformMCPPluginInventoryParams struct {
-	OrganizationID string
 	ProjectID      uuid.UUID
+	OrganizationID string
 	UseAfter       bool
 	AfterID        uuid.UUID
 	ResultLimit    int32
@@ -4646,8 +4696,8 @@ type ListPlatformMCPPluginInventoryRow struct {
 // surface must not carry.
 func (q *Queries) ListPlatformMCPPluginInventory(ctx context.Context, arg ListPlatformMCPPluginInventoryParams) ([]ListPlatformMCPPluginInventoryRow, error) {
 	rows, err := q.db.Query(ctx, listPlatformMCPPluginInventory,
-		arg.OrganizationID,
 		arg.ProjectID,
+		arg.OrganizationID,
 		arg.UseAfter,
 		arg.AfterID,
 		arg.ResultLimit,

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -22,8 +22,9 @@ const SubjectReferenceTTL = 10 * time.Minute
 // Subject reference kinds. A reference minted for one kind cannot be presented
 // as another, so a trace handle can never be spent where a person is expected.
 const (
-	subjectKindUser  = "user"
-	subjectKindTrace = "trace"
+	subjectKindUser           = "user"
+	subjectKindTrace          = "trace"
+	subjectKindPluginAudience = "plugin_audience"
 	// subjectKindCursor is separate from subjectKindTrace so a correlation
 	// handle a caller was given to quote cannot be presented back as a page
 	// position, and a cursor cannot be quoted as an occurrence.

--- a/server/internal/platformmcp/subject_reference.go
+++ b/server/internal/platformmcp/subject_reference.go
@@ -22,9 +22,9 @@ const SubjectReferenceTTL = 10 * time.Minute
 // Subject reference kinds. A reference minted for one kind cannot be presented
 // as another, so a trace handle can never be spent where a person is expected.
 const (
-	subjectKindUser           = "user"
-	subjectKindTrace          = "trace"
-	subjectKindPluginAudience = "plugin_audience"
+	subjectKindUser             = "user"
+	subjectKindTrace            = "trace"
+	subjectKindPluginAssignment = "plugin_assignment"
 	// subjectKindCursor is separate from subjectKindTrace so a correlation
 	// handle a caller was given to quote cannot be presented back as a page
 	// position, and a cursor cannot be quoted as an occurrence.

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -20,6 +20,17 @@ type pluginRefusalResult struct {
 // choose between two tools that answer the same question.
 func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 	addTool(reg, &mcp.Tool{
+		Name:        "list_plugin_audiences",
+		Title:       "List Plugin Audiences",
+		Description: "List up to 100 existing roles and directory audiences that can receive plugins in an explicit project. Each audience has a short-lived opaque reference and, where available, a privacy-safe member count; Everyone has no member count. Raw principal identifiers are never returned. If truncated is true, use the dashboard to choose from the complete audience set.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginAudiencesInput) (*mcp.CallToolResult, ListPluginAudiencesOutput, error) {
+		return pluginToolCall(ctx, func(principal Principal) (ListPluginAudiencesOutput, error) {
+			return plugins.ListPluginAudiences(ctx, principal, input)
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
 		Name:        "list_plugins",
 		Title:       "List Plugins",
 		Description: "List the plugins in a named project. A plugin is the bundle of MCP servers and skills an administrator shares with people, so this is the level to answer \"what do we ship\" at, rather than adding up individual servers. Each entry reports how much the plugin carries, who receives it, and whether it has been published — that is, whether the people it is shared with have it yet.",
@@ -33,7 +44,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 	addTool(reg, &mcp.Tool{
 		Name:        "get_plugin",
 		Title:       "Get One Plugin",
-		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, and its skills with the version each is fixed to. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
+		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, skills, up to 100 current audience assignments, and an assignment version for safe follow-up edits. Audience references expire at the returned time; if audiences_truncated is true or audience_details_complete is false, use the dashboard before editing assignments. The general truncated field applies only to MCP servers and skills. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetPluginInput) (*mcp.CallToolResult, GetPluginOutput, error) {
 		return pluginToolCall(ctx, func(principal Principal) (GetPluginOutput, error) {
@@ -48,6 +59,7 @@ func registerUnavailablePluginTools(reg *Registrar) {
 		title       string
 		description string
 	}{
+		{"list_plugin_audiences", "List Plugin Audiences", "List the roles and directory audiences that can receive plugins. This is not switched on for your organization yet."},
 		{"list_plugins", "List Plugins", "List the plugins in a project. This is not switched on for your organization yet."},
 		{"get_plugin", "Get One Plugin", "Get one plugin and what it carries. This is not switched on for your organization yet."},
 	} {

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -20,13 +20,13 @@ type pluginRefusalResult struct {
 // choose between two tools that answer the same question.
 func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 	addTool(reg, &mcp.Tool{
-		Name:        "list_plugin_audiences",
-		Title:       "List Plugin Audiences",
-		Description: "List up to 100 existing roles and directory audiences that can receive plugins in an explicit project. Each audience has a short-lived opaque reference and, where available, a privacy-safe member count; Everyone has no member count. Raw principal identifiers are never returned. If truncated is true, use the dashboard to choose from the complete audience set.",
+		Name:        "list_plugin_assignments",
+		Title:       "List Plugin Assignments",
+		Description: "List up to 100 existing roles and directory assignment targets that can receive plugins in an explicit project. Each assignment has a short-lived opaque reference and, where available, a privacy-safe member count; Everyone has no member count. Raw principal identifiers are never returned. If truncated is true, use the dashboard to choose from the complete assignment set.",
 		Annotations: readOnlyAnnotations(),
-	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginAudiencesInput) (*mcp.CallToolResult, ListPluginAudiencesOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (ListPluginAudiencesOutput, error) {
-			return plugins.ListPluginAudiences(ctx, principal, input)
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginAssignmentsInput) (*mcp.CallToolResult, ListPluginAssignmentsOutput, error) {
+		return pluginToolCall(ctx, func(principal Principal) (ListPluginAssignmentsOutput, error) {
+			return plugins.ListPluginAssignments(ctx, principal, input)
 		})
 	})
 
@@ -44,7 +44,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 	addTool(reg, &mcp.Tool{
 		Name:        "get_plugin",
 		Title:       "Get One Plugin",
-		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, skills, up to 100 current audience assignments, and an assignment version for safe follow-up edits. Audience references expire at the returned time; if audiences_truncated is true or audience_details_complete is false, use the dashboard before editing assignments. The general truncated field applies only to MCP servers and skills. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
+		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, skills, up to 100 current assignments, and an assignment version for safe follow-up edits. Assignment references expire at the returned time; if assignments_truncated is true or assignment_details_complete is false, use the dashboard before editing assignments. The general truncated field applies only to MCP servers and skills. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetPluginInput) (*mcp.CallToolResult, GetPluginOutput, error) {
 		return pluginToolCall(ctx, func(principal Principal) (GetPluginOutput, error) {
@@ -59,7 +59,7 @@ func registerUnavailablePluginTools(reg *Registrar) {
 		title       string
 		description string
 	}{
-		{"list_plugin_audiences", "List Plugin Audiences", "List the roles and directory audiences that can receive plugins. This is not switched on for your organization yet."},
+		{"list_plugin_assignments", "List Plugin Assignments", "List the roles and directory assignment targets that can receive plugins. This is not switched on for your organization yet."},
 		{"list_plugins", "List Plugins", "List the plugins in a project. This is not switched on for your organization yet."},
 		{"get_plugin", "Get One Plugin", "Get one plugin and what it carries. This is not switched on for your organization yet."},
 	} {

--- a/server/internal/plugins/audience/resolver.go
+++ b/server/internal/plugins/audience/resolver.go
@@ -1,0 +1,72 @@
+package audience
+
+import (
+	"context"
+	"fmt"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/database"
+	"github.com/speakeasy-api/gram/server/internal/directory"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// Audience is one organization audience that can receive a plugin. PrincipalURN
+// is transport-neutral internal state: callers must project it through a
+// privacy-safe reference before returning it outside the server.
+type Audience struct {
+	Kind         string
+	DisplayName  string
+	MemberCount  *int64
+	PrincipalURN string
+}
+
+// Resolve returns the current roles and directory audiences used by plugin
+// assignment flows. Transport adapters decide which fields are safe to expose.
+func Resolve(ctx context.Context, db database.DBTX, organizationID string) ([]Audience, error) {
+	roles, err := accessrepo.New(db).ListActiveOrganizationRoles(ctx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("list roles for plugin assignments: %w", err)
+	}
+	directoryService := directory.NewService(db)
+	groups, err := directoryService.ListActiveGroups(ctx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("list directory groups for plugin assignments: %w", err)
+	}
+	attributes, err := directoryService.ListActiveAttributeValues(ctx, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("list directory attribute values for plugin assignments: %w", err)
+	}
+
+	audiences := make([]Audience, 0, 1+len(roles)+len(groups)+len(attributes))
+	audiences = append(audiences, Audience{
+		Kind:         "everyone",
+		DisplayName:  "Everyone",
+		MemberCount:  nil,
+		PrincipalURN: urn.PrincipalWildcard,
+	})
+	for _, role := range roles {
+		audiences = append(audiences, Audience{
+			Kind:         "role",
+			DisplayName:  role.WorkosName,
+			MemberCount:  &role.MemberCount,
+			PrincipalURN: role.RoleUrn,
+		})
+	}
+	for _, group := range groups {
+		audiences = append(audiences, Audience{
+			Kind:         "directory_group",
+			DisplayName:  group.Name,
+			MemberCount:  &group.MemberCount,
+			PrincipalURN: directory.GroupPrincipal(group.ID),
+		})
+	}
+	for _, attribute := range attributes {
+		audiences = append(audiences, Audience{
+			Kind:         "directory_attribute",
+			DisplayName:  fmt.Sprintf("%s: %s", attribute.Key, attribute.Value),
+			MemberCount:  &attribute.MemberCount,
+			PrincipalURN: directory.AttributePrincipal(attribute.Key, attribute.Value),
+		})
+	}
+	return audiences, nil
+}

--- a/server/internal/plugins/audiences.go
+++ b/server/internal/plugins/audiences.go
@@ -1,0 +1,22 @@
+package plugins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/database"
+	pluginaudience "github.com/speakeasy-api/gram/server/internal/plugins/audience"
+)
+
+// Audience is the transport-neutral plugin audience projection.
+type Audience = pluginaudience.Audience
+
+// ResolveAudiences preserves the plugins package API while the dashboard and
+// other internal callers share the leaf resolver implementation.
+func ResolveAudiences(ctx context.Context, db database.DBTX, organizationID string) ([]Audience, error) {
+	audiences, err := pluginaudience.Resolve(ctx, db, organizationID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve plugin audiences: %w", err)
+	}
+	return audiences, nil
+}

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -33,7 +33,6 @@ import (
 
 	srv "github.com/speakeasy-api/gram/server/gen/http/plugins/server"
 	gen "github.com/speakeasy-api/gram/server/gen/plugins"
-	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
@@ -1102,54 +1101,20 @@ func (s *Service) ListAudiences(ctx context.Context, payload *gen.ListAudiencesP
 		return nil, err
 	}
 
-	directoryService := directory.NewService(s.db)
-	roles, err := accessrepo.New(s.db).ListActiveOrganizationRoles(ctx, ac.ActiveOrganizationID)
+	audiences, err := ResolveAudiences(ctx, s.db, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list roles for plugin assignments").LogError(ctx, s.logger)
-	}
-	groups, err := directoryService.ListActiveGroups(ctx, ac.ActiveOrganizationID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list directory groups for plugin assignments").LogError(ctx, s.logger)
-	}
-	attributes, err := directoryService.ListActiveAttributeValues(ctx, ac.ActiveOrganizationID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list directory attribute values for plugin assignments").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin audience options").LogError(ctx, s.logger)
 	}
 
-	result := &gen.ListAudiencesResult{
-		Audiences: make([]*gen.PluginAudience, 0, 1+len(roles)+len(groups)+len(attributes)),
-	}
-	result.Audiences = append(result.Audiences, &gen.PluginAudience{
-		Kind:         "everyone",
-		DisplayName:  "Everyone",
-		MemberCount:  nil,
-		PrincipalUrn: urn.PrincipalWildcard,
-	})
-	for _, role := range roles {
+	result := &gen.ListAudiencesResult{Audiences: make([]*gen.PluginAudience, 0, len(audiences))}
+	for _, audience := range audiences {
 		result.Audiences = append(result.Audiences, &gen.PluginAudience{
-			Kind:         "role",
-			DisplayName:  role.WorkosName,
-			MemberCount:  &role.MemberCount,
-			PrincipalUrn: role.RoleUrn,
+			Kind:         audience.Kind,
+			DisplayName:  audience.DisplayName,
+			MemberCount:  audience.MemberCount,
+			PrincipalUrn: audience.PrincipalURN,
 		})
 	}
-	for _, group := range groups {
-		result.Audiences = append(result.Audiences, &gen.PluginAudience{
-			Kind:         "directory_group",
-			DisplayName:  group.Name,
-			MemberCount:  &group.MemberCount,
-			PrincipalUrn: directory.GroupPrincipal(group.ID),
-		})
-	}
-	for _, attribute := range attributes {
-		result.Audiences = append(result.Audiences, &gen.PluginAudience{
-			Kind:         "directory_attribute",
-			DisplayName:  fmt.Sprintf("%s: %s", attribute.Key, attribute.Value),
-			MemberCount:  &attribute.MemberCount,
-			PrincipalUrn: directory.AttributePrincipal(attribute.Key, attribute.Value),
-		})
-	}
-
 	return result, nil
 }
 


### PR DESCRIPTION
## Linear

- [AIM-226](https://linear.app/speakeasy/issue/AIM-226)

## Summary

- Add `list_plugin_assignments` for privacy-safe inspection of existing roles and directory assignment targets in an explicit project.
- Extend `get_plugin` with current assignment summaries, short-lived encrypted references, and an assignment version derived from the complete canonical assignment set.
- Share the dashboard assignment resolver through a transport-neutral leaf package while preserving existing dashboard behavior.
- Suppress small member counts, filter sensitive directory attributes, and bound assignment results with explicit completeness signals.

## Motivation

Platform MCP could inspect plugin contents but could not show which existing assignment targets were available or currently assigned. This adds the read-only contract needed to choose assignments safely and detect concurrent dashboard edits before mutation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privacy-safe read access to plugin assignments so Platform MCP can show which roles and directory audiences exist and which are assigned to a plugin.

- New `list_plugin_assignments` tool returns up to 100 assignment targets with short-lived encrypted references and explicit truncation signals.
- `get_plugin` now includes current assignment summaries, an opaque assignment version for optimistic concurrency, and completeness flags; sensitive directory attributes and the Everyone member count are suppressed.
- Assignment counts, references, and version tokens are scoped to the caller's organization so foreign-tenant rows are ignored.
- Extracts the dashboard audience resolver into a shared transport-neutral package without changing dashboard behavior.

**Migration**
- None required; new fields are additive and the new tool is read-only.

<sup>Written for commit df6e1504703342b5d827ce07e6cfd5bf10b86329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

