### PR TITLE
feat(platform-mcp): set plugin assignments

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -219,6 +219,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -297,7 +298,12 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	if err != nil {
 		return AssistantSurface{}, err
 	}
-	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey)
+	pluginAssignmentMutationBudget := platformmcp.OperationBudget{
+		Connection:   ratelimit.New(limitStore, platformmcp.PluginAssignmentMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginAssignmentMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		Organization: ratelimit.New(limitStore, platformmcp.PluginAssignmentMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginAssignmentMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+	}
+	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
+		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 
 	registryHandler := localfixture.NewRegistryHTTP(fixtureConfig).Handler()
@@ -559,6 +565,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.RiskMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.RiskMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.RiskMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+
 		// Diagnostics are read-only aggregate queries an administrator runs
 		// while investigating, so they are metered well above the shared
 		// five-per-minute mutation budget.
@@ -637,7 +644,12 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	if err != nil {
 		return AssistantSurface{}, err
 	}
-	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey)
+	pluginAssignmentMutationBudget := platformmcp.OperationBudget{
+		Connection:   ratelimit.New(limitStore, platformmcp.PluginAssignmentMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginAssignmentMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		Organization: ratelimit.New(limitStore, platformmcp.PluginAssignmentMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginAssignmentMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+	}
+	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
+		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -42,6 +42,10 @@ const (
 	// policy and exclusion writes exposed through Platform MCP. It is evaluated
 	// at invocation time and fails closed when absent, disabled, or indeterminate.
 	FlagPlatformMCPRiskMutations Flag = "platform-mcp-risk-mutations"
+	// FlagPlatformMCPPluginAssignmentMutations is the exact-project kill switch for
+	// replacing a plugin's complete audience assignment set through Platform MCP.
+	// It is evaluated at invocation time and fails closed.
+	FlagPlatformMCPPluginAssignmentMutations Flag = "platform-mcp-plugin-assignment-mutations"
 
 	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
 	// assistant the Platform MCP read toolset — the "platform" platform

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -187,6 +187,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"list_plugin_assignments",
 		"list_plugins",
 		"get_plugin",
+		operationSetPluginAssignments,
 		"list_my_sessions",
 		"continue_session",
 		"list_data_exports",

--- a/server/internal/platformmcp/mutation_receipt_executor.go
+++ b/server/internal/platformmcp/mutation_receipt_executor.go
@@ -1,0 +1,103 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+type mutationReceiptExecution[T any] struct {
+	DB             *pgxpool.Pool
+	Now            func() time.Time
+	Principal      Principal
+	Project        ResolvedProject
+	Operation      string
+	IdempotencyKey string
+	InputHash      string
+	Label          string
+	Invalid        func(error) error
+	Conflict       func(string) error
+	Unavailable    func(error) error
+	ValidateReplay func([]byte) bool
+	EncodeResult   func(T) ([]byte, error)
+	Mutate         func(context.Context, pgx.Tx) (T, error)
+}
+
+// executeMutationReceipt owns the common idempotency transaction used by
+// access-affecting Platform MCP mutations: advisory lock, exact replay,
+// pending receipt, domain+audit callback, result persistence, and one commit.
+func executeMutationReceipt[T any](ctx context.Context, execution mutationReceiptExecution[T]) (OperationReceipt, error) {
+	if execution.DB == nil || execution.Now == nil || execution.Mutate == nil || execution.EncodeResult == nil || execution.ValidateReplay == nil || execution.Invalid == nil || execution.Conflict == nil || execution.Unavailable == nil || execution.Principal.OrganizationID == "" || execution.Principal.UserID == "" || execution.Project.ID == uuid.Nil || execution.Project.Slug == "" || execution.Operation == "" || execution.IdempotencyKey == "" || len(execution.IdempotencyKey) > 128 || execution.InputHash == "" || execution.Label == "" {
+		return OperationReceipt{}, execution.Unavailable(errors.New("invalid mutation receipt execution"))
+	}
+	connectionID, generation, err := principalConnection(execution.Principal)
+	if err != nil {
+		return OperationReceipt{}, execution.Invalid(err)
+	}
+	tx, err := execution.DB.Begin(ctx)
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("begin %s receipt: %w", execution.Label, err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := platformrepo.New(tx)
+	lock := platformrepo.LockPlatformMCPOperationReceiptParams{OrganizationID: execution.Principal.OrganizationID, SubjectUrn: userSubjectURN(execution.Principal.UserID), ProjectID: execution.Project.ID.String(), Operation: execution.Operation, IdempotencyKey: execution.IdempotencyKey}
+	if err := q.LockPlatformMCPOperationReceipt(ctx, lock); err != nil {
+		return OperationReceipt{}, fmt.Errorf("lock %s receipt: %w", execution.Label, err)
+	}
+	lookup := platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: execution.Principal.OrganizationID, UserID: conv.ToPGText(execution.Principal.UserID), SubjectUrn: userSubjectURN(execution.Principal.UserID), ProjectID: execution.Project.ID, Operation: execution.Operation, IdempotencyKey: execution.IdempotencyKey}
+	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(lookup)); err != nil {
+		return OperationReceipt{}, fmt.Errorf("reclaim expired %s receipt: %w", execution.Label, err)
+	}
+	stored, err := q.GetPlatformMCPOperationReceipt(ctx, lookup)
+	switch {
+	case err == nil:
+		if stored.InputHash != execution.InputHash {
+			return OperationReceipt{}, execution.Conflict("The idempotency key was already used with different input.")
+		}
+		if stored.Status != receiptStatusSucceeded || len(stored.ResultPayload) == 0 {
+			return OperationReceipt{}, execution.Conflict("The matching mutation has no completed replay result.")
+		}
+		if !execution.ValidateReplay(stored.ResultPayload) {
+			return OperationReceipt{}, execution.Unavailable(errors.New("stored receipt payload is invalid"))
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return OperationReceipt{}, fmt.Errorf("commit %s replay: %w", execution.Label, err)
+		}
+		return operationReceiptFromRow(stored, true), nil
+	case !errors.Is(err, pgx.ErrNoRows):
+		return OperationReceipt{}, fmt.Errorf("load %s receipt: %w", execution.Label, err)
+	}
+	created, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{
+		OrganizationID: execution.Principal.OrganizationID, ProjectID: execution.Project.ID, RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, ConnectionID: connectionID, ConnectionGeneration: generation,
+		UserID: conv.ToPGText(execution.Principal.UserID), ActingSurface: conv.ToPGText(string(execution.Principal.surface())), Operation: execution.Operation, IdempotencyKey: execution.IdempotencyKey,
+		InputHash: execution.InputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: timestamp(execution.Now().UTC().Add(receiptLifetime)),
+	})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("create %s receipt: %w", execution.Label, err)
+	}
+	result, err := execution.Mutate(ctx, tx)
+	if err != nil {
+		return OperationReceipt{}, err
+	}
+	payload, err := execution.EncodeResult(result)
+	if err != nil {
+		return OperationReceipt{}, err
+	}
+	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText("succeeded"), ResultPayload: payload, ID: created.ID, OrganizationID: execution.Principal.OrganizationID})
+	if err != nil {
+		return OperationReceipt{}, fmt.Errorf("complete %s receipt: %w", execution.Label, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return OperationReceipt{}, fmt.Errorf("commit %s mutation: %w", execution.Label, err)
+	}
+	return operationReceiptFromRow(completed, false), nil
+}

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -33,6 +33,11 @@ const (
 )
 
 const (
+	PluginAssignmentMutationConnectionLimitName   = "platform-mcp-plugin-assignment-mutation-connection"
+	PluginAssignmentMutationOrganizationLimitName = "platform-mcp-plugin-assignment-mutation-organization"
+)
+
+const (
 	// DocsQueriesPerConnectionPerMinute and DocsQueriesPerOrganizationPerMinute
 	// bound documentation search. Retrieval is in-process and cheap, so these
 	// exist to stop a loop from spending the caller's context on repeated
@@ -59,6 +64,11 @@ const (
 	// write rate by alternating between mutation tools.
 	RiskMutationsPerConnectionPerMinute   = 5
 	RiskMutationsPerOrganizationPerMinute = 50
+
+	// PluginAssignmentMutationsPer* bound the access-affecting replacement of one
+	// plugin's complete assignment set on an independent allowance.
+	PluginAssignmentMutationsPerConnectionPerMinute   = 5
+	PluginAssignmentMutationsPerOrganizationPerMinute = 50
 
 	// DrilldownRowsPerConnectionPerWindow and
 	// DrilldownMetricQueriesPerConnectionPerWindow are the second cap the
@@ -211,6 +221,7 @@ type OperationBudgets struct {
 	// RiskMutations is shared by policy and exclusion writes. Connection-less
 	// assistant calls consume only its organization bucket.
 	RiskMutations OperationBudget
+
 	// DrilldownVolume meters what the drill-downs return rather than how often
 	// they are called: rows and spans against one bucket, metric queries
 	// against another, both per connection over DrilldownVolumeWindow.

--- a/server/internal/platformmcp/plugin_audience_mutation.go
+++ b/server/internal/platformmcp/plugin_audience_mutation.go
@@ -1,0 +1,347 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	pluginassignments "github.com/speakeasy-api/gram/server/internal/plugins/assignments"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const operationSetPluginAssignments = "set_plugin_assignments"
+
+var (
+	ErrPluginAssignmentMutationUnavailable = errors.New("platform mcp plugin assignment mutations unavailable")
+	ErrPluginAssignmentMutationInvalid     = errors.New("invalid platform mcp plugin assignment mutation")
+	ErrPluginAssignmentMutationNotFound    = errors.New("platform mcp plugin assignment not found")
+	ErrPluginAssignmentMutationConflict    = errors.New("platform mcp plugin assignment mutation conflict")
+)
+
+type PluginAssignmentMutationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *PluginAssignmentMutationError) Error() string { return e.Message }
+func (e *PluginAssignmentMutationError) Unwrap() error { return e.Cause }
+
+type SetPluginAssignmentsInput struct {
+	ProjectID                 string   `json:"project_id" jsonschema:"explicit project ID that owns the plugin"`
+	Plugin                    string   `json:"plugin" jsonschema:"exact plugin ID, slug, or name returned by list_plugins"`
+	AssignmentReferences      []string `json:"assignment_references" jsonschema:"complete desired set of opaque references returned by list_plugin_assignments or get_plugin; an empty set removes every assignment"`
+	ExpectedAssignmentVersion string   `json:"expected_assignment_version" jsonschema:"assignment version returned by get_plugin immediately before this write"`
+	IdempotencyKey            string   `json:"idempotency_key" jsonschema:"stable unique key for safely retrying this exact write"`
+	Confirmed                 bool     `json:"confirmed" jsonschema:"set true only after the user explicitly confirms the complete assignment replacement for this exact plugin"`
+}
+
+type PluginAssignmentSummaryResult struct {
+	Kind        string        `json:"kind"`
+	DisplayName string        `json:"display_name"`
+	MemberCount *SubjectCount `json:"member_count,omitempty"`
+}
+
+type PluginAssignmentMutationPlugin struct {
+	ID          string                  `json:"id"`
+	Name        string                  `json:"name"`
+	Slug        string                  `json:"slug"`
+	IsDefault   bool                    `json:"is_default"`
+	Assignments PluginAssignmentSummary `json:"assignments"`
+	Publication string                  `json:"publication"`
+}
+
+type SetPluginAssignmentsReceiptResult struct {
+	ProjectID         string                          `json:"project_id"`
+	Plugin            PluginAssignmentMutationPlugin  `json:"plugin"`
+	AssignmentVersion string                          `json:"assignment_version"`
+	Assignments       []PluginAssignmentSummaryResult `json:"assignments"`
+	ResultCategory    string                          `json:"result_category"`
+}
+
+type SetPluginAssignmentsOutput struct {
+	SetPluginAssignmentsReceiptResult
+	Receipt RiskMutationToolReceipt `json:"receipt"`
+}
+
+type normalizedSetPluginAssignments struct {
+	ProjectID                 string   `json:"project_id"`
+	Plugin                    string   `json:"plugin"`
+	AssignmentReferences      []string `json:"assignment_references"`
+	ExpectedAssignmentVersion string   `json:"expected_assignment_version"`
+}
+
+// WithAssignmentMutations enables the separately gated write half of the plugin
+// service. Inventory reads remain available when any write dependency is absent.
+func (s *PluginsService) WithAssignmentMutations(flags feature.Provider, organizations OrganizationSlugResolver, logger *audit.Logger, budget OperationBudget) *PluginsService {
+	if s == nil {
+		return nil
+	}
+	s.mutationFlags = flags
+	s.organizations = organizations
+	s.audit = logger
+	s.mutationBudget = budget
+	s.mutationReceipts = NewPluginAssignmentMutationReceiptStore(s.db)
+	return s
+}
+
+func (s *PluginsService) mutationValid() bool {
+	return s.valid() && s.mutationFlags != nil && s.organizations != nil && s.audit != nil && s.mutationBudget.valid() && s.mutationReceipts != nil
+}
+
+func (s *PluginsService) SetPluginAssignments(ctx context.Context, principal Principal, input SetPluginAssignmentsInput) (SetPluginAssignmentsOutput, error) {
+	if !s.mutationValid() {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationUnavailable(nil)
+	}
+	if err := requirePluginAssignmentConfirmation(input.Confirmed); err != nil {
+		return SetPluginAssignmentsOutput{}, err
+	}
+	input.ProjectID = strings.TrimSpace(input.ProjectID)
+	input.Plugin = strings.TrimSpace(input.Plugin)
+	input.ExpectedAssignmentVersion = strings.TrimSpace(input.ExpectedAssignmentVersion)
+	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
+	if principal.UserID == "" || input.ProjectID == "" || input.Plugin == "" || input.ExpectedAssignmentVersion == "" || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 || len(input.AssignmentReferences) > maxPluginMembers {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationInvalid("The plugin assignment request is invalid.")
+	}
+	if pluginID, err := uuid.Parse(input.Plugin); err == nil && pluginID == uuid.Nil {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationInvalid("The plugin ID must not be all zeroes.")
+	}
+
+	project, err := s.resolveProject(ctx, platformrepo.New(s.db), principal, input.ProjectID)
+	if err != nil {
+		return SetPluginAssignmentsOutput{}, err
+	}
+	organizationSlug, err := s.organizations.OrganizationSlug(ctx, principal.OrganizationID)
+	if err != nil || organizationSlug == "" {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationUnavailable(err)
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, s.mutationFlags, feature.FlagPlatformMCPPluginAssignmentMutations, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, project.Slug))
+	if err != nil {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationUnavailable(err)
+	}
+	if evaluation != feature.EvaluationEnabled {
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationUnavailable(nil)
+	}
+	if err := s.mutationBudget.AllowConnectionOrOrganization(ctx, principal); err != nil {
+		if errors.Is(err, ErrOperationRateLimited) {
+			return SetPluginAssignmentsOutput{}, &PluginAssignmentMutationError{Code: "rate_limited", Message: "The plugin assignment mutation rate limit was reached.", Cause: err}
+		}
+		return SetPluginAssignmentsOutput{}, pluginAssignmentMutationUnavailable(err)
+	}
+	references, err := normalizePluginAssignmentReferences(input.AssignmentReferences)
+	if err != nil {
+		return SetPluginAssignmentsOutput{}, err
+	}
+	normalized := normalizedPluginAssignmentMutationInput(project.ID, input.Plugin, references, input.ExpectedAssignmentVersion)
+	receipt, err := s.mutationReceipts.Execute(ctx, principal, project, input.IdempotencyKey, normalized, func(ctx context.Context, tx pgx.Tx) (SetPluginAssignmentsReceiptResult, error) {
+		target, err := s.resolve(ctx, platformrepo.New(tx), principal, project.ID, input.Plugin)
+		if err != nil {
+			return SetPluginAssignmentsReceiptResult{}, err
+		}
+		locked, err := pluginassignments.Lock(ctx, tx, principal.OrganizationID, project.ID, target.ID)
+		if errors.Is(err, pluginassignments.ErrNotFound) {
+			return SetPluginAssignmentsReceiptResult{}, pluginAssignmentMutationNotFound()
+		}
+		if err != nil {
+			return SetPluginAssignmentsReceiptResult{}, pluginAssignmentMutationUnavailable(err)
+		}
+		principalURNs, summaries, err := s.resolveMutationAssignments(ctx, tx, principal, project, references)
+		if err != nil {
+			return SetPluginAssignmentsReceiptResult{}, err
+		}
+		result, err := pluginassignments.Replace(ctx, tx, s.audit, locked, pluginassignments.Input{
+			OrganizationID:   principal.OrganizationID,
+			ProjectID:        project.ID,
+			PluginID:         target.ID,
+			PrincipalURNs:    principalURNs,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+			ActorDisplayName: nil,
+			ActorSlug:        nil,
+		}, func(ctx context.Context, _ pluginsrepo.Plugin, current, _ []string) error {
+			if pluginAssignmentVersion(s.assignmentVersionKey, project.ID, target.ID, current) != input.ExpectedAssignmentVersion {
+				return pluginAssignmentMutationConflict("The plugin assignments changed after they were read. Read the plugin again and retry with the new assignment version.")
+			}
+			if len(current) > maxPluginMembers {
+				return pluginAssignmentMutationInvalid("This plugin has too many current assignments to replace safely here. Use the dashboard.")
+			}
+			visible, err := visiblePluginAssignments(ctx, tx, principal.OrganizationID, current)
+			if err != nil {
+				return err
+			}
+			for _, currentURN := range current {
+				if _, ok := visible[canonicalPluginAssignmentURN(currentURN)]; !ok {
+					return pluginAssignmentMutationInvalid("This plugin has a current assignment that cannot be shown safely here. Use the dashboard.")
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, pluginassignments.ErrNotFound):
+				return SetPluginAssignmentsReceiptResult{}, pluginAssignmentMutationNotFound()
+			case errors.Is(err, pluginassignments.ErrInvalid):
+				return SetPluginAssignmentsReceiptResult{}, pluginAssignmentMutationInvalid("The selected plugin assignments are no longer valid.")
+			default:
+				return SetPluginAssignmentsReceiptResult{}, fmt.Errorf("replace plugin assignments: %w", err)
+			}
+		}
+		row, err := platformrepo.New(tx).GetPlatformMCPPluginInventoryItem(ctx, platformrepo.GetPlatformMCPPluginInventoryItemParams{
+			PluginID: target.ID, ProjectID: project.ID, OrganizationID: principal.OrganizationID,
+		})
+		if err != nil {
+			return SetPluginAssignmentsReceiptResult{}, fmt.Errorf("read committed plugin assignment state: %w", err)
+		}
+		inventory := pluginFromInventoryRow(platformrepo.ListPlatformMCPPluginInventoryRow(row))
+		return SetPluginAssignmentsReceiptResult{
+			ProjectID: project.ID.String(),
+			Plugin: PluginAssignmentMutationPlugin{
+				ID: inventory.ID, Name: inventory.Name, Slug: inventory.Slug, IsDefault: inventory.IsDefault,
+				Assignments: inventory.Assignments, Publication: inventory.Publication,
+			},
+			AssignmentVersion: pluginAssignmentVersion(s.assignmentVersionKey, project.ID, target.ID, result.PrincipalURNs),
+			Assignments:       summaries,
+			ResultCategory:    "updated",
+		}, nil
+	})
+	if err != nil {
+		return SetPluginAssignmentsOutput{}, err
+	}
+	var result SetPluginAssignmentsReceiptResult
+	if err := json.Unmarshal(receipt.ResultPayload, &result); err != nil {
+		return SetPluginAssignmentsOutput{}, fmt.Errorf("decode plugin assignment mutation receipt: %w", err)
+	}
+	return SetPluginAssignmentsOutput{SetPluginAssignmentsReceiptResult: result, Receipt: riskMutationToolReceipt(receipt)}, nil
+}
+
+func (s *PluginsService) resolveMutationAssignments(ctx context.Context, tx pgx.Tx, principal Principal, project ResolvedProject, references []string) ([]string, []PluginAssignmentSummaryResult, error) {
+	if len(references) == 0 {
+		return []string{}, []PluginAssignmentSummaryResult{}, nil
+	}
+	principalURNs := make([]string, 0, len(references))
+	seen := make(map[string]struct{}, len(references))
+	for _, reference := range references {
+		value, err := s.assignmentReferences.DecodeScoped(reference, principal, subjectKindPluginAssignment, project.ID.String(), s.now().UTC())
+		if err != nil {
+			return nil, nil, pluginAssignmentMutationNotFound()
+		}
+		canonical := canonicalPluginAssignmentURN(value)
+		if _, duplicate := seen[canonical]; duplicate {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		principalURNs = append(principalURNs, canonical)
+	}
+
+	rows, err := platformrepo.New(tx).ListPlatformMCPPluginAssignmentOptions(ctx, platformrepo.ListPlatformMCPPluginAssignmentOptionsParams{
+		SelectedPrincipalUrns: principalURNs,
+		ResultLimit:           maxPluginMembers + 1,
+		OrganizationID:        principal.OrganizationID,
+	})
+	if err != nil {
+		return nil, nil, pluginAssignmentMutationUnavailable(err)
+	}
+	byURN := make(map[string]platformrepo.ListPlatformMCPPluginAssignmentOptionsRow, len(rows))
+	for _, row := range rows {
+		byURN[canonicalPluginAssignmentURN(row.PrincipalUrn)] = row
+	}
+	summaries := make([]PluginAssignmentSummaryResult, 0, len(principalURNs))
+	for _, principalURN := range principalURNs {
+		row, ok := byURN[principalURN]
+		if !ok {
+			return nil, nil, pluginAssignmentMutationNotFound()
+		}
+		var count *SubjectCount
+		if row.MemberCount.Valid {
+			value := NewSubjectCount(row.MemberCount.Int64)
+			count = &value
+		}
+		summaries = append(summaries, PluginAssignmentSummaryResult{Kind: row.Kind, DisplayName: row.DisplayName, MemberCount: count})
+	}
+	slices.SortFunc(summaries, func(a, b PluginAssignmentSummaryResult) int {
+		if compared := strings.Compare(a.Kind, b.Kind); compared != 0 {
+			return compared
+		}
+		return strings.Compare(a.DisplayName, b.DisplayName)
+	})
+	return principalURNs, summaries, nil
+}
+
+func visiblePluginAssignments(ctx context.Context, tx pgx.Tx, organizationID string, principalURNs []string) (map[string]struct{}, error) {
+	if len(principalURNs) == 0 {
+		return map[string]struct{}{}, nil
+	}
+	canonical := make([]string, len(principalURNs))
+	for index, principalURN := range principalURNs {
+		canonical[index] = canonicalPluginAssignmentURN(principalURN)
+	}
+	rows, err := platformrepo.New(tx).ListPlatformMCPPluginAssignmentOptions(ctx, platformrepo.ListPlatformMCPPluginAssignmentOptionsParams{
+		SelectedPrincipalUrns: canonical,
+		ResultLimit:           maxPluginMembers + 1,
+		OrganizationID:        organizationID,
+	})
+	if err != nil {
+		return nil, pluginAssignmentMutationUnavailable(err)
+	}
+	visible := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		visible[canonicalPluginAssignmentURN(row.PrincipalUrn)] = struct{}{}
+	}
+	return visible, nil
+}
+
+func requirePluginAssignmentConfirmation(confirmed bool) error {
+	if confirmed {
+		return nil
+	}
+	return &PluginAssignmentMutationError{Code: "confirmation_required", Message: "Ask the user to confirm the complete assignment replacement for this exact plugin, then retry with confirmed: true.", Cause: ErrPluginAssignmentMutationInvalid}
+}
+
+func normalizePluginAssignmentReferences(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return []string{}, nil
+	}
+	references := slices.Clone(raw)
+	for i := range references {
+		references[i] = strings.TrimSpace(references[i])
+		if references[i] == "" {
+			return nil, pluginAssignmentMutationInvalid("Every assignment reference must be non-empty.")
+		}
+	}
+	slices.Sort(references)
+	return slices.Compact(references), nil
+}
+
+func normalizedPluginAssignmentMutationInput(projectID uuid.UUID, plugin string, references []string, expectedVersion string) normalizedSetPluginAssignments {
+	return normalizedSetPluginAssignments{
+		ProjectID: projectID.String(), Plugin: plugin, AssignmentReferences: slices.Clone(references), ExpectedAssignmentVersion: expectedVersion,
+	}
+}
+
+func pluginAssignmentMutationInvalid(message string) error {
+	return &PluginAssignmentMutationError{Code: "invalid_request", Message: message, Cause: ErrPluginAssignmentMutationInvalid}
+}
+
+func pluginAssignmentMutationNotFound() error {
+	return &PluginAssignmentMutationError{Code: "not_found", Message: "One or more selected plugin assignments are unavailable. List the assignments again and choose from the current result.", Cause: ErrPluginAssignmentMutationNotFound}
+}
+
+func pluginAssignmentMutationConflict(message string) error {
+	return &PluginAssignmentMutationError{Code: "conflict", Message: message, Cause: ErrPluginAssignmentMutationConflict}
+}
+
+func pluginAssignmentMutationUnavailable(cause error) error {
+	if cause == nil {
+		return &PluginAssignmentMutationError{Code: unavailableCode, Message: "Plugin assignment changes are not enabled for this project.", Cause: ErrPluginAssignmentMutationUnavailable}
+	}
+	return &PluginAssignmentMutationError{Code: unavailableCode, Message: "Plugin assignment changes are temporarily unavailable.", Cause: fmt.Errorf("%w: %w", ErrPluginAssignmentMutationUnavailable, cause)}
+}

--- a/server/internal/platformmcp/plugin_audience_mutation_test.go
+++ b/server/internal/platformmcp/plugin_audience_mutation_test.go
@@ -1,0 +1,124 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetPluginAssignmentsOutputProjectsOnlySafeFields(t *testing.T) {
+	t.Parallel()
+
+	count := NewSubjectCount(8)
+	output := SetPluginAssignmentsOutput{
+		SetPluginAssignmentsReceiptResult: SetPluginAssignmentsReceiptResult{
+			ProjectID: "00000000-0000-0000-0000-000000000001",
+			Plugin: PluginAssignmentMutationPlugin{
+				ID: "00000000-0000-0000-0000-000000000002", Name: "Shared Tools", Slug: "shared-tools",
+				Assignments: PluginAssignmentSummary{Roles: 1}, Publication: PluginPublicationPublished,
+			},
+			AssignmentVersion: "opaque-version",
+			Assignments:       []PluginAssignmentSummaryResult{{Kind: "role", DisplayName: "Engineering", MemberCount: &count}},
+			ResultCategory:    "updated",
+		},
+		Receipt: RiskMutationToolReceipt{ID: "00000000-0000-0000-0000-000000000003"},
+	}
+
+	keys := decodeKeys(t, output)
+	require.ElementsMatch(t, []string{
+		"project_id", "plugin", "id", "name", "slug", "is_default", "assignments", "all_members", "roles", "users", "publication",
+		"assignment_version", "assignments", "kind", "display_name", "member_count", "result_category", "receipt", "id", "replayed",
+	}, keys)
+	payload, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.NotContains(t, string(payload), "principal")
+	require.NotContains(t, string(payload), "reference")
+	require.NotContains(t, string(payload), "description")
+}
+
+func TestPluginAssignmentMutationReceiptResultValidation(t *testing.T) {
+	t.Parallel()
+
+	result := SetPluginAssignmentsReceiptResult{
+		ProjectID: uuid.NewString(),
+		Plugin: PluginAssignmentMutationPlugin{
+			ID: uuid.NewString(), Name: "Shared", Slug: "shared", Assignments: PluginAssignmentSummary{AllMembers: true}, Publication: PluginPublicationPublished,
+		},
+		AssignmentVersion: "opaque",
+		Assignments:       []PluginAssignmentSummaryResult{{Kind: "everyone", DisplayName: "Everyone"}},
+		ResultCategory:    "updated",
+	}
+	require.True(t, validPluginAssignmentReceiptResult(result))
+	payload, err := encodePluginAssignmentReceiptResult(result)
+	require.NoError(t, err)
+	require.True(t, validPluginAssignmentReceiptPayload(payload))
+
+	invalid := result
+	invalid.Assignments[0].Kind = "email"
+	require.False(t, validPluginAssignmentReceiptResult(invalid))
+	_, err = encodePluginAssignmentReceiptResult(invalid)
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationUnavailable)
+}
+
+func TestPluginAssignmentMutationInputHashCoversExactNormalizedWrite(t *testing.T) {
+	t.Parallel()
+
+	projectID, pluginID := uuid.New(), uuid.New()
+	empty, err := normalizePluginAssignmentReferences(nil)
+	require.NoError(t, err)
+	require.NotNil(t, empty)
+	require.Empty(t, empty)
+	references, err := normalizePluginAssignmentReferences([]string{" ref-b ", "ref-a", "ref-b"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"ref-a", "ref-b"}, references)
+	base := normalizedPluginAssignmentMutationInput(projectID, pluginID.String(), references, "version")
+	first, err := pluginAssignmentMutationInputHash(base)
+	require.NoError(t, err)
+	second, err := pluginAssignmentMutationInputHash(base)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	changed := base
+	changed.ExpectedAssignmentVersion = "other"
+	other, err := pluginAssignmentMutationInputHash(changed)
+	require.NoError(t, err)
+	require.NotEqual(t, first, other)
+
+	_, err = normalizePluginAssignmentReferences([]string{" "})
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationInvalid)
+}
+
+func TestResolveMutationAssignmentsSkipsEmptyChoiceLookup(t *testing.T) {
+	t.Parallel()
+
+	principalURNs, summaries, err := (&PluginsService{}).resolveMutationAssignments(t.Context(), nil, Principal{}, ResolvedProject{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, principalURNs)
+	require.Empty(t, principalURNs)
+	require.NotNil(t, summaries)
+	require.Empty(t, summaries)
+}
+
+func TestPluginAssignmentMutationToolRequiresConfirmation(t *testing.T) {
+	t.Parallel()
+
+	err := requirePluginAssignmentConfirmation(false)
+	var mutation *PluginAssignmentMutationError
+	require.ErrorAs(t, err, &mutation)
+	require.Equal(t, "confirmation_required", mutation.Code)
+	require.NoError(t, requirePluginAssignmentConfirmation(true))
+
+	service := NewPluginsService(nil, OperationBudget{}, "")
+	_, err = service.SetPluginAssignments(t.Context(), Principal{}, SetPluginAssignmentsInput{})
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationUnavailable)
+
+	refusal, ok := pluginToolResult(&PluginAssignmentMutationError{Code: "confirmation_required", Message: "confirm", Cause: ErrPluginAssignmentMutationInvalid})
+	require.True(t, ok)
+	require.True(t, refusal.IsError)
+	text, ok := refusal.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.Contains(t, text.Text, "confirmation_required")
+}

--- a/server/internal/platformmcp/plugin_audience_receipt.go
+++ b/server/internal/platformmcp/plugin_audience_receipt.go
@@ -1,0 +1,97 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const maxPluginAssignmentReceiptPayloadBytes = 16 << 10
+
+type PluginAssignmentMutationTransaction func(context.Context, pgx.Tx) (SetPluginAssignmentsReceiptResult, error)
+
+type PluginAssignmentMutationReceiptStore struct {
+	db  *pgxpool.Pool
+	now func() time.Time
+}
+
+func NewPluginAssignmentMutationReceiptStore(db *pgxpool.Pool) *PluginAssignmentMutationReceiptStore {
+	return &PluginAssignmentMutationReceiptStore{db: db, now: time.Now}
+}
+
+func (s *PluginAssignmentMutationReceiptStore) Execute(ctx context.Context, principal Principal, project ResolvedProject, idempotencyKey string, normalized normalizedSetPluginAssignments, mutate PluginAssignmentMutationTransaction) (OperationReceipt, error) {
+	if s == nil || s.db == nil || s.now == nil || mutate == nil || principal.OrganizationID == "" || principal.UserID == "" || project.ID == uuid.Nil || project.Slug == "" || idempotencyKey == "" || len(idempotencyKey) > 128 {
+		return OperationReceipt{}, pluginAssignmentMutationInvalid("The plugin assignment receipt request is invalid.")
+	}
+	inputHash, err := pluginAssignmentMutationInputHash(normalized)
+	if err != nil {
+		return OperationReceipt{}, pluginAssignmentMutationInvalid("The plugin assignment request could not be normalized.")
+	}
+	return executeMutationReceipt(ctx, mutationReceiptExecution[SetPluginAssignmentsReceiptResult]{
+		DB: s.db, Now: s.now, Principal: principal, Project: project, Operation: operationSetPluginAssignments, IdempotencyKey: idempotencyKey, InputHash: inputHash, Label: "plugin assignment",
+		Invalid: func(cause error) error {
+			return &PluginAssignmentMutationError{Code: "invalid_request", Message: "The plugin assignment caller identity is invalid.", Cause: fmt.Errorf("%w: %w", ErrPluginAssignmentMutationInvalid, cause)}
+		},
+		Conflict:       pluginAssignmentMutationConflict,
+		Unavailable:    pluginAssignmentMutationUnavailable,
+		ValidateReplay: validPluginAssignmentReceiptPayload,
+		EncodeResult: func(result SetPluginAssignmentsReceiptResult) ([]byte, error) {
+			return encodePluginAssignmentReceiptResult(result)
+		},
+		Mutate: mutate,
+	})
+}
+
+func pluginAssignmentMutationInputHash(normalized normalizedSetPluginAssignments) (string, error) {
+	if normalized.ProjectID == "" || normalized.Plugin == "" || normalized.ExpectedAssignmentVersion == "" {
+		return "", ErrPluginAssignmentMutationInvalid
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("encode normalized plugin assignment input: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("platform-mcp-plugin-assignment-v1\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func encodePluginAssignmentReceiptResult(result SetPluginAssignmentsReceiptResult) (json.RawMessage, error) {
+	if !validPluginAssignmentReceiptResult(result) {
+		return nil, pluginAssignmentMutationUnavailable(errors.New("unsafe plugin assignment receipt result"))
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode plugin assignment receipt result: %w", err)
+	}
+	if len(payload) == 0 || len(payload) > maxPluginAssignmentReceiptPayloadBytes {
+		return nil, pluginAssignmentMutationUnavailable(errors.New("plugin assignment receipt result is too large"))
+	}
+	return payload, nil
+}
+
+func validPluginAssignmentReceiptPayload(payload []byte) bool {
+	var result SetPluginAssignmentsReceiptResult
+	return len(payload) <= maxPluginAssignmentReceiptPayloadBytes && json.Unmarshal(payload, &result) == nil && validPluginAssignmentReceiptResult(result)
+}
+
+func validPluginAssignmentReceiptResult(result SetPluginAssignmentsReceiptResult) bool {
+	if uuid.Validate(result.ProjectID) != nil || uuid.Validate(result.Plugin.ID) != nil || result.Plugin.Name == "" || result.Plugin.Slug == "" || result.AssignmentVersion == "" || result.ResultCategory != "updated" || len(result.Assignments) > maxPluginMembers {
+		return false
+	}
+	if result.Plugin.Publication != PluginPublicationPublished && result.Plugin.Publication != PluginPublicationUnpublished && result.Plugin.Publication != PluginPublicationNoRepository {
+		return false
+	}
+	for _, assignment := range result.Assignments {
+		if assignment.DisplayName == "" || (assignment.Kind != "everyone" && assignment.Kind != "role" && assignment.Kind != "directory_group" && assignment.Kind != "directory_attribute") {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/platformmcp/plugins.go
+++ b/server/internal/platformmcp/plugins.go
@@ -16,7 +16,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/directory"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -246,6 +248,12 @@ type PluginsService struct {
 	assignmentReferences *subjectReferenceCodec
 	assignmentVersionKey []byte
 	now                  func() time.Time
+
+	mutationFlags    feature.Provider
+	organizations    OrganizationSlugResolver
+	audit            *audit.Logger
+	mutationBudget   OperationBudget
+	mutationReceipts *PluginAssignmentMutationReceiptStore
 }
 
 func NewPluginsService(db *pgxpool.Pool, budget OperationBudget, cursorKeyMaterial string) *PluginsService {
@@ -269,6 +277,11 @@ func NewPluginsService(db *pgxpool.Pool, budget OperationBudget, cursorKeyMateri
 		assignmentReferences: references,
 		assignmentVersionKey: versionKey,
 		now:                  time.Now,
+		mutationFlags:        nil,
+		organizations:        nil,
+		audit:                nil,
+		mutationBudget:       OperationBudget{},
+		mutationReceipts:     nil,
 	}
 }
 

--- a/server/internal/platformmcp/plugins_integration_test.go
+++ b/server/internal/platformmcp/plugins_integration_test.go
@@ -2,20 +2,29 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/directory"
 	directoryrepo "github.com/speakeasy-api/gram/server/internal/directory/repo"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	pluginassignments "github.com/speakeasy-api/gram/server/internal/plugins/assignments"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -335,6 +344,283 @@ func TestPluginInventoryRefusesAnotherOrganizationsProject(t *testing.T) {
 
 	_, err = service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: otherProject.ID.String()})
 	require.ErrorIs(t, err, ErrPluginProjectNotFound)
+}
+
+func TestSetPluginAssignmentsReplacesAtomicallyAndReplaysSafely(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_set_plugin_assignments")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagPlatformMCPPluginAssignmentMutations, principal.OrganizationID, true)
+	service := testPluginTargets(conn).WithAssignmentMutations(flags, NewPostgresOrganizationSlugResolver(conn), audit.NewLogger(), testOperationBudget())
+	_, err = service.SetPluginAssignments(ctx, principal, SetPluginAssignmentsInput{
+		ProjectID:                 project.ID.String(),
+		Plugin:                    uuid.Nil.String(),
+		ExpectedAssignmentVersion: "opaque-version",
+		IdempotencyKey:            "reject-zero-plugin-id",
+		Confirmed:                 true,
+	})
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationInvalid)
+
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Shared Tools", "shared-tools")
+	now := time.Now().UTC()
+	role, err := accessrepo.New(conn).CreateOrganizationRole(ctx, accessrepo.CreateOrganizationRoleParams{
+		OrganizationID:    principal.OrganizationID,
+		WorkosSlug:        "engineering",
+		WorkosName:        "Engineering",
+		WorkosDescription: pgtype.Text{},
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: pgtype.Text{},
+	})
+	require.NoError(t, err)
+
+	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	choices, err := service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	var reference string
+	for _, assignment := range choices.Assignments {
+		if assignment.DisplayName == role.WorkosName {
+			reference = assignment.Reference
+		}
+	}
+	require.NotEmpty(t, reference)
+
+	input := SetPluginAssignmentsInput{
+		ProjectID: project.ID.String(), Plugin: plugin.Slug, AssignmentReferences: []string{reference},
+		ExpectedAssignmentVersion: before.AssignmentVersion, IdempotencyKey: "set-assignments", Confirmed: true,
+	}
+	beforeAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+	changed, err := service.SetPluginAssignments(ctx, principal, input)
+	require.NoError(t, err)
+	require.False(t, changed.Receipt.Replayed)
+	require.Equal(t, PluginPublicationNoRepository, changed.Plugin.Publication)
+	require.Equal(t, PluginAssignmentSummary{Roles: 1}, changed.Plugin.Assignments)
+	zeroMembers := NewSubjectCount(0)
+	require.Equal(t, []PluginAssignmentSummaryResult{{Kind: "role", DisplayName: "Engineering", MemberCount: &zeroMembers}}, changed.Assignments)
+	require.NotEqual(t, before.AssignmentVersion, changed.AssignmentVersion)
+
+	stored, err := pluginsrepo.New(conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, role.RoleUrn, stored[0].PrincipalUrn)
+
+	conflicting := input
+	conflicting.AssignmentReferences = nil
+	_, err = service.SetPluginAssignments(ctx, principal, conflicting)
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationConflict)
+
+	stale := input
+	stale.IdempotencyKey = "stale-version"
+	_, err = service.SetPluginAssignments(ctx, principal, stale)
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationConflict)
+
+	_, err = pluginsrepo.New(conn).UpdatePlugin(ctx, pluginsrepo.UpdatePluginParams{
+		Name: "Renamed Tools", Slug: "renamed-tools", Description: plugin.Description,
+		ID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID,
+	})
+	require.NoError(t, err)
+	replayed, err := service.SetPluginAssignments(ctx, principal, input)
+	require.NoError(t, err, "an exact completed receipt replays even when its slug no longer resolves")
+	require.True(t, replayed.Receipt.Replayed)
+	require.Equal(t, changed.Receipt.ID, replayed.Receipt.ID)
+	require.Equal(t, changed.Plugin, replayed.Plugin)
+	afterAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+	require.Equal(t, beforeAudit+1, afterAudit, "receipt replay must not write a second audit event")
+	stored, err = pluginsrepo.New(conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, stored, 1, "stale writes leave the committed assignment untouched")
+
+	receipt, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+		Operation:      operationSetPluginAssignments,
+		IdempotencyKey: input.IdempotencyKey,
+		UserID:         conv.ToPGText(principal.UserID),
+		SubjectUrn:     userSubjectURN(principal.UserID),
+	})
+	require.NoError(t, err)
+	var safe SetPluginAssignmentsReceiptResult
+	require.NoError(t, json.Unmarshal(receipt.ResultPayload, &safe))
+	require.NotContains(t, string(receipt.ResultPayload), role.RoleUrn)
+	require.NotContains(t, string(receipt.ResultPayload), reference)
+}
+
+func TestPluginAssignmentMutationReceiptRollsBackDomainAndReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_audience_receipt_rollback")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Rollback", "rollback")
+	store := NewPluginAssignmentMutationReceiptStore(conn)
+	normalized := normalizedPluginAssignmentMutationInput(project.ID, plugin.ID.String(), nil, "version")
+	_, err = store.Execute(ctx, principal, project, "rollback", normalized, func(ctx context.Context, tx pgx.Tx) (SetPluginAssignmentsReceiptResult, error) {
+		_, err := pluginsrepo.New(tx).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{
+			PluginID: plugin.ID, OrganizationID: principal.OrganizationID, PrincipalUrn: urn.PrincipalWildcard,
+		})
+		require.NoError(t, err)
+		return SetPluginAssignmentsReceiptResult{}, errors.New("injected audit failure")
+	})
+	require.ErrorContains(t, err, "injected audit failure")
+
+	assignments, err := pluginsrepo.New(conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Empty(t, assignments)
+	_, err = platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, Operation: operationSetPluginAssignments,
+		IdempotencyKey: "rollback", UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID),
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+func TestConcurrentVersionProtectedAssignmentWritesSerialize(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_plugin_audience_race")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Race", "race")
+	versionKey := []byte("race-version-key")
+	expected := pluginAssignmentVersion(versionKey, project.ID, plugin.ID, nil)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	results := make(chan error, 2)
+	write := func(principalURN string) {
+		defer wg.Done()
+		<-start
+		tx, beginErr := conn.Begin(ctx) //nolint:glint // transaction contains only package APIs and SQLc-generated queries
+		if beginErr != nil {
+			results <- beginErr
+			return
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		locked, lockErr := pluginassignments.Lock(ctx, tx, principal.OrganizationID, project.ID, plugin.ID)
+		if lockErr != nil {
+			results <- lockErr
+			return
+		}
+		_, replaceErr := pluginassignments.Replace(ctx, tx, audit.NewLogger(), locked, pluginassignments.Input{
+			OrganizationID: principal.OrganizationID, ProjectID: project.ID, PluginID: plugin.ID,
+			PrincipalURNs: []string{principalURN}, Actor: urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID),
+		}, func(_ context.Context, _ pluginsrepo.Plugin, current, _ []string) error {
+			if pluginAssignmentVersion(versionKey, project.ID, plugin.ID, current) != expected {
+				return ErrPluginAssignmentMutationConflict
+			}
+			return nil
+		})
+		if replaceErr != nil {
+			results <- replaceErr
+			return
+		}
+		results <- tx.Commit(ctx)
+	}
+	go write(urn.PrincipalWildcard)
+	go write("email:member@example.com")
+	close(start)
+	wg.Wait()
+	close(results)
+
+	succeeded, conflicted := 0, 0
+	for result := range results {
+		switch {
+		case result == nil:
+			succeeded++
+		case errors.Is(result, ErrPluginAssignmentMutationConflict):
+			conflicted++
+		default:
+			require.NoError(t, result)
+		}
+	}
+	require.Equal(t, 1, succeeded)
+	require.Equal(t, 1, conflicted)
+	assignments, err := pluginsrepo.New(conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	count, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionPluginAssignmentsSet)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count)
+}
+
+func TestSetPluginAssignmentsRefusesHiddenCurrentAssignments(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_set_hidden_plugin_audience")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagPlatformMCPPluginAssignmentMutations, principal.OrganizationID, true)
+	service := testPluginTargets(conn).WithAssignmentMutations(flags, NewPostgresOrganizationSlugResolver(conn), audit.NewLogger(), testOperationBudget())
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Hidden Audience", "hidden-audience")
+	_, err = pluginsrepo.New(conn).AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{
+		PluginID: plugin.ID, OrganizationID: principal.OrganizationID, PrincipalUrn: "user:private-user-id",
+	})
+	require.NoError(t, err)
+	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	require.False(t, before.AssignmentDetailsComplete)
+
+	_, err = service.SetPluginAssignments(ctx, principal, SetPluginAssignmentsInput{
+		ProjectID: project.ID.String(), Plugin: plugin.ID.String(), AssignmentReferences: nil,
+		ExpectedAssignmentVersion: before.AssignmentVersion, IdempotencyKey: "hidden-audience", Confirmed: true,
+	})
+	require.ErrorIs(t, err, ErrPluginAssignmentMutationInvalid)
+	stored, err := pluginsrepo.New(conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: plugin.ID, OrganizationID: principal.OrganizationID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	require.Equal(t, "user:private-user-id", stored[0].PrincipalUrn)
+}
+
+func TestSetPluginAssignmentsRejectsExpiredAndCrossProjectReferences(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_set_plugin_assignment_references")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagPlatformMCPPluginAssignmentMutations, principal.OrganizationID, true)
+	service := testPluginTargets(conn).WithAssignmentMutations(flags, NewPostgresOrganizationSlugResolver(conn), audit.NewLogger(), testOperationBudget())
+	plugin := seedPlugin(t, ctx, conn, principal.OrganizationID, project.ID, "Shared Tools", "shared-tools")
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return now }
+	before, err := service.GetPlugin(ctx, principal, GetPluginInput{ProjectID: project.ID.String(), Plugin: plugin.ID.String()})
+	require.NoError(t, err)
+	choices, err := service.ListPluginAssignments(ctx, principal, ListPluginAssignmentsInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+
+	_, otherProject := seedRegistrationLifecycle(t, ctx, conn)
+	crossProject, err := service.assignmentReferences.EncodeScoped(principal, subjectKindPluginAssignment, otherProject.ID.String(), urn.PrincipalWildcard, now)
+	require.NoError(t, err)
+	for _, test := range []struct {
+		name      string
+		reference string
+		at        time.Time
+	}{
+		{name: "cross-project", reference: crossProject, at: now},
+		{name: "expired", reference: choices.Assignments[0].Reference, at: now.Add(SubjectReferenceTTL)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			localService := testPluginTargets(conn).WithAssignmentMutations(flags, NewPostgresOrganizationSlugResolver(conn), audit.NewLogger(), testOperationBudget())
+			localService.now = func() time.Time { return test.at }
+			_, err := localService.SetPluginAssignments(ctx, principal, SetPluginAssignmentsInput{
+				ProjectID: project.ID.String(), Plugin: plugin.ID.String(), AssignmentReferences: []string{test.reference},
+				ExpectedAssignmentVersion: before.AssignmentVersion, IdempotencyKey: test.name, Confirmed: true,
+			})
+			require.ErrorIs(t, err, ErrPluginAssignmentMutationNotFound)
+		})
+	}
 }
 
 func seedPlugin(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID, name, slug string) pluginsrepo.Plugin {

--- a/server/internal/platformmcp/risk_mutation_receipt.go
+++ b/server/internal/platformmcp/risk_mutation_receipt.go
@@ -5,18 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"slices"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/speakeasy-api/gram/server/internal/conv"
-	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
 )
 
 const maxRiskMutationReceiptPayloadBytes = 16 << 10
@@ -134,68 +129,30 @@ func (s *RiskMutationReceiptStore) Execute(ctx context.Context, principal Princi
 	if err != nil {
 		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation request could not be normalized.", Cause: ErrRiskMutationInvalid}
 	}
-	connectionID, generation, err := principalConnection(principal)
-	if err != nil {
-		return OperationReceipt{}, &RiskMutationError{Code: "invalid_request", Message: "The risk mutation caller identity is invalid.", Cause: ErrRiskMutationInvalid}
-	}
-
-	tx, err := s.db.Begin(ctx)
-	if err != nil {
-		return OperationReceipt{}, fmt.Errorf("begin risk mutation receipt: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	q := platformrepo.New(tx)
-	lock := platformrepo.LockPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID.String(), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
-	if err := q.LockPlatformMCPOperationReceipt(ctx, lock); err != nil {
-		return OperationReceipt{}, fmt.Errorf("lock risk mutation receipt: %w", err)
-	}
-	lookup := platformrepo.GetPlatformMCPOperationReceiptParams{OrganizationID: principal.OrganizationID, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID), ProjectID: project.ID, Operation: request.Operation, IdempotencyKey: request.IdempotencyKey}
-	if _, err := q.DeleteExpiredPlatformMCPOperationReceipt(ctx, platformrepo.DeleteExpiredPlatformMCPOperationReceiptParams(lookup)); err != nil {
-		return OperationReceipt{}, fmt.Errorf("reclaim expired risk mutation receipt: %w", err)
-	}
-	stored, err := q.GetPlatformMCPOperationReceipt(ctx, lookup)
-	switch {
-	case err == nil:
-		if stored.InputHash != inputHash {
-			return OperationReceipt{}, riskMutationConflict("The idempotency key was already used with different risk mutation input.")
-		}
-		if stored.Status != receiptStatusSucceeded || len(stored.ResultPayload) == 0 {
-			return OperationReceipt{}, riskMutationConflict("The matching risk mutation has no completed replay result.")
-		}
-		if err := tx.Commit(ctx); err != nil {
-			return OperationReceipt{}, fmt.Errorf("commit risk mutation replay: %w", err)
-		}
-		return operationReceiptFromRow(stored, true), nil
-	case !errors.Is(err, pgx.ErrNoRows):
-		return OperationReceipt{}, fmt.Errorf("load risk mutation receipt: %w", err)
-	}
-
-	created, err := q.CreatePlatformMCPOperationReceipt(ctx, platformrepo.CreatePlatformMCPOperationReceiptParams{
-		OrganizationID: principal.OrganizationID, ProjectID: project.ID, RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, ConnectionID: connectionID, ConnectionGeneration: generation,
-		UserID: conv.ToPGText(principal.UserID), ActingSurface: conv.ToPGText(string(principal.surface())), Operation: request.Operation, IdempotencyKey: request.IdempotencyKey,
-		InputHash: inputHash, Status: receiptStatusPending, ResultCode: pgtype.Text{String: "", Valid: false}, ResultPayload: nil, ExpiresAt: timestamp(s.now().UTC().Add(receiptLifetime)),
+	return executeMutationReceipt(ctx, mutationReceiptExecution[RiskMutationReceiptResult]{
+		DB: s.db, Now: s.now, Principal: principal, Project: project, Operation: request.Operation, IdempotencyKey: request.IdempotencyKey, InputHash: inputHash, Label: "risk mutation",
+		Invalid: func(cause error) error {
+			return &RiskMutationError{Code: "invalid_request", Message: "The risk mutation caller identity is invalid.", Cause: fmt.Errorf("%w: %w", ErrRiskMutationInvalid, cause)}
+		},
+		Conflict: riskMutationConflict,
+		Unavailable: func(cause error) error {
+			return &RiskMutationError{Code: unavailableCode, Message: "The risk mutation is temporarily unavailable.", Cause: fmt.Errorf("%w: %w", ErrRiskMutationUnavailable, cause)}
+		},
+		ValidateReplay: func(payload []byte) bool {
+			var result any
+			return len(payload) <= maxRiskMutationReceiptPayloadBytes && json.Unmarshal(payload, &result) == nil
+		},
+		EncodeResult: func(result RiskMutationReceiptResult) ([]byte, error) {
+			return encodeRiskMutationResult(request.Operation, result)
+		},
+		Mutate: func(ctx context.Context, tx pgx.Tx) (RiskMutationReceiptResult, error) {
+			result, err := mutate(ctx, tx)
+			if err != nil {
+				return nil, fmt.Errorf("apply risk mutation transaction: %w", err)
+			}
+			return result, nil
+		},
 	})
-	if err != nil {
-		return OperationReceipt{}, fmt.Errorf("create risk mutation receipt: %w", err)
-	}
-	result, err := mutate(ctx, tx)
-	if err != nil {
-		return OperationReceipt{}, fmt.Errorf("apply risk mutation transaction: %w", err)
-	}
-	payload, err := encodeRiskMutationResult(request.Operation, result)
-	if err != nil {
-		return OperationReceipt{}, err
-	}
-	completed, err := q.CompletePlatformMCPOperationReceipt(ctx, platformrepo.CompletePlatformMCPOperationReceiptParams{
-		RegistrationID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, Status: receiptStatusSucceeded, ResultCode: conv.ToPGText("succeeded"), ResultPayload: payload, ID: created.ID, OrganizationID: principal.OrganizationID,
-	})
-	if err != nil {
-		return OperationReceipt{}, fmt.Errorf("complete risk mutation receipt: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return OperationReceipt{}, fmt.Errorf("commit risk mutation: %w", err)
-	}
-	return operationReceiptFromRow(completed, false), nil
 }
 
 func riskMutationInputHash(operation string, normalized any) (string, error) {

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -19,6 +19,17 @@ type pluginRefusalResult struct {
 // admitting a second name for the same capability would make the assistant
 // choose between two tools that answer the same question.
 func registerPluginTools(reg *Registrar, plugins *PluginsService) {
+	setDescription := "Replace the complete assignment set of one exact plugin when assignment changes are enabled for its project. First read the plugin and current assignments. If this capability is available, explain the complete replacement and publication state, ask the user to confirm it, then call this with confirmed: true. Constraints: pass the assignment version from get_plugin, only opaque assignment references from get_plugin or list_plugin_assignments, and a stable idempotency key. An empty set removes every assignment and reaches nobody. This changes who can discover an already-published package; it does not publish package bytes. If the project is not enabled, this returns feature_unavailable without changing anything."
+	addTool(reg, &mcp.Tool{
+		Name:        operationSetPluginAssignments,
+		Title:       "Set Plugin Assignments",
+		Description: setDescription,
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input SetPluginAssignmentsInput) (*mcp.CallToolResult, SetPluginAssignmentsOutput, error) {
+		return pluginToolCall(ctx, func(principal Principal) (SetPluginAssignmentsOutput, error) {
+			return plugins.SetPluginAssignments(ctx, principal, input)
+		})
+	})
+
 	addTool(reg, &mcp.Tool{
 		Name:        "list_plugin_assignments",
 		Title:       "List Plugin Assignments",
@@ -58,17 +69,18 @@ func registerUnavailablePluginTools(reg *Registrar) {
 		name        string
 		title       string
 		description string
+		readOnly    bool
 	}{
-		{"list_plugin_assignments", "List Plugin Assignments", "List the roles and directory assignment targets that can receive plugins. This is not switched on for your organization yet."},
-		{"list_plugins", "List Plugins", "List the plugins in a project. This is not switched on for your organization yet."},
-		{"get_plugin", "Get One Plugin", "Get one plugin and what it carries. This is not switched on for your organization yet."},
+		{operationSetPluginAssignments, "Set Plugin Assignments", "Replace the complete assignment set of one exact plugin. This is not switched on for your organization yet.", false},
+		{"list_plugin_assignments", "List Plugin Assignments", "List the roles and directory assignment targets that can receive plugins. This is not switched on for your organization yet.", true},
+		{"list_plugins", "List Plugins", "List the plugins in a project. This is not switched on for your organization yet.", true},
+		{"get_plugin", "Get One Plugin", "Get one plugin and what it carries. This is not switched on for your organization yet.", true},
 	} {
-		addTool(reg, &mcp.Tool{
-			Name:        tool.name,
-			Title:       tool.title,
-			Description: tool.description,
-			Annotations: readOnlyAnnotations(),
-		}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("plugins"))
+		manifest := &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description}
+		if tool.readOnly {
+			manifest.Annotations = readOnlyAnnotations()
+		}
+		addTool(reg, manifest, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("plugins"))
 	}
 }
 
@@ -103,6 +115,10 @@ func pluginToolResult(err error) (*mcp.CallToolResult, bool) {
 	case errors.Is(err, ErrPluginCursorInvalid):
 		result = pluginRefusalResult{Code: "invalid_request", Message: "That page marker does not belong to this project. Start the list again from the beginning."}
 	default:
+		if mutation, ok := errors.AsType[*PluginAssignmentMutationError](err); ok {
+			result = pluginRefusalResult{Code: mutation.Code, Message: mutation.Message}
+			break
+		}
 		if budgetResult, ok := operationBudgetToolResult(err); ok {
 			return budgetResult, true
 		}

--- a/server/internal/plugins/assignments/command.go
+++ b/server/internal/plugins/assignments/command.go
@@ -1,0 +1,277 @@
+package assignments
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/directory"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+var (
+	ErrInvalid  = errors.New("invalid plugin assignment")
+	ErrNotFound = errors.New("plugin assignment target not found")
+)
+
+type Input struct {
+	OrganizationID   string
+	ProjectID        uuid.UUID
+	PluginID         uuid.UUID
+	PrincipalURNs    []string
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+}
+
+type Result struct {
+	Plugin             pluginsrepo.Plugin
+	Assignments        []pluginsrepo.PluginAssignment
+	PrincipalURNs      []string
+	PreviousPrincipals []string
+}
+
+// Lock selects one exact live plugin under FOR UPDATE. The same lock is used by
+// dashboard and Platform MCP writes, so concurrent assignment replacements are
+// serialized before either computes its current version.
+func Lock(ctx context.Context, tx pgx.Tx, organizationID string, projectID, pluginID uuid.UUID) (pluginsrepo.Plugin, error) {
+	if tx == nil || organizationID == "" || projectID == uuid.Nil || pluginID == uuid.Nil {
+		return pluginsrepo.Plugin{}, ErrInvalid
+	}
+	var plugin pluginsrepo.Plugin
+	err := tx.QueryRow(ctx, `
+SELECT id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
+FROM plugins
+WHERE id = $1
+  AND organization_id = $2
+  AND project_id = $3
+  AND deleted IS FALSE
+FOR UPDATE`, pluginID, organizationID, projectID).Scan(
+		&plugin.ID,
+		&plugin.OrganizationID,
+		&plugin.ProjectID,
+		&plugin.Name,
+		&plugin.Slug,
+		&plugin.Description,
+		&plugin.IsDefault,
+		&plugin.CreatedAt,
+		&plugin.UpdatedAt,
+		&plugin.DeletedAt,
+		&plugin.Deleted,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return pluginsrepo.Plugin{}, ErrNotFound
+	}
+	if err != nil {
+		return pluginsrepo.Plugin{}, fmt.Errorf("lock plugin assignment target: %w", err)
+	}
+	return plugin, nil
+}
+
+// BeforeReplace runs after the exact plugin row is locked and the complete
+// current and desired canonical assignment sets are known, but before any row
+// is replaced. Platform MCP uses it for optimistic concurrency; the dashboard
+// passes nil and otherwise keeps its established behavior.
+type BeforeReplace func(ctx context.Context, plugin pluginsrepo.Plugin, current, desired []string) error
+
+// Replace atomically validates, replaces, and audits one locked plugin's
+// complete assignment set using the caller-owned transaction.
+func Replace(ctx context.Context, tx pgx.Tx, logger *audit.Logger, plugin pluginsrepo.Plugin, input Input, before BeforeReplace) (Result, error) {
+	if tx == nil || logger == nil || input.OrganizationID == "" || input.ProjectID == uuid.Nil || input.PluginID == uuid.Nil || input.Actor.IsZero() || plugin.ID != input.PluginID || plugin.OrganizationID != input.OrganizationID || plugin.ProjectID != input.ProjectID || plugin.Name == "" || plugin.Slug == "" || plugin.Deleted {
+		return Result{}, ErrInvalid
+	}
+
+	queries := pluginsrepo.New(tx)
+	principals, err := normalizePrincipals(ctx, tx, input.OrganizationID, input.PrincipalURNs)
+	if err != nil {
+		return Result{}, err
+	}
+	existing, err := queries.ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{
+		PluginID:       input.PluginID,
+		OrganizationID: input.OrganizationID,
+		ProjectID:      input.ProjectID,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("list existing plugin assignments: %w", err)
+	}
+	current := make([]string, 0, len(existing))
+	existingCanonical := make(map[string]struct{}, len(existing))
+	for _, assignment := range existing {
+		canonical := canonicalPrincipal(assignment.PrincipalUrn)
+		current = append(current, canonical)
+		existingCanonical[canonical] = struct{}{}
+	}
+
+	directoryService := directory.NewService(tx)
+	for _, principal := range principals {
+		if _, alreadyAssigned := existingCanonical[principal.URN]; alreadyAssigned {
+			continue
+		}
+		switch principal.kind {
+		case principalStandard:
+			continue
+		case principalDirectoryGroup:
+			groupID, parseErr := directory.ParseGroupPrincipal(principal.URN)
+			if parseErr != nil {
+				return Result{}, fmt.Errorf("%w: directory group", ErrInvalid)
+			}
+			exists, existsErr := directoryService.GroupExists(ctx, input.OrganizationID, groupID)
+			if existsErr != nil {
+				return Result{}, fmt.Errorf("validate directory group assignment: %w", existsErr)
+			}
+			if !exists {
+				return Result{}, fmt.Errorf("%w: directory group", ErrInvalid)
+			}
+		case principalDirectoryAttribute:
+			attribute, parseErr := directory.ParseAttributePrincipal(principal.URN)
+			if parseErr != nil {
+				return Result{}, fmt.Errorf("%w: directory attribute", ErrInvalid)
+			}
+			exists, existsErr := directoryService.AttributeValueExists(ctx, input.OrganizationID, attribute)
+			if existsErr != nil {
+				return Result{}, fmt.Errorf("validate directory attribute assignment: %w", existsErr)
+			}
+			if !exists {
+				return Result{}, fmt.Errorf("%w: directory attribute", ErrInvalid)
+			}
+		}
+	}
+
+	desired := make([]string, 0, len(principals))
+	for _, principal := range principals {
+		desired = append(desired, principal.URN)
+	}
+	if before != nil {
+		if err := before(ctx, plugin, current, desired); err != nil {
+			return Result{}, err
+		}
+	}
+
+	if _, err := queries.RemoveAllPluginAssignments(ctx, pluginsrepo.RemoveAllPluginAssignmentsParams{
+		PluginID:       input.PluginID,
+		OrganizationID: input.OrganizationID,
+		ProjectID:      input.ProjectID,
+	}); err != nil {
+		return Result{}, fmt.Errorf("remove existing plugin assignments: %w", err)
+	}
+	created := make([]pluginsrepo.PluginAssignment, 0, len(principals))
+	for _, principal := range principals {
+		row, err := queries.AddPluginAssignment(ctx, pluginsrepo.AddPluginAssignmentParams{
+			PluginID:       input.PluginID,
+			OrganizationID: input.OrganizationID,
+			PrincipalUrn:   principal.URN,
+		})
+		if err != nil {
+			return Result{}, fmt.Errorf("add plugin assignment: %w", err)
+		}
+		created = append(created, row)
+	}
+	if err := logger.LogPluginAssignmentsSet(ctx, tx, audit.LogPluginAssignmentsSetEvent{
+		OrganizationID:   input.OrganizationID,
+		ProjectID:        input.ProjectID,
+		Actor:            input.Actor,
+		ActorDisplayName: input.ActorDisplayName,
+		ActorSlug:        input.ActorSlug,
+		PluginID:         plugin.ID,
+		PluginName:       plugin.Name,
+		PluginSlug:       plugin.Slug,
+		PrincipalURNs:    desired,
+	}); err != nil {
+		return Result{}, fmt.Errorf("audit plugin assignments set: %w", err)
+	}
+	return Result{Plugin: plugin, Assignments: created, PrincipalURNs: desired, PreviousPrincipals: current}, nil
+}
+
+type principalKind uint8
+
+const (
+	principalStandard principalKind = iota
+	principalDirectoryGroup
+	principalDirectoryAttribute
+)
+
+type normalizedPrincipal struct {
+	kind principalKind
+	URN  string
+}
+
+func normalizePrincipals(ctx context.Context, db pluginsrepo.DBTX, organizationID string, rawURNs []string) ([]normalizedPrincipal, error) {
+	principals := make([]normalizedPrincipal, 0, len(rawURNs))
+	seen := make(map[string]struct{}, len(rawURNs))
+	for _, raw := range rawURNs {
+		principal, err := normalizePrincipal(ctx, db, organizationID, raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[principal.URN]; ok {
+			continue
+		}
+		seen[principal.URN] = struct{}{}
+		principals = append(principals, principal)
+	}
+	return principals, nil
+}
+
+func normalizePrincipal(ctx context.Context, db pluginsrepo.DBTX, organizationID, raw string) (normalizedPrincipal, error) {
+	switch {
+	case raw == urn.PrincipalWildcard:
+		return normalizedPrincipal{kind: principalStandard, URN: raw}, nil
+	case directory.IsGroupPrincipal(raw):
+		id, err := directory.ParseGroupPrincipal(raw)
+		if err != nil {
+			return normalizedPrincipal{}, fmt.Errorf("%w: directory group", ErrInvalid)
+		}
+		return normalizedPrincipal{kind: principalDirectoryGroup, URN: directory.GroupPrincipal(id)}, nil
+	case directory.IsAttributePrincipal(raw):
+		attribute, err := directory.ParseAttributePrincipal(raw)
+		if err != nil {
+			return normalizedPrincipal{}, fmt.Errorf("%w: directory attribute", ErrInvalid)
+		}
+		return normalizedPrincipal{kind: principalDirectoryAttribute, URN: directory.AttributePrincipal(attribute.Key, attribute.Value)}, nil
+	default:
+		normalized := raw
+		if address, ok := strings.CutPrefix(raw, string(urn.PrincipalTypeEmail)+":"); ok {
+			normalized = string(urn.PrincipalTypeEmail) + ":" + conv.NormalizeEmail(address)
+		}
+		principal, err := urn.ParsePrincipal(normalized)
+		if err != nil {
+			return normalizedPrincipal{}, fmt.Errorf("%w: principal", ErrInvalid)
+		}
+		if principal.Type == urn.PrincipalTypeAgent {
+			return normalizedPrincipal{}, fmt.Errorf("%w: agent principals are not supported", ErrInvalid)
+		}
+		if principal.Type == urn.PrincipalTypeRole {
+			if err := authz.ValidatePrincipal(ctx, db, organizationID, principal); err != nil {
+				if errors.Is(err, authz.ErrPrincipalInvalid) || errors.Is(err, authz.ErrPrincipalNotFound) {
+					return normalizedPrincipal{}, fmt.Errorf("%w: role", ErrInvalid)
+				}
+				return normalizedPrincipal{}, fmt.Errorf("validate role principal: %w", err)
+			}
+		}
+		return normalizedPrincipal{kind: principalStandard, URN: principal.String()}, nil
+	}
+}
+
+func canonicalPrincipal(value string) string {
+	if value == urn.PrincipalWildcard {
+		return value
+	}
+	if groupID, err := directory.ParseGroupPrincipal(value); err == nil {
+		return directory.GroupPrincipal(groupID)
+	}
+	if attribute, err := directory.ParseAttributePrincipal(value); err == nil {
+		return directory.AttributePrincipal(attribute.Key, attribute.Value)
+	}
+	if principal, err := urn.ParsePrincipal(value); err == nil {
+		return principal.String()
+	}
+	return value
+}

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -39,7 +39,7 @@ func TestEnsureDefaultPlugin_CreatesWhenMissing(t *testing.T) {
 	// A freshly-created Default plugin in the org's default project (the test's
 	// only, and thus oldest, project) is assigned to the org wildcard so it
 	// delivers to everyone under agent.getPlugins' per-principal scoping.
-	assignments, err := pluginsrepo.New(tx).ListPluginAssignments(ctx, result.Plugin.ID)
+	assignments, err := pluginsrepo.New(tx).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: result.Plugin.ID, OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID})
 	require.NoError(t, err)
 	require.Len(t, assignments, 1)
 	require.Equal(t, "*", assignments[0].PrincipalUrn)
@@ -72,7 +72,7 @@ func TestEnsureDefaultPlugin_NonDefaultProjectSeedsNoAudience(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.Created)
 
-	assignments, err := pluginsrepo.New(tx).ListPluginAssignments(ctx, result.Plugin.ID)
+	assignments, err := pluginsrepo.New(tx).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: result.Plugin.ID, OrganizationID: authCtx.ActiveOrganizationID, ProjectID: other.ID})
 	require.NoError(t, err)
 	require.Empty(t, assignments,
 		"a non-default project's Default plugin starts with no audience")

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -41,7 +41,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/directory"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
@@ -49,6 +48,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	pluginassignments "github.com/speakeasy-api/gram/server/internal/plugins/assignments"
 	"github.com/speakeasy-api/gram/server/internal/plugins/naming"
 	"github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
@@ -409,7 +409,7 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").LogError(ctx, s.logger)
 	}
 
-	assignments, err := s.repo.ListPluginAssignments(ctx, pluginID)
+	assignments, err := s.repo.ListPluginAssignments(ctx, repo.ListPluginAssignmentsParams{PluginID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
@@ -624,7 +624,7 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin servers").LogError(ctx, s.logger)
 	}
 
-	assignments, err := s.repo.ListPluginAssignments(ctx, pluginID)
+	assignments, err := s.repo.ListPluginAssignments(ctx, repo.ListPluginAssignmentsParams{PluginID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
@@ -684,7 +684,7 @@ func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPay
 		return oops.E(oops.CodeUnexpected, err, "soft-delete plugin servers").LogError(ctx, s.logger)
 	}
 
-	if _, err := txRepo.RemoveAllPluginAssignments(ctx, pluginID); err != nil {
+	if _, err := txRepo.RemoveAllPluginAssignments(ctx, repo.RemoveAllPluginAssignmentsParams{PluginID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "remove plugin assignments").LogError(ctx, s.logger)
 	}
 
@@ -1132,29 +1132,8 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin id").LogError(ctx, s.logger)
 	}
-
-	// Verify the plugin belongs to this project.
-	plugin, err := s.repo.GetPlugin(ctx, repo.GetPluginParams{ID: pluginID, OrganizationID: ac.ActiveOrganizationID, ProjectID: *ac.ProjectID})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, oops.C(oops.CodeNotFound)
-		}
-		return nil, oops.E(oops.CodeUnexpected, err, "verify plugin ownership").LogError(ctx, s.logger)
-	}
-
-	principals := make([]pluginAssignmentPrincipal, 0, len(payload.PrincipalUrns))
-	seenURNs := make(map[string]struct{}, len(payload.PrincipalUrns))
-	for _, raw := range payload.PrincipalUrns {
-		principal, err := s.parsePluginAssignmentPrincipal(ctx, ac.ActiveOrganizationID, raw)
-		if err != nil {
-			return nil, err
-		}
-
-		if _, ok := seenURNs[principal.URN]; ok {
-			continue
-		}
-		seenURNs[principal.URN] = struct{}{}
-		principals = append(principals, principal)
+	if pluginID == uuid.Nil {
+		return nil, oops.E(oops.CodeBadRequest, pluginassignments.ErrInvalid, "invalid plugin id").LogError(ctx, s.logger)
 	}
 
 	tx, err := s.db.Begin(ctx)
@@ -1163,95 +1142,40 @@ func (s *Service) SetPluginAssignments(ctx context.Context, payload *gen.SetPlug
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
-	txRepo := s.repo.WithTx(tx)
-	directoryService := directory.NewService(tx)
-	existingAssignments, err := txRepo.ListPluginAssignments(ctx, pluginID)
+	locked, err := pluginassignments.Lock(ctx, tx, ac.ActiveOrganizationID, *ac.ProjectID, pluginID)
+	if errors.Is(err, pluginassignments.ErrNotFound) {
+		return nil, oops.C(oops.CodeNotFound)
+	}
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list existing assignments").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "lock plugin assignments target").LogError(ctx, s.logger)
 	}
-	existingPrincipalURNs := make(map[string]struct{}, len(existingAssignments))
-	for _, assignment := range existingAssignments {
-		existingPrincipalURNs[assignment.PrincipalUrn] = struct{}{}
-		if attribute, err := directory.ParseAttributePrincipal(assignment.PrincipalUrn); err == nil {
-			existingPrincipalURNs[directory.AttributePrincipal(attribute.Key, attribute.Value)] = struct{}{}
-		}
-	}
-	for _, principal := range principals {
-		switch principal.Type {
-		case pluginAssignmentPrincipalStandard:
-			continue
-		case pluginAssignmentPrincipalDirectoryGroup:
-			if _, alreadyAssigned := existingPrincipalURNs[principal.URN]; alreadyAssigned {
-				continue
-			}
-			groupID, err := directory.ParseGroupPrincipal(principal.URN)
-			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "invalid directory group assignment: %s", principal.URN)
-			}
-			exists, err := directoryService.GroupExists(ctx, ac.ActiveOrganizationID, groupID)
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "validate directory group assignment").LogError(ctx, s.logger)
-			}
-			if !exists {
-				return nil, oops.E(oops.CodeBadRequest, nil, "invalid directory group assignment: %s", principal.URN)
-			}
-		case pluginAssignmentPrincipalDirectoryAttribute:
-			if _, alreadyAssigned := existingPrincipalURNs[principal.URN]; alreadyAssigned {
-				continue
-			}
-			attribute, err := directory.ParseAttributePrincipal(principal.URN)
-			if err != nil {
-				return nil, oops.E(oops.CodeBadRequest, err, "invalid directory attribute assignment: %s", principal.URN)
-			}
-			exists, err := directoryService.AttributeValueExists(ctx, ac.ActiveOrganizationID, attribute)
-			if err != nil {
-				return nil, oops.E(oops.CodeUnexpected, err, "validate directory attribute assignment").LogError(ctx, s.logger)
-			}
-			if !exists {
-				return nil, oops.E(oops.CodeBadRequest, nil, "invalid directory attribute assignment: %s", principal.URN)
-			}
-		}
-	}
-
-	if _, err := txRepo.RemoveAllPluginAssignments(ctx, pluginID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "remove existing assignments").LogError(ctx, s.logger)
-	}
-
-	assignments := make([]*gen.PluginAssignment, 0, len(principals))
-	for _, principal := range principals {
-		row, err := txRepo.AddPluginAssignment(ctx, repo.AddPluginAssignmentParams{
-			PluginID:       pluginID,
-			OrganizationID: ac.ActiveOrganizationID,
-			PrincipalUrn:   principal.URN,
-		})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "add plugin assignment").LogError(ctx, s.logger)
-		}
-		assignments = append(assignments, pluginAssignmentToGen(row))
-	}
-	principalURNs := make([]string, 0, len(principals))
-	for _, principal := range principals {
-		principalURNs = append(principalURNs, principal.URN)
-	}
-
-	if err := s.audit.LogPluginAssignmentsSet(ctx, tx, audit.LogPluginAssignmentsSetEvent{
+	result, err := pluginassignments.Replace(ctx, tx, s.audit, locked, pluginassignments.Input{
 		OrganizationID:   ac.ActiveOrganizationID,
 		ProjectID:        *ac.ProjectID,
+		PluginID:         pluginID,
+		PrincipalURNs:    payload.PrincipalUrns,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, ac.UserID),
 		ActorDisplayName: ac.Email,
 		ActorSlug:        nil,
-		PluginID:         plugin.ID,
-		PluginName:       plugin.Name,
-		PluginSlug:       plugin.Slug,
-		PrincipalURNs:    principalURNs,
-	}); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "audit log plugin assignments set").LogError(ctx, s.logger)
+	}, nil)
+	if err != nil {
+		switch {
+		case errors.Is(err, pluginassignments.ErrNotFound):
+			return nil, oops.C(oops.CodeNotFound)
+		case errors.Is(err, pluginassignments.ErrInvalid):
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid plugin assignment")
+		default:
+			return nil, oops.E(oops.CodeUnexpected, err, "set plugin assignments").LogError(ctx, s.logger)
+		}
 	}
-
 	if err := tx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
+	assignments := make([]*gen.PluginAssignment, 0, len(result.Assignments))
+	for _, assignment := range result.Assignments {
+		assignments = append(assignments, pluginAssignmentToGen(assignment))
+	}
 	return &gen.SetPluginAssignmentsResult{Assignments: assignments}, nil
 }
 

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -863,6 +863,22 @@ func TestPluginsService_SetPluginAssignments_PreservesLegacyDirectoryAttributePr
 	require.Equal(t, principal, result.Assignments[0].PrincipalUrn)
 }
 
+func TestPluginsService_SetPluginAssignments_ZeroPluginIDReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	_, err := ti.service.SetPluginAssignments(ctx, &gen.SetPluginAssignmentsPayload{
+		PluginID:      uuid.Nil.String(),
+		PrincipalUrns: []string{"*"},
+	})
+	require.Error(t, err)
+
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+}
+
 func TestPluginsService_SetPluginAssignments_NonExistentPluginReturnsNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -1531,7 +1547,7 @@ func TestCreatePlugin_DefaultsToOrgWildcardOnlyInDefaultProject(t *testing.T) {
 	// the default — so a plugin created here is seeded with the org wildcard.
 	inDefault, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "In Default"})
 	require.NoError(t, err)
-	defaultAssignments, err := pluginsrepo.New(ti.conn).ListPluginAssignments(ctx, uuid.MustParse(inDefault.ID))
+	defaultAssignments, err := pluginsrepo.New(ti.conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: uuid.MustParse(inDefault.ID), OrganizationID: orgID, ProjectID: *authCtx.ProjectID})
 	require.NoError(t, err)
 	require.Len(t, defaultAssignments, 1)
 	require.Equal(t, "*", defaultAssignments[0].PrincipalUrn)
@@ -1548,7 +1564,7 @@ func TestCreatePlugin_DefaultsToOrgWildcardOnlyInDefaultProject(t *testing.T) {
 
 	inOther, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "In Other"})
 	require.NoError(t, err)
-	otherAssignments, err := pluginsrepo.New(ti.conn).ListPluginAssignments(ctx, uuid.MustParse(inOther.ID))
+	otherAssignments, err := pluginsrepo.New(ti.conn).ListPluginAssignments(ctx, pluginsrepo.ListPluginAssignmentsParams{PluginID: uuid.MustParse(inOther.ID), OrganizationID: orgID, ProjectID: other.ID})
 	require.NoError(t, err)
 	require.Empty(t, otherAssignments,
 		"a plugin in a non-default project starts with no audience")

--- a/server/internal/plugins/principal.go
+++ b/server/internal/plugins/principal.go
@@ -2,31 +2,11 @@ package plugins
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/speakeasy-api/gram/server/internal/authz"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/database"
 	"github.com/speakeasy-api/gram/server/internal/directory"
-	"github.com/speakeasy-api/gram/server/internal/oops"
-	"github.com/speakeasy-api/gram/server/internal/urn"
 )
-
-type pluginAssignmentPrincipalType uint8
-
-const (
-	pluginAssignmentPrincipalStandard pluginAssignmentPrincipalType = iota
-	pluginAssignmentPrincipalDirectoryGroup
-	pluginAssignmentPrincipalDirectoryAttribute
-)
-
-type pluginAssignmentPrincipal struct {
-	Type pluginAssignmentPrincipalType
-
-	URN string
-}
 
 func ResolveDirectoryAudiencePrincipalsByEmails(ctx context.Context, db database.DBTX, organizationID string, emails []string) (map[string][]string, error) {
 	associations, err := directory.NewService(db).ResolveUserAssociationsByEmails(ctx, organizationID, emails)
@@ -44,48 +24,4 @@ func ResolveDirectoryAudiencePrincipalsByEmails(ctx context.Context, db database
 		}
 	}
 	return principals, nil
-}
-
-func (s *Service) parsePluginAssignmentPrincipal(ctx context.Context, organizationID, raw string) (pluginAssignmentPrincipal, error) {
-	switch {
-	case raw == urn.PrincipalWildcard:
-		return pluginAssignmentPrincipal{Type: pluginAssignmentPrincipalStandard, URN: raw}, nil
-	case directory.IsGroupPrincipal(raw):
-		id, err := directory.ParseGroupPrincipal(raw)
-		if err != nil {
-			return pluginAssignmentPrincipal{}, oops.E(oops.CodeBadRequest, err, "invalid directory group assignment: %s", raw)
-		}
-		return pluginAssignmentPrincipal{Type: pluginAssignmentPrincipalDirectoryGroup, URN: directory.GroupPrincipal(id)}, nil
-	case directory.IsAttributePrincipal(raw):
-		attribute, err := directory.ParseAttributePrincipal(raw)
-		if err != nil {
-			return pluginAssignmentPrincipal{}, oops.E(oops.CodeBadRequest, err, "invalid directory attribute assignment: %s", raw)
-		}
-		return pluginAssignmentPrincipal{
-			Type: pluginAssignmentPrincipalDirectoryAttribute,
-			URN:  directory.AttributePrincipal(attribute.Key, attribute.Value),
-		}, nil
-	default:
-		normalized := raw
-		if addr, ok := strings.CutPrefix(raw, string(urn.PrincipalTypeEmail)+":"); ok {
-			normalized = string(urn.PrincipalTypeEmail) + ":" + conv.NormalizeEmail(addr)
-		}
-		principal, err := urn.ParsePrincipal(normalized)
-		if err != nil {
-			return pluginAssignmentPrincipal{}, oops.E(oops.CodeBadRequest, err, "invalid principal URN: %s", raw)
-		}
-		if principal.Type == urn.PrincipalTypeAgent {
-			return pluginAssignmentPrincipal{}, oops.E(oops.CodeBadRequest, nil, "agent principal assignments are not supported: %s", raw)
-		}
-		if principal.Type != urn.PrincipalTypeRole {
-			return pluginAssignmentPrincipal{Type: pluginAssignmentPrincipalStandard, URN: principal.String()}, nil
-		}
-		if err := authz.ValidatePrincipal(ctx, s.db, organizationID, principal); err != nil {
-			if errors.Is(err, authz.ErrPrincipalInvalid) || errors.Is(err, authz.ErrPrincipalNotFound) {
-				return pluginAssignmentPrincipal{}, oops.E(oops.CodeBadRequest, err, "invalid role principal URN: %s", raw)
-			}
-			return pluginAssignmentPrincipal{}, oops.E(oops.CodeUnexpected, err, "validate role principal URN: %s", raw).LogError(ctx, s.logger)
-		}
-		return pluginAssignmentPrincipal{Type: pluginAssignmentPrincipalStandard, URN: principal.String()}, nil
-	}
 }

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -339,13 +339,24 @@ ON CONFLICT (plugin_id, principal_urn) DO UPDATE
 RETURNING *;
 
 -- name: ListPluginAssignments :many
-SELECT *
-FROM plugin_assignments
-WHERE plugin_id = @plugin_id;
+SELECT pa.*
+FROM plugin_assignments pa
+JOIN plugins p
+  ON p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND p.deleted IS FALSE
+WHERE pa.plugin_id = @plugin_id
+  AND pa.organization_id = @organization_id
+  AND p.project_id = @project_id;
 
 -- name: RemoveAllPluginAssignments :execrows
-DELETE FROM plugin_assignments
-WHERE plugin_id = @plugin_id;
+DELETE FROM plugin_assignments pa
+USING plugins p
+WHERE p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND pa.plugin_id = @plugin_id
+  AND pa.organization_id = @organization_id
+  AND p.project_id = @project_id;
 
 -- name: ListPluginsWithServersForProject :many
 -- Used during plugin generation: returns all active plugin servers joined with

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -927,13 +927,25 @@ func (q *Queries) ListOrgPluginPublishTargets(ctx context.Context, organizationI
 }
 
 const listPluginAssignments = `-- name: ListPluginAssignments :many
-SELECT id, plugin_id, organization_id, principal_urn, created_at, updated_at
-FROM plugin_assignments
-WHERE plugin_id = $1
+SELECT pa.id, pa.plugin_id, pa.organization_id, pa.principal_urn, pa.created_at, pa.updated_at
+FROM plugin_assignments pa
+JOIN plugins p
+  ON p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND p.deleted IS FALSE
+WHERE pa.plugin_id = $1
+  AND pa.organization_id = $2
+  AND p.project_id = $3
 `
 
-func (q *Queries) ListPluginAssignments(ctx context.Context, pluginID uuid.UUID) ([]PluginAssignment, error) {
-	rows, err := q.db.Query(ctx, listPluginAssignments, pluginID)
+type ListPluginAssignmentsParams struct {
+	PluginID       uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+func (q *Queries) ListPluginAssignments(ctx context.Context, arg ListPluginAssignmentsParams) ([]PluginAssignment, error) {
+	rows, err := q.db.Query(ctx, listPluginAssignments, arg.PluginID, arg.OrganizationID, arg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -1621,12 +1633,23 @@ func (q *Queries) PromoteToDefaultPlugin(ctx context.Context, arg PromoteToDefau
 }
 
 const removeAllPluginAssignments = `-- name: RemoveAllPluginAssignments :execrows
-DELETE FROM plugin_assignments
-WHERE plugin_id = $1
+DELETE FROM plugin_assignments pa
+USING plugins p
+WHERE p.id = pa.plugin_id
+  AND p.organization_id = pa.organization_id
+  AND pa.plugin_id = $1
+  AND pa.organization_id = $2
+  AND p.project_id = $3
 `
 
-func (q *Queries) RemoveAllPluginAssignments(ctx context.Context, pluginID uuid.UUID) (int64, error) {
-	result, err := q.db.Exec(ctx, removeAllPluginAssignments, pluginID)
+type RemoveAllPluginAssignmentsParams struct {
+	PluginID       uuid.UUID
+	OrganizationID string
+	ProjectID      uuid.UUID
+}
+
+func (q *Queries) RemoveAllPluginAssignments(ctx context.Context, arg RemoveAllPluginAssignmentsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, removeAllPluginAssignments, arg.PluginID, arg.OrganizationID, arg.ProjectID)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Linear

- [AIM-227](https://linear.app/speakeasy/issue/AIM-227)

## Why

Admins can inspect which roles and directory groups receive a plugin, but Platform MCP could not safely change those assignments. This closes the write half of the plugin-distribution journey without exposing principal URNs or silently overwriting a concurrent dashboard edit.

Stacked on #6062, which adds the assignment references and assignment-version read contract this change consumes.

## What changed

- Add `set_plugin_assignments` for an explicit project and exact plugin target.
- Require the complete desired opaque assignment-reference set, a current assignment version, an idempotency key, and explicit confirmation.
- Serialize dashboard and Platform assignment replacements through one shared plugin row lock and one shared validation/audit command.
- Reuse a shared receipt executor so assignment and risk mutations have one implementation of locking, replay, rollback, and commit semantics.
- Store the assignment, audit event, and privacy-safe replay receipt in one transaction; exact retries return the stored result without another write.
- Tenant-qualify assignment reads/deletes by plugin, organization, and project, including deletion cleanup after a plugin is soft-deleted.
- Refuse all-zero plugin UUIDs, expired/cross-project references, stale versions, hidden legacy/user assignments, and ambiguous plugin names without changing state.
- Return the committed assignment summary and existing publication state. Assignment changes do not publish package bytes.
- Keep the manifest rollout-neutral: disabled projects receive `feature_unavailable` without a write.

## Review notes

Start with:

1. `server/internal/plugins/assignments/command.go` — shared lock, normalization, tenant-scoped replacement, and audit behavior.
2. `server/internal/platformmcp/plugin_audience_mutation.go` — confirmation, gate, bounded reference resolution, and assignment-version check.
3. `server/internal/platformmcp/mutation_receipt_executor.go` — shared idempotency orchestration.
4. `server/internal/platformmcp/plugin_audience_receipt.go` — assignment-specific hashing and closed safe result projection.
5. `server/internal/platformmcp/plugins_integration_test.go` — replay, stale-version, rollback, concurrency, hidden-assignment, reference-boundary, and zero-UUID coverage.

## Validation

- [x] `hk fix`
- [x] `mise run test:server ./internal/platformmcp` — 572 tests
- [x] `mise lint:server`
- [x] `mise build:server`
- [x] compile-only checks for `./internal/platformmcp` and `./internal/plugins`
- [x] `git diff --check`
- [ ] `mise run test:server ./internal/plugins` — package compiles, but the local harness timed out waiting for ClickHouse on two attempts; no plugin test body ran

## Rollout / rollback

- Roll out by enabling `platform-mcp-plugin-assignment-mutations` for the intended organization/project cohort.
- Roll back by disabling that flag. This removes the write capability immediately; committed plugin assignments remain editable through the existing dashboard flow.

