### PR TITLE
fix: roll back test transactions during cleanup

### DIFF
--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -125,14 +125,21 @@ func RejectWritesTo(t *testing.T, ctx context.Context, conn *pgxpool.Pool, table
 
 // BeginTx starts a transaction that's rolled back on test cleanup, so tests
 // that need a real pgx.Tx (e.g. for savepoint-using functions) don't leak
-// open transactions. Callers that need a write visible to a later call in
-// the same test (simulating separate requests) must Commit explicitly.
+// open transactions. Cleanup uses its own timeout because testing cancels the
+// test context before running cleanup functions. Callers that need a write
+// visible to a later call in the same test (simulating separate requests) must
+// Commit explicitly.
 func BeginTx(t *testing.T, ctx context.Context, conn *pgxpool.Pool) pgx.Tx {
 	t.Helper()
 
 	tx, err := conn.Begin(ctx)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = tx.Rollback(ctx) })
+	t.Cleanup(func() {
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+
+		_ = tx.Rollback(rollbackCtx)
+	})
 
 	return tx
 }


### PR DESCRIPTION
## Why?

Go cancels a test's context before running its cleanup functions. Passing that cancelled context to PostgreSQL transaction rollback forces pgx down a connection-destruction path that can race during parallel test teardown and panic an otherwise unrelated server test shard.

## What?

Roll back test transactions with a cancellation-detached context and a 30-second timeout. This allows PostgreSQL to perform a normal rollback while keeping cleanup bounded, and documents the lifecycle requirement in the shared test helper.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back test transactions with a cancellation-detached context so cleanup no longer races during parallel test teardown.

- Go cancels a test's context before running its cleanup functions, which previously sent a cancelled context to `tx.Rollback` and could panic unrelated server test shards.
- Cleanup now uses `context.WithoutCancel` with a 30-second timeout to keep rollback bounded.

<sup>Written for commit cc4a614a0dc17cc85cc68a94b91665f326534c07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

