### PR TITLE
fix: align Codex MDM setup with device agent telemetry

### DIFF
--- a/client/dashboard/src/pages/setup/setup-data.test.ts
+++ b/client/dashboard/src/pages/setup/setup-data.test.ts
@@ -34,4 +34,17 @@ describe("AGENT_PLATFORMS", () => {
       OTEL_TRACES_EXPORTER: "otlp",
     });
   });
+
+  it("delegates Codex telemetry configuration to the device agent", () => {
+    const codex = AGENT_PLATFORMS.find(({ id }) => id === "codex");
+
+    expect(codex?.setupSteps).toHaveLength(1);
+    const step = codex?.setupSteps[0];
+    expect(step?.title).toBe("Deploy the Speakeasy device agent via MDM");
+    expect(step).not.toHaveProperty("code");
+    expect(step).not.toHaveProperty("requiresApiKey");
+    expect(step?.description).toContain(
+      "OpenTelemetry logs, metrics, and traces",
+    );
+  });
 });

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -146,28 +146,12 @@ const SETUP_AGENT_PLATFORMS: Array<{
       {
         title: "Deploy the Speakeasy device agent via MDM",
         description:
-          "Codex is instrumented centrally by the Speakeasy device agent — this covers the Codex CLI and Codex mode in the ChatGPT desktop app, which OpenAI merged the standalone Codex app into. Chat and Work modes in that same app are not covered here; they are captured through the OpenAI Compliance API integration instead. Roll the agent out through your MDM (Jamf, Iru (formerly Kandji), Intune, ...) using the Fleet (MDM) path, then select Codex as a managed platform so its configuration is applied to every developer with no per-user setup.",
+          "Codex is instrumented centrally by the Speakeasy device agent — this covers the Codex CLI and Codex mode in the ChatGPT desktop app, which OpenAI merged the standalone Codex app into. Chat and Work modes in that same app are not covered here; they are captured through the OpenAI Compliance API integration instead. Roll the agent out through your MDM (Jamf, Iru (formerly Kandji), Intune, ...) using the Fleet (MDM) path, then select Codex as a managed platform. The agent installs the observability plugin and configures authenticated OpenTelemetry logs, metrics, and traces for every managed developer with no per-user setup. Restart Codex after the first policy sync.",
         helpLink: {
           url: "{{GRAM_DEVICE_AGENT_URL}}",
           linkLabel: "device agent setup",
           sentence:
             "Follow the Fleet (MDM) walkthrough on the {LINK} page, then hand the profile to your MDM admin.",
-        },
-      },
-      {
-        title: "Forward Codex OpenTelemetry logs to Speakeasy",
-        description:
-          "Codex exports OpenTelemetry logs for every turn, tool call, and approval. Point its OTLP exporter at Speakeasy so Codex activity lands in your dashboard alongside your other agents. Add the block below to ~/.codex/config.toml, or push it fleet-wide from your MDM by dropping it in /etc/codex/managed_config.toml (com.openai.codex on macOS).",
-        code: `[otel]
-environment = "prod"
-exporter = { otlp-http = { endpoint = "https://app.getgram.ai/rpc/hooks.otel/v1/logs", protocol = "json", headers = { "Gram-Project" = "default", "Gram-Key" = "{{GRAM_API_KEY}}" } } }`,
-        language: "toml",
-        requiresApiKey: true,
-        helpLink: {
-          url: "https://learn.chatgpt.com/docs/config-file/config-reference",
-          linkLabel: "Codex OTEL config reference",
-          sentence:
-            "See the {LINK} for every OpenTelemetry option and managed-config precedence.",
         },
       },
     ],


### PR DESCRIPTION
## Summary

- remove the obsolete per-user Codex OTLP snippet from organization setup
- describe device-agent ownership of authenticated logs, metrics, and traces
- add a setup-data contract test that prevents the manual configuration step from returning

## Motivation

The setup flow claimed Codex was centrally managed, then instructed every user or MDM administrator to install a legacy JSON, logs-only exporter. The corresponding device-agent release now reconciles the native OTLP configuration, so the dashboard should present one fleet-managed path and require a Codex restart after the first policy sync.

## Rollout

Merge after the corresponding device-agent version has reached the stable auto-update channel so the setup guidance never gets ahead of fleet behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Codex MDM setup with device-agent telemetry so the dashboard no longer instructs per-user OTLP configuration.

- Removes the obsolete per-user Codex OTLP snippet from organization setup.
- Updates the device-agent step to describe authenticated logs, metrics, and traces, and requires a Codex restart after the first policy sync.
- Adds a test that locks the setup step to the MDM path without manual config.

**Rollout**

- Merge after the corresponding device-agent version reaches the stable auto-update channel.

<sup>Written for commit b377fc71055ccc517d9a7f764bbc6740965d5649. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

