### PR TITLE
feat: extend MCP sessions for agent subjects

### DIFF
--- a/.changeset/agent-mcp-sessions.md
+++ b/.changeset/agent-mcp-sessions.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Extend MCP sessions to agent subjects with delegated grants and live authorization checks during session admission and refresh, including cached refresh replay.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -985,8 +985,9 @@ func newStartCommand() *cli.Command {
 				challengeLoggingEnabled,
 				roleClient,
 				authz.EngineOpts{
-					AdmitPrincipalCredential: runtimepolicy.AdmitPrincipalCredential,
-					DevMode:                  c.String("environment") == "local",
+					AdmitPrincipalCredential:         runtimepolicy.AdmitPrincipalCredential,
+					AdmitPrincipalCredentialWithDBTX: runtimepolicy.AdmitPrincipalCredentialWithDBTX,
+					DevMode:                          c.String("environment") == "local",
 				})
 
 			telemetryLogPublisher := tm.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -569,8 +569,9 @@ func newWorkerCommand() *cli.Command {
 				challengeLoggingEnabled,
 				workos.NewStubClient(),
 				authz.EngineOpts{
-					AdmitPrincipalCredential: runtimepolicy.AdmitPrincipalCredential,
-					DevMode:                  c.String("environment") == "local",
+					AdmitPrincipalCredential:         runtimepolicy.AdmitPrincipalCredential,
+					AdmitPrincipalCredentialWithDBTX: runtimepolicy.AdmitPrincipalCredentialWithDBTX,
+					DevMode:                          c.String("environment") == "local",
 				})
 
 			workosClient, workosAvailable, err := newWorkOSClient(guardianPolicy, c)

--- a/server/internal/agents/runtimepolicy/credential_admission.go
+++ b/server/internal/agents/runtimepolicy/credential_admission.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/agents"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -26,6 +27,33 @@ import (
 // this function before minting credentials, resolving upstream authority, or
 // executing an operation. Successful results must not be cached across requests.
 func AdmitPrincipalCredential(ctx context.Context, db *pgxpool.Pool) (authz.PrincipalCredentialAdmission, error) {
+	if !hasPrincipalCredentialAdmissionContext(ctx) {
+		return authz.PrincipalCredentialAdmission{}, oops.C(oops.CodeUnauthorized)
+	}
+
+	tx, err := db.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly, DeferrableMode: pgx.NotDeferrable, BeginQuery: "", CommitQuery: "",
+	})
+	if err != nil {
+		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("begin credential admission snapshot: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	admission, err := AdmitPrincipalCredentialWithDBTX(ctx, tx)
+	if err != nil {
+		return authz.PrincipalCredentialAdmission{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("commit credential admission snapshot: %w", err)
+	}
+
+	return admission, nil
+}
+
+// AdmitPrincipalCredentialWithDBTX performs live admission in the caller-owned
+// transaction so refresh admission and credential rotation share one snapshot.
+func AdmitPrincipalCredentialWithDBTX(ctx context.Context, tx accessrepo.DBTX) (authz.PrincipalCredentialAdmission, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	credential, hasCredential := contextvalues.PrincipalCredentialAuthorization(ctx)
 	actor, hasActor := contextvalues.AuthenticatedActor(ctx)
@@ -41,14 +69,6 @@ func AdmitPrincipalCredential(ctx context.Context, db *pgxpool.Pool) (authz.Prin
 		}
 		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("decode delegated credential policy: %w", err)
 	}
-
-	tx, err := db.BeginTx(ctx, pgx.TxOptions{
-		IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly, DeferrableMode: pgx.NotDeferrable, BeginQuery: "", CommitQuery: "",
-	})
-	if err != nil {
-		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("begin credential admission snapshot: %w", err)
-	}
-	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	if mode, hasMode := contextvalues.APIKeyAuthorization(ctx); hasMode && mode == contextvalues.APIKeyAuthorizationModePrincipal {
 		apiKeyID, parseErr := uuid.Parse(authCtx.APIKeyID)
@@ -110,9 +130,12 @@ func AdmitPrincipalCredential(ctx context.Context, db *pgxpool.Pool) (authz.Prin
 		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("load live owner policy: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return authz.PrincipalCredentialAdmission{}, fmt.Errorf("commit credential admission snapshot: %w", err)
-	}
-
 	return authz.PrincipalCredentialAdmission{OwnerUserID: agent.OwnerUserID, Credential: policy.RuntimeGrants(), Agent: agentPolicy, Owner: ownerPolicy}, nil
+}
+
+func hasPrincipalCredentialAdmissionContext(ctx context.Context) bool {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	credential, hasCredential := contextvalues.PrincipalCredentialAuthorization(ctx)
+	actor, hasActor := contextvalues.AuthenticatedActor(ctx)
+	return ok && authCtx != nil && hasCredential && hasActor && authCtx.ActiveOrganizationID != "" && credential.AuthorizerUserID != "" && actor.Type == urn.PrincipalTypeAgent
 }

--- a/server/internal/agents/runtimepolicy/credential_admission_test.go
+++ b/server/internal/agents/runtimepolicy/credential_admission_test.go
@@ -317,3 +317,11 @@ func requireUnauthorized(t *testing.T, err error) {
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
+
+func TestCredentialAdmissionRejectsMissingContextBeforeDatabaseAccess(t *testing.T) {
+	t.Parallel()
+	_, err := AdmitPrincipalCredential(t.Context(), nil)
+	require.Error(t, err)
+	_, err = AdmitPrincipalCredentialWithDBTX(t.Context(), nil)
+	require.Error(t, err)
+}

--- a/server/internal/authz/credential_admission.go
+++ b/server/internal/authz/credential_admission.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
@@ -31,6 +32,25 @@ func (e *Engine) AdmitPrincipalCredential(ctx context.Context) (context.Context,
 	if err != nil {
 		return ctx, err
 	}
+	return applyPrincipalCredentialAdmission(ctx, admission)
+}
+
+// PrincipalCredentialDBTXAdmitter admits credentials on a caller-owned snapshot.
+type PrincipalCredentialDBTXAdmitter func(context.Context, accessrepo.DBTX) (PrincipalCredentialAdmission, error)
+
+// AdmitPrincipalCredentialWithDBTX fails closed without transaction-bound admission.
+func (e *Engine) AdmitPrincipalCredentialWithDBTX(ctx context.Context, db accessrepo.DBTX) (context.Context, error) {
+	if e.admitPrincipalCredentialWithDBTX == nil {
+		return ctx, oops.C(oops.CodeUnauthorized)
+	}
+	admission, err := e.admitPrincipalCredentialWithDBTX(ctx, db)
+	if err != nil {
+		return ctx, err
+	}
+	return applyPrincipalCredentialAdmission(ctx, admission)
+}
+
+func applyPrincipalCredentialAdmission(ctx context.Context, admission PrincipalCredentialAdmission) (context.Context, error) {
 	if admission.OwnerUserID == "" {
 		return ctx, oops.C(oops.CodeUnauthorized)
 	}

--- a/server/internal/authz/credential_admission_test.go
+++ b/server/internal/authz/credential_admission_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -64,6 +65,60 @@ func TestCredentialAdmissionHookReloadsAndConjoinsPolicies(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "current-owner", owner)
 	prepared, err = engine.PrepareContext(prepared)
+	require.NoError(t, err)
+	require.Equal(t, 2, calls, "even a prepared context must repeat admission")
+	require.Error(t, engine.Require(prepared, Check{Scope: ScopeProjectRead, ResourceID: "project-one"}), "empty live agent policy must not inherit credential or owner authority")
+}
+
+func TestCredentialDBTXAdmissionHookFailsClosed(t *testing.T) {
+	t.Parallel()
+	admissionError := errors.New("admission failed")
+	tests := map[string]PrincipalCredentialDBTXAdmitter{
+		"unconfigured": nil,
+		"missing owner": func(context.Context, accessrepo.DBTX) (PrincipalCredentialAdmission, error) {
+			return PrincipalCredentialAdmission{}, nil
+		},
+		"failed admission": func(context.Context, accessrepo.DBTX) (PrincipalCredentialAdmission, error) {
+			return PrincipalCredentialAdmission{}, admissionError
+		},
+	}
+	for name, admit := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			engine := NewEngine(testenv.NewLogger(t), nil, func(context.Context, string) (bool, error) { return false, nil }, workos.NewStubClient(), EngineOpts{AdmitPrincipalCredentialWithDBTX: admit})
+			_, err := engine.AdmitPrincipalCredentialWithDBTX(t.Context(), nil)
+			if name == "failed admission" {
+				require.ErrorIs(t, err, admissionError)
+				return
+			}
+			var denied *oops.ShareableError
+			require.ErrorAs(t, err, &denied)
+			require.Equal(t, oops.CodeUnauthorized, denied.Code)
+		})
+	}
+}
+
+func TestCredentialDBTXAdmissionHookReloadsAndConjoinsPolicies(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	grants := []Grant{NewGrant(ScopeProjectRead, "project-one")}
+	admit := func(context.Context, accessrepo.DBTX) (PrincipalCredentialAdmission, error) {
+		calls++
+		agent := grants
+		if calls > 1 {
+			agent = nil
+		}
+		return PrincipalCredentialAdmission{OwnerUserID: "current-owner", Credential: grants, Agent: agent, Owner: grants}, nil
+	}
+	engine := NewEngine(testenv.NewLogger(t), nil, func(context.Context, string) (bool, error) { return false, nil }, workos.NewStubClient(), EngineOpts{AdmitPrincipalCredentialWithDBTX: admit})
+	ctx := contextvalues.WithPrincipalCredentialAuthorization(t.Context(), &contextvalues.AuthContext{ActiveOrganizationID: "org-test"}, urn.NewPrincipal(urn.PrincipalTypeAgent, "018f8d7b-58d7-7cc4-bb16-9f8c6b99a001"), contextvalues.PrincipalCredential{})
+	prepared, err := engine.AdmitPrincipalCredentialWithDBTX(ctx, nil)
+	require.NoError(t, err)
+	require.NoError(t, engine.Require(prepared, Check{Scope: ScopeProjectRead, ResourceID: "project-one"}))
+	_, owner, ok := contextvalues.PrincipalCredentialProvenance(prepared)
+	require.True(t, ok)
+	require.Equal(t, "current-owner", owner)
+	prepared, err = engine.AdmitPrincipalCredentialWithDBTX(prepared, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, calls, "even a prepared context must repeat admission")
 	require.Error(t, engine.Require(prepared, Check{Scope: ScopeProjectRead, ResourceID: "project-one"}), "empty live agent policy must not inherit credential or owner authority")

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -25,6 +25,8 @@ type EngineOpts struct {
 	// AdmitPrincipalCredential must be configured to accept principal-backed credentials.
 	// Omission disables them rather than falling back to user authorization.
 	AdmitPrincipalCredential PrincipalCredentialAdmitter
+	// AdmitPrincipalCredentialWithDBTX must be configured for atomic credential refresh.
+	AdmitPrincipalCredentialWithDBTX PrincipalCredentialDBTXAdmitter
 }
 
 // ChallengeLoggingEnabled checks whether authz challenge logging to ClickHouse
@@ -32,12 +34,13 @@ type EngineOpts struct {
 type ChallengeLoggingEnabled func(ctx context.Context, organizationID string) (bool, error)
 
 type Engine struct {
-	admitPrincipalCredential PrincipalCredentialAdmitter
-	logger                   *slog.Logger
-	db                       *pgxpool.Pool
-	challengeLoggingEnabled  ChallengeLoggingEnabled
-	isDev                    bool
-	membership               MembershipFetcher
+	admitPrincipalCredential         PrincipalCredentialAdmitter
+	admitPrincipalCredentialWithDBTX PrincipalCredentialDBTXAdmitter
+	logger                           *slog.Logger
+	db                               *pgxpool.Pool
+	challengeLoggingEnabled          ChallengeLoggingEnabled
+	isDev                            bool
+	membership                       MembershipFetcher
 }
 
 func NewEngine(
@@ -49,20 +52,23 @@ func NewEngine(
 ) *Engine {
 	var devMode bool
 	var admitPrincipalCredential PrincipalCredentialAdmitter
+	var admitPrincipalCredentialWithDBTX PrincipalCredentialDBTXAdmitter
 	if len(opts) > 0 {
 		devMode = opts[0].DevMode
 		admitPrincipalCredential = opts[0].AdmitPrincipalCredential
+		admitPrincipalCredentialWithDBTX = opts[0].AdmitPrincipalCredentialWithDBTX
 	}
 
 	authzLogger := logger.With(attr.SlogComponent("authz"))
 
 	return &Engine{
-		admitPrincipalCredential: admitPrincipalCredential,
-		logger:                   authzLogger,
-		db:                       db,
-		challengeLoggingEnabled:  challengeLogging,
-		isDev:                    devMode,
-		membership:               membership,
+		admitPrincipalCredential:         admitPrincipalCredential,
+		admitPrincipalCredentialWithDBTX: admitPrincipalCredentialWithDBTX,
+		logger:                           authzLogger,
+		db:                               db,
+		challengeLoggingEnabled:          challengeLogging,
+		isDev:                            devMode,
+		membership:                       membership,
 	}
 }
 

--- a/server/internal/killswitches/mcptoolexecution/adapters_test.go
+++ b/server/internal/killswitches/mcptoolexecution/adapters_test.go
@@ -115,13 +115,15 @@ func TestAuthenticatedUserAdapterDeriveCandidates(t *testing.T) {
 		"anonymous":    testIdentity(t, mcpidentity.KindAnonymous, ""),
 		"api key":      testIdentity(t, mcpidentity.KindAPIKey, ""),
 		"assistant":    testIdentity(t, mcpidentity.KindAssistant, ""),
-		"agent":        testIdentity(t, mcpidentity.KindAgent, ""),
 		"chat session": testIdentity(t, mcpidentity.KindChatSession, ""),
 	} {
 		result, err := adapter.DeriveCandidates(t.Context(), organization, identity)
 		require.NoError(t, err, name)
 		require.Equal(t, killswitches.PrincipalCandidateResultUnsupported, result.Kind(), name)
 	}
+
+	_, err = adapter.DeriveCandidates(t.Context(), organization, testIdentity(t, mcpidentity.KindAgent, ""))
+	require.Error(t, err, "agent sessions must fail closed until kill-switch agent principals are supported")
 
 	// Values that merely name a user — caller strings, hollow or padded
 	// authoritative claims, unknown provenance — are never quietly promoted.

--- a/server/internal/killswitches/mcptoolexecution/adapters_test.go
+++ b/server/internal/killswitches/mcptoolexecution/adapters_test.go
@@ -115,6 +115,7 @@ func TestAuthenticatedUserAdapterDeriveCandidates(t *testing.T) {
 		"anonymous":    testIdentity(t, mcpidentity.KindAnonymous, ""),
 		"api key":      testIdentity(t, mcpidentity.KindAPIKey, ""),
 		"assistant":    testIdentity(t, mcpidentity.KindAssistant, ""),
+		"agent":        testIdentity(t, mcpidentity.KindAgent, ""),
 		"chat session": testIdentity(t, mcpidentity.KindChatSession, ""),
 	} {
 		result, err := adapter.DeriveCandidates(t.Context(), organization, identity)

--- a/server/internal/killswitches/mcptoolexecution/adapters_test.go
+++ b/server/internal/killswitches/mcptoolexecution/adapters_test.go
@@ -115,15 +115,13 @@ func TestAuthenticatedUserAdapterDeriveCandidates(t *testing.T) {
 		"anonymous":    testIdentity(t, mcpidentity.KindAnonymous, ""),
 		"api key":      testIdentity(t, mcpidentity.KindAPIKey, ""),
 		"assistant":    testIdentity(t, mcpidentity.KindAssistant, ""),
+		"agent":        testIdentity(t, mcpidentity.KindAgent, ""),
 		"chat session": testIdentity(t, mcpidentity.KindChatSession, ""),
 	} {
 		result, err := adapter.DeriveCandidates(t.Context(), organization, identity)
 		require.NoError(t, err, name)
 		require.Equal(t, killswitches.PrincipalCandidateResultUnsupported, result.Kind(), name)
 	}
-
-	_, err = adapter.DeriveCandidates(t.Context(), organization, testIdentity(t, mcpidentity.KindAgent, ""))
-	require.Error(t, err, "agent sessions must fail closed until kill-switch agent principals are supported")
 
 	// Values that merely name a user — caller strings, hollow or padded
 	// authoritative claims, unknown provenance — are never quietly promoted.

--- a/server/internal/killswitches/mcptoolexecution/checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint.go
@@ -134,6 +134,9 @@ func (c *Checkpoint) Evaluate(ctx context.Context, organizationID, mcpServerID s
 		return c.infrastructureFailure(fmt.Errorf("derive authenticated user: %w", derivation.principalErr))
 	}
 	if derivation.principalResult.Kind() == killswitches.PrincipalCandidateResultUnsupported {
+		if derivation.hasAgentPrincipal() {
+			return c.infrastructureFailure(errors.New("agent principals are not supported by the MCP tool-execution kill switch"))
+		}
 		return killswitches.NewContinueDisposition(), nil
 	}
 

--- a/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
+++ b/server/internal/killswitches/mcptoolexecution/checkpoint_test.go
@@ -126,6 +126,12 @@ func TestCheckpointPreservesUnsupportedIdentityAndFailsClosedOnCoverageFailure(t
 	require.Equal(t, killswitches.TransportDispositionContinue, disposition.Kind())
 	require.Zero(t, evaluation.calls)
 
+	agentCtx := testIdentityContext(t, mcpidentity.KindAgent, "")
+	disposition, err = checkpoint.Evaluate(agentCtx, orgID, serverID.String())
+	require.Error(t, err)
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+	require.Zero(t, evaluation.calls)
+
 	// Missing canonical resources are coverage failures even when identity is
 	// unsupported; a private serving path cannot use that to bypass checks.
 	disposition, err = checkpoint.Evaluate(apiKeyCtx, orgID, "")

--- a/server/internal/killswitches/mcptoolexecution/classify.go
+++ b/server/internal/killswitches/mcptoolexecution/classify.go
@@ -33,6 +33,8 @@ func ClassifyPrincipalCoverage(source any, result killswitches.PrincipalCandidat
 		return mcpmetrics.KillswitchIdentityAPIKey
 	case mcpidentity.KindAssistant:
 		return mcpmetrics.KillswitchIdentityAssistant
+	case mcpidentity.KindAgent:
+		return mcpmetrics.KillswitchIdentityAgent
 	case mcpidentity.KindChatSession:
 		return mcpmetrics.KillswitchIdentityChatSession
 	default:

--- a/server/internal/killswitches/mcptoolexecution/classify_test.go
+++ b/server/internal/killswitches/mcptoolexecution/classify_test.go
@@ -36,6 +36,7 @@ func TestClassifyIdentityCoverage(t *testing.T) {
 		{name: "anonymous", source: testIdentity(t, mcpidentity.KindAnonymous, ""), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAnonymous},
 		{name: "api key", source: testIdentity(t, mcpidentity.KindAPIKey, ""), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAPIKey},
 		{name: "assistant", source: testIdentity(t, mcpidentity.KindAssistant, ""), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAssistant},
+		{name: "agent", source: testIdentity(t, mcpidentity.KindAgent, ""), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityAgent},
 		{name: "chat session", source: testIdentity(t, mcpidentity.KindChatSession, ""), result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityChatSession},
 		{name: "no provenance", source: nil, result: zero, err: nil, want: mcpmetrics.KillswitchIdentityUnattributed},
 		{name: "opaque zero value", source: mcpidentity.Identity{}, result: unsupported, err: nil, want: mcpmetrics.KillswitchIdentityUnattributed},

--- a/server/internal/killswitches/mcptoolexecution/coverage.go
+++ b/server/internal/killswitches/mcptoolexecution/coverage.go
@@ -56,6 +56,11 @@ func deriveCoverage(
 	return result
 }
 
+func (d coverageDerivation) hasAgentPrincipal() bool {
+	identity, ok := d.principalSource.(mcpidentity.Identity)
+	return ok && identity.Kind() == mcpidentity.KindAgent
+}
+
 func (d coverageDerivation) record(ctx context.Context, recorder IdentityCoverageRecorder, surface mcpmetrics.KillswitchCoverageSurface) {
 	if recorder == nil {
 		return

--- a/server/internal/killswitches/mcptoolexecution/evaluation_test.go
+++ b/server/internal/killswitches/mcptoolexecution/evaluation_test.go
@@ -59,6 +59,16 @@ func TestHostedCheckpoint_ReevaluatesAndFailsClosed(t *testing.T) {
 		}, observation)
 	}
 
+	agentCtx := testIdentityContext(t, mcpidentity.KindAgent, "")
+	disposition, err = checkpoint.Evaluate(agentCtx, orgID, source)
+	require.NoError(t, err)
+	require.Equal(t, killswitches.TransportDispositionInfrastructureRejection, disposition.Kind())
+	require.Equal(t, coverageObservation{
+		surface:  mcpmetrics.KillswitchSurfaceHosted,
+		identity: mcpmetrics.KillswitchIdentityAgent,
+		resource: mcpmetrics.KillswitchResourceCanonicalServer,
+	}, recorder.observations[len(recorder.observations)-1])
+
 	_, err = conn.Exec(t.Context(), "DROP TABLE killswitch_prescriptions CASCADE") //nolint:glint // notestingrawsql: deterministic DDL breakage in this test's isolated database forces an evaluator failure
 	require.NoError(t, err)
 

--- a/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
+++ b/server/internal/killswitches/mcptoolexecution/hosted_checkpoint.go
@@ -92,6 +92,9 @@ func (c *HostedCheckpoint) Evaluate(ctx context.Context, organizationID string, 
 		return c.infrastructureRejection(ctx, err)
 	}
 	if derivation.principalResult.Kind() == killswitches.PrincipalCandidateResultUnsupported {
+		if derivation.hasAgentPrincipal() {
+			return c.infrastructureRejection(ctx, errors.New("agent principals are not supported by the MCP tool-execution kill switch"))
+		}
 		return c.noMatch(killswitches.NoMatchReasonUnsupportedIdentity)
 	}
 	if !supported {

--- a/server/internal/killswitches/mcptoolexecution/principal.go
+++ b/server/internal/killswitches/mcptoolexecution/principal.go
@@ -2,6 +2,7 @@ package mcptoolexecution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -81,8 +82,9 @@ func (a *AuthenticatedUserPrincipalAdapter) ValidateCurrentOrganization(ctx cont
 //
 // Only KindUserSession claims an authoritative acting user; that claim is
 // then revalidated as an active organization membership before producing the
-// single concrete candidate. Anonymous, API-key, assistant, agent, and
-// chat-session provenance are deliberately unsupported. A stamped identity with a zero or
+// single concrete candidate. Anonymous, API-key, assistant, and chat-session
+// provenance are deliberately unsupported. Agent provenance fails closed until
+// the definition supports agent principals. A stamped identity with a zero or
 // unknown kind, a malformed authoritative claim, or a membership lookup
 // failure is an error and follows the definition's fail-closed policy.
 func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
@@ -113,8 +115,10 @@ func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context
 			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
 		}
 		return result, nil
-	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindAgent, mcpidentity.KindChatSession:
+	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindChatSession:
 		return killswitches.UnsupportedPrincipalCandidateResult(), nil
+	case mcpidentity.KindAgent:
+		return killswitches.PrincipalCandidateResult{}, errors.New("agent principals are not supported by the MCP tool-execution kill switch")
 	default:
 		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unknown identity provenance kind %q", identity.Kind())
 	}

--- a/server/internal/killswitches/mcptoolexecution/principal.go
+++ b/server/internal/killswitches/mcptoolexecution/principal.go
@@ -2,7 +2,6 @@ package mcptoolexecution
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"unicode"
@@ -82,9 +81,9 @@ func (a *AuthenticatedUserPrincipalAdapter) ValidateCurrentOrganization(ctx cont
 //
 // Only KindUserSession claims an authoritative acting user; that claim is
 // then revalidated as an active organization membership before producing the
-// single concrete candidate. Anonymous, API-key, assistant, and chat-session
-// provenance are deliberately unsupported. Agent provenance fails closed until
-// the definition supports agent principals. A stamped identity with a zero or
+// single concrete candidate. Anonymous, API-key, assistant, agent, and
+// chat-session provenance are deliberately unsupported. Enforcement checkpoints
+// explicitly reject agent provenance until the definition supports it. A stamped identity with a zero or
 // unknown kind, a malformed authoritative claim, or a membership lookup
 // failure is an error and follows the definition's fail-closed policy.
 func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
@@ -115,10 +114,8 @@ func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context
 			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
 		}
 		return result, nil
-	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindChatSession:
+	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindAgent, mcpidentity.KindChatSession:
 		return killswitches.UnsupportedPrincipalCandidateResult(), nil
-	case mcpidentity.KindAgent:
-		return killswitches.PrincipalCandidateResult{}, errors.New("agent principals are not supported by the MCP tool-execution kill switch")
 	default:
 		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unknown identity provenance kind %q", identity.Kind())
 	}

--- a/server/internal/killswitches/mcptoolexecution/principal.go
+++ b/server/internal/killswitches/mcptoolexecution/principal.go
@@ -81,8 +81,8 @@ func (a *AuthenticatedUserPrincipalAdapter) ValidateCurrentOrganization(ctx cont
 //
 // Only KindUserSession claims an authoritative acting user; that claim is
 // then revalidated as an active organization membership before producing the
-// single concrete candidate. Anonymous, API-key, assistant, and chat-session
-// provenance are deliberately unsupported. A stamped identity with a zero or
+// single concrete candidate. Anonymous, API-key, assistant, agent, and
+// chat-session provenance are deliberately unsupported. A stamped identity with a zero or
 // unknown kind, a malformed authoritative claim, or a membership lookup
 // failure is an error and follows the definition's fail-closed policy.
 func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context, organizationID killswitches.OrganizationID, source any) (killswitches.PrincipalCandidateResult, error) {
@@ -113,7 +113,7 @@ func (a *AuthenticatedUserPrincipalAdapter) DeriveCandidates(ctx context.Context
 			return killswitches.PrincipalCandidateResult{}, fmt.Errorf("build principal candidate: %w", err)
 		}
 		return result, nil
-	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindChatSession:
+	case mcpidentity.KindAnonymous, mcpidentity.KindAPIKey, mcpidentity.KindAssistant, mcpidentity.KindAgent, mcpidentity.KindChatSession:
 		return killswitches.UnsupportedPrincipalCandidateResult(), nil
 	default:
 		return killswitches.PrincipalCandidateResult{}, fmt.Errorf("unknown identity provenance kind %q", identity.Kind())

--- a/server/internal/killswitches/mcptoolexecution/provenance_test.go
+++ b/server/internal/killswitches/mcptoolexecution/provenance_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/mcpidentity"
@@ -47,6 +48,8 @@ func testIdentityContext(t *testing.T, kind mcpidentity.Kind, userID string) con
 		return boundary.StampAPIKey(t.Context())
 	case mcpidentity.KindAssistant:
 		return boundary.StampAssistant(t.Context())
+	case mcpidentity.KindAgent:
+		return stampValidatedSession(t, boundary, urn.NewAgentSubject(uuid.New()))
 	case mcpidentity.KindChatSession:
 		return boundary.StampChatSession(t.Context())
 	default:

--- a/server/internal/mcp/agent_session.go
+++ b/server/internal/mcp/agent_session.go
@@ -117,7 +117,7 @@ func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEn
 	})
 	ctx, err := s.authz.PrepareContext(ctx)
 	if err != nil {
-		return ctx, err
+		return ctx, fmt.Errorf("prepare agent session authorization: %w", err)
 	}
 	target, ok := agentAuthorizationTarget(endpoint)
 	if !ok {

--- a/server/internal/mcp/agent_session.go
+++ b/server/internal/mcp/agent_session.go
@@ -1,0 +1,127 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type agentSessionCredential struct {
+	AuthorizerUserID       string
+	DelegatedGrants        []byte
+	DelegatedGrantsVersion int32
+}
+
+func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version authz.DelegatedPolicyVersion) ([]byte, error) {
+	if target.Scope != authz.ScopeMCPConnect {
+		return nil, fmt.Errorf("agent session target has unsupported scope %q", target.Scope)
+	}
+	policy, err := authz.NewDelegatedPolicy(version, []authz.Grant{{
+		Scope: target.Scope,
+		Selector: authz.Selector{
+			authz.SelectorKeyResourceKind: authz.ResourceKindMCP,
+			authz.SelectorKeyResourceID:   target.MCPResourceID.String(),
+			authz.SelectorKeyProjectID:    target.ProjectID.String(),
+		},
+	}})
+	if err != nil {
+		return nil, fmt.Errorf("construct agent session policy: %w", err)
+	}
+	encoded, err := authz.EncodeDelegatedPolicy(version, policy)
+	if err != nil {
+		return nil, fmt.Errorf("encode agent session policy: %w", err)
+	}
+	return encoded, nil
+}
+
+func newAgentSessionCredential(target AgentAuthorizationTarget, authorizerUserID string) (agentSessionCredential, error) {
+	version := authz.CurrentDelegatedPolicyVersion
+	encoded, err := encodeAgentSessionPolicy(target, version)
+	if err != nil {
+		return agentSessionCredential{}, err
+	}
+	if authorizerUserID == "" {
+		return agentSessionCredential{}, fmt.Errorf("agent session authorizer is missing")
+	}
+	return agentSessionCredential{
+		AuthorizerUserID:       authorizerUserID,
+		DelegatedGrants:        encoded,
+		DelegatedGrantsVersion: int32(version),
+	}, nil
+}
+
+func loadAgentSessionCredential(
+	endpoint *ResolvedMcpEndpoint,
+	subject urn.SessionSubject,
+	storedSubject urn.SessionSubject,
+	organizationID pgtype.Text,
+	authorizerUserID pgtype.Text,
+	delegatedGrants []byte,
+	delegatedGrantsVersion pgtype.Int4,
+) (agentSessionCredential, error) {
+	if subject.Kind != urn.SessionSubjectKindAgent || subject.String() != storedSubject.String() ||
+		!organizationID.Valid || organizationID.String != endpoint.OrganizationID ||
+		!authorizerUserID.Valid || authorizerUserID.String == "" || delegatedGrants == nil || !delegatedGrantsVersion.Valid {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+	if _, err := uuid.Parse(subject.ID); err != nil {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+
+	version := authz.DelegatedPolicyVersion(delegatedGrantsVersion.Int32)
+	decoded, err := authz.DecodeDelegatedPolicy(version, delegatedGrants)
+	if err != nil {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+	normalized, err := authz.EncodeDelegatedPolicy(version, decoded)
+	if err != nil {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+	target, ok := agentAuthorizationTarget(endpoint)
+	if !ok {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+	expected, err := encodeAgentSessionPolicy(*target, version)
+	if err != nil || !bytes.Equal(normalized, expected) {
+		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
+	}
+
+	return agentSessionCredential{
+		AuthorizerUserID:       authorizerUserID.String,
+		DelegatedGrants:        append([]byte(nil), delegatedGrants...),
+		DelegatedGrantsVersion: delegatedGrantsVersion.Int32,
+	}, nil
+}
+
+func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEndpoint, subject urn.SessionSubject, credential agentSessionCredential) (context.Context, error) {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || subject.Kind != urn.SessionSubjectKindAgent {
+		return ctx, oops.C(oops.CodeUnauthorized)
+	}
+	actor := urn.NewPrincipal(urn.PrincipalTypeAgent, subject.ID)
+	ctx = contextvalues.WithPrincipalCredentialAuthorization(ctx, authCtx, actor, contextvalues.PrincipalCredential{
+		AuthorizerUserID:       credential.AuthorizerUserID,
+		DelegatedGrants:        credential.DelegatedGrants,
+		DelegatedGrantsVersion: credential.DelegatedGrantsVersion,
+	})
+	ctx, err := s.authz.PrepareContext(ctx)
+	if err != nil {
+		return ctx, err
+	}
+	target, ok := agentAuthorizationTarget(endpoint)
+	if !ok {
+		return ctx, oops.C(oops.CodeUnauthorized)
+	}
+	if err := s.authz.Require(ctx, target.connectCheck()); err != nil {
+		return ctx, err
+	}
+	return ctx, nil
+}

--- a/server/internal/mcp/agent_session.go
+++ b/server/internal/mcp/agent_session.go
@@ -25,7 +25,8 @@ func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version authz.Del
 		return nil, fmt.Errorf("agent session target has unsupported scope %q", target.Scope)
 	}
 	policy, err := authz.NewDelegatedPolicy(version, []authz.Grant{{
-		Scope: target.Scope,
+		PrincipalUrn: "",
+		Scope:        target.Scope,
 		Selector: authz.Selector{
 			authz.SelectorKeyResourceKind: authz.ResourceKindMCP,
 			authz.SelectorKeyResourceID:   target.MCPResourceID.String(),
@@ -101,7 +102,7 @@ func loadAgentSessionCredential(
 	}, nil
 }
 
-func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEndpoint, subject urn.SessionSubject, credential agentSessionCredential) (context.Context, error) {
+func (s *Service) prepareAgentSessionContext(ctx context.Context, endpoint *ResolvedMcpEndpoint, subject urn.SessionSubject, credential agentSessionCredential) (context.Context, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || subject.Kind != urn.SessionSubjectKindAgent {
 		return ctx, oops.C(oops.CodeUnauthorized)
@@ -115,10 +116,22 @@ func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEn
 		DelegatedGrants:        credential.DelegatedGrants,
 		DelegatedGrantsVersion: credential.DelegatedGrantsVersion,
 	})
-	ctx, err := s.authz.PrepareContext(ctx)
+	return ctx, nil
+}
+
+func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEndpoint, subject urn.SessionSubject, credential agentSessionCredential) (context.Context, error) {
+	ctx, err := s.prepareAgentSessionContext(ctx, endpoint, subject, credential)
+	if err != nil {
+		return ctx, err
+	}
+	ctx, err = s.authz.PrepareContext(ctx)
 	if err != nil {
 		return ctx, fmt.Errorf("prepare agent session authorization: %w", err)
 	}
+	return s.requireAgentSessionAuthorization(ctx, endpoint)
+}
+
+func (s *Service) requireAgentSessionAuthorization(ctx context.Context, endpoint *ResolvedMcpEndpoint) (context.Context, error) {
 	target, ok := agentAuthorizationTarget(endpoint)
 	if !ok {
 		return ctx, oops.C(oops.CodeUnauthorized)

--- a/server/internal/mcp/agent_session.go
+++ b/server/internal/mcp/agent_session.go
@@ -106,6 +106,9 @@ func (s *Service) admitAgentSession(ctx context.Context, endpoint *ResolvedMcpEn
 	if !ok || authCtx == nil || subject.Kind != urn.SessionSubjectKindAgent {
 		return ctx, oops.C(oops.CodeUnauthorized)
 	}
+	if enabled, _ := s.agentAuthorizationRollout(ctx, s.logger, endpoint); !enabled {
+		return ctx, oops.C(oops.CodeNotFound)
+	}
 	actor := urn.NewPrincipal(urn.PrincipalTypeAgent, subject.ID)
 	ctx = contextvalues.WithPrincipalCredentialAuthorization(ctx, authCtx, actor, contextvalues.PrincipalCredential{
 		AuthorizerUserID:       credential.AuthorizerUserID,

--- a/server/internal/mcp/agent_session.go
+++ b/server/internal/mcp/agent_session.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -20,11 +21,11 @@ type agentSessionCredential struct {
 	DelegatedGrantsVersion int32
 }
 
-func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version authz.DelegatedPolicyVersion) ([]byte, error) {
+func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version runtimepolicy.DelegatedPolicyVersion) ([]byte, error) {
 	if target.Scope != authz.ScopeMCPConnect {
 		return nil, fmt.Errorf("agent session target has unsupported scope %q", target.Scope)
 	}
-	policy, err := authz.NewDelegatedPolicy(version, []authz.Grant{{
+	policy, err := runtimepolicy.NewDelegatedPolicy(version, []authz.Grant{{
 		PrincipalUrn: "",
 		Scope:        target.Scope,
 		Selector: authz.Selector{
@@ -36,7 +37,7 @@ func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version authz.Del
 	if err != nil {
 		return nil, fmt.Errorf("construct agent session policy: %w", err)
 	}
-	encoded, err := authz.EncodeDelegatedPolicy(version, policy)
+	encoded, err := runtimepolicy.EncodeDelegatedPolicy(version, policy)
 	if err != nil {
 		return nil, fmt.Errorf("encode agent session policy: %w", err)
 	}
@@ -44,7 +45,7 @@ func encodeAgentSessionPolicy(target AgentAuthorizationTarget, version authz.Del
 }
 
 func newAgentSessionCredential(target AgentAuthorizationTarget, authorizerUserID string) (agentSessionCredential, error) {
-	version := authz.CurrentDelegatedPolicyVersion
+	version := runtimepolicy.CurrentDelegatedPolicyVersion
 	encoded, err := encodeAgentSessionPolicy(target, version)
 	if err != nil {
 		return agentSessionCredential{}, err
@@ -77,12 +78,12 @@ func loadAgentSessionCredential(
 		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
 	}
 
-	version := authz.DelegatedPolicyVersion(delegatedGrantsVersion.Int32)
-	decoded, err := authz.DecodeDelegatedPolicy(version, delegatedGrants)
+	version := runtimepolicy.DelegatedPolicyVersion(delegatedGrantsVersion.Int32)
+	decoded, err := runtimepolicy.DecodeDelegatedPolicy(version, delegatedGrants)
 	if err != nil {
 		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
 	}
-	normalized, err := authz.EncodeDelegatedPolicy(version, decoded)
+	normalized, err := runtimepolicy.EncodeDelegatedPolicy(version, decoded)
 	if err != nil {
 		return agentSessionCredential{}, oops.C(oops.CodeUnauthorized)
 	}

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -231,8 +231,7 @@ type UserSessionGrant struct {
 	// this field landed; authorization-code TTL bounds that compatibility window.
 	Endpoint *EndpointRef `json:"endpoint,omitempty"`
 	// AgentAuthorization is the final, human-approved handoff consumed by the
-	// agent-session lane. Until that lane is present, token redemption rejects
-	// grants carrying this field instead of minting a human session.
+	// existing session lane to mint an agent-subject session.
 	AgentAuthorization *AgentAuthorizationResult `json:"agent_authorization,omitempty"`
 	// DesiredSessionDurationHours is the subject's consent-screen session
 	// length choice. Token minting clamps it to the issuer maximum. Zero means
@@ -274,7 +273,10 @@ func (g UserSessionGrant) TTL() time.Duration { return 10 * time.Minute }
 // validateUserSessionToken: the bearer token itself was accepted but the
 // endpoint's organization could not be described, so the resulting 401 is
 // not a credential rejection.
-var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated endpoint")
+var (
+	errIssuerGateOrgLookup        = errors.New("describe organization for issuer-gated endpoint")
+	errAgentSessionCredentialLoad = errors.New("load agent session credential")
+)
 
 // The gram.oauth.failure_reason values the issuer gate emits on its rejection
 // logs and on the mcp.request.rejected counter, beyond the bearer-token
@@ -302,6 +304,8 @@ func issuerGateFailureReason(err error) string {
 		return "tool_selection_resource_mismatch"
 	case errors.Is(err, errToolSelectionLoad):
 		return "tool_selection_load_failed"
+	case errors.Is(err, errAgentSessionCredentialLoad):
+		return "agent_session_load_failed"
 	default:
 		return "invalid_bearer_token"
 	}
@@ -395,6 +399,26 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	if err != nil {
 		return ctx, nil, nil, err
 	}
+	if subject.Kind == urn.SessionSubjectKindAgent {
+		row, qerr := usersessions_repo.New(s.db).GetUserSessionPrincipalCredentialByJTI(ctx, usersessions_repo.GetUserSessionPrincipalCredentialByJTIParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			Jti:                 session.JTI(),
+		})
+		if qerr != nil {
+			if errors.Is(qerr, pgx.ErrNoRows) {
+				return ctx, nil, nil, oops.C(oops.CodeUnauthorized)
+			}
+			return ctx, nil, nil, fmt.Errorf("%w: %w", errAgentSessionCredentialLoad, qerr)
+		}
+		credential, cerr := loadAgentSessionCredential(endpoint, subject, row.SubjectUrn, row.OrganizationID, row.AuthorizerUserID, row.DelegatedGrants, row.DelegatedGrantsVersion)
+		if cerr != nil {
+			return ctx, nil, nil, cerr
+		}
+		newCtx, err = s.admitAgentSession(newCtx, endpoint, subject, credential)
+		if err != nil {
+			return ctx, nil, nil, err
+		}
+	}
 	newCtx = s.identityValidator.StampValidatedSession(newCtx, session)
 	return newCtx, &subject, toolSelection, nil
 }
@@ -440,10 +464,12 @@ func (s *Service) contextForSessionSubject(
 		ctx = contextvalues.SetOAuthClientID(ctx, oauthClientID)
 	}
 
-	// Stamped for every subject kind, anonymous included: liveness describes
-	// the connection, and an anonymous session is a real connection whose
-	// principal happens to be unknown.
-	s.touchUserSessionLastUsed(ctx, endpoint, sessionID)
+	// Stamped for every persisted subject kind, anonymous included: liveness
+	// describes the connection. Authorization-code completion passes no session
+	// id because no row exists yet.
+	if sessionID != "" {
+		s.touchUserSessionLastUsed(ctx, endpoint, sessionID)
+	}
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
 		return ctx, nil
@@ -462,7 +488,7 @@ func (s *Service) contextForSessionSubject(
 		APIKeyID:              "",
 		APIKeyName:            "",
 		OrgWidePluginHooksKey: false,
-		SessionID:             &sessionID,
+		SessionID:             nil,
 		OrganizationSlug:      orgMetadata.Slug,
 		Email:                 nil,
 		AccountType:           orgMetadata.GramAccountType,
@@ -473,6 +499,9 @@ func (s *Service) contextForSessionSubject(
 		IsAdmin:               false,
 		SupportOrganizationID: "",
 	}
+	if sessionID != "" {
+		authCtx.SessionID = &sessionID
+	}
 	switch subject.Kind {
 	case urn.SessionSubjectKindUser:
 		authCtx.UserID = subject.ID
@@ -482,6 +511,10 @@ func (s *Service) contextForSessionSubject(
 	case urn.SessionSubjectKindAPIKey:
 		authCtx.APIKeyID = subject.ID
 		return contextvalues.WithLegacyAPIKeyAuthorization(ctx, authCtx), nil
+	case urn.SessionSubjectKindAgent:
+		return contextvalues.WithAuthenticatedActor(
+			ctx, authCtx, urn.NewPrincipal(urn.PrincipalTypeAgent, subject.ID),
+		), nil
 	case urn.SessionSubjectKindAnonymous:
 		// Unreachable: anonymous subjects return ctx untouched above. Listed
 		// for exhaustiveness so the linter doesn't flag the switch.

--- a/server/internal/mcp/authnchallenge_provenance_internal_test.go
+++ b/server/internal/mcp/authnchallenge_provenance_internal_test.go
@@ -42,6 +42,7 @@ func TestIdentityForValidatedSession(t *testing.T) {
 	}{
 		{name: "concrete user is authoritative", subject: urn.NewUserSubject("user_01J8EXAMPLE"), wantKind: mcpidentity.KindUserSession, wantUser: "user_01J8EXAMPLE"},
 		{name: "api key never carries an acting user", subject: urn.NewAPIKeySubject(uuid.MustParse("11111111-1111-1111-1111-111111111111")), wantKind: mcpidentity.KindAPIKey},
+		{name: "agent never carries an acting user", subject: urn.NewAgentSubject(uuid.MustParse("22222222-2222-2222-2222-222222222222")), wantKind: mcpidentity.KindAgent},
 		{name: "anonymous never carries an acting user", subject: urn.NewAnonymousSubject("session_01J8EXAMPLE"), wantKind: mcpidentity.KindAnonymous},
 	}
 

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -90,7 +90,10 @@ type userSessionRefreshReplayPayload struct {
 
 type mintSessionParams struct {
 	AuthorizationExpiresAt *time.Time
+	AuthorizerUserID       pgtype.Text
 	BaseURL                string
+	DelegatedGrants        []byte
+	DelegatedGrantsVersion pgtype.Int4
 	DesiredSessionDuration *time.Duration
 	Replayable             bool
 	Subject                urn.SessionSubject
@@ -357,13 +360,40 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "code_verifier does not match code_challenge")
 	}
 
-	// AIM-196 hands a fully authorized agent choice to the existing token flow,
-	// but AIM-197 owns minting the corresponding agent session. Reject rather
-	// than silently ignoring the handoff and creating a human session.
-	if grant.AgentAuthorization != nil {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "agent_session_not_available")
+	if grant.AgentAuthorization == nil && grant.Subject.Kind == urn.SessionSubjectKindAgent {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "agent_handoff_missing")
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
-		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent sessions are not available")
+		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization handoff is missing")
+	}
+	subject := grant.Subject
+	var authorizerUserID pgtype.Text
+	var delegatedGrants []byte
+	var delegatedGrantsVersion pgtype.Int4
+	if agentAuthorization := grant.AgentAuthorization; agentAuthorization != nil {
+		if !agentAuthorization.Target.matches(endpoint) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "agent_target_mismatch")
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "authorization code is bound to a different MCP endpoint")
+		}
+		credential, cerr := newAgentSessionCredential(agentAuthorization.Target, agentAuthorization.AuthorizerUserID)
+		if cerr != nil {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is invalid")
+		}
+		subject = urn.NewAgentSubject(agentAuthorization.AgentID)
+		authorizationCtx, cerr := s.contextForSessionSubject(ctx, endpoint, subject, "", clientRow.ClientID)
+		if cerr == nil {
+			authorizationCtx, cerr = s.admitAgentSession(authorizationCtx, endpoint, subject, credential)
+		}
+		if cerr != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth authorization_code token request rejected", clientRow.ClientID, presentedAuthMethod, "authorization_code", "agent_admission_denied")
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, mcpmetrics.OAuthFlowStageToken)
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid")
+		}
+		ctx = authorizationCtx
+		authorizerUserID = pgtype.Text{String: credential.AuthorizerUserID, Valid: true}
+		delegatedGrants = credential.DelegatedGrants
+		delegatedGrantsVersion = pgtype.Int4{Int32: credential.DelegatedGrantsVersion, Valid: true}
 	}
 
 	var desiredSessionDuration *time.Duration
@@ -393,10 +423,13 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 
 	minted, err := s.mintSession(ctx, endpoint, clientRow, usersessions_repo.New(s.db), mintSessionParams{
 		AuthorizationExpiresAt: nil,
+		AuthorizerUserID:       authorizerUserID,
 		BaseURL:                baseURL,
+		DelegatedGrants:        delegatedGrants,
+		DelegatedGrantsVersion: delegatedGrantsVersion,
 		DesiredSessionDuration: desiredSessionDuration,
 		Replayable:             false,
-		Subject:                grant.Subject,
+		Subject:                subject,
 		ToolSelection:          toolSelection,
 	}, logger)
 	if err != nil {
@@ -676,10 +709,31 @@ func (s *Service) rotateRefreshToken(
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "tool_selection_resource_mismatch")
 		return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "session tool selection is bound to a different MCP endpoint; reauthorize")
 	}
+	if oldSession.SubjectUrn.Kind == urn.SessionSubjectKindAgent {
+		credential, cerr := loadAgentSessionCredential(
+			endpoint, oldSession.SubjectUrn, oldSession.SubjectUrn, oldSession.OrganizationID,
+			oldSession.AuthorizerUserID, oldSession.DelegatedGrants, oldSession.DelegatedGrantsVersion,
+		)
+		authorizationCtx := ctx
+		if cerr == nil {
+			authorizationCtx, cerr = s.contextForSessionSubject(ctx, endpoint, oldSession.SubjectUrn, "", clientRow.ClientID)
+		}
+		if cerr == nil {
+			authorizationCtx, cerr = s.admitAgentSession(authorizationCtx, endpoint, oldSession.SubjectUrn, credential)
+		}
+		if cerr != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
+			return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
+		}
+		ctx = authorizationCtx
+	}
 
 	minted, err := s.mintSession(ctx, endpoint, clientRow, txRepo, mintSessionParams{
 		AuthorizationExpiresAt: &authorizationExpiresAt,
+		AuthorizerUserID:       oldSession.AuthorizerUserID,
 		BaseURL:                baseURL,
+		DelegatedGrants:        oldSession.DelegatedGrants,
+		DelegatedGrantsVersion: oldSession.DelegatedGrantsVersion,
 		DesiredSessionDuration: nil,
 		Replayable:             true,
 		Subject:                oldSession.SubjectUrn,
@@ -782,6 +836,39 @@ func (s *Service) writeRefreshTokenReplay(
 	if payload.Subject == nil {
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay failed", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_replay_payload_invalid")
 		return oops.E(oops.CodeUnexpected, nil, "refresh token replay response is missing subject").LogError(ctx, logger)
+	}
+	replaySession, err := usersessions_repo.New(s.db).GetUserSessionByJTI(ctx, usersessions_repo.GetUserSessionByJTIParams{
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		Jti:                 payload.JTI,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_revoked")
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refreshed session is no longer active")
+		}
+		return oops.E(oops.CodeUnexpected, err, "load refreshed session for replay").LogError(ctx, logger)
+	}
+	if !replaySession.UserSessionClientID.Valid || replaySession.UserSessionClientID.UUID != clientRow.ID ||
+		replaySession.SubjectUrn.String() != payload.Subject.String() || !replaySession.ExpiresAt.Valid || !replaySession.ExpiresAt.Time.After(time.Now()) {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_replay_session_mismatch")
+		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refreshed session is no longer active")
+	}
+	if payload.Subject.Kind == urn.SessionSubjectKindAgent {
+		credential, cerr := loadAgentSessionCredential(
+			endpoint, *payload.Subject, replaySession.SubjectUrn, replaySession.OrganizationID,
+			replaySession.AuthorizerUserID, replaySession.DelegatedGrants, replaySession.DelegatedGrantsVersion,
+		)
+		authorizationCtx := ctx
+		if cerr == nil {
+			authorizationCtx, cerr = s.contextForSessionSubject(ctx, endpoint, *payload.Subject, "", clientRow.ClientID)
+		}
+		if cerr == nil {
+			_, cerr = s.admitAgentSession(authorizationCtx, endpoint, *payload.Subject, credential)
+		}
+		if cerr != nil {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
+			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
+		}
 	}
 
 	endpointIssuer, err := endpoint.RootURL(baseURL)
@@ -948,6 +1035,17 @@ func (s *Service) mintSession(
 	params mintSessionParams,
 	logger *slog.Logger,
 ) (*mintedSession, error) {
+	if params.Subject.Kind == urn.SessionSubjectKindAgent {
+		if _, err := loadAgentSessionCredential(
+			endpoint, params.Subject, params.Subject, pgtype.Text{String: endpoint.OrganizationID, Valid: true},
+			params.AuthorizerUserID, params.DelegatedGrants, params.DelegatedGrantsVersion,
+		); err != nil {
+			return nil, oops.C(oops.CodeUnauthorized)
+		}
+	} else if params.AuthorizerUserID.Valid || params.DelegatedGrants != nil || params.DelegatedGrantsVersion.Valid {
+		return nil, oops.C(oops.CodeUnauthorized)
+	}
+
 	now := time.Now()
 	if params.AuthorizationExpiresAt == nil {
 		// Resolve the issuer's session_duration — the maximum absolute
@@ -1022,14 +1120,17 @@ func (s *Service) mintSession(
 	}
 
 	if _, err := queries.CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		UserSessionClientID: uuid.NullUUID{UUID: clientRow.ID, Valid: true},
-		SubjectUrn:          params.Subject,
-		Jti:                 jti,
-		RefreshTokenHash:    sha256Hex(refreshTokenRaw),
-		ExpiresAt:           pgtype.Timestamptz{Time: accessExpiresAt, InfinityModifier: 0, Valid: true},
-		RefreshExpiresAt:    pgtype.Timestamptz{Time: *params.AuthorizationExpiresAt, InfinityModifier: 0, Valid: true},
-		ToolSelection:       params.ToolSelection,
+		UserSessionIssuerID:    endpoint.UserSessionIssuerID,
+		UserSessionClientID:    uuid.NullUUID{UUID: clientRow.ID, Valid: true},
+		SubjectUrn:             params.Subject,
+		AuthorizerUserID:       params.AuthorizerUserID,
+		DelegatedGrants:        params.DelegatedGrants,
+		DelegatedGrantsVersion: params.DelegatedGrantsVersion,
+		Jti:                    jti,
+		RefreshTokenHash:       sha256Hex(refreshTokenRaw),
+		ExpiresAt:              pgtype.Timestamptz{Time: accessExpiresAt, InfinityModifier: 0, Valid: true},
+		RefreshExpiresAt:       pgtype.Timestamptz{Time: *params.AuthorizationExpiresAt, InfinityModifier: 0, Valid: true},
+		ToolSelection:          params.ToolSelection,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, logger)
 	}

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -633,6 +633,10 @@ func (s *Service) rotateRefreshToken(
 				admittedAgentContext, admissionErr = s.prepareAgentSessionContext(admittedAgentContext, endpoint, refreshSession.SubjectUrn, credential)
 			}
 			if admissionErr != nil {
+				var rolloutErr *oops.ShareableError
+				if errors.As(admissionErr, &rolloutErr) && rolloutErr.Code == oops.CodeNotFound {
+					return true, admissionErr
+				}
 				logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
 				return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
 			}
@@ -902,6 +906,10 @@ func (s *Service) writeRefreshTokenReplay(
 			_, cerr = s.admitAgentSession(authorizationCtx, endpoint, *payload.Subject, credential)
 		}
 		if cerr != nil {
+			var rolloutErr *oops.ShareableError
+			if errors.As(cerr, &rolloutErr) && rolloutErr.Code == oops.CodeNotFound {
+				return cerr
+			}
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
 		}

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -604,6 +604,42 @@ func (s *Service) rotateRefreshToken(
 	canPublishFailure bool,
 	logger *slog.Logger,
 ) (releaseLease bool, err error) {
+	// Agent admission performs live organization, rollout, and policy reads. Do
+	// those reads before claiming a transaction connection so concurrent
+	// rotations cannot exhaust the pool while waiting for nested pool work.
+	var admittedAgentSessionID uuid.UUID
+	admittedAgentContext := ctx
+	refreshSession, lookupErr := usersessions_repo.New(s.db).GetUserSessionByRefreshTokenHash(ctx, usersessions_repo.GetUserSessionByRefreshTokenHashParams{
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		RefreshTokenHash:    refreshTokenHash,
+	})
+	if lookupErr != nil && !errors.Is(lookupErr, pgx.ErrNoRows) {
+		return true, oops.E(oops.CodeUnexpected, lookupErr, "load refresh token session").LogError(ctx, logger)
+	}
+	if lookupErr == nil && refreshSession.SubjectUrn.Kind == urn.SessionSubjectKindAgent &&
+		refreshSession.UserSessionClientID.Valid && refreshSession.UserSessionClientID.UUID == clientRow.ID &&
+		refreshSession.RefreshExpiresAt.Valid && refreshSession.RefreshExpiresAt.Time.After(time.Now()) {
+		selection, selectionErr := toolfilter.ParseSessionSelection(refreshSession.ToolSelection)
+		selectionMatches := selectionErr == nil && (selection == nil || selection.Resource == endpointToolSelectionResource(endpoint))
+		if selectionMatches {
+			credential, admissionErr := loadAgentSessionCredential(
+				endpoint, refreshSession.SubjectUrn, refreshSession.SubjectUrn, refreshSession.OrganizationID,
+				refreshSession.AuthorizerUserID, refreshSession.DelegatedGrants, refreshSession.DelegatedGrantsVersion,
+			)
+			if admissionErr == nil {
+				admittedAgentContext, admissionErr = s.contextForSessionSubject(ctx, endpoint, refreshSession.SubjectUrn, "", clientRow.ClientID)
+			}
+			if admissionErr == nil {
+				admittedAgentContext, admissionErr = s.admitAgentSession(admittedAgentContext, endpoint, refreshSession.SubjectUrn, credential)
+			}
+			if admissionErr != nil {
+				logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
+				return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
+			}
+			admittedAgentSessionID = refreshSession.ID
+		}
+	}
+
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return true, oops.E(oops.CodeUnexpected, err, "begin refresh token rotation").LogError(ctx, logger)
@@ -710,22 +746,11 @@ func (s *Service) rotateRefreshToken(
 		return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "session tool selection is bound to a different MCP endpoint; reauthorize")
 	}
 	if oldSession.SubjectUrn.Kind == urn.SessionSubjectKindAgent {
-		credential, cerr := loadAgentSessionCredential(
-			endpoint, oldSession.SubjectUrn, oldSession.SubjectUrn, oldSession.OrganizationID,
-			oldSession.AuthorizerUserID, oldSession.DelegatedGrants, oldSession.DelegatedGrantsVersion,
-		)
-		authorizationCtx := ctx
-		if cerr == nil {
-			authorizationCtx, cerr = s.contextForSessionSubject(ctx, endpoint, oldSession.SubjectUrn, "", clientRow.ClientID)
-		}
-		if cerr == nil {
-			authorizationCtx, cerr = s.admitAgentSession(authorizationCtx, endpoint, oldSession.SubjectUrn, credential)
-		}
-		if cerr != nil {
+		if admittedAgentSessionID == uuid.Nil || admittedAgentSessionID != oldSession.ID {
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
 			return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
 		}
-		ctx = authorizationCtx
+		ctx = admittedAgentContext
 	}
 
 	minted, err := s.mintSession(ctx, endpoint, clientRow, txRepo, mintSessionParams{
@@ -837,23 +862,23 @@ func (s *Service) writeRefreshTokenReplay(
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay failed", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_replay_payload_invalid")
 		return oops.E(oops.CodeUnexpected, nil, "refresh token replay response is missing subject").LogError(ctx, logger)
 	}
-	replaySession, err := usersessions_repo.New(s.db).GetUserSessionByJTI(ctx, usersessions_repo.GetUserSessionByJTIParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		Jti:                 payload.JTI,
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_revoked")
+	if payload.Subject.Kind == urn.SessionSubjectKindAgent {
+		replaySession, err := usersessions_repo.New(s.db).GetUserSessionByJTI(ctx, usersessions_repo.GetUserSessionByJTIParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			Jti:                 payload.JTI,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_revoked")
+				return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refreshed session is no longer active")
+			}
+			return oops.E(oops.CodeUnexpected, err, "load refreshed session for replay").LogError(ctx, logger)
+		}
+		if !replaySession.UserSessionClientID.Valid || replaySession.UserSessionClientID.UUID != clientRow.ID ||
+			replaySession.SubjectUrn.String() != payload.Subject.String() || !replaySession.ExpiresAt.Valid || !replaySession.ExpiresAt.Time.After(time.Now()) {
+			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_replay_session_mismatch")
 			return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refreshed session is no longer active")
 		}
-		return oops.E(oops.CodeUnexpected, err, "load refreshed session for replay").LogError(ctx, logger)
-	}
-	if !replaySession.UserSessionClientID.Valid || replaySession.UserSessionClientID.UUID != clientRow.ID ||
-		replaySession.SubjectUrn.String() != payload.Subject.String() || !replaySession.ExpiresAt.Valid || !replaySession.ExpiresAt.Time.After(time.Now()) {
-		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token replay rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "refresh_token_replay_session_mismatch")
-		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "refreshed session is no longer active")
-	}
-	if payload.Subject.Kind == urn.SessionSubjectKindAgent {
 		credential, cerr := loadAgentSessionCredential(
 			endpoint, *payload.Subject, replaySession.SubjectUrn, replaySession.OrganizationID,
 			replaySession.AuthorizerUserID, replaySession.DelegatedGrants, replaySession.DelegatedGrantsVersion,

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -659,6 +659,11 @@ func (s *Service) rotateRefreshToken(
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			// Replay performs live agent admission through the pool. Release the
+			// losing claim's connection before either replay fallback can run.
+			if rollbackErr := dbtx.Rollback(ctx); rollbackErr != nil {
+				return true, oops.E(oops.CodeUnexpected, rollbackErr, "rollback lost refresh token claim").LogError(ctx, logger)
+			}
 			// Coordination can degrade independently of the response cache
 			// during a Redis reconnect. Adopt a completed winner when possible.
 			replay, replayErr := s.userSessionRefreshReplayCache.Get(ctx, replayKey)

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -604,9 +604,9 @@ func (s *Service) rotateRefreshToken(
 	canPublishFailure bool,
 	logger *slog.Logger,
 ) (releaseLease bool, err error) {
-	// Agent admission performs live organization, rollout, and policy reads. Do
-	// those reads before claiming a transaction connection so concurrent
-	// rotations cannot exhaust the pool while waiting for nested pool work.
+	// Resolve rollout and request context before claiming a transaction
+	// connection. Live parent and policy admission runs later on the rotation
+	// transaction itself, immediately before minting the successor.
 	var admittedAgentSessionID uuid.UUID
 	admittedAgentContext := ctx
 	refreshSession, lookupErr := usersessions_repo.New(s.db).GetUserSessionByRefreshTokenHash(ctx, usersessions_repo.GetUserSessionByRefreshTokenHashParams{
@@ -630,7 +630,7 @@ func (s *Service) rotateRefreshToken(
 				admittedAgentContext, admissionErr = s.contextForSessionSubject(ctx, endpoint, refreshSession.SubjectUrn, "", clientRow.ClientID)
 			}
 			if admissionErr == nil {
-				admittedAgentContext, admissionErr = s.admitAgentSession(admittedAgentContext, endpoint, refreshSession.SubjectUrn, credential)
+				admittedAgentContext, admissionErr = s.prepareAgentSessionContext(admittedAgentContext, endpoint, refreshSession.SubjectUrn, credential)
 			}
 			if admissionErr != nil {
 				logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
@@ -640,7 +640,9 @@ func (s *Service) rotateRefreshToken(
 		}
 	}
 
-	dbtx, err := s.db.Begin(ctx)
+	dbtx, err := s.db.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadWrite, DeferrableMode: pgx.NotDeferrable, BeginQuery: "", CommitQuery: "",
+	})
 	if err != nil {
 		return true, oops.E(oops.CodeUnexpected, err, "begin refresh token rotation").LogError(ctx, logger)
 	}
@@ -746,7 +748,16 @@ func (s *Service) rotateRefreshToken(
 		return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "session tool selection is bound to a different MCP endpoint; reauthorize")
 	}
 	if oldSession.SubjectUrn.Kind == urn.SessionSubjectKindAgent {
+		var admissionErr error
 		if admittedAgentSessionID == uuid.Nil || admittedAgentSessionID != oldSession.ID {
+			admissionErr = oops.C(oops.CodeUnauthorized)
+		} else {
+			admittedAgentContext, admissionErr = s.authz.AdmitPrincipalCredentialWithDBTX(admittedAgentContext, dbtx)
+			if admissionErr == nil {
+				admittedAgentContext, admissionErr = s.requireAgentSessionAuthorization(admittedAgentContext, endpoint)
+			}
+		}
+		if admissionErr != nil {
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "agent_admission_denied")
 			return true, writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "agent authorization is no longer valid; reauthorize")
 		}

--- a/server/internal/mcp/authnchallenge_token_claim_loser_test.go
+++ b/server/internal/mcp/authnchallenge_token_claim_loser_test.go
@@ -1,0 +1,154 @@
+package mcp_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	agents_repo "github.com/speakeasy-api/gram/server/internal/agents/repo"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// The winner has already committed, but a stale cache read sends the loser to
+// the database claim. No concurrent scheduling or Redis expiry is needed.
+func TestHandleToken_AgentRefreshClaimLoserReleasesConnectionBeforeReplay(t *testing.T) {
+	t.Parallel()
+
+	for _, fallback := range []string{"immediate_cache_hit", "failure_publication_loses_then_cache_hit"} {
+		t.Run(fallback, func(t *testing.T) {
+			t.Parallel()
+			for _, suspend := range []bool{false, true} {
+				name := "live_agent"
+				if suspend {
+					name = "suspended_agent"
+				}
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+					var replayCache *claimLoserReplayCache
+					ctx, ti := newTestMCPServiceWithPoolConfig(
+						t, testenv.NewLogger(t), testenv.NewMeterProvider(t),
+						&mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{},
+						func(delegate cache.Cache) cache.Cache {
+							replayCache = &claimLoserReplayCache{Cache: delegate, t: t}
+							return replayCache
+						},
+						func(config *pgxpool.Config) {
+							config.MaxConns = 1
+							config.MinConns = 0
+						},
+					)
+					require.EqualValues(t, 1, ti.conn.Config().MaxConns)
+					fx, agent, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+					winner := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+					require.NoError(t, winner.err)
+					require.Equal(t, http.StatusOK, winner.code, winner.body)
+
+					replayCache.key, _ = refreshReplayKeys(fx.target.UserSessionIssuerID, refreshToken)
+					replayCache.missAfterClaim = fallback == "failure_publication_loses_then_cache_hit"
+					replayCache.beforeClaimReplay = func(ctx context.Context) {
+						// This hook runs at the FIRST cache Get after ErrNoRows, even
+						// when that Get misses. A deferred rollback is too late.
+						require.Zero(t, ti.conn.Stat().AcquiredConns(), "lost database claim must release its connection before reading replay cache")
+						if suspend {
+							_, err := agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{
+								OrganizationID: fx.orgID, ID: agent.ID,
+							})
+							require.NoError(t, err)
+						}
+					}
+					// Bound unexpected pool starvation without using time to steer
+					// execution. All interleavings are forced by the cache hooks.
+					requestCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+					defer cancel()
+					loser := performRefreshRequest(requestCtx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+					require.NoError(t, loser.err)
+					require.NoError(t, requestCtx.Err())
+					if suspend {
+						require.Equal(t, http.StatusBadRequest, loser.code, loser.body)
+						require.Contains(t, loser.body, "agent authorization is no longer valid")
+					} else {
+						require.Equal(t, http.StatusOK, loser.code, loser.body)
+						assertSameTokenPair(t, winner.body, loser.body)
+					}
+					if replayCache.missAfterClaim {
+						require.Equal(t, 3, replayCache.gets)
+						require.Equal(t, 1, replayCache.failurePublications)
+					} else {
+						require.Equal(t, 2, replayCache.gets)
+						require.Zero(t, replayCache.failurePublications)
+					}
+					require.Equal(t, 1, replayCache.leases)
+					require.Zero(t, ti.conn.Stat().AcquiredConns())
+				})
+			}
+		})
+	}
+}
+
+// Armed only after a real rotation has stored a valid, encrypted winner replay.
+// Hide that replay on the initial lookup (and optionally after claim loss),
+// while preserving it for the real conditional publication to lose against.
+// Requests are synchronous, so these counters need no synchronization.
+type claimLoserReplayCache struct {
+	cache.Cache
+	t                   *testing.T
+	key                 string
+	missAfterClaim      bool
+	gets                int
+	leases              int
+	failurePublications int
+	beforeClaimReplay   func(context.Context)
+}
+
+func (c *claimLoserReplayCache) Get(ctx context.Context, key string, value any) error {
+	if key == c.key {
+		c.gets++
+		if c.gets == 1 {
+			return redisCache.ErrCacheMiss
+		}
+		if c.gets == 2 {
+			c.beforeClaimReplay(ctx)
+			if c.missAfterClaim {
+				return redisCache.ErrCacheMiss
+			}
+		}
+	}
+	if err := c.Cache.Get(ctx, key, value); err != nil {
+		return fmt.Errorf("get claim loser replay: %w", err)
+	}
+	return nil
+}
+
+func (c *claimLoserReplayCache) AcquireLease(ctx context.Context, key, owner string, ttl time.Duration) (bool, error) {
+	acquired, err := acquireLease(ctx, c.Cache, key, owner, ttl)
+	if key == "lock:"+c.key {
+		require.NoError(c.t, err)
+		require.True(c.t, acquired, "claim loser must own the lease to attempt failure publication")
+		c.leases++
+	}
+	return acquired, err
+}
+
+func (c *claimLoserReplayCache) ReleaseLeaseIfOwner(ctx context.Context, key, owner string) (bool, error) {
+	return releaseLease(ctx, c.Cache, key, owner)
+}
+
+func (c *claimLoserReplayCache) SetIfAbsent(ctx context.Context, key string, value any, ttl time.Duration) (bool, error) {
+	stored, err := setIfAbsent(ctx, c.Cache, key, value, ttl)
+	if key == c.key {
+		c.failurePublications++
+		require.True(c.t, c.missAfterClaim)
+		require.Equal(c.t, 2, c.gets)
+		require.NoError(c.t, err)
+		require.False(c.t, stored, "failure publication must lose to the cached winner")
+	}
+	return stored, err
+}

--- a/server/internal/mcp/authnchallenge_token_claim_loser_test.go
+++ b/server/internal/mcp/authnchallenge_token_claim_loser_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,11 +48,19 @@ func TestHandleToken_AgentRefreshClaimLoserReleasesConnectionBeforeReplay(t *tes
 					)
 					require.EqualValues(t, 1, ti.conn.Config().MaxConns)
 					fx, agent, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+					replayKey, lockKey := refreshReplayKeys(fx.target.UserSessionIssuerID, refreshToken)
+					// TypedCacheObject.fullKey appends a colon even with SuffixNone;
+					// coordination leases use the unsuffixed logical replay key.
+					replayCache.key = replayKey + ":"
+					replayCache.lockKey = lockKey
 					winner := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
 					require.NoError(t, winner.err)
 					require.Equal(t, http.StatusOK, winner.code, winner.body)
 
-					replayCache.key, _ = refreshReplayKeys(fx.target.UserSessionIssuerID, refreshToken)
+					// Observe the real service's winner lookup before arming any
+					// fault injection, so a detached wrapper or key mismatch fails here.
+					require.Equal(t, replayCache.key, replayCache.observedReplayKey, "wrapper must observe the effective typed replay cache key")
+					replayCache.armed = true
 					replayCache.missAfterClaim = fallback == "failure_publication_loses_then_cache_hit"
 					replayCache.beforeClaimReplay = func(ctx context.Context) {
 						// This hook runs at the FIRST cache Get after ErrNoRows, even
@@ -101,6 +110,9 @@ type claimLoserReplayCache struct {
 	cache.Cache
 	t                   *testing.T
 	key                 string
+	lockKey             string
+	observedReplayKey   string
+	armed               bool
 	missAfterClaim      bool
 	gets                int
 	leases              int
@@ -109,7 +121,10 @@ type claimLoserReplayCache struct {
 }
 
 func (c *claimLoserReplayCache) Get(ctx context.Context, key string, value any) error {
-	if key == c.key {
+	if strings.HasPrefix(key, "userSessionRefreshReplay:") {
+		c.observedReplayKey = key
+	}
+	if c.armed && key == c.key {
 		c.gets++
 		if c.gets == 1 {
 			return redisCache.ErrCacheMiss
@@ -129,7 +144,7 @@ func (c *claimLoserReplayCache) Get(ctx context.Context, key string, value any) 
 
 func (c *claimLoserReplayCache) AcquireLease(ctx context.Context, key, owner string, ttl time.Duration) (bool, error) {
 	acquired, err := acquireLease(ctx, c.Cache, key, owner, ttl)
-	if key == "lock:"+c.key {
+	if c.armed && key == c.lockKey {
 		require.NoError(c.t, err)
 		require.True(c.t, acquired, "claim loser must own the lease to attempt failure publication")
 		c.leases++
@@ -143,7 +158,7 @@ func (c *claimLoserReplayCache) ReleaseLeaseIfOwner(ctx context.Context, key, ow
 
 func (c *claimLoserReplayCache) SetIfAbsent(ctx context.Context, key string, value any, ttl time.Duration) (bool, error) {
 	stored, err := setIfAbsent(ctx, c.Cache, key, value, ttl)
-	if key == c.key {
+	if c.armed && key == c.key {
 		c.failurePublications++
 		require.True(c.t, c.missAfterClaim)
 		require.Equal(c.t, 2, c.gets)

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -185,7 +185,7 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	require.Error(t, err)
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, true)
 
 	_, err = agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{OrganizationID: fx.orgID, ID: agent.ID})

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -176,6 +177,13 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	credential, ok := contextvalues.PrincipalCredentialAuthorization(admittedCtx)
 	require.True(t, ok)
 	require.Equal(t, fx.userID, credential.AuthorizerUserID)
+
+	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, false)
+	w = httptest.NewRecorder()
+	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, true)
 
 	_, err = agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{OrganizationID: fx.orgID, ID: agent.ID})
 	require.NoError(t, err)

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -198,6 +198,37 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
+func TestHandleToken_AgentRefreshHidesDisabledRollout(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, _, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, false)
+
+	result := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.Error(t, result.err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, result.err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+}
+
+func TestHandleToken_AgentRefreshReplayHidesDisabledRollout(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, _, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+	winner := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.NoError(t, winner.err)
+	require.Equal(t, http.StatusOK, winner.code, winner.body)
+
+	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, false)
+	replay := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.Error(t, replay.err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, replay.err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
+}
+
 func TestHandleToken_AgentRefreshPreservesCredentialProfile(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -182,7 +183,9 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	w = httptest.NewRecorder()
 	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
 	require.Error(t, err)
-	require.Equal(t, http.StatusUnauthorized, w.Code)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, true)
 
 	_, err = agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{OrganizationID: fx.orgID, ID: agent.ID})
@@ -190,7 +193,9 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	w = httptest.NewRecorder()
 	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
 	require.Error(t, err)
-	require.Equal(t, http.StatusUnauthorized, w.Code)
+	oopsErr = nil
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
 func TestHandleToken_AgentRefreshPreservesCredentialProfile(t *testing.T) {

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -184,6 +185,14 @@ func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
 	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
 	require.Error(t, err)
 	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+
+	// A previously admitted context must not bypass a newly disabled rollout.
+	w = httptest.NewRecorder()
+	_, _, _, err = ti.service.ApplyIssuerGate(admittedCtx, w, accessToken, ti.serverURL.String(), endpoint)
+	require.Error(t, err)
+	oopsErr = nil
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 	ti.features.SetFlag(feature.FlagAgentMCPAuthorizationM2, fx.orgID, true)
@@ -722,7 +731,7 @@ func seedAgentRefreshSession(
 	agent := createConsentAgent(t, ctx, ti, fx, "Refresh subject agent")
 	seedUserMCPConnectGrant(t, ctx, ti.conn, fx.orgID, fx.userID, fx.target.MCPResourceID.String())
 	seedPrincipalMCPConnectGrant(t, ctx, ti, fx.orgID, urn.NewPrincipal(urn.PrincipalTypeAgent, agent.ID.String()), fx.target.MCPResourceID)
-	policy, err := authz.NewDelegatedPolicyV1([]authz.Grant{{
+	policy, err := runtimepolicy.NewDelegatedPolicyV1([]authz.Grant{{
 		Scope: authz.ScopeMCPConnect,
 		Selector: authz.Selector{
 			authz.SelectorKeyResourceKind: authz.ResourceKindMCP,
@@ -731,7 +740,7 @@ func seedAgentRefreshSession(
 		},
 	}})
 	require.NoError(t, err)
-	delegatedGrants, err := authz.EncodeDelegatedPolicy(authz.CurrentDelegatedPolicyVersion, policy)
+	delegatedGrants, err := runtimepolicy.EncodeDelegatedPolicy(runtimepolicy.CurrentDelegatedPolicyVersion, policy)
 	require.NoError(t, err)
 	refreshToken := "agent-refresh-" + uuid.NewString()
 	refreshHash := sha256.Sum256([]byte(refreshToken))
@@ -742,7 +751,7 @@ func seedAgentRefreshSession(
 		SubjectUrn:             urn.NewAgentSubject(agent.ID),
 		AuthorizerUserID:       pgtype.Text{String: fx.userID, Valid: true},
 		DelegatedGrants:        delegatedGrants,
-		DelegatedGrantsVersion: pgtype.Int4{Int32: int32(authz.CurrentDelegatedPolicyVersion), Valid: true},
+		DelegatedGrantsVersion: pgtype.Int4{Int32: int32(runtimepolicy.CurrentDelegatedPolicyVersion), Valid: true},
 		Jti:                    base64.RawURLEncoding.EncodeToString(oldJTIHash[:]),
 		RefreshTokenHash:       base64.RawURLEncoding.EncodeToString(refreshHash[:]),
 		RefreshExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true},

--- a/server/internal/mcp/authnchallenge_token_refresh_test.go
+++ b/server/internal/mcp/authnchallenge_token_refresh_test.go
@@ -20,8 +20,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	agents_repo "github.com/speakeasy-api/gram/server/internal/agents/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -136,6 +140,118 @@ func TestHandleToken_ConcurrentRefreshReplayReturnsWinnerResponse(t *testing.T) 
 	require.NoError(t, secondUnknown.err)
 	require.Equal(t, http.StatusBadRequest, secondUnknown.code)
 	require.Less(t, time.Since(started), 3*time.Second, "cached terminal refresh failures must not wait for the replay grace period")
+}
+
+func TestApplyIssuerGate_AgentSessionAdmitsLiveParent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, agent, _, session := seedAgentRefreshSession(t, ctx, ti)
+	issuer := ti.serverURL.JoinPath("mcp", fx.toolset.McpSlug.String).String()
+	accessToken, _, err := sessiontokens.NewSigner("test-jwt-secret").Mint(sessiontokens.MintParams{
+		Subject:   session.SubjectUrn,
+		Audience:  urn.NewToolset(fx.toolset.ID).String(),
+		Issuer:    issuer,
+		ExpiresAt: &session.ExpiresAt.Time,
+		ClientID:  fx.client.ClientID,
+		JTI:       session.Jti,
+	})
+	require.NoError(t, err)
+	endpoint := &mcp.ResolvedMcpEndpoint{
+		AudienceURN:         urn.NewToolset(fx.toolset.ID).String(),
+		OrganizationID:      fx.orgID,
+		ProjectID:           fx.target.ProjectID,
+		RouteBase:           "mcp",
+		Slug:                fx.toolset.McpSlug.String,
+		ToolsetID:           uuid.NullUUID{UUID: fx.toolset.ID, Valid: true},
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+	}
+
+	w := httptest.NewRecorder()
+	admittedCtx, _, _, err := ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
+	require.NoError(t, err)
+	actor, ok := contextvalues.AuthenticatedActor(admittedCtx)
+	require.True(t, ok)
+	require.Equal(t, urn.NewPrincipal(urn.PrincipalTypeAgent, agent.ID.String()).String(), actor.String())
+	credential, ok := contextvalues.PrincipalCredentialAuthorization(admittedCtx)
+	require.True(t, ok)
+	require.Equal(t, fx.userID, credential.AuthorizerUserID)
+
+	_, err = agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{OrganizationID: fx.orgID, ID: agent.ID})
+	require.NoError(t, err)
+	w = httptest.NewRecorder()
+	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), w, accessToken, ti.serverURL.String(), endpoint)
+	require.Error(t, err)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestHandleToken_AgentRefreshPreservesCredentialProfile(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, _, refreshToken, oldSession := seedAgentRefreshSession(t, ctx, ti)
+
+	result := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.NoError(t, result.err)
+	require.Equal(t, http.StatusOK, result.code, result.body)
+	var response tokenResponseFixture
+	require.NoError(t, json.Unmarshal([]byte(result.body), &response))
+	claims, err := sessiontokens.NewSigner("test-jwt-secret").Validate(response.AccessToken, urn.NewToolset(fx.toolset.ID).String())
+	require.NoError(t, err)
+
+	rotated, err := usersessions_repo.New(ti.conn).GetUserSessionByJTI(ctx, usersessions_repo.GetUserSessionByJTIParams{
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+		Jti:                 claims.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, oldSession.SubjectUrn.String(), rotated.SubjectUrn.String())
+	require.Equal(t, oldSession.AuthorizerUserID, rotated.AuthorizerUserID)
+	require.JSONEq(t, string(oldSession.DelegatedGrants), string(rotated.DelegatedGrants))
+	require.Equal(t, oldSession.DelegatedGrantsVersion, rotated.DelegatedGrantsVersion)
+}
+
+func TestHandleToken_AgentRefreshReplayDeniesDirectlyRevokedSuccessor(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, _, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+	winner := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.NoError(t, winner.err)
+	require.Equal(t, http.StatusOK, winner.code, winner.body)
+	var response tokenResponseFixture
+	require.NoError(t, json.Unmarshal([]byte(winner.body), &response))
+	claims, err := sessiontokens.NewSigner("test-jwt-secret").Validate(response.AccessToken, urn.NewToolset(fx.toolset.ID).String())
+	require.NoError(t, err)
+	successor, err := usersessions_repo.New(ti.conn).GetUserSessionByJTI(ctx, usersessions_repo.GetUserSessionByJTIParams{
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+		Jti:                 claims.ID,
+	})
+	require.NoError(t, err)
+	_, err = usersessions_repo.New(ti.conn).RevokeUserSession(ctx, usersessions_repo.RevokeUserSessionParams{
+		ID:             successor.ID,
+		ProjectID:      fx.target.ProjectID,
+		OrganizationID: fx.orgID,
+	})
+	require.NoError(t, err)
+
+	replay := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.NoError(t, replay.err)
+	require.Equal(t, http.StatusBadRequest, replay.code, replay.body)
+	require.Contains(t, replay.body, "refreshed session is no longer active")
+}
+
+func TestHandleToken_AgentRefreshDeniesSuspendedParent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	fx, agent, refreshToken, _ := seedAgentRefreshSession(t, ctx, ti)
+	_, err := agents_repo.New(ti.conn).SuspendAgent(ctx, agents_repo.SuspendAgentParams{OrganizationID: fx.orgID, ID: agent.ID})
+	require.NoError(t, err)
+
+	result := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, refreshToken)
+	require.NoError(t, result.err)
+	require.Equal(t, http.StatusBadRequest, result.code, result.body)
+	require.Contains(t, result.body, "agent authorization is no longer valid")
 }
 
 func TestHandleToken_UnpublishedRollbackReleasesLease(t *testing.T) {
@@ -549,6 +665,47 @@ func assertSameTokenPair(t *testing.T, expectedBody, actualBody string) {
 	require.NoError(t, json.Unmarshal([]byte(actualBody), &actual))
 	require.Equal(t, expected.AccessToken, actual.AccessToken)
 	require.Equal(t, expected.RefreshToken, actual.RefreshToken)
+}
+
+func seedAgentRefreshSession(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+) (agentConsentFixture, agents_repo.Agent, string, usersessions_repo.UserSession) {
+	t.Helper()
+
+	fx := newAgentConsentFixture(t, ctx, ti)
+	agent := createConsentAgent(t, ctx, ti, fx, "Refresh subject agent")
+	seedUserMCPConnectGrant(t, ctx, ti.conn, fx.orgID, fx.userID, fx.target.MCPResourceID.String())
+	seedPrincipalMCPConnectGrant(t, ctx, ti, fx.orgID, urn.NewPrincipal(urn.PrincipalTypeAgent, agent.ID.String()), fx.target.MCPResourceID)
+	policy, err := authz.NewDelegatedPolicyV1([]authz.Grant{{
+		Scope: authz.ScopeMCPConnect,
+		Selector: authz.Selector{
+			authz.SelectorKeyResourceKind: authz.ResourceKindMCP,
+			authz.SelectorKeyResourceID:   fx.target.MCPResourceID.String(),
+			authz.SelectorKeyProjectID:    fx.target.ProjectID.String(),
+		},
+	}})
+	require.NoError(t, err)
+	delegatedGrants, err := authz.EncodeDelegatedPolicy(authz.CurrentDelegatedPolicyVersion, policy)
+	require.NoError(t, err)
+	refreshToken := "agent-refresh-" + uuid.NewString()
+	refreshHash := sha256.Sum256([]byte(refreshToken))
+	oldJTIHash := sha256.Sum256([]byte("agent-jti-" + uuid.NewString()))
+	session, err := usersessions_repo.New(ti.conn).CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
+		UserSessionIssuerID:    fx.target.UserSessionIssuerID,
+		UserSessionClientID:    uuid.NullUUID{UUID: fx.client.ID, Valid: true},
+		SubjectUrn:             urn.NewAgentSubject(agent.ID),
+		AuthorizerUserID:       pgtype.Text{String: fx.userID, Valid: true},
+		DelegatedGrants:        delegatedGrants,
+		DelegatedGrantsVersion: pgtype.Int4{Int32: int32(authz.CurrentDelegatedPolicyVersion), Valid: true},
+		Jti:                    base64.RawURLEncoding.EncodeToString(oldJTIHash[:]),
+		RefreshTokenHash:       base64.RawURLEncoding.EncodeToString(refreshHash[:]),
+		RefreshExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true},
+		ExpiresAt:              pgtype.Timestamptz{Time: time.Now().Add(10 * time.Minute), Valid: true},
+	})
+	require.NoError(t, err)
+	return fx, agent, refreshToken, session
 }
 
 func seedRefreshReplaySession(

--- a/server/internal/mcp/authnchallenge_token_test.go
+++ b/server/internal/mcp/authnchallenge_token_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,18 +16,24 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 func TestHandleTokenCode_AgentAuthorizationUsesIsolatedGrantNamespace(t *testing.T) {
 	t.Parallel()
 
-	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
-	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	ctx, ti := newTestMCPService(t)
+	fx := newAgentConsentFixture(t, ctx, ti)
+	agent := createConsentAgent(t, ctx, ti, fx, "Token subject agent")
+	seedUserMCPConnectGrant(t, ctx, ti.conn, fx.orgID, fx.userID, fx.target.MCPResourceID.String())
+	seedPrincipalMCPConnectGrant(t, ctx, ti, fx.orgID, urn.NewPrincipal(urn.PrincipalTypeAgent, agent.ID.String()), fx.target.MCPResourceID)
 
 	verifier := "verifier-" + uuid.NewString()
 	sum := sha256.Sum256([]byte(verifier))
@@ -34,14 +41,14 @@ func TestHandleTokenCode_AgentAuthorizationUsesIsolatedGrantNamespace(t *testing
 	grantCache := cache.NewTypedObjectCache[mcp.UserSessionGrant](ti.logger, ti.cacheAdapter, cache.SuffixNone)
 	require.NoError(t, grantCache.Store(ctx, mcp.UserSessionGrant{
 		Code:                        code,
-		UserSessionIssuerID:         toolset.UserSessionIssuerID.UUID,
-		UserSessionClientID:         client.ID,
-		ClientID:                    client.ClientID,
-		RedirectURI:                 client.RedirectUris[0],
+		UserSessionIssuerID:         fx.target.UserSessionIssuerID,
+		UserSessionClientID:         fx.client.ID,
+		ClientID:                    fx.client.ClientID,
+		RedirectURI:                 fx.client.RedirectUris[0],
 		CodeChallenge:               base64.RawURLEncoding.EncodeToString(sum[:]),
 		CodeChallengeMethod:         "S256",
-		Subject:                     urn.NewUserSubject("agent-authorizer-" + uuid.NewString()),
-		AgentAuthorization:          &mcp.AgentAuthorizationResult{AgentID: uuid.New(), AuthorizerUserID: "agent-authorizer"},
+		Subject:                     urn.NewUserSubject(fx.userID),
+		AgentAuthorization:          &mcp.AgentAuthorizationResult{AgentID: agent.ID, AuthorizerUserID: fx.userID, Target: fx.target},
 		DesiredSessionDurationHours: 0,
 		CreatedAt:                   time.Now(),
 	}))
@@ -49,12 +56,74 @@ func TestHandleTokenCode_AgentAuthorizationUsesIsolatedGrantNamespace(t *testing
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("code", code)
-	form.Set("redirect_uri", client.RedirectUris[0])
-	form.Set("client_id", client.ClientID)
+	form.Set("redirect_uri", fx.client.RedirectUris[0])
+	form.Set("client_id", fx.client.ClientID)
 	form.Set("code_verifier", verifier)
-	w := postForm(t, ti, toolset.McpSlug.String, "token", form)
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "agent sessions are not available")
+	w := postForm(t, ti, fx.toolset.McpSlug.String, "token", form)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var response struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	claims, err := sessiontokens.NewSigner("test-jwt-secret").Validate(response.AccessToken, urn.NewToolset(fx.toolset.ID).String())
+	require.NoError(t, err)
+	require.Equal(t, urn.NewAgentSubject(agent.ID).String(), claims.Subject)
+	require.Equal(t, fx.client.ClientID, claims.ClientID)
+
+	session, err := usersessionsrepo.New(ti.conn).GetUserSessionByJTI(ctx, usersessionsrepo.GetUserSessionByJTIParams{
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+		Jti:                 claims.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, urn.NewAgentSubject(agent.ID).String(), session.SubjectUrn.String())
+	require.True(t, session.AuthorizerUserID.Valid)
+	require.Equal(t, fx.userID, session.AuthorizerUserID.String)
+	require.True(t, session.DelegatedGrantsVersion.Valid)
+	require.Equal(t, int32(authz.CurrentDelegatedPolicyVersion), session.DelegatedGrantsVersion.Int32)
+	policy, err := authz.DecodeDelegatedPolicy(authz.DelegatedPolicyVersion(session.DelegatedGrantsVersion.Int32), session.DelegatedGrants)
+	require.NoError(t, err)
+	require.Len(t, policy.Requested, 1)
+	require.Equal(t, authz.ScopeMCPConnect, policy.Requested[0].Scope)
+	require.Equal(t, authz.Selector{
+		authz.SelectorKeyResourceKind: authz.ResourceKindMCP,
+		authz.SelectorKeyResourceID:   fx.target.MCPResourceID.String(),
+		authz.SelectorKeyProjectID:    fx.target.ProjectID.String(),
+	}, policy.Requested[0].Selector)
+	require.True(t, authz.GrantsSatisfy(policy.RuntimeGrants(), authz.MCPCheck(authz.ScopeMCPConnect, fx.target.MCPResourceID.String(), fx.target.ProjectID.String())))
+
+	endpoint := &mcp.ResolvedMcpEndpoint{
+		AudienceURN:         urn.NewToolset(fx.toolset.ID).String(),
+		OrganizationID:      fx.orgID,
+		ProjectID:           fx.target.ProjectID,
+		RouteBase:           "mcp",
+		Slug:                fx.toolset.McpSlug.String,
+		ToolsetID:           uuid.NullUUID{UUID: fx.toolset.ID, Valid: true},
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+	}
+	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), httptest.NewRecorder(), response.AccessToken, ti.serverURL.String(), endpoint)
+	require.NoError(t, err)
+	refreshed := performRefreshRequest(ctx, ti, fx.toolset.McpSlug.String, fx.client.ClientID, response.RefreshToken)
+	require.NoError(t, refreshed.err)
+	require.Equal(t, http.StatusOK, refreshed.code, refreshed.body)
+	var refreshedResponse struct {
+		AccessToken string `json:"access_token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(refreshed.body), &refreshedResponse))
+	refreshedClaims, err := sessiontokens.NewSigner("test-jwt-secret").Validate(refreshedResponse.AccessToken, urn.NewToolset(fx.toolset.ID).String())
+	require.NoError(t, err)
+	_, _, _, err = ti.service.ApplyIssuerGate(t.Context(), httptest.NewRecorder(), refreshedResponse.AccessToken, ti.serverURL.String(), endpoint)
+	require.NoError(t, err)
+	refreshedSession, err := usersessionsrepo.New(ti.conn).GetUserSessionByJTI(ctx, usersessionsrepo.GetUserSessionByJTIParams{
+		UserSessionIssuerID: fx.target.UserSessionIssuerID,
+		Jti:                 refreshedClaims.ID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, session.SubjectUrn.String(), refreshedSession.SubjectUrn.String())
+	require.Equal(t, session.AuthorizerUserID, refreshedSession.AuthorizerUserID)
+	require.JSONEq(t, string(session.DelegatedGrants), string(refreshedSession.DelegatedGrants))
+	require.Equal(t, session.DelegatedGrantsVersion, refreshedSession.DelegatedGrantsVersion)
 }
 
 // TestHandleTokenCode_ResourceIndicator covers the RFC 8707 check on the

--- a/server/internal/mcp/authnchallenge_token_test.go
+++ b/server/internal/mcp/authnchallenge_token_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -20,8 +21,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
-	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
@@ -81,8 +82,8 @@ func TestHandleTokenCode_AgentAuthorizationUsesIsolatedGrantNamespace(t *testing
 	require.True(t, session.AuthorizerUserID.Valid)
 	require.Equal(t, fx.userID, session.AuthorizerUserID.String)
 	require.True(t, session.DelegatedGrantsVersion.Valid)
-	require.Equal(t, int32(authz.CurrentDelegatedPolicyVersion), session.DelegatedGrantsVersion.Int32)
-	policy, err := authz.DecodeDelegatedPolicy(authz.DelegatedPolicyVersion(session.DelegatedGrantsVersion.Int32), session.DelegatedGrants)
+	require.Equal(t, int32(runtimepolicy.CurrentDelegatedPolicyVersion), session.DelegatedGrantsVersion.Int32)
+	policy, err := runtimepolicy.DecodeDelegatedPolicy(runtimepolicy.DelegatedPolicyVersion(session.DelegatedGrantsVersion.Int32), session.DelegatedGrants)
 	require.NoError(t, err)
 	require.Len(t, policy.Requested, 1)
 	require.Equal(t, authz.ScopeMCPConnect, policy.Requested[0].Scope)

--- a/server/internal/mcp/mcpmetrics/identitycoverage.go
+++ b/server/internal/mcp/mcpmetrics/identitycoverage.go
@@ -54,6 +54,10 @@ const (
 	// assistant-runtime token, which is not an authoritative acting user.
 	KillswitchIdentityAssistant KillswitchIdentityClass = "assistant"
 
+	// KillswitchIdentityAgent means the validated credential is an agent
+	// session, which is not an authoritative acting user.
+	KillswitchIdentityAgent KillswitchIdentityClass = "agent"
+
 	// KillswitchIdentityChatSession means the validated credential is a
 	// chat-session token, which attributes an embedded chat session or
 	// external end-user and is not an authoritative acting user.
@@ -106,7 +110,7 @@ func validKillswitchCoverageSurface(surface KillswitchCoverageSurface) bool {
 func validKillswitchIdentityClass(class KillswitchIdentityClass) bool {
 	switch class {
 	case KillswitchIdentityActiveUser, KillswitchIdentityInactiveUser, KillswitchIdentityAnonymous,
-		KillswitchIdentityAPIKey, KillswitchIdentityAssistant, KillswitchIdentityChatSession,
+		KillswitchIdentityAPIKey, KillswitchIdentityAssistant, KillswitchIdentityAgent, KillswitchIdentityChatSession,
 		KillswitchIdentityUnattributed, KillswitchIdentityUnavailable:
 		return true
 	default:

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -2,6 +2,7 @@ package mcp_test
 
 import (
 	"context"
+	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
 	"log"
 	"log/slog"
 	"net/url"
@@ -320,7 +321,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
 
-	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
+	authzEngine := authz.NewEngine(logger, conn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient(), authz.EngineOpts{AdmitPrincipalCredential: runtimepolicy.AdmitPrincipalCredential, AdmitPrincipalCredentialWithDBTX: runtimepolicy.AdmitPrincipalCredentialWithDBTX})
 
 	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter), telemetry.NewNoopLogPublisher(testenv.NewLogger(t)))
 	telemService := telemetry.NewService(

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -268,6 +268,20 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	guardianOpts ...func(*guardian.Policy),
 ) (context.Context, *testInstance) {
 	t.Helper()
+	return newTestMCPServiceWithPoolConfig(t, logger, meterProvider, identityResolver, tunnelPublicConfig, wrapCache, nil, guardianOpts...)
+}
+
+func newTestMCPServiceWithPoolConfig(
+	t *testing.T,
+	logger *slog.Logger,
+	meterProvider metric.MeterProvider,
+	identityResolver mcp.IdentityResolver,
+	tunnelPublicConfig mcp.TunnelPublicConfig,
+	wrapCache func(cache.Cache) cache.Cache,
+	configurePool func(*pgxpool.Config),
+	guardianOpts ...func(*guardian.Policy),
+) (context.Context, *testInstance) {
+	t.Helper()
 
 	ctx := t.Context()
 
@@ -277,6 +291,13 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 
 	conn, err := infra.CloneTestDatabase(t, "mcptest")
 	require.NoError(t, err)
+	if configurePool != nil {
+		config := conn.Config()
+		configurePool(config)
+		conn, err = pgxpool.NewWithConfig(ctx, config)
+		require.NoError(t, err)
+		t.Cleanup(conn.Close)
+	}
 
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)

--- a/server/internal/mcpidentity/identity.go
+++ b/server/internal/mcpidentity/identity.go
@@ -26,6 +26,10 @@ const (
 	// authoritative acting user.
 	KindUserSession Kind = "user_session"
 
+	// KindAgent marks a validated agent-subject session. Its owner and immutable
+	// authorizer are attribution, not authoritative acting users.
+	KindAgent Kind = "agent"
+
 	// KindAnonymous marks a validated session whose subject is anonymous.
 	KindAnonymous Kind = "anonymous"
 
@@ -98,6 +102,8 @@ func (b *ValidatorBoundary) StampValidatedSession(ctx context.Context, session s
 		return b.withIdentity(ctx, KindUserSession, subject.ID)
 	case urn.SessionSubjectKindAPIKey:
 		return b.withIdentity(ctx, KindAPIKey, "")
+	case urn.SessionSubjectKindAgent:
+		return b.withIdentity(ctx, KindAgent, "")
 	case urn.SessionSubjectKindAnonymous:
 		return b.withIdentity(ctx, KindAnonymous, "")
 	default:

--- a/server/internal/mcpidentity/identity_test.go
+++ b/server/internal/mcpidentity/identity_test.go
@@ -50,6 +50,7 @@ func TestValidatorBoundaryValidatedSessions(t *testing.T) {
 	}{
 		{name: "user", subject: urn.NewUserSubject("user_01J8EXAMPLE"), want: mcpidentity.KindUserSession, userID: "user_01J8EXAMPLE"},
 		{name: "api key", subject: urn.NewAPIKeySubject(uuid.MustParse("11111111-1111-1111-1111-111111111111")), want: mcpidentity.KindAPIKey},
+		{name: "agent", subject: urn.NewAgentSubject(uuid.MustParse("22222222-2222-2222-2222-222222222222")), want: mcpidentity.KindAgent},
 		{name: "anonymous", subject: urn.NewAnonymousSubject("session"), want: mcpidentity.KindAnonymous},
 	}
 	for _, test := range tests {

--- a/server/internal/platformtools/usersessions/tools.go
+++ b/server/internal/platformtools/usersessions/tools.go
@@ -55,8 +55,8 @@ func buildView(row repo.ListUserSessionsByProjectIDRow) *types.UserSession {
 		}
 	case urn.SessionSubjectKindAPIKey:
 		subjectName = conv.FromPGText[string](row.ApiKeyName)
-	case urn.SessionSubjectKindAnonymous:
-		// anonymous subjects have no resolved display name
+	case urn.SessionSubjectKindAnonymous, urn.SessionSubjectKindAgent:
+		// anonymous and agent subjects have no resolved display name
 	}
 
 	var revokedAt *string

--- a/server/internal/urn/session_subject.go
+++ b/server/internal/urn/session_subject.go
@@ -18,18 +18,20 @@ const (
 
 	SessionSubjectKindUser      SessionSubjectKind = "user"
 	SessionSubjectKindAPIKey    SessionSubjectKind = "apikey"
+	SessionSubjectKindAgent     SessionSubjectKind = "agent"
 	SessionSubjectKindAnonymous SessionSubjectKind = "anonymous"
 )
 
 var sessionSubjectKinds = map[SessionSubjectKind]struct{}{
 	SessionSubjectKindUser:      {},
 	SessionSubjectKindAPIKey:    {},
+	SessionSubjectKindAgent:     {},
 	SessionSubjectKindAnonymous: {},
 }
 
 // SessionSubject is the URN that may appear as the `sub` claim of a
 // Gram-issued session JWT. Format: `<kind>:<id>` where kind is exactly one of
-// `user`, `apikey`, or `anonymous`.
+// `user`, `apikey`, `agent`, or `anonymous`.
 //
 // `role` is NOT a valid session subject — roles are not authentication
 // principals; use urn.Principal for RBAC subjects.
@@ -51,6 +53,13 @@ func NewUserSubject(id string) SessionSubject {
 // NewAPIKeySubject constructs an `apikey:<uuid>` session subject.
 func NewAPIKeySubject(id uuid.UUID) SessionSubject {
 	s := SessionSubject{Kind: SessionSubjectKindAPIKey, ID: id.String(), checked: false, err: nil}
+	_ = s.validate()
+	return s
+}
+
+// NewAgentSubject constructs an `agent:<uuid>` session subject.
+func NewAgentSubject(id uuid.UUID) SessionSubject {
+	s := SessionSubject{Kind: SessionSubjectKindAgent, ID: id.String(), checked: false, err: nil}
 	_ = s.validate()
 	return s
 }
@@ -206,9 +215,9 @@ func (u *SessionSubject) validate() error {
 		return u.err
 	}
 
-	if u.Kind == SessionSubjectKindAPIKey {
+	if u.Kind == SessionSubjectKindAPIKey || u.Kind == SessionSubjectKindAgent {
 		if _, parseErr := uuid.Parse(u.ID); parseErr != nil {
-			u.err = fmt.Errorf("%w: apikey id must be a uuid", ErrInvalid)
+			u.err = fmt.Errorf("%w: %s id must be a uuid", ErrInvalid, u.Kind)
 			return u.err
 		}
 	}

--- a/server/internal/urn/session_subject.go
+++ b/server/internal/urn/session_subject.go
@@ -216,8 +216,13 @@ func (u *SessionSubject) validate() error {
 	}
 
 	if u.Kind == SessionSubjectKindAPIKey || u.Kind == SessionSubjectKindAgent {
-		if _, parseErr := uuid.Parse(u.ID); parseErr != nil {
+		id, parseErr := uuid.Parse(u.ID)
+		if parseErr != nil {
 			u.err = fmt.Errorf("%w: %s id must be a uuid", ErrInvalid, u.Kind)
+			return u.err
+		}
+		if u.Kind == SessionSubjectKindAgent && id.String() != u.ID {
+			u.err = fmt.Errorf("%w: agent id must use canonical uuid format", ErrInvalid)
 			return u.err
 		}
 	}

--- a/server/internal/urn/session_subject_test.go
+++ b/server/internal/urn/session_subject_test.go
@@ -131,6 +131,7 @@ func TestParseSessionSubject(t *testing.T) {
 	t.Parallel()
 
 	apikeyID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	agentID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 
 	tests := []struct {
 		name    string
@@ -151,6 +152,12 @@ func TestParseSessionSubject(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid agent",
+			input:   "agent:22222222-2222-2222-2222-222222222222",
+			want:    urn.NewAgentSubject(agentID),
+			wantErr: false,
+		},
+		{
 			name:    "valid anonymous",
 			input:   "anonymous:mcp-session-id",
 			want:    urn.NewAnonymousSubject("mcp-session-id"),
@@ -164,6 +171,11 @@ func TestParseSessionSubject(t *testing.T) {
 		{
 			name:    "apikey non-uuid rejected",
 			input:   "apikey:not-a-uuid",
+			wantErr: true,
+		},
+		{
+			name:    "agent non-uuid rejected",
+			input:   "agent:not-a-uuid",
 			wantErr: true,
 		},
 		{

--- a/server/internal/urn/session_subject_test.go
+++ b/server/internal/urn/session_subject_test.go
@@ -179,6 +179,11 @@ func TestParseSessionSubject(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "agent non-canonical uuid rejected",
+			input:   "agent:22222222222222222222222222222222",
+			wantErr: true,
+		},
+		{
 			name:    "empty string",
 			input:   "",
 			wantErr: true,

--- a/server/internal/usersessions/listusersessions_test.go
+++ b/server/internal/usersessions/listusersessions_test.go
@@ -15,6 +15,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+func TestCreateUserSessionDerivesOrganizationForLegacyProjectIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	issuerID := seedLegacyProjectIssuer(t, ctx, ti.conn, "legacy-session-issuer")
+	session, err := seedUserSession(t, ctx, ti.conn, issuerID, urn.NewUserSubject("legacy-session-user"))
+	require.NoError(t, err)
+	requireOrganizationID(t, ctx, session.OrganizationID)
+}
+
 func TestListUserSessions(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -154,9 +154,12 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	if _, err := repo.New(s.db).CreateUserSession(ctx, repo.CreateUserSessionParams{
 		UserSessionIssuerID: target.issuerID,
 		// No DCR-registered client — this mint bypasses the OAuth dance.
-		UserSessionClientID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		SubjectUrn:          subject,
-		Jti:                 jti,
+		UserSessionClientID:    uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		SubjectUrn:             subject,
+		AuthorizerUserID:       pgtype.Text{String: "", Valid: false},
+		DelegatedGrants:        nil,
+		DelegatedGrantsVersion: pgtype.Int4{Int32: 0, Valid: false},
+		Jti:                    jti,
 		// No refresh token issued: the dashboard re-mints by calling this method
 		// again. Store a sentinel that satisfies the NOT NULL + unique constraint
 		// without colliding with any real sha256 hash; the column will be migrated

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -843,7 +843,12 @@ INSERT INTO user_sessions (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
-    (SELECT organization_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
+    (
+        SELECT COALESCE(issuer.organization_id, project.organization_id)
+        FROM user_session_issuers AS issuer
+        LEFT JOIN projects AS project ON project.id = issuer.project_id
+        WHERE issuer.id = @user_session_issuer_id
+    ),
     @user_session_issuer_id,
     @user_session_client_id,
     @subject_urn,

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -541,6 +541,17 @@ WHERE user_session_issuer_id = @user_session_issuer_id
   AND jti = @jti
   AND deleted IS FALSE;
 
+-- name: GetUserSessionPrincipalCredentialByJTI :one
+-- Authoritative serve-path lookup for an agent session's immutable credential
+-- profile. It intentionally bypasses caches so direct session revocation and
+-- expiry remain authoritative on every admission.
+SELECT organization_id, subject_urn, authorizer_user_id, delegated_grants, delegated_grants_version
+FROM user_sessions
+WHERE user_session_issuer_id = @user_session_issuer_id
+  AND jti = @jti
+  AND deleted IS FALSE
+  AND expires_at > clock_timestamp();
+
 -- name: GetLatestLiveUserSessionToolSelection :one
 -- Reauth prefill: the identified subject's newest live restrictive policy
 -- for the same issuer + client + endpoint resource. Filtering by resource in
@@ -821,6 +832,9 @@ INSERT INTO user_sessions (
     user_session_issuer_id,
     user_session_client_id,
     subject_urn,
+    authorizer_user_id,
+    delegated_grants,
+    delegated_grants_version,
     jti,
     refresh_token_hash,
     refresh_expires_at,
@@ -833,6 +847,9 @@ VALUES (
     @user_session_issuer_id,
     @user_session_client_id,
     @subject_urn,
+    @authorizer_user_id,
+    @delegated_grants,
+    @delegated_grants_version,
     @jti,
     @refresh_token_hash,
     @refresh_expires_at,

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -108,6 +108,9 @@ INSERT INTO user_sessions (
     user_session_issuer_id,
     user_session_client_id,
     subject_urn,
+    authorizer_user_id,
+    delegated_grants,
+    delegated_grants_version,
     jti,
     refresh_token_hash,
     refresh_expires_at,
@@ -124,20 +127,26 @@ VALUES (
     $5,
     $6,
     $7,
-    $8
+    $8,
+    $9,
+    $10,
+    $11
 )
 RETURNING id, project_id, organization_id, user_session_issuer_id, user_session_client_id, subject_urn, authorizer_user_id, delegated_grants, delegated_grants_version, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, last_used_at, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateUserSessionParams struct {
-	UserSessionIssuerID uuid.UUID
-	UserSessionClientID uuid.NullUUID
-	SubjectUrn          urn.SessionSubject
-	Jti                 string
-	RefreshTokenHash    string
-	RefreshExpiresAt    pgtype.Timestamptz
-	ExpiresAt           pgtype.Timestamptz
-	ToolSelection       []byte
+	UserSessionIssuerID    uuid.UUID
+	UserSessionClientID    uuid.NullUUID
+	SubjectUrn             urn.SessionSubject
+	AuthorizerUserID       pgtype.Text
+	DelegatedGrants        []byte
+	DelegatedGrantsVersion pgtype.Int4
+	Jti                    string
+	RefreshTokenHash       string
+	RefreshExpiresAt       pgtype.Timestamptz
+	ExpiresAt              pgtype.Timestamptz
+	ToolSelection          []byte
 }
 
 // user_session_client_id binds the session to the DCR client that minted it.
@@ -148,6 +157,9 @@ func (q *Queries) CreateUserSession(ctx context.Context, arg CreateUserSessionPa
 		arg.UserSessionIssuerID,
 		arg.UserSessionClientID,
 		arg.SubjectUrn,
+		arg.AuthorizerUserID,
+		arg.DelegatedGrants,
+		arg.DelegatedGrantsVersion,
 		arg.Jti,
 		arg.RefreshTokenHash,
 		arg.RefreshExpiresAt,
@@ -997,6 +1009,44 @@ func (q *Queries) GetUserSessionIssuerCimdClientByID(ctx context.Context, arg Ge
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Deleted,
+	)
+	return i, err
+}
+
+const getUserSessionPrincipalCredentialByJTI = `-- name: GetUserSessionPrincipalCredentialByJTI :one
+SELECT organization_id, subject_urn, authorizer_user_id, delegated_grants, delegated_grants_version
+FROM user_sessions
+WHERE user_session_issuer_id = $1
+  AND jti = $2
+  AND deleted IS FALSE
+  AND expires_at > clock_timestamp()
+`
+
+type GetUserSessionPrincipalCredentialByJTIParams struct {
+	UserSessionIssuerID uuid.UUID
+	Jti                 string
+}
+
+type GetUserSessionPrincipalCredentialByJTIRow struct {
+	OrganizationID         pgtype.Text
+	SubjectUrn             urn.SessionSubject
+	AuthorizerUserID       pgtype.Text
+	DelegatedGrants        []byte
+	DelegatedGrantsVersion pgtype.Int4
+}
+
+// Authoritative serve-path lookup for an agent session's immutable credential
+// profile. It intentionally bypasses caches so direct session revocation and
+// expiry remain authoritative on every admission.
+func (q *Queries) GetUserSessionPrincipalCredentialByJTI(ctx context.Context, arg GetUserSessionPrincipalCredentialByJTIParams) (GetUserSessionPrincipalCredentialByJTIRow, error) {
+	row := q.db.QueryRow(ctx, getUserSessionPrincipalCredentialByJTI, arg.UserSessionIssuerID, arg.Jti)
+	var i GetUserSessionPrincipalCredentialByJTIRow
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.SubjectUrn,
+		&i.AuthorizerUserID,
+		&i.DelegatedGrants,
+		&i.DelegatedGrantsVersion,
 	)
 	return i, err
 }

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -119,7 +119,12 @@ INSERT INTO user_sessions (
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
-    (SELECT organization_id FROM user_session_issuers WHERE id = $1),
+    (
+        SELECT COALESCE(issuer.organization_id, project.organization_id)
+        FROM user_session_issuers AS issuer
+        LEFT JOIN projects AS project ON project.id = issuer.project_id
+        WHERE issuer.id = $1
+    ),
     $1,
     $2,
     $3,

--- a/server/internal/usersessions/setup_test.go
+++ b/server/internal/usersessions/setup_test.go
@@ -431,6 +431,27 @@ func createSiblingProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool,
 	return project.ID
 }
 
+// seedLegacyProjectIssuer writes the pre-dual-write shape: a project-tier
+// issuer whose organization_id is NULL. Session creation must recover its
+// organization from the owning project.
+func seedLegacyProjectIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) uuid.UUID {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuer, err := repo.New(conn).CreateUserSessionIssuer(ctx, repo.CreateUserSessionIssuerParams{
+		ProjectID:          *authCtx.ProjectID,
+		OrganizationID:     pgtype.Text{},
+		Slug:               slug,
+		AuthnChallengeMode: "chain",
+		SessionDuration:    pgtype.Interval{Microseconds: int64(24 * time.Hour / time.Microsecond), Valid: true},
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
 // seedIssuerInProject creates a project-tier issuer owned by an arbitrary
 // project rather than the one on the auth context. organization_id is written
 // the way the production create handler writes it, so the row is a faithful


### PR DESCRIPTION
## Summary
Extends existing MCP user-session issuance and refresh flows to support agent subjects. Agent sessions retain immutable authorizer and delegated policy provenance while every access and refresh admission resolves the live parent and applies the credential admission boundary.

## Motivation
Agent principals need delegated MCP sessions without introducing a parallel OAuth transport or dedicated token persistence model.

## Technical details
### Credential profile and admission
Agent subjects use the existing session, challenge, token, refresh, and revocation machinery. The stored profile carries the immutable authorizer plus delegated restriction, while admission enforces the effective `R ∩ A ∩ O` policy against current lifecycle and ownership state.

### Refresh and revocation
Refresh rotation preserves the credential profile and re-admits the parent. Replay responses are denied when the authoritative successor session has been directly revoked.

### Dependency and retargeting
This PR depends on #6068 (AIM-193 credential admission) and #6066 (AIM-196 prerequisite model work). It temporarily targets `integration/aim-197-prerequisites`, built from the recorded prerequisite heads. After both dependencies land on `main`, this branch should be rebased or otherwise reconciled and the PR retargeted to `main`.

Design context: [First-class agent principals and delegated credentials RFC](https://linear.app/speakeasy/document/rfc-first-class-agent-principals-and-delegated-credentials-56ddf2dd2afb).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mints and refreshes MCP sessions for agent subjects from the authorized agent handoff instead of rejecting it, re-admitting the live parent and delegated policy on every access and refresh.

- Agent is a first-class session subject (`agent:<uuid>`) and identity kind; sessions persist an immutable authorizer and endpoint-scoped delegated grants on the existing `user_sessions` row.
- Every access and refresh re-admits the live parent; refresh shares the rotation transaction snapshot, preserves the credential profile, denies replay when the successor session was directly revoked, and releases losing claims before replay fallback.
- Credential admission fails closed when the required principal context is missing; the MCP tool-execution killswitch classifies agent provenance separately and rejects it until agent principals are supported.
- Issuance and access sit behind a rollout flag; when disabled, token, refresh, and replay return 404 and access returns 401.
- Session creation now derives organization from the owning project for legacy project-tier issuers.
- No agent-specific OAuth endpoints or token stores are introduced; existing human sessions and MCP behavior are unchanged.
- Depends on #6068 and #6066; temporarily targets `integration/aim-197-prerequisites` and should be retargeted to `main` after they land.

<sup>Written for commit e944ceb88a9f555d434695105bbc243af3c93a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

