### PR TITLE
feat: improve data export destination graph

### DIFF
--- a/client/dashboard/src/lib/data-export-validation.test.ts
+++ b/client/dashboard/src/lib/data-export-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isValidDataExportEndpointURL } from "./data-export-validation";
+
+describe("isValidDataExportEndpointURL", () => {
+  it.each([
+    "http://collector.example.com",
+    "https://collector.example.com/v1/traces",
+    "  https://collector.example.com  ",
+    "HTTPS://collector.example.com",
+  ])("accepts HTTP and HTTPS endpoint %s", (endpoint) => {
+    expect(isValidDataExportEndpointURL(endpoint)).toBe(true);
+  });
+
+  it.each([
+    "https://user@collector.example.com",
+    "https://user:password@collector.example.com",
+    "https://@collector.example.com",
+  ])("rejects endpoint userinfo in %s", (endpoint) => {
+    expect(isValidDataExportEndpointURL(endpoint)).toBe(false);
+  });
+
+  it.each([
+    "https://collector.example.com?format=json",
+    "https://collector.example.com?",
+  ])("rejects endpoint queries in %s", (endpoint) => {
+    expect(isValidDataExportEndpointURL(endpoint)).toBe(false);
+  });
+
+  it.each([
+    "https://collector.example.com#traces",
+    "https://collector.example.com#",
+  ])("rejects endpoint fragments in %s", (endpoint) => {
+    expect(isValidDataExportEndpointURL(endpoint)).toBe(false);
+  });
+
+  it.each([
+    "https://collector.example.com\\otlp",
+    "https://collector.exam\tple.com",
+    "https://collector.example.com/\notlp",
+  ])("rejects endpoint syntax normalized by the browser in %s", (endpoint) => {
+    expect(isValidDataExportEndpointURL(endpoint)).toBe(false);
+  });
+
+  it.each(["http:/traces", "https:///traces", "https://"])(
+    "rejects hostless endpoint %s",
+    (endpoint) => {
+      expect(isValidDataExportEndpointURL(endpoint)).toBe(false);
+    },
+  );
+});

--- a/client/dashboard/src/lib/data-export-validation.ts
+++ b/client/dashboard/src/lib/data-export-validation.ts
@@ -1,0 +1,36 @@
+const INVALID_URL_CONTROL_PATTERN = /[\u0000-\u001f\u007f]/;
+
+export function isValidDataExportEndpointURL(raw: string): boolean {
+  const value = raw.trim();
+  if (
+    value.includes("?") ||
+    value.includes("#") ||
+    INVALID_URL_CONTROL_PATTERN.test(value)
+  ) {
+    return false;
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+
+    const schemePrefix = `${url.protocol}//`;
+    if (
+      value.slice(0, schemePrefix.length).toLowerCase() !== schemePrefix ||
+      url.hostname === ""
+    ) {
+      return false;
+    }
+
+    const pathStart = value.indexOf("/", schemePrefix.length);
+    const authority = value.slice(
+      schemePrefix.length,
+      pathStart === -1 ? undefined : pathStart,
+    );
+    return (
+      authority !== "" && !authority.includes("@") && !authority.includes("\\")
+    );
+  } catch {
+    return false;
+  }
+}

--- a/client/dashboard/src/lib/data-export-validation.ts
+++ b/client/dashboard/src/lib/data-export-validation.ts
@@ -1,11 +1,17 @@
-const INVALID_URL_CONTROL_PATTERN = /[\u0000-\u001f\u007f]/;
+function hasInvalidURLControl(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
 
 export function isValidDataExportEndpointURL(raw: string): boolean {
   const value = raw.trim();
   if (
     value.includes("?") ||
     value.includes("#") ||
-    INVALID_URL_CONTROL_PATTERN.test(value)
+    hasInvalidURLControl(value)
   ) {
     return false;
   }

--- a/client/dashboard/src/lib/write-only-headers.test.ts
+++ b/client/dashboard/src/lib/write-only-headers.test.ts
@@ -62,6 +62,36 @@ describe("write-only header form helpers", () => {
     expect(hasValidWriteOnlyHeaders([first, duplicate])).toBe(false);
   });
 
+  it.each(["Bad Header", "Bad:Header", "Bad(Header)"])(
+    "rejects invalid HTTP header name %s",
+    (name) => {
+      const header = blankWriteOnlyHeader();
+      header.name = name;
+      header.value = "value";
+
+      expect(hasValidWriteOnlyHeaders([header])).toBe(false);
+    },
+  );
+
+  it.each(["Bearer\nexample", "Bearer\u0000example", "Bearer\u007fexample"])(
+    "rejects HTTP header values containing control characters",
+    (value) => {
+      const header = blankWriteOnlyHeader();
+      header.name = "Authorization";
+      header.value = value;
+
+      expect(hasValidWriteOnlyHeaders([header])).toBe(false);
+    },
+  );
+
+  it("allows horizontal tabs in HTTP header values", () => {
+    const header = blankWriteOnlyHeader();
+    header.name = "X-Trace-Context";
+    header.value = "one\ttwo";
+
+    expect(hasValidWriteOnlyHeaders([header])).toBe(true);
+  });
+
   it("trims submitted names and includes replacement values", () => {
     const header = blankWriteOnlyHeader();
     header.name = "  Authorization  ";

--- a/client/dashboard/src/lib/write-only-headers.ts
+++ b/client/dashboard/src/lib/write-only-headers.ts
@@ -52,15 +52,26 @@ export function preservesStoredHeaderValue(
   );
 }
 
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const INVALID_HTTP_HEADER_VALUE_PATTERN = /[\u0000-\u0008\u000a-\u001f\u007f]/;
+
 export function hasValidWriteOnlyHeaders(
   headers: EditableWriteOnlyHeader[],
 ): boolean {
   const names = new Set<string>();
   return headers.every((header) => {
-    const name = header.name.trim().toLowerCase();
-    if (name === "" || names.has(name)) return false;
-    names.add(name);
-    return header.value !== "" || preservesStoredHeaderValue(header);
+    const name = header.name.trim();
+    const foldedName = name.toLowerCase();
+    if (!HTTP_HEADER_NAME_PATTERN.test(name) || names.has(foldedName)) {
+      return false;
+    }
+    names.add(foldedName);
+
+    if (preservesStoredHeaderValue(header)) return true;
+    return (
+      header.value !== "" &&
+      !INVALID_HTTP_HEADER_VALUE_PATTERN.test(header.value)
+    );
   });
 }
 

--- a/client/dashboard/src/lib/write-only-headers.ts
+++ b/client/dashboard/src/lib/write-only-headers.ts
@@ -53,7 +53,13 @@ export function preservesStoredHeaderValue(
 }
 
 const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
-const INVALID_HTTP_HEADER_VALUE_PATTERN = /[\u0000-\u0008\u000a-\u001f\u007f]/;
+function hasInvalidHTTPHeaderValue(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if ((code < 0x20 && code !== 0x09) || code === 0x7f) return true;
+  }
+  return false;
+}
 
 export function hasValidWriteOnlyHeaders(
   headers: EditableWriteOnlyHeader[],
@@ -68,10 +74,7 @@ export function hasValidWriteOnlyHeaders(
     names.add(foldedName);
 
     if (preservesStoredHeaderValue(header)) return true;
-    return (
-      header.value !== "" &&
-      !INVALID_HTTP_HEADER_VALUE_PATTERN.test(header.value)
-    );
+    return header.value !== "" && !hasInvalidHTTPHeaderValue(header.value);
   });
 }
 

--- a/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.test.tsx
+++ b/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ConfigureDestinationSheet,
+  type ConfigureDestinationValues,
+} from "./ConfigureDestinationSheet";
+import type { OtelDataExportDestination } from "./ConfigureExportSheet";
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/Sheet", () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => children,
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SheetDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  SheetFooter: ({ children }: { children: React.ReactNode }) => (
+    <footer>{children}</footer>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => (
+    <header>{children}</header>
+  ),
+  SheetTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+const destination = {
+  createdAt: new Date(0),
+  destinationType: "otel",
+  id: "destination-1",
+  name: "Clickstack",
+  otel: {
+    endpointUrl: "https://clickstack.example.com",
+    headers: [{ name: "Authorization", hasValue: true }],
+  },
+  projectId: "project-1",
+  sensitiveData: "exclude",
+  updatedAt: new Date(0),
+} satisfies OtelDataExportDestination;
+
+describe("ConfigureDestinationSheet", () => {
+  it("prefills and saves an existing destination without exposing stored header values", async () => {
+    const onClose = vi.fn<() => void>();
+    const onSave =
+      vi.fn<(values: ConfigureDestinationValues) => Promise<void>>();
+    onSave.mockResolvedValue(undefined);
+
+    render(
+      <ConfigureDestinationSheet
+        destination={destination}
+        saving={false}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("Clickstack")).toBeTruthy();
+    expect(
+      screen.getByDisplayValue("https://clickstack.example.com"),
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue("Authorization")).toBeTruthy();
+    expect(screen.queryByDisplayValue(/Bearer|token/i)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Destination name"), {
+      target: { value: "Primary collector" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save destination" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave).toHaveBeenCalledWith({
+      destinationName: "Primary collector",
+      endpointUrl: "https://clickstack.example.com",
+      includeSensitiveData: false,
+      headers: [
+        {
+          rowID: "existing-0-Authorization",
+          name: "Authorization",
+          storedName: "Authorization",
+          hasStoredValue: true,
+          value: "",
+        },
+      ],
+    });
+  });
+});

--- a/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.tsx
+++ b/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.tsx
@@ -1,0 +1,266 @@
+import { RequireScope } from "@/components/require-scope";
+import { WriteOnlyHeaderRow } from "@/components/write-only-header-row";
+import { Alert } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/Sheet";
+import { Stack } from "@/components/ui/Stack";
+import { Switch } from "@/components/ui/Switch";
+import { Text } from "@/components/ui/Text";
+import {
+  blankWriteOnlyHeader,
+  editableHeaderFromServer,
+  hasValidWriteOnlyHeaders,
+  type EditableWriteOnlyHeader,
+} from "@/lib/write-only-headers";
+import { useForm } from "@tanstack/react-form";
+import { Plus } from "lucide-react";
+import type { OtelDataExportDestination } from "./ConfigureExportSheet";
+
+function isValidDataExportEndpointURL(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export type ConfigureDestinationValues = {
+  destinationName: string;
+  endpointUrl: string;
+  includeSensitiveData: boolean;
+  headers: EditableWriteOnlyHeader[];
+};
+
+function destinationValuesAreValid(
+  values: ConfigureDestinationValues,
+): boolean {
+  return (
+    values.destinationName.trim() !== "" &&
+    isValidDataExportEndpointURL(values.endpointUrl.trim()) &&
+    hasValidWriteOnlyHeaders(values.headers)
+  );
+}
+
+export function ConfigureDestinationSheet({
+  destination,
+  saving,
+  onClose,
+  onSave,
+}: {
+  destination: OtelDataExportDestination;
+  saving: boolean;
+  onClose: () => void;
+  onSave: (values: ConfigureDestinationValues) => Promise<void>;
+}): JSX.Element {
+  const form = useForm({
+    defaultValues: {
+      destinationName: destination.name,
+      endpointUrl: destination.otel.endpointUrl,
+      includeSensitiveData: destination.sensitiveData === "include",
+      headers: destination.otel.headers.map(editableHeaderFromServer),
+    } satisfies ConfigureDestinationValues,
+    onSubmit: async ({ value }) => onSave(value),
+  });
+
+  return (
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open && !saving) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="w-[560px] max-w-[calc(100vw-2rem)] gap-0 bg-card p-0 sm:max-w-[560px]"
+      >
+        <SheetHeader className="border-b px-6 py-5">
+          <SheetTitle>Configure destination</SheetTitle>
+          <SheetDescription>
+            Changes apply to every export using this destination.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form
+          className="flex min-h-0 flex-1 flex-col"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void form.handleSubmit();
+          }}
+        >
+          <div className="min-h-0 flex-1 overflow-y-auto px-6">
+            <div className="space-y-2 py-5">
+              <form.Field name="destinationName">
+                {(field) => (
+                  <>
+                    <Label htmlFor={field.name}>Destination name</Label>
+                    <Input
+                      id={field.name}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      placeholder="Datadog"
+                    />
+                  </>
+                )}
+              </form.Field>
+            </div>
+
+            <div className="space-y-2 border-t py-5">
+              <form.Field name="endpointUrl">
+                {(field) => (
+                  <>
+                    <Label htmlFor={field.name}>OTLP endpoint</Label>
+                    <Input
+                      id={field.name}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      placeholder="https://collector.example.com"
+                      className="font-mono"
+                    />
+                  </>
+                )}
+              </form.Field>
+              <Text muted className="text-xs leading-relaxed">
+                HTTP or HTTPS. Signal-specific paths are appended during
+                delivery.
+              </Text>
+            </div>
+
+            <form.Field name="headers" mode="array">
+              {(headersField) => (
+                <div className="space-y-3 border-t py-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label>Headers</Label>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() =>
+                        headersField.pushValue(blankWriteOnlyHeader())
+                      }
+                    >
+                      <Button.LeftIcon>
+                        <Plus className="size-3.5" />
+                      </Button.LeftIcon>
+                      Add header
+                    </Button>
+                  </div>
+                  {headersField.state.value.length === 0 ? (
+                    <Text muted className="text-sm">
+                      No custom headers.
+                    </Text>
+                  ) : (
+                    <Stack gap={2}>
+                      {headersField.state.value.map((header, index) => (
+                        <form.Field
+                          key={header.rowID}
+                          name={`headers[${index}].name` as const}
+                        >
+                          {(nameField) => (
+                            <form.Field
+                              name={`headers[${index}].value` as const}
+                            >
+                              {(valueField) => (
+                                <WriteOnlyHeaderRow
+                                  name={nameField.state.value}
+                                  value={valueField.state.value}
+                                  hasStoredValue={header.hasStoredValue}
+                                  nameInputName={nameField.name}
+                                  valueInputName={valueField.name}
+                                  nameInputLabel={`Header ${index + 1} name`}
+                                  valueInputLabel={`Header ${index + 1} value`}
+                                  disabled={saving}
+                                  onNameChange={nameField.handleChange}
+                                  onNameBlur={nameField.handleBlur}
+                                  onValueChange={valueField.handleChange}
+                                  onValueBlur={valueField.handleBlur}
+                                  onRemove={() =>
+                                    headersField.removeValue(index)
+                                  }
+                                />
+                              )}
+                            </form.Field>
+                          )}
+                        </form.Field>
+                      ))}
+                    </Stack>
+                  )}
+                </div>
+              )}
+            </form.Field>
+
+            <form.Field name="includeSensitiveData">
+              {(field) => (
+                <div className="space-y-3 border-t py-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <Label>Include sensitive data</Label>
+                      <Text muted className="text-sm">
+                        Send tool arguments, results, and prompt content.
+                      </Text>
+                    </div>
+                    <Switch
+                      checked={field.state.value}
+                      onCheckedChange={field.handleChange}
+                      aria-label="Include sensitive data"
+                    />
+                  </div>
+                  {field.state.value ? (
+                    <Alert variant="warning" alignTop>
+                      This export may contain customer data.
+                    </Alert>
+                  ) : null}
+                </div>
+              )}
+            </form.Field>
+          </div>
+
+          <form.Subscribe
+            selector={(state) => [state.values, state.isSubmitting] as const}
+          >
+            {([values, isSubmitting]) => (
+              <SheetFooter className="min-h-14 flex-row items-center justify-end gap-2 border-t bg-muted/30 px-6 py-3">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={onClose}
+                  disabled={saving || isSubmitting}
+                >
+                  Cancel
+                </Button>
+                <RequireScope scope="org:admin" level="component">
+                  <Button
+                    type="submit"
+                    variant="primary"
+                    size="sm"
+                    disabled={
+                      saving ||
+                      isSubmitting ||
+                      !destinationValuesAreValid(values)
+                    }
+                  >
+                    {saving ? "Saving" : "Save destination"}
+                  </Button>
+                </RequireScope>
+              </SheetFooter>
+            )}
+          </form.Subscribe>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.tsx
+++ b/client/dashboard/src/pages/data-exports/ConfigureDestinationSheet.tsx
@@ -15,6 +15,7 @@ import {
 import { Stack } from "@/components/ui/Stack";
 import { Switch } from "@/components/ui/Switch";
 import { Text } from "@/components/ui/Text";
+import { isValidDataExportEndpointURL } from "@/lib/data-export-validation";
 import {
   blankWriteOnlyHeader,
   editableHeaderFromServer,
@@ -24,15 +25,6 @@ import {
 import { useForm } from "@tanstack/react-form";
 import { Plus } from "lucide-react";
 import type { OtelDataExportDestination } from "./ConfigureExportSheet";
-
-function isValidDataExportEndpointURL(value: string): boolean {
-  try {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
-}
 
 export type ConfigureDestinationValues = {
   destinationName: string;

--- a/client/dashboard/src/pages/data-exports/ConfigureExportSheet.tsx
+++ b/client/dashboard/src/pages/data-exports/ConfigureExportSheet.tsx
@@ -24,6 +24,7 @@ import {
 import { Stack } from "@/components/ui/Stack";
 import { Switch } from "@/components/ui/Switch";
 import { Text } from "@/components/ui/Text";
+import { isValidDataExportEndpointURL } from "@/lib/data-export-validation";
 import {
   blankWriteOnlyHeader,
   hasValidWriteOnlyHeaders,
@@ -64,15 +65,6 @@ export type ConfigureExportValues = {
   includeSensitiveData: boolean;
   headers: EditableWriteOnlyHeader[];
 };
-
-function isValidDataExportEndpointURL(value: string): boolean {
-  try {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
-}
 
 function initialDestinationID(
   route: DataExportRoute | undefined,

--- a/client/dashboard/src/pages/data-exports/ConfigureExportSheet.tsx
+++ b/client/dashboard/src/pages/data-exports/ConfigureExportSheet.tsx
@@ -65,7 +65,7 @@ export type ConfigureExportValues = {
   headers: EditableWriteOnlyHeader[];
 };
 
-function isValidEndpointURL(value: string): boolean {
+function isValidDataExportEndpointURL(value: string): boolean {
   try {
     const protocol = new URL(value).protocol;
     return protocol === "http:" || protocol === "https:";
@@ -100,7 +100,7 @@ function destinationSelectionIsValid(
   }
   return (
     values.destinationName.trim() !== "" &&
-    isValidEndpointURL(values.endpointUrl.trim()) &&
+    isValidDataExportEndpointURL(values.endpointUrl.trim()) &&
     hasValidWriteOnlyHeaders(values.headers)
   );
 }
@@ -471,7 +471,7 @@ export function ConfigureExportSheet({
                   <div className="space-y-1">
                     <Label>Start exporting</Label>
                     <Text muted className="text-sm">
-                      Turn off to save this export paused.
+                      When enabled, data starts exporting as soon as you save.
                     </Text>
                   </div>
                   <Switch

--- a/client/dashboard/src/pages/data-exports/DataExports.test.tsx
+++ b/client/dashboard/src/pages/data-exports/DataExports.test.tsx
@@ -1,0 +1,185 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExportMap } from "./DataExports";
+
+vi.mock("@/components/project-menu", () => ({
+  ProjectAvatar: () => <span aria-hidden="true" />,
+}));
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/components/ui/MoreActions", () => ({
+  MoreActions: ({
+    actions,
+  }: {
+    actions: Array<{ label: string; onClick: () => void }>;
+  }) => (
+    <>
+      {actions.map((action) => (
+        <button key={action.label} onClick={action.onClick}>
+          {action.label}
+        </button>
+      ))}
+    </>
+  ),
+}));
+
+vi.mock("@/components/ui/Switch", () => ({
+  Switch: ({
+    checked,
+    disabled,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    disabled?: boolean;
+    "aria-label"?: string;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      readOnly
+    />
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+type ExportRow = Parameters<typeof ExportMap>[0]["exports"][number];
+
+const project = {
+  id: "project-1",
+  slug: "default",
+  name: "Default",
+} as ExportRow["project"];
+
+function exportRow({
+  routeID,
+  dataSource,
+  destinationID,
+  destinationName,
+}: {
+  routeID: string;
+  dataSource: string;
+  destinationID: string;
+  destinationName: string;
+}): ExportRow {
+  const timestamp = new Date(0);
+
+  return {
+    project,
+    route: {
+      createdAt: timestamp,
+      id: routeID,
+      projectId: project.id,
+      dataSource: dataSource as ExportRow["route"]["dataSource"],
+      enabled: true,
+      otelDestinationId: destinationID,
+      updatedAt: timestamp,
+    },
+    destination: {
+      createdAt: timestamp,
+      id: destinationID,
+      projectId: project.id,
+      destinationType: "otel",
+      name: destinationName,
+      sensitiveData: "exclude",
+      otel: {
+        endpointUrl: `https://${destinationName.toLowerCase()}.example.com`,
+        headers: [],
+      },
+      updatedAt: timestamp,
+    },
+  };
+}
+
+const callbacks = {
+  mutating: false,
+  onConfigure: vi.fn(),
+  onConfigureDestination: vi.fn(),
+  onToggle: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe("ExportMap", () => {
+  it("renders one destination node for routes sharing a destination", () => {
+    render(
+      <ExportMap
+        exports={[
+          exportRow({
+            routeID: "route-telemetry",
+            dataSource: "product_telemetry",
+            destinationID: "destination-1",
+            destinationName: "Clickstack",
+          }),
+          exportRow({
+            routeID: "route-risk",
+            dataSource: "risk_findings",
+            destinationID: "destination-1",
+            destinationName: "Clickstack",
+          }),
+        ]}
+        {...callbacks}
+      />,
+    );
+
+    expect(screen.getByText("Product telemetry")).toBeTruthy();
+    expect(screen.getByText("Risk findings")).toBeTruthy();
+    expect(screen.getAllByText("Clickstack")).toHaveLength(1);
+    expect(screen.getAllByText("https://clickstack.example.com")).toHaveLength(
+      1,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure Product telemetry export",
+      }),
+    );
+    expect(callbacks.onConfigure).toHaveBeenCalledWith(
+      project,
+      expect.objectContaining({ id: "route-telemetry" }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure Clickstack destination",
+      }),
+    );
+    expect(callbacks.onConfigureDestination).toHaveBeenCalledTimes(1);
+    expect(callbacks.onConfigureDestination).toHaveBeenCalledWith(
+      project,
+      expect.objectContaining({ id: "destination-1" }),
+    );
+  });
+
+  it("keeps separate destination nodes for different destination IDs", () => {
+    render(
+      <ExportMap
+        exports={[
+          exportRow({
+            routeID: "route-a",
+            dataSource: "product_telemetry",
+            destinationID: "destination-1",
+            destinationName: "Collector A",
+          }),
+          exportRow({
+            routeID: "route-b",
+            dataSource: "risk_findings",
+            destinationID: "destination-2",
+            destinationName: "Collector B",
+          }),
+        ]}
+        {...callbacks}
+      />,
+    );
+
+    expect(screen.getByText("Collector A")).toBeTruthy();
+    expect(screen.getByText("Collector B")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/data-exports/DataExports.tsx
+++ b/client/dashboard/src/pages/data-exports/DataExports.tsx
@@ -13,6 +13,7 @@ import { Switch } from "@/components/ui/Switch";
 import { Text } from "@/components/ui/Text";
 import { useOrganization } from "@/contexts/Auth";
 import { toError } from "@/lib/errors";
+import { writeOnlyHeaderInput } from "@/lib/write-only-headers";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DataSource,
@@ -29,9 +30,14 @@ import { useDeleteDataExportRouteMutation } from "@gram/client/react-query/delet
 import { useListProjects } from "@gram/client/react-query/listProjects.js";
 import { invalidateDataExportDestinations } from "@gram/client/react-query/dataExportDestinations.js";
 import { buildListDataExportsForOrgQuery } from "@gram/client/react-query/listDataExportsForOrg.js";
+import { useUpdateDataExportDestinationMutation } from "@gram/client/react-query/updateDataExportDestination.js";
 import { useUpdateDataExportRouteMutation } from "@gram/client/react-query/updateDataExportRoute.js";
 import { useId, useState } from "react";
 import { toast } from "sonner";
+import {
+  ConfigureDestinationSheet,
+  type ConfigureDestinationValues,
+} from "./ConfigureDestinationSheet";
 import {
   ConfigureExportSheet,
   type ConfigureExportValues,
@@ -117,6 +123,10 @@ type ProjectExports = {
 type DeleteCandidate = {
   project: ProjectEntry;
   route: DataExportRoute;
+};
+type DestinationEditCandidate = {
+  project: ProjectEntry;
+  destination: OtelDataExportDestination;
 };
 
 function sourceLabel(dataSource: string): string {
@@ -222,6 +232,7 @@ function DataExportsInner(): JSX.Element {
   const projectQueryError = exportsQuery.error;
 
   const createDestination = useCreateDataExportDestinationMutation();
+  const updateDestination = useUpdateDataExportDestinationMutation();
   const createRoute = useCreateDataExportRouteMutation();
   const updateRoute = useUpdateDataExportRouteMutation();
   const deleteRoute = useDeleteDataExportRouteMutation();
@@ -230,6 +241,8 @@ function DataExportsInner(): JSX.Element {
     routeId?: string;
   }>();
   const [deleteCandidate, setDeleteCandidate] = useState<DeleteCandidate>();
+  const [destinationEditCandidate, setDestinationEditCandidate] =
+    useState<DestinationEditCandidate>();
   const configureState = projectExports.find(
     ({ project }) => project.slug === configureTarget?.projectSlug,
   );
@@ -252,6 +265,7 @@ function DataExportsInner(): JSX.Element {
       : availableProjectExports.map(({ project }) => project);
   const mutating =
     createDestination.isPending ||
+    updateDestination.isPending ||
     createRoute.isPending ||
     updateRoute.isPending ||
     deleteRoute.isPending;
@@ -333,6 +347,36 @@ function DataExportsInner(): JSX.Element {
     } catch (error) {
       await invalidateProjectExports(state.project.slug);
       toast.error(`Failed to configure export: ${toError(error).message}`);
+    }
+  };
+  const handleSaveDestination = async (
+    values: ConfigureDestinationValues,
+  ): Promise<void> => {
+    if (!destinationEditCandidate) return;
+
+    const { project, destination } = destinationEditCandidate;
+    try {
+      await updateDestination.mutateAsync({
+        request: {
+          id: destination.id,
+          gramProject: project.slug,
+          updateDestinationRequestBody: {
+            destinationType: "otel",
+            name: values.destinationName.trim(),
+            sensitiveData: values.includeSensitiveData ? "include" : "exclude",
+            otel: {
+              endpointUrl: values.endpointUrl.trim(),
+              headers: values.headers.map(writeOnlyHeaderInput),
+            },
+          },
+        },
+      });
+      await invalidateProjectExports(project.slug);
+      toast.success("Destination updated");
+      setDestinationEditCandidate(undefined);
+    } catch (error) {
+      await invalidateProjectExports(project.slug);
+      toast.error(`Failed to update destination: ${toError(error).message}`);
     }
   };
 
@@ -442,6 +486,9 @@ function DataExportsInner(): JSX.Element {
               routeId: route.id,
             })
           }
+          onConfigureDestination={(project, destination) =>
+            setDestinationEditCandidate({ project, destination })
+          }
           onToggle={(project, route, enabled) =>
             void handleToggleExport(project, route, enabled)
           }
@@ -502,6 +549,15 @@ function DataExportsInner(): JSX.Element {
           onSave={handleSaveExport}
         />
       ) : null}
+      {destinationEditCandidate ? (
+        <ConfigureDestinationSheet
+          key={destinationEditCandidate.destination.id}
+          destination={destinationEditCandidate.destination}
+          saving={updateDestination.isPending}
+          onClose={() => setDestinationEditCandidate(undefined)}
+          onSave={handleSaveDestination}
+        />
+      ) : null}
 
       <DeleteExportDialog
         exportRoute={deleteCandidate?.route}
@@ -536,24 +592,64 @@ function ExportAnimationStyles(): JSX.Element {
   );
 }
 
-function ExportMap({
-  exports,
-  mutating,
-  onConfigure,
-  onToggle,
-  onDelete,
-}: {
+type ExportDestinationGroup = {
+  destination: VisualDestination;
+  firstExport: ProjectExportRow;
+  exports: ProjectExportRow[];
+};
+
+const EXPORT_NODE_HEIGHT = 112;
+const EXPORT_ROW_GAP = 24;
+
+function groupExportsByDestination(
+  exports: ProjectExportRow[],
+): ExportDestinationGroup[] {
+  const groups = new Map<string, ExportDestinationGroup>();
+
+  for (const exportRow of exports) {
+    const destination = visualDestination(exportRow);
+    const existing = groups.get(destination.key);
+    if (existing) {
+      existing.exports.push(exportRow);
+      continue;
+    }
+
+    groups.set(destination.key, {
+      destination,
+      firstExport: exportRow,
+      exports: [exportRow],
+    });
+  }
+
+  return [...groups.values()];
+}
+
+type ExportMapProps = {
   exports: ProjectExportRow[];
   mutating: boolean;
   onConfigure: (project: ProjectEntry, route: DataExportRoute) => void;
+  onConfigureDestination: (
+    project: ProjectEntry,
+    destination: OtelDataExportDestination,
+  ) => void;
   onToggle: (
     project: ProjectEntry,
     route: DataExportRoute,
     enabled: boolean,
   ) => void;
   onDelete: (project: ProjectEntry, route: DataExportRoute) => void;
-}): JSX.Element {
+};
+
+export function ExportMap({
+  exports,
+  mutating,
+  onConfigure,
+  onConfigureDestination,
+  onToggle,
+  onDelete,
+}: ExportMapProps): JSX.Element {
   const markerID = `export-map-arrow-${useId().replaceAll(":", "")}`;
+  const destinationGroups = groupExportsByDestination(exports);
 
   return (
     <div className="overflow-x-auto border bg-card px-6 py-6">
@@ -564,146 +660,272 @@ function ExportMap({
           <span className="text-eyebrow text-muted-foreground">Sent to</span>
         </div>
         <div className="space-y-6">
-          {exports.map((exportRow, exportIndex) => {
-            const { project, route } = exportRow;
-            const source = visualSource(exportRow);
-            const destination = visualDestination(exportRow);
-            const arrowID = `${markerID}-${exportIndex}`;
-            return (
-              <div
-                key={route.id}
-                className="grid grid-cols-[360px_minmax(180px,260px)_minmax(360px,1fr)] items-stretch"
-              >
-                <div className="relative min-h-28 border border-foreground px-5 py-3">
-                  <div className="min-w-0 pr-10 pb-8">
-                    <div className="mb-1 flex items-center gap-2">
-                      <ProjectAvatar
-                        project={project}
-                        className="size-3 min-h-3 min-w-3"
-                      />
-                      <span className="text-eyebrow text-muted-foreground">
-                        {project.name}
-                      </span>
-                    </div>
-                    <Text className="truncate font-medium">{source.name}</Text>
-                    <span className="mt-1 block truncate font-mono text-xs text-placeholder">
-                      {source.detail}
-                    </span>
-                  </div>
-                  <RequireScope scope="org:admin" level="component">
-                    <div className="absolute top-3 right-3">
-                      <MoreActions
-                        actions={[
-                          {
-                            label: "Configure export",
-                            icon: "pencil",
-                            onClick: () => onConfigure(project, route),
-                          },
-                          {
-                            label: "Delete export",
-                            icon: "trash-2",
-                            destructive: true,
-                            disabled: mutating,
-                            onClick: () => onDelete(project, route),
-                          },
-                        ]}
-                      />
-                    </div>
-                  </RequireScope>
-                  <div className="absolute right-3 bottom-3 flex items-center gap-2">
-                    <span
-                      className={
-                        route.enabled
-                          ? "flex items-center gap-1.5 text-sm text-default-success"
-                          : "text-sm text-placeholder"
-                      }
-                    >
-                      {route.enabled ? (
-                        <Icon name="check" className="size-3.5" />
-                      ) : null}
-                      {route.enabled ? "Enabled" : "Paused"}
-                    </span>
-                    <RequireScope scope="org:admin" level="component">
-                      <Switch
-                        checked={route.enabled}
-                        onCheckedChange={(enabled) =>
-                          onToggle(project, route, enabled)
-                        }
-                        disabled={mutating}
-                        aria-label={`${route.enabled ? "Pause" : "Enable"} export from ${source.name}`}
-                      />
-                    </RequireScope>
-                  </div>
-                </div>
-                <svg
-                  viewBox="0 0 200 100"
-                  preserveAspectRatio="none"
-                  className="h-full min-h-24 w-full overflow-visible"
-                  aria-hidden="true"
-                >
-                  <defs>
-                    <marker
-                      id={arrowID}
-                      markerWidth="8"
-                      markerHeight="8"
-                      refX="7"
-                      refY="4"
-                      orient="auto"
-                    >
-                      <path
-                        d="M0,0 L8,4 L0,8 Z"
-                        className="fill-card stroke-card"
-                        strokeWidth="3"
-                        strokeLinejoin="round"
-                      />
-                      <path
-                        d="M0,0 L8,4 L0,8 Z"
-                        className={
-                          route.enabled
-                            ? "fill-foreground"
-                            : "fill-muted-foreground"
-                        }
-                      />
-                    </marker>
-                  </defs>
-                  <path
-                    d="M 0 50 C 70 50, 120 50, 196 50"
-                    fill="none"
-                    className={
-                      route.enabled
-                        ? "data-export-flow-line stroke-foreground"
-                        : "stroke-muted-foreground"
-                    }
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeDasharray={route.enabled ? "8 7" : undefined}
-                    vectorEffect="non-scaling-stroke"
-                    markerEnd={`url(#${arrowID})`}
-                  />
-                </svg>
-                <div className="flex min-h-24 items-center justify-between gap-4 border px-5 py-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Badge size="sm">{destination.type}</Badge>
-                      <Text className="truncate font-medium">
-                        {destination.name}
-                      </Text>
-                      {destination.sensitive ? (
-                        <Badge variant="warning" background={false} size="sm">
-                          Sensitive
-                        </Badge>
-                      ) : null}
-                    </div>
-                    <span className="mt-1 block truncate font-mono text-xs text-placeholder">
-                      {destination.detail}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+          {destinationGroups.map((group, groupIndex) => (
+            <div
+              key={group.destination.key}
+              className="grid grid-cols-[360px_minmax(180px,260px)_minmax(360px,1fr)] gap-y-6"
+              style={{
+                gridTemplateRows: `repeat(${group.exports.length}, ${EXPORT_NODE_HEIGHT}px)`,
+              }}
+            >
+              {group.exports.map((exportRow, rowIndex) => (
+                <ExportSourceNode
+                  key={exportRow.route.id}
+                  exportRow={exportRow}
+                  row={rowIndex + 1}
+                  mutating={mutating}
+                  onConfigure={onConfigure}
+                  onToggle={onToggle}
+                  onDelete={onDelete}
+                />
+              ))}
+              <ExportFlow
+                exports={group.exports}
+                markerID={`${markerID}-${groupIndex}`}
+              />
+              <ExportDestinationNode
+                destination={group.destination}
+                configuredDestination={group.firstExport.destination}
+                project={group.firstExport.project}
+                rowSpan={group.exports.length}
+                mutating={mutating}
+                onConfigure={onConfigureDestination}
+              />
+            </div>
+          ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+function ExportSourceNode({
+  exportRow,
+  row,
+  mutating,
+  onConfigure,
+  onToggle,
+  onDelete,
+}: {
+  exportRow: ProjectExportRow;
+  row: number;
+  mutating: boolean;
+  onConfigure: ExportMapProps["onConfigure"];
+  onToggle: ExportMapProps["onToggle"];
+  onDelete: ExportMapProps["onDelete"];
+}): JSX.Element {
+  const { project, route } = exportRow;
+  const source = visualSource(exportRow);
+
+  return (
+    <div
+      className="relative h-full border border-foreground px-5 py-3"
+      style={{ gridColumn: 1, gridRow: row }}
+    >
+      <RequireScope scope="org:admin" level="component">
+        <button
+          type="button"
+          onClick={() => onConfigure(project, route)}
+          disabled={mutating}
+          aria-label={`Configure ${source.name} export`}
+          className="absolute inset-0 z-10 cursor-pointer transition-colors hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:hover:bg-transparent"
+        />
+      </RequireScope>
+      <div className="pointer-events-none relative z-20 min-w-0 pr-10 pb-8">
+        <div className="mb-1 flex items-center gap-2">
+          <ProjectAvatar project={project} className="size-3 min-h-3 min-w-3" />
+          <span className="text-eyebrow text-muted-foreground">
+            {project.name}
+          </span>
+        </div>
+        <Text className="truncate font-medium">{source.name}</Text>
+        <span className="mt-1 block truncate font-mono text-xs text-placeholder">
+          {source.detail}
+        </span>
+      </div>
+      <RequireScope scope="org:admin" level="component">
+        <div className="pointer-events-auto absolute top-3 right-3 z-30">
+          <MoreActions
+            actions={[
+              {
+                label: "Configure export",
+                icon: "pencil",
+                onClick: () => onConfigure(project, route),
+              },
+              {
+                label: "Delete export",
+                icon: "trash-2",
+                destructive: true,
+                disabled: mutating,
+                onClick: () => onDelete(project, route),
+              },
+            ]}
+          />
+        </div>
+      </RequireScope>
+      <div className="pointer-events-none absolute right-3 bottom-3 z-20 flex items-center gap-2">
+        <span
+          className={
+            route.enabled
+              ? "flex items-center gap-1.5 text-sm text-default-success"
+              : "text-sm text-placeholder"
+          }
+        >
+          {route.enabled ? <Icon name="check" className="size-3.5" /> : null}
+          {route.enabled ? "Enabled" : "Paused"}
+        </span>
+        <RequireScope scope="org:admin" level="component">
+          <div className="pointer-events-auto">
+            <Switch
+              checked={route.enabled}
+              onCheckedChange={(enabled) => onToggle(project, route, enabled)}
+              disabled={mutating}
+              aria-label={`${route.enabled ? "Pause" : "Enable"} export from ${source.name}`}
+            />
+          </div>
+        </RequireScope>
+      </div>
+    </div>
+  );
+}
+
+function ExportFlow({
+  exports,
+  markerID,
+}: {
+  exports: ProjectExportRow[];
+  markerID: string;
+}): JSX.Element {
+  const height =
+    exports.length * EXPORT_NODE_HEIGHT + (exports.length - 1) * EXPORT_ROW_GAP;
+  const destinationY = height / 2;
+  const anyEnabled = exports.some(({ route }) => route.enabled);
+
+  return (
+    <svg
+      viewBox={`0 0 200 ${height}`}
+      preserveAspectRatio="none"
+      className="h-full w-full overflow-visible"
+      style={{ gridColumn: 2, gridRow: `1 / span ${exports.length}` }}
+      aria-hidden="true"
+    >
+      <defs>
+        <marker
+          id={markerID}
+          markerWidth="8"
+          markerHeight="8"
+          refX="7"
+          refY="4"
+          orient="auto"
+        >
+          <path
+            d="M0,0 L8,4 L0,8 Z"
+            className="fill-card stroke-card"
+            strokeWidth="3"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M0,0 L8,4 L0,8 Z"
+            className={anyEnabled ? "fill-foreground" : "fill-muted-foreground"}
+          />
+        </marker>
+      </defs>
+      {exports.map(({ route }, rowIndex) => {
+        const sourceY =
+          rowIndex * (EXPORT_NODE_HEIGHT + EXPORT_ROW_GAP) +
+          EXPORT_NODE_HEIGHT / 2;
+
+        return (
+          <path
+            key={route.id}
+            d={`M 0 ${sourceY} C 70 ${sourceY}, 120 ${destinationY}, 184 ${destinationY}`}
+            fill="none"
+            className={
+              route.enabled
+                ? "data-export-flow-line stroke-foreground"
+                : "stroke-muted-foreground"
+            }
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeDasharray={route.enabled ? "8 7" : undefined}
+            vectorEffect="non-scaling-stroke"
+          />
+        );
+      })}
+      <path
+        d={`M 184 ${destinationY} L 196 ${destinationY}`}
+        fill="none"
+        className={anyEnabled ? "stroke-foreground" : "stroke-muted-foreground"}
+        strokeWidth="2"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        markerEnd={`url(#${markerID})`}
+      />
+    </svg>
+  );
+}
+
+function ExportDestinationNode({
+  destination,
+  configuredDestination,
+  project,
+  rowSpan,
+  mutating,
+  onConfigure,
+}: {
+  destination: VisualDestination;
+  configuredDestination: OtelDataExportDestination | undefined;
+  project: ProjectEntry;
+  rowSpan: number;
+  mutating: boolean;
+  onConfigure: ExportMapProps["onConfigureDestination"];
+}): JSX.Element {
+  return (
+    <div
+      className="relative flex min-h-24 self-center items-center gap-4 border px-5 py-3"
+      style={{ gridColumn: 3, gridRow: `1 / span ${rowSpan}` }}
+    >
+      {configuredDestination ? (
+        <RequireScope scope="org:admin" level="component">
+          <button
+            type="button"
+            onClick={() => onConfigure(project, configuredDestination)}
+            disabled={mutating}
+            aria-label={`Configure ${destination.name} destination`}
+            className="absolute inset-0 z-10 cursor-pointer transition-colors hover:bg-muted/30 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:hover:bg-transparent"
+          />
+        </RequireScope>
+      ) : null}
+      <div className="pointer-events-none relative z-20 min-w-0 pr-10">
+        <div className="flex items-center gap-2">
+          <Badge size="sm">{destination.type}</Badge>
+          <Text className="truncate font-medium">{destination.name}</Text>
+          {destination.sensitive ? (
+            <Badge variant="warning" background={false} size="sm">
+              Sensitive
+            </Badge>
+          ) : null}
+        </div>
+        <span className="mt-1 block truncate font-mono text-xs text-placeholder">
+          {destination.detail}
+        </span>
+      </div>
+      {configuredDestination ? (
+        <RequireScope scope="org:admin" level="component">
+          <div className="pointer-events-auto absolute top-3 right-3 z-30">
+            <MoreActions
+              actions={[
+                {
+                  label: "Configure destination",
+                  icon: "pencil",
+                  disabled: mutating,
+                  onClick: () => onConfigure(project, configuredDestination),
+                },
+              ]}
+            />
+          </div>
+        </RequireScope>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Group export routes by destination so shared collectors render once with converging connections.
- Make source and destination nodes clickable, and add a destination editor for names, OTLP endpoints, headers, and sensitive-data policy.
- Preserve stored write-only header values during edits and clarify the export-enabled helper text.
- Add focused coverage for grouping, node interactions, and destination editing.

## Motivation

The export graph duplicated collectors when multiple data sources sent to the same destination. Destinations also had no direct editing path, which forced users to recreate configuration instead of maintaining the shared collector in place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups export routes by destination so a shared collector renders once with converging connections, and makes source and destination nodes clickable with a new destination editor. Previously each route rendered its own destination node and destinations had no in-place editing path.

**Details**
- Tightens endpoint validation to reject query strings, fragments, userinfo, control characters, and non-HTTP(S) URLs.
- Validates header names as HTTP tokens and rejects control characters in header values.
- Clicking a source node opens the existing export configuration sheet.
- Clicking a destination node opens a new sheet for editing name, OTLP endpoint, headers, and sensitive-data policy.
- Write-only header values stay preserved on edit and are never displayed back in the form.
- The enable toggle helper text now says data starts exporting as soon as you save.
- Adds unit tests for destination grouping, node interactions, destination editing, and the new validation rules.

<sup>Written for commit a7c09fb7eacd95860c7a7a8831558294c739b011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

