### PR TITLE
feat(platform-mcp): inspect MCP access

### DIFF
--- a/.changeset/platform-mcp-inspect-access.md
+++ b/.changeset/platform-mcp-inspect-access.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add privacy-safe Platform MCP tools for inspecting role, member, and configured MCP access.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -231,6 +231,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessReads: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -304,6 +308,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	}
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
+	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 
 	registryHandler := localfixture.NewRegistryHTTP(fixtureConfig).Handler()
@@ -361,6 +366,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		sessionRecall,
 		riskMutations,
 		fixtureConfig.CatalogDescriptor(),
+		accessReads,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
@@ -577,6 +583,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessReads: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -650,6 +660,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	}
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
+	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
@@ -693,6 +704,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		sessionRecall,
 		riskMutations,
 		platformmcp.CatalogDescriptor{},
+		accessReads,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -56,6 +56,9 @@ func GrantsSatisfy(grants []Grant, check Check) bool {
 // Read-only projections use this when they need to explain another principal's
 // effective access without replacing the request context's acting principal.
 func GrantsAuthorize(grants []Grant, check Check) (bool, error) {
+	if err := validateInput(check); err != nil {
+		return false, err
+	}
 	evaluation, err := evaluateGrantCheck(grants, check)
 	if err != nil {
 		return false, err

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -40,13 +40,27 @@ type ScopedGrant struct {
 	Selectors []Selector
 }
 
-// GrantsSatisfy reports whether the loaded grant set authorizes check.
+// GrantsSatisfy reports whether the loaded grant set has an allow grant matching
+// check. It intentionally does not evaluate exclusion scopes; callers answering
+// an effective authorization question should use GrantsAuthorize.
 func GrantsSatisfy(grants []Grant, check Check) bool {
 	if err := validateInput(check); err != nil {
 		return false
 	}
 	grant, _ := matchingGrant(grants, check.expand())
 	return grant != nil
+}
+
+// GrantsAuthorize evaluates one check against already-loaded grants with the
+// same scope expansion, selector matching, and exclusion semantics as Engine.
+// Read-only projections use this when they need to explain another principal's
+// effective access without replacing the request context's acting principal.
+func GrantsAuthorize(grants []Grant, check Check) (bool, error) {
+	evaluation, err := evaluateGrantCheck(grants, check)
+	if err != nil {
+		return false, err
+	}
+	return evaluation.Grant != nil && !evaluation.Denied, nil
 }
 
 // SystemRoleGrants defines the canonical grant sets for the built-in system

--- a/server/internal/authz/grants_authorize_test.go
+++ b/server/internal/authz/grants_authorize_test.go
@@ -1,0 +1,33 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantsAuthorizeAppliesMCPExclusions(t *testing.T) {
+	t.Parallel()
+
+	serverID := "server-1"
+	tool := "delete_tasks"
+	allow := NewSelector(ScopeMCPConnect, serverID)
+	block := NewSelector(ScopeMCPBlockedConnect, serverID)
+	block[SelectorKeyTool] = tool
+	grants := []Grant{
+		{PrincipalUrn: "role:organization:role-1", Scope: ScopeMCPConnect, Selector: allow},
+		{PrincipalUrn: "role:organization:role-1", Scope: ScopeMCPBlockedConnect, Selector: block},
+	}
+
+	allowed, err := GrantsAuthorize(grants, MCPCheck(ScopeMCPConnect, serverID, "project-1"))
+	require.NoError(t, err)
+	require.True(t, allowed)
+
+	allowed, err = GrantsAuthorize(grants, MCPToolCallCheck(serverID, MCPToolCallDimensions{Tool: tool, ProjectID: "project-1"}))
+	require.NoError(t, err)
+	require.False(t, allowed)
+
+	allowed, err = GrantsAuthorize(grants, MCPToolCallCheck(serverID, MCPToolCallDimensions{Tool: "list_tasks", ProjectID: "project-1"}))
+	require.NoError(t, err)
+	require.True(t, allowed)
+}

--- a/server/internal/authz/grants_test.go
+++ b/server/internal/authz/grants_test.go
@@ -1,0 +1,27 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantsAuthorizeRejectsEmptyResourceID(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := GrantsAuthorize([]Grant{NewGrant(ScopeRoot, WildcardResource)}, Check{
+		Scope: ScopeMCPConnect, ResourceKind: "", ResourceID: "", Dimensions: nil,
+	})
+	require.ErrorIs(t, err, ErrInvalidCheck)
+	require.False(t, allowed)
+}
+
+func TestGrantsAuthorizeRejectsWildcardResourceID(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := GrantsAuthorize([]Grant{NewGrant(ScopeRoot, WildcardResource)}, Check{
+		Scope: ScopeMCPConnect, ResourceKind: "", ResourceID: WildcardResource, Dimensions: nil,
+	})
+	require.ErrorIs(t, err, ErrInvalidCheck)
+	require.False(t, allowed)
+}

--- a/server/internal/platformmcp/access_reads.go
+++ b/server/internal/platformmcp/access_reads.go
@@ -55,6 +55,8 @@ type MCPConnectSummary struct {
 	ToolRules               int      `json:"tool_rules"`
 	DispositionRules        []string `json:"disposition_rules"`
 	BlockedServers          bool     `json:"blocked_servers"`
+	BlockedProjectRules     int      `json:"blocked_project_rules"`
+	BlockedServerRules      int      `json:"blocked_server_rules"`
 	BlockedToolRules        int      `json:"blocked_tool_rules"`
 	BlockedDispositionRules []string `json:"blocked_disposition_rules"`
 }
@@ -232,59 +234,52 @@ func (s *AccessReadService) ListMembers(ctx context.Context, principal Principal
 		}
 	}
 
-	members, err := s.roles.ListMembers(ctx, principal.OrganizationID)
-	if err != nil {
-		return ListAccessMembersOutput{}, fmt.Errorf("list platform mcp access members: %w", err)
-	}
-	matching := make([]*accessgen.AccessMember, 0, len(members.Members))
-	for _, member := range members.Members {
-		if roleID != "" && !slices.Contains(member.RoleIds, roleID) {
-			continue
-		}
-		if query != "" && !matchesAccessMember(member, query, roleNames) {
-			continue
-		}
-		matching = append(matching, member)
-	}
-
-	count := len(matching)
-	output := ListAccessMembersOutput{
-		Members:      []AccessMember{},
-		TotalMatches: NewSubjectCount(int64(count)),
-		Suppressed:   count > 0 && count < SubjectSuppressionThreshold,
-		Truncated:    false,
-		ExpiresAt:    "",
-	}
-	// Organization-privacy rules do not allow a row-bearing response to reveal
-	// a filtered cohort smaller than five. Return only the suppressed count.
-	if output.Suppressed || count == 0 {
-		return output, nil
-	}
-
 	limit := maxAccessMembers
 	if input.Limit > 0 {
 		limit = min(input.Limit, maxAccessMembers)
 	}
-	if len(matching) > limit {
-		matching = matching[:limit]
-		output.Truncated = true
+	rows, err := platformrepo.New(s.db).SearchPlatformMCPAccessMembers(ctx, platformrepo.SearchPlatformMCPAccessMembersParams{
+		ResultLimit:    int32(limit),
+		OrganizationID: principal.OrganizationID,
+		RoleID:         roleID,
+		Query:          query,
+	})
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("search platform mcp access members: %w", err)
 	}
+	var total int64
+	if len(rows) > 0 {
+		total = rows[0].TotalMatches
+	}
+	output := ListAccessMembersOutput{
+		Members:      []AccessMember{},
+		TotalMatches: NewSubjectCount(total),
+		Suppressed:   total > 0 && total < SubjectSuppressionThreshold,
+		Truncated:    total > int64(len(rows)),
+		ExpiresAt:    "",
+	}
+	// Organization-privacy rules do not allow a row-bearing response to reveal
+	// a filtered cohort smaller than five. Return only the suppressed count.
+	if output.Suppressed || total == 0 {
+		return output, nil
+	}
+
 	now := s.now().UTC()
 	output.ExpiresAt = now.Add(SubjectReferenceTTL).Format(time.RFC3339)
-	for _, member := range matching {
-		reference, err := s.references.Encode(principal, subjectKindAccessMember, member.ID, now)
+	for _, row := range rows {
+		reference, err := s.references.Encode(principal, subjectKindAccessMember, row.ID, now)
 		if err != nil {
 			return ListAccessMembersOutput{}, fmt.Errorf("issue access member reference: %w", err)
 		}
-		names := make([]string, 0, len(member.RoleIds))
-		for _, id := range member.RoleIds {
+		names := make([]string, 0, len(row.RoleIds))
+		for _, id := range row.RoleIds {
 			if name := roleNames[id]; name != "" {
 				names = append(names, name)
 			}
 		}
 		slices.Sort(names)
 		output.Members = append(output.Members, AccessMember{
-			MaskedIdentity: maskAccessMember(member),
+			MaskedIdentity: maskSubject(conv.Default(row.Email, row.DisplayName)),
 			Roles:          slices.Compact(names),
 			Reference:      reference,
 		})
@@ -475,7 +470,7 @@ func accessRoleType(role *accessgen.Role) string {
 }
 
 func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
-	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
+	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedProjectRules: 0, BlockedServerRules: 0, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
 	dispositions := map[string]struct{}{}
 	blockedDispositions := map[string]struct{}{}
 	for _, grant := range grants {
@@ -495,11 +490,19 @@ func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
 			if selector == nil {
 				continue
 			}
-			if selector.ProjectID != nil && !blocked {
-				summary.ProjectRules++
+			if selector.ProjectID != nil {
+				if blocked {
+					summary.BlockedProjectRules++
+				} else {
+					summary.ProjectRules++
+				}
 			}
-			if selector.ResourceID != authz.WildcardResource && !blocked {
-				summary.ServerRules++
+			if selector.ResourceID != authz.WildcardResource {
+				if blocked {
+					summary.BlockedServerRules++
+				} else {
+					summary.ServerRules++
+				}
 			}
 			if selector.Tool != nil {
 				if blocked {
@@ -666,13 +669,17 @@ func accessAuthorizationMode(row platformrepo.GetPlatformMCPInventoryItemRow) st
 	if row.Visibility == "disabled" {
 		return "disabled"
 	}
-	if row.Visibility == "public" {
-		return "public_bypass"
-	}
 	if row.UnproxiedMcpServerID.Valid {
 		return "not_served"
 	}
-	return "rbac"
+	switch row.Visibility {
+	case "public":
+		return "public_bypass"
+	case "private":
+		return "rbac"
+	default:
+		return "not_served"
+	}
 }
 
 func accessSummary(row platformrepo.GetPlatformMCPInventoryItemRow) string {
@@ -708,26 +715,4 @@ func knownToolAccess(allowed, total int, catalog string, truncated bool) string 
 
 func normalizeAccessQuery(value string) string {
 	return strings.ToLower(strings.Join(strings.Fields(value), " "))
-}
-
-func matchesAccessMember(member *accessgen.AccessMember, query string, roleNames map[string]string) bool {
-	if strings.Contains(normalizeAccessQuery(member.Name), query) || strings.Contains(normalizeAccessQuery(member.Email), query) {
-		return true
-	}
-	for _, roleID := range member.RoleIds {
-		if strings.Contains(normalizeAccessQuery(roleNames[roleID]), query) {
-			return true
-		}
-	}
-	return false
-}
-
-func maskAccessMember(member *accessgen.AccessMember) string {
-	if member == nil {
-		return ""
-	}
-	if member.Email != "" {
-		return maskSubject(member.Email)
-	}
-	return maskSubject(member.Name)
 }

--- a/server/internal/platformmcp/access_reads.go
+++ b/server/internal/platformmcp/access_reads.go
@@ -1,0 +1,733 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/mv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+const (
+	AccessReadsConnectionLimitName   = "platform-mcp-access-reads-connection"
+	AccessReadsOrganizationLimitName = "platform-mcp-access-reads-organization"
+
+	AccessReadQueriesPerConnectionPerMinute   = 30
+	AccessReadQueriesPerOrganizationPerMinute = 300
+
+	maxAccessMembers     = 50
+	maxAccessTools       = 100
+	minAccessQueryLength = 3
+)
+
+const (
+	subjectKindAccessRole   = "access_role"
+	subjectKindAccessMember = "access_member"
+)
+
+var (
+	ErrAccessReferenceNotFound = errors.New("platform mcp access reference not found")
+	ErrAccessMCPNotFound       = errors.New("platform mcp access target not found")
+	ErrAccessQueryRequired     = errors.New("platform mcp access member filter required")
+)
+
+type MCPConnectSummary struct {
+	AllServers              bool     `json:"all_servers"`
+	ProjectRules            int      `json:"project_rules"`
+	ServerRules             int      `json:"server_rules"`
+	ToolRules               int      `json:"tool_rules"`
+	DispositionRules        []string `json:"disposition_rules"`
+	BlockedServers          bool     `json:"blocked_servers"`
+	BlockedToolRules        int      `json:"blocked_tool_rules"`
+	BlockedDispositionRules []string `json:"blocked_disposition_rules"`
+}
+
+type AccessRole struct {
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	MemberCount SubjectCount      `json:"member_count"`
+	MCPAccess   MCPConnectSummary `json:"mcp_access"`
+	Reference   string            `json:"reference"`
+}
+
+type ListAccessRolesOutput struct {
+	Roles     []AccessRole `json:"roles"`
+	ExpiresAt string       `json:"expires_at"`
+}
+
+type ListAccessMembersInput struct {
+	Query         string `json:"query,omitempty" jsonschema:"identity text to search for; required unless role_reference is supplied"`
+	RoleReference string `json:"role_reference,omitempty" jsonschema:"opaque role reference returned by list_access_roles"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"maximum number of matching members to return; server clamps this to 50"`
+}
+
+type AccessMember struct {
+	MaskedIdentity string   `json:"masked_identity"`
+	Roles          []string `json:"roles"`
+	Reference      string   `json:"reference"`
+}
+
+type ListAccessMembersOutput struct {
+	Members      []AccessMember `json:"members"`
+	TotalMatches SubjectCount   `json:"total_matches"`
+	Suppressed   bool           `json:"suppressed"`
+	Truncated    bool           `json:"truncated"`
+	ExpiresAt    string         `json:"expires_at,omitempty"`
+}
+
+type MCPAccessTool struct {
+	Name        string `json:"name"`
+	Disposition string `json:"disposition,omitempty"`
+}
+
+type MCPAccessTarget struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	Backend              string          `json:"backend"`
+	Visibility           string          `json:"visibility"`
+	AuthorizationMode    string          `json:"authorization_mode"`
+	AuthorizationSurface string          `json:"authorization_surface"`
+	AccessSummary        string          `json:"access_summary"`
+	ToolCatalog          string          `json:"tool_catalog"`
+	Tools                []MCPAccessTool `json:"tools"`
+	ToolsTruncated       bool            `json:"tools_truncated"`
+}
+
+type MCPRoleCoverage struct {
+	Name                string       `json:"name"`
+	Type                string       `json:"type"`
+	MemberCount         SubjectCount `json:"member_count"`
+	Reference           string       `json:"reference"`
+	CanEnterServer      bool         `json:"can_enter_server"`
+	KnownToolAccess     string       `json:"known_tool_access"`
+	AllowedKnownTools   []string     `json:"allowed_known_tools"`
+	DispositionRules    []string     `json:"disposition_rules"`
+	BlockedDispositions []string     `json:"blocked_dispositions"`
+	UnevaluatedGrants   bool         `json:"unevaluated_grants"`
+}
+
+type GetMCPAccessInput struct {
+	ProjectID string `json:"project_id" jsonschema:"project ID that owns the configured MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp"`
+}
+
+type GetMCPAccessOutput struct {
+	ProjectID string            `json:"project_id"`
+	MCP       MCPAccessTarget   `json:"mcp"`
+	Roles     []MCPRoleCoverage `json:"roles"`
+	ExpiresAt string            `json:"expires_at"`
+}
+
+// AccessReadService projects the access service's local role/member authority
+// into privacy-safe Platform MCP reads. It never contacts WorkOS or a configured
+// MCP and never accepts raw role, member, principal, or grant identifiers.
+type AccessReadService struct {
+	logger     *slog.Logger
+	db         *pgxpool.Pool
+	roles      *access.RoleManager
+	budget     OperationBudget
+	references *subjectReferenceCodec
+	now        func() time.Time
+}
+
+func NewAccessReadService(logger *slog.Logger, db *pgxpool.Pool, budget OperationBudget, keyMaterial string) *AccessReadService {
+	if logger == nil {
+		return &AccessReadService{logger: nil, db: nil, roles: nil, budget: OperationBudget{Connection: nil, Organization: nil}, references: nil, now: nil}
+	}
+	references, err := newSubjectReferenceCodec(keyMaterial)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "build Platform MCP access reference codec", attr.SlogError(err))
+	}
+	return &AccessReadService{
+		logger:     logger,
+		db:         db,
+		roles:      access.NewRoleManager(logger, db, nil, nil),
+		budget:     budget,
+		references: references,
+		now:        time.Now,
+	}
+}
+
+func (s *AccessReadService) valid() bool {
+	return s != nil && s.db != nil && s.roles != nil && s.budget.valid() && s.references != nil && s.now != nil
+}
+
+func (s *AccessReadService) ListRoles(ctx context.Context, principal Principal) (ListAccessRolesOutput, error) {
+	if !s.valid() {
+		return ListAccessRolesOutput{}, ErrUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ListAccessRolesOutput{}, err
+	}
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessRolesOutput{}, fmt.Errorf("list platform mcp access roles: %w", err)
+	}
+	now := s.now().UTC()
+	output := ListAccessRolesOutput{
+		Roles:     make([]AccessRole, 0, len(roles.Roles)),
+		ExpiresAt: now.Add(SubjectReferenceTTL).Format(time.RFC3339),
+	}
+	for _, role := range roles.Roles {
+		reference, err := s.references.Encode(principal, subjectKindAccessRole, role.ID, now)
+		if err != nil {
+			return ListAccessRolesOutput{}, fmt.Errorf("issue access role reference: %w", err)
+		}
+		output.Roles = append(output.Roles, AccessRole{
+			Name:        role.Name,
+			Type:        accessRoleType(role),
+			MemberCount: NewSubjectCount(int64(role.MemberCount)),
+			MCPAccess:   summarizeMCPConnect(role.Grants),
+			Reference:   reference,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) ListMembers(ctx context.Context, principal Principal, input ListAccessMembersInput) (ListAccessMembersOutput, error) {
+	if !s.valid() {
+		return ListAccessMembersOutput{}, ErrUnavailable
+	}
+	query := normalizeAccessQuery(input.Query)
+	if input.RoleReference == "" && len([]rune(query)) < minAccessQueryLength {
+		return ListAccessMembersOutput{}, ErrAccessQueryRequired
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ListAccessMembersOutput{}, err
+	}
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("list roles for platform mcp members: %w", err)
+	}
+	roleNames := make(map[string]string, len(roles.Roles))
+	for _, role := range roles.Roles {
+		roleNames[role.ID] = role.Name
+	}
+
+	roleID := ""
+	if input.RoleReference != "" {
+		roleID, err = s.references.Decode(input.RoleReference, principal, subjectKindAccessRole, s.now())
+		if err != nil {
+			return ListAccessMembersOutput{}, ErrAccessReferenceNotFound
+		}
+		if _, ok := roleNames[roleID]; !ok {
+			return ListAccessMembersOutput{}, ErrAccessReferenceNotFound
+		}
+	}
+
+	members, err := s.roles.ListMembers(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("list platform mcp access members: %w", err)
+	}
+	matching := make([]*accessgen.AccessMember, 0, len(members.Members))
+	for _, member := range members.Members {
+		if roleID != "" && !slices.Contains(member.RoleIds, roleID) {
+			continue
+		}
+		if query != "" && !matchesAccessMember(member, query, roleNames) {
+			continue
+		}
+		matching = append(matching, member)
+	}
+
+	count := len(matching)
+	output := ListAccessMembersOutput{
+		Members:      []AccessMember{},
+		TotalMatches: NewSubjectCount(int64(count)),
+		Suppressed:   count > 0 && count < SubjectSuppressionThreshold,
+		Truncated:    false,
+		ExpiresAt:    "",
+	}
+	// Organization-privacy rules do not allow a row-bearing response to reveal
+	// a filtered cohort smaller than five. Return only the suppressed count.
+	if output.Suppressed || count == 0 {
+		return output, nil
+	}
+
+	limit := maxAccessMembers
+	if input.Limit > 0 {
+		limit = min(input.Limit, maxAccessMembers)
+	}
+	if len(matching) > limit {
+		matching = matching[:limit]
+		output.Truncated = true
+	}
+	now := s.now().UTC()
+	output.ExpiresAt = now.Add(SubjectReferenceTTL).Format(time.RFC3339)
+	for _, member := range matching {
+		reference, err := s.references.Encode(principal, subjectKindAccessMember, member.ID, now)
+		if err != nil {
+			return ListAccessMembersOutput{}, fmt.Errorf("issue access member reference: %w", err)
+		}
+		names := make([]string, 0, len(member.RoleIds))
+		for _, id := range member.RoleIds {
+			if name := roleNames[id]; name != "" {
+				names = append(names, name)
+			}
+		}
+		slices.Sort(names)
+		output.Members = append(output.Members, AccessMember{
+			MaskedIdentity: maskAccessMember(member),
+			Roles:          slices.Compact(names),
+			Reference:      reference,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) GetMCPAccess(ctx context.Context, principal Principal, input GetMCPAccessInput) (GetMCPAccessOutput, error) {
+	if !s.valid() {
+		return GetMCPAccessOutput{}, ErrUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return GetMCPAccessOutput{}, err
+	}
+	projectID, err := uuid.Parse(input.ProjectID)
+	if err != nil {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	mcpID, err := uuid.Parse(input.MCPID)
+	if err != nil {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	row, err := platformrepo.New(s.db).GetPlatformMCPInventoryItem(ctx, platformrepo.GetPlatformMCPInventoryItemParams{
+		OrganizationID:       principal.OrganizationID,
+		ConnectionID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ConnectionGeneration: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		UserID:               inventoryText(principal.UserID),
+		ActingSurface:        inventoryText(string(principal.surface())),
+		McpServerID:          mcpID,
+		ProjectID:            projectID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	if err != nil {
+		return GetMCPAccessOutput{}, fmt.Errorf("get platform mcp access target: %w", err)
+	}
+
+	tools, catalog, truncated, err := s.accessTools(ctx, row)
+	if err != nil {
+		return GetMCPAccessOutput{}, err
+	}
+	name := row.McpName.String
+	if name == "" {
+		name = row.McpSlug.String
+	}
+	if name == "" {
+		name = row.McpServerID.String()
+	}
+	target := MCPAccessTarget{
+		ID:                   row.McpServerID.String(),
+		Name:                 name,
+		Backend:              accessBackend(row),
+		Visibility:           row.Visibility,
+		AuthorizationMode:    accessAuthorizationMode(row),
+		AuthorizationSurface: "configured_endpoint",
+		AccessSummary:        accessSummary(row),
+		ToolCatalog:          catalog,
+		Tools:                tools,
+		ToolsTruncated:       truncated,
+	}
+
+	if target.AuthorizationMode != "rbac" {
+		return GetMCPAccessOutput{
+			ProjectID: projectID.String(),
+			MCP:       target,
+			Roles:     []MCPRoleCoverage{},
+			ExpiresAt: "",
+		}, nil
+	}
+
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return GetMCPAccessOutput{}, fmt.Errorf("list roles for platform mcp access: %w", err)
+	}
+	now := s.now().UTC()
+	output := GetMCPAccessOutput{
+		ProjectID: projectID.String(),
+		MCP:       target,
+		Roles:     make([]MCPRoleCoverage, 0, len(roles.Roles)),
+		ExpiresAt: now.Add(SubjectReferenceTTL).Format(time.RFC3339),
+	}
+	for _, role := range roles.Roles {
+		grants, unevaluated := roleAuthzGrants(role)
+		serverCheck := authz.MCPCheck(authz.ScopeMCPConnect, row.McpServerID.String(), projectID.String())
+		canEnter, err := authz.GrantsAuthorize(grants, serverCheck)
+		if err != nil {
+			return GetMCPAccessOutput{}, fmt.Errorf("evaluate server access for role %q: %w", role.Name, err)
+		}
+		allowedTools := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			allowed, err := authz.GrantsAuthorize(grants, authz.MCPToolCallCheck(row.McpServerID.String(), authz.MCPToolCallDimensions{
+				Tool: tool.Name, Disposition: tool.Disposition, ProjectID: projectID.String(),
+			}))
+			if err != nil {
+				return GetMCPAccessOutput{}, fmt.Errorf("evaluate tool access for role %q: %w", role.Name, err)
+			}
+			if allowed {
+				allowedTools = append(allowedTools, tool.Name)
+			}
+		}
+		dispositions, blockedDispositions := matchingDispositionRules(role.Grants, row.McpServerID.String(), projectID.String())
+		if !canEnter && len(allowedTools) == 0 && len(dispositions) == 0 && len(blockedDispositions) == 0 && !unevaluated {
+			continue
+		}
+		reference, err := s.references.Encode(principal, subjectKindAccessRole, role.ID, now)
+		if err != nil {
+			return GetMCPAccessOutput{}, fmt.Errorf("issue MCP access role reference: %w", err)
+		}
+		output.Roles = append(output.Roles, MCPRoleCoverage{
+			Name:                role.Name,
+			Type:                accessRoleType(role),
+			MemberCount:         NewSubjectCount(int64(role.MemberCount)),
+			Reference:           reference,
+			CanEnterServer:      canEnter,
+			KnownToolAccess:     knownToolAccess(len(allowedTools), len(tools), catalog, truncated),
+			AllowedKnownTools:   allowedTools,
+			DispositionRules:    dispositions,
+			BlockedDispositions: blockedDispositions,
+			UnevaluatedGrants:   unevaluated,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) accessTools(ctx context.Context, row platformrepo.GetPlatformMCPInventoryItemRow) ([]MCPAccessTool, string, bool, error) {
+	var tools []MCPAccessTool
+	catalog := "dynamic"
+	switch {
+	case row.ToolsetID.Valid:
+		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{ID: row.ToolsetID.UUID, ProjectID: row.ProjectID})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("get hosted MCP toolset: %w", err)
+		}
+		entries, err := mv.DescribeToolsetEntries(ctx, s.logger, s.db, mv.ProjectID(row.ProjectID), []toolsetsrepo.Toolset{toolset})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("describe hosted MCP tools: %w", err)
+		}
+		catalog = "authoritative"
+		if len(entries) > 0 {
+			for _, tool := range entries[0].Tools {
+				if tool == nil || tool.Name == "" {
+					continue
+				}
+				tools = append(tools, MCPAccessTool{Name: tool.Name, Disposition: conv.DispositionFromAnnotations(tool.Annotations)})
+			}
+		}
+	case row.RemoteMcpServerID.Valid || row.TunneledMcpServerID.Valid:
+		rows, err := mcpserversrepo.New(s.db).ListMCPServerToolMetadata(ctx, mcpserversrepo.ListMCPServerToolMetadataParams{
+			McpServerID: row.McpServerID, ProjectID: row.ProjectID, IncludeDeleted: false,
+		})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("list configured MCP tool metadata: %w", err)
+		}
+		if len(rows) > 0 {
+			catalog = "stored_metadata"
+		}
+		for _, tool := range rows {
+			tools = append(tools, MCPAccessTool{
+				Name: tool.ToolName,
+				Disposition: conv.DispositionFromAnnotations(conv.AnnotationsFromColumns(
+					tool.ReadOnlyHint, tool.DestructiveHint, tool.IdempotentHint, tool.OpenWorldHint,
+				)),
+			})
+		}
+	case row.UnproxiedMcpServerID.Valid:
+		catalog = "unavailable"
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Name == tools[j].Name {
+			return tools[i].Disposition < tools[j].Disposition
+		}
+		return tools[i].Name < tools[j].Name
+	})
+	tools = omitAmbiguousAccessTools(tools)
+	truncated := len(tools) > maxAccessTools
+	if truncated {
+		tools = tools[:maxAccessTools]
+	}
+	return tools, catalog, truncated, nil
+}
+
+func accessRoleType(role *accessgen.Role) string {
+	if role.IsSystem {
+		return "system"
+	}
+	return "custom"
+}
+
+func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
+	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
+	dispositions := map[string]struct{}{}
+	blockedDispositions := map[string]struct{}{}
+	for _, grant := range grants {
+		if grant == nil || (!scopeMayAllowConnect(grant.Scope) && !scopeMayBlockConnect(grant.Scope)) {
+			continue
+		}
+		blocked := scopeMayBlockConnect(grant.Scope)
+		if grant.Scope == string(authz.ScopeRoot) || grant.Selectors == nil {
+			if blocked {
+				summary.BlockedServers = true
+			} else {
+				summary.AllServers = true
+			}
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil {
+				continue
+			}
+			if selector.ProjectID != nil && !blocked {
+				summary.ProjectRules++
+			}
+			if selector.ResourceID != authz.WildcardResource && !blocked {
+				summary.ServerRules++
+			}
+			if selector.Tool != nil {
+				if blocked {
+					summary.BlockedToolRules++
+				} else {
+					summary.ToolRules++
+				}
+			}
+			if selector.Disposition != nil && *selector.Disposition != "" {
+				if blocked {
+					blockedDispositions[*selector.Disposition] = struct{}{}
+				} else {
+					dispositions[*selector.Disposition] = struct{}{}
+				}
+			}
+			if selector.ResourceID == authz.WildcardResource && selector.ProjectID == nil && selector.Tool == nil && selector.Disposition == nil {
+				if blocked {
+					summary.BlockedServers = true
+				} else {
+					summary.AllServers = true
+				}
+			}
+		}
+	}
+	for disposition := range dispositions {
+		summary.DispositionRules = append(summary.DispositionRules, disposition)
+	}
+	for disposition := range blockedDispositions {
+		summary.BlockedDispositionRules = append(summary.BlockedDispositionRules, disposition)
+	}
+	slices.Sort(summary.DispositionRules)
+	slices.Sort(summary.BlockedDispositionRules)
+	return summary
+}
+
+func roleAuthzGrants(role *accessgen.Role) ([]authz.Grant, bool) {
+	grants := make([]authz.Grant, 0)
+	if role == nil {
+		return grants, false
+	}
+	unevaluated := false
+	for _, grant := range role.Grants {
+		if grant == nil {
+			continue
+		}
+		scope := authz.Scope(grant.Scope)
+		if grant.Selectors == nil {
+			grants = append(grants, authz.Grant{PrincipalUrn: role.PrincipalUrn, Scope: scope, Selector: authz.NewSelector(scope, authz.WildcardResource)})
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil {
+				continue
+			}
+			converted := authz.Selector{
+				authz.SelectorKeyResourceKind: selector.ResourceKind,
+				authz.SelectorKeyResourceID:   selector.ResourceID,
+			}
+			if selector.ProjectID != nil {
+				converted[authz.SelectorKeyProjectID] = *selector.ProjectID
+			}
+			if selector.Tool != nil {
+				converted[authz.SelectorKeyTool] = *selector.Tool
+			}
+			if selector.Disposition != nil {
+				converted[authz.SelectorKeyDisposition] = *selector.Disposition
+			}
+			if err := authz.ValidateSelector(scope, converted); err != nil {
+				unevaluated = true
+				continue
+			}
+			grants = append(grants, authz.Grant{PrincipalUrn: role.PrincipalUrn, Scope: scope, Selector: converted})
+		}
+	}
+	return grants, unevaluated
+}
+
+func matchingDispositionRules(grants []*accessgen.RoleGrant, mcpID, projectID string) ([]string, []string) {
+	found := map[string]struct{}{}
+	blocked := map[string]struct{}{}
+	for _, grant := range grants {
+		if grant == nil || (!scopeMayAllowConnect(grant.Scope) && !scopeMayBlockConnect(grant.Scope)) {
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil || selector.Disposition == nil || *selector.Disposition == "" {
+				continue
+			}
+			if selector.ResourceID != authz.WildcardResource && selector.ResourceID != mcpID {
+				continue
+			}
+			if selector.ProjectID != nil && *selector.ProjectID != authz.WildcardResource && *selector.ProjectID != projectID {
+				continue
+			}
+			if scopeMayBlockConnect(grant.Scope) {
+				blocked[*selector.Disposition] = struct{}{}
+			} else {
+				found[*selector.Disposition] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(found))
+	for value := range found {
+		out = append(out, value)
+	}
+	blockedOut := make([]string, 0, len(blocked))
+	for value := range blocked {
+		blockedOut = append(blockedOut, value)
+	}
+	slices.Sort(out)
+	slices.Sort(blockedOut)
+	return out, blockedOut
+}
+
+func scopeMayAllowConnect(scope string) bool {
+	switch authz.Scope(scope) {
+	case authz.ScopeRoot, authz.ScopeMCPConnect, authz.ScopeMCPRead, authz.ScopeMCPWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+func scopeMayBlockConnect(scope string) bool {
+	switch authz.Scope(scope) {
+	case authz.ScopeMCPBlockedConnect, authz.ScopeMCPBlockedRead, authz.ScopeMCPBlockedWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+func omitAmbiguousAccessTools(tools []MCPAccessTool) []MCPAccessTool {
+	result := make([]MCPAccessTool, 0, len(tools))
+	for start := 0; start < len(tools); {
+		end := start + 1
+		for end < len(tools) && tools[end].Name == tools[start].Name {
+			end++
+		}
+		if end-start == 1 {
+			result = append(result, tools[start])
+		}
+		start = end
+	}
+	return result
+}
+
+func accessBackend(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	switch {
+	case row.RemoteMcpServerID.Valid:
+		return "remote"
+	case row.TunneledMcpServerID.Valid:
+		return "tunneled"
+	case row.ToolsetID.Valid:
+		return "hosted"
+	case row.UnproxiedMcpServerID.Valid:
+		return "unproxied"
+	default:
+		return "legacy"
+	}
+}
+
+func accessAuthorizationMode(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	if row.Visibility == "disabled" {
+		return "disabled"
+	}
+	if row.Visibility == "public" {
+		return "public_bypass"
+	}
+	if row.UnproxiedMcpServerID.Valid {
+		return "not_served"
+	}
+	return "rbac"
+}
+
+func accessSummary(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	switch accessAuthorizationMode(row) {
+	case "public_bypass":
+		return "everyone"
+	case "disabled", "not_served":
+		return "nobody"
+	default:
+		return "by_role"
+	}
+}
+
+func knownToolAccess(allowed, total int, catalog string, truncated bool) string {
+	if total == 0 {
+		if catalog == "dynamic" || catalog == "unavailable" {
+			return "not_enumerable"
+		}
+		return "none"
+	}
+	switch allowed {
+	case 0:
+		return "none"
+	case total:
+		if truncated {
+			return "some_known_tools"
+		}
+		return "all"
+	default:
+		return "some"
+	}
+}
+
+func normalizeAccessQuery(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(value), " "))
+}
+
+func matchesAccessMember(member *accessgen.AccessMember, query string, roleNames map[string]string) bool {
+	if strings.Contains(normalizeAccessQuery(member.Name), query) || strings.Contains(normalizeAccessQuery(member.Email), query) {
+		return true
+	}
+	for _, roleID := range member.RoleIds {
+		if strings.Contains(normalizeAccessQuery(roleNames[roleID]), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func maskAccessMember(member *accessgen.AccessMember) string {
+	if member == nil {
+		return ""
+	}
+	if member.Email != "" {
+		return maskSubject(member.Email)
+	}
+	return maskSubject(member.Name)
+}

--- a/server/internal/platformmcp/access_reads_integration_test.go
+++ b/server/internal/platformmcp/access_reads_integration_test.go
@@ -1,0 +1,130 @@
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_access_members")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	service := NewAccessReadService(testenv.NewLogger(t), conn, allowBudget(), "access-read-key")
+
+	_, err = service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "o"})
+	require.ErrorIs(t, err, ErrAccessQueryRequired)
+
+	for i := range 5 {
+		seedAccessMember(t, ctx, conn, principal.OrganizationID, fmt.Sprintf("member-%d", i), fmt.Sprintf("operator%d@example.test", i))
+	}
+
+	small, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator0"})
+	require.NoError(t, err)
+	require.True(t, small.Suppressed)
+	require.Empty(t, small.Members)
+	require.Empty(t, small.ExpiresAt)
+
+	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator"})
+	require.NoError(t, err)
+	require.False(t, large.Suppressed)
+	require.Len(t, large.Members, 5)
+	for _, member := range large.Members {
+		require.NotContains(t, member.MaskedIdentity, "example.test")
+		require.NotEmpty(t, member.Reference)
+		decoded, err := service.references.Decode(member.Reference, principal, subjectKindAccessMember, service.now())
+		require.NoError(t, err)
+		require.NotEmpty(t, decoded)
+	}
+}
+
+func TestGetMCPAccessUsesFrontingServerIDAndStoredToolMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_access_target")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	service := NewAccessReadService(testenv.NewLogger(t), conn, allowBudget(), "access-read-key")
+
+	// seedRegistrationLifecycle creates a remote cohort server; select it through
+	// the same tenant-qualified inventory query the service uses.
+	rows, err := platformrepo.New(conn).ListPlatformMCPInventory(ctx, platformrepo.ListPlatformMCPInventoryParams{
+		OrganizationID: principal.OrganizationID, ConnectionID: uuid.NullUUID{}, ConnectionGeneration: uuid.NullUUID{},
+		UserID: inventoryText(principal.UserID), ActingSurface: inventoryText(string(principal.surface())),
+		ProjectID: uuid.NullUUID{UUID: project.ID, Valid: true}, AfterMcpID: uuid.NullUUID{}, QueryText: "", ReadinessState: pgtype.Text{}, LimitValue: 10,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	target := rows[0]
+
+	_, err = mcpserversrepo.New(conn).AddMCPServerToolMetadata(ctx, mcpserversrepo.AddMCPServerToolMetadataParams{
+		ProjectID: target.ProjectID, McpServerID: target.McpServerID,
+		Tools: []byte(`[{"tool_name":"list_tasks","read_only_hint":true}]`),
+	})
+	require.NoError(t, err)
+
+	role := seedAccessRole(t, ctx, conn, principal.OrganizationID, "operators", "Operators")
+	selector := authz.NewSelector(authz.ScopeMCPConnect, target.McpServerID.String())
+	selector[authz.SelectorKeyTool] = "list_tasks"
+	selectorBytes, err := selector.MarshalJSON()
+	require.NoError(t, err)
+	_, err = accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: principal.OrganizationID, PrincipalUrn: role, Scope: string(authz.ScopeMCPConnect), Selectors: selectorBytes,
+	})
+	require.NoError(t, err)
+
+	output, err := service.GetMCPAccess(ctx, principal, GetMCPAccessInput{ProjectID: project.ID.String(), MCPID: target.McpServerID.String()})
+	require.NoError(t, err)
+	require.Equal(t, "remote", output.MCP.Backend)
+	require.Equal(t, "stored_metadata", output.MCP.ToolCatalog)
+	require.Equal(t, []MCPAccessTool{{Name: "list_tasks", Disposition: "read_only"}}, output.MCP.Tools)
+	require.Len(t, output.Roles, 1)
+	require.Equal(t, "Operators", output.Roles[0].Name)
+	require.True(t, output.Roles[0].CanEnterServer)
+	require.Equal(t, "all", output.Roles[0].KnownToolAccess)
+	require.Equal(t, []string{"list_tasks"}, output.Roles[0].AllowedKnownTools)
+}
+
+func seedAccessMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, userID, email string) {
+	t.Helper()
+	_, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{ID: userID, Email: email, DisplayName: userID, PhotoUrl: pgtype.Text{}, Admin: false})
+	require.NoError(t, err)
+	workosUserID := "workos-" + userID
+	require.NoError(t, usersrepo.New(conn).OverwriteUserWorkosID(ctx, usersrepo.OverwriteUserWorkosIDParams{WorkosID: conv.ToPGText(workosUserID), ID: userID}))
+	require.NoError(t, orgrepo.New(conn).AttachWorkOSUserToOrg(ctx, orgrepo.AttachWorkOSUserToOrgParams{
+		OrganizationID: organizationID, UserID: conv.ToPGText(userID), WorkosMembershipID: conv.PtrToPGText(conv.PtrEmpty("membership-" + userID)),
+	}))
+}
+
+func seedAccessRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug, name string) urn.Principal {
+	t.Helper()
+	now := time.Now().UTC()
+	row, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID: organizationID, WorkosSlug: slug, WorkosName: name, WorkosDescription: pgtype.Text{},
+		WorkosCreatedAt: conv.ToPGTimestamptz(now), WorkosUpdatedAt: conv.ToPGTimestamptz(now), WorkosLastEventID: pgtype.Text{},
+	})
+	require.NoError(t, err)
+	principal, err := urn.ParsePrincipal(row.RoleUrn)
+	require.NoError(t, err)
+	return principal
+}

--- a/server/internal/platformmcp/access_reads_integration_test.go
+++ b/server/internal/platformmcp/access_reads_integration_test.go
@@ -3,6 +3,7 @@ package platformmcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,8 +35,16 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 	_, err = service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "o"})
 	require.ErrorIs(t, err, ErrAccessQueryRequired)
 
+	seedAccessRole(t, ctx, conn, principal.OrganizationID, "operators", "Operators")
 	for i := range 5 {
-		seedAccessMember(t, ctx, conn, principal.OrganizationID, fmt.Sprintf("member-%d", i), fmt.Sprintf("operator%d@example.test", i))
+		userID := fmt.Sprintf("member-%d", i)
+		seedAccessMember(t, ctx, conn, principal.OrganizationID, userID, fmt.Sprintf("operator%d@example.test", i))
+		_, err = accessrepo.New(conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+			OrganizationID: principal.OrganizationID, WorkosUserID: "workos-" + userID, UserID: conv.ToPGText(userID),
+			WorkosMembershipID: conv.ToPGText("membership-" + userID), WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+			WorkosLastEventID: conv.ToPGTextEmpty(""), WorkosRoleSlug: "operators",
+		})
+		require.NoError(t, err)
 	}
 
 	small, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator0"})
@@ -44,10 +53,12 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 	require.Empty(t, small.Members)
 	require.Empty(t, small.ExpiresAt)
 
-	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator"})
+	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator", Limit: 2})
 	require.NoError(t, err)
 	require.False(t, large.Suppressed)
-	require.Len(t, large.Members, 5)
+	require.Equal(t, NewSubjectCount(5), large.TotalMatches)
+	require.True(t, large.Truncated)
+	require.Len(t, large.Members, 2)
 	for _, member := range large.Members {
 		require.NotContains(t, member.MaskedIdentity, "example.test")
 		require.NotEmpty(t, member.Reference)
@@ -55,6 +66,27 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 		require.NoError(t, err)
 		require.NotEmpty(t, decoded)
 	}
+
+	roles, err := service.ListRoles(ctx, principal)
+	require.NoError(t, err)
+	var roleReference string
+	for _, candidate := range roles.Roles {
+		if candidate.Name == "Operators" {
+			roleReference = candidate.Reference
+		}
+	}
+	require.NotEmpty(t, roleReference)
+	byRole, err := service.ListMembers(ctx, principal, ListAccessMembersInput{RoleReference: roleReference})
+	require.NoError(t, err)
+	require.Equal(t, NewSubjectCount(5), byRole.TotalMatches)
+	require.Len(t, byRole.Members, 5)
+	for _, member := range byRole.Members {
+		require.Equal(t, []string{"Operators"}, member.Roles)
+	}
+
+	byRoleName, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: strings.ToUpper("Operators")})
+	require.NoError(t, err)
+	require.Equal(t, NewSubjectCount(5), byRoleName.TotalMatches)
 }
 
 func TestGetMCPAccessUsesFrontingServerIDAndStoredToolMetadata(t *testing.T) {

--- a/server/internal/platformmcp/access_reads_test.go
+++ b/server/internal/platformmcp/access_reads_test.go
@@ -18,10 +18,10 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 
 	roles := ListAccessRolesOutput{Roles: []AccessRole{{
 		Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7),
-		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
+		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedProjectRules: 1, BlockedServerRules: 1, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
 		Reference: "opaque-role",
 	}}, ExpiresAt: "2026-09-04T12:10:00Z"}
-	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
+	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_project_rules", "blocked_server_rules", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
 
 	members := ListAccessMembersOutput{
 		Members:      []AccessMember{{MaskedIdentity: "a***@e***", Roles: []string{"Operators"}, Reference: "opaque-member"}},
@@ -47,17 +47,6 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 	}
 }
 
-func TestAccessMemberFiltersAndMasks(t *testing.T) {
-	t.Parallel()
-
-	roleNames := map[string]string{"role-a": "Operators"}
-	member := &accessgen.AccessMember{ID: "user-internal", PrincipalUrn: "user:user-internal", Name: "Ada Lovelace", Email: "ada@example.test", RoleIds: []string{"role-a"}}
-	require.True(t, matchesAccessMember(member, "ada", roleNames))
-	require.True(t, matchesAccessMember(member, "operators", roleNames))
-	require.False(t, matchesAccessMember(member, "finance", roleNames))
-	require.Equal(t, "a**@e***", maskAccessMember(member))
-}
-
 func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
 	t.Parallel()
 
@@ -79,6 +68,11 @@ func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
 	require.False(t, summary.BlockedServers)
 	require.Equal(t, 1, summary.BlockedToolRules)
 	require.Equal(t, []string{"destructive"}, summary.BlockedDispositionRules)
+
+	project = uuid.NewString()
+	summary = summarizeMCPConnect([]*accessgen.RoleGrant{{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, ProjectID: &project}}}})
+	require.Equal(t, 1, summary.BlockedProjectRules)
+	require.Equal(t, 1, summary.BlockedServerRules)
 }
 
 func TestRoleAuthzGrantsUseEffectiveExclusions(t *testing.T) {
@@ -108,6 +102,8 @@ func TestAccessSummaryAndKnownToolCoverageCannotOverclaim(t *testing.T) {
 	require.Equal(t, "everyone", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public"}))
 	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "disabled"}))
 	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "future_value"}))
 	require.Equal(t, "by_role", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private"}))
 
 	require.Equal(t, "all", knownToolAccess(2, 2, "authoritative", false))

--- a/server/internal/platformmcp/access_reads_test.go
+++ b/server/internal/platformmcp/access_reads_test.go
@@ -1,0 +1,161 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	roles := ListAccessRolesOutput{Roles: []AccessRole{{
+		Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7),
+		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
+		Reference: "opaque-role",
+	}}, ExpiresAt: "2026-09-04T12:10:00Z"}
+	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
+
+	members := ListAccessMembersOutput{
+		Members:      []AccessMember{{MaskedIdentity: "a***@e***", Roles: []string{"Operators"}, Reference: "opaque-member"}},
+		TotalMatches: NewSubjectCount(7), Suppressed: false, Truncated: false, ExpiresAt: "2026-09-04T12:10:00Z",
+	}
+	require.ElementsMatch(t, []string{"members", "masked_identity", "roles", "reference", "total_matches", "suppressed", "truncated", "expires_at"}, decodeKeys(t, members))
+
+	access := GetMCPAccessOutput{
+		ProjectID: uuid.NewString(),
+		MCP:       MCPAccessTarget{ID: uuid.NewString(), Name: "Tasks", Backend: "remote", Visibility: "private", AuthorizationMode: "rbac", AuthorizationSurface: "configured_endpoint", AccessSummary: "by_role", ToolCatalog: "stored_metadata", Tools: []MCPAccessTool{{Name: "list_tasks", Disposition: "read_only"}}},
+		Roles:     []MCPRoleCoverage{{Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7), Reference: "opaque-role", CanEnterServer: true, KnownToolAccess: "all", AllowedKnownTools: []string{"list_tasks"}, DispositionRules: []string{"read_only"}, BlockedDispositions: []string{}, UnevaluatedGrants: false}},
+		ExpiresAt: "2026-09-04T12:10:00Z",
+	}
+	keys := decodeKeys(t, access)
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp", "id", "name", "backend", "visibility", "authorization_mode", "authorization_surface", "access_summary", "tool_catalog", "tools", "name", "tools_truncated", "disposition",
+		"roles", "name", "type", "member_count", "reference", "can_enter_server", "known_tool_access", "allowed_known_tools", "disposition_rules", "blocked_dispositions", "unevaluated_grants", "expires_at",
+	}, keys)
+	encoded, err := json.Marshal(access)
+	require.NoError(t, err)
+	for _, forbidden := range []string{"principal_urn", "user_id", "role_id", "email", "selector", "resource_id"} {
+		require.NotContains(t, string(encoded), forbidden)
+	}
+}
+
+func TestAccessMemberFiltersAndMasks(t *testing.T) {
+	t.Parallel()
+
+	roleNames := map[string]string{"role-a": "Operators"}
+	member := &accessgen.AccessMember{ID: "user-internal", PrincipalUrn: "user:user-internal", Name: "Ada Lovelace", Email: "ada@example.test", RoleIds: []string{"role-a"}}
+	require.True(t, matchesAccessMember(member, "ada", roleNames))
+	require.True(t, matchesAccessMember(member, "operators", roleNames))
+	require.False(t, matchesAccessMember(member, "finance", roleNames))
+	require.Equal(t, "a**@e***", maskAccessMember(member))
+}
+
+func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
+	t.Parallel()
+
+	readOnly := "read_only"
+	project := uuid.NewString()
+	server := uuid.NewString()
+	summary := summarizeMCPConnect([]*accessgen.RoleGrant{
+		{Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, Tool: new("list_tasks")}}},
+		{Scope: string(authz.ScopeMCPRead), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: authz.WildcardResource, ProjectID: &project, Disposition: &readOnly}}},
+	})
+	require.False(t, summary.AllServers)
+	require.Equal(t, 1, summary.ProjectRules)
+	require.Equal(t, 1, summary.ServerRules)
+	require.Equal(t, 1, summary.ToolRules)
+	require.Equal(t, []string{"read_only"}, summary.DispositionRules)
+
+	blocked := "destructive"
+	summary = summarizeMCPConnect([]*accessgen.RoleGrant{{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: authz.WildcardResource, Tool: new("delete_tasks"), Disposition: &blocked}}}})
+	require.False(t, summary.BlockedServers)
+	require.Equal(t, 1, summary.BlockedToolRules)
+	require.Equal(t, []string{"destructive"}, summary.BlockedDispositionRules)
+}
+
+func TestRoleAuthzGrantsUseEffectiveExclusions(t *testing.T) {
+	t.Parallel()
+
+	server := uuid.NewString()
+	tool := "delete_tasks"
+	role := &accessgen.Role{PrincipalUrn: "role:organization:" + uuid.NewString(), Grants: []*accessgen.RoleGrant{
+		{Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server}}},
+		{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, Tool: &tool}}},
+	}}
+	grants, unevaluated := roleAuthzGrants(role)
+	require.False(t, unevaluated)
+
+	serverAllowed, err := authz.GrantsAuthorize(grants, authz.MCPCheck(authz.ScopeMCPConnect, server, uuid.NewString()))
+	require.NoError(t, err)
+	require.True(t, serverAllowed, "a tool-specific exclusion does not block the server-level check")
+
+	toolAllowed, err := authz.GrantsAuthorize(grants, authz.MCPToolCallCheck(server, authz.MCPToolCallDimensions{Tool: tool}))
+	require.NoError(t, err)
+	require.False(t, toolAllowed)
+}
+
+func TestAccessSummaryAndKnownToolCoverageCannotOverclaim(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "everyone", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public"}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "disabled"}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "by_role", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private"}))
+
+	require.Equal(t, "all", knownToolAccess(2, 2, "authoritative", false))
+	require.Equal(t, "some_known_tools", knownToolAccess(100, 100, "authoritative", true))
+	require.Equal(t, "not_enumerable", knownToolAccess(0, 0, "dynamic", false))
+}
+
+func TestAmbiguousAccessToolsAreOmitted(t *testing.T) {
+	t.Parallel()
+
+	tools := omitAmbiguousAccessTools([]MCPAccessTool{
+		{Name: "alpha", Disposition: "read_only"},
+		{Name: "shared", Disposition: "destructive"},
+		{Name: "shared", Disposition: "read_only"},
+		{Name: "zeta", Disposition: ""},
+	})
+	require.Equal(t, []MCPAccessTool{{Name: "alpha", Disposition: "read_only"}, {Name: "zeta", Disposition: ""}}, tools)
+}
+
+func TestRoleAuthzGrantsSkipsLegacyMalformedSelectors(t *testing.T) {
+	t.Parallel()
+
+	role := &accessgen.Role{PrincipalUrn: "role:organization:" + uuid.NewString(), Grants: []*accessgen.RoleGrant{{
+		Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "project", ResourceID: uuid.NewString()}},
+	}}}
+	grants, unevaluated := roleAuthzGrants(role)
+	require.True(t, unevaluated)
+	require.Empty(t, grants)
+}
+
+func TestAccessReferencesAreBoundByKindPrincipalAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("access-read-test-key")
+	require.NoError(t, err)
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	principal := Principal{UserID: "user-a", OrganizationID: "org-a", ConnectionID: "connection-a", Generation: "generation-a"}
+	reference, err := codec.Encode(principal, subjectKindAccessMember, "internal-user-id", now)
+	require.NoError(t, err)
+	require.NotContains(t, reference, "internal-user-id")
+
+	value, err := codec.Decode(reference, principal, subjectKindAccessMember, now)
+	require.NoError(t, err)
+	require.Equal(t, "internal-user-id", value)
+	_, err = codec.Decode(reference, principal, subjectKindAccessRole, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.Decode(reference, Principal{UserID: "user-b", OrganizationID: "org-a", ConnectionID: "connection-b", Generation: "generation-b"}, subjectKindAccessMember, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.Decode(reference, principal, subjectKindAccessMember, now.Add(SubjectReferenceTTL))
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -280,5 +280,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Plugins.valid() && b.AccessReads.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -207,6 +207,9 @@ type OperationBudgets struct {
 	// an administrator walking the inventory does not spend the allowance the
 	// failure diagnosis it leads to will need.
 	Plugins OperationBudget
+	// AccessReads meters role/member access inspection separately. Member search
+	// returns masked personal data and must not be fundable by another read lane.
+	AccessReads OperationBudget
 	// Diagnostics meters the observability reads. They are bounded aggregate
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 )
 
+func TestOperationBudgetsValidRequiresAccessReads(t *testing.T) {
+	t.Parallel()
+
+	budget := allowBudget()
+	budgets := OperationBudgets{
+		Catalog: budget, Registration: budget, Handoff: budget, SetupStart: budget,
+		Repair: budget, Docs: budget, Skills: budget, LifecycleMetadata: budget,
+		Plugins: budget, AccessReads: budget, Diagnostics: budget,
+		SensitiveDiagnostics: budget, SensitiveSessionRecall: budget, RiskMutations: budget,
+		DrilldownVolume: DrilldownVolumeBudget{Rows: allowOperationLimiter{}, MetricQueries: allowOperationLimiter{}},
+	}
+	require.True(t, budgets.Valid())
+
+	budgets.AccessReads.Connection = nil
+	require.False(t, budgets.Valid())
+	budgets.AccessReads.Connection = allowOperationLimiter{}
+	budgets.AccessReads.Organization = nil
+	require.False(t, budgets.Valid())
+	budgets.AccessReads = budget
+	budgets.Plugins.Connection = nil
+	require.False(t, budgets.Valid())
+	budgets.Plugins.Connection = allowOperationLimiter{}
+	budgets.Plugins.Organization = nil
+	require.False(t, budgets.Valid())
+}
+
 func TestOperationBudgetChargesConnectionBeforeOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2894,6 +2894,39 @@ WHERE p.project_id = @project_id
 ORDER BY p.id ASC
 LIMIT 2;
 
+-- name: SearchPlatformMCPAccessMembers :many
+-- Count distinct members and return only a bounded page from the same snapshot.
+-- Active local role assignments follow the access roster's WorkOS identity join.
+WITH member_roles AS (
+  SELECT ora.workos_user_id,
+    array_agg(DISTINCT COALESCE(r.id::text, g.id::text)) AS role_ids,
+    array_agg(DISTINCT COALESCE(r.workos_name, g.workos_name)) AS role_names
+  FROM organization_role_assignments ora
+  LEFT JOIN organization_roles r ON ora.role_urn = 'role:organization:' || r.id::text
+    AND r.organization_id = @organization_id AND r.deleted IS FALSE AND r.workos_deleted IS FALSE
+  LEFT JOIN global_roles g ON ora.role_urn = 'role:global:' || g.id::text
+    AND g.deleted IS FALSE AND g.workos_deleted IS FALSE
+  WHERE ora.organization_id = @organization_id AND ora.deleted_at IS NULL
+    AND COALESCE(r.id, g.id) IS NOT NULL
+  GROUP BY ora.workos_user_id
+), matching AS (
+  SELECT DISTINCT u.id, u.display_name, u.email, COALESCE(m.role_ids, '{}'::text[])::text[] AS role_ids
+  FROM organization_user_relationships rel
+  JOIN users u ON u.id = rel.user_id AND u.deleted_at IS NULL
+  LEFT JOIN member_roles m ON m.workos_user_id = u.workos_id
+  WHERE rel.organization_id = @organization_id AND rel.deleted IS FALSE
+    AND (@role_id::text = '' OR @role_id::text = ANY(m.role_ids))
+    AND (@query::text = ''
+      OR strpos(lower(trim(regexp_replace(u.display_name, '[[:space:]]+', ' ', 'g'))), @query::text) > 0
+      OR strpos(lower(trim(regexp_replace(u.email, '[[:space:]]+', ' ', 'g'))), @query::text) > 0
+      OR EXISTS (SELECT 1 FROM unnest(m.role_names) AS role_name
+        WHERE strpos(lower(trim(regexp_replace(role_name, '[[:space:]]+', ' ', 'g'))), @query::text) > 0))
+)
+SELECT id, display_name, email, role_ids, count(*) OVER ()::bigint AS total_matches
+FROM matching
+ORDER BY email, id
+LIMIT @result_limit;
+
 -- name: GetPlatformMCPPluginForUpdate :one
 -- Serializes an MCP distribution write against concurrent deletion of the
 -- exact plugin the caller named. A deleted plugin deliberately returns no row,

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -6427,6 +6427,86 @@ func (q *Queries) RotatePlatformMCPSession(ctx context.Context, arg RotatePlatfo
 	return i, err
 }
 
+const searchPlatformMCPAccessMembers = `-- name: SearchPlatformMCPAccessMembers :many
+WITH member_roles AS (
+  SELECT ora.workos_user_id,
+    array_agg(DISTINCT COALESCE(r.id::text, g.id::text)) AS role_ids,
+    array_agg(DISTINCT COALESCE(r.workos_name, g.workos_name)) AS role_names
+  FROM organization_role_assignments ora
+  LEFT JOIN organization_roles r ON ora.role_urn = 'role:organization:' || r.id::text
+    AND r.organization_id = $2 AND r.deleted IS FALSE AND r.workos_deleted IS FALSE
+  LEFT JOIN global_roles g ON ora.role_urn = 'role:global:' || g.id::text
+    AND g.deleted IS FALSE AND g.workos_deleted IS FALSE
+  WHERE ora.organization_id = $2 AND ora.deleted_at IS NULL
+    AND COALESCE(r.id, g.id) IS NOT NULL
+  GROUP BY ora.workos_user_id
+), matching AS (
+  SELECT DISTINCT u.id, u.display_name, u.email, COALESCE(m.role_ids, '{}'::text[])::text[] AS role_ids
+  FROM organization_user_relationships rel
+  JOIN users u ON u.id = rel.user_id AND u.deleted_at IS NULL
+  LEFT JOIN member_roles m ON m.workos_user_id = u.workos_id
+  WHERE rel.organization_id = $2 AND rel.deleted IS FALSE
+    AND ($3::text = '' OR $3::text = ANY(m.role_ids))
+    AND ($4::text = ''
+      OR strpos(lower(trim(regexp_replace(u.display_name, '[[:space:]]+', ' ', 'g'))), $4::text) > 0
+      OR strpos(lower(trim(regexp_replace(u.email, '[[:space:]]+', ' ', 'g'))), $4::text) > 0
+      OR EXISTS (SELECT 1 FROM unnest(m.role_names) AS role_name
+        WHERE strpos(lower(trim(regexp_replace(role_name, '[[:space:]]+', ' ', 'g'))), $4::text) > 0))
+)
+SELECT id, display_name, email, role_ids, count(*) OVER ()::bigint AS total_matches
+FROM matching
+ORDER BY email, id
+LIMIT $1
+`
+
+type SearchPlatformMCPAccessMembersParams struct {
+	ResultLimit    int32
+	OrganizationID string
+	RoleID         string
+	Query          string
+}
+
+type SearchPlatformMCPAccessMembersRow struct {
+	ID           string
+	DisplayName  string
+	Email        string
+	RoleIds      []string
+	TotalMatches int64
+}
+
+// Count distinct members and return only a bounded page from the same snapshot.
+// Active local role assignments follow the access roster's WorkOS identity join.
+func (q *Queries) SearchPlatformMCPAccessMembers(ctx context.Context, arg SearchPlatformMCPAccessMembersParams) ([]SearchPlatformMCPAccessMembersRow, error) {
+	rows, err := q.db.Query(ctx, searchPlatformMCPAccessMembers,
+		arg.ResultLimit,
+		arg.OrganizationID,
+		arg.RoleID,
+		arg.Query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchPlatformMCPAccessMembersRow
+	for rows.Next() {
+		var i SearchPlatformMCPAccessMembersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.DisplayName,
+			&i.Email,
+			&i.RoleIds,
+			&i.TotalMatches,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const softDeletePendingPlatformMCPCatalogRegistration = `-- name: SoftDeletePendingPlatformMCPCatalogRegistration :exec
 UPDATE platform_mcp_catalog_registrations
 SET deleted_at = clock_timestamp()

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -127,14 +127,14 @@ func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, ga
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
 func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
-	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
 }
 
-func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) *Runtime {
+func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessReads *AccessReadService) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate)
+	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate, accessReads)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/tool_access_reads.go
+++ b/server/internal/platformmcp/tool_access_reads.go
@@ -21,7 +21,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "List the organization's roles and summarize the MCP access each role carries. Member counts are withheld for small groups, and each role is represented by a short-lived opaque reference rather than a role ID or principal.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ListAccessRolesOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (ListAccessRolesOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (ListAccessRolesOutput, error) {
 			return accessReads.ListRoles(ctx, principal)
 		})
 	})
@@ -32,7 +32,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "Find organization members by an explicit identity query of at least three characters or a role reference. Returns masked identities, role names, and short-lived opaque member references only when at least five people match; smaller result sets are withheld rather than enumerated.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListAccessMembersInput) (*mcp.CallToolResult, ListAccessMembersOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (ListAccessMembersOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (ListAccessMembersOutput, error) {
 			return accessReads.ListMembers(ctx, principal, input)
 		})
 	})
@@ -43,7 +43,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "Inspect which roles can enter one exact configured MCP server through its configured endpoint and which known tools or behavior classes they can use. Uses the same authorization resource and selector semantics as that endpoint; dynamic servers may not have an enumerable tool catalog.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetMCPAccessInput) (*mcp.CallToolResult, GetMCPAccessOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (GetMCPAccessOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (GetMCPAccessOutput, error) {
 			return accessReads.GetMCPAccess(ctx, principal, input)
 		})
 	})
@@ -67,22 +67,6 @@ func registerUnavailableAccessReadTools(reg *Registrar) {
 			Annotations: readOnlyAnnotations(),
 		}, ToolMeta{Audiences: externalOnly, ProjectScope: tool.projectScope}, unavailableTool("mcp_access_reads"))
 	}
-}
-
-func accessReadToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
-	var zero Out
-	principal, err := principalFromToolContext(ctx)
-	if err != nil {
-		return nil, zero, err
-	}
-	output, err := call(principal)
-	if err != nil {
-		if refusal, ok := accessReadToolResult(err); ok {
-			return refusal, zero, nil
-		}
-		return nil, zero, err
-	}
-	return nil, output, nil
 }
 
 func accessReadToolResult(err error) (*mcp.CallToolResult, bool) {

--- a/server/internal/platformmcp/tool_access_reads.go
+++ b/server/internal/platformmcp/tool_access_reads.go
@@ -1,0 +1,108 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type accessReadRefusalResult struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_access_roles",
+		Title:       "List MCP Access Roles",
+		Description: "List the organization's roles and summarize the MCP access each role carries. Member counts are withheld for small groups, and each role is represented by a short-lived opaque reference rather than a role ID or principal.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ListAccessRolesOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (ListAccessRolesOutput, error) {
+			return accessReads.ListRoles(ctx, principal)
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "list_access_members",
+		Title:       "Find Organization Members for MCP Access",
+		Description: "Find organization members by an explicit identity query of at least three characters or a role reference. Returns masked identities, role names, and short-lived opaque member references only when at least five people match; smaller result sets are withheld rather than enumerated.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListAccessMembersInput) (*mcp.CallToolResult, ListAccessMembersOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (ListAccessMembersOutput, error) {
+			return accessReads.ListMembers(ctx, principal, input)
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "get_mcp_access",
+		Title:       "Inspect Access to One MCP Server",
+		Description: "Inspect which roles can enter one exact configured MCP server through its configured endpoint and which known tools or behavior classes they can use. Uses the same authorization resource and selector semantics as that endpoint; dynamic servers may not have an enumerable tool catalog.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetMCPAccessInput) (*mcp.CallToolResult, GetMCPAccessOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (GetMCPAccessOutput, error) {
+			return accessReads.GetMCPAccess(ctx, principal, input)
+		})
+	})
+}
+
+func registerUnavailableAccessReadTools(reg *Registrar) {
+	for _, tool := range []struct {
+		name         string
+		title        string
+		description  string
+		projectScope ProjectScope
+	}{
+		{"list_access_roles", "List MCP Access Roles", "List MCP access roles. This is not switched on for your organization yet.", ProjectScopeNone},
+		{"list_access_members", "Find Organization Members for MCP Access", "Find organization members for MCP access. This is not switched on for your organization yet.", ProjectScopeNone},
+		{"get_mcp_access", "Inspect Access to One MCP Server", "Inspect access to one MCP server. This is not switched on for your organization yet.", ProjectScopeExplicit},
+	} {
+		addTool(reg, &mcp.Tool{
+			Name:        tool.name,
+			Title:       tool.title,
+			Description: tool.description,
+			Annotations: readOnlyAnnotations(),
+		}, ToolMeta{Audiences: externalOnly, ProjectScope: tool.projectScope}, unavailableTool("mcp_access_reads"))
+	}
+}
+
+func accessReadToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err != nil {
+		if refusal, ok := accessReadToolResult(err); ok {
+			return refusal, zero, nil
+		}
+		return nil, zero, err
+	}
+	return nil, output, nil
+}
+
+func accessReadToolResult(err error) (*mcp.CallToolResult, bool) {
+	var result accessReadRefusalResult
+	switch {
+	case errors.Is(err, ErrAccessQueryRequired):
+		result = accessReadRefusalResult{Code: "invalid_request", Message: "Supply an identity query of at least three characters or choose one of the role references returned by list_access_roles; the full employee directory is not exposed."}
+	case errors.Is(err, ErrAccessReferenceNotFound):
+		result = accessReadRefusalResult{Code: "not_found", Message: "That access reference is not available here. List the roles or members again and use a reference from the new result."}
+	case errors.Is(err, ErrAccessMCPNotFound):
+		result = accessReadRefusalResult{Code: "not_found", Message: "That MCP server is not in the selected project. Choose one returned by find_mcp."}
+	default:
+		if budgetResult, ok := operationBudgetToolResult(err); ok {
+			return budgetResult, true
+		}
+		return nil, false
+	}
+	content, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
+}

--- a/server/internal/platformmcp/tool_access_reads_test.go
+++ b/server/internal/platformmcp/tool_access_reads_test.go
@@ -1,0 +1,64 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	wanted := map[string]ProjectScope{
+		"list_access_roles":   ProjectScopeNone,
+		"list_access_members": ProjectScopeNone,
+		"get_mcp_access":      ProjectScopeExplicit,
+	}
+	for _, descriptor := range registrar.Descriptors() {
+		projectScope, ok := wanted[descriptor.Name]
+		if !ok {
+			continue
+		}
+		require.Equal(t, projectScope, descriptor.Meta.ProjectScope)
+		require.Equal(t, externalOnly, descriptor.Meta.Audiences)
+		require.NotEmpty(t, descriptor.InputSchema)
+		delete(wanted, descriptor.Name)
+	}
+	require.Empty(t, wanted)
+
+	tools := registrar.For(AudienceAssistant)
+	for _, descriptor := range tools {
+		require.NotContains(t, []string{"list_access_roles", "list_access_members", "get_mcp_access"}, descriptor.Name)
+	}
+}
+
+func TestAccessReadToolRefusalsAreStructured(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "query", err: ErrAccessQueryRequired, code: "invalid_request"},
+		{name: "reference", err: ErrAccessReferenceNotFound, code: "not_found"},
+		{name: "mcp", err: ErrAccessMCPNotFound, code: "not_found"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := accessReadToolResult(test.err)
+			require.True(t, ok)
+			require.True(t, result.IsError)
+			require.Len(t, result.Content, 1)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+			var refusal accessReadRefusalResult
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &refusal))
+			require.Equal(t, test.code, refusal.Code)
+			require.NotEmpty(t, refusal.Message)
+		})
+	}
+}

--- a/server/internal/platformmcp/tool_access_reads_test.go
+++ b/server/internal/platformmcp/tool_access_reads_test.go
@@ -2,6 +2,7 @@ package platformmcp
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -12,6 +13,20 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 	t.Parallel()
 
 	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	requireAccessReadToolDescriptors(t, registrar)
+}
+
+func TestAvailableAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
+	t.Parallel()
+
+	registrar := newRegistrar(mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil))
+	registerAccessReadTools(registrar, nil)
+	requireAccessReadToolDescriptors(t, registrar)
+}
+
+func requireAccessReadToolDescriptors(t *testing.T, registrar *Registrar) {
+	t.Helper()
+
 	wanted := map[string]ProjectScope{
 		"list_access_roles":   ProjectScopeNone,
 		"list_access_members": ProjectScopeNone,
@@ -22,6 +37,8 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 		if !ok {
 			continue
 		}
+		require.NotNil(t, descriptor.Annotations)
+		require.True(t, descriptor.Annotations.ReadOnlyHint)
 		require.Equal(t, projectScope, descriptor.Meta.ProjectScope)
 		require.Equal(t, externalOnly, descriptor.Meta.Audiences)
 		require.NotEmpty(t, descriptor.InputSchema)
@@ -32,6 +49,82 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 	tools := registrar.For(AudienceAssistant)
 	for _, descriptor := range tools {
 		require.NotContains(t, []string{"list_access_roles", "list_access_members", "get_mcp_access"}, descriptor.Name)
+	}
+}
+
+func TestPrincipalToolCallRequiresPrincipal(t *testing.T) {
+	t.Parallel()
+
+	result, output, err := principalToolCall(t.Context(), func(error) (*mcp.CallToolResult, bool) {
+		t.Fatal("principal errors must not be translated")
+		return nil, false
+	}, func(Principal) (string, error) {
+		t.Fatal("call must not run without a principal")
+		return "", nil
+	})
+	require.ErrorIs(t, err, ErrUnauthorized)
+	require.Nil(t, result)
+	require.Empty(t, output)
+}
+
+func TestPrincipalToolCallReturnsSuccessfulOutput(t *testing.T) {
+	t.Parallel()
+
+	principal := registrationServicePrincipal()
+	ctx := contextWithPrincipal(t.Context(), principal)
+	result, output, err := principalToolCall(ctx, accessReadToolResult, func(actual Principal) (string, error) {
+		require.Equal(t, principal, actual)
+		return "output", nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "output", output)
+}
+
+func TestPrincipalToolCallPreservesUnexpectedErrors(t *testing.T) {
+	t.Parallel()
+
+	unexpected := errors.New("unexpected service failure")
+	ctx := contextWithPrincipal(t.Context(), registrationServicePrincipal())
+	for _, refusalResult := range []func(error) (*mcp.CallToolResult, bool){accessReadToolResult, pluginToolResult} {
+		result, output, err := principalToolCall(ctx, refusalResult, func(Principal) (string, error) {
+			return "partial output", unexpected
+		})
+		require.ErrorIs(t, err, unexpected)
+		require.Nil(t, result)
+		require.Empty(t, output)
+	}
+}
+
+func TestPrincipalToolCallTranslatesKnownRefusals(t *testing.T) {
+	t.Parallel()
+
+	ctx := contextWithPrincipal(t.Context(), registrationServicePrincipal())
+	for _, test := range []struct {
+		refusalResult func(error) (*mcp.CallToolResult, bool)
+		err           error
+	}{
+		{accessReadToolResult, ErrAccessQueryRequired},
+		{accessReadToolResult, ErrAccessReferenceNotFound},
+		{accessReadToolResult, ErrAccessMCPNotFound},
+		{accessReadToolResult, ErrOperationRateLimited},
+		{accessReadToolResult, ErrOperationBudgetUnavailable},
+		{pluginToolResult, ErrPluginProjectNotFound},
+		{pluginToolResult, ErrPluginNotFound},
+		{pluginToolResult, ErrPluginAmbiguous},
+		{pluginToolResult, ErrPluginCursorInvalid},
+		{pluginToolResult, ErrOperationRateLimited},
+		{pluginToolResult, ErrOperationBudgetUnavailable},
+	} {
+		result, output, err := principalToolCall(ctx, test.refusalResult, func(Principal) (string, error) {
+			return "partial output", test.err
+		})
+		require.NoError(t, err)
+		require.Empty(t, output)
+		expected, ok := test.refusalResult(test.err)
+		require.True(t, ok)
+		require.Equal(t, expected, result)
+		require.True(t, result.IsError)
 	}
 }
 

--- a/server/internal/platformmcp/tool_call.go
+++ b/server/internal/platformmcp/tool_call.go
@@ -1,0 +1,25 @@
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// principalToolCall shares caller extraction and refusal handling while leaving
+// each tool family responsible for its own safe error projection.
+func principalToolCall[Out any](ctx context.Context, refusalFor func(error) (*mcp.CallToolResult, bool), call func(Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err != nil {
+		if refusal, ok := refusalFor(err); ok {
+			return refusal, zero, nil
+		}
+		return nil, zero, err
+	}
+	return nil, output, nil
+}

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -25,7 +25,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Title:       "Set Plugin Assignments",
 		Description: setDescription,
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input SetPluginAssignmentsInput) (*mcp.CallToolResult, SetPluginAssignmentsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (SetPluginAssignmentsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (SetPluginAssignmentsOutput, error) {
 			return plugins.SetPluginAssignments(ctx, principal, input)
 		})
 	})
@@ -36,7 +36,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "List up to 100 existing roles and directory assignment targets that can receive plugins in an explicit project. Each assignment has a short-lived opaque reference and, where available, a privacy-safe member count; Everyone has no member count. Raw principal identifiers are never returned. If truncated is true, use the dashboard to choose from the complete assignment set.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginAssignmentsInput) (*mcp.CallToolResult, ListPluginAssignmentsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (ListPluginAssignmentsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (ListPluginAssignmentsOutput, error) {
 			return plugins.ListPluginAssignments(ctx, principal, input)
 		})
 	})

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -47,7 +47,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "List the plugins in a named project. A plugin is the bundle of MCP servers and skills an administrator shares with people, so this is the level to answer \"what do we ship\" at, rather than adding up individual servers. Each entry reports how much the plugin carries, who receives it, and whether it has been published — that is, whether the people it is shared with have it yet.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginsInput) (*mcp.CallToolResult, ListPluginsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (ListPluginsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (ListPluginsOutput, error) {
 			return plugins.ListPlugins(ctx, principal, input)
 		})
 	})
@@ -58,7 +58,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, skills, up to 100 current assignments, and an assignment version for safe follow-up edits. Assignment references expire at the returned time; if assignments_truncated is true or assignment_details_complete is false, use the dashboard before editing assignments. The general truncated field applies only to MCP servers and skills. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetPluginInput) (*mcp.CallToolResult, GetPluginOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (GetPluginOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (GetPluginOutput, error) {
 			return plugins.GetPlugin(ctx, principal, input)
 		})
 	})
@@ -82,25 +82,6 @@ func registerUnavailablePluginTools(reg *Registrar) {
 		}
 		addTool(reg, manifest, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("plugins"))
 	}
-}
-
-// pluginToolCall runs one plugin call and turns a refusal into a structured
-// error result rather than a transport error, so the reason survives to the
-// model that has to act on it.
-func pluginToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
-	var zero Out
-	principal, err := principalFromToolContext(ctx)
-	if err != nil {
-		return nil, zero, err
-	}
-	output, err := call(principal)
-	if err != nil {
-		if refusal, ok := pluginToolResult(err); ok {
-			return refusal, zero, nil
-		}
-		return nil, zero, err
-	}
-	return nil, output, nil
 }
 
 func pluginToolResult(err error) (*mcp.CallToolResult, bool) {

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -151,10 +151,10 @@ type operationBudgetResult struct {
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
-	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
 }
 
-func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessRead *AccessReadService) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -296,6 +296,11 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 		registerUnavailablePluginTools(reg)
 	} else {
 		registerPluginTools(reg, plugins)
+	}
+	if !accessRead.valid() {
+		registerUnavailableAccessReadTools(reg)
+	} else {
+		registerAccessReadTools(reg, accessRead)
 	}
 	if !sessionRecall.valid() {
 		registerUnavailableSessionRecallTools(reg)


### PR DESCRIPTION
## Linear

- [AIM-223](https://linear.app/speakeasy/issue/AIM-223)

## Why

Administrators can inspect configured MCP servers, but Platform MCP could not answer which roles can use a server or its individual tools without exposing the generic grant model or raw member identities. This adds the read-only foundation required before managing MCP access through roles.

## What changed

- Add `list_access_roles` with privacy-safe member counts, allow/block rule summaries, and short-lived opaque role references.
- Add `list_access_members`, requiring a role filter or identity query of at least three characters; mask identities and suppress result rows when fewer than five members match.
- Add `get_mcp_access` for one configured endpoint, mapping hosted and proxied backends to the runtime authorization resource and reporting effective role/tool coverage with exclusion semantics.
- Reuse local access-role/member authority and stored tool metadata without contacting WorkOS or an upstream MCP.
- Add a separate access-read budget and a server patch changeset.

## Review notes

1. `server/internal/platformmcp/access_reads.go` — positive projections, privacy floor, opaque references, and effective grant evaluation.
2. `server/internal/authz/grants.go` — `GrantsAuthorize` exposes the existing loaded-grant evaluation path, including block scopes, without replacing the acting request context.
3. `server/internal/platformmcp/access_reads_integration_test.go` — member suppression and configured-endpoint resource mapping.
4. These tools are external Platform MCP only. Role/member mutations and the managed-assistant surface remain out of scope.

## Testing

- `hk fix` — passed.
- `mise run test:server -count=1 ./internal/platformmcp/` — passed, 565 tests.
- `mise lint:server` — passed.
- `mise build:server` — passed.
- Compile checks for `server/internal/platformmcp` and `server/cmd/gram` — passed.
- `git diff --check` — passed.
- `mise run test:server -count=1 ./internal/authz/` — package compiles, but the local harness could not start ClickHouse (`context deadline exceeded`) on two attempts, so no package test body ran. The new helper is covered through the passing Platform MCP tests.

## Rollout / deployment notes

These are admin-only reads under the existing Platform MCP gate and a dedicated rate limit. Rollback removes the tools; no state or schema migration is involved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read-only Platform MCP tools so admins can inspect which roles and members can access a configured MCP server, without exposing raw grant data or member identities. Plugin read tools now share the same principal extraction and refusal handling.

**New Features**
- `list_access_roles` returns role summaries, privacy-safe member counts, and short-lived opaque role references.
- `list_access_members` requires a role reference or identity query of at least three characters, masks identities, and withholds rows when fewer than five members match.
- `get_mcp_access` evaluates effective role and tool coverage for one configured endpoint, with block-scope exclusions applied through a new authz helper that leaves the request's acting principal untouched.
- Access reads use a separate rate-limit budget and are external Platform MCP only; rollback removes the tools with no state or schema migration.

<sup>Written for commit 9fb425577ecef269f9a298b3b231f52825c97081. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


