### PR TITLE
fix: return generic MCP availability errors

### DIFF
--- a/server/internal/mcp/servepublic_tunneled_test.go
+++ b/server/internal/mcp/servepublic_tunneled_test.go
@@ -49,6 +49,8 @@ type fakeTunnelGateway struct {
 	// dead simulates the agent session being gone: every forward answers
 	// no-live-session.
 	dead bool
+	// busy simulates a live gateway that cannot accept another backend request.
+	busy bool
 	// challenge, when set, is emitted as WWW-Authenticate on every backend
 	// response to prove Gram strips it for anonymous callers.
 	challenge string
@@ -94,6 +96,11 @@ func (g *fakeTunnelGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.forwards = append(g.forwards, r.Header.Clone())
 	g.forwardBodies = append(g.forwardBodies, buf.String())
 	g.mu.Unlock()
+	if g.busy {
+		w.Header().Set(wire.HeaderTunnelError, wire.TunnelErrorTunnelBusy)
+		http.Error(w, "MCP server is temporarily unavailable", http.StatusBadGateway)
+		return
+	}
 
 	exact := strings.TrimSpace(r.Header.Get(wire.HeaderTunnelAgentSession))
 	if g.dead || (exact != "" && exact != g.agentSessionID) {
@@ -266,7 +273,7 @@ func TestServePublic_Tunneled_AnonymousInitializeMintsGramSession(t *testing.T) 
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	sid := initializeTunneledPublicSession(t, ti, fixture)
@@ -277,11 +284,36 @@ func TestServePublic_Tunneled_AnonymousInitializeMintsGramSession(t *testing.T) 
 	require.Empty(t, forwarded.Get(wire.HeaderTunnelAgentSession), "initialize must not pin an exact target")
 }
 
+func TestServePublic_Tunneled_BusyGatewayReturnsGenericJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: "", busy: true}
+	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
+
+	w, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeInitializeBody(), "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Empty(t, w.Header().Get(wire.HeaderTunnelError))
+	require.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"error": {
+			"code": -32000,
+			"message": "The MCP server is temporarily unavailable. Please retry.",
+			"data": {
+				"code": "service_unavailable",
+				"retryable": true
+			}
+		}
+	}`, w.Body.String())
+}
+
 func TestServePublic_Tunneled_SessionRequestPinsExactTarget(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	sid := initializeTunneledPublicSession(t, ti, fixture)
@@ -302,7 +334,7 @@ func TestServePublic_Tunneled_UnknownOrMalformedSessionIs404(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	for _, sid := range []string{
@@ -326,7 +358,7 @@ func TestServePublic_Tunneled_OfflineTunnelIs404(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	require.NoError(t, ti.tunnelRoutes.Delete(ctx, fixture.tunnelID.String()))
@@ -346,7 +378,7 @@ func TestServePublic_Tunneled_DeadAgentSessionTranslatesTo404(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	sid := initializeTunneledPublicSession(t, ti, fixture)
@@ -373,7 +405,7 @@ func TestServePublic_Tunneled_DeadGatewayDialDropsSession(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	sid := initializeTunneledPublicSession(t, ti, fixture)
@@ -388,7 +420,7 @@ func TestServePublic_Tunneled_DeadGatewayDialDropsSession(t *testing.T) {
 
 	listener, err := net.Listen("tcp", addr)
 	require.NoError(t, err)
-	replacementGateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	replacementGateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	replacementServer := httptest.NewUnstartedServer(replacementGateway)
 	replacementServer.Listener = listener
 	replacementServer.Start()
@@ -405,7 +437,7 @@ func TestServePublic_Tunneled_DeleteTerminatesSession(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	sid := initializeTunneledPublicSession(t, ti, fixture)
@@ -428,7 +460,7 @@ func TestServePublic_Tunneled_SessionlessBackendGetsNoSyntheticSession(t *testin
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	w, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeInitializeBody(), "")
@@ -448,7 +480,7 @@ func TestServePublic_Tunneled_LegacyGatewayFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: true, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: true, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	_, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeInitializeBody(), "")
@@ -467,7 +499,7 @@ func TestServePublic_Tunneled_StripsBackendChallenge(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: `Bearer resource_metadata="http://internal.example/.well-known"`}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: `Bearer resource_metadata="http://internal.example/.well-known"`}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	w, err := serveTunneledPublicRequest(t, ti, fixture.endpointSlug, http.MethodPost, makeInitializeBody(), "")
@@ -489,7 +521,7 @@ func TestServePublic_Tunneled_LiveSessionCapRejectsInitialize(t *testing.T) {
 		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
 		MaxRequestLifetime: 0,
 	})
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	initializeTunneledPublicSession(t, ti, fixture)
@@ -512,7 +544,7 @@ func TestServePublic_Tunneled_OAuthSurfaceIs404(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	logger := ti.logger
@@ -621,7 +653,7 @@ func TestServePublic_Tunneled_RequestRateLimitRejects(t *testing.T) {
 		RequestRate:        ratelimit.Rate{Tokens: 1, Interval: time.Hour, Burst: 1},
 		MaxRequestLifetime: 0,
 	}, nil)
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	// The single token admits the first request.
@@ -681,7 +713,7 @@ func TestServePublic_Tunneled_StoredRateLimitsOverrideDefaults(t *testing.T) {
 		RequestRate:        ratelimit.Rate{Tokens: 1, Interval: time.Hour, Burst: 1},
 		MaxRequestLifetime: 0,
 	})
-	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, challenge: ""}
+	gateway := &fakeTunnelGateway{t: t, agentSessionID: "agent-1", backendSessionID: "backend-secret-session", legacy: false, dead: false, busy: false, challenge: ""}
 	fixture := newPublicTunnelFixture(t, ctx, ti, gateway, true)
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)

--- a/server/internal/mcp/tunnel_manager.go
+++ b/server/internal/mcp/tunnel_manager.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -108,6 +109,12 @@ func (m *tunnelManager) buildProxy(
 		options...,
 	)
 	p.UpstreamResponseRetryer = tunnelrouting.Retryer(m.routes, tunnelID, addr, clientAffinityKey, m.forwardToken)
+	p.UpstreamResponseInterceptor = func(_ context.Context, resp *http.Response) error {
+		if rejection := tunnelrouting.BusyResponseRejection(resp); rejection != nil {
+			return rejection
+		}
+		return nil
+	}
 	// Redirects won't work across a tunnel boundary; disable.
 	p.DisableRedirects = true
 	p.GuardianClientOptions = m.guardianClientOptions()

--- a/server/internal/mcp/tunnelpublic.go
+++ b/server/internal/mcp/tunnelpublic.go
@@ -440,6 +440,9 @@ func (s *Service) serveTunneledPublicInit(
 
 	committed := false
 	p.UpstreamResponseInterceptor = func(ctx context.Context, resp *http.Response) error {
+		if rejection := tunnelrouting.BusyResponseRejection(resp); rejection != nil {
+			return rejection
+		}
 		stripPublicResponseHeaders(resp)
 		if !reserved {
 			return nil
@@ -691,6 +694,9 @@ func (s *Service) serveTunneledPublicSession(
 
 	isDelete := r.Method == http.MethodDelete
 	p.UpstreamResponseInterceptor = func(ctx context.Context, resp *http.Response) error {
+		if rejection := tunnelrouting.BusyResponseRejection(resp); rejection != nil {
+			return rejection
+		}
 		stripPublicResponseHeaders(resp)
 
 		// The exact agent session is gone: the backend session died with it.

--- a/server/internal/mcp/tunnelrouting/routing.go
+++ b/server/internal/mcp/tunnelrouting/routing.go
@@ -100,6 +100,28 @@ func SelectRoute(clientAffinityKey string, candidates []string, exclude map[stri
 	return available[index.Int64()], true
 }
 
+// BusyResponseRejection converts an exhausted internal capacity response to a
+// transport-neutral JSON-RPC error for POST requests. GET and DELETE retain
+// their HTTP response semantics; the gateway supplies their generic body.
+func BusyResponseRejection(resp *http.Response) *proxy.RejectError {
+	if resp == nil ||
+		resp.Request == nil ||
+		resp.Request.Method != http.MethodPost ||
+		resp.StatusCode != http.StatusBadGateway ||
+		resp.Header.Get(ErrorHeader) != wire.TunnelErrorTunnelBusy {
+		return nil
+	}
+
+	return &proxy.RejectError{
+		Code:    proxy.RejectCodeServerError,
+		Message: "The MCP server is temporarily unavailable. Please retry.",
+		Data: map[string]any{
+			"code":      "service_unavailable",
+			"retryable": true,
+		},
+	}
+}
+
 // Retryer returns the tunnel-specific proxy retry policy.
 func Retryer(routes route.Store, tunnelID, selectedAddr, clientAffinityKey, forwardToken string) proxy.UpstreamResponseRetryer {
 	return func(ctx context.Context, resp *http.Response) (*proxy.UpstreamResponseRetry, error) {

--- a/server/internal/mcp/tunnelrouting/routing_test.go
+++ b/server/internal/mcp/tunnelrouting/routing_test.go
@@ -77,6 +77,31 @@ func TestRetryerSubstreamFailedRetriesSameRouteWithoutUnpublish(t *testing.T) {
 	require.Equal(t, []string{"127.0.0.1:1001"}, candidates)
 }
 
+func TestBusyResponseRejectionMapsPostToGenericAvailabilityError(t *testing.T) {
+	t.Parallel()
+
+	resp := tunnelErrorResponseForMethod(wire.TunnelErrorTunnelBusy, http.MethodPost)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	rejection := BusyResponseRejection(resp)
+	require.NotNil(t, rejection)
+	require.Equal(t, proxy.RejectCodeServerError, rejection.Code)
+	require.Equal(t, "The MCP server is temporarily unavailable. Please retry.", rejection.Message)
+	require.Equal(t, map[string]any{
+		"code":      "service_unavailable",
+		"retryable": true,
+	}, rejection.Data)
+}
+
+func TestBusyResponseRejectionLeavesGetAsHTTPResponse(t *testing.T) {
+	t.Parallel()
+
+	resp := tunnelErrorResponseForMethod(wire.TunnelErrorTunnelBusy, http.MethodGet)
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Nil(t, BusyResponseRejection(resp))
+}
+
 // TestRetryerTunnelBusyFailsOverWithoutUnpublish: tunnel-busy means the
 // selected gateway is healthy but at capacity — its route must stay published
 // while the request fails over to another candidate, and replay is safe for

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -237,9 +237,9 @@ type Proxy struct {
 	// UpstreamResponseInterceptor, when set, runs once against the final
 	// upstream response — after any retry, before any header or body byte is
 	// relayed to the user. It may mutate resp.Header (headers are copied to
-	// the client afterwards). A non-nil error aborts the relay entirely; no
-	// status or headers have been written yet, so the caller's error path
-	// owns the client response.
+	// the client afterwards). On POST, a [RejectError] is converted into a
+	// correlated JSON-RPC error response; any other non-nil error aborts the
+	// relay entirely so the caller's error path owns the client response.
 	UpstreamResponseInterceptor func(ctx context.Context, resp *http.Response) error
 
 	// DisableRedirects stops the upstream client from following redirect
@@ -698,6 +698,10 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 
 	if p.UpstreamResponseInterceptor != nil {
 		if err := p.UpstreamResponseInterceptor(ctx, upstreamResp); err != nil {
+			if rejection, ok := errors.AsType[*RejectError](err); ok {
+				responseBytes = p.writeRejection(ctx, w, span, userReqID, rejection)
+				return nil
+			}
 			return fmt.Errorf("upstream response interceptor: %w", err)
 		}
 	}

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -2740,6 +2740,50 @@ func TestProxy_Post_UpstreamResponseInterceptorRuns(t *testing.T) {
 	require.Equal(t, "gram-sid", rr.Header().Get("Mcp-Session-Id"), "interceptor header mutation must reach the client")
 }
 
+func TestProxy_Post_UpstreamResponseInterceptorRejectionWritesJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Gram-Tunnel-Error", "tunnel-busy")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("internal transport detail"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.UpstreamResponseInterceptor = func(_ context.Context, _ *http.Response) error {
+		return &proxy.RejectError{
+			Code:    proxy.RejectCodeServerError,
+			Message: "The MCP server is temporarily unavailable. Please retry.",
+			Data: map[string]any{
+				"code":      "service_unavailable",
+				"retryable": true,
+			},
+		}
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	require.NoError(t, p.Post(rr, req))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+	require.Empty(t, rr.Header().Get("X-Gram-Tunnel-Error"))
+	require.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"error": {
+			"code": -32000,
+			"message": "The MCP server is temporarily unavailable. Please retry.",
+			"data": {
+				"code": "service_unavailable",
+				"retryable": true
+			}
+		}
+	}`, rr.Body.String())
+}
+
 // An interceptor error must abort the relay with nothing written to the
 // client, so callers can fail closed.
 func TestProxy_Post_UpstreamResponseInterceptorErrorAbortsBeforeFlush(t *testing.T) {

--- a/tunnel/gateway/gateway.go
+++ b/tunnel/gateway/gateway.go
@@ -356,7 +356,7 @@ func (g *Gateway) handleForward(w http.ResponseWriter, r *http.Request) {
 		// is healthy: callers must not unpublish its route; they may retry
 		// another gateway or surface the 502.
 		w.Header().Set(wire.HeaderTunnelError, wire.TunnelErrorTunnelBusy)
-		http.Error(w, "tunnel is at capacity", http.StatusBadGateway)
+		http.Error(w, "MCP server is temporarily unavailable", http.StatusBadGateway)
 		return
 	default:
 		// Distinguish known tunnel/no live session from auth failures.

--- a/tunnel/gateway/gateway_test.go
+++ b/tunnel/gateway/gateway_test.go
@@ -223,6 +223,7 @@ func TestForwardHandlerReportsTunnelBusyAtCap(t *testing.T) {
 
 	require.Equal(t, http.StatusBadGateway, rec.Code)
 	require.Equal(t, wire.TunnelErrorTunnelBusy, rec.Header().Get("X-Gram-Tunnel-Error"))
+	require.Equal(t, "MCP server is temporarily unavailable\n", rec.Body.String())
 }
 
 // recordingKeyStore wraps StaticKeyStore with a MarkConnected spy.


### PR DESCRIPTION
## Summary

- Translate exhausted tunneled MCP capacity responses into correlated JSON-RPC errors.
- Keep gateway and capacity details internal while returning a stable, retryable `service_unavailable` error to MCP clients.
- Preserve alternate-gateway failover and existing handling for unrelated upstream HTTP errors.

## Motivation

A terminal capacity response used a plain-text body, causing MCP clients to report a JSON decoding failure instead of an actionable availability error. Converting the final response at the proxy boundary preserves protocol correctness without exposing internal routing details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tunneled MCP clients seeing JSON decode failures when gateway capacity is exhausted, replacing the plain-text capacity body with a stable, retryable `service_unavailable` JSON-RPC error.

**Bug Fixes**
- Adds `RejectError` handling to the proxy response interceptor so it can write a correlated JSON-RPC error on POST.
- Keeps gateway and capacity details internal; alternate-gateway failover and unrelated upstream HTTP errors behave as before.

<sup>Written for commit 464a8bf17ec6f492b199fc00b2c13c6e0c3e5321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

